### PR TITLE
Long running actions (CRI, GC, Stats) in Kubelet should pass context.Context

### DIFF
--- a/pkg/client/tests/portfoward_test.go
+++ b/pkg/client/tests/portfoward_test.go
@@ -18,6 +18,7 @@ package tests
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -51,7 +52,7 @@ type fakePortForwarder struct {
 
 var _ portforward.PortForwarder = &fakePortForwarder{}
 
-func (pf *fakePortForwarder) PortForward(name string, uid types.UID, port int32, stream io.ReadWriteCloser) error {
+func (pf *fakePortForwarder) PortForward(ctx context.Context, name string, uid types.UID, port int32, stream io.ReadWriteCloser) error {
 	defer stream.Close()
 
 	// read from the client

--- a/pkg/client/tests/remotecommand_test.go
+++ b/pkg/client/tests/remotecommand_test.go
@@ -18,6 +18,7 @@ package tests
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -58,11 +59,11 @@ type fakeExecutor struct {
 	exec          bool
 }
 
-func (ex *fakeExecutor) ExecInContainer(name string, uid types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remoteclient.TerminalSize, timeout time.Duration) error {
+func (ex *fakeExecutor) ExecInContainer(ctx context.Context, name string, uid types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remoteclient.TerminalSize, timeout time.Duration) error {
 	return ex.run(name, uid, container, cmd, in, out, err, tty)
 }
 
-func (ex *fakeExecutor) AttachContainer(name string, uid types.UID, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remoteclient.TerminalSize) error {
+func (ex *fakeExecutor) AttachContainer(ctx context.Context, name string, uid types.UID, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remoteclient.TerminalSize) error {
 	return ex.run(name, uid, container, nil, in, out, err, tty)
 }
 

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -21,6 +21,7 @@ package cm
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -731,13 +731,13 @@ func (cm *containerManagerImpl) SystemCgroupsLimit() v1.ResourceList {
 
 func buildContainerMapFromRuntime(runtimeService internalapi.RuntimeService) containermap.ContainerMap {
 	podSandboxMap := make(map[string]string)
-	podSandboxList, _ := runtimeService.ListPodSandbox(nil)
+	podSandboxList, _ := runtimeService.ListPodSandbox(context.Background(), nil)
 	for _, p := range podSandboxList {
 		podSandboxMap[p.Id] = p.Metadata.Uid
 	}
 
 	containerMap := containermap.NewContainerMap()
-	containerList, _ := runtimeService.ListContainers(nil)
+	containerList, _ := runtimeService.ListContainers(context.Background(), nil)
 	for _, c := range containerList {
 		if _, exists := podSandboxMap[c.PodSandboxId]; !exists {
 			klog.InfoS("no PodSandBox found for the container", "podSandboxId", c.PodSandboxId, "containerName", c.Metadata.Name, "containerId", c.Id)

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cpumanager
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sync"

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -504,6 +504,7 @@ func (m *manager) updateContainerCPUSet(containerID string, cpus cpuset.CPUSet) 
 	// It would be better to pass the full container resources here instead of
 	// this patch-like partial resources.
 	return m.containerRuntime.UpdateContainerResources(
+		context.TODO(),
 		containerID,
 		&runtimeapi.LinuxContainerResources{
 			CpusetCpus: cpus.String(),

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -42,7 +42,7 @@ import (
 type ActivePodsFunc func() []*v1.Pod
 
 type runtimeService interface {
-	UpdateContainerResources(id string, resources *runtimeapi.LinuxContainerResources) error
+	UpdateContainerResources(ctx context.Context, id string, resources *runtimeapi.LinuxContainerResources) error
 }
 
 type policyName string

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cpumanager
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -128,7 +129,7 @@ type mockRuntimeService struct {
 	err error
 }
 
-func (rt mockRuntimeService) UpdateContainerResources(id string, resources *runtimeapi.LinuxContainerResources) error {
+func (rt mockRuntimeService) UpdateContainerResources(ctx context.Context, id string, resources *runtimeapi.LinuxContainerResources) error {
 	return rt.err
 }
 

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package memorymanager
 
 import (
+	"context"
 	"fmt"
 	"sync"
 

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -43,7 +43,7 @@ const memoryManagerStateFileName = "memory_manager_state"
 type ActivePodsFunc func() []*v1.Pod
 
 type runtimeService interface {
-	UpdateContainerResources(id string, resources *runtimeapi.LinuxContainerResources) error
+	UpdateContainerResources(ctx context.Context, id string, resources *runtimeapi.LinuxContainerResources) error
 }
 
 type sourcesReadyStub struct{}

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package memorymanager
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -122,7 +123,7 @@ type mockRuntimeService struct {
 	err error
 }
 
-func (rt mockRuntimeService) UpdateContainerResources(id string, resources *runtimeapi.LinuxContainerResources) error {
+func (rt mockRuntimeService) UpdateContainerResources(ctx context.Context, id string, resources *runtimeapi.LinuxContainerResources) error {
 	return rt.err
 }
 

--- a/pkg/kubelet/container/container_gc.go
+++ b/pkg/kubelet/container/container_gc.go
@@ -17,6 +17,7 @@ limitations under the License.
 package container
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -77,11 +78,11 @@ func NewContainerGC(runtime Runtime, policy GCPolicy, sourcesReadyProvider Sourc
 	}, nil
 }
 
-func (cgc *realContainerGC) GarbageCollect() error {
-	return cgc.runtime.GarbageCollect(cgc.policy, cgc.sourcesReadyProvider.AllReady(), false)
+func (cgc *realContainerGC) GarbageCollect(ctx context.Context) error {
+	return cgc.runtime.GarbageCollect(ctx, cgc.policy, cgc.sourcesReadyProvider.AllReady(), false)
 }
 
-func (cgc *realContainerGC) DeleteAllUnusedContainers() error {
+func (cgc *realContainerGC) DeleteAllUnusedContainers(ctx context.Context) error {
 	klog.InfoS("Attempting to delete unused containers")
-	return cgc.runtime.GarbageCollect(cgc.policy, cgc.sourcesReadyProvider.AllReady(), true)
+	return cgc.runtime.GarbageCollect(ctx, cgc.policy, cgc.sourcesReadyProvider.AllReady(), true)
 }

--- a/pkg/kubelet/container/container_gc.go
+++ b/pkg/kubelet/container/container_gc.go
@@ -41,9 +41,9 @@ type GCPolicy struct {
 // Implementation is thread-compatible.
 type GC interface {
 	// Garbage collect containers.
-	GarbageCollect() error
+	GarbageCollect(ctx context.Context) error
 	// Deletes all unused containers, including containers belonging to pods that are terminated but not deleted
-	DeleteAllUnusedContainers() error
+	DeleteAllUnusedContainers(ctx context.Context) error
 }
 
 // SourcesReadyProvider knows how to determine if configuration sources are ready

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -39,7 +39,7 @@ import (
 
 // HandlerRunner runs a lifecycle handler for a container.
 type HandlerRunner interface {
-	Run(containerID ContainerID, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler) (string, error)
+	Run(ctx context.Context, containerID ContainerID, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler) (string, error)
 }
 
 // RuntimeHelper wraps kubelet to make container runtime

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package container
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"

--- a/pkg/kubelet/container/runtime_cache.go
+++ b/pkg/kubelet/container/runtime_cache.go
@@ -18,6 +18,7 @@ limitations under the License.
 package container
 
 import (
+	"context"
 	"sync"
 	"time"
 )

--- a/pkg/kubelet/container/runtime_cache.go
+++ b/pkg/kubelet/container/runtime_cache.go
@@ -34,7 +34,7 @@ type RuntimeCache interface {
 }
 
 type podsGetter interface {
-	GetPods(bool) ([]*Pod, error)
+	GetPods(ctx context.Context, all bool) ([]*Pod, error)
 }
 
 // NewRuntimeCache creates a container runtime cache.

--- a/pkg/kubelet/container/runtime_cache.go
+++ b/pkg/kubelet/container/runtime_cache.go
@@ -93,6 +93,6 @@ func (r *runtimeCache) updateCache() error {
 func (r *runtimeCache) getPodsWithTimestamp() ([]*Pod, time.Time, error) {
 	// Always record the timestamp before getting the pods to avoid stale pods.
 	timestamp := time.Now()
-	pods, err := r.getter.GetPods(false)
+	pods, err := r.getter.GetPods(context.Background(), false)
 	return pods, timestamp, err
 }

--- a/pkg/kubelet/container/testing/fake_cache.go
+++ b/pkg/kubelet/container/testing/fake_cache.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testing
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/kubelet/container/testing/fake_cache.go
+++ b/pkg/kubelet/container/testing/fake_cache.go
@@ -32,7 +32,7 @@ func NewFakeCache(runtime container.Runtime) container.Cache {
 }
 
 func (c *fakeCache) Get(id types.UID) (*container.PodStatus, error) {
-	return c.runtime.GetPodStatus(id, "", "")
+	return c.runtime.GetPodStatus(context.TODO(), id, "", "")
 }
 
 func (c *fakeCache) GetNewerThan(id types.UID, minTime time.Time) (*container.PodStatus, error) {

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -91,7 +91,7 @@ func (fv *FakeVersion) Compare(other string) (int, error) {
 }
 
 type podsGetter interface {
-	GetPods(bool) ([]*kubecontainer.Pod, error)
+	GetPods(context.Context, bool) ([]*kubecontainer.Pod, error)
 }
 
 type FakeRuntimeCache struct {

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -132,7 +132,7 @@ func (f *FakeRuntime) ClearCalls() {
 }
 
 // UpdatePodCIDR fulfills the cri interface.
-func (f *FakeRuntime) UpdatePodCIDR(c string) error {
+func (f *FakeRuntime) UpdatePodCIDR(ctx context.Context, c string) error {
 	return nil
 }
 
@@ -179,7 +179,7 @@ func (f *FakeRuntime) Type() string {
 	return f.RuntimeType
 }
 
-func (f *FakeRuntime) Version() (kubecontainer.Version, error) {
+func (f *FakeRuntime) Version(ctx context.Context) (kubecontainer.Version, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -195,7 +195,7 @@ func (f *FakeRuntime) APIVersion() (kubecontainer.Version, error) {
 	return &FakeVersion{Version: f.APIVersionInfo}, f.Err
 }
 
-func (f *FakeRuntime) Status() (*kubecontainer.RuntimeStatus, error) {
+func (f *FakeRuntime) Status(ctx context.Context) (*kubecontainer.RuntimeStatus, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -203,7 +203,7 @@ func (f *FakeRuntime) Status() (*kubecontainer.RuntimeStatus, error) {
 	return f.RuntimeStatus, f.StatusErr
 }
 
-func (f *FakeRuntime) GetPods(all bool) ([]*kubecontainer.Pod, error) {
+func (f *FakeRuntime) GetPods(ctx context.Context, all bool) ([]*kubecontainer.Pod, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -222,7 +222,7 @@ func (f *FakeRuntime) GetPods(all bool) ([]*kubecontainer.Pod, error) {
 	return pods, f.Err
 }
 
-func (f *FakeRuntime) SyncPod(pod *v1.Pod, _ *kubecontainer.PodStatus, _ []v1.Secret, backOff *flowcontrol.Backoff) (result kubecontainer.PodSyncResult) {
+func (f *FakeRuntime) SyncPod(ctx context.Context, pod *v1.Pod, _ *kubecontainer.PodStatus, _ []v1.Secret, backOff *flowcontrol.Backoff) (result kubecontainer.PodSyncResult) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -238,7 +238,7 @@ func (f *FakeRuntime) SyncPod(pod *v1.Pod, _ *kubecontainer.PodStatus, _ []v1.Se
 	return
 }
 
-func (f *FakeRuntime) KillPod(pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) error {
+func (f *FakeRuntime) KillPod(ctx context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) error {
 	f.Lock()
 	defer f.Unlock()
 
@@ -250,7 +250,7 @@ func (f *FakeRuntime) KillPod(pod *v1.Pod, runningPod kubecontainer.Pod, gracePe
 	return f.Err
 }
 
-func (f *FakeRuntime) RunContainerInPod(container v1.Container, pod *v1.Pod, volumeMap map[string]volume.VolumePlugin) error {
+func (f *FakeRuntime) RunContainerInPod(ctx context.Context, container v1.Container, pod *v1.Pod, volumeMap map[string]volume.VolumePlugin) error {
 	f.Lock()
 	defer f.Unlock()
 
@@ -267,7 +267,7 @@ func (f *FakeRuntime) RunContainerInPod(container v1.Container, pod *v1.Pod, vol
 	return f.Err
 }
 
-func (f *FakeRuntime) KillContainerInPod(container v1.Container, pod *v1.Pod) error {
+func (f *FakeRuntime) KillContainerInPod(ctx context.Context, container v1.Container, pod *v1.Pod) error {
 	f.Lock()
 	defer f.Unlock()
 
@@ -276,7 +276,7 @@ func (f *FakeRuntime) KillContainerInPod(container v1.Container, pod *v1.Pod) er
 	return f.Err
 }
 
-func (f *FakeRuntime) GetPodStatus(uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
+func (f *FakeRuntime) GetPodStatus(ctx context.Context, uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -293,7 +293,7 @@ func (f *FakeRuntime) GetContainerLogs(_ context.Context, pod *v1.Pod, container
 	return f.Err
 }
 
-func (f *FakeRuntime) PullImage(image kubecontainer.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+func (f *FakeRuntime) PullImage(ctx context.Context, image kubecontainer.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -308,7 +308,7 @@ func (f *FakeRuntime) PullImage(image kubecontainer.ImageSpec, pullSecrets []v1.
 	return image.Image, f.Err
 }
 
-func (f *FakeRuntime) GetImageRef(image kubecontainer.ImageSpec) (string, error) {
+func (f *FakeRuntime) GetImageRef(ctx context.Context, image kubecontainer.ImageSpec) (string, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -321,7 +321,7 @@ func (f *FakeRuntime) GetImageRef(image kubecontainer.ImageSpec) (string, error)
 	return "", f.InspectErr
 }
 
-func (f *FakeRuntime) ListImages() ([]kubecontainer.Image, error) {
+func (f *FakeRuntime) ListImages(ctx context.Context) ([]kubecontainer.Image, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -329,7 +329,7 @@ func (f *FakeRuntime) ListImages() ([]kubecontainer.Image, error) {
 	return f.ImageList, f.Err
 }
 
-func (f *FakeRuntime) RemoveImage(image kubecontainer.ImageSpec) error {
+func (f *FakeRuntime) RemoveImage(ctx context.Context, image kubecontainer.ImageSpec) error {
 	f.Lock()
 	defer f.Unlock()
 
@@ -346,7 +346,7 @@ func (f *FakeRuntime) RemoveImage(image kubecontainer.ImageSpec) error {
 	return f.Err
 }
 
-func (f *FakeRuntime) GarbageCollect(gcPolicy kubecontainer.GCPolicy, ready bool, evictNonDeletedPods bool) error {
+func (f *FakeRuntime) GarbageCollect(ctx context.Context, gcPolicy kubecontainer.GCPolicy, ready bool, evictNonDeletedPods bool) error {
 	f.Lock()
 	defer f.Unlock()
 
@@ -354,7 +354,7 @@ func (f *FakeRuntime) GarbageCollect(gcPolicy kubecontainer.GCPolicy, ready bool
 	return f.Err
 }
 
-func (f *FakeRuntime) DeleteContainer(containerID kubecontainer.ContainerID) error {
+func (f *FakeRuntime) DeleteContainer(ctx context.Context, containerID kubecontainer.ContainerID) error {
 	f.Lock()
 	defer f.Unlock()
 
@@ -362,7 +362,7 @@ func (f *FakeRuntime) DeleteContainer(containerID kubecontainer.ContainerID) err
 	return f.Err
 }
 
-func (f *FakeRuntime) ImageStats() (*kubecontainer.ImageStats, error) {
+func (f *FakeRuntime) ImageStats(ctx context.Context) (*kubecontainer.ImageStats, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -370,7 +370,7 @@ func (f *FakeRuntime) ImageStats() (*kubecontainer.ImageStats, error) {
 	return nil, f.Err
 }
 
-func (f *FakeStreamingRuntime) GetExec(id kubecontainer.ContainerID, cmd []string, stdin, stdout, stderr, tty bool) (*url.URL, error) {
+func (f *FakeStreamingRuntime) GetExec(ctx context.Context, id kubecontainer.ContainerID, cmd []string, stdin, stdout, stderr, tty bool) (*url.URL, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -378,7 +378,7 @@ func (f *FakeStreamingRuntime) GetExec(id kubecontainer.ContainerID, cmd []strin
 	return &url.URL{Host: FakeHost}, f.Err
 }
 
-func (f *FakeStreamingRuntime) GetAttach(id kubecontainer.ContainerID, stdin, stdout, stderr, tty bool) (*url.URL, error) {
+func (f *FakeStreamingRuntime) GetAttach(ctx context.Context, id kubecontainer.ContainerID, stdin, stdout, stderr, tty bool) (*url.URL, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -386,7 +386,7 @@ func (f *FakeStreamingRuntime) GetAttach(id kubecontainer.ContainerID, stdin, st
 	return &url.URL{Host: FakeHost}, f.Err
 }
 
-func (f *FakeStreamingRuntime) GetPortForward(podName, podNamespace string, podUID types.UID, ports []int32) (*url.URL, error) {
+func (f *FakeStreamingRuntime) GetPortForward(ctx context.Context, podName, podNamespace string, podUID types.UID, ports []int32) (*url.URL, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -406,7 +406,7 @@ type FakeContainerCommandRunner struct {
 
 var _ kubecontainer.CommandRunner = &FakeContainerCommandRunner{}
 
-func (f *FakeContainerCommandRunner) RunInContainer(containerID kubecontainer.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
+func (f *FakeContainerCommandRunner) RunInContainer(ctx context.Context, containerID kubecontainer.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
 	// record invoked values
 	f.ContainerID = containerID
 	f.Cmd = cmd

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -103,7 +103,7 @@ func NewFakeRuntimeCache(getter podsGetter) kubecontainer.RuntimeCache {
 }
 
 func (f *FakeRuntimeCache) GetPods() ([]*kubecontainer.Pod, error) {
-	return f.getter.GetPods(false)
+	return f.getter.GetPods(context.Background(), false)
 }
 
 func (f *FakeRuntimeCache) ForceUpdateIfOlder(time.Time) error {

--- a/pkg/kubelet/container/testing/mock_runtime_cache.go
+++ b/pkg/kubelet/container/testing/mock_runtime_cache.go
@@ -21,6 +21,7 @@ limitations under the License.
 package testing
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	container "k8s.io/kubernetes/pkg/kubelet/container"
 	reflect "reflect"
@@ -103,16 +104,16 @@ func (m *MockpodsGetter) EXPECT() *MockpodsGetterMockRecorder {
 }
 
 // GetPods mocks base method
-func (m *MockpodsGetter) GetPods(arg0 bool) ([]*container.Pod, error) {
+func (m *MockpodsGetter) GetPods(ctx context.Context, all bool) ([]*container.Pod, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPods", arg0)
+	ret := m.ctrl.Call(m, "GetPods", ctx, all)
 	ret0, _ := ret[0].([]*container.Pod)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPods indicates an expected call of GetPods
-func (mr *MockpodsGetterMockRecorder) GetPods(arg0 interface{}) *gomock.Call {
+func (mr *MockpodsGetterMockRecorder) GetPods(ctx, all interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPods", reflect.TypeOf((*MockpodsGetter)(nil).GetPods), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPods", reflect.TypeOf((*MockpodsGetter)(nil).GetPods), ctx, all)
 }

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -127,16 +127,16 @@ func (mr *MockRuntimeMockRecorder) Type() *gomock.Call {
 // Version mocks base method
 func (m *MockRuntime) Version(ctx context.Context) (container.Version, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Version")
+	ret := m.ctrl.Call(m, "Version", ctx)
 	ret0, _ := ret[0].(container.Version)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Version indicates an expected call of Version
-func (mr *MockRuntimeMockRecorder) Version() *gomock.Call {
+func (mr *MockRuntimeMockRecorder) Version(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockRuntime)(nil).Version))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockRuntime)(nil).Version), ctx)
 }
 
 // APIVersion mocks base method
@@ -157,88 +157,88 @@ func (mr *MockRuntimeMockRecorder) APIVersion() *gomock.Call {
 // Status mocks base method
 func (m *MockRuntime) Status(ctx context.Context) (*container.RuntimeStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Status")
+	ret := m.ctrl.Call(m, "Status", ctx)
 	ret0, _ := ret[0].(*container.RuntimeStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Status indicates an expected call of Status
-func (mr *MockRuntimeMockRecorder) Status() *gomock.Call {
+func (mr *MockRuntimeMockRecorder) Status(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockRuntime)(nil).Status))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockRuntime)(nil).Status), ctx)
 }
 
 // GetPods mocks base method
 func (m *MockRuntime) GetPods(ctx context.Context, all bool) ([]*container.Pod, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPods", all)
+	ret := m.ctrl.Call(m, "GetPods", ctx, all)
 	ret0, _ := ret[0].([]*container.Pod)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPods indicates an expected call of GetPods
-func (mr *MockRuntimeMockRecorder) GetPods(all interface{}) *gomock.Call {
+func (mr *MockRuntimeMockRecorder) GetPods(ctx, all interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPods", reflect.TypeOf((*MockRuntime)(nil).GetPods), all)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPods", reflect.TypeOf((*MockRuntime)(nil).GetPods), ctx, all)
 }
 
 // GarbageCollect mocks base method
 func (m *MockRuntime) GarbageCollect(ctx context.Context, gcPolicy container.GCPolicy, allSourcesReady, evictNonDeletedPods bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollect", gcPolicy, allSourcesReady, evictNonDeletedPods)
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, gcPolicy, allSourcesReady, evictNonDeletedPods)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GarbageCollect indicates an expected call of GarbageCollect
-func (mr *MockRuntimeMockRecorder) GarbageCollect(gcPolicy, allSourcesReady, evictNonDeletedPods interface{}) *gomock.Call {
+func (mr *MockRuntimeMockRecorder) GarbageCollect(ctx, gcPolicy, allSourcesReady, evictNonDeletedPods interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockRuntime)(nil).GarbageCollect), gcPolicy, allSourcesReady, evictNonDeletedPods)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockRuntime)(nil).GarbageCollect), ctx, gcPolicy, allSourcesReady, evictNonDeletedPods)
 }
 
 // SyncPod mocks base method
 func (m *MockRuntime) SyncPod(ctx context.Context, pod *v1.Pod, podStatus *container.PodStatus, pullSecrets []v1.Secret, backOff *flowcontrol.Backoff) container.PodSyncResult {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncPod", pod, podStatus, pullSecrets, backOff)
+	ret := m.ctrl.Call(m, "SyncPod", ctx, pod, podStatus, pullSecrets, backOff)
 	ret0, _ := ret[0].(container.PodSyncResult)
 	return ret0
 }
 
 // SyncPod indicates an expected call of SyncPod
-func (mr *MockRuntimeMockRecorder) SyncPod(pod, podStatus, pullSecrets, backOff interface{}) *gomock.Call {
+func (mr *MockRuntimeMockRecorder) SyncPod(ctx, pod, podStatus, pullSecrets, backOff interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncPod", reflect.TypeOf((*MockRuntime)(nil).SyncPod), pod, podStatus, pullSecrets, backOff)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncPod", reflect.TypeOf((*MockRuntime)(nil).SyncPod), ctx, pod, podStatus, pullSecrets, backOff)
 }
 
 // KillPod mocks base method
 func (m *MockRuntime) KillPod(ctx context.Context, pod *v1.Pod, runningPod container.Pod, gracePeriodOverride *int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "KillPod", pod, runningPod, gracePeriodOverride)
+	ret := m.ctrl.Call(m, "KillPod", ctx, pod, runningPod, gracePeriodOverride)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // KillPod indicates an expected call of KillPod
-func (mr *MockRuntimeMockRecorder) KillPod(pod, runningPod, gracePeriodOverride interface{}) *gomock.Call {
+func (mr *MockRuntimeMockRecorder) KillPod(ctx, pod, runningPod, gracePeriodOverride interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KillPod", reflect.TypeOf((*MockRuntime)(nil).KillPod), pod, runningPod, gracePeriodOverride)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KillPod", reflect.TypeOf((*MockRuntime)(nil).KillPod), ctx, pod, runningPod, gracePeriodOverride)
 }
 
 // GetPodStatus mocks base method
 func (m *MockRuntime) GetPodStatus(ctx context.Context, uid types.UID, name, namespace string) (*container.PodStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPodStatus", uid, name, namespace)
+	ret := m.ctrl.Call(m, "GetPodStatus", ctx, uid, name, namespace)
 	ret0, _ := ret[0].(*container.PodStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPodStatus indicates an expected call of GetPodStatus
-func (mr *MockRuntimeMockRecorder) GetPodStatus(uid, name, namespace interface{}) *gomock.Call {
+func (mr *MockRuntimeMockRecorder) GetPodStatus(ctx, uid, name, namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodStatus", reflect.TypeOf((*MockRuntime)(nil).GetPodStatus), uid, name, namespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodStatus", reflect.TypeOf((*MockRuntime)(nil).GetPodStatus), ctx, uid, name, namespace)
 }
 
 // GetContainerLogs mocks base method
@@ -258,103 +258,103 @@ func (mr *MockRuntimeMockRecorder) GetContainerLogs(ctx, pod, containerID, logOp
 // DeleteContainer mocks base method
 func (m *MockRuntime) DeleteContainer(ctx context.Context, containerID container.ContainerID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteContainer", containerID)
+	ret := m.ctrl.Call(m, "DeleteContainer", ctx, containerID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteContainer indicates an expected call of DeleteContainer
-func (mr *MockRuntimeMockRecorder) DeleteContainer(containerID interface{}) *gomock.Call {
+func (mr *MockRuntimeMockRecorder) DeleteContainer(ctx, containerID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContainer", reflect.TypeOf((*MockRuntime)(nil).DeleteContainer), containerID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContainer", reflect.TypeOf((*MockRuntime)(nil).DeleteContainer), ctx, containerID)
 }
 
 // PullImage mocks base method
 func (m *MockRuntime) PullImage(ctx context.Context, image container.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *v10.PodSandboxConfig) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PullImage", image, pullSecrets, podSandboxConfig)
+	ret := m.ctrl.Call(m, "PullImage", ctx, image, pullSecrets, podSandboxConfig)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PullImage indicates an expected call of PullImage
-func (mr *MockRuntimeMockRecorder) PullImage(image, pullSecrets, podSandboxConfig interface{}) *gomock.Call {
+func (mr *MockRuntimeMockRecorder) PullImage(ctx, image, pullSecrets, podSandboxConfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockRuntime)(nil).PullImage), image, pullSecrets, podSandboxConfig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockRuntime)(nil).PullImage), ctx, image, pullSecrets, podSandboxConfig)
 }
 
 // GetImageRef mocks base method
 func (m *MockRuntime) GetImageRef(ctx context.Context, image container.ImageSpec) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImageRef", image)
+	ret := m.ctrl.Call(m, "GetImageRef", ctx, image)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetImageRef indicates an expected call of GetImageRef
-func (mr *MockRuntimeMockRecorder) GetImageRef(image interface{}) *gomock.Call {
+func (mr *MockRuntimeMockRecorder) GetImageRef(ctx, image interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageRef", reflect.TypeOf((*MockRuntime)(nil).GetImageRef), image)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageRef", reflect.TypeOf((*MockRuntime)(nil).GetImageRef), ctx, image)
 }
 
 // ListImages mocks base method
 func (m *MockRuntime) ListImages(ctx context.Context) ([]container.Image, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListImages")
+	ret := m.ctrl.Call(m, "ListImages", ctx)
 	ret0, _ := ret[0].([]container.Image)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListImages indicates an expected call of ListImages
-func (mr *MockRuntimeMockRecorder) ListImages() *gomock.Call {
+func (mr *MockRuntimeMockRecorder) ListImages(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*MockRuntime)(nil).ListImages))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*MockRuntime)(nil).ListImages), ctx)
 }
 
 // RemoveImage mocks base method
 func (m *MockRuntime) RemoveImage(ctx context.Context, image container.ImageSpec) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveImage", image)
+	ret := m.ctrl.Call(m, "RemoveImage", ctx, image)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveImage indicates an expected call of RemoveImage
-func (mr *MockRuntimeMockRecorder) RemoveImage(image interface{}) *gomock.Call {
+func (mr *MockRuntimeMockRecorder) RemoveImage(ctx, image interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveImage", reflect.TypeOf((*MockRuntime)(nil).RemoveImage), image)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveImage", reflect.TypeOf((*MockRuntime)(nil).RemoveImage), ctx, image)
 }
 
 // ImageStats mocks base method
 func (m *MockRuntime) ImageStats(ctx context.Context) (*container.ImageStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ImageStats")
+	ret := m.ctrl.Call(m, "ImageStats", ctx)
 	ret0, _ := ret[0].(*container.ImageStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ImageStats indicates an expected call of ImageStats
-func (mr *MockRuntimeMockRecorder) ImageStats() *gomock.Call {
+func (mr *MockRuntimeMockRecorder) ImageStats(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageStats", reflect.TypeOf((*MockRuntime)(nil).ImageStats))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageStats", reflect.TypeOf((*MockRuntime)(nil).ImageStats), ctx)
 }
 
 // UpdatePodCIDR mocks base method
 func (m *MockRuntime) UpdatePodCIDR(ctx context.Context, podCIDR string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePodCIDR", podCIDR)
+	ret := m.ctrl.Call(m, "UpdatePodCIDR", ctx, podCIDR)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdatePodCIDR indicates an expected call of UpdatePodCIDR
-func (mr *MockRuntimeMockRecorder) UpdatePodCIDR(podCIDR interface{}) *gomock.Call {
+func (mr *MockRuntimeMockRecorder) UpdatePodCIDR(ctx, podCIDR interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePodCIDR", reflect.TypeOf((*MockRuntime)(nil).UpdatePodCIDR), podCIDR)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePodCIDR", reflect.TypeOf((*MockRuntime)(nil).UpdatePodCIDR), ctx, podCIDR)
 }
 
 // MockStreamingRuntime is a mock of StreamingRuntime interface
@@ -383,46 +383,46 @@ func (m *MockStreamingRuntime) EXPECT() *MockStreamingRuntimeMockRecorder {
 // GetExec mocks base method
 func (m *MockStreamingRuntime) GetExec(ctx context.Context, id container.ContainerID, cmd []string, stdin, stdout, stderr, tty bool) (*url.URL, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetExec", id, cmd, stdin, stdout, stderr, tty)
+	ret := m.ctrl.Call(m, "GetExec", ctx, id, cmd, stdin, stdout, stderr, tty)
 	ret0, _ := ret[0].(*url.URL)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetExec indicates an expected call of GetExec
-func (mr *MockStreamingRuntimeMockRecorder) GetExec(id, cmd, stdin, stdout, stderr, tty interface{}) *gomock.Call {
+func (mr *MockStreamingRuntimeMockRecorder) GetExec(ctx, id, cmd, stdin, stdout, stderr, tty interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExec", reflect.TypeOf((*MockStreamingRuntime)(nil).GetExec), id, cmd, stdin, stdout, stderr, tty)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExec", reflect.TypeOf((*MockStreamingRuntime)(nil).GetExec), ctx, id, cmd, stdin, stdout, stderr, tty)
 }
 
 // GetAttach mocks base method
 func (m *MockStreamingRuntime) GetAttach(ctx context.Context, id container.ContainerID, stdin, stdout, stderr, tty bool) (*url.URL, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAttach", id, stdin, stdout, stderr, tty)
+	ret := m.ctrl.Call(m, "GetAttach", ctx, id, stdin, stdout, stderr, tty)
 	ret0, _ := ret[0].(*url.URL)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAttach indicates an expected call of GetAttach
-func (mr *MockStreamingRuntimeMockRecorder) GetAttach(id, stdin, stdout, stderr, tty interface{}) *gomock.Call {
+func (mr *MockStreamingRuntimeMockRecorder) GetAttach(ctx, id, stdin, stdout, stderr, tty interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttach", reflect.TypeOf((*MockStreamingRuntime)(nil).GetAttach), id, stdin, stdout, stderr, tty)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttach", reflect.TypeOf((*MockStreamingRuntime)(nil).GetAttach), ctx, id, stdin, stdout, stderr, tty)
 }
 
 // GetPortForward mocks base method
 func (m *MockStreamingRuntime) GetPortForward(ctx context.Context, podName, podNamespace string, podUID types.UID, ports []int32) (*url.URL, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPortForward", podName, podNamespace, podUID, ports)
+	ret := m.ctrl.Call(m, "GetPortForward", ctx, podName, podNamespace, podUID, ports)
 	ret0, _ := ret[0].(*url.URL)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPortForward indicates an expected call of GetPortForward
-func (mr *MockStreamingRuntimeMockRecorder) GetPortForward(podName, podNamespace, podUID, ports interface{}) *gomock.Call {
+func (mr *MockStreamingRuntimeMockRecorder) GetPortForward(ctx, podName, podNamespace, podUID, ports interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortForward", reflect.TypeOf((*MockStreamingRuntime)(nil).GetPortForward), podName, podNamespace, podUID, ports)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortForward", reflect.TypeOf((*MockStreamingRuntime)(nil).GetPortForward), ctx, podName, podNamespace, podUID, ports)
 }
 
 // MockImageService is a mock of ImageService interface
@@ -451,75 +451,75 @@ func (m *MockImageService) EXPECT() *MockImageServiceMockRecorder {
 // PullImage mocks base method
 func (m *MockImageService) PullImage(ctx context.Context, image container.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *v10.PodSandboxConfig) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PullImage", image, pullSecrets, podSandboxConfig)
+	ret := m.ctrl.Call(m, "PullImage", ctx, image, pullSecrets, podSandboxConfig)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PullImage indicates an expected call of PullImage
-func (mr *MockImageServiceMockRecorder) PullImage(image, pullSecrets, podSandboxConfig interface{}) *gomock.Call {
+func (mr *MockImageServiceMockRecorder) PullImage(ctx, image, pullSecrets, podSandboxConfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockImageService)(nil).PullImage), image, pullSecrets, podSandboxConfig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockImageService)(nil).PullImage), ctx, image, pullSecrets, podSandboxConfig)
 }
 
 // GetImageRef mocks base method
 func (m *MockImageService) GetImageRef(ctx context.Context, image container.ImageSpec) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImageRef", image)
+	ret := m.ctrl.Call(m, "GetImageRef", ctx, image)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetImageRef indicates an expected call of GetImageRef
-func (mr *MockImageServiceMockRecorder) GetImageRef(image interface{}) *gomock.Call {
+func (mr *MockImageServiceMockRecorder) GetImageRef(ctx, image interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageRef", reflect.TypeOf((*MockImageService)(nil).GetImageRef), image)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageRef", reflect.TypeOf((*MockImageService)(nil).GetImageRef), ctx, image)
 }
 
 // ListImages mocks base method
 func (m *MockImageService) ListImages(ctx context.Context) ([]container.Image, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListImages")
+	ret := m.ctrl.Call(m, "ListImages", ctx)
 	ret0, _ := ret[0].([]container.Image)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListImages indicates an expected call of ListImages
-func (mr *MockImageServiceMockRecorder) ListImages() *gomock.Call {
+func (mr *MockImageServiceMockRecorder) ListImages(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*MockImageService)(nil).ListImages))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*MockImageService)(nil).ListImages), ctx)
 }
 
 // RemoveImage mocks base method
 func (m *MockImageService) RemoveImage(ctx context.Context, image container.ImageSpec) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveImage", image)
+	ret := m.ctrl.Call(m, "RemoveImage", ctx, image)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveImage indicates an expected call of RemoveImage
-func (mr *MockImageServiceMockRecorder) RemoveImage(image interface{}) *gomock.Call {
+func (mr *MockImageServiceMockRecorder) RemoveImage(ctx, image interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveImage", reflect.TypeOf((*MockImageService)(nil).RemoveImage), image)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveImage", reflect.TypeOf((*MockImageService)(nil).RemoveImage), ctx, image)
 }
 
 // ImageStats mocks base method
 func (m *MockImageService) ImageStats(ctx context.Context) (*container.ImageStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ImageStats")
+	ret := m.ctrl.Call(m, "ImageStats", ctx)
 	ret0, _ := ret[0].(*container.ImageStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ImageStats indicates an expected call of ImageStats
-func (mr *MockImageServiceMockRecorder) ImageStats() *gomock.Call {
+func (mr *MockImageServiceMockRecorder) ImageStats(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageStats", reflect.TypeOf((*MockImageService)(nil).ImageStats))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageStats", reflect.TypeOf((*MockImageService)(nil).ImageStats), ctx)
 }
 
 // MockAttacher is a mock of Attacher interface
@@ -548,15 +548,15 @@ func (m *MockAttacher) EXPECT() *MockAttacherMockRecorder {
 // AttachContainer mocks base method
 func (m *MockAttacher) AttachContainer(ctx context.Context, id container.ContainerID, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AttachContainer", id, stdin, stdout, stderr, tty, resize)
+	ret := m.ctrl.Call(m, "AttachContainer", ctx, id, stdin, stdout, stderr, tty, resize)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AttachContainer indicates an expected call of AttachContainer
-func (mr *MockAttacherMockRecorder) AttachContainer(id, stdin, stdout, stderr, tty, resize interface{}) *gomock.Call {
+func (mr *MockAttacherMockRecorder) AttachContainer(ctx, id, stdin, stdout, stderr, tty, resize interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachContainer", reflect.TypeOf((*MockAttacher)(nil).AttachContainer), id, stdin, stdout, stderr, tty, resize)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachContainer", reflect.TypeOf((*MockAttacher)(nil).AttachContainer), ctx, id, stdin, stdout, stderr, tty, resize)
 }
 
 // MockCommandRunner is a mock of CommandRunner interface
@@ -585,14 +585,14 @@ func (m *MockCommandRunner) EXPECT() *MockCommandRunnerMockRecorder {
 // RunInContainer mocks base method
 func (m *MockCommandRunner) RunInContainer(ctx context.Context, id container.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunInContainer", id, cmd, timeout)
+	ret := m.ctrl.Call(m, "RunInContainer", ctx, id, cmd, timeout)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RunInContainer indicates an expected call of RunInContainer
-func (mr *MockCommandRunnerMockRecorder) RunInContainer(id, cmd, timeout interface{}) *gomock.Call {
+func (mr *MockCommandRunnerMockRecorder) RunInContainer(ctx, id, cmd, timeout interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInContainer", reflect.TypeOf((*MockCommandRunner)(nil).RunInContainer), id, cmd, timeout)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInContainer", reflect.TypeOf((*MockCommandRunner)(nil).RunInContainer), ctx, id, cmd, timeout)
 }

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -125,7 +125,7 @@ func (mr *MockRuntimeMockRecorder) Type() *gomock.Call {
 }
 
 // Version mocks base method
-func (m *MockRuntime) Version() (container.Version, error) {
+func (m *MockRuntime) Version(ctx context.Context) (container.Version, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version")
 	ret0, _ := ret[0].(container.Version)
@@ -155,7 +155,7 @@ func (mr *MockRuntimeMockRecorder) APIVersion() *gomock.Call {
 }
 
 // Status mocks base method
-func (m *MockRuntime) Status() (*container.RuntimeStatus, error) {
+func (m *MockRuntime) Status(ctx context.Context) (*container.RuntimeStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
 	ret0, _ := ret[0].(*container.RuntimeStatus)
@@ -170,7 +170,7 @@ func (mr *MockRuntimeMockRecorder) Status() *gomock.Call {
 }
 
 // GetPods mocks base method
-func (m *MockRuntime) GetPods(all bool) ([]*container.Pod, error) {
+func (m *MockRuntime) GetPods(ctx context.Context, all bool) ([]*container.Pod, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPods", all)
 	ret0, _ := ret[0].([]*container.Pod)
@@ -185,7 +185,7 @@ func (mr *MockRuntimeMockRecorder) GetPods(all interface{}) *gomock.Call {
 }
 
 // GarbageCollect mocks base method
-func (m *MockRuntime) GarbageCollect(gcPolicy container.GCPolicy, allSourcesReady, evictNonDeletedPods bool) error {
+func (m *MockRuntime) GarbageCollect(ctx context.Context, gcPolicy container.GCPolicy, allSourcesReady, evictNonDeletedPods bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GarbageCollect", gcPolicy, allSourcesReady, evictNonDeletedPods)
 	ret0, _ := ret[0].(error)
@@ -199,7 +199,7 @@ func (mr *MockRuntimeMockRecorder) GarbageCollect(gcPolicy, allSourcesReady, evi
 }
 
 // SyncPod mocks base method
-func (m *MockRuntime) SyncPod(pod *v1.Pod, podStatus *container.PodStatus, pullSecrets []v1.Secret, backOff *flowcontrol.Backoff) container.PodSyncResult {
+func (m *MockRuntime) SyncPod(ctx context.Context, pod *v1.Pod, podStatus *container.PodStatus, pullSecrets []v1.Secret, backOff *flowcontrol.Backoff) container.PodSyncResult {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SyncPod", pod, podStatus, pullSecrets, backOff)
 	ret0, _ := ret[0].(container.PodSyncResult)
@@ -213,7 +213,7 @@ func (mr *MockRuntimeMockRecorder) SyncPod(pod, podStatus, pullSecrets, backOff 
 }
 
 // KillPod mocks base method
-func (m *MockRuntime) KillPod(pod *v1.Pod, runningPod container.Pod, gracePeriodOverride *int64) error {
+func (m *MockRuntime) KillPod(ctx context.Context, pod *v1.Pod, runningPod container.Pod, gracePeriodOverride *int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KillPod", pod, runningPod, gracePeriodOverride)
 	ret0, _ := ret[0].(error)
@@ -227,7 +227,7 @@ func (mr *MockRuntimeMockRecorder) KillPod(pod, runningPod, gracePeriodOverride 
 }
 
 // GetPodStatus mocks base method
-func (m *MockRuntime) GetPodStatus(uid types.UID, name, namespace string) (*container.PodStatus, error) {
+func (m *MockRuntime) GetPodStatus(ctx context.Context, uid types.UID, name, namespace string) (*container.PodStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPodStatus", uid, name, namespace)
 	ret0, _ := ret[0].(*container.PodStatus)
@@ -256,7 +256,7 @@ func (mr *MockRuntimeMockRecorder) GetContainerLogs(ctx, pod, containerID, logOp
 }
 
 // DeleteContainer mocks base method
-func (m *MockRuntime) DeleteContainer(containerID container.ContainerID) error {
+func (m *MockRuntime) DeleteContainer(ctx context.Context, containerID container.ContainerID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteContainer", containerID)
 	ret0, _ := ret[0].(error)
@@ -270,7 +270,7 @@ func (mr *MockRuntimeMockRecorder) DeleteContainer(containerID interface{}) *gom
 }
 
 // PullImage mocks base method
-func (m *MockRuntime) PullImage(image container.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *v10.PodSandboxConfig) (string, error) {
+func (m *MockRuntime) PullImage(ctx context.Context, image container.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *v10.PodSandboxConfig) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PullImage", image, pullSecrets, podSandboxConfig)
 	ret0, _ := ret[0].(string)
@@ -285,7 +285,7 @@ func (mr *MockRuntimeMockRecorder) PullImage(image, pullSecrets, podSandboxConfi
 }
 
 // GetImageRef mocks base method
-func (m *MockRuntime) GetImageRef(image container.ImageSpec) (string, error) {
+func (m *MockRuntime) GetImageRef(ctx context.Context, image container.ImageSpec) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetImageRef", image)
 	ret0, _ := ret[0].(string)
@@ -300,7 +300,7 @@ func (mr *MockRuntimeMockRecorder) GetImageRef(image interface{}) *gomock.Call {
 }
 
 // ListImages mocks base method
-func (m *MockRuntime) ListImages() ([]container.Image, error) {
+func (m *MockRuntime) ListImages(ctx context.Context) ([]container.Image, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListImages")
 	ret0, _ := ret[0].([]container.Image)
@@ -315,7 +315,7 @@ func (mr *MockRuntimeMockRecorder) ListImages() *gomock.Call {
 }
 
 // RemoveImage mocks base method
-func (m *MockRuntime) RemoveImage(image container.ImageSpec) error {
+func (m *MockRuntime) RemoveImage(ctx context.Context, image container.ImageSpec) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveImage", image)
 	ret0, _ := ret[0].(error)
@@ -329,7 +329,7 @@ func (mr *MockRuntimeMockRecorder) RemoveImage(image interface{}) *gomock.Call {
 }
 
 // ImageStats mocks base method
-func (m *MockRuntime) ImageStats() (*container.ImageStats, error) {
+func (m *MockRuntime) ImageStats(ctx context.Context) (*container.ImageStats, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImageStats")
 	ret0, _ := ret[0].(*container.ImageStats)
@@ -344,7 +344,7 @@ func (mr *MockRuntimeMockRecorder) ImageStats() *gomock.Call {
 }
 
 // UpdatePodCIDR mocks base method
-func (m *MockRuntime) UpdatePodCIDR(podCIDR string) error {
+func (m *MockRuntime) UpdatePodCIDR(ctx context.Context, podCIDR string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePodCIDR", podCIDR)
 	ret0, _ := ret[0].(error)
@@ -381,7 +381,7 @@ func (m *MockStreamingRuntime) EXPECT() *MockStreamingRuntimeMockRecorder {
 }
 
 // GetExec mocks base method
-func (m *MockStreamingRuntime) GetExec(id container.ContainerID, cmd []string, stdin, stdout, stderr, tty bool) (*url.URL, error) {
+func (m *MockStreamingRuntime) GetExec(ctx context.Context, id container.ContainerID, cmd []string, stdin, stdout, stderr, tty bool) (*url.URL, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExec", id, cmd, stdin, stdout, stderr, tty)
 	ret0, _ := ret[0].(*url.URL)
@@ -396,7 +396,7 @@ func (mr *MockStreamingRuntimeMockRecorder) GetExec(id, cmd, stdin, stdout, stde
 }
 
 // GetAttach mocks base method
-func (m *MockStreamingRuntime) GetAttach(id container.ContainerID, stdin, stdout, stderr, tty bool) (*url.URL, error) {
+func (m *MockStreamingRuntime) GetAttach(ctx context.Context, id container.ContainerID, stdin, stdout, stderr, tty bool) (*url.URL, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAttach", id, stdin, stdout, stderr, tty)
 	ret0, _ := ret[0].(*url.URL)
@@ -411,7 +411,7 @@ func (mr *MockStreamingRuntimeMockRecorder) GetAttach(id, stdin, stdout, stderr,
 }
 
 // GetPortForward mocks base method
-func (m *MockStreamingRuntime) GetPortForward(podName, podNamespace string, podUID types.UID, ports []int32) (*url.URL, error) {
+func (m *MockStreamingRuntime) GetPortForward(ctx context.Context, podName, podNamespace string, podUID types.UID, ports []int32) (*url.URL, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPortForward", podName, podNamespace, podUID, ports)
 	ret0, _ := ret[0].(*url.URL)
@@ -449,7 +449,7 @@ func (m *MockImageService) EXPECT() *MockImageServiceMockRecorder {
 }
 
 // PullImage mocks base method
-func (m *MockImageService) PullImage(image container.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *v10.PodSandboxConfig) (string, error) {
+func (m *MockImageService) PullImage(ctx context.Context, image container.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *v10.PodSandboxConfig) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PullImage", image, pullSecrets, podSandboxConfig)
 	ret0, _ := ret[0].(string)
@@ -464,7 +464,7 @@ func (mr *MockImageServiceMockRecorder) PullImage(image, pullSecrets, podSandbox
 }
 
 // GetImageRef mocks base method
-func (m *MockImageService) GetImageRef(image container.ImageSpec) (string, error) {
+func (m *MockImageService) GetImageRef(ctx context.Context, image container.ImageSpec) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetImageRef", image)
 	ret0, _ := ret[0].(string)
@@ -479,7 +479,7 @@ func (mr *MockImageServiceMockRecorder) GetImageRef(image interface{}) *gomock.C
 }
 
 // ListImages mocks base method
-func (m *MockImageService) ListImages() ([]container.Image, error) {
+func (m *MockImageService) ListImages(ctx context.Context) ([]container.Image, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListImages")
 	ret0, _ := ret[0].([]container.Image)
@@ -494,7 +494,7 @@ func (mr *MockImageServiceMockRecorder) ListImages() *gomock.Call {
 }
 
 // RemoveImage mocks base method
-func (m *MockImageService) RemoveImage(image container.ImageSpec) error {
+func (m *MockImageService) RemoveImage(ctx context.Context, image container.ImageSpec) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveImage", image)
 	ret0, _ := ret[0].(error)
@@ -508,7 +508,7 @@ func (mr *MockImageServiceMockRecorder) RemoveImage(image interface{}) *gomock.C
 }
 
 // ImageStats mocks base method
-func (m *MockImageService) ImageStats() (*container.ImageStats, error) {
+func (m *MockImageService) ImageStats(ctx context.Context) (*container.ImageStats, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImageStats")
 	ret0, _ := ret[0].(*container.ImageStats)
@@ -546,7 +546,7 @@ func (m *MockAttacher) EXPECT() *MockAttacherMockRecorder {
 }
 
 // AttachContainer mocks base method
-func (m *MockAttacher) AttachContainer(id container.ContainerID, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+func (m *MockAttacher) AttachContainer(ctx context.Context, id container.ContainerID, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachContainer", id, stdin, stdout, stderr, tty, resize)
 	ret0, _ := ret[0].(error)
@@ -583,7 +583,7 @@ func (m *MockCommandRunner) EXPECT() *MockCommandRunnerMockRecorder {
 }
 
 // RunInContainer mocks base method
-func (m *MockCommandRunner) RunInContainer(id container.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
+func (m *MockCommandRunner) RunInContainer(ctx context.Context, id container.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunInContainer", id, cmd, timeout)
 	ret0, _ := ret[0].([]byte)

--- a/pkg/kubelet/cri/remote/fake/fake_image_service.go
+++ b/pkg/kubelet/cri/remote/fake/fake_image_service.go
@@ -24,7 +24,7 @@ import (
 
 // ListImages lists existing images.
 func (f *RemoteRuntime) ListImages(ctx context.Context, req *kubeapi.ListImagesRequest) (*kubeapi.ListImagesResponse, error) {
-	images, err := f.ImageService.ListImages(req.Filter)
+	images, err := f.ImageService.ListImages(ctx, req.Filter)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func (f *RemoteRuntime) ListImages(ctx context.Context, req *kubeapi.ListImagesR
 // present, returns a response with ImageStatusResponse.Image set to
 // nil.
 func (f *RemoteRuntime) ImageStatus(ctx context.Context, req *kubeapi.ImageStatusRequest) (*kubeapi.ImageStatusResponse, error) {
-	resp, err := f.ImageService.ImageStatus(req.Image, false)
+	resp, err := f.ImageService.ImageStatus(ctx, req.Image, false)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (f *RemoteRuntime) ImageStatus(ctx context.Context, req *kubeapi.ImageStatu
 
 // PullImage pulls an image with authentication config.
 func (f *RemoteRuntime) PullImage(ctx context.Context, req *kubeapi.PullImageRequest) (*kubeapi.PullImageResponse, error) {
-	image, err := f.ImageService.PullImage(req.Image, req.Auth, req.SandboxConfig)
+	image, err := f.ImageService.PullImage(ctx, req.Image, req.Auth, req.SandboxConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (f *RemoteRuntime) PullImage(ctx context.Context, req *kubeapi.PullImageReq
 // This call is idempotent, and must not return an error if the image has
 // already been removed.
 func (f *RemoteRuntime) RemoveImage(ctx context.Context, req *kubeapi.RemoveImageRequest) (*kubeapi.RemoveImageResponse, error) {
-	err := f.ImageService.RemoveImage(req.Image)
+	err := f.ImageService.RemoveImage(ctx, req.Image)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (f *RemoteRuntime) RemoveImage(ctx context.Context, req *kubeapi.RemoveImag
 
 // ImageFsInfo returns information of the filesystem that is used to store images.
 func (f *RemoteRuntime) ImageFsInfo(ctx context.Context, req *kubeapi.ImageFsInfoRequest) (*kubeapi.ImageFsInfoResponse, error) {
-	fsUsage, err := f.ImageService.ImageFsInfo()
+	fsUsage, err := f.ImageService.ImageFsInfo(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/cri/remote/fake/fake_runtime.go
+++ b/pkg/kubelet/cri/remote/fake/fake_runtime.go
@@ -80,13 +80,13 @@ func (f *RemoteRuntime) Stop() {
 
 // Version returns the runtime name, runtime version, and runtime API version.
 func (f *RemoteRuntime) Version(ctx context.Context, req *kubeapi.VersionRequest) (*kubeapi.VersionResponse, error) {
-	return f.RuntimeService.Version(req.Version)
+	return f.RuntimeService.Version(ctx, req.Version)
 }
 
 // RunPodSandbox creates and starts a pod-level sandbox. Runtimes must ensure
 // the sandbox is in the ready state on success.
 func (f *RemoteRuntime) RunPodSandbox(ctx context.Context, req *kubeapi.RunPodSandboxRequest) (*kubeapi.RunPodSandboxResponse, error) {
-	sandboxID, err := f.RuntimeService.RunPodSandbox(req.Config, req.RuntimeHandler)
+	sandboxID, err := f.RuntimeService.RunPodSandbox(ctx, req.Config, req.RuntimeHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (f *RemoteRuntime) RunPodSandbox(ctx context.Context, req *kubeapi.RunPodSa
 // If there are any running containers in the sandbox, they must be forcibly
 // terminated.
 func (f *RemoteRuntime) StopPodSandbox(ctx context.Context, req *kubeapi.StopPodSandboxRequest) (*kubeapi.StopPodSandboxResponse, error) {
-	err := f.RuntimeService.StopPodSandbox(req.PodSandboxId)
+	err := f.RuntimeService.StopPodSandbox(ctx, req.PodSandboxId)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (f *RemoteRuntime) StopPodSandbox(ctx context.Context, req *kubeapi.StopPod
 // This call is idempotent, and must not return an error if the sandbox has
 // already been removed.
 func (f *RemoteRuntime) RemovePodSandbox(ctx context.Context, req *kubeapi.RemovePodSandboxRequest) (*kubeapi.RemovePodSandboxResponse, error) {
-	err := f.RuntimeService.StopPodSandbox(req.PodSandboxId)
+	err := f.RuntimeService.StopPodSandbox(ctx, req.PodSandboxId)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (f *RemoteRuntime) RemovePodSandbox(ctx context.Context, req *kubeapi.Remov
 // PodSandboxStatus returns the status of the PodSandbox. If the PodSandbox is not
 // present, returns an error.
 func (f *RemoteRuntime) PodSandboxStatus(ctx context.Context, req *kubeapi.PodSandboxStatusRequest) (*kubeapi.PodSandboxStatusResponse, error) {
-	resp, err := f.RuntimeService.PodSandboxStatus(req.PodSandboxId, false)
+	resp, err := f.RuntimeService.PodSandboxStatus(ctx, req.PodSandboxId, false)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (f *RemoteRuntime) PodSandboxStatus(ctx context.Context, req *kubeapi.PodSa
 
 // ListPodSandbox returns a list of PodSandboxes.
 func (f *RemoteRuntime) ListPodSandbox(ctx context.Context, req *kubeapi.ListPodSandboxRequest) (*kubeapi.ListPodSandboxResponse, error) {
-	items, err := f.RuntimeService.ListPodSandbox(req.Filter)
+	items, err := f.RuntimeService.ListPodSandbox(ctx, req.Filter)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (f *RemoteRuntime) ListPodSandbox(ctx context.Context, req *kubeapi.ListPod
 
 // CreateContainer creates a new container in specified PodSandbox
 func (f *RemoteRuntime) CreateContainer(ctx context.Context, req *kubeapi.CreateContainerRequest) (*kubeapi.CreateContainerResponse, error) {
-	containerID, err := f.RuntimeService.CreateContainer(req.PodSandboxId, req.Config, req.SandboxConfig)
+	containerID, err := f.RuntimeService.CreateContainer(ctx, req.PodSandboxId, req.Config, req.SandboxConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (f *RemoteRuntime) CreateContainer(ctx context.Context, req *kubeapi.Create
 
 // StartContainer starts the container.
 func (f *RemoteRuntime) StartContainer(ctx context.Context, req *kubeapi.StartContainerRequest) (*kubeapi.StartContainerResponse, error) {
-	err := f.RuntimeService.StartContainer(req.ContainerId)
+	err := f.RuntimeService.StartContainer(ctx, req.ContainerId)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (f *RemoteRuntime) StartContainer(ctx context.Context, req *kubeapi.StartCo
 // This call is idempotent, and must not return an error if the container has
 // already been stopped.
 func (f *RemoteRuntime) StopContainer(ctx context.Context, req *kubeapi.StopContainerRequest) (*kubeapi.StopContainerResponse, error) {
-	err := f.RuntimeService.StopContainer(req.ContainerId, req.Timeout)
+	err := f.RuntimeService.StopContainer(ctx, req.ContainerId, req.Timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (f *RemoteRuntime) StopContainer(ctx context.Context, req *kubeapi.StopCont
 // This call is idempotent, and must not return an error if the container has
 // already been removed.
 func (f *RemoteRuntime) RemoveContainer(ctx context.Context, req *kubeapi.RemoveContainerRequest) (*kubeapi.RemoveContainerResponse, error) {
-	err := f.RuntimeService.RemoveContainer(req.ContainerId)
+	err := f.RuntimeService.RemoveContainer(ctx, req.ContainerId)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (f *RemoteRuntime) RemoveContainer(ctx context.Context, req *kubeapi.Remove
 
 // ListContainers lists all containers by filters.
 func (f *RemoteRuntime) ListContainers(ctx context.Context, req *kubeapi.ListContainersRequest) (*kubeapi.ListContainersResponse, error) {
-	items, err := f.RuntimeService.ListContainers(req.Filter)
+	items, err := f.RuntimeService.ListContainers(ctx, req.Filter)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (f *RemoteRuntime) ListContainers(ctx context.Context, req *kubeapi.ListCon
 // ContainerStatus returns status of the container. If the container is not
 // present, returns an error.
 func (f *RemoteRuntime) ContainerStatus(ctx context.Context, req *kubeapi.ContainerStatusRequest) (*kubeapi.ContainerStatusResponse, error) {
-	resp, err := f.RuntimeService.ContainerStatus(req.ContainerId, false)
+	resp, err := f.RuntimeService.ContainerStatus(ctx, req.ContainerId, false)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func (f *RemoteRuntime) ContainerStatus(ctx context.Context, req *kubeapi.Contai
 // ExecSync runs a command in a container synchronously.
 func (f *RemoteRuntime) ExecSync(ctx context.Context, req *kubeapi.ExecSyncRequest) (*kubeapi.ExecSyncResponse, error) {
 	var exitCode int32
-	stdout, stderr, err := f.RuntimeService.ExecSync(req.ContainerId, req.Cmd, time.Duration(req.Timeout)*time.Second)
+	stdout, stderr, err := f.RuntimeService.ExecSync(ctx, req.ContainerId, req.Cmd, time.Duration(req.Timeout)*time.Second)
 	if err != nil {
 		exitError, ok := err.(utilexec.ExitError)
 		if !ok {
@@ -228,23 +228,23 @@ func (f *RemoteRuntime) ExecSync(ctx context.Context, req *kubeapi.ExecSyncReque
 
 // Exec prepares a streaming endpoint to execute a command in the container.
 func (f *RemoteRuntime) Exec(ctx context.Context, req *kubeapi.ExecRequest) (*kubeapi.ExecResponse, error) {
-	return f.RuntimeService.Exec(req)
+	return f.RuntimeService.Exec(ctx, req)
 }
 
 // Attach prepares a streaming endpoint to attach to a running container.
 func (f *RemoteRuntime) Attach(ctx context.Context, req *kubeapi.AttachRequest) (*kubeapi.AttachResponse, error) {
-	return f.RuntimeService.Attach(req)
+	return f.RuntimeService.Attach(ctx, req)
 }
 
 // PortForward prepares a streaming endpoint to forward ports from a PodSandbox.
 func (f *RemoteRuntime) PortForward(ctx context.Context, req *kubeapi.PortForwardRequest) (*kubeapi.PortForwardResponse, error) {
-	return f.RuntimeService.PortForward(req)
+	return f.RuntimeService.PortForward(ctx, req)
 }
 
 // ContainerStats returns stats of the container. If the container does not
 // exist, the call returns an error.
 func (f *RemoteRuntime) ContainerStats(ctx context.Context, req *kubeapi.ContainerStatsRequest) (*kubeapi.ContainerStatsResponse, error) {
-	stats, err := f.RuntimeService.ContainerStats(req.ContainerId)
+	stats, err := f.RuntimeService.ContainerStats(ctx, req.ContainerId)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (f *RemoteRuntime) ContainerStats(ctx context.Context, req *kubeapi.Contain
 
 // ListContainerStats returns stats of all running containers.
 func (f *RemoteRuntime) ListContainerStats(ctx context.Context, req *kubeapi.ListContainerStatsRequest) (*kubeapi.ListContainerStatsResponse, error) {
-	stats, err := f.RuntimeService.ListContainerStats(req.Filter)
+	stats, err := f.RuntimeService.ListContainerStats(ctx, req.Filter)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +265,7 @@ func (f *RemoteRuntime) ListContainerStats(ctx context.Context, req *kubeapi.Lis
 // PodSandboxStats returns stats of the pod. If the pod does not
 // exist, the call returns an error.
 func (f *RemoteRuntime) PodSandboxStats(ctx context.Context, req *kubeapi.PodSandboxStatsRequest) (*kubeapi.PodSandboxStatsResponse, error) {
-	stats, err := f.RuntimeService.PodSandboxStats(req.PodSandboxId)
+	stats, err := f.RuntimeService.PodSandboxStats(ctx, req.PodSandboxId)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +275,7 @@ func (f *RemoteRuntime) PodSandboxStats(ctx context.Context, req *kubeapi.PodSan
 
 // ListPodSandboxStats returns stats of all running pods.
 func (f *RemoteRuntime) ListPodSandboxStats(ctx context.Context, req *kubeapi.ListPodSandboxStatsRequest) (*kubeapi.ListPodSandboxStatsResponse, error) {
-	stats, err := f.RuntimeService.ListPodSandboxStats(req.Filter)
+	stats, err := f.RuntimeService.ListPodSandboxStats(ctx, req.Filter)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (f *RemoteRuntime) ListPodSandboxStats(ctx context.Context, req *kubeapi.Li
 
 // UpdateRuntimeConfig updates the runtime configuration based on the given request.
 func (f *RemoteRuntime) UpdateRuntimeConfig(ctx context.Context, req *kubeapi.UpdateRuntimeConfigRequest) (*kubeapi.UpdateRuntimeConfigResponse, error) {
-	err := f.RuntimeService.UpdateRuntimeConfig(req.RuntimeConfig)
+	err := f.RuntimeService.UpdateRuntimeConfig(ctx, req.RuntimeConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +295,7 @@ func (f *RemoteRuntime) UpdateRuntimeConfig(ctx context.Context, req *kubeapi.Up
 
 // Status returns the status of the runtime.
 func (f *RemoteRuntime) Status(ctx context.Context, req *kubeapi.StatusRequest) (*kubeapi.StatusResponse, error) {
-	resp, err := f.RuntimeService.Status(false)
+	resp, err := f.RuntimeService.Status(ctx, false)
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func (f *RemoteRuntime) Status(ctx context.Context, req *kubeapi.StatusRequest) 
 
 // UpdateContainerResources updates ContainerConfig of the container.
 func (f *RemoteRuntime) UpdateContainerResources(ctx context.Context, req *kubeapi.UpdateContainerResourcesRequest) (*kubeapi.UpdateContainerResourcesResponse, error) {
-	err := f.RuntimeService.UpdateContainerResources(req.ContainerId, req.Linux)
+	err := f.RuntimeService.UpdateContainerResources(ctx, req.ContainerId, req.Linux)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (f *RemoteRuntime) UpdateContainerResources(ctx context.Context, req *kubea
 
 // ReopenContainerLog reopens the container log file.
 func (f *RemoteRuntime) ReopenContainerLog(ctx context.Context, req *kubeapi.ReopenContainerLogRequest) (*kubeapi.ReopenContainerLogResponse, error) {
-	err := f.RuntimeService.ReopenContainerLog(req.ContainerId)
+	err := f.RuntimeService.ReopenContainerLog(ctx, req.ContainerId)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/cri/remote/remote_image.go
+++ b/pkg/kubelet/cri/remote/remote_image.go
@@ -59,7 +59,7 @@ func NewRemoteImageService(endpoint string, connectionTimeout time.Duration) (in
 
 	service := &remoteImageService{timeout: connectionTimeout}
 
-	if err := service.determineAPIVersion(conn); err != nil {
+	if err := service.determineAPIVersion(ctx, conn); err != nil {
 		return nil, err
 	}
 

--- a/pkg/kubelet/cri/remote/remote_runtime.go
+++ b/pkg/kubelet/cri/remote/remote_runtime.go
@@ -87,7 +87,7 @@ func NewRemoteRuntimeService(endpoint string, connectionTimeout time.Duration) (
 		logReduction: logreduction.NewLogReduction(identicalErrorDelay),
 	}
 
-	if err := service.determineAPIVersion(conn); err != nil {
+	if err := service.determineAPIVersion(ctx, conn); err != nil {
 		return nil, err
 	}
 

--- a/pkg/kubelet/cri/remote/remote_runtime_test.go
+++ b/pkg/kubelet/cri/remote/remote_runtime_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package remote
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -66,7 +67,7 @@ func TestVersion(t *testing.T) {
 	}()
 
 	r := createRemoteRuntimeService(endpoint, t)
-	version, err := r.Version(apitest.FakeVersion)
+	version, err := r.Version(context.Background(), apitest.FakeVersion)
 	assert.NoError(t, err)
 	assert.Equal(t, apitest.FakeVersion, version.Version)
 	assert.Equal(t, apitest.FakeRuntimeName, version.RuntimeName)

--- a/pkg/kubelet/cri/remote/utils.go
+++ b/pkg/kubelet/cri/remote/utils.go
@@ -17,9 +17,7 @@ limitations under the License.
 package remote
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -27,16 +25,6 @@ import (
 // maxMsgSize use 16MB as the default message size limit.
 // grpc library default is 4MB
 const maxMsgSize = 1024 * 1024 * 16
-
-// getContextWithTimeout returns a context with timeout.
-func getContextWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), timeout)
-}
-
-// getContextWithCancel returns a context with cancel.
-func getContextWithCancel() (context.Context, context.CancelFunc) {
-	return context.WithCancel(context.Background())
-}
 
 // verifySandboxStatus verified whether all required fields are set in PodSandboxStatus.
 func verifySandboxStatus(status *runtimeapi.PodSandboxStatus) error {

--- a/pkg/kubelet/cri/streaming/portforward/httpstream.go
+++ b/pkg/kubelet/cri/streaming/portforward/httpstream.go
@@ -17,6 +17,7 @@ limitations under the License.
 package portforward
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"

--- a/pkg/kubelet/cri/streaming/portforward/httpstream.go
+++ b/pkg/kubelet/cri/streaming/portforward/httpstream.go
@@ -247,7 +247,7 @@ func (h *httpStreamHandler) portForward(p *httpStreamPair) {
 	port, _ := strconv.ParseInt(portString, 10, 32)
 
 	klog.V(5).InfoS("Connection request invoking forwarder.PortForward for port", "connection", h.conn, "request", p.requestID, "port", portString)
-	err := h.forwarder.PortForward(h.pod, h.uid, int32(port), p.dataStream)
+	err := h.forwarder.PortForward(context.Background(), h.pod, h.uid, int32(port), p.dataStream)
 	klog.V(5).InfoS("Connection request done invoking forwarder.PortForward for port", "connection", h.conn, "request", p.requestID, "port", portString)
 
 	if err != nil {

--- a/pkg/kubelet/cri/streaming/portforward/portforward.go
+++ b/pkg/kubelet/cri/streaming/portforward/portforward.go
@@ -30,7 +30,7 @@ import (
 // in a pod.
 type PortForwarder interface {
 	// PortForwarder copies data between a data stream and a port in a pod.
-	PortForward(name string, uid types.UID, port int32, stream io.ReadWriteCloser) error
+	PortForward(ctx context.Context, name string, uid types.UID, port int32, stream io.ReadWriteCloser) error
 }
 
 // ServePortForward handles a port forwarding request.  A single request is

--- a/pkg/kubelet/cri/streaming/portforward/portforward.go
+++ b/pkg/kubelet/cri/streaming/portforward/portforward.go
@@ -17,6 +17,7 @@ limitations under the License.
 package portforward
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"time"

--- a/pkg/kubelet/cri/streaming/portforward/websocket.go
+++ b/pkg/kubelet/cri/streaming/portforward/websocket.go
@@ -17,6 +17,7 @@ limitations under the License.
 package portforward
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"

--- a/pkg/kubelet/cri/streaming/portforward/websocket.go
+++ b/pkg/kubelet/cri/streaming/portforward/websocket.go
@@ -186,7 +186,7 @@ func (h *websocketStreamHandler) portForward(p *websocketStreamPair) {
 	defer p.errorStream.Close()
 
 	klog.V(5).InfoS("Connection invoking forwarder.PortForward for port", "connection", h.conn, "port", p.port)
-	err := h.forwarder.PortForward(h.pod, h.uid, p.port, p.dataStream)
+	err := h.forwarder.PortForward(context.Background(), h.pod, h.uid, p.port, p.dataStream)
 	klog.V(5).InfoS("Connection done invoking forwarder.PortForward for port", "connection", h.conn, "port", p.port)
 
 	if err != nil {

--- a/pkg/kubelet/cri/streaming/remotecommand/attach.go
+++ b/pkg/kubelet/cri/streaming/remotecommand/attach.go
@@ -33,7 +33,7 @@ import (
 type Attacher interface {
 	// AttachContainer attaches to the running container in the pod, copying data between in/out/err
 	// and the container's stdin/stdout/stderr.
-	AttachContainer(name string, uid types.UID, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
+	AttachContainer(ctx context.Context, name string, uid types.UID, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
 }
 
 // ServeAttach handles requests to attach to a container. After creating/receiving the required

--- a/pkg/kubelet/cri/streaming/remotecommand/attach.go
+++ b/pkg/kubelet/cri/streaming/remotecommand/attach.go
@@ -17,6 +17,7 @@ limitations under the License.
 package remotecommand
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"

--- a/pkg/kubelet/cri/streaming/remotecommand/attach.go
+++ b/pkg/kubelet/cri/streaming/remotecommand/attach.go
@@ -46,7 +46,7 @@ func ServeAttach(w http.ResponseWriter, req *http.Request, attacher Attacher, po
 	}
 	defer ctx.conn.Close()
 
-	err := attacher.AttachContainer(podName, uid, container, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan)
+	err := attacher.AttachContainer(req.Context(), podName, uid, container, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan)
 	if err != nil {
 		err = fmt.Errorf("error attaching to container: %v", err)
 		runtime.HandleError(err)

--- a/pkg/kubelet/cri/streaming/remotecommand/exec.go
+++ b/pkg/kubelet/cri/streaming/remotecommand/exec.go
@@ -35,7 +35,7 @@ import (
 type Executor interface {
 	// ExecInContainer executes a command in a container in the pod, copying data
 	// between in/out/err and the container's stdin/stdout/stderr.
-	ExecInContainer(name string, uid types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize, timeout time.Duration) error
+	ExecInContainer(ctx context.Context, name string, uid types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize, timeout time.Duration) error
 }
 
 // ServeExec handles requests to execute a command in a container. After

--- a/pkg/kubelet/cri/streaming/remotecommand/exec.go
+++ b/pkg/kubelet/cri/streaming/remotecommand/exec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package remotecommand
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"

--- a/pkg/kubelet/cri/streaming/remotecommand/exec.go
+++ b/pkg/kubelet/cri/streaming/remotecommand/exec.go
@@ -49,7 +49,7 @@ func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, podN
 	}
 	defer ctx.conn.Close()
 
-	err := executor.ExecInContainer(podName, uid, container, cmd, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan, 0)
+	err := executor.ExecInContainer(req.Context(), podName, uid, container, cmd, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan, 0)
 	if err != nil {
 		if exitErr, ok := err.(utilexec.ExitError); ok && exitErr.Exited() {
 			rc := exitErr.ExitStatus()

--- a/pkg/kubelet/cri/streaming/remotecommand/httpstream.go
+++ b/pkg/kubelet/cri/streaming/remotecommand/httpstream.go
@@ -72,7 +72,7 @@ func NewOptions(req *http.Request) (*Options, error) {
 
 // context contains the connection and streams used when
 // forwarding an attach or execute session into a container.
-type context struct {
+type remoteContext struct {
 	conn         io.Closer
 	stdinStream  io.ReadCloser
 	stdoutStream io.WriteCloser
@@ -102,8 +102,8 @@ func waitStreamReply(replySent <-chan struct{}, notify chan<- struct{}, stop <-c
 	}
 }
 
-func createStreams(req *http.Request, w http.ResponseWriter, opts *Options, supportedStreamProtocols []string, idleTimeout, streamCreationTimeout time.Duration) (*context, bool) {
-	var ctx *context
+func createStreams(req *http.Request, w http.ResponseWriter, opts *Options, supportedStreamProtocols []string, idleTimeout, streamCreationTimeout time.Duration) (*remoteContext, bool) {
+	var ctx *remoteContext
 	var ok bool
 	if wsstream.IsWebSocketRequest(req) {
 		ctx, ok = createWebSocketStreams(req, w, opts, idleTimeout)
@@ -122,7 +122,7 @@ func createStreams(req *http.Request, w http.ResponseWriter, opts *Options, supp
 	return ctx, true
 }
 
-func createHTTPStreamStreams(req *http.Request, w http.ResponseWriter, opts *Options, supportedStreamProtocols []string, idleTimeout, streamCreationTimeout time.Duration) (*context, bool) {
+func createHTTPStreamStreams(req *http.Request, w http.ResponseWriter, opts *Options, supportedStreamProtocols []string, idleTimeout, streamCreationTimeout time.Duration) (*remoteContext, bool) {
 	protocol, err := httpstream.Handshake(req, w, supportedStreamProtocols)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -194,7 +194,7 @@ func createHTTPStreamStreams(req *http.Request, w http.ResponseWriter, opts *Opt
 type protocolHandler interface {
 	// waitForStreams waits for the expected streams or a timeout, returning a
 	// remoteCommandContext if all the streams were received, or an error if not.
-	waitForStreams(streams <-chan streamAndReply, expectedStreams int, expired <-chan time.Time) (*context, error)
+	waitForStreams(streams <-chan streamAndReply, expectedStreams int, expired <-chan time.Time) (*remoteContext, error)
 	// supportsTerminalResizing returns true if the protocol handler supports terminal resizing
 	supportsTerminalResizing() bool
 }
@@ -204,8 +204,8 @@ type protocolHandler interface {
 // the process' exit code.
 type v4ProtocolHandler struct{}
 
-func (*v4ProtocolHandler) waitForStreams(streams <-chan streamAndReply, expectedStreams int, expired <-chan time.Time) (*context, error) {
-	ctx := &context{}
+func (*v4ProtocolHandler) waitForStreams(streams <-chan streamAndReply, expectedStreams int, expired <-chan time.Time) (*remoteContext, error) {
+	ctx := &remoteContext{}
 	receivedStreams := 0
 	replyChan := make(chan struct{})
 	stop := make(chan struct{})
@@ -255,8 +255,8 @@ func (*v4ProtocolHandler) supportsTerminalResizing() bool { return true }
 // v3ProtocolHandler implements the V3 protocol version for streaming command execution.
 type v3ProtocolHandler struct{}
 
-func (*v3ProtocolHandler) waitForStreams(streams <-chan streamAndReply, expectedStreams int, expired <-chan time.Time) (*context, error) {
-	ctx := &context{}
+func (*v3ProtocolHandler) waitForStreams(streams <-chan streamAndReply, expectedStreams int, expired <-chan time.Time) (*remoteContext, error) {
+	ctx := &remoteContext{}
 	receivedStreams := 0
 	replyChan := make(chan struct{})
 	stop := make(chan struct{})
@@ -306,8 +306,8 @@ func (*v3ProtocolHandler) supportsTerminalResizing() bool { return true }
 // v2ProtocolHandler implements the V2 protocol version for streaming command execution.
 type v2ProtocolHandler struct{}
 
-func (*v2ProtocolHandler) waitForStreams(streams <-chan streamAndReply, expectedStreams int, expired <-chan time.Time) (*context, error) {
-	ctx := &context{}
+func (*v2ProtocolHandler) waitForStreams(streams <-chan streamAndReply, expectedStreams int, expired <-chan time.Time) (*remoteContext, error) {
+	ctx := &remoteContext{}
 	receivedStreams := 0
 	replyChan := make(chan struct{})
 	stop := make(chan struct{})
@@ -354,8 +354,8 @@ func (*v2ProtocolHandler) supportsTerminalResizing() bool { return false }
 // v1ProtocolHandler implements the V1 protocol version for streaming command execution.
 type v1ProtocolHandler struct{}
 
-func (*v1ProtocolHandler) waitForStreams(streams <-chan streamAndReply, expectedStreams int, expired <-chan time.Time) (*context, error) {
-	ctx := &context{}
+func (*v1ProtocolHandler) waitForStreams(streams <-chan streamAndReply, expectedStreams int, expired <-chan time.Time) (*remoteContext, error) {
+	ctx := &remoteContext{}
 	receivedStreams := 0
 	replyChan := make(chan struct{})
 	stop := make(chan struct{})

--- a/pkg/kubelet/cri/streaming/remotecommand/websocket.go
+++ b/pkg/kubelet/cri/streaming/remotecommand/websocket.go
@@ -70,7 +70,7 @@ func writeChannel(real bool) wsstream.ChannelType {
 
 // createWebSocketStreams returns a context containing the websocket connection and
 // streams needed to perform an exec or an attach.
-func createWebSocketStreams(req *http.Request, w http.ResponseWriter, opts *Options, idleTimeout time.Duration) (*context, bool) {
+func createWebSocketStreams(req *http.Request, w http.ResponseWriter, opts *Options, idleTimeout time.Duration) (*remoteContext, bool) {
 	channels := createChannels(opts)
 	conn := wsstream.NewConn(map[string]wsstream.ChannelProtocolConfig{
 		"": {
@@ -112,7 +112,7 @@ func createWebSocketStreams(req *http.Request, w http.ResponseWriter, opts *Opti
 		streams[errorChannel].Write([]byte{})
 	}
 
-	ctx := &context{
+	ctx := &remoteContext{
 		conn:         conn,
 		stdinStream:  streams[stdinChannel],
 		stdoutStream: streams[stdoutChannel],

--- a/pkg/kubelet/cri/streaming/server.go
+++ b/pkg/kubelet/cri/streaming/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package streaming
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"io"
@@ -369,14 +370,14 @@ var _ remotecommandserver.Executor = &criAdapter{}
 var _ remotecommandserver.Attacher = &criAdapter{}
 var _ portforward.PortForwarder = &criAdapter{}
 
-func (a *criAdapter) ExecInContainer(podName string, podUID types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize, timeout time.Duration) error {
-	return a.Runtime.Exec(container, cmd, in, out, err, tty, resize)
+func (a *criAdapter) ExecInContainer(ctx context.Context, podName string, podUID types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize, timeout time.Duration) error {
+	return a.Runtime.Exec(ctx, container, cmd, in, out, err, tty, resize)
 }
 
-func (a *criAdapter) AttachContainer(podName string, podUID types.UID, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
-	return a.Runtime.Attach(container, in, out, err, tty, resize)
+func (a *criAdapter) AttachContainer(ctx context.Context, podName string, podUID types.UID, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+	return a.Runtime.Attach(ctx, container, in, out, err, tty, resize)
 }
 
-func (a *criAdapter) PortForward(podName string, podUID types.UID, port int32, stream io.ReadWriteCloser) error {
-	return a.Runtime.PortForward(podName, port, stream)
+func (a *criAdapter) PortForward(ctx context.Context, podName string, podUID types.UID, port int32, stream io.ReadWriteCloser) error {
+	return a.Runtime.PortForward(ctx, podName, port, stream)
 }

--- a/pkg/kubelet/cri/streaming/server.go
+++ b/pkg/kubelet/cri/streaming/server.go
@@ -61,9 +61,9 @@ type Server interface {
 
 // Runtime is the interface to execute the commands and provide the streams.
 type Runtime interface {
-	Exec(containerID string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
-	Attach(containerID string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
-	PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error
+	Exec(ctx context.Context, containerID string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
+	Attach(ctx context.Context, containerID string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
+	PortForward(ctx context.Context, podSandboxID string, port int32, stream io.ReadWriteCloser) error
 }
 
 // Config defines the options used for running the stream server.

--- a/pkg/kubelet/cri/streaming/server_test.go
+++ b/pkg/kubelet/cri/streaming/server_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package streaming
 
 import (
+	"context"
 	"crypto/tls"
 	"io"
 	"net/http"
@@ -414,19 +415,19 @@ type fakeRuntime struct {
 	t *testing.T
 }
 
-func (f *fakeRuntime) Exec(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+func (f *fakeRuntime) Exec(ctx context.Context, containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	assert.Equal(f.t, testContainerID, containerID)
 	doServerStreams(f.t, "exec", stdin, stdout, stderr)
 	return nil
 }
 
-func (f *fakeRuntime) Attach(containerID string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+func (f *fakeRuntime) Attach(ctx context.Context, containerID string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	assert.Equal(f.t, testContainerID, containerID)
 	doServerStreams(f.t, "attach", stdin, stdout, stderr)
 	return nil
 }
 
-func (f *fakeRuntime) PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+func (f *fakeRuntime) PortForward(ctx context.Context, podSandboxID string, port int32, stream io.ReadWriteCloser) error {
 	assert.Equal(f.t, testPodSandboxID, podSandboxID)
 	assert.EqualValues(f.t, testPort, port)
 	doServerStreams(f.t, "portforward", stream, stream, nil)

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package eviction
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -227,7 +228,7 @@ func (m *managerImpl) IsUnderPIDPressure() bool {
 
 // synchronize is the main control loop that enforces eviction thresholds.
 // Returns the pod that was killed, or nil if no pod was killed.
-func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc ActivePodsFunc) []*v1.Pod {
+func (m *managerImpl) synchronize(ctx context.Context, diskInfoProvider DiskInfoProvider, podFunc ActivePodsFunc) []*v1.Pod {
 	// if we have nothing to do, just return
 	thresholds := m.config.Thresholds
 	if len(thresholds) == 0 && !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
@@ -249,7 +250,7 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 
 	activePods := podFunc()
 	updateStats := true
-	summary, err := m.summaryProvider.Get(updateStats)
+	summary, err := m.summaryProvider.Get(ctx, updateStats)
 	if err != nil {
 		klog.ErrorS(err, "Eviction manager: failed to get summary stats")
 		return nil
@@ -341,7 +342,7 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 	m.recorder.Eventf(m.nodeRef, v1.EventTypeWarning, "EvictionThresholdMet", "Attempting to reclaim %s", resourceToReclaim)
 
 	// check if there are node-level resources we can reclaim to reduce pressure before evicting end-user pods.
-	if m.reclaimNodeLevelResources(thresholdToReclaim.Signal, resourceToReclaim) {
+	if m.reclaimNodeLevelResources(ctx, thresholdToReclaim.Signal, resourceToReclaim) {
 		klog.InfoS("Eviction manager: able to reduce resource pressure without evicting pods.", "resourceName", resourceToReclaim)
 		return nil
 	}
@@ -416,17 +417,17 @@ func (m *managerImpl) waitForPodsCleanup(podCleanedUpFunc PodCleanedUpFunc, pods
 }
 
 // reclaimNodeLevelResources attempts to reclaim node level resources.  returns true if thresholds were satisfied and no pod eviction is required.
-func (m *managerImpl) reclaimNodeLevelResources(signalToReclaim evictionapi.Signal, resourceToReclaim v1.ResourceName) bool {
+func (m *managerImpl) reclaimNodeLevelResources(ctx context.Context, signalToReclaim evictionapi.Signal, resourceToReclaim v1.ResourceName) bool {
 	nodeReclaimFuncs := m.signalToNodeReclaimFuncs[signalToReclaim]
 	for _, nodeReclaimFunc := range nodeReclaimFuncs {
 		// attempt to reclaim the pressured resource.
-		if err := nodeReclaimFunc(); err != nil {
+		if err := nodeReclaimFunc(ctx); err != nil {
 			klog.InfoS("Eviction manager: unexpected error when attempting to reduce resource pressure", "resourceName", resourceToReclaim, "err", err)
 		}
 
 	}
 	if len(nodeReclaimFuncs) > 0 {
-		summary, err := m.summaryProvider.Get(true)
+		summary, err := m.summaryProvider.Get(ctx, true)
 		if err != nil {
 			klog.ErrorS(err, "Eviction manager: failed to get summary stats after resource reclaim")
 			return false

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -176,7 +176,7 @@ func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAd
 func (m *managerImpl) Start(diskInfoProvider DiskInfoProvider, podFunc ActivePodsFunc, podCleanedUpFunc PodCleanedUpFunc, monitoringInterval time.Duration) {
 	thresholdHandler := func(message string) {
 		klog.InfoS(message)
-		m.synchronize(diskInfoProvider, podFunc)
+		m.synchronize(context.Background(), diskInfoProvider, podFunc)
 	}
 	if m.config.KernelMemcgNotification {
 		for _, threshold := range m.config.Thresholds {
@@ -194,7 +194,7 @@ func (m *managerImpl) Start(diskInfoProvider DiskInfoProvider, podFunc ActivePod
 	// start the eviction manager monitoring
 	go func() {
 		for {
-			if evictedPods := m.synchronize(diskInfoProvider, podFunc); evictedPods != nil {
+			if evictedPods := m.synchronize(context.Background(), diskInfoProvider, podFunc); evictedPods != nil {
 				klog.InfoS("Eviction manager: pods evicted, waiting for pod to be cleaned up", "pods", klog.KObjs(evictedPods))
 				m.waitForPodsCleanup(podCleanedUpFunc, evictedPods)
 			} else {

--- a/pkg/kubelet/eviction/helpers_test.go
+++ b/pkg/kubelet/eviction/helpers_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package eviction
 
 import (
+	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/diff"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1252,11 +1254,11 @@ type fakeSummaryProvider struct {
 	result *statsapi.Summary
 }
 
-func (f *fakeSummaryProvider) Get(updateStats bool) (*statsapi.Summary, error) {
+func (f *fakeSummaryProvider) Get(ctx context.Context, updateStats bool) (*statsapi.Summary, error) {
 	return f.result, nil
 }
 
-func (f *fakeSummaryProvider) GetCPUAndMemoryStats() (*statsapi.Summary, error) {
+func (f *fakeSummaryProvider) GetCPUAndMemoryStats(ctx context.Context) (*statsapi.Summary, error) {
 	return f.result, nil
 }
 

--- a/pkg/kubelet/eviction/mock_threshold_notifier_test.go
+++ b/pkg/kubelet/eviction/mock_threshold_notifier_test.go
@@ -21,6 +21,7 @@ limitations under the License.
 package eviction
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	reflect "reflect"
@@ -166,17 +167,17 @@ func (m *MockImageGC) EXPECT() *MockImageGCMockRecorder {
 }
 
 // DeleteUnusedImages mocks base method
-func (m *MockImageGC) DeleteUnusedImages() error {
+func (m *MockImageGC) DeleteUnusedImages(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteUnusedImages")
+	ret := m.ctrl.Call(m, "DeleteUnusedImages", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteUnusedImages indicates an expected call of DeleteUnusedImages
-func (mr *MockImageGCMockRecorder) DeleteUnusedImages() *gomock.Call {
+func (mr *MockImageGCMockRecorder) DeleteUnusedImages(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUnusedImages", reflect.TypeOf((*MockImageGC)(nil).DeleteUnusedImages))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUnusedImages", reflect.TypeOf((*MockImageGC)(nil).DeleteUnusedImages), ctx)
 }
 
 // MockContainerGC is a mock of ContainerGC interface
@@ -203,17 +204,17 @@ func (m *MockContainerGC) EXPECT() *MockContainerGCMockRecorder {
 }
 
 // DeleteAllUnusedContainers mocks base method
-func (m *MockContainerGC) DeleteAllUnusedContainers() error {
+func (m *MockContainerGC) DeleteAllUnusedContainers(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAllUnusedContainers")
+	ret := m.ctrl.Call(m, "DeleteAllUnusedContainers", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteAllUnusedContainers indicates an expected call of DeleteAllUnusedContainers
-func (mr *MockContainerGCMockRecorder) DeleteAllUnusedContainers() *gomock.Call {
+func (mr *MockContainerGCMockRecorder) DeleteAllUnusedContainers(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllUnusedContainers", reflect.TypeOf((*MockContainerGC)(nil).DeleteAllUnusedContainers))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllUnusedContainers", reflect.TypeOf((*MockContainerGC)(nil).DeleteAllUnusedContainers), ctx)
 }
 
 // MockCgroupNotifier is a mock of CgroupNotifier interface

--- a/pkg/kubelet/eviction/types.go
+++ b/pkg/kubelet/eviction/types.go
@@ -18,6 +18,7 @@ limitations under the License.
 package eviction
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"

--- a/pkg/kubelet/eviction/types.go
+++ b/pkg/kubelet/eviction/types.go
@@ -77,13 +77,13 @@ type DiskInfoProvider interface {
 // ImageGC is responsible for performing garbage collection of unused images.
 type ImageGC interface {
 	// DeleteUnusedImages deletes unused images.
-	DeleteUnusedImages() error
+	DeleteUnusedImages(ctx context.Context) error
 }
 
 // ContainerGC is responsible for performing garbage collection of unused containers.
 type ContainerGC interface {
 	// DeleteAllUnusedContainers deletes all unused containers, even those that belong to pods that are terminated, but not deleted.
-	DeleteAllUnusedContainers() error
+	DeleteAllUnusedContainers(ctx context.Context) error
 }
 
 // KillPodFunc kills a pod.
@@ -131,7 +131,7 @@ type thresholdsObservedAt map[evictionapi.Threshold]time.Time
 type nodeConditionsObservedAt map[v1.NodeConditionType]time.Time
 
 // nodeReclaimFunc is a function that knows how to reclaim a resource from the node without impacting pods.
-type nodeReclaimFunc func() error
+type nodeReclaimFunc func(context.Context) error
 
 // nodeReclaimFuncs is an ordered list of nodeReclaimFunc
 type nodeReclaimFuncs []nodeReclaimFunc

--- a/pkg/kubelet/images/helpers.go
+++ b/pkg/kubelet/images/helpers.go
@@ -17,9 +17,10 @@ limitations under the License.
 package images
 
 import (
+	"context"
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/flowcontrol"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -43,9 +44,9 @@ type throttledImageService struct {
 	limiter flowcontrol.RateLimiter
 }
 
-func (ts throttledImageService) PullImage(image kubecontainer.ImageSpec, secrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+func (ts throttledImageService) PullImage(ctx context.Context, image kubecontainer.ImageSpec, secrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	if ts.limiter.TryAccept() {
-		return ts.ImageService.PullImage(image, secrets, podSandboxConfig)
+		return ts.ImageService.PullImage(ctx, image, secrets, podSandboxConfig)
 	}
 	return "", fmt.Errorf("pull QPS exceeded")
 }

--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package images
 
 import (
+	"context"
 	goerrors "errors"
 	"fmt"
 	"math"
@@ -24,9 +25,9 @@ import (
 	"sync"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
-	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -205,24 +206,24 @@ func (im *realImageGCManager) Start() {
 }
 
 // Get a list of images on this node
-func (im *realImageGCManager) GetImageList() ([]container.Image, error) {
+func (im *realImageGCManager) GetImageList(ctx context.Context) ([]container.Image, error) {
 	return im.imageCache.get(), nil
 }
 
-func (im *realImageGCManager) detectImages(detectTime time.Time) (sets.String, error) {
+func (im *realImageGCManager) detectImages(ctx context.Context, detectTime time.Time) (sets.String, error) {
 	imagesInUse := sets.NewString()
 
 	// Always consider the container runtime pod sandbox image in use
-	imageRef, err := im.runtime.GetImageRef(container.ImageSpec{Image: im.sandboxImage})
+	imageRef, err := im.runtime.GetImageRef(ctx, container.ImageSpec{Image: im.sandboxImage})
 	if err == nil && imageRef != "" {
 		imagesInUse.Insert(imageRef)
 	}
 
-	images, err := im.runtime.ListImages()
+	images, err := im.runtime.ListImages(ctx)
 	if err != nil {
 		return imagesInUse, err
 	}
-	pods, err := im.runtime.GetPods(true)
+	pods, err := im.runtime.GetPods(ctx, true)
 	if err != nil {
 		return imagesInUse, err
 	}
@@ -276,9 +277,9 @@ func (im *realImageGCManager) detectImages(detectTime time.Time) (sets.String, e
 	return imagesInUse, nil
 }
 
-func (im *realImageGCManager) GarbageCollect() error {
+func (im *realImageGCManager) GarbageCollect(ctx context.Context) error {
 	// Get disk usage on disk holding images.
-	fsStats, err := im.statsProvider.ImageFsStats()
+	fsStats, err := im.statsProvider.ImageFsStats(ctx)
 	if err != nil {
 		return err
 	}
@@ -308,7 +309,7 @@ func (im *realImageGCManager) GarbageCollect() error {
 	if usagePercent >= im.policy.HighThresholdPercent {
 		amountToFree := capacity*int64(100-im.policy.LowThresholdPercent)/100 - available
 		klog.InfoS("Disk usage on image filesystem is over the high threshold, trying to free bytes down to the low threshold", "usage", usagePercent, "highThreshold", im.policy.HighThresholdPercent, "amountToFree", amountToFree, "lowThreshold", im.policy.LowThresholdPercent)
-		freed, err := im.freeSpace(amountToFree, time.Now())
+		freed, err := im.freeSpace(ctx, amountToFree, time.Now())
 		if err != nil {
 			return err
 		}
@@ -323,9 +324,9 @@ func (im *realImageGCManager) GarbageCollect() error {
 	return nil
 }
 
-func (im *realImageGCManager) DeleteUnusedImages() error {
+func (im *realImageGCManager) DeleteUnusedImages(ctx context.Context) error {
 	klog.InfoS("Attempting to delete unused images")
-	_, err := im.freeSpace(math.MaxInt64, time.Now())
+	_, err := im.freeSpace(ctx, math.MaxInt64, time.Now())
 	return err
 }
 
@@ -335,8 +336,8 @@ func (im *realImageGCManager) DeleteUnusedImages() error {
 // bytes freed is always returned.
 // Note that error may be nil and the number of bytes free may be less
 // than bytesToFree.
-func (im *realImageGCManager) freeSpace(bytesToFree int64, freeTime time.Time) (int64, error) {
-	imagesInUse, err := im.detectImages(freeTime)
+func (im *realImageGCManager) freeSpace(ctx context.Context, bytesToFree int64, freeTime time.Time) (int64, error) {
+	imagesInUse, err := im.detectImages(ctx, freeTime)
 	if err != nil {
 		return 0, err
 	}
@@ -385,7 +386,7 @@ func (im *realImageGCManager) freeSpace(bytesToFree int64, freeTime time.Time) (
 
 		// Remove image. Continue despite errors.
 		klog.InfoS("Removing image to free bytes", "imageID", image.id, "size", image.size)
-		err := im.runtime.RemoveImage(container.ImageSpec{Image: image.id})
+		err := im.runtime.RemoveImage(ctx, container.ImageSpec{Image: image.id})
 		if err != nil {
 			deletionErrors = append(deletionErrors, err)
 			continue

--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -41,7 +41,7 @@ import (
 // collection.
 type StatsProvider interface {
 	// ImageFsStats returns the stats of the image filesystem.
-	ImageFsStats() (*statsapi.FsStats, error)
+	ImageFsStats(ctx context.Context) (*statsapi.FsStats, error)
 }
 
 // ImageGCManager is an interface for managing lifecycle of all images.
@@ -49,15 +49,15 @@ type StatsProvider interface {
 type ImageGCManager interface {
 	// Applies the garbage collection policy. Errors include being unable to free
 	// enough space as per the garbage collection policy.
-	GarbageCollect() error
+	GarbageCollect(ctx context.Context) error
 
 	// Start async garbage collection of images.
 	Start()
 
-	GetImageList() ([]container.Image, error)
+	GetImageList(ctx context.Context) ([]container.Image, error)
 
 	// Delete all unused images.
-	DeleteUnusedImages() error
+	DeleteUnusedImages(ctx context.Context) error
 }
 
 // ImageGCPolicy is a policy for garbage collecting images. Policy defines an allowed band in

--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -184,7 +184,7 @@ func (im *realImageGCManager) Start() {
 		if im.initialized {
 			ts = time.Now()
 		}
-		_, err := im.detectImages(ts)
+		_, err := im.detectImages(context.Background(), ts)
 		if err != nil {
 			klog.InfoS("Failed to monitor images", "err", err)
 		} else {
@@ -194,7 +194,7 @@ func (im *realImageGCManager) Start() {
 
 	// Start a goroutine periodically updates image cache.
 	go wait.Until(func() {
-		images, err := im.runtime.ListImages()
+		images, err := im.runtime.ListImages(context.Background())
 		if err != nil {
 			klog.InfoS("Failed to update image list", "err", err)
 		} else {

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package images
 
 import (
+	"context"
 	"fmt"
 	"time"
 

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -113,7 +113,7 @@ func (m *imageManager) EnsureImageExists(pod *v1.Pod, container *v1.Container, p
 		Image:       image,
 		Annotations: podAnnotations,
 	}
-	imageRef, err := m.imageService.GetImageRef(spec)
+	imageRef, err := m.imageService.GetImageRef(context.Background(), spec)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to inspect image %q: %v", container.Image, err)
 		m.logIt(ref, v1.EventTypeWarning, events.FailedToInspectImage, logPrefix, msg, klog.Warning)

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package images
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -287,7 +288,7 @@ func TestPullAndListImageWithPodAnnotations(t *testing.T) {
 		fakeRuntime.AssertCalls(c.expected[0].calls)
 		assert.Equal(t, c.expected[0].err, err, "tick=%d", 0)
 
-		images, _ := fakeRuntime.ListImages()
+		images, _ := fakeRuntime.ListImages(context.Background())
 		assert.Equal(t, 1, len(images), "ListImages() count")
 
 		image := images[0]

--- a/pkg/kubelet/images/puller.go
+++ b/pkg/kubelet/images/puller.go
@@ -46,7 +46,7 @@ func newParallelImagePuller(imageService kubecontainer.ImageService) imagePuller
 
 func (pip *parallelImagePuller) pullImage(spec kubecontainer.ImageSpec, pullSecrets []v1.Secret, pullChan chan<- pullResult, podSandboxConfig *runtimeapi.PodSandboxConfig) {
 	go func() {
-		imageRef, err := pip.imageService.PullImage(spec, pullSecrets, podSandboxConfig)
+		imageRef, err := pip.imageService.PullImage(context.Background(), spec, pullSecrets, podSandboxConfig)
 		pullChan <- pullResult{
 			imageRef: imageRef,
 			err:      err,
@@ -86,7 +86,7 @@ func (sip *serialImagePuller) pullImage(spec kubecontainer.ImageSpec, pullSecret
 
 func (sip *serialImagePuller) processImagePullRequests() {
 	for pullRequest := range sip.pullRequests {
-		imageRef, err := sip.imageService.PullImage(pullRequest.spec, pullRequest.pullSecrets, pullRequest.podSandboxConfig)
+		imageRef, err := sip.imageService.PullImage(context.Background(), pullRequest.spec, pullRequest.pullSecrets, pullRequest.podSandboxConfig)
 		pullRequest.pullChan <- pullResult{
 			imageRef: imageRef,
 			err:      err,

--- a/pkg/kubelet/images/puller.go
+++ b/pkg/kubelet/images/puller.go
@@ -17,9 +17,10 @@ limitations under the License.
 package images
 
 import (
+	"context"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1265,7 +1265,7 @@ func (kl *Kubelet) setupDataDirs() error {
 func (kl *Kubelet) StartGarbageCollection() {
 	loggedContainerGCFailure := false
 	go wait.Until(func() {
-		if err := kl.containerGC.GarbageCollect(); err != nil {
+		if err := kl.containerGC.GarbageCollect(context.Background()); err != nil {
 			klog.ErrorS(err, "Container garbage collection failed")
 			kl.recorder.Eventf(kl.nodeRef, v1.EventTypeWarning, events.ContainerGCFailed, err.Error())
 			loggedContainerGCFailure = true
@@ -1288,7 +1288,7 @@ func (kl *Kubelet) StartGarbageCollection() {
 
 	prevImageGCFailed := false
 	go wait.Until(func() {
-		if err := kl.imageManager.GarbageCollect(); err != nil {
+		if err := kl.imageManager.GarbageCollect(context.Background()); err != nil {
 			if prevImageGCFailed {
 				klog.ErrorS(err, "Image garbage collection failed multiple times in a row")
 				// Only create an event for repeated failures
@@ -2307,7 +2307,7 @@ func (kl *Kubelet) updateRuntimeUp() {
 	kl.updateRuntimeMux.Lock()
 	defer kl.updateRuntimeMux.Unlock()
 
-	s, err := kl.containerRuntime.Status()
+	s, err := kl.containerRuntime.Status(context.Background())
 	if err != nil {
 		klog.ErrorS(err, "Container runtime sanity check failed")
 		return

--- a/pkg/kubelet/kubelet_getters_test.go
+++ b/pkg/kubelet/kubelet_getters_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubelet
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -25,7 +26,7 @@ import (
 
 func TestKubeletDirs(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	root := kubelet.rootDirectory
 

--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -17,9 +17,10 @@ limitations under the License.
 package kubelet
 
 import (
+	"context"
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"

--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -68,7 +68,7 @@ func (kl *Kubelet) updatePodCIDR(cidr string) (bool, error) {
 
 	// kubelet -> generic runtime -> runtime shim -> network plugin
 	// docker/non-cri implementations have a passthrough UpdatePodCIDR
-	if err := kl.getRuntime().UpdatePodCIDR(cidr); err != nil {
+	if err := kl.getRuntime().UpdatePodCIDR(context.Background(), cidr); err != nil {
 		// If updatePodCIDR would fail, theoretically pod CIDR could not change.
 		// But it is better to be on the safe side to still return true here.
 		return true, fmt.Errorf("failed to update pod CIDR: %v", err)

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -183,7 +183,7 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 			inputImageList, expectedImageList := generateTestingImageLists(numTestImages, int(tc.nodeStatusMaxImages))
 			testKubelet := newTestKubeletWithImageList(
 				t, inputImageList, false /* controllerAttachDetachEnabled */, true /*initFakeVolumePlugin*/)
-			defer testKubelet.Cleanup()
+			defer testKubelet.Cleanup(context.Background())
 			kubelet := testKubelet.kubelet
 			kubelet.nodeStatusMaxImages = tc.nodeStatusMaxImages
 			kubelet.kubeClient = nil // ensure only the heartbeat client is used
@@ -313,7 +313,7 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 
 func TestUpdateExistingNodeStatus(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	kubelet.nodeStatusMaxImages = 5 // don't truncate the image list that gets constructed by hand for this test
 	kubelet.kubeClient = nil        // ensure only the heartbeat client is used
@@ -531,7 +531,7 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 	assert.NoError(t, err)
 
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	kubelet.kubeClient = nil // ensure only the heartbeat client is used
 	kubelet.heartbeatClient, err = clientset.NewForConfig(config)
@@ -566,7 +566,7 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 
 func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	kubelet.nodeStatusMaxImages = 5 // don't truncate the image list that gets constructed by hand for this test
 	kubelet.kubeClient = nil        // ensure only the heartbeat client is used
@@ -775,7 +775,7 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 
 func TestUpdateNodeStatusError(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	kubelet.kubeClient = nil // ensure only the heartbeat client is used
 	// No matching node for the kubelet
@@ -786,7 +786,7 @@ func TestUpdateNodeStatusError(t *testing.T) {
 
 func TestUpdateNodeStatusWithLease(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	clock := testKubelet.fakeClock
 	kubelet := testKubelet.kubelet
 	kubelet.nodeStatusMaxImages = 5 // don't truncate the image list that gets constructed by hand for this test
@@ -1074,7 +1074,7 @@ func TestUpdateNodeStatusAndVolumesInUseWithNodeLease(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			// Setup
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-			defer testKubelet.Cleanup()
+			defer testKubelet.Cleanup(context.Background())
 
 			kubelet := testKubelet.kubelet
 			kubelet.kubeClient = nil // ensure only the heartbeat client is used
@@ -1123,7 +1123,7 @@ func TestUpdateNodeStatusAndVolumesInUseWithNodeLease(t *testing.T) {
 
 func TestRegisterWithApiServer(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	kubeClient := testKubelet.fakeKubeClient
 	kubeClient.AddReactor("create", "nodes", func(action core.Action) (bool, runtime.Object, error) {
@@ -1287,7 +1287,7 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 
 	for _, tc := range cases {
 		testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled is a don't-care for this test */)
-		defer testKubelet.Cleanup()
+		defer testKubelet.Cleanup(context.Background())
 		kubelet := testKubelet.kubelet
 		kubeClient := testKubelet.fakeKubeClient
 
@@ -1345,7 +1345,7 @@ func TestUpdateNewNodeStatusTooLargeReservation(t *testing.T) {
 	inputImageList, _ := generateTestingImageLists(nodeStatusMaxImages+1, nodeStatusMaxImages)
 	testKubelet := newTestKubeletWithImageList(
 		t, inputImageList, false /* controllerAttachDetachEnabled */, true /* initFakeVolumePlugin */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	kubelet.nodeStatusMaxImages = nodeStatusMaxImages
 	kubelet.kubeClient = nil // ensure only the heartbeat client is used
@@ -1704,7 +1704,7 @@ func TestUpdateDefaultLabels(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		defer testKubelet.Cleanup()
+		defer testKubelet.Cleanup(context.Background())
 		kubelet := testKubelet.kubelet
 
 		needsUpdate := kubelet.updateDefaultLabels(tc.initialNode, tc.existingNode)
@@ -2205,7 +2205,7 @@ func TestReconcileHugePageResource(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(T *testing.T) {
-			defer testKubelet.Cleanup()
+			defer testKubelet.Cleanup(context.Background())
 			kubelet := testKubelet.kubelet
 
 			needsUpdate := kubelet.reconcileHugePageResource(tc.initialNode, tc.existingNode)
@@ -2220,7 +2220,7 @@ func TestReconcileExtendedResource(t *testing.T) {
 	testKubelet.kubelet.kubeClient = nil // ensure only the heartbeat client is used
 	testKubelet.kubelet.containerManager = cm.NewStubContainerManagerWithExtendedResource(true /* shouldResetExtendedResourceCapacity*/)
 	testKubeletNoReset := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubeletNoReset.Cleanup()
+	defer testKubeletNoReset.Cleanup(context.Background())
 	extendedResourceName1 := v1.ResourceName("test.com/resource1")
 	extendedResourceName2 := v1.ResourceName("test.com/resource2")
 
@@ -2393,7 +2393,7 @@ func TestReconcileExtendedResource(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		defer testKubelet.Cleanup()
+		defer testKubelet.Cleanup(context.Background())
 		kubelet := testKubelet.kubelet
 
 		needsUpdate := kubelet.reconcileExtendedResource(tc.initialNode, tc.existingNode)
@@ -2496,7 +2496,7 @@ func TestValidateNodeIPParam(t *testing.T) {
 
 func TestRegisterWithApiServerWithTaint(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	kubeClient := testKubelet.fakeKubeClient
 
@@ -2698,7 +2698,7 @@ func TestNodeStatusHasChanged(t *testing.T) {
 
 func TestUpdateNodeAddresses(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	kubeClient := testKubelet.fakeKubeClient
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1635,12 +1635,8 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 		case cs.State == kubecontainer.ContainerStateRunning:
 			status.State.Running = &v1.ContainerStateRunning{StartedAt: metav1.NewTime(cs.StartedAt)}
 		case cs.State == kubecontainer.ContainerStateCreated:
-			// Treat containers in the "created" state as if they are exited.
-			// The pod workers are supposed start all containers it creates in
-			// one sync (syncPod) iteration. There should not be any normal
-			// "created" containers when the pod worker generates the status at
-			// the beginning of a sync iteration.
-			fallthrough
+			// containers that are created but not running are "waiting to be running"
+			status.State.Waiting = &v1.ContainerStateWaiting{}
 		case cs.State == kubecontainer.ContainerStateExited:
 			status.State.Terminated = &v1.ContainerStateTerminated{
 				ExitCode:    int32(cs.ExitCode),

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1041,6 +1041,8 @@ func (kl *Kubelet) deleteOrphanedMirrorPods() {
 // NOTE: This function is executed by the main sync loop, so it
 // should not contain any blocking calls.
 func (kl *Kubelet) HandlePodCleanups() error {
+	ctx := context.Background()
+
 	// The kubelet lacks checkpointing, so we need to introspect the set of pods
 	// in the cgroup tree prior to inspecting the set of pods in our pod manager.
 	// this ensures our view of the cgroup tree does not mistakenly observe pods
@@ -1142,7 +1144,7 @@ func (kl *Kubelet) HandlePodCleanups() error {
 	// in the cache. We need to bypass the cache to get the latest set of
 	// running pods to clean up the volumes.
 	// TODO: Evaluate the performance impact of bypassing the runtime cache.
-	runningRuntimePods, err = kl.containerRuntime.GetPods(false)
+	runningRuntimePods, err = kl.containerRuntime.GetPods(ctx, false)
 	if err != nil {
 		klog.ErrorS(err, "Error listing containers")
 		return err

--- a/pkg/kubelet/kubelet_pods_linux_test.go
+++ b/pkg/kubelet/kubelet_pods_linux_test.go
@@ -20,10 +20,11 @@ limitations under the License.
 package kubelet
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
@@ -272,7 +273,7 @@ func TestMakeMounts(t *testing.T) {
 
 func TestMakeBlockVolumes(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	testCases := map[string]struct {
 		container       v1.Container

--- a/pkg/kubelet/kubelet_resources_test.go
+++ b/pkg/kubelet/kubelet_resources_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package kubelet
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,7 @@ import (
 
 func TestPodResourceLimitsDefaulting(t *testing.T) {
 	tk := newTestKubelet(t, true)
-	defer tk.Cleanup()
+	defer tk.Cleanup(context.Background())
 	tk.kubelet.nodeLister = &testNodeLister{
 		nodes: []*v1.Node{
 			{

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -105,8 +105,8 @@ type fakeImageGCManager struct {
 	images.ImageGCManager
 }
 
-func (f *fakeImageGCManager) GetImageList() ([]kubecontainer.Image, error) {
-	return f.fakeImageService.ListImages()
+func (f *fakeImageGCManager) GetImageList(ctx context.Context) ([]kubecontainer.Image, error) {
+	return f.fakeImageService.ListImages(ctx)
 }
 
 type TestKubelet struct {
@@ -120,7 +120,7 @@ type TestKubelet struct {
 	volumePlugin         *volumetest.FakeVolumePlugin
 }
 
-func (tk *TestKubelet) Cleanup() {
+func (tk *TestKubelet) Cleanup(ctx context.Context) {
 	if tk.kubelet != nil {
 		os.RemoveAll(tk.kubelet.rootDirectory)
 		tk.kubelet = nil
@@ -400,7 +400,7 @@ func newTestPods(count int) []*v1.Pod {
 
 func TestSyncLoopAbort(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	kubelet.runtimeState.setRuntimeSync(time.Now())
 	// The syncLoop waits on time.After(resyncInterval), set it really big so that we don't race for
@@ -420,7 +420,7 @@ func TestSyncLoopAbort(t *testing.T) {
 
 func TestSyncPodsStartPod(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	fakeRuntime := testKubelet.fakeRuntime
 	pods := []*v1.Pod{
@@ -437,7 +437,7 @@ func TestSyncPodsStartPod(t *testing.T) {
 
 func TestHandlePodCleanupsPerQOS(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 
 	pod := &kubecontainer.Pod{
 		ID:        "12345678",
@@ -501,7 +501,7 @@ func TestHandlePodCleanupsPerQOS(t *testing.T) {
 
 func TestDispatchWorkOfCompletedPod(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	var got bool
 	kubelet.podWorkers = &fakePodWorkers{
@@ -580,7 +580,7 @@ func TestDispatchWorkOfCompletedPod(t *testing.T) {
 
 func TestDispatchWorkOfActivePod(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	var got bool
 	kubelet.podWorkers = &fakePodWorkers{
@@ -634,7 +634,7 @@ func TestDispatchWorkOfActivePod(t *testing.T) {
 
 func TestHandlePodCleanups(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 
 	pod := &kubecontainer.Pod{
 		ID:        "12345678",
@@ -664,7 +664,7 @@ func TestHandlePodRemovesWhenSourcesAreReady(t *testing.T) {
 	ready := false
 
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 
 	fakePod := &kubecontainer.Pod{
 		ID:        "1",
@@ -731,7 +731,7 @@ func checkPodStatus(t *testing.T, kl *Kubelet, pod *v1.Pod, phase v1.PodPhase) {
 // Tests that we handle port conflicts correctly by setting the failed status in status map.
 func TestHandlePortConflicts(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kl := testKubelet.kubelet
 
 	kl.nodeLister = testNodeLister{nodes: []*v1.Node{
@@ -781,7 +781,7 @@ func TestHandlePortConflicts(t *testing.T) {
 // Tests that we handle host name conflicts correctly by setting the failed status in status map.
 func TestHandleHostNameConflicts(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kl := testKubelet.kubelet
 
 	kl.nodeLister = testNodeLister{nodes: []*v1.Node{
@@ -824,7 +824,7 @@ func TestHandleHostNameConflicts(t *testing.T) {
 // Tests that we handle not matching labels selector correctly by setting the failed status in status map.
 func TestHandleNodeSelector(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kl := testKubelet.kubelet
 	nodes := []*v1.Node{
 		{
@@ -894,7 +894,7 @@ func TestHandleNodeSelectorBasedOnOS(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-			defer testKubelet.Cleanup()
+			defer testKubelet.Cleanup(context.Background())
 			kl := testKubelet.kubelet
 			nodes := []*v1.Node{
 				{
@@ -931,7 +931,7 @@ func TestHandleNodeSelectorBasedOnOS(t *testing.T) {
 // Tests that we handle exceeded resources correctly by setting the failed status in status map.
 func TestHandleMemExceeded(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kl := testKubelet.kubelet
 	nodes := []*v1.Node{
 		{ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname},
@@ -986,7 +986,7 @@ func TestHandleMemExceeded(t *testing.T) {
 // by setting corresponding status in status map.
 func TestHandlePluginResources(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kl := testKubelet.kubelet
 
 	adjustedResource := v1.ResourceName("domain1.com/adjustedResource")
@@ -1119,7 +1119,7 @@ func TestHandlePluginResources(t *testing.T) {
 // TODO(filipg): This test should be removed once StatusSyncer can do garbage collection without external signal.
 func TestPurgingObsoleteStatusMapEntries(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 
 	kl := testKubelet.kubelet
 	pods := []*v1.Pod{
@@ -1142,7 +1142,7 @@ func TestPurgingObsoleteStatusMapEntries(t *testing.T) {
 
 func TestValidateContainerLogStatus(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	containerName := "x"
 	testCases := []struct {
@@ -1292,7 +1292,7 @@ func TestValidateContainerLogStatus(t *testing.T) {
 func TestCreateMirrorPod(t *testing.T) {
 	for _, updateType := range []kubetypes.SyncPodType{kubetypes.SyncPodCreate, kubetypes.SyncPodUpdate} {
 		testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-		defer testKubelet.Cleanup()
+		defer testKubelet.Cleanup(context.Background())
 
 		kl := testKubelet.kubelet
 		manager := testKubelet.fakeMirrorClient
@@ -1310,7 +1310,7 @@ func TestCreateMirrorPod(t *testing.T) {
 
 func TestDeleteOutdatedMirrorPod(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 
 	kl := testKubelet.kubelet
 	manager := testKubelet.fakeMirrorClient
@@ -1343,7 +1343,7 @@ func TestDeleteOutdatedMirrorPod(t *testing.T) {
 
 func TestDeleteOrphanedMirrorPods(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 
 	kl := testKubelet.kubelet
 	manager := testKubelet.fakeMirrorClient
@@ -1447,7 +1447,7 @@ func TestGetContainerInfoForMirrorPods(t *testing.T) {
 	}
 
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	fakeRuntime := testKubelet.fakeRuntime
 	cadvisorReq := &cadvisorapi.ContainerInfoRequest{}
 	kubelet := testKubelet.kubelet
@@ -1475,7 +1475,7 @@ func TestGetContainerInfoForMirrorPods(t *testing.T) {
 
 func TestNetworkErrorsWithoutHostNetwork(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 
 	kubelet.runtimeState.setNetworkState(fmt.Errorf("simulated network error"))
@@ -1500,7 +1500,7 @@ func TestNetworkErrorsWithoutHostNetwork(t *testing.T) {
 
 func TestFilterOutInactivePods(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	pods := newTestPods(8)
 	now := metav1.NewTime(time.Now())
@@ -1549,7 +1549,7 @@ func TestFilterOutInactivePods(t *testing.T) {
 
 func TestSyncPodsSetStatusToFailedForPodsThatRunTooLong(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	fakeRuntime := testKubelet.fakeRuntime
 	kubelet := testKubelet.kubelet
 
@@ -1598,7 +1598,7 @@ func TestSyncPodsSetStatusToFailedForPodsThatRunTooLong(t *testing.T) {
 
 func TestSyncPodsDoesNotSetPodsThatDidNotRunTooLongToFailed(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	fakeRuntime := testKubelet.fakeRuntime
 
 	kubelet := testKubelet.kubelet
@@ -1663,7 +1663,7 @@ func podWithUIDNameNsSpec(uid types.UID, name, namespace string, spec v1.PodSpec
 
 func TestDeletePodDirsForDeletedPods(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kl := testKubelet.kubelet
 	pods := []*v1.Pod{
 		podWithUIDNameNs("12345678", "pod1", "ns"),
@@ -1699,7 +1699,7 @@ func syncAndVerifyPodDir(t *testing.T, testKubelet *TestKubelet, pods []*v1.Pod,
 
 func TestDoesNotDeletePodDirsForTerminatedPods(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kl := testKubelet.kubelet
 	pods := []*v1.Pod{
 		podWithUIDNameNs("12345678", "pod1", "ns"),
@@ -1716,7 +1716,7 @@ func TestDoesNotDeletePodDirsForTerminatedPods(t *testing.T) {
 
 func TestDoesNotDeletePodDirsIfContainerIsRunning(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	runningPod := &kubecontainer.Pod{
 		ID:        "12345678",
 		Name:      "pod1",
@@ -1746,7 +1746,7 @@ func TestDoesNotDeletePodDirsIfContainerIsRunning(t *testing.T) {
 
 func TestGetPodsToSync(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	clock := testKubelet.fakeClock
 	pods := newTestPods(5)
@@ -1777,7 +1777,7 @@ func TestGetPodsToSync(t *testing.T) {
 
 func TestGenerateAPIPodStatusWithSortedContainers(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	numContainers := 10
 	expectedOrder := []string{}
@@ -1834,7 +1834,7 @@ func TestGenerateAPIPodStatusWithReasonCache(t *testing.T) {
 	testErrorReason := fmt.Errorf("test-error")
 	emptyContainerID := (&kubecontainer.ContainerID{}).String()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	pod := podWithUIDNameNs("12345678", "foo", "new")
 	pod.Spec = v1.PodSpec{RestartPolicy: v1.RestartPolicyOnFailure}
@@ -2052,7 +2052,7 @@ func TestGenerateAPIPodStatusWithDifferentRestartPolicies(t *testing.T) {
 	testErrorReason := fmt.Errorf("test-error")
 	emptyContainerID := (&kubecontainer.ContainerID{}).String()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	pod := podWithUIDNameNs("12345678", "foo", "new")
 	containers := []v1.Container{{Name: "succeed"}, {Name: "failed"}}
@@ -2215,7 +2215,7 @@ func (a *testPodAdmitHandler) Admit(attrs *lifecycle.PodAdmitAttributes) lifecyc
 // Test verifies that the kubelet invokes an admission handler during HandlePodAdditions.
 func TestHandlePodAdditionsInvokesPodAdmitHandlers(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kl := testKubelet.kubelet
 	kl.nodeLister = testNodeLister{nodes: []*v1.Node{
 		{
@@ -2276,7 +2276,7 @@ func (a *testPodSyncLoopHandler) ShouldSync(pod *v1.Pod) bool {
 // TestGetPodsToSyncInvokesPodSyncLoopHandlers ensures that the get pods to sync routine invokes the handler.
 func TestGetPodsToSyncInvokesPodSyncLoopHandlers(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	pods := newTestPods(5)
 	expected := []*v1.Pod{pods[0]}
@@ -2312,7 +2312,7 @@ func (a *testPodSyncHandler) ShouldEvict(pod *v1.Pod) lifecycle.ShouldEvictRespo
 // TestGenerateAPIPodStatusInvokesPodSyncHandlers invokes the handlers and reports the proper status
 func TestGenerateAPIPodStatusInvokesPodSyncHandlers(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	pod := newTestPods(1)[0]
 	podsToEvict := []*v1.Pod{pod}
@@ -2330,7 +2330,7 @@ func TestGenerateAPIPodStatusInvokesPodSyncHandlers(t *testing.T) {
 
 func TestSyncTerminatingPodKillPod(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kl := testKubelet.kubelet
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2385,7 +2385,7 @@ func TestSyncLabels(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			testKubelet := newTestKubelet(t, false)
-			defer testKubelet.Cleanup()
+			defer testKubelet.Cleanup(context.Background())
 			kl := testKubelet.kubelet
 			kubeClient := testKubelet.fakeKubeClient
 

--- a/pkg/kubelet/kubelet_volumes_linux_test.go
+++ b/pkg/kubelet/kubelet_volumes_linux_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package kubelet
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -169,7 +170,7 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-			defer testKubelet.Cleanup()
+			defer testKubelet.Cleanup(context.Background())
 			kubelet := testKubelet.kubelet
 
 			if tc.prepareFunc != nil {
@@ -291,7 +292,7 @@ func TestPodVolumesExistWithMount(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-			defer testKubelet.Cleanup()
+			defer testKubelet.Cleanup(context.Background())
 			kubelet := testKubelet.kubelet
 
 			if tc.prepareFunc != nil {

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubelet
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -36,7 +37,7 @@ import (
 
 func TestListVolumesForPod(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 
 	pod := podWithUIDNameNsSpec("12345678", "foo", "test", v1.PodSpec{
@@ -79,7 +80,7 @@ func TestListVolumesForPod(t *testing.T) {
 	defer close(stopCh)
 
 	kubelet.podManager.SetPods([]*v1.Pod{pod})
-	err := kubelet.volumeManager.WaitForAttachAndMount(pod)
+	err := kubelet.volumeManager.WaitForAttachAndMount(context.TODO(), pod)
 	assert.NoError(t, err)
 
 	podName := util.GetUniquePodName(pod)
@@ -98,7 +99,7 @@ func TestPodVolumesExist(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIMigrationGCE, false)()
 
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 
 	pods := []*v1.Pod{
@@ -196,7 +197,7 @@ func TestPodVolumesExist(t *testing.T) {
 
 	kubelet.podManager.SetPods(pods)
 	for _, pod := range pods {
-		err := kubelet.volumeManager.WaitForAttachAndMount(pod)
+		err := kubelet.volumeManager.WaitForAttachAndMount(context.TODO(), pod)
 		assert.NoError(t, err)
 	}
 
@@ -210,7 +211,7 @@ func TestVolumeAttachAndMountControllerDisabled(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIMigrationGCE, false)()
 
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 
 	pod := podWithUIDNameNsSpec("12345678", "foo", "test", v1.PodSpec{
@@ -241,7 +242,7 @@ func TestVolumeAttachAndMountControllerDisabled(t *testing.T) {
 	defer close(stopCh)
 
 	kubelet.podManager.SetPods([]*v1.Pod{pod})
-	err := kubelet.volumeManager.WaitForAttachAndMount(pod)
+	err := kubelet.volumeManager.WaitForAttachAndMount(context.TODO(), pod)
 	assert.NoError(t, err)
 
 	podVolumes := kubelet.volumeManager.GetMountedVolumesForPod(
@@ -267,7 +268,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIMigrationGCE, false)()
 
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 
 	pod := podWithUIDNameNsSpec("12345678", "foo", "test", v1.PodSpec{
@@ -301,7 +302,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	kubelet.podManager.SetPods([]*v1.Pod{pod})
 
 	// Verify volumes attached
-	err := kubelet.volumeManager.WaitForAttachAndMount(pod)
+	err := kubelet.volumeManager.WaitForAttachAndMount(context.Background(), pod)
 	assert.NoError(t, err)
 
 	podVolumes := kubelet.volumeManager.GetMountedVolumesForPod(
@@ -328,7 +329,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	kubelet.podWorkers.(*fakePodWorkers).setPodRuntimeBeRemoved(pod.UID)
 	kubelet.podManager.SetPods([]*v1.Pod{})
 
-	assert.NoError(t, kubelet.volumeManager.WaitForUnmount(pod))
+	assert.NoError(t, kubelet.volumeManager.WaitForUnmount(context.TODO(), pod))
 	if actual := kubelet.volumeManager.GetMountedVolumesForPod(util.GetUniquePodName(pod)); len(actual) > 0 {
 		t.Fatalf("expected volume unmount to wait for no volumes: %v", actual)
 	}
@@ -354,7 +355,7 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIMigrationGCE, false)()
 
 	testKubelet := newTestKubelet(t, true /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	kubeClient := testKubelet.fakeKubeClient
 	kubeClient.AddReactor("get", "nodes",
@@ -409,7 +410,7 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 		stopCh,
 		kubelet.volumeManager)
 
-	assert.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(pod))
+	assert.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(context.TODO(), pod))
 
 	podVolumes := kubelet.volumeManager.GetMountedVolumesForPod(
 		util.GetUniquePodName(pod))
@@ -436,7 +437,7 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIMigrationGCE, false)()
 
 	testKubelet := newTestKubelet(t, true /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
+	defer testKubelet.Cleanup(context.Background())
 	kubelet := testKubelet.kubelet
 	kubeClient := testKubelet.fakeKubeClient
 	kubeClient.AddReactor("get", "nodes",
@@ -493,7 +494,7 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 		kubelet.volumeManager)
 
 	// Verify volumes attached
-	assert.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(pod))
+	assert.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(context.TODO(), pod))
 
 	podVolumes := kubelet.volumeManager.GetMountedVolumesForPod(
 		util.GetUniquePodName(pod))

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
 	"net/http"
 	"time"
 

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -107,7 +107,7 @@ func newFakeKubeRuntimeManager(runtimeService internalapi.RuntimeService, imageS
 		memoryThrottlingFactor: 0.8,
 	}
 
-	typedVersion, err := runtimeService.Version(kubeRuntimeAPIVersion)
+	typedVersion, err := runtimeService.Version(context.Background(), kubeRuntimeAPIVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -119,8 +120,8 @@ func (m *kubeGenericRuntimeManager) sandboxToKubeContainer(s *runtimeapi.PodSand
 
 // getImageUser gets uid or user name that will run the command(s) from image. The function
 // guarantees that only one of them is set.
-func (m *kubeGenericRuntimeManager) getImageUser(image string) (*int64, string, error) {
-	resp, err := m.imageService.ImageStatus(&runtimeapi.ImageSpec{Image: image}, false)
+func (m *kubeGenericRuntimeManager) getImageUser(ctx context.Context, image string) (*int64, string, error) {
+	resp, err := m.imageService.ImageStatus(ctx, &runtimeapi.ImageSpec{Image: image}, false)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -225,7 +225,7 @@ func TestGetImageUser(t *testing.T) {
 		i.Images[test.originalImage.name].Username = test.originalImage.username
 		i.Images[test.originalImage.name].Uid = test.originalImage.uid
 
-		uid, username, err := m.getImageUser(test.originalImage.name)
+		uid, username, err := m.getImageUser(context.Background(), test.originalImage.name)
 		assert.NoError(t, err, "TestCase[%d]", j)
 
 		if test.expectedImageUserValues.uid == (*int64)(nil) {

--- a/pkg/kubelet/kuberuntime/instrumented_services.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
 	"time"
 
 	internalapi "k8s.io/cri-api/pkg/apis"
@@ -59,130 +60,130 @@ func recordError(operation string, err error) {
 	}
 }
 
-func (in instrumentedRuntimeService) Version(apiVersion string) (*runtimeapi.VersionResponse, error) {
+func (in instrumentedRuntimeService) Version(ctx context.Context, apiVersion string) (*runtimeapi.VersionResponse, error) {
 	const operation = "version"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.Version(apiVersion)
+	out, err := in.service.Version(ctx, apiVersion)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedRuntimeService) Status(verbose bool) (*runtimeapi.StatusResponse, error) {
+func (in instrumentedRuntimeService) Status(ctx context.Context, verbose bool) (*runtimeapi.StatusResponse, error) {
 	const operation = "status"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.Status(verbose)
+	out, err := in.service.Status(ctx, verbose)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedRuntimeService) CreateContainer(podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+func (in instrumentedRuntimeService) CreateContainer(ctx context.Context, podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	const operation = "create_container"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.CreateContainer(podSandboxID, config, sandboxConfig)
+	out, err := in.service.CreateContainer(ctx, podSandboxID, config, sandboxConfig)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedRuntimeService) StartContainer(containerID string) error {
+func (in instrumentedRuntimeService) StartContainer(ctx context.Context, containerID string) error {
 	const operation = "start_container"
 	defer recordOperation(operation, time.Now())
 
-	err := in.service.StartContainer(containerID)
+	err := in.service.StartContainer(ctx, containerID)
 	recordError(operation, err)
 	return err
 }
 
-func (in instrumentedRuntimeService) StopContainer(containerID string, timeout int64) error {
+func (in instrumentedRuntimeService) StopContainer(ctx context.Context, containerID string, timeout int64) error {
 	const operation = "stop_container"
 	defer recordOperation(operation, time.Now())
 
-	err := in.service.StopContainer(containerID, timeout)
+	err := in.service.StopContainer(ctx, containerID, timeout)
 	recordError(operation, err)
 	return err
 }
 
-func (in instrumentedRuntimeService) RemoveContainer(containerID string) error {
+func (in instrumentedRuntimeService) RemoveContainer(ctx context.Context, containerID string) error {
 	const operation = "remove_container"
 	defer recordOperation(operation, time.Now())
 
-	err := in.service.RemoveContainer(containerID)
+	err := in.service.RemoveContainer(ctx, containerID)
 	recordError(operation, err)
 	return err
 }
 
-func (in instrumentedRuntimeService) ListContainers(filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+func (in instrumentedRuntimeService) ListContainers(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
 	const operation = "list_containers"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.ListContainers(filter)
+	out, err := in.service.ListContainers(ctx, filter)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedRuntimeService) ContainerStatus(containerID string, verbose bool) (*runtimeapi.ContainerStatusResponse, error) {
+func (in instrumentedRuntimeService) ContainerStatus(ctx context.Context, containerID string, verbose bool) (*runtimeapi.ContainerStatusResponse, error) {
 	const operation = "container_status"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.ContainerStatus(containerID, verbose)
+	out, err := in.service.ContainerStatus(ctx, containerID, verbose)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedRuntimeService) UpdateContainerResources(containerID string, resources *runtimeapi.LinuxContainerResources) error {
+func (in instrumentedRuntimeService) UpdateContainerResources(ctx context.Context, containerID string, resources *runtimeapi.LinuxContainerResources) error {
 	const operation = "update_container"
 	defer recordOperation(operation, time.Now())
 
-	err := in.service.UpdateContainerResources(containerID, resources)
+	err := in.service.UpdateContainerResources(ctx, containerID, resources)
 	recordError(operation, err)
 	return err
 }
 
-func (in instrumentedRuntimeService) ReopenContainerLog(containerID string) error {
+func (in instrumentedRuntimeService) ReopenContainerLog(ctx context.Context, containerID string) error {
 	const operation = "reopen_container_log"
 	defer recordOperation(operation, time.Now())
 
-	err := in.service.ReopenContainerLog(containerID)
+	err := in.service.ReopenContainerLog(ctx, containerID)
 	recordError(operation, err)
 	return err
 }
 
-func (in instrumentedRuntimeService) ExecSync(containerID string, cmd []string, timeout time.Duration) ([]byte, []byte, error) {
+func (in instrumentedRuntimeService) ExecSync(ctx context.Context, containerID string, cmd []string, timeout time.Duration) ([]byte, []byte, error) {
 	const operation = "exec_sync"
 	defer recordOperation(operation, time.Now())
 
-	stdout, stderr, err := in.service.ExecSync(containerID, cmd, timeout)
+	stdout, stderr, err := in.service.ExecSync(ctx, containerID, cmd, timeout)
 	recordError(operation, err)
 	return stdout, stderr, err
 }
 
-func (in instrumentedRuntimeService) Exec(req *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+func (in instrumentedRuntimeService) Exec(ctx context.Context, req *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
 	const operation = "exec"
 	defer recordOperation(operation, time.Now())
 
-	resp, err := in.service.Exec(req)
+	resp, err := in.service.Exec(ctx, req)
 	recordError(operation, err)
 	return resp, err
 }
 
-func (in instrumentedRuntimeService) Attach(req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
+func (in instrumentedRuntimeService) Attach(ctx context.Context, req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
 	const operation = "attach"
 	defer recordOperation(operation, time.Now())
 
-	resp, err := in.service.Attach(req)
+	resp, err := in.service.Attach(ctx, req)
 	recordError(operation, err)
 	return resp, err
 }
 
-func (in instrumentedRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error) {
+func (in instrumentedRuntimeService) RunPodSandbox(ctx context.Context, config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error) {
 	const operation = "run_podsandbox"
 	startTime := time.Now()
 	defer recordOperation(operation, startTime)
 	defer metrics.RunPodSandboxDuration.WithLabelValues(runtimeHandler).Observe(metrics.SinceInSeconds(startTime))
 
-	out, err := in.service.RunPodSandbox(config, runtimeHandler)
+	out, err := in.service.RunPodSandbox(ctx, config, runtimeHandler)
 	recordError(operation, err)
 	if err != nil {
 		metrics.RunPodSandboxErrors.WithLabelValues(runtimeHandler).Inc()
@@ -190,137 +191,137 @@ func (in instrumentedRuntimeService) RunPodSandbox(config *runtimeapi.PodSandbox
 	return out, err
 }
 
-func (in instrumentedRuntimeService) StopPodSandbox(podSandboxID string) error {
+func (in instrumentedRuntimeService) StopPodSandbox(ctx context.Context, podSandboxID string) error {
 	const operation = "stop_podsandbox"
 	defer recordOperation(operation, time.Now())
 
-	err := in.service.StopPodSandbox(podSandboxID)
+	err := in.service.StopPodSandbox(ctx, podSandboxID)
 	recordError(operation, err)
 	return err
 }
 
-func (in instrumentedRuntimeService) RemovePodSandbox(podSandboxID string) error {
+func (in instrumentedRuntimeService) RemovePodSandbox(ctx context.Context, podSandboxID string) error {
 	const operation = "remove_podsandbox"
 	defer recordOperation(operation, time.Now())
 
-	err := in.service.RemovePodSandbox(podSandboxID)
+	err := in.service.RemovePodSandbox(ctx, podSandboxID)
 	recordError(operation, err)
 	return err
 }
 
-func (in instrumentedRuntimeService) PodSandboxStatus(podSandboxID string, verbose bool) (*runtimeapi.PodSandboxStatusResponse, error) {
+func (in instrumentedRuntimeService) PodSandboxStatus(ctx context.Context, podSandboxID string, verbose bool) (*runtimeapi.PodSandboxStatusResponse, error) {
 	const operation = "podsandbox_status"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.PodSandboxStatus(podSandboxID, verbose)
+	out, err := in.service.PodSandboxStatus(ctx, podSandboxID, verbose)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedRuntimeService) ListPodSandbox(filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
+func (in instrumentedRuntimeService) ListPodSandbox(ctx context.Context, filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
 	const operation = "list_podsandbox"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.ListPodSandbox(filter)
+	out, err := in.service.ListPodSandbox(ctx, filter)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedRuntimeService) ContainerStats(containerID string) (*runtimeapi.ContainerStats, error) {
+func (in instrumentedRuntimeService) ContainerStats(ctx context.Context, containerID string) (*runtimeapi.ContainerStats, error) {
 	const operation = "container_stats"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.ContainerStats(containerID)
+	out, err := in.service.ContainerStats(ctx, containerID)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedRuntimeService) ListContainerStats(filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error) {
+func (in instrumentedRuntimeService) ListContainerStats(ctx context.Context, filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error) {
 	const operation = "list_container_stats"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.ListContainerStats(filter)
+	out, err := in.service.ListContainerStats(ctx, filter)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedRuntimeService) PodSandboxStats(podSandboxID string) (*runtimeapi.PodSandboxStats, error) {
+func (in instrumentedRuntimeService) PodSandboxStats(ctx context.Context, podSandboxID string) (*runtimeapi.PodSandboxStats, error) {
 	const operation = "podsandbox_stats"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.PodSandboxStats(podSandboxID)
+	out, err := in.service.PodSandboxStats(ctx, podSandboxID)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedRuntimeService) ListPodSandboxStats(filter *runtimeapi.PodSandboxStatsFilter) ([]*runtimeapi.PodSandboxStats, error) {
+func (in instrumentedRuntimeService) ListPodSandboxStats(ctx context.Context, filter *runtimeapi.PodSandboxStatsFilter) ([]*runtimeapi.PodSandboxStats, error) {
 	const operation = "list_podsandbox_stats"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.ListPodSandboxStats(filter)
+	out, err := in.service.ListPodSandboxStats(ctx, filter)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedRuntimeService) PortForward(req *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
+func (in instrumentedRuntimeService) PortForward(ctx context.Context, req *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
 	const operation = "port_forward"
 	defer recordOperation(operation, time.Now())
 
-	resp, err := in.service.PortForward(req)
+	resp, err := in.service.PortForward(ctx, req)
 	recordError(operation, err)
 	return resp, err
 }
 
-func (in instrumentedRuntimeService) UpdateRuntimeConfig(runtimeConfig *runtimeapi.RuntimeConfig) error {
+func (in instrumentedRuntimeService) UpdateRuntimeConfig(ctx context.Context, runtimeConfig *runtimeapi.RuntimeConfig) error {
 	const operation = "update_runtime_config"
 	defer recordOperation(operation, time.Now())
 
-	err := in.service.UpdateRuntimeConfig(runtimeConfig)
+	err := in.service.UpdateRuntimeConfig(ctx, runtimeConfig)
 	recordError(operation, err)
 	return err
 }
 
-func (in instrumentedImageManagerService) ListImages(filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error) {
+func (in instrumentedImageManagerService) ListImages(ctx context.Context, filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error) {
 	const operation = "list_images"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.ListImages(filter)
+	out, err := in.service.ListImages(ctx, filter)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedImageManagerService) ImageStatus(image *runtimeapi.ImageSpec, verbose bool) (*runtimeapi.ImageStatusResponse, error) {
+func (in instrumentedImageManagerService) ImageStatus(ctx context.Context, image *runtimeapi.ImageSpec, verbose bool) (*runtimeapi.ImageStatusResponse, error) {
 	const operation = "image_status"
 	defer recordOperation(operation, time.Now())
 
-	out, err := in.service.ImageStatus(image, verbose)
+	out, err := in.service.ImageStatus(ctx, image, verbose)
 	recordError(operation, err)
 	return out, err
 }
 
-func (in instrumentedImageManagerService) PullImage(image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+func (in instrumentedImageManagerService) PullImage(ctx context.Context, image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	const operation = "pull_image"
 	defer recordOperation(operation, time.Now())
 
-	imageRef, err := in.service.PullImage(image, auth, podSandboxConfig)
+	imageRef, err := in.service.PullImage(ctx, image, auth, podSandboxConfig)
 	recordError(operation, err)
 	return imageRef, err
 }
 
-func (in instrumentedImageManagerService) RemoveImage(image *runtimeapi.ImageSpec) error {
+func (in instrumentedImageManagerService) RemoveImage(ctx context.Context, image *runtimeapi.ImageSpec) error {
 	const operation = "remove_image"
 	defer recordOperation(operation, time.Now())
 
-	err := in.service.RemoveImage(image)
+	err := in.service.RemoveImage(ctx, image)
 	recordError(operation, err)
 	return err
 }
 
-func (in instrumentedImageManagerService) ImageFsInfo() ([]*runtimeapi.FilesystemUsage, error) {
+func (in instrumentedImageManagerService) ImageFsInfo(ctx context.Context) ([]*runtimeapi.FilesystemUsage, error) {
 	const operation = "image_fs_info"
 	defer recordOperation(operation, time.Now())
 
-	fsInfo, err := in.service.ImageFsInfo()
+	fsInfo, err := in.service.ImageFsInfo(ctx)
 	recordError(operation, err)
 	return fsInfo, nil
 }

--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"testing"
@@ -72,7 +73,7 @@ func TestRecordOperation(t *testing.T) {
 func TestInstrumentedVersion(t *testing.T) {
 	fakeRuntime, _, _, _ := createTestRuntimeManager()
 	irs := newInstrumentedRuntimeService(fakeRuntime)
-	vr, err := irs.Version("1")
+	vr, err := irs.Version(context.Background(), "1")
 	assert.NoError(t, err)
 	assert.Equal(t, kubeRuntimeAPIVersion, vr.Version)
 }
@@ -86,7 +87,7 @@ func TestStatus(t *testing.T) {
 		},
 	}
 	irs := newInstrumentedRuntimeService(fakeRuntime)
-	actural, err := irs.Status(false)
+	actural, err := irs.Status(context.Background(), false)
 	assert.NoError(t, err)
 	expected := &runtimeapi.RuntimeStatus{
 		Conditions: []*runtimeapi.RuntimeCondition{

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -173,7 +173,7 @@ func calcRestartCountByLogDir(path string) (int, error) {
 // * create the container
 // * start the container
 // * run the post start lifecycle hooks (if applicable)
-func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandboxConfig *runtimeapi.PodSandboxConfig, spec *startSpec, pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, podIP string, podIPs []string) (string, error) {
+func (m *kubeGenericRuntimeManager) startContainer(ctx context.Context, podSandboxID string, podSandboxConfig *runtimeapi.PodSandboxConfig, spec *startSpec, pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, podIP string, podIPs []string) (string, error) {
 	container := spec.container
 
 	// Step 1: pull the image.
@@ -215,7 +215,7 @@ func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandb
 		return s.Message(), ErrCreateContainerConfig
 	}
 
-	containerConfig, cleanupAction, err := m.generateContainerConfig(container, pod, restartCount, podIP, imageRef, podIPs, target)
+	containerConfig, cleanupAction, err := m.generateContainerConfig(ctx, container, pod, restartCount, podIP, imageRef, podIPs, target)
 	if cleanupAction != nil {
 		defer cleanupAction()
 	}
@@ -232,7 +232,7 @@ func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandb
 		return s.Message(), ErrPreCreateHook
 	}
 
-	containerID, err := m.runtimeService.CreateContainer(podSandboxID, containerConfig, podSandboxConfig)
+	containerID, err := m.runtimeService.CreateContainer(ctx, podSandboxID, containerConfig, podSandboxConfig)
 	if err != nil {
 		s, _ := grpcstatus.FromError(err)
 		m.recordContainerEvent(pod, container, containerID, v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", s.Message())
@@ -247,7 +247,7 @@ func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandb
 	m.recordContainerEvent(pod, container, containerID, v1.EventTypeNormal, events.CreatedContainer, fmt.Sprintf("Created container %s", container.Name))
 
 	// Step 3: start the container.
-	err = m.runtimeService.StartContainer(containerID)
+	err = m.runtimeService.StartContainer(ctx, containerID)
 	if err != nil {
 		s, _ := grpcstatus.FromError(err)
 		m.recordContainerEvent(pod, container, containerID, v1.EventTypeWarning, events.FailedToStartContainer, "Error: %v", s.Message())
@@ -280,12 +280,12 @@ func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandb
 			Type: m.runtimeName,
 			ID:   containerID,
 		}
-		msg, handlerErr := m.runner.Run(kubeContainerID, pod, container, container.Lifecycle.PostStart)
+		msg, handlerErr := m.runner.Run(ctx, kubeContainerID, pod, container, container.Lifecycle.PostStart)
 		if handlerErr != nil {
 			klog.ErrorS(handlerErr, "Failed to execute PostStartHook", "pod", klog.KObj(pod),
 				"podUID", pod.UID, "containerName", container.Name, "containerID", kubeContainerID.String())
 			m.recordContainerEvent(pod, container, kubeContainerID.ID, v1.EventTypeWarning, events.FailedPostStartHook, msg)
-			if err := m.killContainer(pod, kubeContainerID, container.Name, "FailedPostStartHook", reasonFailedPostStartHook, nil); err != nil {
+			if err := m.killContainer(ctx, pod, kubeContainerID, container.Name, "FailedPostStartHook", reasonFailedPostStartHook, nil); err != nil {
 				klog.ErrorS(err, "Failed to kill container", "pod", klog.KObj(pod),
 					"podUID", pod.UID, "containerName", container.Name, "containerID", kubeContainerID.String())
 			}
@@ -297,13 +297,13 @@ func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandb
 }
 
 // generateContainerConfig generates container config for kubelet runtime v1.
-func (m *kubeGenericRuntimeManager) generateContainerConfig(container *v1.Container, pod *v1.Pod, restartCount int, podIP, imageRef string, podIPs []string, nsTarget *kubecontainer.ContainerID) (*runtimeapi.ContainerConfig, func(), error) {
+func (m *kubeGenericRuntimeManager) generateContainerConfig(ctx context.Context, container *v1.Container, pod *v1.Pod, restartCount int, podIP, imageRef string, podIPs []string, nsTarget *kubecontainer.ContainerID) (*runtimeapi.ContainerConfig, func(), error) {
 	opts, cleanupAction, err := m.runtimeHelper.GenerateRunContainerOptions(pod, container, podIP, podIPs)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	uid, username, err := m.getImageUser(container.Image)
+	uid, username, err := m.getImageUser(ctx, container.Image)
 	if err != nil {
 		return nil, cleanupAction, err
 	}
@@ -434,7 +434,7 @@ func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerO
 // getKubeletContainers lists containers managed by kubelet.
 // The boolean parameter specifies whether returns all containers including
 // those already exited and dead containers (used for garbage collection).
-func (m *kubeGenericRuntimeManager) getKubeletContainers(allContainers bool) ([]*runtimeapi.Container, error) {
+func (m *kubeGenericRuntimeManager) getKubeletContainers(ctx context.Context, allContainers bool) ([]*runtimeapi.Container, error) {
 	filter := &runtimeapi.ContainerFilter{}
 	if !allContainers {
 		filter.State = &runtimeapi.ContainerStateValue{
@@ -442,7 +442,7 @@ func (m *kubeGenericRuntimeManager) getKubeletContainers(allContainers bool) ([]
 		}
 	}
 
-	containers, err := m.runtimeService.ListContainers(filter)
+	containers, err := m.runtimeService.ListContainers(ctx, filter)
 	if err != nil {
 		klog.ErrorS(err, "ListContainers failed")
 		return nil, err
@@ -493,9 +493,9 @@ func (m *kubeGenericRuntimeManager) readLastStringFromContainerLogs(path string)
 }
 
 // getPodContainerStatuses gets all containers' statuses for the pod.
-func (m *kubeGenericRuntimeManager) getPodContainerStatuses(uid kubetypes.UID, name, namespace string) ([]*kubecontainer.Status, error) {
+func (m *kubeGenericRuntimeManager) getPodContainerStatuses(ctx context.Context, uid kubetypes.UID, name, namespace string) ([]*kubecontainer.Status, error) {
 	// Select all containers of the given pod.
-	containers, err := m.runtimeService.ListContainers(&runtimeapi.ContainerFilter{
+	containers, err := m.runtimeService.ListContainers(ctx, &runtimeapi.ContainerFilter{
 		LabelSelector: map[string]string{types.KubernetesPodUIDLabel: string(uid)},
 	})
 	if err != nil {
@@ -506,7 +506,7 @@ func (m *kubeGenericRuntimeManager) getPodContainerStatuses(uid kubetypes.UID, n
 	statuses := []*kubecontainer.Status{}
 	// TODO: optimization: set maximum number of containers per container name to examine.
 	for _, c := range containers {
-		resp, err := m.runtimeService.ContainerStatus(c.Id, false)
+		resp, err := m.runtimeService.ContainerStatus(ctx, c.Id, false)
 		// Between List (ListContainers) and check (ContainerStatus) another thread might remove a container, and that is normal.
 		// The previous call (ListContainers) never fails due to a pod container not existing.
 		// Therefore, this method should not either, but instead act as if the previous call failed,
@@ -581,7 +581,7 @@ func toKubeContainerStatus(status *runtimeapi.ContainerStatus, runtimeName strin
 }
 
 // executePreStopHook runs the pre-stop lifecycle hooks if applicable and returns the duration it takes.
-func (m *kubeGenericRuntimeManager) executePreStopHook(pod *v1.Pod, containerID kubecontainer.ContainerID, containerSpec *v1.Container, gracePeriod int64) int64 {
+func (m *kubeGenericRuntimeManager) executePreStopHook(ctx context.Context, pod *v1.Pod, containerID kubecontainer.ContainerID, containerSpec *v1.Container, gracePeriod int64) int64 {
 	klog.V(3).InfoS("Running preStop hook", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerSpec.Name, "containerID", containerID.String())
 
 	start := metav1.Now()
@@ -589,7 +589,7 @@ func (m *kubeGenericRuntimeManager) executePreStopHook(pod *v1.Pod, containerID 
 	go func() {
 		defer close(done)
 		defer utilruntime.HandleCrash()
-		if msg, err := m.runner.Run(containerID, pod, containerSpec, containerSpec.Lifecycle.PreStop); err != nil {
+		if msg, err := m.runner.Run(ctx, containerID, pod, containerSpec, containerSpec.Lifecycle.PreStop); err != nil {
 			klog.ErrorS(err, "PreStop hook failed", "pod", klog.KObj(pod), "podUID", pod.UID,
 				"containerName", containerSpec.Name, "containerID", containerID.String())
 			m.recordContainerEvent(pod, containerSpec, containerID.ID, v1.EventTypeWarning, events.FailedPreStopHook, msg)
@@ -616,10 +616,10 @@ func (m *kubeGenericRuntimeManager) executePreStopHook(pod *v1.Pod, containerID 
 // TODO(random-liu): Add a node e2e test to test this behaviour.
 // TODO(random-liu): Change the lifecycle handler to just accept information needed, so that we can
 // just pass the needed function not create the fake object.
-func (m *kubeGenericRuntimeManager) restoreSpecsFromContainerLabels(containerID kubecontainer.ContainerID) (*v1.Pod, *v1.Container, error) {
+func (m *kubeGenericRuntimeManager) restoreSpecsFromContainerLabels(ctx context.Context, containerID kubecontainer.ContainerID) (*v1.Pod, *v1.Container, error) {
 	var pod *v1.Pod
 	var container *v1.Container
-	resp, err := m.runtimeService.ContainerStatus(containerID.ID, false)
+	resp, err := m.runtimeService.ContainerStatus(ctx, containerID.ID, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -659,7 +659,7 @@ func (m *kubeGenericRuntimeManager) restoreSpecsFromContainerLabels(containerID 
 // killContainer kills a container through the following steps:
 // * Run the pre-stop lifecycle hooks (if applicable).
 // * Stop the container.
-func (m *kubeGenericRuntimeManager) killContainer(pod *v1.Pod, containerID kubecontainer.ContainerID, containerName string, message string, reason containerKillReason, gracePeriodOverride *int64) error {
+func (m *kubeGenericRuntimeManager) killContainer(ctx context.Context, pod *v1.Pod, containerID kubecontainer.ContainerID, containerName string, message string, reason containerKillReason, gracePeriodOverride *int64) error {
 	var containerSpec *v1.Container
 	if pod != nil {
 		if containerSpec = kubecontainer.GetContainerSpec(pod, containerName); containerSpec == nil {
@@ -668,7 +668,7 @@ func (m *kubeGenericRuntimeManager) killContainer(pod *v1.Pod, containerID kubec
 		}
 	} else {
 		// Restore necessary information if one of the specs is nil.
-		restoredPod, restoredContainer, err := m.restoreSpecsFromContainerLabels(containerID)
+		restoredPod, restoredContainer, err := m.restoreSpecsFromContainerLabels(ctx, containerID)
 		if err != nil {
 			return err
 		}
@@ -707,7 +707,7 @@ func (m *kubeGenericRuntimeManager) killContainer(pod *v1.Pod, containerID kubec
 
 	// Run the pre-stop lifecycle hooks if applicable and if there is enough time to run it
 	if containerSpec.Lifecycle != nil && containerSpec.Lifecycle.PreStop != nil && gracePeriod > 0 {
-		gracePeriod = gracePeriod - m.executePreStopHook(pod, containerID, containerSpec, gracePeriod)
+		gracePeriod = gracePeriod - m.executePreStopHook(ctx, pod, containerID, containerSpec, gracePeriod)
 	}
 	// always give containers a minimal shutdown window to avoid unnecessary SIGKILLs
 	if gracePeriod < minimumGracePeriodInSeconds {
@@ -722,7 +722,7 @@ func (m *kubeGenericRuntimeManager) killContainer(pod *v1.Pod, containerID kubec
 	klog.V(2).InfoS("Killing container with a grace period", "pod", klog.KObj(pod), "podUID", pod.UID,
 		"containerName", containerName, "containerID", containerID.String(), "gracePeriod", gracePeriod)
 
-	err := m.runtimeService.StopContainer(containerID.ID, gracePeriod)
+	err := m.runtimeService.StopContainer(ctx, containerID.ID, gracePeriod)
 	if err != nil && !crierror.IsNotFound(err) {
 		klog.ErrorS(err, "Container termination failed with gracePeriod", "pod", klog.KObj(pod), "podUID", pod.UID,
 			"containerName", containerName, "containerID", containerID.String(), "gracePeriod", gracePeriod)
@@ -735,7 +735,7 @@ func (m *kubeGenericRuntimeManager) killContainer(pod *v1.Pod, containerID kubec
 }
 
 // killContainersWithSyncResult kills all pod's containers with sync results.
-func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) (syncResults []*kubecontainer.SyncResult) {
+func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) (syncResults []*kubecontainer.SyncResult) {
 	containerResults := make(chan *kubecontainer.SyncResult, len(runningPod.Containers))
 	wg := sync.WaitGroup{}
 
@@ -746,7 +746,7 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(pod *v1.Pod, ru
 			defer wg.Done()
 
 			killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, container.Name)
-			if err := m.killContainer(pod, container.ID, container.Name, "", reasonUnknown, gracePeriodOverride); err != nil {
+			if err := m.killContainer(ctx, pod, container.ID, container.Name, "", reasonUnknown, gracePeriodOverride); err != nil {
 				killContainerResult.Fail(kubecontainer.ErrKillContainer, err.Error())
 				// Use runningPod for logging as the pod passed in could be *nil*.
 				klog.ErrorS(err, "Kill container failed", "pod", klog.KRef(runningPod.Namespace, runningPod.Name), "podUID", runningPod.ID,
@@ -768,7 +768,7 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(pod *v1.Pod, ru
 // containers, we have reduced the number of outstanding init containers still
 // present. This reduces load on the container garbage collector by only
 // preserving the most recent terminated init container.
-func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(pod *v1.Pod, podStatus *kubecontainer.PodStatus) {
+func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus) {
 	// only the last execution of each init container should be preserved, and only preserve it if it is in the
 	// list of init containers to keep.
 	initContainerNames := sets.NewString()
@@ -793,7 +793,7 @@ func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(pod *v1.Pod, 
 			}
 			// prune all other init containers that match this container name
 			klog.V(4).InfoS("Removing init container", "containerName", status.Name, "containerID", status.ID.ID, "count", count)
-			if err := m.removeContainer(status.ID.ID); err != nil {
+			if err := m.removeContainer(ctx, status.ID.ID); err != nil {
 				utilruntime.HandleError(fmt.Errorf("failed to remove pod init container %q: %v; Skipping pod %q", status.Name, err, format.Pod(pod)))
 				continue
 			}
@@ -804,7 +804,7 @@ func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(pod *v1.Pod, 
 // Remove all init containers. Note that this function does not check the state
 // of the container because it assumes all init containers have been stopped
 // before the call happens.
-func (m *kubeGenericRuntimeManager) purgeInitContainers(pod *v1.Pod, podStatus *kubecontainer.PodStatus) {
+func (m *kubeGenericRuntimeManager) purgeInitContainers(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus) {
 	initContainerNames := sets.NewString()
 	for _, container := range pod.Spec.InitContainers {
 		initContainerNames.Insert(container.Name)
@@ -818,7 +818,7 @@ func (m *kubeGenericRuntimeManager) purgeInitContainers(pod *v1.Pod, podStatus *
 			count++
 			// Purge all init containers that match this container name
 			klog.V(4).InfoS("Removing init container", "containerName", status.Name, "containerID", status.ID.ID, "count", count)
-			if err := m.removeContainer(status.ID.ID); err != nil {
+			if err := m.removeContainer(ctx, status.ID.ID); err != nil {
 				utilruntime.HandleError(fmt.Errorf("failed to remove pod init container %q: %v; Skipping pod %q", status.Name, err, format.Pod(pod)))
 				continue
 			}
@@ -885,7 +885,7 @@ func findNextInitContainerToRun(pod *v1.Pod, podStatus *kubecontainer.PodStatus)
 
 // GetContainerLogs returns logs of a specific container.
 func (m *kubeGenericRuntimeManager) GetContainerLogs(ctx context.Context, pod *v1.Pod, containerID kubecontainer.ContainerID, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) (err error) {
-	resp, err := m.runtimeService.ContainerStatus(containerID.ID, false)
+	resp, err := m.runtimeService.ContainerStatus(ctx, containerID.ID, false)
 	if err != nil {
 		klog.V(4).InfoS("Failed to get container status", "containerID", containerID.String(), "err", err)
 		return fmt.Errorf("unable to retrieve container logs for %v", containerID.String())
@@ -898,7 +898,7 @@ func (m *kubeGenericRuntimeManager) GetContainerLogs(ctx context.Context, pod *v
 }
 
 // GetExec gets the endpoint the runtime will serve the exec request from.
-func (m *kubeGenericRuntimeManager) GetExec(id kubecontainer.ContainerID, cmd []string, stdin, stdout, stderr, tty bool) (*url.URL, error) {
+func (m *kubeGenericRuntimeManager) GetExec(ctx context.Context, id kubecontainer.ContainerID, cmd []string, stdin, stdout, stderr, tty bool) (*url.URL, error) {
 	req := &runtimeapi.ExecRequest{
 		ContainerId: id.ID,
 		Cmd:         cmd,
@@ -907,7 +907,7 @@ func (m *kubeGenericRuntimeManager) GetExec(id kubecontainer.ContainerID, cmd []
 		Stdout:      stdout,
 		Stderr:      stderr,
 	}
-	resp, err := m.runtimeService.Exec(req)
+	resp, err := m.runtimeService.Exec(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -916,7 +916,7 @@ func (m *kubeGenericRuntimeManager) GetExec(id kubecontainer.ContainerID, cmd []
 }
 
 // GetAttach gets the endpoint the runtime will serve the attach request from.
-func (m *kubeGenericRuntimeManager) GetAttach(id kubecontainer.ContainerID, stdin, stdout, stderr, tty bool) (*url.URL, error) {
+func (m *kubeGenericRuntimeManager) GetAttach(ctx context.Context, id kubecontainer.ContainerID, stdin, stdout, stderr, tty bool) (*url.URL, error) {
 	req := &runtimeapi.AttachRequest{
 		ContainerId: id.ID,
 		Stdin:       stdin,
@@ -924,7 +924,7 @@ func (m *kubeGenericRuntimeManager) GetAttach(id kubecontainer.ContainerID, stdi
 		Stderr:      stderr,
 		Tty:         tty,
 	}
-	resp, err := m.runtimeService.Attach(req)
+	resp, err := m.runtimeService.Attach(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -932,8 +932,8 @@ func (m *kubeGenericRuntimeManager) GetAttach(id kubecontainer.ContainerID, stdi
 }
 
 // RunInContainer synchronously executes the command in the container, and returns the output.
-func (m *kubeGenericRuntimeManager) RunInContainer(id kubecontainer.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
-	stdout, stderr, err := m.runtimeService.ExecSync(id.ID, cmd, timeout)
+func (m *kubeGenericRuntimeManager) RunInContainer(ctx context.Context, id kubecontainer.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
+	stdout, stderr, err := m.runtimeService.ExecSync(ctx, id.ID, cmd, timeout)
 	// NOTE(tallclair): This does not correctly interleave stdout & stderr, but should be sufficient
 	// for logging purposes. A combined output option will need to be added to the ExecSyncRequest
 	// if more precise output ordering is ever required.
@@ -946,7 +946,7 @@ func (m *kubeGenericRuntimeManager) RunInContainer(id kubecontainer.ContainerID,
 // that container logs to be removed with the container.
 // Notice that we assume that the container should only be removed in non-running state, and
 // it will not write container logs anymore in that state.
-func (m *kubeGenericRuntimeManager) removeContainer(containerID string) error {
+func (m *kubeGenericRuntimeManager) removeContainer(ctx context.Context, containerID string) error {
 	klog.V(4).InfoS("Removing container", "containerID", containerID)
 	// Call internal container post-stop lifecycle hook.
 	if err := m.internalLifecycle.PostStopContainer(containerID); err != nil {
@@ -955,22 +955,22 @@ func (m *kubeGenericRuntimeManager) removeContainer(containerID string) error {
 
 	// Remove the container log.
 	// TODO: Separate log and container lifecycle management.
-	if err := m.removeContainerLog(containerID); err != nil {
+	if err := m.removeContainerLog(ctx, containerID); err != nil {
 		return err
 	}
 	// Remove the container.
-	return m.runtimeService.RemoveContainer(containerID)
+	return m.runtimeService.RemoveContainer(ctx, containerID)
 }
 
 // removeContainerLog removes the container log.
-func (m *kubeGenericRuntimeManager) removeContainerLog(containerID string) error {
+func (m *kubeGenericRuntimeManager) removeContainerLog(ctx context.Context, containerID string) error {
 	// Use log manager to remove rotated logs.
-	err := m.logManager.Clean(containerID)
+	err := m.logManager.Clean(ctx, containerID)
 	if err != nil {
 		return err
 	}
 
-	resp, err := m.runtimeService.ContainerStatus(containerID, false)
+	resp, err := m.runtimeService.ContainerStatus(ctx, containerID, false)
 	if err != nil {
 		return fmt.Errorf("failed to get container status %q: %v", containerID, err)
 	}
@@ -991,6 +991,6 @@ func (m *kubeGenericRuntimeManager) removeContainerLog(containerID string) error
 }
 
 // DeleteContainer removes a container.
-func (m *kubeGenericRuntimeManager) DeleteContainer(containerID kubecontainer.ContainerID) error {
-	return m.removeContainer(containerID.ID)
+func (m *kubeGenericRuntimeManager) DeleteContainer(ctx context.Context, containerID kubecontainer.ContainerID) error {
+	return m.removeContainer(ctx, containerID.ID)
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -111,18 +112,18 @@ func (a sandboxByCreated) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a sandboxByCreated) Less(i, j int) bool { return a[i].createTime.After(a[j].createTime) }
 
 // enforceMaxContainersPerEvictUnit enforces MaxPerPodContainer for each evictUnit.
-func (cgc *containerGC) enforceMaxContainersPerEvictUnit(evictUnits containersByEvictUnit, MaxContainers int) {
+func (cgc *containerGC) enforceMaxContainersPerEvictUnit(ctx context.Context, evictUnits containersByEvictUnit, MaxContainers int) {
 	for key := range evictUnits {
 		toRemove := len(evictUnits[key]) - MaxContainers
 
 		if toRemove > 0 {
-			evictUnits[key] = cgc.removeOldestN(evictUnits[key], toRemove)
+			evictUnits[key] = cgc.removeOldestN(ctx, evictUnits[key], toRemove)
 		}
 	}
 }
 
 // removeOldestN removes the oldest toRemove containers and returns the resulting slice.
-func (cgc *containerGC) removeOldestN(containers []containerGCInfo, toRemove int) []containerGCInfo {
+func (cgc *containerGC) removeOldestN(ctx context.Context, containers []containerGCInfo, toRemove int) []containerGCInfo {
 	// Remove from oldest to newest (last to first).
 	numToKeep := len(containers) - toRemove
 	if numToKeep > 0 {
@@ -137,12 +138,12 @@ func (cgc *containerGC) removeOldestN(containers []containerGCInfo, toRemove int
 				ID:   containers[i].id,
 			}
 			message := "Container is in unknown state, try killing it before removal"
-			if err := cgc.manager.killContainer(nil, id, containers[i].name, message, reasonUnknown, nil); err != nil {
+			if err := cgc.manager.killContainer(ctx, nil, id, containers[i].name, message, reasonUnknown, nil); err != nil {
 				klog.ErrorS(err, "Failed to stop container", "containerID", containers[i].id)
 				continue
 			}
 		}
-		if err := cgc.manager.removeContainer(containers[i].id); err != nil {
+		if err := cgc.manager.removeContainer(ctx, containers[i].id); err != nil {
 			klog.ErrorS(err, "Failed to remove container", "containerID", containers[i].id)
 		}
 	}
@@ -153,7 +154,7 @@ func (cgc *containerGC) removeOldestN(containers []containerGCInfo, toRemove int
 
 // removeOldestNSandboxes removes the oldest inactive toRemove sandboxes and
 // returns the resulting slice.
-func (cgc *containerGC) removeOldestNSandboxes(sandboxes []sandboxGCInfo, toRemove int) {
+func (cgc *containerGC) removeOldestNSandboxes(ctx context.Context, sandboxes []sandboxGCInfo, toRemove int) {
 	numToKeep := len(sandboxes) - toRemove
 	if numToKeep > 0 {
 		sort.Sort(sandboxByCreated(sandboxes))
@@ -161,30 +162,30 @@ func (cgc *containerGC) removeOldestNSandboxes(sandboxes []sandboxGCInfo, toRemo
 	// Remove from oldest to newest (last to first).
 	for i := len(sandboxes) - 1; i >= numToKeep; i-- {
 		if !sandboxes[i].active {
-			cgc.removeSandbox(sandboxes[i].id)
+			cgc.removeSandbox(ctx, sandboxes[i].id)
 		}
 	}
 }
 
 // removeSandbox removes the sandbox by sandboxID.
-func (cgc *containerGC) removeSandbox(sandboxID string) {
+func (cgc *containerGC) removeSandbox(ctx context.Context, sandboxID string) {
 	klog.V(4).InfoS("Removing sandbox", "sandboxID", sandboxID)
 	// In normal cases, kubelet should've already called StopPodSandbox before
 	// GC kicks in. To guard against the rare cases where this is not true, try
 	// stopping the sandbox before removing it.
-	if err := cgc.client.StopPodSandbox(sandboxID); err != nil {
+	if err := cgc.client.StopPodSandbox(ctx, sandboxID); err != nil {
 		klog.ErrorS(err, "Failed to stop sandbox before removing", "sandboxID", sandboxID)
 		return
 	}
-	if err := cgc.client.RemovePodSandbox(sandboxID); err != nil {
+	if err := cgc.client.RemovePodSandbox(ctx, sandboxID); err != nil {
 		klog.ErrorS(err, "Failed to remove sandbox", "sandboxID", sandboxID)
 	}
 }
 
 // evictableContainers gets all containers that are evictable. Evictable containers are: not running
 // and created more than MinAge ago.
-func (cgc *containerGC) evictableContainers(minAge time.Duration) (containersByEvictUnit, error) {
-	containers, err := cgc.manager.getKubeletContainers(true)
+func (cgc *containerGC) evictableContainers(ctx context.Context, minAge time.Duration) (containersByEvictUnit, error) {
+	containers, err := cgc.manager.getKubeletContainers(ctx, true)
 	if err != nil {
 		return containersByEvictUnit{}, err
 	}
@@ -220,9 +221,9 @@ func (cgc *containerGC) evictableContainers(minAge time.Duration) (containersByE
 }
 
 // evict all containers that are evictable
-func (cgc *containerGC) evictContainers(gcPolicy kubecontainer.GCPolicy, allSourcesReady bool, evictNonDeletedPods bool) error {
+func (cgc *containerGC) evictContainers(ctx context.Context, gcPolicy kubecontainer.GCPolicy, allSourcesReady bool, evictNonDeletedPods bool) error {
 	// Separate containers by evict units.
-	evictUnits, err := cgc.evictableContainers(gcPolicy.MinAge)
+	evictUnits, err := cgc.evictableContainers(ctx, gcPolicy.MinAge)
 	if err != nil {
 		return err
 	}
@@ -231,7 +232,7 @@ func (cgc *containerGC) evictContainers(gcPolicy kubecontainer.GCPolicy, allSour
 	if allSourcesReady {
 		for key, unit := range evictUnits {
 			if cgc.podStateProvider.ShouldPodContentBeRemoved(key.uid) || (evictNonDeletedPods && cgc.podStateProvider.ShouldPodRuntimeBeRemoved(key.uid)) {
-				cgc.removeOldestN(unit, len(unit)) // Remove all.
+				cgc.removeOldestN(ctx, unit, len(unit)) // Remove all.
 				delete(evictUnits, key)
 			}
 		}
@@ -239,7 +240,7 @@ func (cgc *containerGC) evictContainers(gcPolicy kubecontainer.GCPolicy, allSour
 
 	// Enforce max containers per evict unit.
 	if gcPolicy.MaxPerPodContainer >= 0 {
-		cgc.enforceMaxContainersPerEvictUnit(evictUnits, gcPolicy.MaxPerPodContainer)
+		cgc.enforceMaxContainersPerEvictUnit(ctx, evictUnits, gcPolicy.MaxPerPodContainer)
 	}
 
 	// Enforce max total number of containers.
@@ -249,7 +250,7 @@ func (cgc *containerGC) evictContainers(gcPolicy kubecontainer.GCPolicy, allSour
 		if numContainersPerEvictUnit < 1 {
 			numContainersPerEvictUnit = 1
 		}
-		cgc.enforceMaxContainersPerEvictUnit(evictUnits, numContainersPerEvictUnit)
+		cgc.enforceMaxContainersPerEvictUnit(ctx, evictUnits, numContainersPerEvictUnit)
 
 		// If we still need to evict, evict oldest first.
 		numContainers := evictUnits.NumContainers()
@@ -260,7 +261,7 @@ func (cgc *containerGC) evictContainers(gcPolicy kubecontainer.GCPolicy, allSour
 			}
 			sort.Sort(byCreated(flattened))
 
-			cgc.removeOldestN(flattened, numContainers-gcPolicy.MaxContainers)
+			cgc.removeOldestN(ctx, flattened, numContainers-gcPolicy.MaxContainers)
 		}
 	}
 	return nil
@@ -272,13 +273,13 @@ func (cgc *containerGC) evictContainers(gcPolicy kubecontainer.GCPolicy, allSour
 //   2. contains no containers.
 //   3. belong to a non-existent (i.e., already removed) pod, or is not the
 //      most recently created sandbox for the pod.
-func (cgc *containerGC) evictSandboxes(evictNonDeletedPods bool) error {
-	containers, err := cgc.manager.getKubeletContainers(true)
+func (cgc *containerGC) evictSandboxes(ctx context.Context, evictNonDeletedPods bool) error {
+	containers, err := cgc.manager.getKubeletContainers(ctx, true)
 	if err != nil {
 		return err
 	}
 
-	sandboxes, err := cgc.manager.getKubeletSandboxes(true)
+	sandboxes, err := cgc.manager.getKubeletSandboxes(ctx, true)
 	if err != nil {
 		return err
 	}
@@ -315,10 +316,10 @@ func (cgc *containerGC) evictSandboxes(evictNonDeletedPods bool) error {
 			// Remove all evictable sandboxes if the pod has been removed.
 			// Note that the latest dead sandbox is also removed if there is
 			// already an active one.
-			cgc.removeOldestNSandboxes(sandboxes, len(sandboxes))
+			cgc.removeOldestNSandboxes(ctx, sandboxes, len(sandboxes))
 		} else {
 			// Keep latest one if the pod still exists.
-			cgc.removeOldestNSandboxes(sandboxes, len(sandboxes)-1)
+			cgc.removeOldestNSandboxes(ctx, sandboxes, len(sandboxes)-1)
 		}
 	}
 	return nil
@@ -326,7 +327,7 @@ func (cgc *containerGC) evictSandboxes(evictNonDeletedPods bool) error {
 
 // evictPodLogsDirectories evicts all evictable pod logs directories. Pod logs directories
 // are evictable if there are no corresponding pods.
-func (cgc *containerGC) evictPodLogsDirectories(allSourcesReady bool) error {
+func (cgc *containerGC) evictPodLogsDirectories(ctx context.Context, allSourcesReady bool) error {
 	osInterface := cgc.manager.osInterface
 	if allSourcesReady {
 		// Only remove pod logs directories when all sources are ready.
@@ -354,7 +355,7 @@ func (cgc *containerGC) evictPodLogsDirectories(allSourcesReady bool) error {
 	for _, logSymlink := range logSymlinks {
 		if _, err := osInterface.Stat(logSymlink); os.IsNotExist(err) {
 			if containerID, err := getContainerIDFromLegacyLogSymlink(logSymlink); err == nil {
-				resp, err := cgc.manager.runtimeService.ContainerStatus(containerID, false)
+				resp, err := cgc.manager.runtimeService.ContainerStatus(ctx, containerID, false)
 				if err != nil {
 					// TODO: we should handle container not found (i.e. container was deleted) case differently
 					// once https://github.com/kubernetes/kubernetes/issues/63336 is resolved
@@ -405,20 +406,20 @@ func (cgc *containerGC) evictPodLogsDirectories(allSourcesReady bool) error {
 // * removes oldest dead containers by enforcing gcPolicy.MaxContainers.
 // * gets evictable sandboxes which are not ready and contains no containers.
 // * removes evictable sandboxes.
-func (cgc *containerGC) GarbageCollect(gcPolicy kubecontainer.GCPolicy, allSourcesReady bool, evictNonDeletedPods bool) error {
+func (cgc *containerGC) GarbageCollect(ctx context.Context, gcPolicy kubecontainer.GCPolicy, allSourcesReady bool, evictNonDeletedPods bool) error {
 	errors := []error{}
 	// Remove evictable containers
-	if err := cgc.evictContainers(gcPolicy, allSourcesReady, evictNonDeletedPods); err != nil {
+	if err := cgc.evictContainers(ctx, gcPolicy, allSourcesReady, evictNonDeletedPods); err != nil {
 		errors = append(errors, err)
 	}
 
 	// Remove sandboxes with zero containers
-	if err := cgc.evictSandboxes(evictNonDeletedPods); err != nil {
+	if err := cgc.evictSandboxes(ctx, evictNonDeletedPods); err != nil {
 		errors = append(errors, err)
 	}
 
 	// Remove pod sandbox log directory
-	if err := cgc.evictPodLogsDirectories(allSourcesReady); err != nil {
+	if err := cgc.evictPodLogsDirectories(ctx, allSourcesReady); err != nil {
 		errors = append(errors, err)
 	}
 	return utilerrors.NewAggregate(errors)

--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -28,7 +30,7 @@ import (
 
 // PullImage pulls an image from the network to local storage using the supplied
 // secrets if necessary.
-func (m *kubeGenericRuntimeManager) PullImage(image kubecontainer.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+func (m *kubeGenericRuntimeManager) PullImage(ctx context.Context, image kubecontainer.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	img := image.Image
 	repoToPull, _, _, err := parsers.ParseImageName(img)
 	if err != nil {
@@ -46,7 +48,7 @@ func (m *kubeGenericRuntimeManager) PullImage(image kubecontainer.ImageSpec, pul
 	if !withCredentials {
 		klog.V(3).InfoS("Pulling image without credentials", "image", img)
 
-		imageRef, err := m.imageService.PullImage(imgSpec, nil, podSandboxConfig)
+		imageRef, err := m.imageService.PullImage(ctx, imgSpec, nil, podSandboxConfig)
 		if err != nil {
 			klog.ErrorS(err, "Failed to pull image", "image", img)
 			return "", err
@@ -66,7 +68,7 @@ func (m *kubeGenericRuntimeManager) PullImage(image kubecontainer.ImageSpec, pul
 			RegistryToken: currentCreds.RegistryToken,
 		}
 
-		imageRef, err := m.imageService.PullImage(imgSpec, auth, podSandboxConfig)
+		imageRef, err := m.imageService.PullImage(ctx, imgSpec, auth, podSandboxConfig)
 		// If there was no error, return success
 		if err == nil {
 			return imageRef, nil
@@ -80,8 +82,8 @@ func (m *kubeGenericRuntimeManager) PullImage(image kubecontainer.ImageSpec, pul
 
 // GetImageRef gets the ID of the image which has already been in
 // the local storage. It returns ("", nil) if the image isn't in the local storage.
-func (m *kubeGenericRuntimeManager) GetImageRef(image kubecontainer.ImageSpec) (string, error) {
-	resp, err := m.imageService.ImageStatus(toRuntimeAPIImageSpec(image), false)
+func (m *kubeGenericRuntimeManager) GetImageRef(ctx context.Context, image kubecontainer.ImageSpec) (string, error) {
+	resp, err := m.imageService.ImageStatus(ctx, toRuntimeAPIImageSpec(image), false)
 	if err != nil {
 		klog.ErrorS(err, "Failed to get image status", "image", image.Image)
 		return "", err
@@ -93,10 +95,10 @@ func (m *kubeGenericRuntimeManager) GetImageRef(image kubecontainer.ImageSpec) (
 }
 
 // ListImages gets all images currently on the machine.
-func (m *kubeGenericRuntimeManager) ListImages() ([]kubecontainer.Image, error) {
+func (m *kubeGenericRuntimeManager) ListImages(ctx context.Context) ([]kubecontainer.Image, error) {
 	var images []kubecontainer.Image
 
-	allImages, err := m.imageService.ListImages(nil)
+	allImages, err := m.imageService.ListImages(ctx, nil)
 	if err != nil {
 		klog.ErrorS(err, "Failed to list images")
 		return nil, err
@@ -116,8 +118,8 @@ func (m *kubeGenericRuntimeManager) ListImages() ([]kubecontainer.Image, error) 
 }
 
 // RemoveImage removes the specified image.
-func (m *kubeGenericRuntimeManager) RemoveImage(image kubecontainer.ImageSpec) error {
-	err := m.imageService.RemoveImage(&runtimeapi.ImageSpec{Image: image.Image})
+func (m *kubeGenericRuntimeManager) RemoveImage(ctx context.Context, image kubecontainer.ImageSpec) error {
+	err := m.imageService.RemoveImage(ctx, &runtimeapi.ImageSpec{Image: image.Image})
 	if err != nil {
 		klog.ErrorS(err, "Failed to remove image", "image", image.Image)
 		return err
@@ -130,8 +132,8 @@ func (m *kubeGenericRuntimeManager) RemoveImage(image kubecontainer.ImageSpec) e
 // Notice that current logic doesn't really work for images which share layers (e.g. docker image),
 // this is a known issue, and we'll address this by getting imagefs stats directly from CRI.
 // TODO: Get imagefs stats directly from CRI.
-func (m *kubeGenericRuntimeManager) ImageStats() (*kubecontainer.ImageStats, error) {
-	allImages, err := m.imageService.ListImages(nil)
+func (m *kubeGenericRuntimeManager) ImageStats(ctx context.Context) (*kubecontainer.ImageStats, error) {
+	allImages, err := m.imageService.ListImages(ctx, nil)
 	if err != nil {
 		klog.ErrorS(err, "Failed to list images")
 		return nil, err

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -218,7 +218,7 @@ func NewKubeGenericRuntimeManager(
 		memoryThrottlingFactor: memoryThrottlingFactor,
 	}
 
-	typedVersion, err := kubeRuntimeManager.getTypedVersion()
+	typedVersion, err := kubeRuntimeManager.getTypedVersion(context.Background())
 	if err != nil {
 		klog.ErrorS(err, "Get runtime version failed")
 		return nil, err
@@ -274,7 +274,7 @@ func NewKubeGenericRuntimeManager(
 
 	kubeRuntimeManager.versionCache = cache.NewObjectCache(
 		func() (interface{}, error) {
-			return kubeRuntimeManager.getTypedVersion()
+			return kubeRuntimeManager.getTypedVersion(context.Background())
 		},
 		versionCacheTTL,
 	)

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,10 +50,10 @@ func TestCreatePodSandbox(t *testing.T) {
 		assert.Equal(t, os.FileMode(0755), perm)
 		return nil
 	}
-	id, _, err := m.createPodSandbox(pod, 1)
+	id, _, err := m.createPodSandbox(context.Background(), pod, 1)
 	assert.NoError(t, err)
 	assert.Contains(t, fakeRuntime.Called, "RunPodSandbox")
-	sandboxes, err := fakeRuntime.ListPodSandbox(&runtimeapi.PodSandboxFilter{Id: id})
+	sandboxes, err := fakeRuntime.ListPodSandbox(context.Background(), &runtimeapi.PodSandboxFilter{Id: id})
 	assert.NoError(t, err)
 	assert.Equal(t, len(sandboxes), 1)
 	// TODO Check pod sandbox configuration
@@ -125,7 +126,7 @@ func TestCreatePodSandbox_RuntimeClass(t *testing.T) {
 			pod := newTestPod()
 			pod.Spec.RuntimeClassName = test.rcn
 
-			id, _, err := m.createPodSandbox(pod, 1)
+			id, _, err := m.createPodSandbox(context.Background(), pod, 1)
 			if test.expectError {
 				assert.Error(t, err)
 			} else {

--- a/pkg/kubelet/kuberuntime/logs/logs.go
+++ b/pkg/kubelet/kuberuntime/logs/logs.go
@@ -412,8 +412,8 @@ func ReadLogs(ctx context.Context, path, containerID string, opts *LogOptions, r
 	}
 }
 
-func isContainerRunning(id string, r internalapi.RuntimeService) (bool, error) {
-	resp, err := r.ContainerStatus(id, false)
+func isContainerRunning(ctx context.Context, id string, r internalapi.RuntimeService) (bool, error) {
+	resp, err := r.ContainerStatus(ctx, id, false)
 	if err != nil {
 		return false, err
 	}
@@ -436,7 +436,7 @@ func isContainerRunning(id string, r internalapi.RuntimeService) (bool, error) {
 // the error is error happens during waiting new logs.
 func waitLogs(ctx context.Context, id string, w *fsnotify.Watcher, runtimeService internalapi.RuntimeService) (bool, bool, error) {
 	// no need to wait if the pod is not running
-	if running, err := isContainerRunning(id, runtimeService); !running {
+	if running, err := isContainerRunning(ctx, id, runtimeService); !running {
 		return false, false, err
 	}
 	errRetry := 5

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -44,7 +44,7 @@ type handlerRunner struct {
 }
 
 type podStatusProvider interface {
-	GetPodStatus(uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error)
+	GetPodStatus(ctx context.Context, uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error)
 }
 
 // NewHandlerRunner returns a configured lifecycle handler for a container.

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package lifecycle
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -83,7 +84,7 @@ type fakeContainerCommandRunner struct {
 	Msg string
 }
 
-func (f *fakeContainerCommandRunner) RunInContainer(id kubecontainer.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
+func (f *fakeContainerCommandRunner) RunInContainer(ctx context.Context, id kubecontainer.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
 	f.Cmd = cmd
 	f.ID = id
 	return []byte(f.Msg), f.Err
@@ -111,7 +112,7 @@ func TestRunHandlerExec(t *testing.T) {
 	pod.ObjectMeta.Name = "podFoo"
 	pod.ObjectMeta.Namespace = "nsFoo"
 	pod.Spec.Containers = []v1.Container{container}
-	_, err := handlerRunner.Run(containerID, &pod, &container, container.Lifecycle.PostStart)
+	_, err := handlerRunner.Run(context.Background(), containerID, &pod, &container, container.Lifecycle.PostStart)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -155,7 +156,7 @@ func TestRunHandlerHttp(t *testing.T) {
 	pod.ObjectMeta.Name = "podFoo"
 	pod.ObjectMeta.Namespace = "nsFoo"
 	pod.Spec.Containers = []v1.Container{container}
-	_, err := handlerRunner.Run(containerID, &pod, &container, container.Lifecycle.PostStart)
+	_, err := handlerRunner.Run(context.Background(), containerID, &pod, &container, container.Lifecycle.PostStart)
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -182,7 +183,7 @@ func TestRunHandlerNil(t *testing.T) {
 	pod.ObjectMeta.Name = podName
 	pod.ObjectMeta.Namespace = podNamespace
 	pod.Spec.Containers = []v1.Container{container}
-	_, err := handlerRunner.Run(containerID, &pod, &container, container.Lifecycle.PostStart)
+	_, err := handlerRunner.Run(context.Background(), containerID, &pod, &container, container.Lifecycle.PostStart)
 	if err == nil {
 		t.Errorf("expect error, but got nil")
 	}
@@ -213,7 +214,7 @@ func TestRunHandlerExecFailure(t *testing.T) {
 	pod.ObjectMeta.Namespace = "nsFoo"
 	pod.Spec.Containers = []v1.Container{container}
 	expectedErrMsg := fmt.Sprintf("Exec lifecycle hook (%s) for Container %q in Pod %q failed - error: %v, message: %q", command, containerName, format.Pod(&pod), expectedErr, expectedErr.Error())
-	msg, err := handlerRunner.Run(containerID, &pod, &container, container.Lifecycle.PostStart)
+	msg, err := handlerRunner.Run(context.Background(), containerID, &pod, &container, container.Lifecycle.PostStart)
 	if err == nil {
 		t.Errorf("expected error: %v", expectedErr)
 	}
@@ -248,7 +249,7 @@ func TestRunHandlerHttpFailure(t *testing.T) {
 	pod.ObjectMeta.Namespace = "nsFoo"
 	pod.Spec.Containers = []v1.Container{container}
 	expectedErrMsg := fmt.Sprintf("HTTP lifecycle hook (%s) for Container %q in Pod %q failed - error: %v, message: %q", "bar", containerName, format.Pod(&pod), expectedErr, expectedErr.Error())
-	msg, err := handlerRunner.Run(containerID, &pod, &container, container.Lifecycle.PostStart)
+	msg, err := handlerRunner.Run(context.Background(), containerID, &pod, &container, container.Lifecycle.PostStart)
 	if err == nil {
 		t.Errorf("expected error: %v", expectedErr)
 	}

--- a/pkg/kubelet/logs/container_log_manager.go
+++ b/pkg/kubelet/logs/container_log_manager.go
@@ -179,7 +179,7 @@ func NewContainerLogManager(runtimeService internalapi.RuntimeService, osInterfa
 func (c *containerLogManager) Start() {
 	// Start a goroutine periodically does container log rotation.
 	go wait.Forever(func() {
-		if err := c.rotateLogs(); err != nil {
+		if err := c.rotateLogs(context.TODO()); err != nil {
 			klog.ErrorS(err, "Failed to rotate container logs")
 		}
 	}, logMonitorPeriod)

--- a/pkg/kubelet/logs/container_log_manager.go
+++ b/pkg/kubelet/logs/container_log_manager.go
@@ -58,7 +58,7 @@ type ContainerLogManager interface {
 	// Start container log manager.
 	Start()
 	// Clean removes all logs of specified container.
-	Clean(containerID string) error
+	Clean(ctx context.Context, containerID string) error
 }
 
 // LogRotatePolicy is a policy for container log rotation. The policy applies to all

--- a/pkg/kubelet/logs/container_log_manager_stub.go
+++ b/pkg/kubelet/logs/container_log_manager_stub.go
@@ -16,11 +16,13 @@ limitations under the License.
 
 package logs
 
+import "context"
+
 type containerLogManagerStub struct{}
 
 func (*containerLogManagerStub) Start() {}
 
-func (*containerLogManagerStub) Clean(containerID string) error {
+func (*containerLogManagerStub) Clean(ctx context.Context, containerID string) error {
 	return nil
 }
 

--- a/pkg/kubelet/logs/container_log_manager_test.go
+++ b/pkg/kubelet/logs/container_log_manager_test.go
@@ -18,6 +18,7 @@ package logs
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -148,7 +149,7 @@ func TestRotateLogs(t *testing.T) {
 		},
 	}
 	f.SetFakeContainers(testContainers)
-	require.NoError(t, c.rotateLogs())
+	require.NoError(t, c.rotateLogs(context.Background()))
 
 	timestamp := now.Format(timestampFormat)
 	logs, err := ioutil.ReadDir(dir)
@@ -220,7 +221,7 @@ func TestClean(t *testing.T) {
 	}
 	f.SetFakeContainers(testContainers)
 
-	err = c.Clean("container-3")
+	err = c.Clean(context.Background(), "container-3")
 	require.NoError(t, err)
 
 	logs, err := ioutil.ReadDir(dir)
@@ -392,7 +393,7 @@ func TestRotateLatestLog(t *testing.T) {
 		defer testFile.Close()
 		testLog := testFile.Name()
 		rotatedLog := fmt.Sprintf("%s.%s", testLog, now.Format(timestampFormat))
-		err = c.rotateLatestLog("test-id", testLog)
+		err = c.rotateLatestLog(context.Background(), "test-id", testLog)
 		assert.Equal(t, test.expectError, err != nil)
 		_, err = os.Stat(testLog)
 		assert.Equal(t, test.expectOriginal, err == nil)

--- a/pkg/kubelet/metrics/collectors/log_metrics.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics.go
@@ -61,7 +61,7 @@ func (c *logMetricsCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
 
 // CollectWithStability implements the metrics.StableCollector interface.
 func (c *logMetricsCollector) CollectWithStability(ch chan<- metrics.Metric) {
-	podStats, err := c.podStats()
+	podStats, err := c.podStats(context.Background())
 	if err != nil {
 		klog.ErrorS(err, "Failed to get pod stats")
 		return

--- a/pkg/kubelet/metrics/collectors/log_metrics.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics.go
@@ -17,6 +17,8 @@ limitations under the License.
 package collectors
 
 import (
+	"context"
+
 	"k8s.io/component-base/metrics"
 	"k8s.io/klog/v2"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
@@ -48,7 +50,7 @@ var _ metrics.StableCollector = &logMetricsCollector{}
 
 // NewLogMetricsCollector implements the metrics.StableCollector interface and
 // exposes metrics about container's log volume size.
-func NewLogMetricsCollector(podStats func() ([]statsapi.PodStats, error)) metrics.StableCollector {
+func NewLogMetricsCollector(podStats func(context.Context) ([]statsapi.PodStats, error)) metrics.StableCollector {
 	return &logMetricsCollector{
 		podStats: podStats,
 	}

--- a/pkg/kubelet/metrics/collectors/log_metrics.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics.go
@@ -40,7 +40,7 @@ var (
 type logMetricsCollector struct {
 	metrics.BaseStableCollector
 
-	podStats func() ([]statsapi.PodStats, error)
+	podStats func(context.Context) ([]statsapi.PodStats, error)
 }
 
 // Check if logMetricsCollector implements necessary interface

--- a/pkg/kubelet/metrics/collectors/log_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package collectors
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -29,7 +30,7 @@ func TestNoMetricsCollected(t *testing.T) {
 	descLogSize = descLogSize.GetRawDesc()
 
 	collector := &logMetricsCollector{
-		podStats: func() ([]statsapi.PodStats, error) {
+		podStats: func(context.Context) ([]statsapi.PodStats, error) {
 			return []statsapi.PodStats{}, nil
 		},
 	}
@@ -45,7 +46,7 @@ func TestMetricsCollected(t *testing.T) {
 
 	size := uint64(18)
 	collector := &logMetricsCollector{
-		podStats: func() ([]statsapi.PodStats, error) {
+		podStats: func(context.Context) ([]statsapi.PodStats, error) {
 			return []statsapi.PodStats{
 				{
 					PodRef: statsapi.PodReference{

--- a/pkg/kubelet/metrics/collectors/resource_metrics.go
+++ b/pkg/kubelet/metrics/collectors/resource_metrics.go
@@ -120,7 +120,7 @@ func (rc *resourceMetricsCollector) CollectWithStability(ch chan<- metrics.Metri
 	defer func() {
 		ch <- metrics.NewLazyConstMetric(resourceScrapeResultDesc, metrics.GaugeValue, errorCount)
 	}()
-	statsSummary, err := rc.provider.GetCPUAndMemoryStats()
+	statsSummary, err := rc.provider.GetCPUAndMemoryStats(context.Background())
 	if err != nil {
 		errorCount = 1
 		klog.ErrorS(err, "Error getting summary for resourceMetric prometheus endpoint")

--- a/pkg/kubelet/metrics/collectors/resource_metrics.go
+++ b/pkg/kubelet/metrics/collectors/resource_metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package collectors
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/component-base/metrics"

--- a/pkg/kubelet/metrics/collectors/resource_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/resource_metrics_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package collectors
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -207,8 +208,10 @@ func TestCollectResourceMetrics(t *testing.T) {
 	for _, test := range tests {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
 			provider := summaryprovidertest.NewMockSummaryProvider(mockCtrl)
-			provider.EXPECT().GetCPUAndMemoryStats().Return(tc.summary, tc.summaryErr).AnyTimes()
+			provider.EXPECT().GetCPUAndMemoryStats(ctx).Return(tc.summary, tc.summaryErr).AnyTimes()
 			collector := NewResourceMetricsCollector(provider)
 
 			if err := testutil.CustomCollectAndCompare(collector, strings.NewReader(tc.expectedMetrics), interestedMetrics...); err != nil {

--- a/pkg/kubelet/metrics/collectors/volume_stats.go
+++ b/pkg/kubelet/metrics/collectors/volume_stats.go
@@ -89,7 +89,7 @@ func (collector *volumeStatsCollector) DescribeWithStability(ch chan<- *metrics.
 
 // CollectWithStability implements the metrics.StableCollector interface.
 func (collector *volumeStatsCollector) CollectWithStability(ch chan<- metrics.Metric) {
-	podStats, err := collector.statsProvider.ListPodStats()
+	podStats, err := collector.statsProvider.ListPodStats(context.Background())
 	if err != nil {
 		return
 	}

--- a/pkg/kubelet/metrics/collectors/volume_stats.go
+++ b/pkg/kubelet/metrics/collectors/volume_stats.go
@@ -17,6 +17,8 @@ limitations under the License.
 package collectors
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/metrics"
 	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"

--- a/pkg/kubelet/metrics/collectors/volume_stats_test.go
+++ b/pkg/kubelet/metrics/collectors/volume_stats_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package collectors
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -133,9 +134,10 @@ func TestVolumeStatsCollector(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockStatsProvider := statstest.NewMockProvider(mockCtrl)
+	ctx := context.Background()
 
-	mockStatsProvider.EXPECT().ListPodStats().Return(podStats, nil).AnyTimes()
-	mockStatsProvider.EXPECT().ListPodStatsAndUpdateCPUNanoCoreUsage().Return(podStats, nil).AnyTimes()
+	mockStatsProvider.EXPECT().ListPodStats(ctx).Return(podStats, nil).AnyTimes()
+	mockStatsProvider.EXPECT().ListPodStatsAndUpdateCPUNanoCoreUsage(ctx).Return(podStats, nil).AnyTimes()
 	if err := testutil.CustomCollectAndCompare(&volumeStatsCollector{statsProvider: mockStatsProvider}, strings.NewReader(want), metrics...); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodestatus
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net"
@@ -411,7 +412,7 @@ func MachineInfo(nodeName string,
 // VersionInfo returns a Setter that updates version-related information on the node.
 func VersionInfo(versionInfoFunc func() (*cadvisorapiv1.VersionInfo, error), // typically Kubelet.cadvisor.VersionInfo
 	runtimeTypeFunc func() string, // typically Kubelet.containerRuntime.Type
-	runtimeVersionFunc func() (kubecontainer.Version, error), // typically Kubelet.containerRuntime.Version
+	runtimeVersionFunc func(ctx context.Context) (kubecontainer.Version, error), // typically Kubelet.containerRuntime.Version
 ) Setter {
 	return func(node *v1.Node) error {
 		verinfo, err := versionInfoFunc()
@@ -447,7 +448,7 @@ func DaemonEndpoints(daemonEndpoints *v1.NodeDaemonEndpoints) Setter {
 // imageListFunc is expected to return a list of images sorted in descending order by image size.
 // nodeStatusMaxImages is ignored if set to -1.
 func Images(nodeStatusMaxImages int32,
-	imageListFunc func() ([]kubecontainer.Image, error), // typically Kubelet.imageManager.GetImageList
+	imageListFunc func(ctx context.Context) ([]kubecontainer.Image, error), // typically Kubelet.imageManager.GetImageList
 ) Setter {
 	return func(node *v1.Node) error {
 		// Update image list of this node

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -423,7 +423,7 @@ func VersionInfo(versionInfoFunc func() (*cadvisorapiv1.VersionInfo, error), // 
 		node.Status.NodeInfo.OSImage = verinfo.ContainerOsVersion
 
 		runtimeVersion := "Unknown"
-		if runtimeVer, err := runtimeVersionFunc(); err == nil {
+		if runtimeVer, err := runtimeVersionFunc(context.Background()); err == nil {
 			runtimeVersion = runtimeVer.String()
 		}
 		node.Status.NodeInfo.ContainerRuntimeVersion = fmt.Sprintf("%s://%s", runtimeTypeFunc(), runtimeVersion)
@@ -452,7 +452,7 @@ func Images(nodeStatusMaxImages int32,
 	return func(node *v1.Node) error {
 		// Update image list of this node
 		var imagesOnNode []v1.ContainerImage
-		containerImages, err := imageListFunc()
+		containerImages, err := imageListFunc(context.Background())
 		if err != nil {
 			node.Status.Images = imagesOnNode
 			return fmt.Errorf("error getting image list: %v", err)

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodestatus
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -1012,7 +1013,7 @@ func TestVersionInfo(t *testing.T) {
 			runtimeTypeFunc := func() string {
 				return tc.runtimeType
 			}
-			runtimeVersionFunc := func() (kubecontainer.Version, error) {
+			runtimeVersionFunc := func(ctx context.Context) (kubecontainer.Version, error) {
 				return tc.runtimeVersion, tc.runtimeVersionError
 			}
 			// construct setter
@@ -1082,7 +1083,7 @@ func TestImages(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			imageListFunc := func() ([]kubecontainer.Image, error) {
+			imageListFunc := func(context.Context) ([]kubecontainer.Image, error) {
 				// today, imageListFunc is expected to return a sorted list,
 				// but we may choose to sort in the setter at some future point
 				// (e.g. if the image cache stopped sorting for us)

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -128,7 +128,7 @@ func (g *GenericPLEG) Watch() chan *PodLifecycleEvent {
 
 // Start spawns a goroutine to relist periodically.
 func (g *GenericPLEG) Start() {
-	go wait.Until(g.relist, g.relistPeriod, wait.NeverStop)
+	go wait.UntilWithContext(context.Background(), g.relist, g.relistPeriod)
 }
 
 // Healthy check if PLEG work properly.
@@ -404,7 +404,7 @@ func (g *GenericPLEG) updateCache(pod *kubecontainer.Pod, pid types.UID) error {
 	// TODO: Consider adding a new runtime method
 	// GetPodStatus(pod *kubecontainer.Pod) so that Docker can avoid listing
 	// all containers again.
-	status, err := g.runtime.GetPodStatus(pod.ID, pod.Name, pod.Namespace)
+	status, err := g.runtime.GetPodStatus(context.Background(), pod.ID, pod.Name, pod.Namespace)
 	if err != nil {
 		if klog.V(6).Enabled() {
 			klog.ErrorS(err, "PLEG: Write status", "pod", klog.KRef(pod.Namespace, pod.Name), "podStatus", status)

--- a/pkg/kubelet/pod_container_deletor.go
+++ b/pkg/kubelet/pod_container_deletor.go
@@ -46,9 +46,10 @@ func (a containerStatusbyCreatedList) Less(i, j int) bool {
 func newPodContainerDeletor(runtime kubecontainer.Runtime, containersToKeep int) *podContainerDeletor {
 	buffer := make(chan kubecontainer.ContainerID, containerDeletorBufferLimit)
 	go wait.Until(func() {
+		ctx := context.Background()
 		for {
 			id := <-buffer
-			if err := runtime.DeleteContainer(id); err != nil {
+			if err := runtime.DeleteContainer(ctx, id); err != nil {
 				klog.InfoS("DeleteContainer returned error", "containerID", id, "err", err)
 			}
 		}

--- a/pkg/kubelet/pod_container_deletor.go
+++ b/pkg/kubelet/pod_container_deletor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubelet
 
 import (
+	"context"
 	"sort"
 
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -17,6 +17,7 @@ limitations under the License.
 package prober
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -93,7 +94,7 @@ func (pb *prober) recordContainerEvent(pod *v1.Pod, container *v1.Container, eve
 }
 
 // probe probes the container.
-func (pb *prober) probe(probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -111,7 +112,7 @@ func (pb *prober) probe(probeType probeType, pod *v1.Pod, status v1.PodStatus, c
 		return results.Success, nil
 	}
 
-	result, output, err := pb.runProbeWithRetries(probeType, probeSpec, pod, status, container, containerID, maxProbeRetries)
+	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, maxProbeRetries)
 	if err != nil || (result != probe.Success && result != probe.Warning) {
 		// Probe failed in one way or another.
 		if err != nil {
@@ -134,12 +135,12 @@ func (pb *prober) probe(probeType probeType, pod *v1.Pod, status v1.PodStatus, c
 
 // runProbeWithRetries tries to probe the container in a finite loop, it returns the last result
 // if it never succeeds.
-func (pb *prober) runProbeWithRetries(probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, retries int) (probe.Result, string, error) {
+func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, retries int) (probe.Result, string, error) {
 	var err error
 	var result probe.Result
 	var output string
 	for i := 0; i < retries; i++ {
-		result, output, err = pb.runProbe(probeType, p, pod, status, container, containerID)
+		result, output, err = pb.runProbe(ctx, probeType, p, pod, status, container, containerID)
 		if err == nil {
 			return result, output, nil
 		}
@@ -157,12 +158,12 @@ func buildHeader(headerList []v1.HTTPHeader) http.Header {
 	return headers
 }
 
-func (pb *prober) runProbe(probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (probe.Result, string, error) {
+func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (probe.Result, string, error) {
 	timeout := time.Duration(p.TimeoutSeconds) * time.Second
 	if p.Exec != nil {
 		klog.V(4).InfoS("Exec-Probe runProbe", "pod", klog.KObj(pod), "containerName", container.Name, "execCommand", p.Exec.Command)
 		command := kubecontainer.ExpandContainerCommandOnlyStatic(p.Exec.Command, container.Env)
-		return pb.exec.Probe(pb.newExecInContainer(container, containerID, command, timeout))
+		return pb.exec.Probe(pb.newExecInContainer(ctx, container, containerID, command, timeout))
 	}
 	if p.HTTPGet != nil {
 		scheme := strings.ToLower(string(p.HTTPGet.Scheme))
@@ -265,9 +266,9 @@ type execInContainer struct {
 	writer io.Writer
 }
 
-func (pb *prober) newExecInContainer(container v1.Container, containerID kubecontainer.ContainerID, cmd []string, timeout time.Duration) exec.Cmd {
+func (pb *prober) newExecInContainer(ctx context.Context, container v1.Container, containerID kubecontainer.ContainerID, cmd []string, timeout time.Duration) exec.Cmd {
 	return &execInContainer{run: func() ([]byte, error) {
-		return pb.runner.RunInContainer(containerID, cmd, timeout)
+		return pb.runner.RunInContainer(ctx, containerID, cmd, timeout)
 	}}
 }
 

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -18,6 +18,7 @@ package prober
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -303,7 +304,7 @@ func TestProbe(t *testing.T) {
 				prober.exec = fakeExecProber{test.execResult, nil}
 			}
 
-			result, err := prober.probe(probeType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+			result, err := prober.probe(context.Background(), probeType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
 			if test.expectError && err == nil {
 				t.Errorf("[%s] Expected probe error but no error was returned.", testID)
 			}
@@ -317,7 +318,7 @@ func TestProbe(t *testing.T) {
 			if len(test.expectCommand) > 0 {
 				prober.exec = execprobe.New()
 				prober.runner = &containertest.FakeContainerCommandRunner{}
-				_, err := prober.probe(probeType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+				_, err := prober.probe(context.Background(), probeType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
 				if err != nil {
 					t.Errorf("[%s] Didn't expect probe error but got: %v", testID, err)
 					continue
@@ -372,7 +373,7 @@ func TestNewExecInContainer(t *testing.T) {
 		container := v1.Container{}
 		containerID := kubecontainer.ContainerID{Type: "docker", ID: "containerID"}
 		cmd := []string{"/foo", "bar"}
-		exec := prober.newExecInContainer(container, containerID, cmd, 0)
+		exec := prober.newExecInContainer(context.Background(), container, containerID, cmd, 0)
 
 		var dataBuffer bytes.Buffer
 		writer := ioutils.LimitWriter(&dataBuffer, int64(limit))

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package prober
 
 import (
+	"context"
 	"math/rand"
 	"time"
 

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -264,7 +264,7 @@ func (w *worker) doProbe() (keepGoing bool) {
 	// TODO: in order for exec probes to correctly handle downward API env, we must be able to reconstruct
 	// the full container environment here, OR we must make a call to the CRI in order to get those environment
 	// values from the running container.
-	result, err := w.probeManager.prober.probe(w.probeType, w.pod, status, w.container, w.containerID)
+	result, err := w.probeManager.prober.probe(context.TODO(), w.probeType, w.pod, status, w.container, w.containerID)
 	if err != nil {
 		// Prober error, throw away the result.
 		return true

--- a/pkg/kubelet/runonce.go
+++ b/pkg/kubelet/runonce.go
@@ -59,7 +59,7 @@ func (kl *Kubelet) RunOnce(updates <-chan kubetypes.PodUpdate) ([]RunPodResult, 
 	select {
 	case u := <-updates:
 		klog.InfoS("Processing manifest with pods", "numPods", len(u.Pods))
-		result, err := kl.runOnce(u.Pods, runOnceRetryDelay)
+		result, err := kl.runOnce(context.Background(), u.Pods, runOnceRetryDelay)
 		klog.InfoS("Finished processing pods", "numPods", len(u.Pods))
 		return result, err
 	case <-time.After(runOnceManifestDelay):

--- a/pkg/kubelet/runonce.go
+++ b/pkg/kubelet/runonce.go
@@ -68,7 +68,7 @@ func (kl *Kubelet) RunOnce(updates <-chan kubetypes.PodUpdate) ([]RunPodResult, 
 }
 
 // runOnce runs a given set of pods and returns their status.
-func (kl *Kubelet) runOnce(pods []*v1.Pod, retryDelay time.Duration) (results []RunPodResult, err error) {
+func (kl *Kubelet) runOnce(ctx context.Context, pods []*v1.Pod, retryDelay time.Duration) (results []RunPodResult, err error) {
 	ch := make(chan RunPodResult)
 	admitted := []*v1.Pod{}
 	for _, pod := range pods {
@@ -81,7 +81,7 @@ func (kl *Kubelet) runOnce(pods []*v1.Pod, retryDelay time.Duration) (results []
 
 		admitted = append(admitted, pod)
 		go func(pod *v1.Pod) {
-			err := kl.runPod(pod, retryDelay)
+			err := kl.runPod(ctx, pod, retryDelay)
 			ch <- RunPodResult{pod, err}
 		}(pod)
 	}
@@ -92,7 +92,7 @@ func (kl *Kubelet) runOnce(pods []*v1.Pod, retryDelay time.Duration) (results []
 		res := <-ch
 		results = append(results, res)
 		if res.Err != nil {
-			failedContainerName, err := kl.getFailedContainers(res.Pod)
+			failedContainerName, err := kl.getFailedContainers(ctx, res.Pod)
 			if err != nil {
 				klog.InfoS("Unable to get failed containers' names for pod", "pod", klog.KObj(res.Pod), "err", err)
 			} else {
@@ -111,11 +111,11 @@ func (kl *Kubelet) runOnce(pods []*v1.Pod, retryDelay time.Duration) (results []
 }
 
 // runPod runs a single pod and wait until all containers are running.
-func (kl *Kubelet) runPod(pod *v1.Pod, retryDelay time.Duration) error {
+func (kl *Kubelet) runPod(ctx context.Context, pod *v1.Pod, retryDelay time.Duration) error {
 	delay := retryDelay
 	retry := 0
 	for {
-		status, err := kl.containerRuntime.GetPodStatus(pod.UID, pod.Name, pod.Namespace)
+		status, err := kl.containerRuntime.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
 		if err != nil {
 			return fmt.Errorf("unable to get status for pod %q: %v", format.Pod(pod), err)
 		}
@@ -158,8 +158,8 @@ func (kl *Kubelet) isPodRunning(pod *v1.Pod, status *kubecontainer.PodStatus) bo
 }
 
 // getFailedContainer returns failed container name for pod.
-func (kl *Kubelet) getFailedContainers(pod *v1.Pod) ([]string, error) {
-	status, err := kl.containerRuntime.GetPodStatus(pod.UID, pod.Name, pod.Namespace)
+func (kl *Kubelet) getFailedContainers(ctx context.Context, pod *v1.Pod) ([]string, error) {
+	status, err := kl.containerRuntime.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get status for pod %q: %v", format.Pod(pod), err)
 	}

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubelet
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -168,7 +169,7 @@ func TestRunOnce(t *testing.T) {
 			},
 		},
 	}
-	results, err := kb.runOnce(pods, time.Millisecond)
+	results, err := kb.runOnce(context.Background(), pods, time.Millisecond)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -223,15 +223,15 @@ type HostInterface interface {
 	GetVersionInfo() (*cadvisorapi.VersionInfo, error)
 	GetCachedMachineInfo() (*cadvisorapi.MachineInfo, error)
 	GetRunningPods() ([]*v1.Pod, error)
-	RunInContainer(name string, uid types.UID, container string, cmd []string) ([]byte, error)
+	RunInContainer(ctx context.Context, name string, uid types.UID, container string, cmd []string) ([]byte, error)
 	GetKubeletContainerLogs(ctx context.Context, podFullName, containerName string, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) error
 	ServeLogs(w http.ResponseWriter, req *http.Request)
 	ResyncInterval() time.Duration
 	GetHostname() string
 	LatestLoopEntryTime() time.Time
-	GetExec(podFullName string, podUID types.UID, containerName string, cmd []string, streamOpts remotecommandserver.Options) (*url.URL, error)
-	GetAttach(podFullName string, podUID types.UID, containerName string, streamOpts remotecommandserver.Options) (*url.URL, error)
-	GetPortForward(podName, podNamespace string, podUID types.UID, portForwardOpts portforward.V4Options) (*url.URL, error)
+	GetExec(ctx context.Context, podFullName string, podUID types.UID, containerName string, cmd []string, streamOpts remotecommandserver.Options) (*url.URL, error)
+	GetAttach(ctx context.Context, podFullName string, podUID types.UID, containerName string, streamOpts remotecommandserver.Options) (*url.URL, error)
+	GetPortForward(ctx context.Context, podName, podNamespace string, podUID types.UID, portForwardOpts portforward.V4Options) (*url.URL, error)
 }
 
 // NewServer initializes and configures a kubelet.Server object to handle HTTP requests.

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -782,7 +782,7 @@ func (s *Server) getAttach(request *restful.Request, response *restful.Response)
 	}
 
 	podFullName := kubecontainer.GetPodFullName(pod)
-	url, err := s.host.GetAttach(podFullName, params.podUID, params.containerName, *streamOpts)
+	url, err := s.host.GetAttach(request.Request.Context(), podFullName, params.podUID, params.containerName, *streamOpts)
 	if err != nil {
 		streaming.WriteError(err, response.ResponseWriter)
 		return
@@ -807,7 +807,7 @@ func (s *Server) getExec(request *restful.Request, response *restful.Response) {
 	}
 
 	podFullName := kubecontainer.GetPodFullName(pod)
-	url, err := s.host.GetExec(podFullName, params.podUID, params.containerName, params.cmd, *streamOpts)
+	url, err := s.host.GetExec(request.Request.Context(), podFullName, params.podUID, params.containerName, params.cmd, *streamOpts)
 	if err != nil {
 		streaming.WriteError(err, response.ResponseWriter)
 		return
@@ -826,7 +826,7 @@ func (s *Server) getRun(request *restful.Request, response *restful.Response) {
 
 	// For legacy reasons, run uses different query param than exec.
 	params.cmd = strings.Split(request.QueryParameter("cmd"), " ")
-	data, err := s.host.RunInContainer(kubecontainer.GetPodFullName(pod), params.podUID, params.containerName, params.cmd)
+	data, err := s.host.RunInContainer(request.Request.Context(), kubecontainer.GetPodFullName(pod), params.podUID, params.containerName, params.cmd)
 	if err != nil {
 		response.WriteError(http.StatusInternalServerError, err)
 		return
@@ -869,7 +869,7 @@ func (s *Server) getPortForward(request *restful.Request, response *restful.Resp
 		return
 	}
 
-	url, err := s.host.GetPortForward(pod.Name, pod.Namespace, pod.UID, *portForwardOptions)
+	url, err := s.host.GetPortForward(request.Request.Context(), pod.Name, pod.Namespace, pod.UID, *portForwardOptions)
 	if err != nil {
 		streaming.WriteError(err, response.ResponseWriter)
 		return

--- a/pkg/kubelet/server/stats/handler.go
+++ b/pkg/kubelet/server/stats/handler.go
@@ -18,6 +18,7 @@ limitations under the License.
 package stats
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -26,7 +27,7 @@ import (
 	cadvisorv2 "github.com/google/cadvisor/info/v2"
 	"k8s.io/klog/v2"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/cm"

--- a/pkg/kubelet/server/stats/handler.go
+++ b/pkg/kubelet/server/stats/handler.go
@@ -39,18 +39,18 @@ type Provider interface {
 	// The following stats are provided by either CRI or cAdvisor.
 	//
 	// ListPodStats returns the stats of all the containers managed by pods.
-	ListPodStats() ([]statsapi.PodStats, error)
+	ListPodStats(ctx context.Context) ([]statsapi.PodStats, error)
 	// ListPodStatsAndUpdateCPUNanoCoreUsage updates the cpu nano core usage for
 	// the containers and returns the stats for all the pod-managed containers.
-	ListPodCPUAndMemoryStats() ([]statsapi.PodStats, error)
+	ListPodCPUAndMemoryStats(ctx context.Context) ([]statsapi.PodStats, error)
 	// ListPodStatsAndUpdateCPUNanoCoreUsage returns the stats of all the
 	// containers managed by pods and force update the cpu usageNanoCores.
 	// This is a workaround for CRI runtimes that do not integrate with
 	// cadvisor. See https://github.com/kubernetes/kubernetes/issues/72788
 	// for more details.
-	ListPodStatsAndUpdateCPUNanoCoreUsage() ([]statsapi.PodStats, error)
+	ListPodStatsAndUpdateCPUNanoCoreUsage(ctx context.Context) ([]statsapi.PodStats, error)
 	// ImageFsStats returns the stats of the image filesystem.
-	ImageFsStats() (*statsapi.FsStats, error)
+	ImageFsStats(ctx context.Context) (*statsapi.FsStats, error)
 
 	// The following stats are provided by cAdvisor.
 	//

--- a/pkg/kubelet/server/stats/handler.go
+++ b/pkg/kubelet/server/stats/handler.go
@@ -152,11 +152,11 @@ func (h *handler) handleSummary(request *restful.Request, response *restful.Resp
 	}
 	var summary *statsapi.Summary
 	if onlyCPUAndMemory {
-		summary, err = h.summaryProvider.GetCPUAndMemoryStats()
+		summary, err = h.summaryProvider.GetCPUAndMemoryStats(request.Request.Context())
 	} else {
 		// external calls to the summary API use cached stats
 		forceStatsUpdate := false
-		summary, err = h.summaryProvider.Get(forceStatsUpdate)
+		summary, err = h.summaryProvider.Get(request.Request.Context(), forceStatsUpdate)
 	}
 	if err != nil {
 		handleError(response, "/stats/summary", err)

--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -18,6 +18,7 @@ limitations under the License.
 package stats
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/klog/v2"
@@ -65,7 +66,7 @@ func NewSummaryProvider(statsProvider Provider) SummaryProvider {
 	}
 }
 
-func (sp *summaryProviderImpl) Get(updateStats bool) (*statsapi.Summary, error) {
+func (sp *summaryProviderImpl) Get(ctx context.Context, updateStats bool) (*statsapi.Summary, error) {
 	// TODO(timstclair): Consider returning a best-effort response if any of
 	// the following errors occur.
 	node, err := sp.provider.GetNode()
@@ -81,15 +82,15 @@ func (sp *summaryProviderImpl) Get(updateStats bool) (*statsapi.Summary, error) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rootFs stats: %v", err)
 	}
-	imageFsStats, err := sp.provider.ImageFsStats()
+	imageFsStats, err := sp.provider.ImageFsStats(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get imageFs stats: %v", err)
 	}
 	var podStats []statsapi.PodStats
 	if updateStats {
-		podStats, err = sp.provider.ListPodStatsAndUpdateCPUNanoCoreUsage()
+		podStats, err = sp.provider.ListPodStatsAndUpdateCPUNanoCoreUsage(ctx)
 	} else {
-		podStats, err = sp.provider.ListPodStats()
+		podStats, err = sp.provider.ListPodStats(ctx)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pod stats: %v", err)
@@ -118,7 +119,7 @@ func (sp *summaryProviderImpl) Get(updateStats bool) (*statsapi.Summary, error) 
 	return &summary, nil
 }
 
-func (sp *summaryProviderImpl) GetCPUAndMemoryStats() (*statsapi.Summary, error) {
+func (sp *summaryProviderImpl) GetCPUAndMemoryStats(ctx context.Context) (*statsapi.Summary, error) {
 	// TODO(timstclair): Consider returning a best-effort response if any of
 	// the following errors occur.
 	node, err := sp.provider.GetNode()
@@ -131,7 +132,7 @@ func (sp *summaryProviderImpl) GetCPUAndMemoryStats() (*statsapi.Summary, error)
 		return nil, fmt.Errorf("failed to get root cgroup stats: %v", err)
 	}
 
-	podStats, err := sp.provider.ListPodCPUAndMemoryStats()
+	podStats, err := sp.provider.ListPodCPUAndMemoryStats(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pod stats: %v", err)
 	}

--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -31,9 +31,9 @@ import (
 type SummaryProvider interface {
 	// Get provides a new Summary with the stats from Kubelet,
 	// and will update some stats if updateStats is true
-	Get(updateStats bool) (*statsapi.Summary, error)
+	Get(ctx context.Context, updateStats bool) (*statsapi.Summary, error)
 	// GetCPUAndMemoryStats provides a new Summary with the CPU and memory stats from Kubelet,
-	GetCPUAndMemoryStats() (*statsapi.Summary, error)
+	GetCPUAndMemoryStats(ctx context.Context) (*statsapi.Summary, error)
 }
 
 // summaryProviderImpl implements the SummaryProvider interface.

--- a/pkg/kubelet/server/stats/summary_windows_test.go
+++ b/pkg/kubelet/server/stats/summary_windows_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package stats
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -52,6 +53,7 @@ func TestSummaryProvider(t *testing.T) {
 	)
 
 	assert := assert.New(t)
+	ctx := context.Background()
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -60,15 +62,15 @@ func TestSummaryProvider(t *testing.T) {
 	mockStatsProvider.EXPECT().GetNode().Return(node, nil).AnyTimes()
 	mockStatsProvider.EXPECT().GetNodeConfig().Return(nodeConfig).AnyTimes()
 	mockStatsProvider.EXPECT().GetPodCgroupRoot().Return(cgroupRoot).AnyTimes()
-	mockStatsProvider.EXPECT().ListPodStats().Return(podStats, nil).AnyTimes()
-	mockStatsProvider.EXPECT().ListPodStatsAndUpdateCPUNanoCoreUsage().Return(podStats, nil).AnyTimes()
-	mockStatsProvider.EXPECT().ImageFsStats().Return(imageFsStats, nil).AnyTimes()
+	mockStatsProvider.EXPECT().ListPodStats(ctx).Return(podStats, nil).AnyTimes()
+	mockStatsProvider.EXPECT().ListPodStatsAndUpdateCPUNanoCoreUsage(ctx).Return(podStats, nil).AnyTimes()
+	mockStatsProvider.EXPECT().ImageFsStats(ctx).Return(imageFsStats, nil).AnyTimes()
 	mockStatsProvider.EXPECT().RootFsStats().Return(rootFsStats, nil).AnyTimes()
 	mockStatsProvider.EXPECT().RlimitStats().Return(nil, nil).AnyTimes()
 	mockStatsProvider.EXPECT().GetCgroupStats("/", true).Return(cgroupStatsMap["/"].cs, cgroupStatsMap["/"].ns, nil).AnyTimes()
 
 	provider := NewSummaryProvider(mockStatsProvider)
-	summary, err := provider.Get(true)
+	summary, err := provider.Get(ctx, true)
 	assert.NoError(err)
 
 	assert.Equal(summary.Node.NodeName, "test-node")

--- a/pkg/kubelet/server/stats/testing/mock_stats_provider.go
+++ b/pkg/kubelet/server/stats/testing/mock_stats_provider.go
@@ -21,9 +21,7 @@ limitations under the License.
 package testing
 
 import (
-	"context"
-	reflect "reflect"
-
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/google/cadvisor/info/v1"
 	v2 "github.com/google/cadvisor/info/v2"
@@ -32,6 +30,7 @@ import (
 	v1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	cm "k8s.io/kubernetes/pkg/kubelet/cm"
 	volume "k8s.io/kubernetes/pkg/volume"
+	reflect "reflect"
 )
 
 // MockProvider is a mock of Provider interface
@@ -60,61 +59,61 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 // ListPodStats mocks base method
 func (m *MockProvider) ListPodStats(ctx context.Context) ([]v1alpha1.PodStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPodStats")
+	ret := m.ctrl.Call(m, "ListPodStats", ctx)
 	ret0, _ := ret[0].([]v1alpha1.PodStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListPodStats indicates an expected call of ListPodStats
-func (mr *MockProviderMockRecorder) ListPodStats() *gomock.Call {
+func (mr *MockProviderMockRecorder) ListPodStats(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPodStats", reflect.TypeOf((*MockProvider)(nil).ListPodStats))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPodStats", reflect.TypeOf((*MockProvider)(nil).ListPodStats), ctx)
 }
 
 // ListPodCPUAndMemoryStats mocks base method
 func (m *MockProvider) ListPodCPUAndMemoryStats(ctx context.Context) ([]v1alpha1.PodStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPodCPUAndMemoryStats")
+	ret := m.ctrl.Call(m, "ListPodCPUAndMemoryStats", ctx)
 	ret0, _ := ret[0].([]v1alpha1.PodStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListPodCPUAndMemoryStats indicates an expected call of ListPodCPUAndMemoryStats
-func (mr *MockProviderMockRecorder) ListPodCPUAndMemoryStats() *gomock.Call {
+func (mr *MockProviderMockRecorder) ListPodCPUAndMemoryStats(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPodCPUAndMemoryStats", reflect.TypeOf((*MockProvider)(nil).ListPodCPUAndMemoryStats))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPodCPUAndMemoryStats", reflect.TypeOf((*MockProvider)(nil).ListPodCPUAndMemoryStats), ctx)
 }
 
 // ListPodStatsAndUpdateCPUNanoCoreUsage mocks base method
 func (m *MockProvider) ListPodStatsAndUpdateCPUNanoCoreUsage(ctx context.Context) ([]v1alpha1.PodStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPodStatsAndUpdateCPUNanoCoreUsage")
+	ret := m.ctrl.Call(m, "ListPodStatsAndUpdateCPUNanoCoreUsage", ctx)
 	ret0, _ := ret[0].([]v1alpha1.PodStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListPodStatsAndUpdateCPUNanoCoreUsage indicates an expected call of ListPodStatsAndUpdateCPUNanoCoreUsage
-func (mr *MockProviderMockRecorder) ListPodStatsAndUpdateCPUNanoCoreUsage() *gomock.Call {
+func (mr *MockProviderMockRecorder) ListPodStatsAndUpdateCPUNanoCoreUsage(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPodStatsAndUpdateCPUNanoCoreUsage", reflect.TypeOf((*MockProvider)(nil).ListPodStatsAndUpdateCPUNanoCoreUsage))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPodStatsAndUpdateCPUNanoCoreUsage", reflect.TypeOf((*MockProvider)(nil).ListPodStatsAndUpdateCPUNanoCoreUsage), ctx)
 }
 
 // ImageFsStats mocks base method
 func (m *MockProvider) ImageFsStats(ctx context.Context) (*v1alpha1.FsStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ImageFsStats")
+	ret := m.ctrl.Call(m, "ImageFsStats", ctx)
 	ret0, _ := ret[0].(*v1alpha1.FsStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ImageFsStats indicates an expected call of ImageFsStats
-func (mr *MockProviderMockRecorder) ImageFsStats() *gomock.Call {
+func (mr *MockProviderMockRecorder) ImageFsStats(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageFsStats", reflect.TypeOf((*MockProvider)(nil).ImageFsStats))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageFsStats", reflect.TypeOf((*MockProvider)(nil).ImageFsStats), ctx)
 }
 
 // GetCgroupStats mocks base method

--- a/pkg/kubelet/server/stats/testing/mock_stats_provider.go
+++ b/pkg/kubelet/server/stats/testing/mock_stats_provider.go
@@ -21,6 +21,9 @@ limitations under the License.
 package testing
 
 import (
+	"context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/google/cadvisor/info/v1"
 	v2 "github.com/google/cadvisor/info/v2"
@@ -29,7 +32,6 @@ import (
 	v1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	cm "k8s.io/kubernetes/pkg/kubelet/cm"
 	volume "k8s.io/kubernetes/pkg/volume"
-	reflect "reflect"
 )
 
 // MockProvider is a mock of Provider interface
@@ -56,7 +58,7 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 }
 
 // ListPodStats mocks base method
-func (m *MockProvider) ListPodStats() ([]v1alpha1.PodStats, error) {
+func (m *MockProvider) ListPodStats(ctx context.Context) ([]v1alpha1.PodStats, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPodStats")
 	ret0, _ := ret[0].([]v1alpha1.PodStats)
@@ -71,7 +73,7 @@ func (mr *MockProviderMockRecorder) ListPodStats() *gomock.Call {
 }
 
 // ListPodCPUAndMemoryStats mocks base method
-func (m *MockProvider) ListPodCPUAndMemoryStats() ([]v1alpha1.PodStats, error) {
+func (m *MockProvider) ListPodCPUAndMemoryStats(ctx context.Context) ([]v1alpha1.PodStats, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPodCPUAndMemoryStats")
 	ret0, _ := ret[0].([]v1alpha1.PodStats)
@@ -86,7 +88,7 @@ func (mr *MockProviderMockRecorder) ListPodCPUAndMemoryStats() *gomock.Call {
 }
 
 // ListPodStatsAndUpdateCPUNanoCoreUsage mocks base method
-func (m *MockProvider) ListPodStatsAndUpdateCPUNanoCoreUsage() ([]v1alpha1.PodStats, error) {
+func (m *MockProvider) ListPodStatsAndUpdateCPUNanoCoreUsage(ctx context.Context) ([]v1alpha1.PodStats, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPodStatsAndUpdateCPUNanoCoreUsage")
 	ret0, _ := ret[0].([]v1alpha1.PodStats)
@@ -101,7 +103,7 @@ func (mr *MockProviderMockRecorder) ListPodStatsAndUpdateCPUNanoCoreUsage() *gom
 }
 
 // ImageFsStats mocks base method
-func (m *MockProvider) ImageFsStats() (*v1alpha1.FsStats, error) {
+func (m *MockProvider) ImageFsStats(ctx context.Context) (*v1alpha1.FsStats, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImageFsStats")
 	ret0, _ := ret[0].(*v1alpha1.FsStats)

--- a/pkg/kubelet/server/stats/testing/mock_summary_provider.go
+++ b/pkg/kubelet/server/stats/testing/mock_summary_provider.go
@@ -21,6 +21,7 @@ limitations under the License.
 package testing
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	reflect "reflect"
@@ -50,31 +51,31 @@ func (m *MockSummaryProvider) EXPECT() *MockSummaryProviderMockRecorder {
 }
 
 // Get mocks base method
-func (m *MockSummaryProvider) Get(updateStats bool) (*v1alpha1.Summary, error) {
+func (m *MockSummaryProvider) Get(ctx context.Context, updateStats bool) (*v1alpha1.Summary, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", updateStats)
+	ret := m.ctrl.Call(m, "Get", ctx, updateStats)
 	ret0, _ := ret[0].(*v1alpha1.Summary)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get
-func (mr *MockSummaryProviderMockRecorder) Get(updateStats interface{}) *gomock.Call {
+func (mr *MockSummaryProviderMockRecorder) Get(ctx, updateStats interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSummaryProvider)(nil).Get), updateStats)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSummaryProvider)(nil).Get), ctx, updateStats)
 }
 
 // GetCPUAndMemoryStats mocks base method
-func (m *MockSummaryProvider) GetCPUAndMemoryStats() (*v1alpha1.Summary, error) {
+func (m *MockSummaryProvider) GetCPUAndMemoryStats(ctx context.Context) (*v1alpha1.Summary, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCPUAndMemoryStats")
+	ret := m.ctrl.Call(m, "GetCPUAndMemoryStats", ctx)
 	ret0, _ := ret[0].(*v1alpha1.Summary)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCPUAndMemoryStats indicates an expected call of GetCPUAndMemoryStats
-func (mr *MockSummaryProviderMockRecorder) GetCPUAndMemoryStats() *gomock.Call {
+func (mr *MockSummaryProviderMockRecorder) GetCPUAndMemoryStats(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCPUAndMemoryStats", reflect.TypeOf((*MockSummaryProvider)(nil).GetCPUAndMemoryStats))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCPUAndMemoryStats", reflect.TypeOf((*MockSummaryProvider)(nil).GetCPUAndMemoryStats), ctx)
 }

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package stats
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"sort"
@@ -75,7 +76,7 @@ func newCadvisorStatsProvider(
 }
 
 // ListPodStats returns the stats of all the pod-managed containers.
-func (p *cadvisorStatsProvider) ListPodStats() ([]statsapi.PodStats, error) {
+func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.PodStats, error) {
 	// Gets node root filesystem information and image filesystem stats, which
 	// will be used to populate the available and capacity bytes/inodes in
 	// container stats.
@@ -175,12 +176,12 @@ func (p *cadvisorStatsProvider) ListPodStats() ([]statsapi.PodStats, error) {
 // the containers and returns the stats for all the pod-managed containers.
 // For cadvisor, cpu nano core usages are pre-computed and cached, so this
 // function simply calls ListPodStats.
-func (p *cadvisorStatsProvider) ListPodStatsAndUpdateCPUNanoCoreUsage() ([]statsapi.PodStats, error) {
-	return p.ListPodStats()
+func (p *cadvisorStatsProvider) ListPodStatsAndUpdateCPUNanoCoreUsage(ctx context.Context) ([]statsapi.PodStats, error) {
+	return p.ListPodStats(ctx)
 }
 
 // ListPodCPUAndMemoryStats returns the cpu and memory stats of all the pod-managed containers.
-func (p *cadvisorStatsProvider) ListPodCPUAndMemoryStats() ([]statsapi.PodStats, error) {
+func (p *cadvisorStatsProvider) ListPodCPUAndMemoryStats(ctx context.Context) ([]statsapi.PodStats, error) {
 	infos, err := getCadvisorContainerInfo(p.cadvisor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get container info from cadvisor: %v", err)
@@ -240,12 +241,12 @@ func (p *cadvisorStatsProvider) ListPodCPUAndMemoryStats() ([]statsapi.PodStats,
 }
 
 // ImageFsStats returns the stats of the filesystem for storing images.
-func (p *cadvisorStatsProvider) ImageFsStats() (*statsapi.FsStats, error) {
+func (p *cadvisorStatsProvider) ImageFsStats(ctx context.Context) (*statsapi.FsStats, error) {
 	imageFsInfo, err := p.cadvisor.ImagesFsInfo()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get imageFs info: %v", err)
 	}
-	imageStats, err := p.imageService.ImageStats()
+	imageStats, err := p.imageService.ImageStats(ctx)
 	if err != nil || imageStats == nil {
 		return nil, fmt.Errorf("failed to get image stats: %v", err)
 	}
@@ -269,7 +270,7 @@ func (p *cadvisorStatsProvider) ImageFsStats() (*statsapi.FsStats, error) {
 
 // ImageFsDevice returns name of the device where the image filesystem locates,
 // e.g. /dev/sda1.
-func (p *cadvisorStatsProvider) ImageFsDevice() (string, error) {
+func (p *cadvisorStatsProvider) ImageFsDevice(ctx context.Context) (string, error) {
 	imageFsInfo, err := p.cadvisor.ImagesFsInfo()
 	if err != nil {
 		return "", err

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package stats
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path"
@@ -105,9 +106,9 @@ func newCRIStatsProvider(
 }
 
 // ListPodStats returns the stats of all the pod-managed containers.
-func (p *criStatsProvider) ListPodStats() ([]statsapi.PodStats, error) {
+func (p *criStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.PodStats, error) {
 	// Don't update CPU nano core usage.
-	return p.listPodStats(false)
+	return p.listPodStats(ctx, false)
 }
 
 // ListPodStatsAndUpdateCPUNanoCoreUsage updates the cpu nano core usage for
@@ -120,12 +121,12 @@ func (p *criStatsProvider) ListPodStats() ([]statsapi.PodStats, error) {
 // vary and the usage could be incoherent (e.g., spiky). If no caller calls
 // this function, the cpu usage will stay nil. Right now, eviction manager is
 // the only caller, and it calls this function every 10s.
-func (p *criStatsProvider) ListPodStatsAndUpdateCPUNanoCoreUsage() ([]statsapi.PodStats, error) {
+func (p *criStatsProvider) ListPodStatsAndUpdateCPUNanoCoreUsage(ctx context.Context) ([]statsapi.PodStats, error) {
 	// Update CPU nano core usage.
-	return p.listPodStats(true)
+	return p.listPodStats(ctx, true)
 }
 
-func (p *criStatsProvider) listPodStats(updateCPUNanoCoreUsage bool) ([]statsapi.PodStats, error) {
+func (p *criStatsProvider) listPodStats(ctx context.Context, updateCPUNanoCoreUsage bool) ([]statsapi.PodStats, error) {
 	// Gets node root filesystem information, which will be used to populate
 	// the available and capacity bytes/inodes in container stats.
 	rootFsInfo, err := p.cadvisor.RootFsInfo()
@@ -133,13 +134,13 @@ func (p *criStatsProvider) listPodStats(updateCPUNanoCoreUsage bool) ([]statsapi
 		return nil, fmt.Errorf("failed to get rootFs info: %v", err)
 	}
 
-	containerMap, podSandboxMap, err := p.getPodAndContainerMaps()
+	containerMap, podSandboxMap, err := p.getPodAndContainerMaps(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod or container map: %v", err)
 	}
 
 	if p.podAndContainerStatsFromCRI {
-		_, err := p.listPodStatsStrictlyFromCRI(updateCPUNanoCoreUsage, containerMap, podSandboxMap, &rootFsInfo)
+		_, err := p.listPodStatsStrictlyFromCRI(ctx, updateCPUNanoCoreUsage, containerMap, podSandboxMap, &rootFsInfo)
 		if err != nil {
 			s, ok := status.FromError(err)
 			// Legitimate failure, rather than the CRI implementation does not support ListPodSandboxStats.
@@ -152,10 +153,10 @@ func (p *criStatsProvider) listPodStats(updateCPUNanoCoreUsage bool) ([]statsapi
 			)
 		}
 	}
-	return p.listPodStatsPartiallyFromCRI(updateCPUNanoCoreUsage, containerMap, podSandboxMap, &rootFsInfo)
+	return p.listPodStatsPartiallyFromCRI(ctx, updateCPUNanoCoreUsage, containerMap, podSandboxMap, &rootFsInfo)
 }
 
-func (p *criStatsProvider) listPodStatsPartiallyFromCRI(updateCPUNanoCoreUsage bool, containerMap map[string]*runtimeapi.Container, podSandboxMap map[string]*runtimeapi.PodSandbox, rootFsInfo *cadvisorapiv2.FsInfo) ([]statsapi.PodStats, error) {
+func (p *criStatsProvider) listPodStatsPartiallyFromCRI(ctx context.Context, updateCPUNanoCoreUsage bool, containerMap map[string]*runtimeapi.Container, podSandboxMap map[string]*runtimeapi.PodSandbox, rootFsInfo *cadvisorapiv2.FsInfo) ([]statsapi.PodStats, error) {
 	// fsIDtoInfo is a map from filesystem id to its stats. This will be used
 	// as a cache to avoid querying cAdvisor for the filesystem stats with the
 	// same filesystem id many times.
@@ -164,7 +165,7 @@ func (p *criStatsProvider) listPodStatsPartiallyFromCRI(updateCPUNanoCoreUsage b
 	// sandboxIDToPodStats is a temporary map from sandbox ID to its pod stats.
 	sandboxIDToPodStats := make(map[string]*statsapi.PodStats)
 
-	resp, err := p.runtimeService.ListContainerStats(&runtimeapi.ContainerStatsFilter{})
+	resp, err := p.runtimeService.ListContainerStats(ctx, &runtimeapi.ContainerStatsFilter{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list all container stats: %v", err)
 	}
@@ -229,8 +230,8 @@ func (p *criStatsProvider) listPodStatsPartiallyFromCRI(updateCPUNanoCoreUsage b
 	return result, nil
 }
 
-func (p *criStatsProvider) listPodStatsStrictlyFromCRI(updateCPUNanoCoreUsage bool, containerMap map[string]*runtimeapi.Container, podSandboxMap map[string]*runtimeapi.PodSandbox, rootFsInfo *cadvisorapiv2.FsInfo) ([]statsapi.PodStats, error) {
-	criSandboxStats, err := p.runtimeService.ListPodSandboxStats(&runtimeapi.PodSandboxStatsFilter{})
+func (p *criStatsProvider) listPodStatsStrictlyFromCRI(ctx context.Context, updateCPUNanoCoreUsage bool, containerMap map[string]*runtimeapi.Container, podSandboxMap map[string]*runtimeapi.PodSandbox, rootFsInfo *cadvisorapiv2.FsInfo) ([]statsapi.PodStats, error) {
+	criSandboxStats, err := p.runtimeService.ListPodSandboxStats(ctx, &runtimeapi.PodSandboxStatsFilter{})
 	if err != nil {
 		return nil, err
 	}
@@ -267,17 +268,17 @@ func (p *criStatsProvider) listPodStatsStrictlyFromCRI(updateCPUNanoCoreUsage bo
 }
 
 // ListPodCPUAndMemoryStats returns the CPU and Memory stats of all the pod-managed containers.
-func (p *criStatsProvider) ListPodCPUAndMemoryStats() ([]statsapi.PodStats, error) {
+func (p *criStatsProvider) ListPodCPUAndMemoryStats(ctx context.Context) ([]statsapi.PodStats, error) {
 	// sandboxIDToPodStats is a temporary map from sandbox ID to its pod stats.
 	sandboxIDToPodStats := make(map[string]*statsapi.PodStats)
-	containerMap, podSandboxMap, err := p.getPodAndContainerMaps()
+	containerMap, podSandboxMap, err := p.getPodAndContainerMaps(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod or container map: %v", err)
 	}
 
 	result := make([]statsapi.PodStats, 0, len(podSandboxMap))
 	if p.podAndContainerStatsFromCRI {
-		criSandboxStats, err := p.runtimeService.ListPodSandboxStats(&runtimeapi.PodSandboxStatsFilter{})
+		criSandboxStats, err := p.runtimeService.ListPodSandboxStats(ctx, &runtimeapi.PodSandboxStatsFilter{})
 		// Call succeeded
 		if err == nil {
 			for _, criSandboxStat := range criSandboxStats {
@@ -304,7 +305,7 @@ func (p *criStatsProvider) ListPodCPUAndMemoryStats() ([]statsapi.PodStats, erro
 		)
 	}
 
-	resp, err := p.runtimeService.ListContainerStats(&runtimeapi.ContainerStatsFilter{})
+	resp, err := p.runtimeService.ListContainerStats(ctx, &runtimeapi.ContainerStatsFilter{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list all container stats: %v", err)
 	}
@@ -359,15 +360,15 @@ func (p *criStatsProvider) ListPodCPUAndMemoryStats() ([]statsapi.PodStats, erro
 	return result, nil
 }
 
-func (p *criStatsProvider) getPodAndContainerMaps() (map[string]*runtimeapi.Container, map[string]*runtimeapi.PodSandbox, error) {
-	containers, err := p.runtimeService.ListContainers(&runtimeapi.ContainerFilter{})
+func (p *criStatsProvider) getPodAndContainerMaps(ctx context.Context) (map[string]*runtimeapi.Container, map[string]*runtimeapi.PodSandbox, error) {
+	containers, err := p.runtimeService.ListContainers(ctx, &runtimeapi.ContainerFilter{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to list all containers: %v", err)
 	}
 
 	// Creates pod sandbox map between the pod sandbox ID and the PodSandbox object.
 	podSandboxMap := make(map[string]*runtimeapi.PodSandbox)
-	podSandboxes, err := p.runtimeService.ListPodSandbox(&runtimeapi.PodSandboxFilter{})
+	podSandboxes, err := p.runtimeService.ListPodSandbox(ctx, &runtimeapi.PodSandboxFilter{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to list all pod sandboxes: %v", err)
 	}
@@ -386,8 +387,8 @@ func (p *criStatsProvider) getPodAndContainerMaps() (map[string]*runtimeapi.Cont
 }
 
 // ImageFsStats returns the stats of the image filesystem.
-func (p *criStatsProvider) ImageFsStats() (*statsapi.FsStats, error) {
-	resp, err := p.imageService.ImageFsInfo()
+func (p *criStatsProvider) ImageFsStats(ctx context.Context) (*statsapi.FsStats, error) {
+	resp, err := p.imageService.ImageFsInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -423,8 +424,8 @@ func (p *criStatsProvider) ImageFsStats() (*statsapi.FsStats, error) {
 
 // ImageFsDevice returns name of the device where the image filesystem locates,
 // e.g. /dev/sda1.
-func (p *criStatsProvider) ImageFsDevice() (string, error) {
-	resp, err := p.imageService.ImageFsInfo()
+func (p *criStatsProvider) ImageFsDevice(ctx context.Context) (string, error) {
+	resp, err := p.imageService.ImageFsInfo(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package stats
 
 import (
+	"context"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -239,7 +240,7 @@ func TestCRIListPodStats(t *testing.T) {
 		false,
 	)
 
-	stats, err := provider.ListPodStats()
+	stats, err := provider.ListPodStats(context.Background())
 	assert := assert.New(t)
 	assert.NoError(err)
 	assert.Equal(4, len(stats))
@@ -400,7 +401,7 @@ func TestAcceleratorUsageStatsCanBeDisabled(t *testing.T) {
 		false,
 	)
 
-	stats, err := provider.ListPodStats()
+	stats, err := provider.ListPodStats(context.Background())
 	assert := assert.New(t)
 	assert.NoError(err)
 	assert.Equal(1, len(stats))
@@ -546,7 +547,7 @@ func TestCRIListPodCPUAndMemoryStats(t *testing.T) {
 		false,
 	)
 
-	stats, err := provider.ListPodCPUAndMemoryStats()
+	stats, err := provider.ListPodCPUAndMemoryStats(context.Background())
 	assert := assert.New(t)
 	assert.NoError(err)
 	assert.Equal(5, len(stats))
@@ -677,7 +678,7 @@ func TestCRIImagesFsStats(t *testing.T) {
 		false,
 	)
 
-	stats, err := provider.ImageFsStats()
+	stats, err := provider.ImageFsStats(context.Background())
 	assert := assert.New(t)
 	assert.NoError(err)
 

--- a/pkg/kubelet/stats/provider.go
+++ b/pkg/kubelet/stats/provider.go
@@ -90,11 +90,11 @@ type Provider struct {
 // containerStatsProvider is an interface that provides the stats of the
 // containers managed by pods.
 type containerStatsProvider interface {
-	ListPodStats() ([]statsapi.PodStats, error)
-	ListPodStatsAndUpdateCPUNanoCoreUsage() ([]statsapi.PodStats, error)
-	ListPodCPUAndMemoryStats() ([]statsapi.PodStats, error)
-	ImageFsStats() (*statsapi.FsStats, error)
-	ImageFsDevice() (string, error)
+	ListPodStats(ctx context.Context) ([]statsapi.PodStats, error)
+	ListPodStatsAndUpdateCPUNanoCoreUsage(ctx context.Context) ([]statsapi.PodStats, error)
+	ListPodCPUAndMemoryStats(ctx context.Context) ([]statsapi.PodStats, error)
+	ImageFsStats(ctx context.Context) (*statsapi.FsStats, error)
+	ImageFsDevice(ctx context.Context) (string, error)
 }
 
 type rlimitStatsProvider interface {

--- a/pkg/kubelet/stats/provider.go
+++ b/pkg/kubelet/stats/provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package stats
 
 import (
+	"context"
 	"fmt"
 
 	cadvisorapiv1 "github.com/google/cadvisor/info/v1"

--- a/pkg/kubelet/stats/provider.go
+++ b/pkg/kubelet/stats/provider.go
@@ -202,7 +202,7 @@ func (p *Provider) GetRawContainerInfo(containerName string, req *cadvisorapiv1.
 
 // HasDedicatedImageFs returns true if a dedicated image filesystem exists for storing images.
 func (p *Provider) HasDedicatedImageFs() (bool, error) {
-	device, err := p.containerStatsProvider.ImageFsDevice()
+	device, err := p.containerStatsProvider.ImageFsDevice(context.TODO())
 	if err != nil {
 		return false, err
 	}

--- a/pkg/kubelet/stats/provider_test.go
+++ b/pkg/kubelet/stats/provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package stats
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -717,9 +718,11 @@ type fakeResourceAnalyzer struct {
 	podVolumeStats serverstats.PodVolumeStats
 }
 
-func (o *fakeResourceAnalyzer) Start()                                           {}
-func (o *fakeResourceAnalyzer) Get(bool) (*statsapi.Summary, error)              { return nil, nil }
-func (o *fakeResourceAnalyzer) GetCPUAndMemoryStats() (*statsapi.Summary, error) { return nil, nil }
+func (o *fakeResourceAnalyzer) Start()                                               {}
+func (o *fakeResourceAnalyzer) Get(context.Context, bool) (*statsapi.Summary, error) { return nil, nil }
+func (o *fakeResourceAnalyzer) GetCPUAndMemoryStats(context.Context) (*statsapi.Summary, error) {
+	return nil, nil
+}
 func (o *fakeResourceAnalyzer) GetPodVolumeStats(uid types.UID) (serverstats.PodVolumeStats, bool) {
 	return o.podVolumeStats, true
 }
@@ -728,22 +731,22 @@ type fakeContainerStatsProvider struct {
 	device string
 }
 
-func (p fakeContainerStatsProvider) ListPodStats() ([]statsapi.PodStats, error) {
+func (p fakeContainerStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.PodStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (p fakeContainerStatsProvider) ListPodStatsAndUpdateCPUNanoCoreUsage() ([]statsapi.PodStats, error) {
+func (p fakeContainerStatsProvider) ListPodStatsAndUpdateCPUNanoCoreUsage(ctx context.Context) ([]statsapi.PodStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (p fakeContainerStatsProvider) ListPodCPUAndMemoryStats() ([]statsapi.PodStats, error) {
+func (p fakeContainerStatsProvider) ListPodCPUAndMemoryStats(ctx context.Context) ([]statsapi.PodStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (p fakeContainerStatsProvider) ImageFsStats() (*statsapi.FsStats, error) {
+func (p fakeContainerStatsProvider) ImageFsStats(ctx context.Context) (*statsapi.FsStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (p fakeContainerStatsProvider) ImageFsDevice() (string, error) {
+func (p fakeContainerStatsProvider) ImageFsDevice(ctx context.Context) (string, error) {
 	return p.device, nil
 }

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -103,14 +103,14 @@ type VolumeManager interface {
 	// actual state of the world).
 	// An error is returned if all volumes are not attached and mounted within
 	// the duration defined in podAttachAndMountTimeout.
-	WaitForAttachAndMount(pod *v1.Pod) error
+	WaitForAttachAndMount(ctx context.Context, pod *v1.Pod) error
 
 	// WaitForUnmount processes the volumes referenced in the specified
 	// pod and blocks until they are all unmounted (reflected in the actual
 	// state of the world).
 	// An error is returned if all volumes are not unmounted within
 	// the duration defined in podAttachAndMountTimeout.
-	WaitForUnmount(pod *v1.Pod) error
+	WaitForUnmount(ctx context.Context, pod *v1.Pod) error
 
 	// GetMountedVolumesForPod returns a VolumeMap containing the volumes
 	// referenced by the specified pod that are successfully attached and

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package volumemanager
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -390,7 +391,7 @@ func (vm *volumeManager) MarkVolumesAsReportedInUse(
 	vm.desiredStateOfWorld.MarkVolumesReportedInUse(volumesReportedAsInUse)
 }
 
-func (vm *volumeManager) WaitForAttachAndMount(pod *v1.Pod) error {
+func (vm *volumeManager) WaitForAttachAndMount(ctx context.Context, pod *v1.Pod) error {
 	if pod == nil {
 		return nil
 	}
@@ -436,7 +437,7 @@ func (vm *volumeManager) WaitForAttachAndMount(pod *v1.Pod) error {
 	return nil
 }
 
-func (vm *volumeManager) WaitForUnmount(pod *v1.Pod) error {
+func (vm *volumeManager) WaitForUnmount(ctx context.Context, pod *v1.Pod) error {
 	if pod == nil {
 		return nil
 	}

--- a/pkg/kubelet/volumemanager/volume_manager_fake.go
+++ b/pkg/kubelet/volumemanager/volume_manager_fake.go
@@ -17,6 +17,8 @@ limitations under the License.
 package volumemanager
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/container"
@@ -46,12 +48,12 @@ func (f *FakeVolumeManager) Run(sourcesReady config.SourcesReady, stopCh <-chan 
 }
 
 // WaitForAttachAndMount is not implemented
-func (f *FakeVolumeManager) WaitForAttachAndMount(pod *v1.Pod) error {
+func (f *FakeVolumeManager) WaitForAttachAndMount(ctx context.Context, pod *v1.Pod) error {
 	return nil
 }
 
 // WaitForUnmount is not implemented
-func (f *FakeVolumeManager) WaitForUnmount(pod *v1.Pod) error {
+func (f *FakeVolumeManager) WaitForUnmount(ctx context.Context, pod *v1.Pod) error {
 	return nil
 }
 

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -112,7 +112,7 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 				stopCh,
 				manager)
 
-			err = manager.WaitForAttachAndMount(pod)
+			err = manager.WaitForAttachAndMount(context.TODO(), pod)
 			if err != nil && !test.expectError {
 				t.Errorf("Expected success: %v", err)
 			}
@@ -178,7 +178,7 @@ func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 	go delayClaimBecomesBound(kubeClient, claim.GetNamespace(), claim.ObjectMeta.Name)
 
 	err = wait.Poll(100*time.Millisecond, 1*time.Second, func() (bool, error) {
-		err = manager.WaitForAttachAndMount(pod)
+		err = manager.WaitForAttachAndMount(context.TODO(), pod)
 		if err != nil {
 			// Few "PVC not bound" errors are expected
 			return false, nil
@@ -264,7 +264,7 @@ func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
 			stopCh,
 			manager)
 
-		err = manager.WaitForAttachAndMount(pod)
+		err = manager.WaitForAttachAndMount(context.TODO(), pod)
 		if err != nil {
 			t.Errorf("Expected success: %v", err)
 			continue

--- a/staging/src/k8s.io/cri-api/pkg/apis/services.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/services.go
@@ -25,37 +25,37 @@ import (
 // RuntimeVersioner contains methods for runtime name, version and API version.
 type RuntimeVersioner interface {
 	// Version returns the runtime name, runtime version and runtime API version
-	Version(apiVersion string) (*runtimeapi.VersionResponse, error)
+	Version(ctx context.Context, apiVersion string) (*runtimeapi.VersionResponse, error)
 }
 
 // ContainerManager contains methods to manipulate containers managed by a
 // container runtime. The methods are thread-safe.
 type ContainerManager interface {
 	// CreateContainer creates a new container in specified PodSandbox.
-	CreateContainer(podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error)
+	CreateContainer(ctx context.Context, podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error)
 	// StartContainer starts the container.
-	StartContainer(containerID string) error
+	StartContainer(ctx context.Context, containerID string) error
 	// StopContainer stops a running container with a grace period (i.e., timeout).
-	StopContainer(containerID string, timeout int64) error
+	StopContainer(ctx context.Context, containerID string, timeout int64) error
 	// RemoveContainer removes the container.
-	RemoveContainer(containerID string) error
+	RemoveContainer(ctx context.Context, containerID string) error
 	// ListContainers lists all containers by filters.
-	ListContainers(filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error)
+	ListContainers(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error)
 	// ContainerStatus returns the status of the container.
-	ContainerStatus(containerID string, verbose bool) (*runtimeapi.ContainerStatusResponse, error)
+	ContainerStatus(ctx context.Context, containerID string, verbose bool) (*runtimeapi.ContainerStatusResponse, error)
 	// UpdateContainerResources updates the cgroup resources for the container.
-	UpdateContainerResources(containerID string, resources *runtimeapi.LinuxContainerResources) error
+	UpdateContainerResources(ctx context.Context, containerID string, resources *runtimeapi.LinuxContainerResources) error
 	// ExecSync executes a command in the container, and returns the stdout output.
 	// If command exits with a non-zero exit code, an error is returned.
-	ExecSync(containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error)
+	ExecSync(ctx context.Context, containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error)
 	// Exec prepares a streaming endpoint to execute a command in the container, and returns the address.
-	Exec(*runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error)
+	Exec(ctx context.Context, req *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error)
 	// Attach prepares a streaming endpoint to attach to a running container, and returns the address.
-	Attach(req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error)
+	Attach(ctx context.Context, req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error)
 	// ReopenContainerLog asks runtime to reopen the stdout/stderr log file
 	// for the container. If it returns error, new container log file MUST NOT
 	// be created.
-	ReopenContainerLog(ContainerID string) error
+	ReopenContainerLog(ctx context.Context, containerID string) error
 }
 
 // PodSandboxManager contains methods for operating on PodSandboxes. The methods
@@ -63,19 +63,19 @@ type ContainerManager interface {
 type PodSandboxManager interface {
 	// RunPodSandbox creates and starts a pod-level sandbox. Runtimes should ensure
 	// the sandbox is in ready state.
-	RunPodSandbox(config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error)
+	RunPodSandbox(ctx context.Context, config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error)
 	// StopPodSandbox stops the sandbox. If there are any running containers in the
 	// sandbox, they should be force terminated.
-	StopPodSandbox(podSandboxID string) error
+	StopPodSandbox(ctx context.Context, podSandboxID string) error
 	// RemovePodSandbox removes the sandbox. If there are running containers in the
 	// sandbox, they should be forcibly removed.
-	RemovePodSandbox(podSandboxID string) error
+	RemovePodSandbox(ctx context.Context, podSandboxID string) error
 	// PodSandboxStatus returns the Status of the PodSandbox.
-	PodSandboxStatus(podSandboxID string, verbose bool) (*runtimeapi.PodSandboxStatusResponse, error)
+	PodSandboxStatus(ctx context.Context, podSandboxID string, verbose bool) (*runtimeapi.PodSandboxStatusResponse, error)
 	// ListPodSandbox returns a list of Sandbox.
-	ListPodSandbox(filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error)
+	ListPodSandbox(ctx context.Context, filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error)
 	// PortForward prepares a streaming endpoint to forward ports from a PodSandbox, and returns the address.
-	PortForward(*runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error)
+	PortForward(ctx context.Context, req *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error)
 }
 
 // ContainerStatsManager contains methods for retrieving the container
@@ -83,14 +83,14 @@ type PodSandboxManager interface {
 type ContainerStatsManager interface {
 	// ContainerStats returns stats of the container. If the container does not
 	// exist, the call returns an error.
-	ContainerStats(containerID string) (*runtimeapi.ContainerStats, error)
+	ContainerStats(ctx context.Context, containerID string) (*runtimeapi.ContainerStats, error)
 	// ListContainerStats returns stats of all running containers.
-	ListContainerStats(filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error)
+	ListContainerStats(ctx context.Context, filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error)
 	// PodSandboxStats returns stats of the pod. If the pod does not
 	// exist, the call returns an error.
-	PodSandboxStats(podSandboxID string) (*runtimeapi.PodSandboxStats, error)
+	PodSandboxStats(ctx context.Context, podSandboxID string) (*runtimeapi.PodSandboxStats, error)
 	// ListPodSandboxStats returns stats of all running pods.
-	ListPodSandboxStats(filter *runtimeapi.PodSandboxStatsFilter) ([]*runtimeapi.PodSandboxStats, error)
+	ListPodSandboxStats(ctx context.Context, filter *runtimeapi.PodSandboxStatsFilter) ([]*runtimeapi.PodSandboxStats, error)
 }
 
 // RuntimeService interface should be implemented by a container runtime.
@@ -102,9 +102,9 @@ type RuntimeService interface {
 	ContainerStatsManager
 
 	// UpdateRuntimeConfig updates runtime configuration if specified
-	UpdateRuntimeConfig(runtimeConfig *runtimeapi.RuntimeConfig) error
+	UpdateRuntimeConfig(ctx context.Context, runtimeConfig *runtimeapi.RuntimeConfig) error
 	// Status returns the status of the runtime.
-	Status(verbose bool) (*runtimeapi.StatusResponse, error)
+	Status(ctx context.Context, verbose bool) (*runtimeapi.StatusResponse, error)
 }
 
 // ImageManagerService interface should be implemented by a container image
@@ -112,13 +112,13 @@ type RuntimeService interface {
 // The methods should be thread-safe.
 type ImageManagerService interface {
 	// ListImages lists the existing images.
-	ListImages(filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error)
+	ListImages(ctx context.Context, filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error)
 	// ImageStatus returns the status of the image.
-	ImageStatus(image *runtimeapi.ImageSpec, verbose bool) (*runtimeapi.ImageStatusResponse, error)
+	ImageStatus(ctx context.Context, image *runtimeapi.ImageSpec, verbose bool) (*runtimeapi.ImageStatusResponse, error)
 	// PullImage pulls an image with the authentication config.
-	PullImage(image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error)
+	PullImage(ctx context.Context, image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error)
 	// RemoveImage removes the image.
-	RemoveImage(image *runtimeapi.ImageSpec) error
+	RemoveImage(ctx context.Context, image *runtimeapi.ImageSpec) error
 	// ImageFsInfo returns information of the filesystem that is used to store images.
-	ImageFsInfo() ([]*runtimeapi.FilesystemUsage, error)
+	ImageFsInfo(ctx context.Context) ([]*runtimeapi.FilesystemUsage, error)
 }

--- a/staging/src/k8s.io/cri-api/pkg/apis/services.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/services.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cri
 
 import (
+	"context"
 	"time"
 
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testing
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -131,7 +132,7 @@ func (r *FakeImageService) popError(f string) error {
 }
 
 // ListImages returns the list of images from FakeImageService or error if it was previously set.
-func (r *FakeImageService) ListImages(filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error) {
+func (r *FakeImageService) ListImages(ctx context.Context, filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -154,7 +155,7 @@ func (r *FakeImageService) ListImages(filter *runtimeapi.ImageFilter) ([]*runtim
 }
 
 // ImageStatus returns the status of the image from the FakeImageService.
-func (r *FakeImageService) ImageStatus(image *runtimeapi.ImageSpec, verbose bool) (*runtimeapi.ImageStatusResponse, error) {
+func (r *FakeImageService) ImageStatus(ctx context.Context, image *runtimeapi.ImageSpec, verbose bool) (*runtimeapi.ImageStatusResponse, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -167,7 +168,7 @@ func (r *FakeImageService) ImageStatus(image *runtimeapi.ImageSpec, verbose bool
 }
 
 // PullImage emulate pulling the image from the FakeImageService.
-func (r *FakeImageService) PullImage(image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+func (r *FakeImageService) PullImage(ctx context.Context, image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -188,7 +189,7 @@ func (r *FakeImageService) PullImage(image *runtimeapi.ImageSpec, auth *runtimea
 }
 
 // RemoveImage removes image from the FakeImageService.
-func (r *FakeImageService) RemoveImage(image *runtimeapi.ImageSpec) error {
+func (r *FakeImageService) RemoveImage(ctx context.Context, image *runtimeapi.ImageSpec) error {
 	r.Lock()
 	defer r.Unlock()
 
@@ -204,7 +205,7 @@ func (r *FakeImageService) RemoveImage(image *runtimeapi.ImageSpec) error {
 }
 
 // ImageFsInfo returns information of the filesystem that is used to store images.
-func (r *FakeImageService) ImageFsInfo() ([]*runtimeapi.FilesystemUsage, error) {
+func (r *FakeImageService) ImageFsInfo(ctx context.Context) ([]*runtimeapi.FilesystemUsage, error) {
 	r.Lock()
 	defer r.Unlock()
 

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testing
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sync"
@@ -162,7 +163,7 @@ func NewFakeRuntimeService() *FakeRuntimeService {
 }
 
 // Version returns version information from the FakeRuntimeService.
-func (r *FakeRuntimeService) Version(apiVersion string) (*runtimeapi.VersionResponse, error) {
+func (r *FakeRuntimeService) Version(ctx context.Context, apiVersion string) (*runtimeapi.VersionResponse, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -180,7 +181,7 @@ func (r *FakeRuntimeService) Version(apiVersion string) (*runtimeapi.VersionResp
 }
 
 // Status returns runtime status of the FakeRuntimeService.
-func (r *FakeRuntimeService) Status(verbose bool) (*runtimeapi.StatusResponse, error) {
+func (r *FakeRuntimeService) Status(ctx context.Context, verbose bool) (*runtimeapi.StatusResponse, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -193,7 +194,7 @@ func (r *FakeRuntimeService) Status(verbose bool) (*runtimeapi.StatusResponse, e
 }
 
 // RunPodSandbox emulates the run of the pod sandbox in the FakeRuntimeService.
-func (r *FakeRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error) {
+func (r *FakeRuntimeService) RunPodSandbox(ctx context.Context, config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -246,7 +247,7 @@ func (r *FakeRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig, 
 }
 
 // StopPodSandbox emulates the stop of pod sandbox in the FakeRuntimeService.
-func (r *FakeRuntimeService) StopPodSandbox(podSandboxID string) error {
+func (r *FakeRuntimeService) StopPodSandbox(ctx context.Context, podSandboxID string) error {
 	r.Lock()
 	defer r.Unlock()
 
@@ -265,7 +266,7 @@ func (r *FakeRuntimeService) StopPodSandbox(podSandboxID string) error {
 }
 
 // RemovePodSandbox emulates removal of the pod sadbox in the FakeRuntimeService.
-func (r *FakeRuntimeService) RemovePodSandbox(podSandboxID string) error {
+func (r *FakeRuntimeService) RemovePodSandbox(ctx context.Context, podSandboxID string) error {
 	r.Lock()
 	defer r.Unlock()
 
@@ -281,7 +282,7 @@ func (r *FakeRuntimeService) RemovePodSandbox(podSandboxID string) error {
 }
 
 // PodSandboxStatus returns pod sandbox status from the FakeRuntimeService.
-func (r *FakeRuntimeService) PodSandboxStatus(podSandboxID string, verbose bool) (*runtimeapi.PodSandboxStatusResponse, error) {
+func (r *FakeRuntimeService) PodSandboxStatus(ctx context.Context, podSandboxID string, verbose bool) (*runtimeapi.PodSandboxStatusResponse, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -300,7 +301,7 @@ func (r *FakeRuntimeService) PodSandboxStatus(podSandboxID string, verbose bool)
 }
 
 // ListPodSandbox returns the list of pod sandboxes in the FakeRuntimeService.
-func (r *FakeRuntimeService) ListPodSandbox(filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
+func (r *FakeRuntimeService) ListPodSandbox(ctx context.Context, filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -338,7 +339,7 @@ func (r *FakeRuntimeService) ListPodSandbox(filter *runtimeapi.PodSandboxFilter)
 }
 
 // PortForward emulates the set up of port forward in the FakeRuntimeService.
-func (r *FakeRuntimeService) PortForward(*runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
+func (r *FakeRuntimeService) PortForward(ctx context.Context, req *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -351,7 +352,7 @@ func (r *FakeRuntimeService) PortForward(*runtimeapi.PortForwardRequest) (*runti
 }
 
 // CreateContainer emulates container creation in the FakeRuntimeService.
-func (r *FakeRuntimeService) CreateContainer(podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+func (r *FakeRuntimeService) CreateContainer(ctx context.Context, podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -385,7 +386,7 @@ func (r *FakeRuntimeService) CreateContainer(podSandboxID string, config *runtim
 }
 
 // StartContainer emulates start of a container in the FakeRuntimeService.
-func (r *FakeRuntimeService) StartContainer(containerID string) error {
+func (r *FakeRuntimeService) StartContainer(ctx context.Context, containerID string) error {
 	r.Lock()
 	defer r.Unlock()
 
@@ -407,7 +408,7 @@ func (r *FakeRuntimeService) StartContainer(containerID string) error {
 }
 
 // StopContainer emulates stop of a container in the FakeRuntimeService.
-func (r *FakeRuntimeService) StopContainer(containerID string, timeout int64) error {
+func (r *FakeRuntimeService) StopContainer(ctx context.Context, containerID string, timeout int64) error {
 	r.Lock()
 	defer r.Unlock()
 
@@ -431,7 +432,7 @@ func (r *FakeRuntimeService) StopContainer(containerID string, timeout int64) er
 }
 
 // RemoveContainer emulates remove of a container in the FakeRuntimeService.
-func (r *FakeRuntimeService) RemoveContainer(containerID string) error {
+func (r *FakeRuntimeService) RemoveContainer(ctx context.Context, containerID string) error {
 	r.Lock()
 	defer r.Unlock()
 
@@ -447,7 +448,7 @@ func (r *FakeRuntimeService) RemoveContainer(containerID string) error {
 }
 
 // ListContainers returns the list of containers in the FakeRuntimeService.
-func (r *FakeRuntimeService) ListContainers(filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+func (r *FakeRuntimeService) ListContainers(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -490,7 +491,7 @@ func (r *FakeRuntimeService) ListContainers(filter *runtimeapi.ContainerFilter) 
 }
 
 // ContainerStatus returns the container status given the container ID in FakeRuntimeService.
-func (r *FakeRuntimeService) ContainerStatus(containerID string, verbose bool) (*runtimeapi.ContainerStatusResponse, error) {
+func (r *FakeRuntimeService) ContainerStatus(ctx context.Context, containerID string, verbose bool) (*runtimeapi.ContainerStatusResponse, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -509,7 +510,7 @@ func (r *FakeRuntimeService) ContainerStatus(containerID string, verbose bool) (
 }
 
 // UpdateContainerResources returns the container resource in the FakeRuntimeService.
-func (r *FakeRuntimeService) UpdateContainerResources(string, *runtimeapi.LinuxContainerResources) error {
+func (r *FakeRuntimeService) UpdateContainerResources(ctx context.Context, container string, resources *runtimeapi.LinuxContainerResources) error {
 	r.Lock()
 	defer r.Unlock()
 
@@ -518,7 +519,7 @@ func (r *FakeRuntimeService) UpdateContainerResources(string, *runtimeapi.LinuxC
 }
 
 // ExecSync emulates the sync execution of a command in a container in the FakeRuntimeService.
-func (r *FakeRuntimeService) ExecSync(containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error) {
+func (r *FakeRuntimeService) ExecSync(ctx context.Context, containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -528,7 +529,7 @@ func (r *FakeRuntimeService) ExecSync(containerID string, cmd []string, timeout 
 }
 
 // Exec emulates the execution of a command in a container in the FakeRuntimeService.
-func (r *FakeRuntimeService) Exec(*runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+func (r *FakeRuntimeService) Exec(ctx context.Context, req *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -541,7 +542,7 @@ func (r *FakeRuntimeService) Exec(*runtimeapi.ExecRequest) (*runtimeapi.ExecResp
 }
 
 // Attach emulates the attach request in the FakeRuntimeService.
-func (r *FakeRuntimeService) Attach(req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
+func (r *FakeRuntimeService) Attach(ctx context.Context, req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -554,7 +555,7 @@ func (r *FakeRuntimeService) Attach(req *runtimeapi.AttachRequest) (*runtimeapi.
 }
 
 // UpdateRuntimeConfig emulates the update of a runtime config for the FakeRuntimeService.
-func (r *FakeRuntimeService) UpdateRuntimeConfig(runtimeCOnfig *runtimeapi.RuntimeConfig) error {
+func (r *FakeRuntimeService) UpdateRuntimeConfig(ctx context.Context, runtimeCOnfig *runtimeapi.RuntimeConfig) error {
 	r.Lock()
 	defer r.Unlock()
 
@@ -574,7 +575,7 @@ func (r *FakeRuntimeService) SetFakeContainerStats(containerStats []*runtimeapi.
 }
 
 // ContainerStats returns the container stats in the FakeRuntimeService.
-func (r *FakeRuntimeService) ContainerStats(containerID string) (*runtimeapi.ContainerStats, error) {
+func (r *FakeRuntimeService) ContainerStats(ctx context.Context, containerID string) (*runtimeapi.ContainerStats, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -591,7 +592,7 @@ func (r *FakeRuntimeService) ContainerStats(containerID string) (*runtimeapi.Con
 }
 
 // ListContainerStats returns the list of all container stats given the filter in the FakeRuntimeService.
-func (r *FakeRuntimeService) ListContainerStats(filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error) {
+func (r *FakeRuntimeService) ListContainerStats(ctx context.Context, filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -635,7 +636,7 @@ func (r *FakeRuntimeService) SetFakePodSandboxStats(podStats []*runtimeapi.PodSa
 }
 
 // PodSandboxStats returns the sandbox stats in the FakeRuntimeService.
-func (r *FakeRuntimeService) PodSandboxStats(podSandboxID string) (*runtimeapi.PodSandboxStats, error) {
+func (r *FakeRuntimeService) PodSandboxStats(ctx context.Context, podSandboxID string) (*runtimeapi.PodSandboxStats, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -652,7 +653,7 @@ func (r *FakeRuntimeService) PodSandboxStats(podSandboxID string) (*runtimeapi.P
 }
 
 // ListPodSandboxStats returns the list of all pod sandbox stats given the filter in the FakeRuntimeService.
-func (r *FakeRuntimeService) ListPodSandboxStats(filter *runtimeapi.PodSandboxStatsFilter) ([]*runtimeapi.PodSandboxStats, error) {
+func (r *FakeRuntimeService) ListPodSandboxStats(ctx context.Context, filter *runtimeapi.PodSandboxStatsFilter) ([]*runtimeapi.PodSandboxStats, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -682,7 +683,7 @@ func (r *FakeRuntimeService) ListPodSandboxStats(filter *runtimeapi.PodSandboxSt
 }
 
 // ReopenContainerLog emulates call to the reopen container log in the FakeRuntimeService.
-func (r *FakeRuntimeService) ReopenContainerLog(containerID string) error {
+func (r *FakeRuntimeService) ReopenContainerLog(ctx context.Context, containerID string) error {
 	r.Lock()
 	defer r.Unlock()
 

--- a/test/e2e_node/container_log_rotation_test.go
+++ b/test/e2e_node/container_log_rotation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2enode
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -74,7 +75,7 @@ var _ = SIGDescribe("ContainerLogRotation [Slow] [Serial] [Disruptive]", func() 
 			id := kubecontainer.ParseContainerID(pod.Status.ContainerStatuses[0].ContainerID).ID
 			r, _, err := getCRIClient()
 			framework.ExpectNoError(err)
-			resp, err := r.ContainerStatus(id, false)
+			resp, err := r.ContainerStatus(context.Background(), id, false)
 			framework.ExpectNoError(err)
 			logPath := resp.GetStatus().GetLogPath()
 			ginkgo.By("wait for container log being rotated to max file limit")

--- a/test/e2e_node/container_manager_test.go
+++ b/test/e2e_node/container_manager_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package e2enode
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path"
@@ -157,7 +158,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 						ginkgo.By("Dump all running containers")
 						runtime, _, err := getCRIClient()
 						framework.ExpectNoError(err)
-						containers, err := runtime.ListContainers(&runtimeapi.ContainerFilter{
+						containers, err := runtime.ListContainers(context.Background(), &runtimeapi.ContainerFilter{
 							State: &runtimeapi.ContainerStateValue{
 								State: runtimeapi.ContainerState_CONTAINER_RUNNING,
 							},

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -115,7 +115,7 @@ func waitForContainerRemoval(containerName, podName, podNS string) {
 	rs, _, err := getCRIClient()
 	framework.ExpectNoError(err)
 	gomega.Eventually(func() bool {
-		containers, err := rs.ListContainers(&runtimeapi.ContainerFilter{
+		containers, err := rs.ListContainers(context.Background(), &runtimeapi.ContainerFilter{
 			LabelSelector: map[string]string{
 				types.KubernetesPodNameLabel:       podName,
 				types.KubernetesPodNamespaceLabel:  podNS,

--- a/test/e2e_node/garbage_collector_test.go
+++ b/test/e2e_node/garbage_collector_test.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -151,12 +151,14 @@ func containerGCTest(f *framework.Framework, test testRun) {
 		// Initialize the getContainerNames function to use CRI runtime client.
 		pod.getContainerNames = func() ([]string, error) {
 			relevantContainers := []string{}
-			containers, err := runtime.ListContainers(&runtimeapi.ContainerFilter{
-				LabelSelector: map[string]string{
-					types.KubernetesPodNameLabel:      pod.podName,
-					types.KubernetesPodNamespaceLabel: f.Namespace.Name,
-				},
-			})
+			containers, err := runtime.ListContainers(
+				context.Background(),
+				&runtimeapi.ContainerFilter{
+					LabelSelector: map[string]string{
+						types.KubernetesPodNameLabel:      pod.podName,
+						types.KubernetesPodNamespaceLabel: f.Namespace.Name,
+					},
+				})
 			if err != nil {
 				return relevantContainers, err
 			}

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -125,11 +125,11 @@ func (rp *remotePuller) Name() string {
 }
 
 func (rp *remotePuller) Pull(image string) ([]byte, error) {
-	resp, err := rp.imageService.ImageStatus(&runtimeapi.ImageSpec{Image: image}, false)
+	resp, err := rp.imageService.ImageStatus(context.Background(), &runtimeapi.ImageSpec{Image: image}, false)
 	if err == nil && resp.GetImage() != nil {
 		return nil, nil
 	}
-	_, err = rp.imageService.PullImage(&runtimeapi.ImageSpec{Image: image}, nil, nil)
+	_, err = rp.imageService.PullImage(context.Background(), &runtimeapi.ImageSpec{Image: image}, nil, nil)
 	return nil, err
 }
 

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -381,12 +381,14 @@ func waitForAllContainerRemoval(podName, podNS string) {
 	rs, _, err := getCRIClient()
 	framework.ExpectNoError(err)
 	gomega.Eventually(func() bool {
-		containers, err := rs.ListContainers(&runtimeapi.ContainerFilter{
-			LabelSelector: map[string]string{
-				types.KubernetesPodNameLabel:      podName,
-				types.KubernetesPodNamespaceLabel: podNS,
-			},
-		})
+		containers, err := rs.ListContainers(
+			context.Background(),
+			&runtimeapi.ContainerFilter{
+				LabelSelector: map[string]string{
+					types.KubernetesPodNameLabel:      podName,
+					types.KubernetesPodNamespaceLabel: podNS,
+				},
+			})
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
While investigating #105204 we identified areas where cleanup, cancellation, and logging in the Kubelet's core volume/pod loops could reduce spam and improve readability, as well as improve latency of shutdown.  One of the issues is #100219, which previous changes primed us for by adding support for context cancellation in the pod worker to allow the pod worker to cancel a `syncPod` call when the pod was terminated.

To properly leverage that, we'll need to ensure context is propagated to long running actions, especially CRI calls, so that when we cancel the syncPod method we don't simply hang lower in the stack.

This PR ensures the core CRI methods accept a context, and propagates them upward towards the key top level loops in the Kubelet. The first commit is the interfaces changed, the second commit is the boundaries at which propagation stops, the third commit is mechanical propagation between methods and signature changes, and the fourth commit is changes to tests. Propagation was stopped when we hit a method with a context already, when we hit a top level wait loop (using `context.Background()`), or when we hit a significant inter kubelet boundary where propagation was unclear (used `context.TODO()`).

This will set us up to invoke the cancellation on the syncPod method and terminate the volume call, and give us a reasonably good chance of syncPod cancellation terminating syncPod early.

Fixes #100219

Depends on #107845 #107826 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```