### PR TITLE
[PoC] prototype ExtendDefaultExecProbeTimeout admission plugin

### DIFF
--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/namespace/exists"
 	"k8s.io/kubernetes/plugin/pkg/admission/network/defaultingressclass"
 	"k8s.io/kubernetes/plugin/pkg/admission/network/denyserviceexternalips"
+	"k8s.io/kubernetes/plugin/pkg/admission/node/execprobetimeout"
 	"k8s.io/kubernetes/plugin/pkg/admission/noderestriction"
 	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
 	"k8s.io/kubernetes/plugin/pkg/admission/podnodeselector"
@@ -94,6 +95,7 @@ var AllOrderedPlugins = []string{
 	certsubjectrestriction.PluginName,       // CertificateSubjectRestriction
 	defaultingressclass.PluginName,          // DefaultIngressClass
 	denyserviceexternalips.PluginName,       // DenyServiceExternalIPs
+	execprobetimeout.PluginName,             // ExtendDefaultExecProbeTimeout
 
 	// new admission plugins should generally be inserted above here
 	// webhook, resourcequota, and deny plugins must go at the end
@@ -139,6 +141,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	certapproval.Register(plugins)
 	certsigning.Register(plugins)
 	certsubjectrestriction.Register(plugins)
+	execprobetimeout.Register(plugins)
 }
 
 // DefaultOffAdmissionPlugins get admission plugins off by default for kube-apiserver.
@@ -162,6 +165,7 @@ func DefaultOffAdmissionPlugins() sets.String {
 		certsubjectrestriction.PluginName,       // CertificateSubjectRestriction
 		defaultingressclass.PluginName,          // DefaultIngressClass
 		podsecurity.PluginName,                  // PodSecurity
+		execprobetimeout.PluginName,             // ExtendDefaultExecProbeTimeout
 	)
 
 	return sets.NewString(AllOrderedPlugins...).Difference(defaultOnPlugins)

--- a/plugin/pkg/admission/node/execprobetimeout/admission.go
+++ b/plugin/pkg/admission/node/execprobetimeout/admission.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package execprobetimeout
+
+import (
+	"context"
+	"io"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/admission"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+// PluginName indicates name of admission plugin.
+const PluginName = "ExtendDefaultExecProbeTimeout"
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return NewPlugin(), nil
+	})
+}
+
+// Plugin holds state for and implements the admission plugin.
+type Plugin struct {
+	*admission.Handler
+}
+
+var (
+	_ admission.MutationInterface = &Plugin{}
+)
+
+// NewPlugin constructs a new instance of the ExtendDefaultExecProbeTimeout admission interface.
+func NewPlugin() *Plugin {
+	return &Plugin{
+		Handler: admission.NewHandler(admission.Create),
+	}
+}
+
+func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	if len(a.GetSubresource()) != 0 || a.GetResource().GroupResource() != api.Resource("pods") {
+		return nil
+	}
+
+	pod, ok := a.GetObject().(*api.Pod)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+	}
+
+	for _, container := range pod.Spec.Containers {
+		if container.LivenessProbe != nil {
+			if container.LivenessProbe.ProbeHandler.Exec != nil {
+				if container.LivenessProbe.TimeoutSeconds == 1 {
+					container.LivenessProbe.TimeoutSeconds = 5
+				}
+			}
+		}
+
+		if container.ReadinessProbe != nil {
+			if container.ReadinessProbe.ProbeHandler.Exec != nil {
+				if container.ReadinessProbe.TimeoutSeconds == 1 {
+					container.ReadinessProbe.TimeoutSeconds = 5
+				}
+			}
+		}
+
+		if container.StartupProbe != nil {
+			if container.StartupProbe.ProbeHandler.Exec != nil {
+				if container.StartupProbe.TimeoutSeconds == 1 {
+					container.StartupProbe.TimeoutSeconds = 5
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/plugin/pkg/admission/node/execprobetimeout/admission_test.go
+++ b/plugin/pkg/admission/node/execprobetimeout/admission_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package execprobetimeout

--- a/test/integration/node/exec_probe_test.go
+++ b/test/integration/node/exec_probe_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestExtendedExecProbeTimeout(t *testing.T) {
+	testServer := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
+		"--enable-admission-plugins", "ExtendDefaultExecProbeTimeout",
+	}, framework.SharedEtcd())
+	t.Cleanup(testServer.TearDownFn)
+
+	client := clientset.NewForConfigOrDie(testServer.ClientConfig)
+
+	testNamespace := "extended-exec-probe-timeout"
+	ns, err := client.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.CoreV1().ServiceAccounts(testNamespace).Create(context.TODO(), &v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: testNamespace},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "with-exec-probe-timeout",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "with-probe-timeout",
+					Image: "some:image",
+					LivenessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							Exec: &v1.ExecAction{
+								Command: []string{
+									"ls",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := client.CoreV1().Pods(ns.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+		t.Errorf("failed to create pod: %v", err)
+	}
+
+	pod, err = client.CoreV1().Pods(ns.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("error getting pod: %v", err)
+	}
+
+	if pod.Spec.Containers[0].LivenessProbe.TimeoutSeconds != 5 {
+		t.Errorf("unexpected timeout for exec probe, got %d but expected 5", pod.Spec.Containers[0].LivenessProbe.TimeoutSeconds)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This is just a prototype for how we might be able to automatically extend the default exec timeout. 

Biggest caveat (and probably a blocker) is that this can't distinguish between the timeout being defaulted or a user explicitly setting the value to 1s.  

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
