### PR TITLE
Automated cherry pick of #107956: Deeply copy JSONSchemaProps.XValidations.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/deepcopy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/deepcopy.go
@@ -290,5 +290,11 @@ func (in *JSONSchemaProps) DeepCopy() *JSONSchemaProps {
 		**out = **in
 	}
 
+	if in.XValidations != nil {
+		in, out := &in.XValidations, &out.XValidations
+		*out = make([]ValidationRule, len(*in))
+		copy(*out, *in)
+	}
+
 	return out
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/deepcopy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/deepcopy.go
@@ -250,5 +250,11 @@ func (in *JSONSchemaProps) DeepCopy() *JSONSchemaProps {
 		**out = **in
 	}
 
+	if in.XValidations != nil {
+		in, out := &in.XValidations, &out.XValidations
+		*out = make([]ValidationRule, len(*in))
+		copy(*out, *in)
+	}
+
 	return out
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/deepcopy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/deepcopy.go
@@ -266,5 +266,11 @@ func (in *JSONSchemaProps) DeepCopy() *JSONSchemaProps {
 		**out = **in
 	}
 
+	if in.XValidations != nil {
+		in, out := &in.XValidations, &out.XValidations
+		*out = make([]ValidationRule, len(*in))
+		copy(*out, *in)
+	}
+
 	return out
 }


### PR DESCRIPTION
Cherry pick of #107956 on release-1.23.

#107956: Deeply copy JSONSchemaProps.XValidations.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```