### PR TITLE
e2e: Feature tags must be in square brackets

### DIFF
--- a/test/e2e/network/topology_hints.go
+++ b/test/e2e/network/topology_hints.go
@@ -39,7 +39,7 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
-var _ = common.SIGDescribe("Feature:Topology Hints", func() {
+var _ = common.SIGDescribe("[Feature:Topology Hints]", func() {
 	f := framework.NewDefaultFramework("topology-hints")
 
 	// filled in BeforeEach


### PR DESCRIPTION
Otherwise the feature regexes that we use don't detect them.

This was relatively hidden because we don't have many e2e tests that
test multizone.

/kind failing-test
```release-note
NONE
```
