### PR TITLE
add back FieldPath to event logs

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -291,7 +291,7 @@ func (e *eventBroadcasterImpl) StartLogging(logf func(format string, args ...int
 func (e *eventBroadcasterImpl) StartStructuredLogging(verbosity klog.Level) watch.Interface {
 	return e.StartEventWatcher(
 		func(e *v1.Event) {
-			klog.V(verbosity).InfoS("Event occurred", "object", klog.KRef(e.InvolvedObject.Namespace, e.InvolvedObject.Name), "kind", e.InvolvedObject.Kind, "apiVersion", e.InvolvedObject.APIVersion, "type", e.Type, "reason", e.Reason, "message", e.Message)
+			klog.V(verbosity).InfoS("Event occurred", "object", klog.KRef(e.InvolvedObject.Namespace, e.InvolvedObject.Name), "fieldPath", e.InvolvedObject.fieldPath, "kind", e.InvolvedObject.Kind, "apiVersion", e.InvolvedObject.APIVersion, "type", e.Type, "reason", e.Reason, "message", e.Message)
 		})
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind regression

#### What this PR does / why we need it:
Kubelet log is no longer logging container info(“FieldPath” field in logs) for event logs after this change https://github.com/kubernetes/kubernetes/pull/91712, need to add "FieldPath" field back

#### Which issue(s) this PR fixes:
Fixes #107440 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
