### PR TITLE
reuse InformerFactory in scheduler tests

### DIFF
--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -362,8 +362,9 @@ func TestAddAllEventHandlers(t *testing.T) {
 			name:   "default handlers in framework",
 			gvkMap: map[framework.GVK]framework.ActionType{},
 			expectStaticInformers: map[reflect.Type]bool{
-				reflect.TypeOf(&v1.Pod{}):  true,
-				reflect.TypeOf(&v1.Node{}): true,
+				reflect.TypeOf(&v1.Pod{}):       true,
+				reflect.TypeOf(&v1.Node{}):      true,
+				reflect.TypeOf(&v1.Namespace{}): true,
 			},
 			expectDynamicInformers: map[schema.GroupVersionResource]bool{},
 		},
@@ -377,6 +378,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 			expectStaticInformers: map[reflect.Type]bool{
 				reflect.TypeOf(&v1.Pod{}):                            true,
 				reflect.TypeOf(&v1.Node{}):                           true,
+				reflect.TypeOf(&v1.Namespace{}):                      true,
 				reflect.TypeOf(&v1.PersistentVolume{}):               true,
 				reflect.TypeOf(&storagev1beta1.CSIStorageCapacity{}): true,
 			},
@@ -389,8 +391,9 @@ func TestAddAllEventHandlers(t *testing.T) {
 				"cronjobs.v1.batch":  framework.Delete,
 			},
 			expectStaticInformers: map[reflect.Type]bool{
-				reflect.TypeOf(&v1.Pod{}):  true,
-				reflect.TypeOf(&v1.Node{}): true,
+				reflect.TypeOf(&v1.Pod{}):       true,
+				reflect.TypeOf(&v1.Node{}):      true,
+				reflect.TypeOf(&v1.Namespace{}): true,
 			},
 			expectDynamicInformers: map[schema.GroupVersionResource]bool{
 				{Group: "apps", Version: "v1", Resource: "daemonsets"}: true,
@@ -404,8 +407,9 @@ func TestAddAllEventHandlers(t *testing.T) {
 				"custommetrics.v1beta1": framework.Update,
 			},
 			expectStaticInformers: map[reflect.Type]bool{
-				reflect.TypeOf(&v1.Pod{}):  true,
-				reflect.TypeOf(&v1.Node{}): true,
+				reflect.TypeOf(&v1.Pod{}):       true,
+				reflect.TypeOf(&v1.Node{}):      true,
+				reflect.TypeOf(&v1.Namespace{}): true,
 			},
 			expectDynamicInformers: map[schema.GroupVersionResource]bool{
 				{Group: "apps", Version: "v1", Resource: "daemonsets"}: true,
@@ -424,13 +428,14 @@ func TestAddAllEventHandlers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
+
+			informerFactory := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 0)
+			schedulingQueue := queue.NewTestQueueWithInformerFactory(ctx, nil, informerFactory)
 			testSched := Scheduler{
 				StopEverything:  ctx.Done(),
-				SchedulingQueue: queue.NewTestQueue(ctx, nil),
+				SchedulingQueue: schedulingQueue,
 			}
 
-			client := fake.NewSimpleClientset()
-			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			dynclient := dyfake.NewSimpleDynamicClient(scheme)
 			dynInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynclient, 0)
 

--- a/pkg/scheduler/internal/queue/testing.go
+++ b/pkg/scheduler/internal/queue/testing.go
@@ -25,6 +25,11 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
+// NewTestQueue creates a priority queue with an empty informer factory.
+func NewTestQueue(ctx context.Context, lessFn framework.LessFunc, opts ...Option) *PriorityQueue {
+	return NewTestQueueWithObjects(ctx, lessFn, nil, opts...)
+}
+
 // NewTestQueueWithObjects creates a priority queue with an informer factory
 // populated with the provided objects.
 func NewTestQueueWithObjects(
@@ -34,13 +39,17 @@ func NewTestQueueWithObjects(
 	opts ...Option,
 ) *PriorityQueue {
 	informerFactory := informers.NewSharedInformerFactory(fake.NewSimpleClientset(objs...), 0)
+	return NewTestQueueWithInformerFactory(ctx, lessFn, informerFactory, opts...)
+}
+
+func NewTestQueueWithInformerFactory(
+	ctx context.Context,
+	lessFn framework.LessFunc,
+	informerFactory informers.SharedInformerFactory,
+	opts ...Option,
+) *PriorityQueue {
 	pq := NewPriorityQueue(lessFn, informerFactory, opts...)
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
 	return pq
-}
-
-// NewTestQueue creates a priority queue with an empty informer factory.
-func NewTestQueue(ctx context.Context, lessFn framework.LessFunc, opts ...Option) *PriorityQueue {
-	return NewTestQueueWithObjects(ctx, lessFn, nil, opts...)
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -55,7 +55,6 @@ import (
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	fakecache "k8s.io/kubernetes/pkg/scheduler/internal/cache/fake"
-	"k8s.io/kubernetes/pkg/scheduler/internal/queue"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/internal/queue"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -773,7 +772,6 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 // cache: scheduler cache that might contain assumed pods.
 func setupTestSchedulerWithOnePodOnNode(ctx context.Context, t *testing.T, queuedPodStore *clientcache.FIFO, scache internalcache.Cache,
 	pod *v1.Pod, node *v1.Node, fns ...st.RegisterPluginFunc) (*Scheduler, chan *v1.Binding, chan error) {
-
 	scheduler, bindingChan, errChan := setupTestScheduler(ctx, queuedPodStore, scache, nil, nil, fns...)
 
 	queuedPodStore.Add(pod)
@@ -900,13 +898,10 @@ func setupTestScheduler(ctx context.Context, queuedPodStore *clientcache.FIFO, s
 		recorder = &events.FakeRecorder{}
 	}
 
-	var schedulingQueue *queue.PriorityQueue
 	if informerFactory == nil {
 		informerFactory = informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 0)
-		schedulingQueue = internalqueue.NewTestQueue(ctx, nil)
-	} else {
-		schedulingQueue = internalqueue.NewTestQueueWithInformerFactory(ctx, nil, informerFactory)
 	}
+	schedulingQueue := internalqueue.NewTestQueueWithInformerFactory(ctx, nil, informerFactory)
 
 	fwk, _ := st.NewFramework(
 		fns,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -852,7 +852,9 @@ func TestSchedulerFailedSchedulingReasons(t *testing.T) {
 		st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 		st.RegisterPluginAsExtensions(noderesources.Name, frameworkruntime.FactoryAdapter(feature.Features{}, noderesources.NewFit), "Filter", "PreFilter"),
 	}
-	scheduler, _, errChan := setupTestScheduler(ctx, queuedPodStore, scache, nil, nil, fns...)
+
+	informerFactory := informers.NewSharedInformerFactory(fake.NewSimpleClientset(objects...), 0)
+	scheduler, _, errChan := setupTestScheduler(ctx, queuedPodStore, scache, informerFactory, nil, fns...)
 
 	queuedPodStore.Add(podWithTooBigResourceRequests)
 	scheduler.scheduleOne(ctx)
@@ -962,8 +964,6 @@ func setupTestSchedulerWithVolumeBinding(ctx context.Context, volumeBinder volum
 		}, "PreFilter", "Filter", "Reserve", "PreBind"),
 	}
 	s, bindingChan, errChan := setupTestScheduler(ctx, queuedPodStore, scache, informerFactory, broadcaster, fns...)
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
 	return s, bindingChan, errChan
 }
 


### PR DESCRIPTION
Signed-off-by: kerthcet <kerthcet@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/107710

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
