### PR TITLE
Detect local traffic using interface (rebased)

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -210,6 +210,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 	fs.Float32Var(&o.config.ClientConnection.QPS, "kube-api-qps", o.config.ClientConnection.QPS, "QPS to use while talking with kubernetes apiserver")
 	fs.Var(&o.config.DetectLocalMode, "detect-local-mode", "Mode to use to detect local traffic. This parameter is ignored if a config file is specified by --config.")
+	fs.StringVar(&o.config.InterfacePrefix, "interface-prefix", o.config.InterfacePrefix, "The interface prefix name of the pod interface in the cluster. Kube-proxy considers traffic as local if originating from an interface or a bridge which matches the given prefix. This argument should be set if DetectLocateMode is set to LocalModeInterface.")
 }
 
 // NewOptions returns initialized Options

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -436,7 +436,7 @@ func detectNumCPU() int {
 func getDetectLocalMode(config *proxyconfigapi.KubeProxyConfiguration) (proxyconfigapi.LocalMode, error) {
 	mode := config.DetectLocalMode
 	switch mode {
-	case proxyconfigapi.LocalModeClusterCIDR, proxyconfigapi.LocalModeNodeCIDR:
+	case proxyconfigapi.LocalModeClusterCIDR, proxyconfigapi.LocalModeNodeCIDR, proxyconfigapi.LocalModeInterface:
 		return mode, nil
 	default:
 		if strings.TrimSpace(mode.String()) != "" {
@@ -461,6 +461,12 @@ func getLocalDetector(mode proxyconfigapi.LocalMode, config *proxyconfigapi.Kube
 			break
 		}
 		return proxyutiliptables.NewDetectLocalByCIDR(nodeInfo.Spec.PodCIDR, ipt)
+	case proxyconfigapi.LocalModeInterface:
+		if config.InterfacePrefix == "" {
+			klog.Warning("detect-local-mode set to Interface, but no ifacename or bridge is defined")
+			break
+		}
+		return proxyutiliptables.NewDetectLocalByInterface(config.InterfacePrefix)
 	}
 	klog.V(0).InfoS("Defaulting to no-op detect-local", "detect-local-mode", string(mode))
 	return proxyutiliptables.NewNoOpLocalDetector(), nil
@@ -517,6 +523,18 @@ func getDualStackLocalDetectorTuple(mode proxyconfigapi.LocalMode, config *proxy
 				localDetectors[1], err = proxyutiliptables.NewDetectLocalByCIDR(nodeInfo.Spec.PodCIDRs[1], ipt[1])
 			}
 		}
+		return localDetectors, err
+	case proxyconfigapi.LocalModeInterface:
+		if config.InterfacePrefix == "" {
+			klog.Warning("detect-local-mode set to Interface, but no ifacename or bridge is defined")
+			break
+		}
+		localDetector, err := proxyutiliptables.NewDetectLocalByInterface(config.InterfacePrefix)
+		if err != nil {
+			return localDetectors, err
+		}
+		localDetectors[0] = localDetector
+		localDetectors[1] = localDetector
 		return localDetectors, err
 	default:
 		klog.InfoS("Unknown detect-local-mode", "detect-local-mode", mode)

--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -471,8 +471,14 @@ func Test_getLocalDetector(t *testing.T) {
 		{
 			mode:        proxyconfigapi.LocalModeInterface,
 			config:      &proxyconfigapi.KubeProxyConfiguration{InterfacePrefix: "1234567890123456789"},
-			expected:    nil,
-			errExpected: true,
+			expected:    resolveLocalDetector(t)(proxyutiliptables.NewDetectLocalByInterface("1234567890123456789")),
+			errExpected: false,
+		},
+		{
+			mode:        proxyconfigapi.LocalModeInterface,
+			config:      &proxyconfigapi.KubeProxyConfiguration{InterfacePrefix: "azv"}, // Azure CNI
+			expected:    resolveLocalDetector(t)(proxyutiliptables.NewDetectLocalByInterface("azv")),
+			errExpected: false,
 		},
 	}
 	for i, c := range cases {

--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -197,6 +197,11 @@ func Test_getDetectLocalMode(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			detectLocal: string(proxyconfigapi.LocalModeInterface),
+			expected:    proxyconfigapi.LocalModeInterface,
+			errExpected: false,
+		},
+		{
 			detectLocal: "abcd",
 			expected:    proxyconfigapi.LocalMode("abcd"),
 			errExpected: true,
@@ -450,6 +455,25 @@ func Test_getLocalDetector(t *testing.T) {
 			expected:    proxyutiliptables.NewNoOpLocalDetector(),
 			errExpected: false,
 		},
+		// LocalModeInterface, nodeInfo and ipt are not needed for these cases
+		{
+			mode:        proxyconfigapi.LocalModeInterface,
+			config:      &proxyconfigapi.KubeProxyConfiguration{InterfacePrefix: "eth"},
+			expected:    resolveLocalDetector(t)(proxyutiliptables.NewDetectLocalByInterface("eth")),
+			errExpected: false,
+		},
+		{
+			mode:        proxyconfigapi.LocalModeInterface,
+			config:      &proxyconfigapi.KubeProxyConfiguration{InterfacePrefix: ""},
+			expected:    proxyutiliptables.NewNoOpLocalDetector(),
+			errExpected: false,
+		},
+		{
+			mode:        proxyconfigapi.LocalModeInterface,
+			config:      &proxyconfigapi.KubeProxyConfiguration{InterfacePrefix: "1234567890123456789"},
+			expected:    nil,
+			errExpected: true,
+		},
 	}
 	for i, c := range cases {
 		r, err := getLocalDetector(c.mode, c.config, c.ipt, c.nodeInfo)
@@ -584,6 +608,21 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 			mode:        proxyconfigapi.LocalMode("abcd"),
 			config:      &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: ""},
 			ipt:         [2]utiliptables.Interface{utiliptablestest.NewFake(), utiliptablestest.NewIPv6Fake()},
+			expected:    [2]proxyutiliptables.LocalTrafficDetector{proxyutiliptables.NewNoOpLocalDetector(), proxyutiliptables.NewNoOpLocalDetector()},
+			errExpected: false,
+		},
+		// LocalModeInterface, nodeInfo and ipt are not needed for these cases
+		{
+			mode:   proxyconfigapi.LocalModeInterface,
+			config: &proxyconfigapi.KubeProxyConfiguration{InterfacePrefix: "veth"},
+			expected: resolveDualStackLocalDetectors(t)(
+				proxyutiliptables.NewDetectLocalByInterface("veth"))(
+				proxyutiliptables.NewDetectLocalByInterface("veth")),
+			errExpected: false,
+		},
+		{
+			mode:        proxyconfigapi.LocalModeInterface,
+			config:      &proxyconfigapi.KubeProxyConfiguration{InterfacePrefix: ""},
 			expected:    [2]proxyutiliptables.LocalTrafficDetector{proxyutiliptables.NewNoOpLocalDetector(), proxyutiliptables.NewNoOpLocalDetector()},
 			errExpected: false,
 		},

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -126,6 +126,7 @@ detectLocalMode: "ClusterCIDR"
 nodePortAddresses:
   - "10.20.30.40/16"
   - "fd00:1::0/64"
+interfacePrefix: "eth0"
 `
 
 	testCases := []struct {
@@ -264,6 +265,7 @@ nodePortAddresses:
 			UDPIdleTimeout:     metav1.Duration{Duration: 123 * time.Millisecond},
 			NodePortAddresses:  []string{"10.20.30.40/16", "fd00:1::0/64"},
 			DetectLocalMode:    kubeproxyconfig.LocalModeClusterCIDR,
+			InterfacePrefix:    string("eth0"),
 		}
 
 		options := NewOptions()
@@ -451,7 +453,7 @@ mode: ""
 nodePortAddresses: null
 oomScoreAdj: -999
 portRange: ""
-detectLocalMode: "ClusterCIDR"
+detectLocalMode: "Interface"
 udpIdleTimeout: 250ms`)
 		if err != nil {
 			return nil, "", fmt.Errorf("unexpected error when writing content to temp kube-proxy config file: %v", err)

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
@@ -15,6 +15,7 @@ conntrack:
   tcpCloseWaitTimeout: 1h0m0s
   tcpEstablishedTimeout: 24h0m0s
 detectLocalMode: ""
+interfacePrefix: ""
 enableProfiling: false
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
@@ -15,10 +15,10 @@ conntrack:
   tcpCloseWaitTimeout: 1h0m0s
   tcpEstablishedTimeout: 24h0m0s
 detectLocalMode: ""
-interfacePrefix: ""
 enableProfiling: false
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
+interfacePrefix: ""
 iptables:
   masqueradeAll: false
   masqueradeBit: 14

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/roundtrip/default/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/roundtrip/default/v1alpha1.yaml
@@ -15,6 +15,7 @@ conntrack:
   tcpCloseWaitTimeout: 1h0m0s
   tcpEstablishedTimeout: 24h0m0s
 detectLocalMode: ""
+interfacePrefix: ""
 enableProfiling: false
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/roundtrip/default/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/roundtrip/default/v1alpha1.yaml
@@ -15,10 +15,10 @@ conntrack:
   tcpCloseWaitTimeout: 1h0m0s
   tcpEstablishedTimeout: 24h0m0s
 detectLocalMode: ""
-interfacePrefix: ""
 enableProfiling: false
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
+interfacePrefix: ""
 iptables:
   masqueradeAll: false
   masqueradeBit: 14

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -168,6 +168,12 @@ type KubeProxyConfiguration struct {
 	ShowHiddenMetricsForVersion string
 	// DetectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
 	DetectLocalMode LocalMode
+	// InterfacePrefix is a string argument which represents the interface prefix name of the pods in the node.
+	// This could be an iface prefix name where all pod interfaces start with same prefix, or a bridge name, or
+	// a single interface name. Kube-proxy considers traffic as local if originating from an interface or a
+	// bridge which matches the given prefix. This argument should be set if DetectLocateMode is set to
+	// LocalModeInterface.
+	InterfacePrefix string
 }
 
 // ProxyMode represents modes used by the Kubernetes proxy server. Currently, three modes of proxy are available in
@@ -200,6 +206,7 @@ type LocalMode string
 const (
 	LocalModeClusterCIDR LocalMode = "ClusterCIDR"
 	LocalModeNodeCIDR    LocalMode = "NodeCIDR"
+	LocalModeInterface   LocalMode = "Interface"
 )
 
 // IPVSSchedulerMethod is the algorithm for allocating TCP connections and

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -124,6 +124,7 @@ func autoConvert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguratio
 	}
 	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
 	out.DetectLocalMode = config.LocalMode(in.DetectLocalMode)
+	out.InterfacePrefix = in.InterfacePrefix
 	return nil
 }
 
