### PR TITLE
Benchmark cel.UnstructuredToVal

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/values_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/values_test.go
@@ -619,3 +619,47 @@ func TestMapper(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkUnstructuredToVal(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		if val := UnstructuredToVal([]interface{}{
+			map[string]interface{}{
+				"key": "a",
+				"val": 1,
+			},
+			map[string]interface{}{
+				"key": "b",
+				"val": 2,
+			},
+			map[string]interface{}{
+				"key": "@b",
+				"val": 2,
+			},
+		}, &mapListSchema); val == nil {
+			b.Fatal(val)
+		}
+	}
+}
+
+func BenchmarkUnstructuredToValWithEscape(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		if val := UnstructuredToVal([]interface{}{
+			map[string]interface{}{
+				"key": "a.1",
+				"val": "__i.1",
+			},
+			map[string]interface{}{
+				"key": "b.1",
+				"val": 2,
+			},
+		}, &mapListSchema); val == nil {
+			b.Fatal(val)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/escaping.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/escaping.go
@@ -36,6 +36,57 @@ var celReservedSymbols = sets.NewString(
 // expandMatcher matches the escape sequence, characters that are escaped, and characters that are unsupported
 var expandMatcher = regexp.MustCompile(`(__|[-./]|[^a-zA-Z0-9-./_])`)
 
+// newCharacterFilter returns a boolean array to indicate the allowed characters
+func newCharacterFilter(characters string) []bool {
+	maxChar := 0
+	for _, c := range characters {
+		if maxChar < int(c) {
+			maxChar = int(c)
+		}
+	}
+	filter := make([]bool, maxChar+1)
+
+	for _, c := range characters {
+		filter[int(c)] = true
+	}
+
+	return filter
+}
+
+type escapeCheck struct {
+	canSkipRegex     bool
+	invalidCharFound bool
+}
+
+// skipRegexCheck checks if escape would be skipped.
+// if invalidCharFound is true, it must have invalid character; if invalidCharFound is false, not sure if it has invalid character or not
+func skipRegexCheck(ident string) escapeCheck {
+	escapeCheck := escapeCheck{canSkipRegex: true, invalidCharFound: false}
+	// skip escape if possible
+	previous_underscore := false
+	for _, c := range ident {
+		if c == '/' || c == '-' || c == '.' {
+			escapeCheck.canSkipRegex = false
+			return escapeCheck
+		}
+		intc := int(c)
+		if intc < 0 || intc >= len(validCharacterFilter) || !validCharacterFilter[intc] {
+			escapeCheck.invalidCharFound = true
+			return escapeCheck
+		}
+		if c == '_' && previous_underscore {
+			escapeCheck.canSkipRegex = false
+			return escapeCheck
+		}
+
+		previous_underscore = c == '_'
+	}
+	return escapeCheck
+}
+
+// validCharacterFilter indicates the allowed characters.
+var validCharacterFilter = newCharacterFilter("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+
 // Escape escapes ident and returns a CEL identifier (of the form '[a-zA-Z_][a-zA-Z0-9_]*'), or returns
 // false if the ident does not match the supported input format of `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*`.
 // Escaping Rules:
@@ -53,6 +104,15 @@ func Escape(ident string) (string, bool) {
 	if celReservedSymbols.Has(ident) {
 		return "__" + ident + "__", true
 	}
+
+	escapeCheck := skipRegexCheck(ident)
+	if escapeCheck.invalidCharFound {
+		return "", false
+	}
+	if escapeCheck.canSkipRegex {
+		return ident, true
+	}
+
 	ok := true
 	ident = expandMatcher.ReplaceAllStringFunc(ident, func(s string) string {
 		switch s {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Given that the escapeKeyProps() function spends a significant percentage of its time inside the regex.ReplaceAllStringFunc() function, a potential optimization strategy is to avoid that expensive function call. An assumption is that the vast majority of map keys we encounter in the wild do not contain non-alphanumeric characters, in which case we can potentially avoid the regular expression matching operation.

The result from benchmark test:
**Before**
```
BenchmarkUnstructuredToVal
BenchmarkUnstructuredToVal-4   	  593342	      1696 ns/op	    1248 B/op	      14 allocs/op
PASS

BenchmarkUnstructuredToValWithEscape
BenchmarkUnstructuredToValWithEscape-4   	  826821	      1326 ns/op	     892 B/op	      12 allocs/op
PASS
```
**After**
```
BenchmarkUnstructuredToVal
BenchmarkUnstructuredToVal-4   	 1078765	      1058 ns/op	    1208 B/op	      11 allocs/op
PASS

BenchmarkUnstructuredToValWithEscape
BenchmarkUnstructuredToValWithEscape-4   	 1473859	       790.9 ns/op	     856 B/op	       9 allocs/op
PASS
```
The alternative solutions:
1. Set of Characters
```
BenchmarkUnstructuredToVal
BenchmarkUnstructuredToVal-4   	  895012	      1133 ns/op	    1208 B/op	      11 allocs/op
PASS

BenchmarkUnstructuredToValWithEscape-4   	 1000000	      1014 ns/op	     856 B/op	       9 allocs/op
PASS
```
2. Hardcode conditions
```
BenchmarkUnstructuredToVal
BenchmarkUnstructuredToVal-4   	 1025188	      1580 ns/op	    1208 B/op	      11 allocs/op
PASS

BenchmarkUnstructuredToValWithEscape
BenchmarkUnstructuredToValWithEscape-4   	 1467898	       787.9 ns/op	     856 B/op	       9 allocs/op
PASS
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
