### PR TITLE
[PoC] prototype a feature gate for extending the default timeout for exec probes

### DIFF
--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -210,6 +210,10 @@ func SetDefaults_PodSpec(obj *v1.PodSpec) {
 func SetDefaults_Probe(obj *v1.Probe) {
 	if obj.TimeoutSeconds == 0 {
 		obj.TimeoutSeconds = 1
+
+		if obj.ProbeHandler.Exec != nil && utilfeature.DefaultFeatureGate.Enabled(features.ExtendDefaultExecProbeTimeout) {
+			obj.TimeoutSeconds = 5
+		}
 	}
 	if obj.PeriodSeconds == 0 {
 		obj.PeriodSeconds = 10

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -538,6 +538,12 @@ const (
 	ExecProbeTimeout featuregate.Feature = "ExecProbeTimeout"
 
 	// owner: @andrewsykim
+	// GA: TODO
+	//
+	// Override the default timeout duration for exec probes to 5s.
+	ExtendDefaultExecProbeTimeout featuregate.Feature = "ExtendDefaultExecProbeTimeout"
+
+	// owner: @andrewsykim
 	// alpha: v1.20
 	//
 	// Enable kubelet exec plugins for image pull credentials.
@@ -912,6 +918,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	HPAContainerMetrics:                            {Default: false, PreRelease: featuregate.Alpha},
 	SizeMemoryBackedVolumes:                        {Default: true, PreRelease: featuregate.Beta},
 	ExecProbeTimeout:                               {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
+	ExtendDefaultExecProbeTimeout:                  {Default: true, PreRelease: featuregate.GA},
 	KubeletCredentialProviders:                     {Default: false, PreRelease: featuregate.Alpha},
 	GracefulNodeShutdown:                           {Default: true, PreRelease: featuregate.Beta},
 	GracefulNodeShutdownBasedOnPodPriority:         {Default: false, PreRelease: featuregate.Alpha},

--- a/test/integration/node/exec_probe_test.go
+++ b/test/integration/node/exec_probe_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestExtendedExecProbeTimeout(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ExtendDefaultExecProbeTimeout, true)()
+
+	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
+	_, server, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
+	defer closeFn()
+
+	config := restclient.Config{Host: server.URL}
+	client, err := clientset.NewForConfig(&config)
+	if err != nil {
+		t.Fatalf("Error creating clientset: %v", err)
+	}
+
+	ns := framework.CreateTestingNamespace("test-external-name-drops-internal-traffic-policy", server, t)
+	defer framework.DeleteTestingNamespace(ns, server, t)
+
+	_, err = client.CoreV1().ServiceAccounts(ns.Name).Create(context.TODO(), &v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: ns.Name},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "with-exec-probe-timeout",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "with-probe-timeout",
+					Image: "some:image",
+					LivenessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							Exec: &v1.ExecAction{
+								Command: []string{
+									"ls",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := client.CoreV1().Pods(ns.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+		t.Errorf("failed to create pod: %v", err)
+	}
+
+	pod, err = client.CoreV1().Pods(ns.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("error getting pod: %v", err)
+	}
+
+	if pod.Spec.Containers[0].LivenessProbe.TimeoutSeconds != 5 {
+		t.Errorf("unexpected timeout for exec probe, got %d but expected 5", pod.Spec.Containers[0].LivenessProbe.TimeoutSeconds)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Prototyping whether a feature gate to extend the default exec probe would be worthwhile. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
