### PR TITLE
Make ShowManagedFields public so printers users can tweak the value

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
@@ -36,7 +36,7 @@ func (f *JSONYamlPrintFlags) AllowedFormats() []string {
 // Given the following flag values, a printer can be requested that knows
 // how to handle printing based on these values.
 type JSONYamlPrintFlags struct {
-	showManagedFields bool
+	ShowManagedFields bool
 }
 
 // ToPrinter receives an outputFormat and returns a printer capable of
@@ -56,7 +56,7 @@ func (f *JSONYamlPrintFlags) ToPrinter(outputFormat string) (printers.ResourcePr
 		return nil, NoCompatiblePrinterError{OutputFormat: &outputFormat, AllowedFormats: f.AllowedFormats()}
 	}
 
-	if !f.showManagedFields {
+	if !f.ShowManagedFields {
 		printer = &printers.OmitManagedFieldsPrinter{Delegate: printer}
 	}
 	return printer, nil
@@ -69,7 +69,7 @@ func (f *JSONYamlPrintFlags) AddFlags(c *cobra.Command) {
 		return
 	}
 
-	c.Flags().BoolVar(&f.showManagedFields, "show-managed-fields", f.showManagedFields, "If true, keep the managedFields when printing objects in JSON or YAML format.")
+	c.Flags().BoolVar(&f.ShowManagedFields, "show-managed-fields", f.ShowManagedFields, "If true, keep the managedFields when printing objects in JSON or YAML format.")
 }
 
 // NewJSONYamlPrintFlags returns flags associated with


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli

#### What this PR does / why we need it:
In #96878 we introduced flags allowing to hide `.metadata.managedFields` but we didn't give cli-runtime consumers option to 
modify it, just like all the remaining printers have. This PR changes that field to be public and thus modifiable. 

#### Special notes for your reviewer:
/assign @deads2k 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
