### PR TITLE
Automated cherry pick of #107695: kubelet: fix podstatus not containing pod full name

### DIFF
--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -580,6 +580,7 @@ func (p *podWorkers) UpdatePod(options UpdatePodOptions) {
 						syncedAt:           now,
 						startedTerminating: true,
 						finished:           true,
+						fullname:           kubecontainer.GetPodFullName(pod),
 					}
 				}
 			}


### PR DESCRIPTION
Cherry pick of #107695 on release-1.22.

#107695: kubelet: fix podstatus not containing pod full name

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```