### PR TITLE
Forbid CEL transition rules on unmergeable CRD subschemas.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
@@ -135,6 +135,11 @@ func (s *Validator) validateExpressions(fldPath *field.Path, sts *schema.Structu
 			// rule is empty
 			continue
 		}
+		if compiled.TransitionRule {
+			// transition rules are evaluated only if there is a comparable existing value
+			errs = append(errs, field.InternalError(fldPath, fmt.Errorf("oldSelf validation not implemented")))
+			continue // todo: wire oldObj parameter
+		}
 		evalResult, _, err := compiled.Program.Eval(activation)
 		if err != nil {
 			// see types.Err for list of well defined error types


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implements CRD schema validation for transition rules based on https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2876-crd-validation-expression-language#transition-rules.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
CRD writes will generate validation errors if a CEL validation rule references the identifier "oldSelf" on a part of the schema that does not support it.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/0ad0fc8269165ca300d05ca51c7ce190a79976a5/keps/sig-api-machinery/2876-crd-validation-expression-language#transition-rules
```
