### PR TITLE
Fix cronjob status reconciliation when job template labels change

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -231,13 +231,9 @@ func (jm *ControllerV2) resolveControllerRef(namespace string, controllerRef *me
 }
 
 func (jm *ControllerV2) getJobsToBeReconciled(cronJob *batchv1.CronJob) ([]*batchv1.Job, error) {
-	var jobSelector labels.Selector
-	if len(cronJob.Spec.JobTemplate.Labels) == 0 {
-		jobSelector = labels.Everything()
-	} else {
-		jobSelector = labels.Set(cronJob.Spec.JobTemplate.Labels).AsSelector()
-	}
-	jobList, err := jm.jobLister.Jobs(cronJob.Namespace).List(jobSelector)
+	// list all jobs: there may be jobs with labels that don't match the template anymore,
+	// but that still have a ControllerRef to the given cronjob
+	jobList, err := jm.jobLister.Jobs(cronJob.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/cronjob/cronjob_controllerv2_test.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/robfig/cron/v3"
 
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1066,6 +1066,36 @@ func TestControllerV2GetJobsToBeReconciled(t *testing.T) {
 				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "foo2", Namespace: "bar-ns"}},
 			},
 			expected: []*batchv1.Job{},
+		},
+		{
+			name: "test getting jobs whose labels do not match job template",
+			cronJob: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "foo-ns", Name: "fooer"},
+				Spec: batchv1.CronJobSpec{JobTemplate: batchv1.JobTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"key": "value"}},
+				}},
+			},
+			jobs: []runtime.Object{
+				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "foo-ns",
+					Name:            "foo-fooer-owner-ref",
+					Labels:          map[string]string{"key": "different-value"},
+					OwnerReferences: []metav1.OwnerReference{{Name: "fooer", Controller: &trueRef}}},
+				},
+				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "foo-ns",
+					Name:            "foo-other-owner-ref",
+					Labels:          map[string]string{"key": "different-value"},
+					OwnerReferences: []metav1.OwnerReference{{Name: "another-cronjob", Controller: &trueRef}}},
+				},
+			},
+			expected: []*batchv1.Job{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "foo-ns",
+					Name:            "foo-fooer-owner-ref",
+					Labels:          map[string]string{"key": "different-value"},
+					OwnerReferences: []metav1.OwnerReference{{Name: "fooer", Controller: &trueRef}}},
+			}},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:
In CronJobController V2, the controller only considers jobs with labels that match current cronjob's job template labels. This leads to the controller [losing track of jobs owned by a given cronjob when those template labels change](https://github.com/kubernetes/kubernetes/issues/106496). For example, if job template labels were updated while the cronjob was in the `active` status, that cronjob will be stuck as `active`, since the controller will never find the completed job whose labels now don't match those of the job template.

#### Which issue(s) this PR fixes:
Fixes #106496

#### Special notes for your reviewer:
I see that in https://github.com/kubernetes/kubernetes/pull/93370 filtering by label was added for performance. If anyone has ideas on how to keep that performance improvement while maintaining correct behavior, I'd be happy to close this and work on another solution.

#### Does this PR introduce a user-facing change?
```release-note
Fixes regression in 1.21 default configurations where a bug in CronJob Controller V2 where it would lose track of jobs upon job template labels change.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
