### PR TITLE
[WIP] add integration test to prevent new beta APIs from being enabled by default

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -56,6 +56,7 @@ import (
 	storageapiv1alpha1 "k8s.io/api/storage/v1alpha1"
 	storageapiv1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -639,11 +640,9 @@ func (n nodeAddressProvider) externalAddresses() ([]string, error) {
 	return addrs, nil
 }
 
-// DefaultAPIResourceConfigSource returns default configuration for an APIResource.
-func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
-	ret := serverstorage.NewResourceConfig()
-	// NOTE: GroupVersions listed here will be enabled by default. Don't put alpha versions in the list.
-	ret.EnableVersions(
+var (
+	// stableAPIGroupVersionsEnabledByDefault is a list of our stable versions.
+	stableAPIGroupVersionsEnabledByDefault = []schema.GroupVersion{
 		admissionregistrationv1.SchemeGroupVersion,
 		apiv1.SchemeGroupVersion,
 		appsv1.SchemeGroupVersion,
@@ -651,35 +650,74 @@ func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 		authorizationapiv1.SchemeGroupVersion,
 		autoscalingapiv1.SchemeGroupVersion,
 		autoscalingapiv2.SchemeGroupVersion,
-		autoscalingapiv2beta1.SchemeGroupVersion,
-		autoscalingapiv2beta2.SchemeGroupVersion,
 		batchapiv1.SchemeGroupVersion,
-		batchapiv1beta1.SchemeGroupVersion,
 		certificatesapiv1.SchemeGroupVersion,
 		coordinationapiv1.SchemeGroupVersion,
 		discoveryv1.SchemeGroupVersion,
-		discoveryv1beta1.SchemeGroupVersion,
 		eventsv1.SchemeGroupVersion,
-		eventsv1beta1.SchemeGroupVersion,
 		networkingapiv1.SchemeGroupVersion,
 		nodev1.SchemeGroupVersion,
-		nodev1beta1.SchemeGroupVersion,
 		policyapiv1.SchemeGroupVersion,
-		policyapiv1beta1.SchemeGroupVersion,
 		rbacv1.SchemeGroupVersion,
 		storageapiv1.SchemeGroupVersion,
-		storageapiv1beta1.SchemeGroupVersion,
 		schedulingapiv1.SchemeGroupVersion,
-		flowcontrolv1beta2.SchemeGroupVersion,
+	}
+
+	// legacyBetaEnabledByDefaultResources is the list of beta resources we enable.  You may only add to this list
+	// if your resource is already enabled by default in a beta level we still serve AND there is no stable API for it.
+	// see https://github.com/kubernetes/enhancements/blob/0ad0fc8269165ca300d05ca51c7ce190a79976a5/keps/sig-architecture/3136-beta-apis-off-by-default/README.md
+	// for more details.
+	legacyBetaEnabledByDefaultResources = []schema.GroupVersionResource{
+		autoscalingapiv2beta1.SchemeGroupVersion.WithResource("horizontalpodautoscalers"), // remove in 1.25
+		autoscalingapiv2beta2.SchemeGroupVersion.WithResource("horizontalpodautoscalers"), // remove in 1.26
+		batchapiv1beta1.SchemeGroupVersion.WithResource("jobtemplates"),                   // remove in 1.25
+		batchapiv1beta1.SchemeGroupVersion.WithResource("cronjobs"),                       // remove in 1.25
+		discoveryv1beta1.SchemeGroupVersion.WithResource("endpointslices"),                // remove in 1.25
+		eventsv1beta1.SchemeGroupVersion.WithResource("events"),                           // remove in 1.25
+		nodev1beta1.SchemeGroupVersion.WithResource("runtimeclasses"),                     // remove in 1.25
+		policyapiv1beta1.SchemeGroupVersion.WithResource("runtimeclasses"),                // remove in 1.25
+		storageapiv1beta1.SchemeGroupVersion.WithResource("csinodes"),                     // remove in 1.25
+		storageapiv1beta1.SchemeGroupVersion.WithResource("csistoragecapacities"),         // remove in 1.27
+		flowcontrolv1beta1.SchemeGroupVersion.WithResource("flowschemas"),                 // remove in 1.26
+		flowcontrolv1beta1.SchemeGroupVersion.WithResource("prioritylevelconfigurations"), // remove in 1.26
+		flowcontrolv1beta2.SchemeGroupVersion.WithResource("flowschemas"),                 // remove in 1.29
+		flowcontrolv1beta2.SchemeGroupVersion.WithResource("prioritylevelconfigurations"), // remove in 1.29
+	}
+	// betaAPIGroupVersionsDisabledByDefault is for all future beta groupVersions.
+	betaAPIGroupVersionsDisabledByDefault = []schema.GroupVersion{
+		autoscalingapiv2beta1.SchemeGroupVersion,
+		autoscalingapiv2beta2.SchemeGroupVersion,
+		batchapiv1beta1.SchemeGroupVersion,
+		discoveryv1beta1.SchemeGroupVersion,
+		eventsv1beta1.SchemeGroupVersion,
+		nodev1beta1.SchemeGroupVersion,
+		policyapiv1beta1.SchemeGroupVersion,
+		storageapiv1beta1.SchemeGroupVersion,
 		flowcontrolv1beta1.SchemeGroupVersion,
-	)
-	// disable alpha versions explicitly so we have a full list of what's possible to serve
-	ret.DisableVersions(
+		flowcontrolv1beta2.SchemeGroupVersion,
+	}
+
+	// alphaAPIGroupVersionsDisabledByDefault holds the alpha APIs we have.  They are always disabled by default.
+	alphaAPIGroupVersionsDisabledByDefault = []schema.GroupVersion{
 		apiserverinternalv1alpha1.SchemeGroupVersion,
 		nodev1alpha1.SchemeGroupVersion,
 		storageapiv1alpha1.SchemeGroupVersion,
 		flowcontrolv1alpha1.SchemeGroupVersion,
-	)
+	}
+)
+
+// DefaultAPIResourceConfigSource returns default configuration for an APIResource.
+func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
+	ret := serverstorage.NewResourceConfig()
+	// NOTE: GroupVersions listed here will be enabled by default. Don't put alpha versions in the list.
+	ret.EnableVersions(stableAPIGroupVersionsEnabledByDefault...)
+
+	// disable alpha versions explicitly so we have a full list of what's possible to serve
+	ret.DisableVersions(betaAPIGroupVersionsDisabledByDefault...)
+	ret.DisableVersions(alphaAPIGroupVersionsDisabledByDefault...)
+
+	// enable the legacy beta resources that were present before stopped serving new beta APIs by default.
+	ret.EnableResources(legacyBetaEnabledByDefaultResources...)
 
 	return ret
 }

