### PR TITLE
Fix concurrent usage issue of the same scheme

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -2243,7 +2243,7 @@ func TestConflictingData(t *testing.T) {
 			eventRecorder := record.NewFakeRecorder(100)
 			eventRecorder.IncludeObject = true
 
-			metadataClient := fakemetadata.NewSimpleMetadataClient(legacyscheme.Scheme)
+			metadataClient := fakemetadata.NewSimpleMetadataClient(fakemetadata.NewTestScheme())
 
 			tweakableRM := meta.NewDefaultRESTMapper(nil)
 			tweakableRM.AddSpecific(

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/fake"
-	scheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/metadata"
 	metadatafake "k8s.io/client-go/metadata/fake"
 	restclient "k8s.io/client-go/rest"
@@ -420,7 +419,7 @@ func TestDeleteEncounters404(t *testing.T) {
 		}
 		return false, nil, nil
 	}
-	mockMetadataClient := metadatafake.NewSimpleMetadataClient(scheme.Scheme)
+	mockMetadataClient := metadatafake.NewSimpleMetadataClient(metadatafake.NewTestScheme())
 	mockMetadataClient.PrependReactor("delete-collection", "flakes", ns1FlakesNotFound)
 	mockMetadataClient.PrependReactor("list", "flakes", ns1FlakesNotFound)
 

--- a/staging/src/k8s.io/client-go/metadata/fake/simple.go
+++ b/staging/src/k8s.io/client-go/metadata/fake/simple.go
@@ -41,6 +41,11 @@ type MetadataClient interface {
 	UpdateFake(obj *metav1.PartialObjectMetadata, opts metav1.UpdateOptions, subresources ...string) (*metav1.PartialObjectMetadata, error)
 }
 
+// NewTestScheme creates a unique Scheme for each test.
+func NewTestScheme() *runtime.Scheme {
+	return runtime.NewScheme()
+}
+
 // NewSimpleMetadataClient creates a new client that will use the provided scheme and respond with the
 // provided objects when requests are made. It will track actions made to the client which can be checked
 // with GetActions().

--- a/staging/src/k8s.io/client-go/metadata/fake/simple_test.go
+++ b/staging/src/k8s.io/client-go/metadata/fake/simple_test.go
@@ -39,13 +39,6 @@ const (
 	testAPIVersion = "testgroup/testversion"
 )
 
-var scheme *runtime.Scheme
-
-func init() {
-	scheme = runtime.NewScheme()
-	metav1.AddMetaToScheme(scheme)
-}
-
 func newPartialObjectMetadata(apiVersion, kind, namespace, name string) *metav1.PartialObjectMetadata {
 	return &metav1.PartialObjectMetadata{
 		TypeMeta: metav1.TypeMeta{
@@ -66,6 +59,8 @@ func newPartialObjectMetadataWithAnnotations(annotations map[string]string) *met
 }
 
 func TestList(t *testing.T) {
+	scheme := NewTestScheme()
+	metav1.AddMetaToScheme(scheme)
 	client := NewSimpleMetadataClient(scheme,
 		newPartialObjectMetadata("group/version", "TheKind", "ns-foo", "name-foo"),
 		newPartialObjectMetadata("group2/version", "TheKind", "ns-foo", "name2-foo"),
@@ -98,6 +93,8 @@ type patchTestCase struct {
 }
 
 func (tc *patchTestCase) runner(t *testing.T) {
+	scheme := NewTestScheme()
+	metav1.AddMetaToScheme(scheme)
 	client := NewSimpleMetadataClient(scheme, tc.object)
 	resourceInterface := client.Resource(schema.GroupVersionResource{Group: testGroup, Version: testVersion, Resource: testResource}).Namespace(testNamespace)
 

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_test.go
@@ -125,7 +125,7 @@ func TestMetadataSharedInformerFactory(t *testing.T) {
 			timeout := time.Duration(3 * time.Second)
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
-			scheme := runtime.NewScheme()
+			scheme := fake.NewTestScheme()
 			metav1.AddMetaToScheme(scheme)
 			informerReciveObjectCh := make(chan *metav1.PartialObjectMetadata, 1)
 			objs := []runtime.Object{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Because of this scheme mutation, this leads to concurrent use of the same scheme to cause the program to panic. It would be ideal to do this in some concurrent safe manner.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #107823, #107874

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
