### PR TITLE
storage-e2e: support specify volume name when create e2e test pvc

### DIFF
--- a/test/e2e/framework/pv/pv.go
+++ b/test/e2e/framework/pv/pv.go
@@ -136,6 +136,8 @@ type PersistentVolumeClaimConfig struct {
 	// VolumeMode defaults to nil if unspecified or specified as the empty
 	// string
 	VolumeMode *v1.PersistentVolumeMode
+	// VolumeName defaults to "" if unspecified
+	VolumeName string
 }
 
 // PVPVCCleanup cleans up a pv and pvc in a single pv/pvc test case.
@@ -654,6 +656,7 @@ func MakePersistentVolumeClaim(cfg PersistentVolumeClaimConfig, ns string) *v1.P
 			},
 			StorageClassName: cfg.StorageClassName,
 			VolumeMode:       cfg.VolumeMode,
+			VolumeName:       cfg.VolumeName,
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
In some test scenarios, users need to create pvc with pv specified. This pr support specify volume name when create e2e test pvc

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
