### PR TITLE
make scheduler_perf stable

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -27,15 +27,18 @@
     countParam: $initNodes
     uniqueNodeLabelStrategy:
       labelKey: kubernetes.io/hostname
+  - opcode: createNamespaces
+    prefix: sched
+    count: 2
   - opcode: createPods
     countParam: $initPods
     podTemplatePath: config/pod-with-pod-anti-affinity.yaml
-    namespace: sched-setup
+    namespace: sched-0
   - opcode: createPods
     countParam: $measurePods
     podTemplatePath: config/pod-with-pod-anti-affinity.yaml
     collectMetrics: true
-    namespace: sched-test
+    namespace: sched-1
   workloads:
   - name: 500Nodes
     params:
@@ -173,14 +176,17 @@
     labelNodePrepareStrategy:
       labelKey: "topology.kubernetes.io/zone"
       labelValues: ["zone1"]
+  - opcode: createNamespaces
+    prefix: sched
+    count: 2
   - opcode: createPods
     countParam: $initPods
     podTemplatePath: config/pod-with-pod-affinity.yaml
-    namespace: sched-setup
+    namespace: sched-0
   - opcode: createPods
     countParam: $measurePods
     podTemplatePath: config/pod-with-pod-affinity.yaml
-    namespace: sched-test
+    namespace: sched-1
     collectMetrics: true
   workloads:
   - name: 500Nodes
@@ -200,14 +206,17 @@
     countParam: $initNodes
     uniqueNodeLabelStrategy:
       labelKey: kubernetes.io/hostname
+  - opcode: createNamespaces
+    prefix: sched
+    count: 2
   - opcode: createPods
     countParam: $initPods
     podTemplatePath: config/pod-with-preferred-pod-affinity.yaml
-    namespace: sched-setup
+    namespace: sched-0
   - opcode: createPods
     countParam: $measurePods
     podTemplatePath: config/pod-with-preferred-pod-affinity.yaml
-    namespace: sched-test
+    namespace: sched-1
     collectMetrics: true
   workloads:
   - name: 500Nodes
@@ -227,14 +236,17 @@
     countParam: $initNodes
     uniqueNodeLabelStrategy:
       labelKey: kubernetes.io/hostname
+  - opcode: createNamespaces
+    prefix: sched
+    count: 2
   - opcode: createPods
     countParam: $initPods
     podTemplatePath: config/pod-with-preferred-pod-anti-affinity.yaml
-    namespace: sched-setup
+    namespace: sched-0
   - opcode: createPods
     countParam: $measurePods
     podTemplatePath: config/pod-with-preferred-pod-anti-affinity.yaml
-    namespace: sched-test
+    namespace: sched-1
     collectMetrics: true
   workloads:
   - name: 500Nodes
@@ -337,26 +349,29 @@
     labelNodePrepareStrategy:
       labelKey: "topology.kubernetes.io/zone"
       labelValues: ["zone1"]
+  - opcode: createNamespaces
+    prefix: sched
+    count: 1
   - opcode: createPods
     countParam: $initPods
     podTemplatePath: config/pod-default.yaml
-    namespace: sched-setup
+    namespace: sched-0
   - opcode: createPods
     countParam: $initPods
     podTemplatePath: config/pod-with-pod-affinity.yaml
-    namespace: sched-setup
+    namespace: sched-0
   - opcode: createPods
     countParam: $initPods
     podTemplatePath: config/pod-with-pod-anti-affinity.yaml
-    namespace: sched-setup
+    namespace: sched-0
   - opcode: createPods
     countParam: $initPods
     podTemplatePath: config/pod-with-preferred-pod-affinity.yaml
-    namespace: sched-setup
+    namespace: sched-0
   - opcode: createPods
     countParam: $initPods
     podTemplatePath: config/pod-with-preferred-pod-anti-affinity.yaml
-    namespace: sched-setup
+    namespace: sched-0
   - opcode: createPods
     countParam: $measurePods
     podTemplatePath: config/pod-default.yaml
@@ -478,7 +493,7 @@
 
 - name: SchedulingRequiredPodAntiAffinityWithNSSelector
   featureGates:
-    PodAffinityNamespaceSelector: true  
+    PodAffinityNamespaceSelector: true
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -511,10 +526,10 @@
       initPodsPerNamespace: 40
       initNamespaces: 100
       measurePods: 1000
-      
+
 - name: SchedulingPreferredAntiAffinityWithNSSelector
   featureGates:
-    PodAffinityNamespaceSelector: true  
+    PodAffinityNamespaceSelector: true
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -550,7 +565,7 @@
 
 - name: SchedulingRequiredPodAffinityWithNSSelector
   featureGates:
-    PodAffinityNamespaceSelector: true  
+    PodAffinityNamespaceSelector: true
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -584,10 +599,10 @@
       initPodsPerNamespace: 50
       initNamespaces: 100
       measurePods: 1000
-      
+
 - name: SchedulingPreferredAffinityWithNSSelector
   featureGates:
-    PodAffinityNamespaceSelector: true  
+    PodAffinityNamespaceSelector: true
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -620,4 +635,4 @@
       initPodsPerNamespace: 50
       initNamespaces: 100
       measurePods: 1000
-    
+

--- a/test/integration/scheduler_perf/config/pod-with-pod-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-pod-affinity.yaml
@@ -12,7 +12,7 @@ spec:
           matchLabels:
             color: blue
         topologyKey: topology.kubernetes.io/zone
