### PR TITLE
Added StartsWith and EndsWith Operators to Label Selectors

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1228,6 +1228,8 @@ const (
 	LabelSelectorOpNotIn        LabelSelectorOperator = "NotIn"
 	LabelSelectorOpExists       LabelSelectorOperator = "Exists"
 	LabelSelectorOpDoesNotExist LabelSelectorOperator = "DoesNotExist"
+	LabelSelectorStartsWith     LabelSelectorOperator = "StartsWith"
+	LabelSelectorEndsWith       LabelSelectorOperator = "EndsWith"
 )
 
 // ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -51,6 +51,10 @@ func ValidateLabelSelectorRequirement(sr metav1.LabelSelectorRequirement, fldPat
 		if len(sr.Values) > 0 {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("values"), "may not be specified when `operator` is 'Exists' or 'DoesNotExist'"))
 		}
+	case metav1.LabelSelectorStartsWith, metav1.LabelSelectorEndsWith:
+		if len(sr.Values) != 1 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("values"), "must be specified when `operator` is 'StartsWith' or 'EndsWith'"))
+		}
 	default:
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("operator"), sr.Operator, "not a valid selector operator"))
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -237,10 +237,10 @@ func (r *Requirement) endsWith(value string) bool {
 //     Requirement's key.
 // (5) The operator is GreaterThanOperator or LessThanOperator, and Labels has
 //     the Requirement's key and the corresponding value satisfies mathematical inequality.
-// (6) The operator is StartsWith, Labels has the Requirement's key  and the label value
+// (6) The operator is StartsWith, Labels has the Requirement's key and the label value
 //     starts with the Requirement's value
 // (7) The operator is EndsWith, Labels has the Requirement's key and the label value
-//     starts with the Requirement's value
+//     ends with the Requirement's value
 func (r *Requirement) Matches(ls Labels) bool {
 	switch r.operator {
 	case selection.In, selection.Equals, selection.DoubleEquals:
@@ -370,9 +370,9 @@ func (r *Requirement) String() string {
 	case selection.Exists, selection.DoesNotExist:
 		return sb.String()
 	case selection.StartsWith:
-		sb.WriteString("=*")
+		sb.WriteString("^=")
 	case selection.EndsWith:
-		sb.WriteString("*=")
+		sb.WriteString("$=")
 	}
 
 	switch r.operator {
@@ -507,8 +507,8 @@ var string2token = map[string]Token{
 	"!=":    NotEqualsToken,
 	"notin": NotInToken,
 	"(":     OpenParToken,
-	"=*":    StartsWithToken,
-	"*=":    EndsWithToken,
+	"^=":    StartsWithToken,
+	"$=":    EndsWithToken,
 }
 
 // ScannedItem contains the Token and the literal produced by the lexer.
@@ -525,7 +525,7 @@ func isWhitespace(ch byte) bool {
 // isSpecialSymbol detects if the character ch can be an operator
 func isSpecialSymbol(ch byte) bool {
 	switch ch {
-	case '=', '!', '(', ')', ',', '>', '<', '*':
+	case '=', '!', '(', ')', ',', '>', '<', '^', '$':
 		return true
 	}
 	return false

--- a/staging/src/k8s.io/apimachinery/pkg/selection/operator.go
+++ b/staging/src/k8s.io/apimachinery/pkg/selection/operator.go
@@ -30,4 +30,6 @@ const (
 	Exists       Operator = "exists"
 	GreaterThan  Operator = "gt"
 	LessThan     Operator = "lt"
+	StartsWith   Operator = "=*"
+	EndsWith     Operator = "*="
 )

--- a/staging/src/k8s.io/apimachinery/pkg/selection/operator.go
+++ b/staging/src/k8s.io/apimachinery/pkg/selection/operator.go
@@ -30,6 +30,6 @@ const (
 	Exists       Operator = "exists"
 	GreaterThan  Operator = "gt"
 	LessThan     Operator = "lt"
-	StartsWith   Operator = "=*"
-	EndsWith     Operator = "*="
+	StartsWith   Operator = "^="
+	EndsWith     Operator = "$="
 )


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:
Sometimes we want to be able to select labels with values that “start with” or “end with” a particular string - I have a legitimate use case at the moment with external metrics. I understand that the recent proposition for regular expression support for selectors was rejected with concerns around performance.

In which case, I’m proposing an alternate solution that is more explicit and alleviates the potential performance impacts by bad actors or inefficient regular expressions.


#### Which issue(s) this PR fixes:
No specific issue yet - but it’s supplementary to #107053

#### Special notes for your reviewer:
I considered glob pattern support as suggested in #107053 but that’s a lot more effort and pushing the boundary of my Go/Kubernetes knowledge - I also much prefer the explicit nature of this approach with operators.

I have some questions for the team, around additional functionality.
* Should these operators be extended to field selectors as well?
* Should I add a string contains operator while I’m here?

#### Does this PR introduce a user-facing change?
```release-note
Added new StartsWith `^=` and EndsWith `$=` operators to Label Selectors
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
Does this need a KEP? 

```docs
* To select a label that starts with a particular string you may use the "StartsWith" operator denoted by `^=`
* To select a label that ends with a particular string you may use the "EndsWith" operator denoted by `$=`
```
