### PR TITLE
fix flake in TestTimeoutHeaders

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
@@ -138,7 +138,7 @@ func (t *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}()
 		}()
 
-		postTimeoutFn()
+		defer postTimeoutFn()
 		tw.timeout(err)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:
- move `postTimeoutFn` after we mark the request as `timed out`, this seems more technically accurate. It also allows us to design flake free unit test 
- fix the flake in `TestTimeoutHeaders`

#### Which issue(s) this PR fixes:

Fixes #107991

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
