### PR TITLE
kubelet: If the container status is created, we are waiting

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1632,12 +1632,8 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 		case cs.State == kubecontainer.ContainerStateRunning:
 			status.State.Running = &v1.ContainerStateRunning{StartedAt: metav1.NewTime(cs.StartedAt)}
 		case cs.State == kubecontainer.ContainerStateCreated:
-			// Treat containers in the "created" state as if they are exited.
-			// The pod workers are supposed start all containers it creates in
-			// one sync (syncPod) iteration. There should not be any normal
-			// "created" containers when the pod worker generates the status at
-			// the beginning of a sync iteration.
-			fallthrough
+			// containers that are created but not running are "waiting to be running"
+			status.State.Waiting = &v1.ContainerStateWaiting{}
 		case cs.State == kubecontainer.ContainerStateExited:
 			status.State.Terminated = &v1.ContainerStateTerminated{
 				ExitCode:    int32(cs.ExitCode),


### PR DESCRIPTION
If CRI returns a container that has been created but is not running, it is not safe to assume it is terminal, as our connection to CRI may have failed. Instead, created is treated as waiting, as in "waiting for this container to start". Either syncPod or syncTerminatingPod is responsible for handling the state.

This was intentional in #41382 where @yujuhong observed docker containers created but not started. However, there are many reasons for syncPod to create but not start the container such as the CRI failing between those actions, and syncPod must be crash / failure reentrant no matter what errors occur in the previous syncPod invocation. The issue described should no longer apply, or if it does, computePodActions is incorrect and must be fixed.

Reviewing computePodActions, on the next syncPod call after a failure to start we can see that ShouldContainerBeRestarted returns true if the state of the container is created, which means that the status loop shouldn't assume the container has exited either (we're waiting for the next container, not still terminated from the last)

This was discovered while testing context cancellation in syncPod (when a pod is terminated during startup). https://github.com/kubernetes/kubernetes/pull/107829#issuecomment-1024671245 describes the result of a cancellation during termination where PLEG passes a created container to this method, and syncTerminatingPod incorrectly assigns the "succeeded" state to the pod as a result of treating the container (which is not running) as having exit code 0 (the default in the CRI struct). Instead, the container is clearly waiting, and the effective phase should be Failed since we haven't observed a successful run (pods are "at least once" on execution and "at most once" on transition to a terminal phase).

The scenario where this was caught:

1. Create a pod with a container that should always `exit 1`
2. Invoke termination of that pod by deleting it via the API
3. The Kubelet is in syncPod and has created the container, but not started it
4. The call to StartContainer on CRI fails (due to an error in the CRI, CRI being restarted, the call being cancelled due to context, etc)
5. The syncTerminatingPod starts and attempts to calculate current status from PLEG, which shows the container is created
6. convertToAPIContainerStatuses sees the container is created and falls through ContainerStateExited
7. `ExitCode` in the container status is 0 (the default) because the container hasn't actually ever run, but the container is definitely not successful
8. The status is recorded as terminated with exit code 0
9. The phase calculation in getPhase() sees only terminated successful pods and assigns phase=Succeeded instead of phase=Failed (unknown status is a failure, not success

Prerequisite to #107829, as otherwise a quickly terminated restart never pod that always exits 1 could be treated as "success" (with the corresponding incorrect output for a job or other batch process).

Probably needs a test beyond what we will get with the existing e2e that caught it - it can only be triggered today by the failure to start the container AFTER the container has been successfully created, and if the pod is RestartNever. That's hard to simulate from an e2e node because it is especially racy.  An integration or unit test would catch it, and after #107829 we will be testing this all the time in the current e2e test.

Discovered while mitigating long delays on termination for volume mounting in #105204

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Failure to start a container cannot accidentally result in the pod being considered "Succeeded" in the presence of deletion.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```