### PR TITLE
check activeQ.Len() before Pop()

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -1521,7 +1521,12 @@ func TestPodTimestamp(t *testing.T) {
 				op(queue, test.operands[i])
 			}
 
-			for i := 0; i < len(test.expected); i++ {
+			expectedLen := len(test.expected)
+			if queue.activeQ.Len() != expectedLen {
+				t.Fatalf("Expected %v items to be in activeQ, but got: %v", expectedLen, queue.activeQ.Len())
+			}
+
+			for i := 0; i < expectedLen; i++ {
 				if pInfo, err := queue.activeQ.Pop(); err != nil {
 					t.Errorf("Error while popping the head of the queue: %v", err)
 				} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
We use activeQ.Pop() to check if the items in activeQ are the same as expected here. If the length of activeQ is less than expected, panic will occur when the pop func is called. 

```bash
=== RUN   TestPodTimestamp
--- FAIL: TestPodTimestamp (0.30s)
=== RUN   TestPodTimestamp/add_two_pod_to_activeQ_and_sort_them_by_the_timestamp
    --- PASS: TestPodTimestamp/add_two_pod_to_activeQ_and_sort_them_by_the_timestamp (0.10s)
=== RUN   TestPodTimestamp/update_two_pod_to_activeQ_and_sort_them_by_the_timestamp
    --- PASS: TestPodTimestamp/update_two_pod_to_activeQ_and_sort_them_by_the_timestamp (0.10s)
=== RUN   TestPodTimestamp/add_two_pod_to_unschedulableQ_then_move_them_to_activeQ_and_sort_them_by_the_timestamp
    --- FAIL: TestPodTimestamp/add_two_pod_to_unschedulableQ_then_move_them_to_activeQ_and_sort_them_by_the_timestamp (0.10s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0
```

Therefore, we need to first check whether the length of activeQ is equal to the expected. If not, it will fail instead of panic.

```bash
=== RUN   TestPodTimestamp
--- FAIL: TestPodTimestamp (0.41s)
=== RUN   TestPodTimestamp/add_two_pod_to_activeQ_and_sort_them_by_the_timestamp
    --- PASS: TestPodTimestamp/add_two_pod_to_activeQ_and_sort_them_by_the_timestamp (0.10s)
=== RUN   TestPodTimestamp/update_two_pod_to_activeQ_and_sort_them_by_the_timestamp
    --- PASS: TestPodTimestamp/update_two_pod_to_activeQ_and_sort_them_by_the_timestamp (0.10s)
=== RUN   TestPodTimestamp/add_two_pod_to_unschedulableQ_then_move_them_to_activeQ_and_sort_them_by_the_timestamp
    scheduling_queue_test.go:1526: Expected 3 items to be in activeQ, but got: 2
    --- FAIL: TestPodTimestamp/add_two_pod_to_unschedulableQ_then_move_them_to_activeQ_and_sort_them_by_the_timestamp (0.10s)

=== RUN   TestPodTimestamp/add_one_pod_to_BackoffQ_and_move_it_to_activeQ
    --- PASS: TestPodTimestamp/add_one_pod_to_BackoffQ_and_move_it_to_activeQ (0.10s)
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
