### PR TITLE
Automated cherry pick of #107575: fix: azurefile volumeid conflict in csi migration

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
@@ -103,7 +103,7 @@ func (t *azureDiskCSITranslator) TranslateInTreeInlineVolumeToCSI(volume *v1.Vol
 		ObjectMeta: metav1.ObjectMeta{
 			// Must be unique per disk as it is used as the unique part of the
 			// staging path
-			Name: fmt.Sprintf("%s-%s", AzureDiskDriverName, azureSource.DiskName),
+			Name: azureSource.DataDiskURI,
 		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk_test.go
@@ -127,7 +127,7 @@ func TestTranslateAzureDiskInTreeStorageClassToCSI(t *testing.T) {
 			},
 			expVol: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "disk.csi.azure.com-diskname",
+					Name: "datadiskuri",
 				},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
@@ -81,19 +81,19 @@ func (t *azureFileCSITranslator) TranslateInTreeInlineVolumeToCSI(volume *v1.Vol
 	if podNamespace != "" {
 		secretNamespace = podNamespace
 	}
+	volumeID := fmt.Sprintf(volumeIDTemplate, "", accountName, azureSource.ShareName, volume.Name)
 
 	var (
 		pv = &v1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
-				// Must be unique per disk as it is used as the unique part of the
-				// staging path
-				Name: fmt.Sprintf("%s-%s", AzureFileDriverName, azureSource.ShareName),
+				// Must be unique as it is used as the unique part of the staging path
+				Name: volumeID,
 			},
 			Spec: v1.PersistentVolumeSpec{
 				PersistentVolumeSource: v1.PersistentVolumeSource{
 					CSI: &v1.CSIPersistentVolumeSource{
 						Driver:           AzureFileDriverName,
-						VolumeHandle:     fmt.Sprintf(volumeIDTemplate, "", accountName, azureSource.ShareName, ""),
+						VolumeHandle:     volumeID,
 						ReadOnly:         azureSource.ReadOnly,
 						VolumeAttributes: map[string]string{shareNameField: azureSource.ShareName},
 						NodeStageSecretRef: &v1.SecretReference{
@@ -129,7 +129,7 @@ func (t *azureFileCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume)
 			resourceGroup = v
 		}
 	}
-	volumeID := fmt.Sprintf(volumeIDTemplate, resourceGroup, accountName, azureSource.ShareName, "")
+	volumeID := fmt.Sprintf(volumeIDTemplate, resourceGroup, accountName, azureSource.ShareName, pv.ObjectMeta.Name)
 
 	var (
 		// refer to https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/docs/driver-parameters.md

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go
@@ -131,7 +131,7 @@ func TestTranslateAzureFileInTreeStorageClassToCSI(t *testing.T) {
 			},
 			expVol: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "#secretname#sharename#name",
+					Name: "#secretname#sharename#name#default",
 				},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
@@ -143,7 +143,7 @@ func TestTranslateAzureFileInTreeStorageClassToCSI(t *testing.T) {
 							},
 							ReadOnly:         true,
 							VolumeAttributes: map[string]string{shareNameField: "sharename"},
-							VolumeHandle:     "#secretname#sharename#name",
+							VolumeHandle:     "#secretname#sharename#name#default",
 						},
 					},
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
@@ -165,7 +165,7 @@ func TestTranslateAzureFileInTreeStorageClassToCSI(t *testing.T) {
 			podNamespace: "test",
 			expVol: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "#secretname#sharename#name",
+					Name: "#secretname#sharename#name#test",
 				},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
@@ -177,7 +177,7 @@ func TestTranslateAzureFileInTreeStorageClassToCSI(t *testing.T) {
 							},
 							ReadOnly:         true,
 							VolumeAttributes: map[string]string{shareNameField: "sharename"},
-							VolumeHandle:     "#secretname#sharename#name",
+							VolumeHandle:     "#secretname#sharename#name#test",
 						},
 					},
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
@@ -254,7 +254,7 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 								Namespace: secretNamespace,
 							},
 							VolumeAttributes: map[string]string{shareNameField: "sharename"},
-							VolumeHandle:     "#secretname#sharename#uuid",
+							VolumeHandle:     "#secretname#sharename#uuid#secretnamespace",
 						},
 					},
 				},
