### PR TITLE
kubectl config subcommand cleanup: set-cluster, set-context, set-credentials

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
@@ -57,7 +57,7 @@ func NewCmdConfig(pathOptions *clientcmd.PathOptions, streams genericclioptions.
 	// TODO(juanvallejo): update all subcommands to work with genericclioptions.IOStreams
 	cmd.AddCommand(NewCmdConfigView(streams, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetCluster(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigSetAuthInfo(streams.Out, pathOptions))
+	cmd.AddCommand(NewCmdConfigSetCredentials(streams.Out, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetContext(streams.Out, pathOptions))
 	cmd.AddCommand(NewCmdConfigSet(streams.Out, pathOptions))
 	cmd.AddCommand(NewCmdConfigUnset(streams.Out, pathOptions))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_cluster.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_cluster.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
-type createClusterOptions struct {
+type setClusterOptions struct {
 	configAccess          clientcmd.ConfigAccess
 	name                  string
 	server                cliflag.StringFlag
@@ -45,19 +45,19 @@ type createClusterOptions struct {
 }
 
 var (
-	createClusterLong = templates.LongDesc(i18n.T(`
+	setClusterLong = templates.LongDesc(i18n.T(`
 		Set a cluster entry in kubeconfig.
 
 		Specifying a name that already exists will merge new fields on top of existing values for those fields.`))
 
-	createClusterExample = templates.Examples(`
+	setClusterExample = templates.Examples(`
 		# Set only the server field on the e2e cluster entry without touching other values
 		kubectl config set-cluster e2e --server=https://1.2.3.4
 
 		# Embed certificate authority data for the e2e cluster entry
 		kubectl config set-cluster e2e --embed-certs --certificate-authority=~/.kube/e2e/kubernetes.ca.crt
 
-		# Disable cert checking for the dev cluster entry
+		# Disable cert checking for the e2e cluster entry
 		kubectl config set-cluster e2e --insecure-skip-tls-verify=true
 
 		# Set custom TLS server name to use for validation for the e2e cluster entry
@@ -69,14 +69,14 @@ var (
 
 // NewCmdConfigSetCluster returns a Command instance for 'config set-cluster' sub command
 func NewCmdConfigSetCluster(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
-	options := &createClusterOptions{configAccess: configAccess}
+	options := &setClusterOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
 		Use:                   fmt.Sprintf("set-cluster NAME [--%v=server] [--%v=path/to/certificate/authority] [--%v=true] [--%v=example.com]", clientcmd.FlagAPIServer, clientcmd.FlagCAFile, clientcmd.FlagInsecure, clientcmd.FlagTLSServerName),
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Set a cluster entry in kubeconfig"),
-		Long:                  createClusterLong,
-		Example:               createClusterExample,
+		Long:                  setClusterLong,
+		Example:               setClusterExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd))
 			cmdutil.CheckErr(options.run())
@@ -99,7 +99,7 @@ func NewCmdConfigSetCluster(out io.Writer, configAccess clientcmd.ConfigAccess) 
 	return cmd
 }
 
-func (o createClusterOptions) run() error {
+func (o setClusterOptions) run() error {
 	err := o.validate()
 	if err != nil {
 		return err
@@ -124,8 +124,7 @@ func (o createClusterOptions) run() error {
 	return nil
 }
 
-// cluster builds a Cluster object from the options
-func (o *createClusterOptions) modifyCluster(existingCluster clientcmdapi.Cluster) clientcmdapi.Cluster {
+func (o *setClusterOptions) modifyCluster(existingCluster clientcmdapi.Cluster) clientcmdapi.Cluster {
 	modifiedCluster := existingCluster
 
 	if o.server.Provided() {
@@ -169,7 +168,7 @@ func (o *createClusterOptions) modifyCluster(existingCluster clientcmdapi.Cluste
 	return modifiedCluster
 }
 
-func (o *createClusterOptions) complete(cmd *cobra.Command) error {
+func (o *setClusterOptions) complete(cmd *cobra.Command) error {
 	args := cmd.Flags().Args()
 	if len(args) != 1 {
 		return helpErrorf(cmd, "Unexpected args: %v", args)
@@ -179,7 +178,7 @@ func (o *createClusterOptions) complete(cmd *cobra.Command) error {
 	return nil
 }
 
-func (o createClusterOptions) validate() error {
+func (o setClusterOptions) validate() error {
 	if len(o.name) == 0 {
 		return errors.New("you must specify a non-empty cluster name")
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_cluster_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_cluster_test.go
@@ -26,7 +26,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-type createClusterTest struct {
+type setClusterTest struct {
 	description    string
 	config         clientcmdapi.Config
 	args           []string
@@ -37,7 +37,7 @@ type createClusterTest struct {
 
 func TestCreateCluster(t *testing.T) {
 	conf := clientcmdapi.Config{}
-	test := createClusterTest{
+	test := setClusterTest{
 		description: "Testing 'kubectl config set-cluster' with a new cluster",
 		config:      conf,
 		args:        []string{"my-cluster"},
@@ -57,7 +57,7 @@ func TestCreateCluster(t *testing.T) {
 
 func TestCreateClusterWithProxy(t *testing.T) {
 	conf := clientcmdapi.Config{}
-	test := createClusterTest{
+	test := setClusterTest{
 		description: "Testing 'kubectl config set-cluster' with a new cluster",
 		config:      conf,
 		args:        []string{"my-cluster"},
@@ -86,7 +86,7 @@ func TestModifyCluster(t *testing.T) {
 			"my-cluster": {Server: "https://192.168.0.1", TLSServerName: "to-be-cleared"},
 		},
 	}
-	test := createClusterTest{
+	test := setClusterTest{
 		description: "Testing 'kubectl config set-cluster' with an existing cluster",
 		config:      conf,
 		args:        []string{"my-cluster"},
@@ -110,7 +110,7 @@ func TestModifyClusterWithProxy(t *testing.T) {
 			"my-cluster": {Server: "https://192.168.0.1", TLSServerName: "to-be-cleared"},
 		},
 	}
-	test := createClusterTest{
+	test := setClusterTest{
 		description: "Testing 'kubectl config set-cluster' with an existing cluster",
 		config:      conf,
 		args:        []string{"my-cluster"},
@@ -140,7 +140,7 @@ func TestModifyClusterWithProxyOverride(t *testing.T) {
 			},
 		},
 	}
-	test := createClusterTest{
+	test := setClusterTest{
 		description: "Testing 'kubectl config set-cluster' with an existing cluster",
 		config:      conf,
 		args:        []string{"my-cluster"},
@@ -164,7 +164,7 @@ func TestModifyClusterServerAndTLS(t *testing.T) {
 			"my-cluster": {Server: "https://192.168.0.1"},
 		},
 	}
-	test := createClusterTest{
+	test := setClusterTest{
 		description: "Testing 'kubectl config set-cluster' with an existing cluster",
 		config:      conf,
 		args:        []string{"my-cluster"},
@@ -182,7 +182,7 @@ func TestModifyClusterServerAndTLS(t *testing.T) {
 	test.run(t)
 }
 
-func (test createClusterTest) run(t *testing.T) {
+func (test setClusterTest) run(t *testing.T) {
 	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_context.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
-type createContextOptions struct {
+type setContextOptions struct {
 	configAccess clientcmd.ConfigAccess
 	name         string
 	currContext  bool
@@ -42,26 +42,26 @@ type createContextOptions struct {
 }
 
 var (
-	createContextLong = templates.LongDesc(i18n.T(`
+	setContextLong = templates.LongDesc(i18n.T(`
 		Set a context entry in kubeconfig.
 
 		Specifying a name that already exists will merge new fields on top of existing values for those fields.`))
 
-	createContextExample = templates.Examples(`
+	setContextExample = templates.Examples(`
 		# Set the user field on the gce context entry without touching other values
 		kubectl config set-context gce --user=cluster-admin`)
 )
 
 // NewCmdConfigSetContext returns a Command instance for 'config set-context' sub command
 func NewCmdConfigSetContext(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
-	options := &createContextOptions{configAccess: configAccess}
+	options := &setContextOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
 		Use:                   fmt.Sprintf("set-context [NAME | --current] [--%v=cluster_nickname] [--%v=user_nickname] [--%v=namespace]", clientcmd.FlagClusterName, clientcmd.FlagAuthInfoName, clientcmd.FlagNamespace),
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Set a context entry in kubeconfig"),
-		Long:                  createContextLong,
-		Example:               createContextExample,
+		Long:                  setContextLong,
+		Example:               setContextExample,
 		ValidArgsFunction:     util.ContextCompletionFunc,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd))
@@ -83,7 +83,7 @@ func NewCmdConfigSetContext(out io.Writer, configAccess clientcmd.ConfigAccess) 
 	return cmd
 }
 
-func (o createContextOptions) run() (string, bool, error) {
+func (o setContextOptions) run() (string, bool, error) {
 	err := o.validate()
 	if err != nil {
 		return "", false, err
@@ -116,7 +116,7 @@ func (o createContextOptions) run() (string, bool, error) {
 	return name, exists, nil
 }
 
-func (o *createContextOptions) modifyContext(existingContext clientcmdapi.Context) clientcmdapi.Context {
+func (o *setContextOptions) modifyContext(existingContext clientcmdapi.Context) clientcmdapi.Context {
 	modifiedContext := existingContext
 
 	if o.cluster.Provided() {
@@ -132,7 +132,7 @@ func (o *createContextOptions) modifyContext(existingContext clientcmdapi.Contex
 	return modifiedContext
 }
 
-func (o *createContextOptions) complete(cmd *cobra.Command) error {
+func (o *setContextOptions) complete(cmd *cobra.Command) error {
 	args := cmd.Flags().Args()
 	if len(args) > 1 {
 		return helpErrorf(cmd, "Unexpected args: %v", args)
@@ -143,7 +143,7 @@ func (o *createContextOptions) complete(cmd *cobra.Command) error {
 	return nil
 }
 
-func (o createContextOptions) validate() error {
+func (o setContextOptions) validate() error {
 	if len(o.name) == 0 && !o.currContext {
 		return errors.New("you must specify a non-empty context name or --current")
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_context_test.go
@@ -26,7 +26,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-type createContextTest struct {
+type setContextTest struct {
 	description    string
 	testContext    string              // name of the context being modified
 	config         clientcmdapi.Config //initiate kubectl config
@@ -38,7 +38,7 @@ type createContextTest struct {
 
 func TestCreateContext(t *testing.T) {
 	conf := clientcmdapi.Config{}
-	test := createContextTest{
+	test := setContextTest{
 		testContext: "shaker-context",
 		description: "Testing for create a new context",
 		config:      conf,
@@ -61,7 +61,7 @@ func TestModifyContext(t *testing.T) {
 		Contexts: map[string]*clientcmdapi.Context{
 			"shaker-context": {AuthInfo: "blue-user", Cluster: "big-cluster", Namespace: "saw-ns"},
 			"not-this":       {AuthInfo: "blue-user", Cluster: "big-cluster", Namespace: "saw-ns"}}}
-	test := createContextTest{
+	test := setContextTest{
 		testContext: "shaker-context",
 		description: "Testing for modify a already exist context",
 		config:      conf,
@@ -86,7 +86,7 @@ func TestModifyCurrentContext(t *testing.T) {
 		Contexts: map[string]*clientcmdapi.Context{
 			"shaker-context": {AuthInfo: "blue-user", Cluster: "big-cluster", Namespace: "saw-ns"},
 			"not-this":       {AuthInfo: "blue-user", Cluster: "big-cluster", Namespace: "saw-ns"}}}
-	test := createContextTest{
+	test := setContextTest{
 		testContext: "shaker-context",
 		description: "Testing for modify a current context",
 		config:      conf,
@@ -106,7 +106,7 @@ func TestModifyCurrentContext(t *testing.T) {
 	test.run(t)
 }
 
-func (test createContextTest) run(t *testing.T) {
+func (test setContextTest) run(t *testing.T) {
 	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
While working on another issue, I noticed several inconsistencies in how some of the config sub commands are named.  This PR does the following to fix them:

* Renamed `create_authinfo.go`, `create_cluster.go`, and `create_context.go` to match their kubectl config subcommand names.

* Renamed private variables, functions, and types in those files to be consistent with the naming.

* Deprecated `NewCmdConfigSetAuthInfo` in favor of the new `NewCmdConfigSetCredentials` function.

* Did some minor refactoring of one of the complete functions to eliminate an unused argument and not wrap returned errors that do not add detail and to follow go error convention of lowercase error messages.

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
