### PR TITLE
Record top 3 score in event message

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1204,7 +1204,7 @@ func TestSchedulerBinding(t *testing.T) {
 				Extenders:      test.extenders,
 				SchedulerCache: scache,
 			}
-			err = sched.bind(context.Background(), fwk, pod, "node", nil)
+			err = sched.bind(context.Background(), fwk, pod, ScheduleResult{SuggestedHost: "node"}, nil)
 			if err != nil {
 				t.Error(err)
 			}

--- a/pkg/scheduler/testing/fake_extender.go
+++ b/pkg/scheduler/testing/fake_extender.go
@@ -143,6 +143,9 @@ func (pl *node2PrioritizerPlugin) ScoreExtensions() framework.ScoreExtensions {
 
 // FakeExtender is a data struct which implements the Extender interface.
 type FakeExtender struct {
+	// ExtenderName indicates this fake extender's name.
+	// Note that extender name should be unique.
+	ExtenderName     string
 	Predicates       []FitPredicate
 	Prioritizers     []PriorityConfig
 	Weight           int64
@@ -157,7 +160,10 @@ type FakeExtender struct {
 
 // Name returns name of the extender.
 func (f *FakeExtender) Name() string {
-	return "FakeExtender"
+	if f.ExtenderName == "" {
+		return "FakeExtender"
+	}
+	return f.ExtenderName
 }
 
 // IsIgnorable returns a bool value indicating whether internal errors can be ignored.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR changes the event message of "Scheduled" to have the top 3 Node scores and detailed scoring results for that Nodes.
Like this:

```
Successfully assigned default/pod1 to node3. Top 3 Node scores: [NodeName: node3 FinalScore: 675 Detailed Scores: [VolumeBinding: 0 PodTopologySpread: 200 InterPodAffinity: 0 NodeResourcesBalancedAllocation: 100 ImageLocality: 0 TaintToleration: 300 NodeAffinity: 0 NodeResourcesFit: 75]] [NodeName: node1 FinalScore: 516 Detailed Scores: [NodeResourcesBalancedAllocation: 100 ImageLocality: 0 TaintToleration: 300 NodeAffinity: 0 NodeResourcesFit: 50 VolumeBinding: 0 PodTopologySpread: 66 InterPodAffinity: 0]] [NodeName: node2 FinalScore: 425 Detailed Scores: [TaintToleration: 300 NodeAffinity: 0 NodeResourcesFit: 25 VolumeBinding: 0 PodTopologySpread: 0 InterPodAffinity: 0 NodeResourcesBalancedAllocation: 100 ImageLocality: 0]]]
```

(It will contain the extender scores as well. )

If there are more than three Nodes with the highest final score, they will be chosen randomly, but the score of the Node that is finally selected for Pod will always be included. (Always at the top of the list.)

##### added changes

- `NodeScoreList` field is newly introduced to `ScheduleResult`.
- New types `NodeScoreResultList` and `NodeScoreResult` are implemented.
  - NodeScoreResult has the score result for the Node.
- `selectHost` is changed to return `[]NodeScoreResult`. This return value has top 3 nodes.
- `prioritizeNodes` is changed to return `framework.PluginToNodeScores` which has the scores from each plugin and extender.
- `bind` method is changed to receive `ScheduleResult` to record top3 scores in event message.

##### other changes (not directly related)

- add `ExtenderName` field to `FakeExtender` 
  - This is needed since extender scores are now returned from `prioritizeNodes` in `framework.PluginToNodeScores`.  `framework.PluginToNodeScores` has scores with the name of extenders/plugins. So, `prioritizeNodes` needs to get a extender name to store the score of that extender. The previous `FakeExtender` returned the same name for all `FakeExtender` and  it introduce the bug.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #107556

#### Special notes for your reviewer:

Sorry for the big change. I can split into several PRs if you want.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The "Scheduled" event message has the top 3 Node scores and detailed scoring results for that Nodes. 
It contains:
- Final score calculated by the scheduler.
- All plugins and extenders scores for that Nodes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
