### PR TITLE
WIP fix KUBE-MARK-DROP tests

### DIFF
--- a/pkg/kubelet/kubelet_network_linux.go
+++ b/pkg/kubelet/kubelet_network_linux.go
@@ -88,13 +88,13 @@ func (kl *Kubelet) syncNetworkUtil(iptClient utiliptables.Interface) bool {
 		klog.ErrorS(err, "Failed to ensure that filter table exists KUBE-FIREWALL chain")
 		return false
 	}
-	if _, err := iptClient.EnsureRule(utiliptables.Append, utiliptables.TableFilter, KubeFirewallChain,
-		"-m", "comment", "--comment", "kubernetes firewall for dropping marked packets",
-		"-m", "mark", "--mark", fmt.Sprintf("%s/%s", dropMark, dropMark),
-		"-j", "DROP"); err != nil {
-		klog.ErrorS(err, "Failed to ensure rule to drop packet marked by the KUBE-MARK-DROP in KUBE-FIREWALL chain")
-		return false
-	}
+//	if _, err := iptClient.EnsureRule(utiliptables.Append, utiliptables.TableFilter, KubeFirewallChain,
+//		"-m", "comment", "--comment", "kubernetes firewall for dropping marked packets",
+//		"-m", "mark", "--mark", fmt.Sprintf("%s/%s", dropMark, dropMark),
+//		"-j", "DROP"); err != nil {
+//		klog.ErrorS(err, "Failed to ensure rule to drop packet marked by the KUBE-MARK-DROP in KUBE-FIREWALL chain")
+//		return false
+//	}
 
 	// drop all non-local packets to localhost if they're not part of an existing
 	// forwarded connection. See #90259

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -485,7 +485,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		testNotReachableUDP(udpIngressIP, svcPort, loadBalancerLagTimeout)
 	})
 
-	ginkgo.It("should only allow access from service loadbalancer source ranges [Slow]", func() {
+	ginkgo.It("should only allow access from service loadbalancer source ranges", func() {
 		// this feature currently supported only on GCE/GKE/AWS
 		e2eskipper.SkipUnlessProviderIs("gce", "gke", "aws")
 
@@ -978,7 +978,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 	})
 })
 
-var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
+var _ = common.SIGDescribe("LoadBalancers ESIPP", func() {
 	f := framework.NewDefaultFramework("esipp")
 	var loadBalancerCreateTimeout time.Duration
 
@@ -1005,7 +1005,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 		serviceLBNames = []string{}
 	})
 
-	ginkgo.It("should work for type=LoadBalancer", func() {
+	ginkgo.It("should work for type=LoadBalancer [Slow]", func() {
 		namespace := f.Namespace.Name
 		serviceName := "external-local-lb"
 		jig := e2eservice.NewTestJig(cs, namespace, serviceName)
@@ -1054,7 +1054,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 		}
 	})
 
-	ginkgo.It("should work for type=NodePort", func() {
+	ginkgo.It("should work for type=NodePort [Slow]", func() {
 		namespace := f.Namespace.Name
 		serviceName := "external-local-nodeport"
 		jig := e2eservice.NewTestJig(cs, namespace, serviceName)
@@ -1163,7 +1163,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 		}
 	})
 
-	ginkgo.It("should work from pods", func() {
+	ginkgo.It("should work from pods [Slow]", func() {
 		var err error
 		namespace := f.Namespace.Name
 		serviceName := "external-local-pods"
@@ -1222,7 +1222,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 		}
 	})
 
-	ginkgo.It("should handle updates to ExternalTrafficPolicy field", func() {
+	ginkgo.It("should handle updates to ExternalTrafficPolicy field [Slow]", func() {
 		namespace := f.Namespace.Name
 		serviceName := "external-local-update"
 		jig := e2eservice.NewTestJig(cs, namespace, serviceName)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The e2e test cases that are supposed to ensure that KUBE-MARK-DROP works don't actually test that it works, in that they do not actually fail when that chain doesn't exist (as seen in #85527 / #85572).

[KEP-3178](https://github.com/kubernetes/enhancements/issues/3178) will require rewriting the rules that are supposed to drop traffic, so before we do that we should have tests that will actually catch regressions.

(I'm currently pushing this PR without the actual "fix" part, and instead with just a commit to break the chain again, to confirm that things haven't changed since #85572 was filed, and that the tests are still broken.)

#### Which issue(s) this PR fixes:
Fixes #85572

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig network
/priority important-longterm
/triage accepted