### PR TITLE
Move HPAContainerMetrics feature gate to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -487,6 +487,7 @@ const (
 
 	// owner: @arjunrn @mwielgus @josephburnett
 	// alpha: v1.20
+	// beta: v1.25
 	//
 	// Add support for the HPA to scale based on metrics from individual containers
 	// in target pods
@@ -901,7 +902,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	WinOverlay:                                     {Default: true, PreRelease: featuregate.Beta},
 	WinDSR:                                         {Default: false, PreRelease: featuregate.Alpha},
 	DisableAcceleratorUsageMetrics:                 {Default: true, PreRelease: featuregate.Beta},
-	HPAContainerMetrics:                            {Default: false, PreRelease: featuregate.Alpha},
+	HPAContainerMetrics:                            {Default: true, PreRelease: featuregate.Beta},
 	SizeMemoryBackedVolumes:                        {Default: true, PreRelease: featuregate.Beta},
 	ExecProbeTimeout:                               {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
 	KubeletCredentialProviders:                     {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
This feature has been in _alpha_ since release v1.20

Signed-off-by: Arjun Naik <arjunrn@users.noreply.github.com>

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The feature has been in alpha for 3 releases. It's time to graduate it to beta and enable it by default.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

`Move HPAContainerMetrics to beta`

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

`[KEP]: https://github.com/kubernetes/enhancements/blob/0ad0fc8269165ca300d05ca51c7ce190a79976a5/keps/sig-autoscaling/1610-container-resource-autoscaling/README.md`