### PR TITLE
Add request header retrieval to `agnhost netexec`

### DIFF
--- a/test/images/agnhost/netexec/netexec.go
+++ b/test/images/agnhost/netexec/netexec.go
@@ -63,6 +63,9 @@ var CmdNetexec = &cobra.Command{
 
 - /: Returns the request's timestamp.
 - /clientip: Returns the request's IP address.
+- /header: Returns the request's header value corresponding to the key provided or the entire 
+  header marshalled as json, if no form value (key) is provided.
+  ("/header?key=X-Forwarded-For" or /header)
 - /dial: Creates a given number of requests to the given host and port using the given protocol,
   and returns a JSON with the fields "responses" (successful request responses) and "errors" (
   failed request responses). Returns "200 OK" status code if the last request succeeded,
@@ -198,6 +201,7 @@ func main(cmd *cobra.Command, args []string) {
 func addRoutes(mux *http.ServeMux, exitCh chan shutdownRequest) {
 	mux.HandleFunc("/", rootHandler)
 	mux.HandleFunc("/clientip", clientIPHandler)
+	mux.HandleFunc("/header", headerHandler)
 	mux.HandleFunc("/dial", dialHandler)
 	mux.HandleFunc("/echo", echoHandler)
 	mux.HandleFunc("/exit", func(w http.ResponseWriter, req *http.Request) { exitHandler(w, req, exitCh) })
@@ -254,6 +258,21 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 func clientIPHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("GET /clientip")
 	fmt.Fprintf(w, r.RemoteAddr)
+}
+func headerHandler(w http.ResponseWriter, r *http.Request) {
+	key := r.FormValue("key")
+	if key != "" {
+		log.Printf("GET /header?key=%s", key)
+		fmt.Fprintf(w, "%s", r.Header.Get(key))
+	} else {
+		log.Printf("GET /header")
+		data, err := json.Marshal(r.Header)
+		if err != nil {
+			fmt.Fprintf(w, "error marshalling header, err: %v", err)
+			return
+		}
+		fmt.Fprintf(w, "%s", string(data))
+	}
 }
 
 type shutdownRequest struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

... improvement? 


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This adds a path `/header?key=` to `agnhost netexec` allowing one to view what the header value is of the incoming request. I added a separate path as to allow clients the possibility to programmatically access the results, in tests for example.

It's not really that important, but it helped me and might help others, so I decided to open a PR as to get a consensus going as to whether it should be added or not. 

To test this do:

```
$ curl -H "X-Forwarded-For: something" 172.17.0.2:8080/header?key=X-Forwarded-For
something
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes - nothing

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
This adds a path `/header?key=` to `agnhost netexec` allowing one to view what the header value is of the incoming request.

Ex:

$ curl -H "X-Forwarded-For: something" 172.17.0.2:8080/header?key=X-Forwarded-For
something
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