--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -459,3 +459,12 @@ func TestNoAlphaVersionsEnabledByDefault(t *testing.T) {
 		}
 	}
 }
+
+func TestNoBetaVersionsEnabledByDefault(t *testing.T) {
+	config := DefaultAPIResourceConfigSource()
+	for gv, enable := range config.GroupVersionConfigs {
+		if enable && strings.Contains(gv.Version, "beta") {
+			t.Errorf("Beta API version %s enabled by default", gv.String())
+		}
+	}
+}

--- a/test/integration/apiserver/no_new_betas_test.go
+++ b/test/integration/apiserver/no_new_betas_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestNoNewBetaAPIsByDefault(t *testing.T) {
+	// yes, this *is* a copy/paste from somewhere else.  We really do mean it when we say you shouldn't be modifying
+	// this list and this test was created to make it more painful.
+	// legacyBetaEnabledByDefaultResources is the list of beta resources we enable.  You may only add to this list
+	// if your resource is already enabled by default in a beta level we still serve AND there is no stable API for it.
+	// see https://github.com/kubernetes/enhancements/blob/0ad0fc8269165ca300d05ca51c7ce190a79976a5/keps/sig-architecture/3136-beta-apis-off-by-default/README.md
+	// for more details.
+	legacyBetaEnabledByDefaultResources := map[schema.GroupVersionResource]bool{
+		gvr("autoscaling", "v2beta1", "horizontalpodautoscalers"):                     true, // remove in 1.25
+		gvr("autoscaling", "v2beta2", "horizontalpodautoscalers"):                     true, // remove in 1.26
+		gvr("batch", "v1beta1", "jobtemplates"):                                       true, // remove in 1.25
+		gvr("batch", "v1beta1", "cronjobs"):                                           true, // remove in 1.25
+		gvr("discovery.k8s.io", "v1beta1", "endpointslices"):                          true, // remove in 1.25
+		gvr("events.k8s.io", "v1beta1", "events"):                                     true, // remove in 1.25
+		gvr("node.k8s.io", "v1beta1", "runtimeclasses"):                               true, // remove in 1.25
+		gvr("policy", "v1beta1", "runtimeclasses"):                                    true, // remove in 1.25
+		gvr("storage.k8s.io", "v1beta1", "csinodes"):                                  true, // remove in 1.25
+		gvr("storage.k8s.io", "v1beta1", "csistoragecapacities"):                      true, // remove in 1.27
+		gvr("flowcontrol.apiserver.k8s.io", "v1beta1", "flowschemas"):                 true, // remove in 1.26
+		gvr("flowcontrol.apiserver.k8s.io", "v1beta1", "prioritylevelconfigurations"): true, // remove in 1.26
+		gvr("flowcontrol.apiserver.k8s.io", "v1beta2", "flowschemas"):                 true, // remove in 1.29
+		gvr("flowcontrol.apiserver.k8s.io", "v1beta2", "prioritylevelconfigurations"): true, // remove in 1.29
+	}
+
+	// if you found this because you want to create an integration test for your new beta API, the method you're looking for
+	// is this setupWithResources method and you need to pass the resource you want to enable into it.
+	_, kubeClient, closeFn := setupWithResources(t,
+		[]schema.GroupVersion{},
+		[]schema.GroupVersionResource{},
+	)
+	defer closeFn()
+
+	_, allResourceLists, err := kubeClient.Discovery().ServerGroupsAndResources()
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, currResourceList := range allResourceLists {
+		for _, currResource := range currResourceList.APIResources {
+			if strings.Contains(currResource.Version, "beta") {
+				continue
+			}
+			enabledGVR := schema.GroupVersionResource{
+				Group:    currResource.Group,
+				Version:  currResource.Version,
+				Resource: currResource.Name,
+			}
+			if !legacyBetaEnabledByDefaultResources[enabledGVR] {
+				t.Errorf("%v is a new beta API.  New beta APIs may not be enabled by default.  "+
+					"See https://github.com/kubernetes/enhancements/blob/0ad0fc8269165ca300d05ca51c7ce190a79976a5/keps/sig-architecture/3136-beta-apis-off-by-default/README.md "+
+					"for more details.", enabledGVR)
+			}
+		}
+	}
+}


### PR DESCRIPTION
related to https://github.com/kubernetes/enhancements/pull/3137

This test adds an integration test to catch any cases that slip past reviewers.  The test scans all APIs and checks for any beta APIs that weren't present prior to 1.24.

/kind feature
/priority important-soon
/sig api-machinery

```release-note
NONE
```