-        namespaces: ["sched-test", "sched-setup"]
+        namespaces: ["sched-1", "sched-0"]
   containers:
   - image: k8s.gcr.io/pause:3.6
     name: pause

--- a/test/integration/scheduler_perf/config/pod-with-pod-anti-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-pod-anti-affinity.yaml
@@ -12,7 +12,7 @@ spec:
           matchLabels:
             color: green
         topologyKey: kubernetes.io/hostname
-        namespaces: ["sched-test", "sched-setup"]
+        namespaces: ["sched-1", "sched-0"]
   containers:
   - image: k8s.gcr.io/pause:3.6
     name: pause

--- a/test/integration/scheduler_perf/config/pod-with-preferred-pod-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-preferred-pod-affinity.yaml
@@ -13,7 +13,7 @@ spec:
               matchLabels:
                 color: red
             topologyKey: kubernetes.io/hostname
-            namespaces: ["sched-test", "sched-setup"]
+            namespaces: ["sched-1", "sched-0"]
           weight: 1
   containers:
     - image: k8s.gcr.io/pause:3.6

--- a/test/integration/scheduler_perf/config/pod-with-preferred-pod-anti-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-preferred-pod-anti-affinity.yaml
@@ -13,7 +13,7 @@ spec:
               matchLabels:
                 color: yellow
             topologyKey: kubernetes.io/hostname
-            namespaces: ["sched-test", "sched-setup"]
+            namespaces: ["sched-1", "sched-0"]
           weight: 1
   containers:
     - image: k8s.gcr.io/pause:3.6

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -605,7 +605,7 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 	// All namespaces listed in numPodsScheduledPerNamespace will be cleaned up.
 	numPodsScheduledPerNamespace := make(map[string]int)
 	b.Cleanup(func() {
-		for namespace, _ := range numPodsScheduledPerNamespace {
+		for namespace := range numPodsScheduledPerNamespace {
 			if err := client.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{}); err != nil {
 				b.Errorf("Deleting Namespace in numPodsScheduledPerNamespace: %v", err)
 			}

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -120,6 +120,7 @@ func StartFakePVController(clientSet clientset.Interface) ShutdownFunc {
 	pvInformer := informerFactory.Core().V1().PersistentVolumes()
 
 	syncPV := func(obj *v1.PersistentVolume) {
+		ctx := context.Background()
 		if obj.Spec.ClaimRef != nil {
 			claimRef := obj.Spec.ClaimRef
 			pvc, err := clientSet.CoreV1().PersistentVolumeClaims(claimRef.Namespace).Get(ctx, claimRef.Name, metav1.GetOptions{})

--- a/test/utils/create_resources.go
+++ b/test/utils/create_resources.go
@@ -59,6 +59,9 @@ func CreatePodWithRetries(c clientset.Interface, namespace string, obj *v1.Pod) 
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.CoreV1().Pods(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
@@ -73,6 +76,9 @@ func CreateRCWithRetries(c clientset.Interface, namespace string, obj *v1.Replic
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.CoreV1().ReplicationControllers(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
@@ -87,6 +93,9 @@ func CreateReplicaSetWithRetries(c clientset.Interface, namespace string, obj *a
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.AppsV1().ReplicaSets(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
@@ -101,6 +110,9 @@ func CreateDeploymentWithRetries(c clientset.Interface, namespace string, obj *a
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.AppsV1().Deployments(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
@@ -115,6 +127,9 @@ func CreateDaemonSetWithRetries(c clientset.Interface, namespace string, obj *ap
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.AppsV1().DaemonSets(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
@@ -129,6 +144,9 @@ func CreateJobWithRetries(c clientset.Interface, namespace string, obj *batch.Jo
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.BatchV1().Jobs(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
@@ -143,6 +161,9 @@ func CreateSecretWithRetries(c clientset.Interface, namespace string, obj *v1.Se
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.CoreV1().Secrets(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
@@ -157,6 +178,9 @@ func CreateConfigMapWithRetries(c clientset.Interface, namespace string, obj *v1
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.CoreV1().ConfigMaps(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
@@ -171,6 +195,9 @@ func CreateServiceWithRetries(c clientset.Interface, namespace string, obj *v1.S
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.CoreV1().Services(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
@@ -185,6 +212,9 @@ func CreateStorageClassWithRetries(c clientset.Interface, obj *storage.StorageCl
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.StorageV1().StorageClasses().Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
@@ -199,6 +229,9 @@ func CreateResourceQuotaWithRetries(c clientset.Interface, namespace string, obj
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.CoreV1().ResourceQuotas(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
@@ -213,6 +246,9 @@ func CreatePersistentVolumeWithRetries(c clientset.Interface, obj *v1.Persistent
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.CoreV1().PersistentVolumes().Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
@@ -227,10 +263,21 @@ func CreatePersistentVolumeClaimWithRetries(c clientset.Interface, namespace str
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.CoreV1().PersistentVolumeClaims(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+		if isGenerateNameConflict(obj.ObjectMeta, err) {
+			return false, nil
+		}
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
 		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
 	}
 	return RetryWithExponentialBackOff(createFunc)
+}
+
+// isGenerateNameConflict returns whether the error is generateName conflict or not.
+func isGenerateNameConflict(meta metav1.ObjectMeta, err error) bool {
+	if apierrors.IsAlreadyExists(err) && meta.Name == "" {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- Some test cases are using non-exist namespaces. Add `CreateNamespaceOp` to create these namespaces before using them by Pods.
- Use `numPodsScheduledPerNamespace` to record all created namespaces 
- mark test as failed when cleanup failed
- retry when API returns generateName conflict. Related #107790

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
