### PR TITLE
Fix race on unit test "kube-proxy ipvs: fix to prevent concurrent map read and map w…

### DIFF
--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -80,6 +80,14 @@ func (q *graceTerminateRSList) remove(rs *listItem) bool {
 	return false
 }
 
+// return the size of the list
+func (q *graceTerminateRSList) len() int {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	return len(q.list)
+}
+
 func (q *graceTerminateRSList) flushList(handler func(rsToDelete *listItem) (bool, error)) bool {
 	q.lock.Lock()
 	defer q.lock.Unlock()


### PR DESCRIPTION
/kind bug
/kind failing-test
/kind flake
/kind regression


The test is wrong:
1. the inner loop iterates over `i` instead of `j` , creating an infinite loop
2. the delete is not exercised because it fails in the handler, we have to mock it

Fixes: #107811

```release-note
NONE
```

The test detects the race without the fix running with the race flag `go test -timeout 100s -run ^Test_RaceTerminateRSList$ k8s.io/kubernetes/pkg/proxy/ipvs -v -race` 
```
I0127 09:54:36.303854 3667010 graceful_termination.go:102] "Removed real server from graceful delete real server list" realServer="1.1.1.1:80/tcp/1.1.1.11:80"
I0127 09:54:36.303893 3667010 graceful_termination.go:102] "Removed real server from graceful delete real server list" realServer="1.1.1.1:80/tcp/1.1.1.15:80"
    testing.go:1152: race detected during execution of test
--- FAIL: Test_RaceTerminateRSList (0.00s)
=== CONT  
    testing.go:1152: race detected during execution of test
```

There is no flakes under the stress tool 
```
tress ./ipvs.test 
5s: 304 runs so far, 0 failures
10s: 626 runs so far, 0 failures
15s: 949 runs so far, 0 failures
20s: 1267 runs so far, 0 failures
25s: 1594 runs so far, 0 failures
30s: 1919 runs so far, 0 failures
35s: 2243 runs so far, 0 failures
```
