### PR TITLE
Remove unused and un-enable-able apiserver multiple ports feature

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -159,17 +159,6 @@ type ExtraConfig struct {
 
 	// The range of ports to be assigned to services with type=NodePort or greater
 	ServiceNodePortRange utilnet.PortRange
-	// Additional ports to be exposed on the GenericAPIServer service
-	// extraServicePorts is injectable in the event that more ports
-	// (other than the default 443/tcp) are exposed on the GenericAPIServer
-	// and those ports need to be load balanced by the GenericAPIServer
-	// service because this pkg is linked by out-of-tree projects
-	// like openshift which want to use the GenericAPIServer but also do
-	// more stuff.
-	ExtraServicePorts []apiv1.ServicePort
-	// Additional ports to be exposed on the GenericAPIServer endpoints
-	// Port names should align with ports defined in ExtraServicePorts
-	ExtraEndpointPorts []apiv1.EndpointPort
 	// If non-zero, the "kubernetes" services uses this port as NodePort.
 	KubernetesServiceNodePort int
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

    Theoretically, the apiserver could be told to advertise additional
    ports on the kubernetes service, but there was no way to enable this
    functionality without forking/vendoring the apiserver code. This was
    apparently added in the distant past for OpenShift to use, but it has
    not been used in OpenShift since Kubernetes 1.11.

(essentially reverting #14871. I left the arguments to ReconcileEndpoints, etc, as arrays, because getting rid of the arrays requires a bunch more rewriting (especially in the unit tests) and doesn't really make things any simpler anyway, and we may eventually want to add a QUIC endpoint or something)

#### Which issue(s) this PR fixes:
None; I'm doing some cleanup/refactoring of the endpoint reconciling code in preparation for dual-stack apiserver support (KEP-2438).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2438-dual-stack-apiserver
```

/sig apimachinery
/cc @deads2k