@@ -164,6 +165,7 @@ func autoConvert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguratio
 	}
 	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
 	out.DetectLocalMode = v1alpha1.LocalMode(in.DetectLocalMode)
+	out.InterfacePrefix = in.InterfacePrefix
 	return nil
 }
 

--- a/pkg/proxy/apis/config/validation/validation.go
+++ b/pkg/proxy/apis/config/validation/validation.go
@@ -102,6 +102,7 @@ func Validate(config *kubeproxyconfig.KubeProxyConfiguration) field.ErrorList {
 
 	allErrs = append(allErrs, validateKubeProxyNodePortAddress(config.NodePortAddresses, newPath.Child("NodePortAddresses"))...)
 	allErrs = append(allErrs, validateShowHiddenMetricsVersion(config.ShowHiddenMetricsForVersion, newPath.Child("ShowHiddenMetricsForVersion"))...)
+	allErrs = append(allErrs, validateInterfacePrefix(config.InterfacePrefix, newPath.Child("InterfacePrefix"))...)
 
 	return allErrs
 }
@@ -315,5 +316,14 @@ func validateShowHiddenMetricsVersion(version string, fldPath *field.Path) field
 		allErrs = append(allErrs, field.Invalid(fldPath, version, e.Error()))
 	}
 
+	return allErrs
+}
+
+func validateInterfacePrefix(interfacePrefix string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	const maxIfNameSize = 16 // linux/if.h
+	if len(interfacePrefix)+1 > maxIfNameSize {
+		allErrs = append(allErrs, field.Invalid(fldPath, interfacePrefix, "must be less than 16 bytes long"))
+	}
 	return allErrs
 }

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -2165,9 +2165,9 @@ COMMIT
 	assertIPTablesRulesEqual(t, expected, fp.iptablesData.String())
 }
 
