### PR TITLE
Deeply copy JSONSchemaProps.XValidations.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/deepcopy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/deepcopy.go
@@ -290,5 +290,11 @@ func (in *JSONSchemaProps) DeepCopy() *JSONSchemaProps {
 		**out = **in
 	}
 
+	if in.XValidations != nil {
+		in, out := &in.XValidations, &out.XValidations
+		*out = make([]ValidationRule, len(*in))
+		copy(*out, *in)
+	}
+
 	return out
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/deepcopy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/deepcopy.go
@@ -250,5 +250,11 @@ func (in *JSONSchemaProps) DeepCopy() *JSONSchemaProps {
 		**out = **in
 	}
 
+	if in.XValidations != nil {
+		in, out := &in.XValidations, &out.XValidations
+		*out = make([]ValidationRule, len(*in))
+		copy(*out, *in)
+	}
+
 	return out
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/deepcopy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/deepcopy.go
@@ -266,5 +266,11 @@ func (in *JSONSchemaProps) DeepCopy() *JSONSchemaProps {
 		**out = **in
 	}
 
+	if in.XValidations != nil {
+		in, out := &in.XValidations, &out.XValidations
+		*out = make([]ValidationRule, len(*in))
+		copy(*out, *in)
+	}
+
 	return out
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Mutations to XValidations in a deep-copied CRD's schema can alter the original.

#### Which issue(s) this PR fixes:

Fixes #107954

#### Does this PR introduce a user-facing change?
```release-note
CRD deep copies should no longer contain shallow copies of JSONSchemaProps.XValidations.
```
