### PR TITLE
e2e: improve formatting of failure messages

### DIFF
--- a/test/e2e/framework/format.go
+++ b/test/e2e/framework/format.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// FormatJSON is a helper that prints the inner object in json format.
+//
+// It can be used with log statements, for example:
+//  klog.Infof("object is %s", framework.FormatJSON(o))
+//
+// It returns an object, to avoid json overhead unless the value is actually printed.
+func FormatJSON(o interface{}) formatJSON {
+	return formatJSON{object: o}
+}
+
+// formatJSON is the helper type that defers json rendering until it is needed.
+type formatJSON struct {
+	object interface{}
+}
+
+// formatJSON implements fmt.Stringer
+var _ fmt.Stringer = formatJSON{}
+
+// String implements the Stringer interface
+func (f formatJSON) String() string {
+	b, err := json.Marshal(f.object)
+	if err != nil {
+		return fmt.Sprintf("<error converting to json: %v>", err)
+	}
+	return string(b)
+}

--- a/test/e2e/network/topology_hints.go
+++ b/test/e2e/network/topology_hints.go
@@ -143,13 +143,13 @@ var _ = common.SIGDescribe("Feature:Topology Hints", func() {
 					framework.Failf("Expected endpoint in %s to have zone: %v", slice.Name, ep)
 				}
 				if ep.Hints == nil || len(ep.Hints.ForZones) == 0 {
-					framework.Failf("Expected endpoint in %s to have hints: %v", slice.Name, ep)
+					framework.Failf("Expected endpoint in %s to have exactly 1 zone hint, got 0: %s", slice.Name, framework.FormatJSON(ep))
 				}
 				if len(ep.Hints.ForZones) > 1 {
-					framework.Failf("Expected endpoint in %s to have exactly 1 zone hint, got %d: %v", slice.Name, len(ep.Hints.ForZones), ep)
+					framework.Failf("Expected endpoint in %s to have exactly 1 zone hint, got %d: %s", slice.Name, len(ep.Hints.ForZones), framework.FormatJSON(ep))
 				}
 				if *ep.Zone != ep.Hints.ForZones[0].Name {
-					framework.Failf("Expected endpoint in %s to have same zone hint, got %s: %v", slice.Name, *ep.Zone, ep)
+					framework.Failf("Expected endpoint in %s to have same zone hint, got %s: %v", slice.Name, *ep.Zone, framework.FormatJSON(ep))
 				}
 			}
 		}


### PR DESCRIPTION
We format the output as json, and make the "unexpected count" messages consistent.

Before:

```
Jan 30 09:49:46.963: Expected endpoint in topology-hints-f5vs6 to have hints: {[100.109.32.103] {0xc0044e0c9e 0xc0044e0c9f 0xc0044e0ca0} <nil> &ObjectReference{Kind:Pod,Namespace:topology-hints-1629,Name:topology-serve-hostname-mkn8b,UID:450e8006-37a0-4853-bae3-3493fc6cd916,APIVersion:,ResourceVersion:50994,FieldPath:,} map[] 0xc00245ed70 0xc00245ed80 nil}
```

After:

```
  Jan 30 11:45:50.056: Expected endpoint in topology-hints-9p9hz to have exactly 1 zone hint, got 0: {"addresses":["100.96.1.7"],"conditions":{"ready":true,"serving":true,"terminating":false},"targetRef":{"kind":"Pod","namespace":"topology-hints-6706","name":"topology-serve-hostname-6gpbm","uid":"8695dcf2-8c81-4ed7-8e80-929928b9cf4e","resourceVersion":"23139"},"nodeName":"ip-172-20-88-192.us-east-2.compute.internal","zone":"us-east-2b"}
```

/kind failing-test
```release-note
NONE
```

Example of failing tests: https://testgrid.k8s.io/google-aws#kops-aws-misc-ha-euwest1

(Note _this_ PR does not address the underlying cause of the test failure)