-func TestOnlyLocalLoadBalancingJumpIfLocalLoadbalancerVIPToCulsterIP(t *testing.T) {
+func TestOnlyLocalLoadBalancingJumpIfLocalLoadbalancerVIPToClusterIP(t *testing.T) {
 	ipt := iptablestest.NewFake()
-	fp := NewFakeProxier(ipt, false)
+	fp := NewFakeProxier(ipt)
 	fp.localDetector, _ = proxyutiliptables.NewDetectLocalByInterface("eth")
 	svcIP := "10.20.30.41"
 	svcPort := 80
@@ -2196,23 +2196,20 @@ func TestOnlyLocalLoadBalancingJumpIfLocalLoadbalancerVIPToCulsterIP(t *testing.
 		}),
 	)
 
+	protocol := v1.ProtocolTCP
 	epIP1 := "10.180.0.1"
 	epIP2 := "10.180.2.1"
-	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
-			ept.Subsets = []v1.EndpointSubset{{
-				Addresses: []v1.EndpointAddress{{
-					IP:       epIP1,
-					NodeName: nil,
-				}, {
-					IP:       epIP2,
-					NodeName: utilpointer.StringPtr(testHostname),
-				}},
-				Ports: []v1.EndpointPort{{
-					Name:     svcPortName.Port,
-					Port:     int32(svcPort),
-					Protocol: v1.ProtocolTCP,
-				}},
+	populateEndpointSlices(fp,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{
+				{Addresses: []string{epIP1}},
+				{Addresses: []string{epIP2}, NodeName: utilpointer.StringPtr(testHostname)},
+			}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     utilpointer.StringPtr(svcPortName.Port),
+				Port:     utilpointer.Int32Ptr(int32(svcPort)),
+				Protocol: &protocol,
 			}}
 		}),
 	)
