### PR TITLE
Automated cherry pick of #107764: wrap error from RunCordonOrUncordon

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/default.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/default.go
@@ -60,9 +60,9 @@ func RunCordonOrUncordon(drainer *Helper, node *corev1.Node, desired bool) error
 	err, patchErr := c.PatchOrReplaceWithContext(drainer.Ctx, drainer.Client, false)
 	if err != nil {
 		if patchErr != nil {
-			return fmt.Errorf("cordon error: %s; merge patch error: %s", err.Error(), patchErr.Error())
+			return fmt.Errorf("cordon error: %s; merge patch error: %w", err.Error(), patchErr)
 		}
-		return fmt.Errorf("cordon error: %s", err.Error())
+		return fmt.Errorf("cordon error: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Cherry pick of #107764 on release-1.23.

#107764: wrap error from RunCordonOrUncordon

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes error handling in a kubectl method used in downstream packages.
```

/sig cli
/kind bug