### PR TITLE
apiserver: add egress_type label to egress dial metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -89,7 +89,7 @@ func (s EgressType) AsNetworkContext() NetworkContext {
 	return NetworkContext{EgressSelectionName: s}
 }
 
-func lookupServiceName(name string) (EgressType, error) {
+func serviceNameToEgressType(name string) (EgressType, error) {
 	switch strings.ToLower(name) {
 	case "controlplane":
 		return ControlPlane, nil
@@ -346,15 +346,15 @@ func NewEgressSelector(config *apiserver.EgressSelectorConfiguration) (*EgressSe
 		egressToDialer: make(map[EgressType]utilnet.DialFunc),
 	}
 	for _, service := range config.EgressSelections {
-		name, err := lookupServiceName(service.Name)
+		egressType, err := serviceNameToEgressType(service.Name)
 		if err != nil {
 			return nil, err
 		}
 		dialerCreator, err := connectionToDialerCreator(service.Connection)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create dialer for egressSelection %q: %v", name, err)
+			return nil, fmt.Errorf("failed to create dialer for egressSelection %q: %v", egressType, err)
 		}
-		cs.egressToDialer[name] = dialerCreator.createDialer(name)
+		cs.egressToDialer[egressType] = dialerCreator.createDialer(egressType)
 	}
 	return cs, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/metrics/metrics.go
@@ -68,7 +68,7 @@ func newDialMetrics() *DialMetrics {
 			Buckets:        latencyBuckets,
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"protocol", "transport"},
+		[]string{"protocol", "transport", "egress_type"},
 	)
 
 	failures := metrics.NewCounterVec(
@@ -79,7 +79,7 @@ func newDialMetrics() *DialMetrics {
 			Help:           "Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"protocol", "transport", "stage"},
+		[]string{"protocol", "transport", "stage", "egress_type"},
 	)
 
 	legacyregistry.MustRegister(latencies)
@@ -104,11 +104,11 @@ func (m *DialMetrics) Reset() {
 }
 
 // ObserveDialLatency records the latency of a dial, labeled by protocol, transport.
-func (m *DialMetrics) ObserveDialLatency(elapsed time.Duration, protocol, transport string) {
-	m.latencies.WithLabelValues(protocol, transport).Observe(elapsed.Seconds())
+func (m *DialMetrics) ObserveDialLatency(elapsed time.Duration, protocol, transport, egressType string) {
+	m.latencies.WithLabelValues(protocol, transport, egressType).Observe(elapsed.Seconds())
 }
 
 // ObserveDialFailure records a failed dial, labeled by protocol, transport, and the stage the dial failed at.
-func (m *DialMetrics) ObserveDialFailure(protocol, transport, stage string) {
-	m.failures.WithLabelValues(protocol, transport, stage).Inc()
+func (m *DialMetrics) ObserveDialFailure(protocol, transport, stage, egressType string) {
+	m.failures.WithLabelValues(protocol, transport, stage, egressType).Inc()
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -260,7 +260,7 @@ func (r *proxyHandler) updateAPIService(apiService *apiregistrationv1api.APIServ
 		var egressDialer utilnet.DialFunc
 		egressDialer, err := r.egressSelector.Lookup(networkContext)
 		if err != nil {
-			klog.Warning(err.Error())
+			klog.Warningf("error dialing with egress selector on network context %q, err: %v", networkContext.EgressSelectionName.String(), err)
 		} else {
 			newInfo.restConfig.Dial = egressDialer
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:'

This PR adds an `egress_type` label to the existing apiserver metrics `egress_dialer_dial_duration_seconds` and `egress_dialer_dial_failure_count`.  The label is especially useful to help determine which apiserver code paths are exercised for the respective metric. Cardinality should be minimal since there are only three valid values for the egress type today: `controlplane`, `etcd`, and `cluster`. 

Also includes some minor refactoring and clean up

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
apiserver: add egress_type label to egress dial metrics
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
