### PR TITLE
Optimize PodTopologySpread scheduler plugin performance

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -462,7 +462,7 @@ func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState *framework.C
 					// we log the error here, but do not do anything as if minMatchNum is 0
 					// this may lead to pod failing to schedule when skew is in fact less than maxSkew
 					// but this is ok in most cases
-					klog.Errorf("internal error: fail to calculate per-node min match count for pod %s: %s", pod.Name, err)
+					klog.ErrorS(err, "internal error: fail to calculate per-node min match count for pod", "pod", pod.Name)
 				}
 				skew -= minMatchNum
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This diff includes an optimization for PodTopologySpread scheduler plugin which will have performance benefits under the following conditions:

1. only hostname topology constraint is specified
2. the pod count for the majority of the deployments does not exceed `maxSkew * nodeCount`
3. the pod count inside a namespace is high (tens of thousands)

The optimization works by exploiting the fact that Filter only runs the subset of nodes. And due to the fact, the pod match count calculated during PreFilter is mostly wasted if the only topology constraint provided is the hostname.

In the diff, a new state `nodeMatchCountState` is introduced along with the existing `preFiterState`. It is used to store information regarding the pod match count for hostname topology key specifically, and it will be updated by both PreFilter and Filter.

Also due to the presence of "global min count", scanning all pods running on all nodes cannot be completely avoided. Thus, the current `skew` calculation is changed

from
```
skew = matchNum + selfMatchNum - minMatchNum
```

to
```
skew = matchNum + selfMatchNum
if skew > maxSkew {
    minMatchNum = calMinMatchCount()
    skew -= minMatchNum
}
```

`calMinMatchCount()` should be triggered very minimally if the pod count for most of the deployments do not exceed `maxSkew * nodeCount`

Test Plan:
On a small dev cluster, create a deployment with maxSkew set to 1, and gradually increase its
replicas starting from 1, and ensure that the pod placement obeys the maxSkew value.

Run benchmark test, ensure pods placed obeys maxSkew value. Also comparing the scheduling
throughput with baseline:

Note the test was run with the following configuration:

```
namespaces: 4
deployments per namespace: 1250
total pods: 150000
total nodes: 5000
```

```
baseline:
{
  "perc50": 123.6,
  "perc90": 134.6,
  "perc99": 147.6,
  "max": 152.8
}

with optimization:
{
  "perc50": 134,
  "perc90": 136.6,
  "perc99": 143.6,
  "max": 145.6
}
```

pod creation + binding rate graph:
<img width="1207" alt="Screen_Shot_2021-12-16_at_12 24 37_AM" src="https://user-images.githubusercontent.com/48631960/151120461-4aa1e5d0-3364-4067-a59e-709980032523.png">

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #105750

#### Special notes for your reviewer:
This is related to #107623 which optimizes the plugin's different code path.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Optimize PodToplogySpread scheduler plugin performance when only "hostname" topology key is specified.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
