### PR TITLE
apiserver: correct references to service-account-signing-key-file flag

### DIFF
--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -318,7 +318,7 @@ func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 			"ServiceAccount tokens. The specified file can contain multiple keys, and the flag can "+
 			"be specified multiple times with different files. If unspecified, "+
 			"--tls-private-key-file is used. Must be specified when "+
-			"--service-account-signing-key is provided")
+			"--service-account-signing-key-file is provided")
 
 		fs.BoolVar(&o.ServiceAccounts.Lookup, "service-account-lookup", o.ServiceAccounts.Lookup,
 			"If true, validate ServiceAccount tokens exist in etcd as part of authentication.")


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Documentation for kube-apiserver flag `service-account-key-file` references `service-account-signing-key` flag which doesn't exist. The intended documentation should reference the `service-account-signing-key-file` flag.

#### Which issue(s) this PR fixes:
Fixes #107862

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
