### PR TITLE
AzureFile: Volume without secretNamespace fails to mount after translating to CSI

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
@@ -129,9 +129,21 @@ func (t *azureFileCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume)
 			resourceGroup = v
 		}
 	}
-	namespace := defaultSecretNamespace
+
+	// Secret is required when mounting a volume but pod presence cannot be assumed - we should not try to read pod now.
+	namespace := ""
+	// Try to read SecretNamespace from source pv.
 	if azureSource.SecretNamespace != nil {
 		namespace = *azureSource.SecretNamespace
+	} else {
+		// Try to read namespace from ClaimRef which should be always present.
+		if pv.Spec.ClaimRef != nil {
+			namespace = pv.Spec.ClaimRef.Namespace
+		}
+	}
+
+	if len(namespace) == 0 {
+		return nil, fmt.Errorf("could not find a secret namespace in PersistentVolumeSource or ClaimRef")
 	}
 
 	volumeID := fmt.Sprintf(volumeIDTemplate, resourceGroup, accountName, azureSource.ShareName, pv.ObjectMeta.Name, namespace)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes a bug which can impact users upon enabling CSI migration. Without the bug fix all pods that use claims which reference an existing InTree PV without namespace defined will cause existing pods to get stuck in ContainerCreating status right after enabling CSI migration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Volume without pv.spec.azureFile.secretNamespace could not be mounted due to the secret not found causing pod to fail after CSI migration is enabled.

#### Special notes for your reviewer:
See verification steps below.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Existing InTree AzureFile PVs which don't have a secret namespace defined will now work properly after enabling CSI migration - the namespace will be obtained from ClaimRef.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
I verified the patch using the following procedure:

1. created new PV object referencing existing volume (share) while removing secret namespace - after creation null value is assigned

$ oc get pv/pvc-640b7456-1b41-490b-b2e5-933076d916e4-no-namespace -o json | jq '.spec.azureFile.secretNamespace'
null

2. claim the PV created in previous step and verify ClaimRef was added to PVC

$ oc get pvc/claim-2
NAME      STATUS   VOLUME                                                  CAPACITY   ACCESS MODES   STORAGECLASS   AGE
claim-2   Bound    pvc-640b7456-1b41-490b-b2e5-933076d916e4-no-namespace   1Gi        RWO            azurefile      66s

$ oc get pv/pvc-640b7456-1b41-490b-b2e5-933076d916e4-no-namespace -o json | jq '.spec.claimRef.namespace'
"test-namespace"

3. create a pod using the claim and verify it's running

$ oc get pod/example -o json | jq '.spec.volumes[0].persistentVolumeClaim.claimName'
"claim-2"

$ oc get pod/example
NAME      READY   STATUS    RESTARTS   AGE
example   1/1     Running   0          83s

4. enable CSI migration

$ oc patch featuregate cluster -p '{"spec": {"featureSet": "TechPreviewNoUpgrade"}}' --type merge
featuregate.config.openshift.io/cluster patched

5. wait for featuregate to enable and verify pod is still running

$ oc get pod/example
NAME      READY   STATUS    RESTARTS   AGE
example   1/1     Running   0          8m39s

Without the patch the pod gets stuck in "ContainerCreatinng" at this point:

$ oc get pod mydeploy-manual-x8gfe-69f988b468-v9l5w
NAME                                     READY   STATUS              RESTARTS   AGE
mydeploy-manual-x8gfe-69f988b468-v9l5w   0/1     ContainerCreating   0          4h5m

```
