### PR TITLE
cm: Remove legacy docker references

### DIFF
--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -25,7 +25,7 @@ import (
 
 	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/v1/resource"
@@ -340,12 +340,5 @@ func GetKubeletContainer(kubeletCgroups string) (string, error) {
 
 // GetRuntimeContainer returns the cgroup used by the container runtime
 func GetRuntimeContainer(containerRuntime, runtimeCgroups string) (string, error) {
-	if containerRuntime == "docker" {
-		cont, err := getContainerNameForProcess(dockerProcessName, dockerPidFile)
-		if err != nil {
-			return "", fmt.Errorf("failed to get container name for docker process: %v", err)
-		}
-		return cont, nil
-	}
 	return runtimeCgroups, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node

(because containermanager)
/cc @klueska 

#### What this PR does / why we need it:

Dockershim and built-in Docker support are gone. This removes some leftover references to them in the container manager.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