@@ -2221,45 +2218,46 @@ func TestOnlyLocalLoadBalancingJumpIfLocalLoadbalancerVIPToCulsterIP(t *testing.
 :KUBE-SERVICES - [0:0]
 :KUBE-EXTERNAL-SERVICES - [0:0]
 :KUBE-FORWARD - [0:0]
+:KUBE-NODEPORTS - [0:0]
 -A KUBE-FORWARD -m conntrack --ctstate INVALID -j DROP
 -A KUBE-FORWARD -m comment --comment "kubernetes forwarding rules" -m mark --mark 0x4000/0x4000 -j ACCEPT
--A KUBE-FORWARD -m comment --comment "kubernetes forwarding conntrack pod source rule" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
--A KUBE-FORWARD -m comment --comment "kubernetes forwarding conntrack pod destination rule" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A KUBE-FORWARD -m comment --comment "kubernetes forwarding conntrack rule" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 COMMIT
 *nat
 :KUBE-SERVICES - [0:0]
 :KUBE-NODEPORTS - [0:0]
 :KUBE-POSTROUTING - [0:0]
 :KUBE-MARK-MASQ - [0:0]
+:KUBE-SEP-SXIVWICOYRO3J4NJ - [0:0]
+:KUBE-SEP-ZX7GRIZKSNUQ3LAJ - [0:0]
 :KUBE-SVC-XPGD46QRK7WJZT7O - [0:0]
 :KUBE-XLB-XPGD46QRK7WJZT7O - [0:0]
 :KUBE-FW-XPGD46QRK7WJZT7O - [0:0]
-:KUBE-SEP-SXIVWICOYRO3J4NJ - [0:0]
-:KUBE-SEP-ZX7GRIZKSNUQ3LAJ - [0:0]
 -A KUBE-POSTROUTING -m mark ! --mark 0x4000/0x4000 -j RETURN
 -A KUBE-POSTROUTING -j MARK --xor-mark 0x4000
 -A KUBE-POSTROUTING -m comment --comment "kubernetes service traffic requiring SNAT" -j MASQUERADE
 -A KUBE-MARK-MASQ -j MARK --or-mark 0x4000
--A KUBE-SERVICES -m comment --comment "ns1/svc1:p80 cluster IP" -m tcp -p tcp -d 10.20.30.41/32 --dport 80 ! -i eth+ -j KUBE-MARK-MASQ
--A KUBE-SERVICES -m comment --comment "ns1/svc1:p80 cluster IP" -m tcp -p tcp -d 10.20.30.41/32 --dport 80 -j KUBE-SVC-XPGD46QRK7WJZT7O
--A KUBE-SERVICES -m comment --comment "ns1/svc1:p80 loadbalancer IP" -m tcp -p tcp -d 1.2.3.4/32 --dport 80 -j KUBE-FW-XPGD46QRK7WJZT7O
+-A KUBE-SEP-SXIVWICOYRO3J4NJ -m comment --comment ns1/svc1:p80 -s 10.180.0.1 -j KUBE-MARK-MASQ
+-A KUBE-SEP-SXIVWICOYRO3J4NJ -m comment --comment ns1/svc1:p80 -m tcp -p tcp -j DNAT --to-destination 10.180.0.1:80
+-A KUBE-SEP-ZX7GRIZKSNUQ3LAJ -m comment --comment ns1/svc1:p80 -s 10.180.2.1 -j KUBE-MARK-MASQ
+-A KUBE-SEP-ZX7GRIZKSNUQ3LAJ -m comment --comment ns1/svc1:p80 -m tcp -p tcp -j DNAT --to-destination 10.180.2.1:80
+-A KUBE-SVC-XPGD46QRK7WJZT7O -m comment --comment "ns1/svc1:p80 cluster IP" -m tcp -p tcp -d 10.20.30.41 --dport 80 ! -i eth+ -j KUBE-MARK-MASQ
+-A KUBE-SERVICES -m comment --comment "ns1/svc1:p80 cluster IP" -m tcp -p tcp -d 10.20.30.41 --dport 80 -j KUBE-SVC-XPGD46QRK7WJZT7O
+-A KUBE-SERVICES -m comment --comment "ns1/svc1:p80 loadbalancer IP" -m tcp -p tcp -d 1.2.3.4 --dport 80 -j KUBE-FW-XPGD46QRK7WJZT7O
 -A KUBE-FW-XPGD46QRK7WJZT7O -m comment --comment "ns1/svc1:p80 loadbalancer IP" -j KUBE-XLB-XPGD46QRK7WJZT7O
 -A KUBE-FW-XPGD46QRK7WJZT7O -m comment --comment "ns1/svc1:p80 loadbalancer IP" -j KUBE-MARK-DROP
 -A KUBE-NODEPORTS -m comment --comment ns1/svc1:p80 -m tcp -p tcp --dport 3001 -s 127.0.0.0/8 -j KUBE-MARK-MASQ
 -A KUBE-NODEPORTS -m comment --comment ns1/svc1:p80 -m tcp -p tcp --dport 3001 -j KUBE-XLB-XPGD46QRK7WJZT7O
 -A KUBE-SVC-XPGD46QRK7WJZT7O -m comment --comment ns1/svc1:p80 -m statistic --mode random --probability 0.5000000000 -j KUBE-SEP-SXIVWICOYRO3J4NJ
--A KUBE-SEP-SXIVWICOYRO3J4NJ -m comment --comment ns1/svc1:p80 -s 10.180.0.1/32 -j KUBE-MARK-MASQ
--A KUBE-SEP-SXIVWICOYRO3J4NJ -m comment --comment ns1/svc1:p80 -m tcp -p tcp -j DNAT --to-destination 10.180.0.1:80
 -A KUBE-SVC-XPGD46QRK7WJZT7O -m comment --comment ns1/svc1:p80 -j KUBE-SEP-ZX7GRIZKSNUQ3LAJ
--A KUBE-SEP-ZX7GRIZKSNUQ3LAJ -m comment --comment ns1/svc1:p80 -s 10.180.2.1/32 -j KUBE-MARK-MASQ
--A KUBE-SEP-ZX7GRIZKSNUQ3LAJ -m comment --comment ns1/svc1:p80 -m tcp -p tcp -j DNAT --to-destination 10.180.2.1:80
 -A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment "Redirect pods trying to reach external loadbalancer VIP to clusterIP" -i eth+ -j KUBE-SVC-XPGD46QRK7WJZT7O
 -A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment "masquerade LOCAL traffic for ns1/svc1:p80 LB IP" -m addrtype --src-type LOCAL -j KUBE-MARK-MASQ
 -A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment "route LOCAL traffic for ns1/svc1:p80 LB IP to service chain" -m addrtype --src-type LOCAL -j KUBE-SVC-XPGD46QRK7WJZT7O
--A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment "Balancing rule 0 for ns1/svc1:p80" -j KUBE-SEP-ZX7GRIZKSNUQ3LAJ
+-A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment ns1/svc1:p80 -j KUBE-SEP-ZX7GRIZKSNUQ3LAJ
 -A KUBE-SERVICES -m comment --comment "kubernetes service nodeports; NOTE: this must be the last rule in this chain" -m addrtype --dst-type LOCAL -j KUBE-NODEPORTS
 COMMIT
 `
+
 	fp.syncProxyRules()
 	assert.Equal(t, expectedIPTablesWithDetectLocalTrafficByInterface, fp.iptablesData.String())
 }

--- a/pkg/proxy/util/iptables/traffic.go
+++ b/pkg/proxy/util/iptables/traffic.go
@@ -98,9 +98,8 @@ type detectLocalByInterface struct {
 // NewDetectLocalByInterface implements the LocalTrafficDetector interface using an interface or a bridge.
 // This can be used when a pod interface name/prefix can be used to capture the notion of local traffic.
 func NewDetectLocalByInterface(ifaceName string) (LocalTrafficDetector, error) {
-	maxIfNameSize := 16 // linux/if.h
-	if len(ifaceName)+1 > maxIfNameSize || ifaceName == "" {
-		return nil, fmt.Errorf("invalid interface name")
+	if ifaceName == "" {
+		return nil, fmt.Errorf("no interface set")
 	}
 	return &detectLocalByInterface{ifaceName: ifaceName}, nil
 }

--- a/pkg/proxy/util/iptables/traffic_test.go
+++ b/pkg/proxy/util/iptables/traffic_test.go
@@ -177,11 +177,11 @@ func TestNewDetectLocalByInterface(t *testing.T) {
 			errExpected: false,
 		},
 		{
-			ifaceName:   "2002::1234:abcd:ffff:c0a8:101/64",
-			errExpected: true,
+			ifaceName:   "crb0",
+			errExpected: false,
 		},
 		{
-			ifaceName:   "crb0",
+			ifaceName:   "azv", // Azure CNI
 			errExpected: false,
 		},
 		{

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -167,7 +167,7 @@ type KubeProxyConfiguration struct {
 	// InterfacePrefix is a string argument which represents the interface prefix name of the pods in the node.
 	// This could be an iface prefix name where all pod interfaces start with same prefix, or a bridge name, or
 	// a single interface name. Kube-proxy considers traffic as local if originating from an interface or a
-	// bridge which matches the given prefix. This argument should be set if DetectLocateMode is set to
+	// bridge which matches the given prefix. This argument should be set if DetectLocalMode is set to
 	// LocalModeInterface.
 	InterfacePrefix string `json:"interfacePrefix"`
 }

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -164,6 +164,12 @@ type KubeProxyConfiguration struct {
 	ShowHiddenMetricsForVersion string `json:"showHiddenMetricsForVersion"`
 	// DetectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
 	DetectLocalMode LocalMode `json:"detectLocalMode"`
+	// InterfacePrefix is a string argument which represents the interface prefix name of the pods in the node.
+	// This could be an iface prefix name where all pod interfaces start with same prefix, or a bridge name, or
+	// a single interface name. Kube-proxy considers traffic as local if originating from an interface or a
+	// bridge which matches the given prefix. This argument should be set if DetectLocateMode is set to
+	// LocalModeInterface.
+	InterfacePrefix string `json:"interfacePrefix"`
 }
 
 // ProxyMode represents modes used by the Kubernetes proxy server.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implements the detection of local traffic using an interface parameter as outlined in the KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2450-Remove-knowledge-of-pod-cluster-CIDR-from-iptables-rules

#### Special notes for your reviewer:

This PR builds on https://github.com/kubernetes/kubernetes/pull/95400 (thanks @tssurya !). The additional changes in this PR are (1) resolving conflicts after rebasing onto upstream master, and (2) moving the interface name length check to config validation, per [this PR comment](https://github.com/kubernetes/kubernetes/pull/95400#discussion_r502335295).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds support for "Interface" as an argument to --detect-local-mode option and also introduces a new optional --interface-prefix flag to kube-proxy.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

[KEP 2450](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2450-Remove-knowledge-of-pod-cluster-CIDR-from-iptables-rules)

```docs
Adds support for "Interface" as an argument to --detect-local-mode option and also introduces a new optional --interface-prefix flag to kube-proxy.
```

