### PR TITLE
kubelet: expose OOM metrics

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -91,6 +91,7 @@ func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots [
 		cadvisormetrics.NetworkUsageMetrics: struct{}{},
 		cadvisormetrics.AppMetrics:          struct{}{},
 		cadvisormetrics.ProcessMetrics:      struct{}{},
+		cadvisormetrics.OOMMetrics:          struct{}{},
 	}
 
 	// Only add the Accelerator metrics if the feature is inactive

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -367,6 +367,7 @@ func (s *Server) InstallDefaultHandlers() {
 		cadvisormetrics.NetworkUsageMetrics: struct{}{},
 		cadvisormetrics.AppMetrics:          struct{}{},
 		cadvisormetrics.ProcessMetrics:      struct{}{},
+		cadvisormetrics.OOMMetrics:          struct{}{},
 	}
 
 	// Only add the Accelerator metrics if the feature is inactive


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

cAdvisor has code to expose the OOM metric `container_oom_events_total` [since 0.40.0](https://github.com/google/cadvisor/commit/9614f2d9435c4c9aebf298a29cc73389b4bea59a), which is [included in kubelet since 1.23.0](https://github.com/kubernetes/kubernetes/blob/v1.23.0/go.mod#L48), but this was not activated in Kubelet coede.

#### Which issue(s) this PR fixes:

Fixes # (n/a, if needed, let me know and I'll raise a ticket)

#### Special notes for your reviewer:

My test environment is Talos 0.14.x, with k8s 1.23.3, so I tested it by:
- cherry-picking this commit onto v1.23.3
- `make WHAT=cmd/kubelet` from `golang:1.17-buster`
- monkey-patch resulting binary into an image based on `talos-systems/kubelet`
- Result is `docker.io/jonkerj/talos-kubelet:0.0.2`

The nodes running that specific Kubelet expose the metric, and I see the metric increasing if I go beyond memory resource limits (using `stress-ng`).

#### Does this PR introduce a user-facing change?

```release-note
Add the metric `container_oom_events_total` to kubelet's cAdvisor metric endpoint.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

