### PR TITLE
Ensure the execHostnameTest() compares hostnames

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2214,8 +2214,7 @@ var _ = common.SIGDescribe("Services", func() {
 		}
 		node0 := nodes.Items[0]
 		node1 := nodes.Items[1]
-		// split node name to ensure only hostname (and not FQDN) is compared with return from agnhost's /hostname endpoint.
-		node0Hostname := strings.Split(node0.Name, ".")[0]
+
 		serviceName := "svc-itp"
 		ns := f.Namespace.Name
 		servicePort := 80
@@ -2266,7 +2265,7 @@ var _ = common.SIGDescribe("Services", func() {
 		for i := 0; i < 5; i++ {
 			// the first pause pod should be on the same node as the webserver, so it can connect to the local pod using clusterIP
 			// note that the expected hostname is the node name because the backend pod is on host network
-			execHostnameTest(*pausePod0, serviceAddress, node0Hostname)
+			execHostnameTest(*pausePod0, serviceAddress, node0.Name)
 
 			// the second pause pod is on a different node, so it should see a connection error every time
 			cmd := fmt.Sprintf(`curl -q -s --connect-timeout 5 %s/hostname`, serviceAddress)
@@ -2295,7 +2294,7 @@ var _ = common.SIGDescribe("Services", func() {
 		for i := 0; i < 5; i++ {
 			// the first pause pod should be on the same node as the webserver, so it can connect to the local pod using clusterIP
 			// note that the expected hostname is the node name because the backend pod is on host network
-			execHostnameTest(*pausePod2, serviceAddress, node0Hostname)
+			execHostnameTest(*pausePod2, serviceAddress, node0.Name)
 
 			// the second pause pod is on a different node, so it should see a connection error every time
 			cmd := fmt.Sprintf(`curl -q -s --connect-timeout 5 %s/hostname`, serviceAddress)

--- a/test/e2e/network/util.go
+++ b/test/e2e/network/util.go
@@ -143,6 +143,8 @@ func execSourceIPTest(sourcePod v1.Pod, targetAddr string) (string, string) {
 
 // execHostnameTest executes curl to access "/hostname" endpoint on target address
 // from given Pod to check the hostname of the target destination.
+// It also converts FQDNs to hostnames, so if an FQDN is passed as
+// targetHostname only the hostname part will be considered for comparison.
 func execHostnameTest(sourcePod v1.Pod, targetAddr, targetHostname string) {
 	var (
 		err     error
@@ -166,8 +168,12 @@ func execHostnameTest(sourcePod v1.Pod, targetAddr, targetHostname string) {
 		break
 	}
 
+	// Ensure we're comparing hostnames and not FQDNs
+	targetHostname = strings.Split(targetHostname, ".")[0]
+	hostname := strings.TrimSpace(strings.Split(stdout, ".")[0])
+
 	framework.ExpectNoError(err)
-	framework.ExpectEqual(strings.TrimSpace(stdout), targetHostname)
+	framework.ExpectEqual(hostname, targetHostname)
 }
 
 // createSecondNodePortService creates a service with the same selector as config.NodePortService and same HTTP Port


### PR DESCRIPTION
We do not have guarantee that the agnhost's `/hostname` endpoint returns
a hostname and not an FQDN. We also do not have guarantee a hostname
gets passed to the execHostnameTest() function for comparison.

So make sure we're comparing hostnames in execHostnameTest().

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
We're seeing the `[sig-network] Services should respect internalTrafficPolicy=Local Pod and Node, to Pod (hostNetwork: true) [Feature:ServiceInternalTrafficPolicy] [Skipped:Network/OVNKubernetes] [Suite:openshift/conformance/parallel] [Suite:k8s]` fail in OpenShift on OpenStack platform.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-shiftstack-shiftstack-ci-main-periodic-4.10-e2e-openstack-parallel/1485558245945774080

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
