### PR TITLE
Update documentation to reflect removal of default conversions

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go
@@ -190,10 +190,9 @@ func (c *Converter) RegisterIgnoredConversion(from, to interface{}) error {
 }
 
 // Convert will translate src to dest if it knows how. Both must be pointers.
-// If no conversion func is registered and the default copying mechanism
-// doesn't work on this type pair, an error will be returned.
-// 'meta' is given to allow you to pass information to conversion functions,
-// it is not used by Convert() other than storing it in the scope.
+// If no conversion func is registered for this type pair, an error will be
+// returned. 'meta' is given to allow you to pass information to conversion
+// functions, it is not used by Convert() other than storing it in the scope.
 // Not safe for objects with cyclic references!
 func (c *Converter) Convert(src, dest interface{}, meta *Meta) error {
 	pair := typePair{reflect.TypeOf(src), reflect.TypeOf(dest)}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This touches up the documentation for apimachinery/pkg/conversion to clarify that the default golang copy mechanisms are not called or supported.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Reading the Develoment Guide and Your First Contribution documents, I was unsure if I needed to file an issue before submitting a pull request. I will, of course, file an issue if required.

#### Special notes for your reviewer:

A look at this [history of this file][history] and the commits referenced therein clearly show that this feature was disabled. The documentation simply has to be made current.

Our team was investigating this package given the documented behavior of supporting golang's "default copying mechanism". This change in documentation may save future investigators some time in the future 🕵️

[history]: https://github.com/kubernetes/kubernetes/commits/master/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

