### PR TITLE
[CI Job failure] Fix job containerd-e2e-ubuntu

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -586,19 +586,23 @@ function ensure-container-runtime {
   if [[ -n "${UBUNTU_INSTALL_CONTAINERD_VERSION:-}" || -n "${UBUNTU_INSTALL_RUNC_VERSION:-}" ]]; then
     log-wrap "InstallContainerdUbuntu" install-containerd-ubuntu
   fi
+
+  # when custom containerd version is installed sourcing containerd_env.sh will add all tools like ctr to the PATH
+  if [[ -e "/etc/profile.d/containerd_env.sh" ]]; then
+   log-wrap 'SourceContainerdEnv' source "/etc/profile.d/containerd_env.sh"
+  fi
+    
   # Verify presence and print versions of ctr, containerd, runc
   if ! command -v ctr >/dev/null 2>&1; then
     echo "ERROR ctr not found. Aborting."
     exit 2
   fi
   ctr --version
-
   if ! command -v containerd >/dev/null 2>&1; then
     echo "ERROR containerd not found. Aborting."
     exit 2
   fi
   containerd --version
-
   if ! command -v runc >/dev/null 2>&1; then
     echo "ERROR runc not found. Aborting."
     exit 2


### PR DESCRIPTION
Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test


#### What this PR does / why we need it:
A possible fix for https://testgrid.k8s.io/sig-node-containerd#containerd-e2e-ubuntu
jobs which require containerd installation from ubuntu repos always set this
```
KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION
KUBE_INSTALL_RUNC_VERSION
```
https://cs.k8s.io/?q=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION&i=nope&files=&excludeFiles=&repos=

for this job we install containerd from containerd repo
https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-node/containerd.yaml#L9-#L10
the order of installation might be different for both methods , so checking containerd installation at this point for this job might be causing the failure.

Also before this PR got merged the flag `container_runtime=remote` was preventing to reach this check for this job
https://github.com/kubernetes/kubernetes/pull/107663/files#diff-dcbe601f5e14c1d9d805d0daf3629e02d1e1ea2be615f6e7f3036ca90a25c6e4L597-L608

**EDIT**: on digging further with @bobbypage it turned out that `ctr` is not in the path while doing these checks, so sourcing containerd env if present, see discussion on the issue page for more details

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref https://github.com/kubernetes/kubernetes/issues/107800

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
