### PR TITLE
Test to ensure connectivity with Services works across hybrid networks with Windows

### DIFF
--- a/test/e2e/windows/framework.go
+++ b/test/e2e/windows/framework.go
@@ -17,6 +17,8 @@ limitations under the License.
 package windows
 
 import (
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/e2e/framework"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 
 	"github.com/onsi/ginkgo"
@@ -29,6 +31,18 @@ func SIGDescribe(text string, body func()) bool {
 			// all tests in this package are Windows specific
 			e2eskipper.SkipUnlessNodeOSDistroIs("windows")
 		})
+
+		// enable HostProcessContainers by default (it is Beta and on by default in beta in 1.23)
+		// this allows us to use host process containers in some of the tests but allows for
+		// someone that disables it to still run a subset of the tests
+		if framework.TestContext.FeatureGates == nil {
+			framework.TestContext.FeatureGates = map[string]bool{}
+			framework.TestContext.FeatureGates[string(features.WindowsHostProcessContainers)] = true
+		}
+		_, exists := framework.TestContext.FeatureGates[string(features.WindowsHostProcessContainers)]
+		if !exists {
+			framework.TestContext.FeatureGates[string(features.WindowsHostProcessContainers)] = true
+		}
 
 		body()
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We found a bug with Calico https://github.com/projectcalico/calico/issues/5522 which wasn't caught by the set of tests we currently run.  

We have two tests that we thought would have covered this:

- `should be able to create a functioning NodePort service for Windows` but doesn't test via the service ip but instead goes directly to the node port.
- `should have stable networking for Linux and Windows pods` but goes directly to pod ip instead of via service

Link to slack discussion: https://app.slack.com/client/T09NY5SBT/C0SJ4AFB7/thread/C0SJ4AFB7-1643298946.159400?cdn_fallback=1

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


/sig windows
/assign @knabben @marosset @phillipsj