### PR TITLE
Revert "Populate OpenAPI in all integration tests"

### DIFF
--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -93,6 +93,7 @@ func setupWithResourcesWithOptions(t testing.TB, opts *framework.ControlPlaneCon
 		resourceConfig.EnableResources(resources...)
 		controlPlaneConfig.ExtraConfig.APIResourceConfigSource = resourceConfig
 	}
+	controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 	_, s, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 
 	clientSet, err := clientset.NewForConfig(&restclient.Config{Host: s.URL, QPS: -1})
@@ -226,6 +227,7 @@ func Test4xxStatusCodeInvalidPatch(t *testing.T) {
 
 func TestCacheControl(t *testing.T) {
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&framework.ControlPlaneConfigOptions{})
+	controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 	instanceConfig, _, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 	defer closeFn()
 
@@ -272,6 +274,7 @@ func TestCacheControl(t *testing.T) {
 // Tests that the apiserver returns HSTS headers as expected.
 func TestHSTS(t *testing.T) {
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&framework.ControlPlaneConfigOptions{})
+	controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 	controlPlaneConfig.GenericConfig.HSTSDirectives = []string{"max-age=31536000", "includeSubDomains"}
 	instanceConfig, _, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 	defer closeFn()

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -58,6 +58,7 @@ func setup(t testing.TB, groupVersions ...schema.GroupVersion) (*httptest.Server
 		resourceConfig.EnableVersions(groupVersions...)
 		controlPlaneConfig.ExtraConfig.APIResourceConfigSource = resourceConfig
 	}
+	controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 	_, s, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 
 	clientSet, err := clientset.NewForConfig(&restclient.Config{Host: s.URL, QPS: -1})
@@ -2821,6 +2822,7 @@ func TestStopTrackingManagedFieldsOnFeatureDisabled(t *testing.T) {
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&framework.ControlPlaneConfigOptions{
 		EtcdOptions: sharedEtcd,
 	})
+	controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
 	_, instanceConfig, closeFn := framework.RunAnAPIServer(controlPlaneConfig)

--- a/test/integration/apiserver/flowcontrol/concurrency_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_test.go
@@ -60,6 +60,7 @@ func setup(t testing.TB, maxReadonlyRequestsInFlight, MaxMutatingRequestsInFligh
 	})
 	controlPlaneConfig.GenericConfig.MaxRequestsInFlight = maxReadonlyRequestsInFlight
 	controlPlaneConfig.GenericConfig.MaxMutatingRequestsInFlight = MaxMutatingRequestsInFlight
+	controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 	controlPlaneConfig.ExtraConfig.APIResourceConfigSource = resourceConfig
 	_, s, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 

--- a/test/integration/apiserver/openapi_test.go
+++ b/test/integration/apiserver/openapi_test.go
@@ -56,6 +56,7 @@ func TestEnablingOpenAPIEnumTypes(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.OpenAPIEnums, tc.featureEnabled)()
 
 			controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&framework.ControlPlaneConfigOptions{})
+			controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 			controlPlaneConfig.GenericConfig.OpenAPIConfig.GetDefinitions = openapi.GetOpenAPIDefinitionsWithoutDisabledFeatures(func(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 				defs := generated.GetOpenAPIDefinitions(ref)
 				def := defs[typeToAddEnum]

--- a/test/integration/apiserver/openapiv3_test.go
+++ b/test/integration/apiserver/openapiv3_test.go
@@ -46,6 +46,7 @@ import (
 func TestOpenAPIV3SpecRoundTrip(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.OpenAPIV3, true)()
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&framework.ControlPlaneConfigOptions{})
+	controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 	instanceConfig, _, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 	defer closeFn()
 	paths := []string{
@@ -199,6 +200,7 @@ func TestOpenAPIV3ProtoRoundtrip(t *testing.T) {
 	t.Skip("Skipping OpenAPI V3 Proto roundtrip test")
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.OpenAPIV3, true)()
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&framework.ControlPlaneConfigOptions{})
+	controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 	instanceConfig, _, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 	defer closeFn()
 	rt, err := restclient.TransportFor(instanceConfig.GenericAPIServer.LoopbackClientConfig)

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -535,6 +535,7 @@ func TestRBAC(t *testing.T) {
 			"limitrange-patcher":               {Name: "limitrange-patcher"},
 			"user-with-no-permissions":         {Name: "user-with-no-permissions"},
 		})))
+		controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 		_, s, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 		defer closeFn()
 

--- a/test/integration/framework/controlplane_utils.go
+++ b/test/integration/framework/controlplane_utils.go
@@ -285,11 +285,6 @@ func NewIntegrationTestControlPlaneConfigWithOptions(opts *ControlPlaneConfigOpt
 	// TODO: get rid of these tests or port them to secure serving
 	controlPlaneConfig.GenericConfig.SecureServing = &genericapiserver.SecureServingInfo{Listener: fakeLocalhost443Listener{}}
 
-	// Enable OpenAPI and Server Side Apply in integration tests
-	if controlPlaneConfig.GenericConfig.OpenAPIConfig == nil {
-		controlPlaneConfig.GenericConfig.OpenAPIConfig = DefaultOpenAPIConfig()
-	}
-
 	return controlPlaneConfig
 }
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#107765

https://github.com/kubernetes/kubernetes/issues/107727#issuecomment-1022474266