### PR TITLE
Reduced the number of parallel typechecks to 1

### DIFF
--- a/test/typecheck/main.go
+++ b/test/typecheck/main.go
@@ -33,13 +33,15 @@ import (
 )
 
 var (
-	verbose    = flag.Bool("verbose", false, "print more information")
-	cross      = flag.Bool("cross", true, "build for all platforms")
-	platforms  = flag.String("platform", "", "comma-separated list of platforms to typecheck")
-	timings    = flag.Bool("time", false, "output times taken for each phase")
-	defuses    = flag.Bool("defuse", false, "output defs/uses")
-	serial     = flag.Bool("serial", false, "don't type check platforms in parallel (equivalent to --parallel=1)")
-	parallel   = flag.Int("parallel", 2, "limits how many platforms can be checked in parallel. 0 means no limit.")
+	verbose   = flag.Bool("verbose", false, "print more information")
+	cross     = flag.Bool("cross", true, "build for all platforms")
+	platforms = flag.String("platform", "", "comma-separated list of platforms to typecheck")
+	timings   = flag.Bool("time", false, "output times taken for each phase")
+	defuses   = flag.Bool("defuse", false, "output defs/uses")
+	serial    = flag.Bool("serial", false, "don't type check platforms in parallel (equivalent to --parallel=1)")
+	// Consider increasing the default parallelism once the Go 1.17 memory issue has been addressed
+	// https://github.com/kubernetes/test-infra/issues/23374
+	parallel   = flag.Int("parallel", 1, "limits how many platforms can be checked in parallel. 0 means no limit.")
 	skipTest   = flag.Bool("skip-test", false, "don't type check test code")
 	tags       = flag.String("tags", "", "comma-separated list of build tags to apply in addition to go's defaults")
 	ignoreDirs = flag.String("ignore-dirs", "", "comma-separated list of directories to ignore in addition to the default hardcoded list including staging, vendor, and hidden dirs")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
In https://github.com/kubernetes/kubernetes/pull/104608, we reduced the number of parallel typechecks to 2 yet the OOM still seems to happen in the master branch. Until the original issue has been resolved, reduce the parallel typecheck to 1.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/107702

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
