### PR TITLE
refactor: rename webhook duration tracker

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -265,9 +265,9 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 	}
 
 	do := func() { err = r.Do(ctx).Into(response) }
-	if wd, ok := endpointsrequest.WebhookDurationFrom(ctx); ok {
+	if wd, ok := endpointsrequest.LatencyTrackersFrom(ctx); ok {
 		tmp := do
-		do = func() { wd.AdmitTracker.Track(tmp) }
+		do = func() { wd.MutatingWebhookTracker.Track(tmp) }
 	}
 	do()
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
@@ -274,7 +274,7 @@ func TestWebhookDuration(ts *testing.T) {
 		ts.Run(test.Name, func(t *testing.T) {
 			ctx := context.TODO()
 			if test.InitContext {
-				ctx = request.WithWebhookDurationAndCustomClock(ctx, &clk)
+				ctx = request.WithLatencyTrackersAndCustomClock(ctx, &clk)
 			}
 			wh, err := NewMutatingWebhook(nil)
 			if err != nil {
@@ -299,7 +299,7 @@ func TestWebhookDuration(ts *testing.T) {
 			}
 
 			_ = wh.Admit(ctx, webhooktesting.NewAttribute(ns, nil, test.IsDryRun), objectInterfaces)
-			wd, ok := request.WebhookDurationFrom(ctx)
+			wd, ok := request.LatencyTrackersFrom(ctx)
 			if !ok {
 				if test.InitContext {
 					t.Errorf("expected webhook duration to be initialized")
@@ -310,11 +310,11 @@ func TestWebhookDuration(ts *testing.T) {
 				t.Errorf("expected webhook duration to not be initialized")
 				return
 			}
-			if wd.AdmitTracker.GetLatency() != test.ExpectedDurationSum {
-				t.Errorf("expected admit duration %q got %q", test.ExpectedDurationSum, wd.AdmitTracker.GetLatency())
+			if wd.MutatingWebhookTracker.GetLatency() != test.ExpectedDurationSum {
+				t.Errorf("expected admit duration %q got %q", test.ExpectedDurationSum, wd.MutatingWebhookTracker.GetLatency())
 			}
-			if wd.ValidateTracker.GetLatency() != 0 {
-				t.Errorf("expected validate duraion to be equal to 0 got %q", wd.ValidateTracker.GetLatency())
+			if wd.ValidatingWebhookTracker.GetLatency() != 0 {
+				t.Errorf("expected validate duraion to be equal to 0 got %q", wd.ValidatingWebhookTracker.GetLatency())
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -232,9 +232,9 @@ func (d *validatingDispatcher) callHook(ctx context.Context, h *v1.ValidatingWeb
 	}
 
 	do := func() { err = r.Do(ctx).Into(response) }
-	if wd, ok := endpointsrequest.WebhookDurationFrom(ctx); ok {
+	if wd, ok := endpointsrequest.LatencyTrackersFrom(ctx); ok {
 		tmp := do
-		do = func() { wd.ValidateTracker.Track(tmp) }
+		do = func() { wd.ValidatingWebhookTracker.Track(tmp) }
 	}
 	do()
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
@@ -236,7 +236,7 @@ func TestValidateWebhookDuration(ts *testing.T) {
 		ts.Run(test.Name, func(t *testing.T) {
 			ctx := context.TODO()
 			if test.InitContext {
-				ctx = request.WithWebhookDurationAndCustomClock(ctx, &clk)
+				ctx = request.WithLatencyTrackersAndCustomClock(ctx, &clk)
 			}
 			wh, err := NewValidatingAdmissionWebhook(nil)
 			if err != nil {
@@ -261,7 +261,7 @@ func TestValidateWebhookDuration(ts *testing.T) {
 			}
 
 			_ = wh.Validate(ctx, webhooktesting.NewAttribute(ns, nil, test.IsDryRun), objectInterfaces)
-			wd, ok := request.WebhookDurationFrom(ctx)
+			wd, ok := request.LatencyTrackersFrom(ctx)
 			if !ok {
 				if test.InitContext {
 					t.Errorf("expected webhook duration to be initialized")
@@ -272,11 +272,11 @@ func TestValidateWebhookDuration(ts *testing.T) {
 				t.Errorf("expected webhook duration to not be initialized")
 				return
 			}
-			if wd.AdmitTracker.GetLatency() != 0 {
-				t.Errorf("expected admit duration to be equal to 0 got %q", wd.AdmitTracker.GetLatency())
+			if wd.MutatingWebhookTracker.GetLatency() != 0 {
+				t.Errorf("expected admit duration to be equal to 0 got %q", wd.MutatingWebhookTracker.GetLatency())
 			}
-			if wd.ValidateTracker.GetLatency() < test.ExpectedDurationMax {
-				t.Errorf("expected validate duraion to be greater or equal to %q got %q", test.ExpectedDurationMax, wd.ValidateTracker.GetLatency())
+			if wd.ValidatingWebhookTracker.GetLatency() < test.ExpectedDurationMax {
+				t.Errorf("expected validate duraion to be greater or equal to %q got %q", test.ExpectedDurationMax, wd.ValidatingWebhookTracker.GetLatency())
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go
@@ -22,12 +22,13 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
-// WithWebhookDuration adds WebhookDuration trackers to the
-// context associated with a request.
-func WithWebhookDuration(handler http.Handler) http.Handler {
+// WithLatencyTrackers adds a LatencyTrackers instance to the
+// context associated with a request so that we can measure latency
+// incurred in various components within the apiserver.
+func WithLatencyTrackers(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
-		req = req.WithContext(request.WithWebhookDuration(ctx))
+		req = req.WithContext(request.WithLatencyTrackers(ctx))
 		handler.ServeHTTP(w, req)
 	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -482,8 +482,8 @@ func MonitorRequest(req *http.Request, verb, group, version, resource, subresour
 		}
 	}
 	requestLatencies.WithContext(req.Context()).WithLabelValues(reportedVerb, dryRun, group, version, resource, subresource, scope, component).Observe(elapsedSeconds)
-	if wd, ok := request.WebhookDurationFrom(req.Context()); ok {
-		sloLatency := elapsedSeconds - (wd.AdmitTracker.GetLatency() + wd.ValidateTracker.GetLatency()).Seconds()
+	if wd, ok := request.LatencyTrackersFrom(req.Context()); ok {
+		sloLatency := elapsedSeconds - (wd.MutatingWebhookTracker.GetLatency() + wd.ValidatingWebhookTracker.GetLatency()).Seconds()
 		requestSloLatencies.WithContext(req.Context()).WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component).Observe(sloLatency)
 	}
 	// We are only interested in response sizes of read requests.

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -762,7 +762,7 @@ func BuildHandlerChainWithStorageVersionPrecondition(apiHandler http.Handler, c 
 }
 
 func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
-	handler := genericapifilters.WithWebhookDuration(apiHandler)
+	handler := genericapifilters.WithLatencyTrackers(apiHandler)
 	handler = filterlatency.TrackCompleted(handler)
 	handler = genericapifilters.WithAuthorization(handler, c.Authorization.Authorizer, c.Serializer)
 	handler = filterlatency.TrackStarted(handler, "authorization")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Refactor webhook duration tracker so we can reuse it to track latencies incurred in various layers within the apiserver. This paves the way for https://github.com/kubernetes/kubernetes/pull/107910

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