@@ -293,7 +293,7 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 								Namespace: secretNamespace,
 							},
 							VolumeAttributes: map[string]string{shareNameField: "sharename"},
-							VolumeHandle:     "rg#secretname#sharename#uuid",
+							VolumeHandle:     "rg#secretname#sharename#uuid#secretnamespace",
 						},
 					},
 				},

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go
@@ -120,6 +120,7 @@ func TestTranslateAzureFileInTreeStorageClassToCSI(t *testing.T) {
 		{
 			name: "azure file volume",
 			volume: &corev1.Volume{
+				Name: "name",
 				VolumeSource: corev1.VolumeSource{
 					AzureFile: &corev1.AzureFileVolumeSource{
 						ReadOnly:   true,
@@ -130,7 +131,7 @@ func TestTranslateAzureFileInTreeStorageClassToCSI(t *testing.T) {
 			},
 			expVol: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "file.csi.azure.com-sharename",
+					Name: "#secretname#sharename#name",
 				},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
@@ -142,7 +143,7 @@ func TestTranslateAzureFileInTreeStorageClassToCSI(t *testing.T) {
 							},
 							ReadOnly:         true,
 							VolumeAttributes: map[string]string{shareNameField: "sharename"},
-							VolumeHandle:     "#secretname#sharename#",
+							VolumeHandle:     "#secretname#sharename#name",
 						},
 					},
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
@@ -152,6 +153,7 @@ func TestTranslateAzureFileInTreeStorageClassToCSI(t *testing.T) {
 		{
 			name: "azure file volume with a pod namespace",
 			volume: &corev1.Volume{
+				Name: "name",
 				VolumeSource: corev1.VolumeSource{
 					AzureFile: &corev1.AzureFileVolumeSource{
 						ReadOnly:   true,
@@ -163,7 +165,7 @@ func TestTranslateAzureFileInTreeStorageClassToCSI(t *testing.T) {
 			podNamespace: "test",
 			expVol: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "file.csi.azure.com-sharename",
+					Name: "#secretname#sharename#name",
 				},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
@@ -175,7 +177,7 @@ func TestTranslateAzureFileInTreeStorageClassToCSI(t *testing.T) {
 							},
 							ReadOnly:         true,
 							VolumeAttributes: map[string]string{shareNameField: "sharename"},
-							VolumeHandle:     "#secretname#sharename#",
+							VolumeHandle:     "#secretname#sharename#name",
 						},
 					},
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
@@ -225,7 +227,7 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 			name: "azure file volume",
 			volume: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "file.csi.azure.com-sharename",
+					Name: "uuid",
 				},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
@@ -240,7 +242,7 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 			},
 			expVol: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "file.csi.azure.com-sharename",
+					Name: "uuid",
 				},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
@@ -252,7 +254,7 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 								Namespace: secretNamespace,
 							},
 							VolumeAttributes: map[string]string{shareNameField: "sharename"},
-							VolumeHandle:     "#secretname#sharename#",
+							VolumeHandle:     "#secretname#sharename#uuid",
 						},
 					},
 				},
@@ -262,7 +264,7 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 			name: "azure file volume with rg annotation",
 			volume: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "file.csi.azure.com-sharename",
+					Name:        "uuid",
 					Annotations: map[string]string{resourceGroupAnnotation: "rg"},
 				},
 				Spec: corev1.PersistentVolumeSpec{
@@ -278,7 +280,7 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 			},
 			expVol: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "file.csi.azure.com-sharename",
+					Name:        "uuid",
 					Annotations: map[string]string{resourceGroupAnnotation: "rg"},
 				},
 				Spec: corev1.PersistentVolumeSpec{
@@ -291,7 +293,7 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 								Namespace: secretNamespace,
 							},
 							VolumeAttributes: map[string]string{shareNameField: "sharename"},
-							VolumeHandle:     "rg#secretname#sharename#",
+							VolumeHandle:     "rg#secretname#sharename#uuid",
 						},
 					},
 				},


### PR DESCRIPTION
Cherry pick of #107575 on release-1.21.

#107575: fix: azurefile volumeid conflict in csi migration

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.