### PR TITLE
[Summary API [NodeConformance]] Increase timeout for initial /stats/summary validation

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -68,7 +68,7 @@ var _ = SIGDescribe("Summary API [NodeConformance]", func() {
 					}
 				}
 				return nil
-			}, 2*time.Minute, 5*time.Second).Should(gomega.BeNil())
+			}, time.Minute, 5*time.Second).Should(gomega.BeNil())
 
 			ginkgo.By("Waiting 15 seconds for cAdvisor to collect 2 stats points")
 			time.Sleep(15 * time.Second)
@@ -324,7 +324,7 @@ var _ = SIGDescribe("Summary API [NodeConformance]", func() {
 
 			ginkgo.By("Validating /stats/summary")
 			// Give pods a minute to actually start up.
-			gomega.Eventually(getNodeSummary, 90*time.Second, 15*time.Second).Should(matchExpectations)
+			gomega.Eventually(getNodeSummary, 180*time.Second, 15*time.Second).Should(matchExpectations)
 			// Then the summary should match the expectations a few more times.
 			gomega.Consistently(getNodeSummary, 30*time.Second, 15*time.Second).Should(matchExpectations)
 		})


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
Test `E2eNode Suite.[sig-node] Summary API [NodeConformance] when querying /stats/summary should report resource usage through the stats api` sometimes flakes. These failures are due to a timeout.
This is not the only job or the first time where we see this flake:
- https://github.com/kubernetes/kubernetes/issues/106367
- https://github.com/kubernetes/kubernetes/issues/100788
- https://github.com/kubernetes/kubernetes/issues/104292

#### Which issue(s) this PR fixes:
Attempts to address #107412.

#### Special notes for your reviewer:
I attempted to fix this previously on https://github.com/kubernetes/kubernetes/pull/107768. However, this didn't stop the flakiness. After a deep dive into the build logs, I discovered that the failure occurs in the last validation. This PR does two things:
1. Extend the timeout period for this validation.
2. Restore the container restart timeout period to the original duration (1 minute).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```
