### PR TITLE
update the --runtime-config handling to ensure that user preferences always take priority over hardcoded preferences

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -146,7 +146,7 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 			// let the CRD controller process the initial set of CRDs before starting the autoregistration controller.
 			// this prevents the autoregistration controller's initial sync from deleting APIServices for CRDs that still exist.
 			// we only need to do this if CRDs are enabled on this server.  We can't use discovery because we are the source for discovery.
-			if aggregatorConfig.GenericConfig.MergedResourceConfig.AnyVersionForGroupEnabled("apiextensions.k8s.io") {
+			if aggregatorConfig.GenericConfig.MergedResourceConfig.AnyResourceForGroupEnabled("apiextensions.k8s.io") {
 				crdRegistrationController.WaitForInitialSync()
 			}
 			autoRegistrationController.Run(5, context.StopCh)

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -563,7 +563,7 @@ func (m *Instance) InstallAPIs(apiResourceConfigSource serverstorage.APIResource
 
 	for _, restStorageBuilder := range restStorageProviders {
 		groupName := restStorageBuilder.GroupName()
-		if !apiResourceConfigSource.AnyVersionForGroupEnabled(groupName) {
+		if !apiResourceConfigSource.AnyResourceForGroupEnabled(groupName) {
 			klog.V(1).Infof("Skipping disabled API group %q.", groupName)
 			continue
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	serverstore "k8s.io/apiserver/pkg/server/storage"
 	cliflag "k8s.io/component-base/cli/flag"
-	"k8s.io/klog/v2"
 )
 
 // GroupVersionRegistry provides access to registered group versions.
@@ -65,7 +64,7 @@ var (
 	betaPattern  = regexp.MustCompile(`^v\d+beta\d+$`)
 	alphaPattern = regexp.MustCompile(`^v\d+alpha\d+$`)
 
-	matchers = map[string]func(gv schema.GroupVersion) bool{
+	groupVersionMatchers = map[string]func(gv schema.GroupVersion) bool{
 		// allows users to address all api versions
 		APIAll: func(gv schema.GroupVersion) bool { return true },
 		// allows users to address all api versions in the form v[0-9]+
@@ -76,8 +75,27 @@ var (
 		APIAlpha: func(gv schema.GroupVersion) bool { return alphaPattern.MatchString(gv.Version) },
 	}
 
-	matcherOrder = []string{APIAll, APIGA, APIBeta, APIAlpha}
+	groupVersionMatchersOrder = []string{APIAll, APIGA, APIBeta, APIAlpha}
+
+	groupVersionResourceMatchers = map[string]func(gvr schema.GroupVersionResource) bool{
+		// allows users to address all api versions
+		APIAll: func(gvr schema.GroupVersionResource) bool { return true },
+		// allows users to address all api versions in the form v[0-9]+
+		APIGA: func(gvr schema.GroupVersionResource) bool { return gaPattern.MatchString(gvr.Version) },
+		// allows users to address all beta api versions
+		APIBeta: func(gvr schema.GroupVersionResource) bool { return betaPattern.MatchString(gvr.Version) },
+		// allows users to address all alpha api versions
+		APIAlpha: func(gvr schema.GroupVersionResource) bool { return alphaPattern.MatchString(gvr.Version) },
+	}
+
+	groupVersionResourceMatchersOrder = []string{APIAll, APIGA, APIBeta, APIAlpha}
 )
+
+func resourceMatcherForVersion(gv schema.GroupVersion) func(gvr schema.GroupVersionResource) bool {
+	return func(gvr schema.GroupVersionResource) bool {
+		return gv == gvr.GroupVersion()
+	}
+}
 
 // MergeAPIResourceConfigs merges the given defaultAPIResourceConfig with the given resourceConfigOverrides.
 // Exclude the groups not registered in registry, and check if version is
@@ -90,42 +108,50 @@ func MergeAPIResourceConfigs(
 	resourceConfig := defaultAPIResourceConfig
 	overrides := resourceConfigOverrides
 
-	for _, flag := range matcherOrder {
+	for _, flag := range groupVersionMatchersOrder {
 		if value, ok := overrides[flag]; ok {
 			if value == "false" {
-				resourceConfig.DisableMatchingVersions(matchers[flag])
+				resourceConfig.DisableMatchingVersions(groupVersionMatchers[flag])
 			} else if value == "true" {
-				resourceConfig.EnableMatchingVersions(matchers[flag])
+				resourceConfig.EnableMatchingVersions(groupVersionMatchers[flag])
 			} else {
 				return nil, fmt.Errorf("invalid value %v=%v", flag, value)
 			}
+			// remove individual resource preferences that were hardcoded into the default.  The override trumps those settings.
+			resourceConfig.RemoveMatchingResourcePreferences(groupVersionResourceMatchers[flag])
 		}
 	}
+
+	type versionEnablementPreference struct {
+		key          string
+		enabled      bool
+		groupVersion schema.GroupVersion
+	}
+	type resourceEnablementPreference struct {
+		key                  string
+		enabled              bool
+		groupVersionResource schema.GroupVersionResource
+	}
+	versionPreferences := []versionEnablementPreference{}
+	resourcePreferences := []resourceEnablementPreference{}
 
 	// "<resourceSpecifier>={true|false} allows users to enable/disable API.
 	// This takes preference over api/all, if specified.
 	// Iterate through all group/version overrides specified in runtimeConfig.
 	for key := range overrides {
 		// Have already handled them above. Can skip them here.
-		if _, ok := matchers[key]; ok {
+		if _, ok := groupVersionMatchers[key]; ok {
 			continue
 		}
 
 		tokens := strings.Split(key, "/")
-		if len(tokens) < 2 {
+		if len(tokens) < 2 || len(tokens) > 3 {
 			continue
 		}
 		groupVersionString := tokens[0] + "/" + tokens[1]
 		groupVersion, err := schema.ParseGroupVersion(groupVersionString)
 		if err != nil {
 			return nil, fmt.Errorf("invalid key %s", key)
-		}
-
-		// individual resource enablement/disablement is only supported in the extensions/v1beta1 API group for legacy reasons.
-		// all other API groups are expected to contain coherent sets of resources that are enabled/disabled together.
-		if len(tokens) > 2 && (groupVersion != schema.GroupVersion{Group: "extensions", Version: "v1beta1"}) {
-			klog.Warningf("ignoring invalid key %s, individual resource enablement/disablement is not supported in %s, and will prevent starting in future releases", key, groupVersion.String())
-			continue
 		}
 
 		// Exclude group not registered into the registry.
@@ -141,22 +167,46 @@ func MergeAPIResourceConfigs(
 		if err != nil {
 			return nil, err
 		}
-		if enabled {
-			// enable the groupVersion for "group/version=true" and "group/version/resource=true"
-			resourceConfig.EnableVersions(groupVersion)
-		} else if len(tokens) == 2 {
-			// disable the groupVersion only for "group/version=false", not "group/version/resource=false"
-			resourceConfig.DisableVersions(groupVersion)
-		}
 
-		if len(tokens) < 3 {
-			continue
+		switch len(tokens) {
+		case 2:
+			versionPreferences = append(versionPreferences, versionEnablementPreference{
+				key:          key,
+				enabled:      enabled,
+				groupVersion: groupVersion,
+			})
+		case 3:
+			if strings.ToLower(tokens[2]) != tokens[2] {
+				return nil, fmt.Errorf("invalid key %v: group/version/resource and resource is always lowercase plural, not %q", key, tokens[2])
+			}
+			resourcePreferences = append(resourcePreferences, resourceEnablementPreference{
+				key:                  key,
+				enabled:              enabled,
+				groupVersionResource: groupVersion.WithResource(tokens[2]),
+			})
 		}
-		groupVersionResource := groupVersion.WithResource(tokens[2])
-		if enabled {
-			resourceConfig.EnableResources(groupVersionResource)
+	}
+
+	// apply version preferences first, so that we can remove the hardcoded resource preferences that are being overridden
+	for _, versionPreference := range versionPreferences {
+		// if a user has expressed a preference about a version, that preference takes priority over the hardcoded resources
+		resourceConfig.RemoveMatchingResourcePreferences(resourceMatcherForVersion(versionPreference.groupVersion))
+		if versionPreference.enabled {
+			// enable the groupVersion for "group/version=true" and "group/version/resource=true"
+			resourceConfig.EnableVersions(versionPreference.groupVersion)
+
 		} else {
-			resourceConfig.DisableResources(groupVersionResource)
+			// disable the groupVersion only for "group/version=false", not "group/version/resource=false"
+			resourceConfig.DisableVersions(versionPreference.groupVersion)
+		}
+	}
+
+	// apply resource preferences last, so they have the highest priority
+	for _, resourcePreference := range resourcePreferences {
+		if resourcePreference.enabled {
+			resourceConfig.EnableResources(resourcePreference.groupVersionResource)
+		} else {
+			resourceConfig.DisableResources(resourcePreference.groupVersionResource)
 		}
 	}
 
@@ -182,7 +232,7 @@ func getRuntimeConfigValue(overrides cliflag.ConfigurationMap, apiKey string, de
 func ParseGroups(resourceConfig cliflag.ConfigurationMap) ([]string, error) {
 	groups := []string{}
 	for key := range resourceConfig {
-		if _, ok := matchers[key]; ok {
+		if _, ok := groupVersionMatchers[key]; ok {
 			continue
 		}
 		tokens := strings.Split(key, "/")

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers.go
@@ -87,8 +87,6 @@ var (
 		// allows users to address all alpha api versions
 		APIAlpha: func(gvr schema.GroupVersionResource) bool { return alphaPattern.MatchString(gvr.Version) },
 	}
-
-	groupVersionResourceMatchersOrder = []string{APIAll, APIGA, APIBeta, APIAlpha}
 )
 
 func resourceMatcherForVersion(gv schema.GroupVersion) func(gvr schema.GroupVersionResource) bool {
@@ -192,11 +190,11 @@ func MergeAPIResourceConfigs(
 		// if a user has expressed a preference about a version, that preference takes priority over the hardcoded resources
 		resourceConfig.RemoveMatchingResourcePreferences(resourceMatcherForVersion(versionPreference.groupVersion))
 		if versionPreference.enabled {
-			// enable the groupVersion for "group/version=true" and "group/version/resource=true"
+			// enable the groupVersion for "group/version=true"
 			resourceConfig.EnableVersions(versionPreference.groupVersion)
 
 		} else {
-			// disable the groupVersion only for "group/version=false", not "group/version/resource=false"
+			// disable the groupVersion only for "group/version=false"
 			resourceConfig.DisableVersions(versionPreference.groupVersion)
 		}
 	}
@@ -204,6 +202,7 @@ func MergeAPIResourceConfigs(
 	// apply resource preferences last, so they have the highest priority
 	for _, resourcePreference := range resourcePreferences {
 		if resourcePreference.enabled {
+			// enable the resource for "group/version/resource=true"
 			resourceConfig.EnableResources(resourcePreference.groupVersionResource)
 		} else {
 			resourceConfig.DisableResources(resourcePreference.groupVersionResource)

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
@@ -70,6 +70,20 @@ func (o *ResourceConfig) EnableMatchingVersions(matcher func(gv schema.GroupVers
 	}
 }
 
+// RemoveMatchingResourcePreferences removes individual resource preferences that match.  This is useful when an override of a version or level enablement should
+// override the previously individual preferences.
+func (o *ResourceConfig) RemoveMatchingResourcePreferences(matcher func(gvr schema.GroupVersionResource) bool) {
+	keysToRemove := []schema.GroupVersionResource{}
+	for k := range o.ResourceConfigs {
+		if matcher(k) {
+			keysToRemove = append(keysToRemove, k)
+		}
+	}
+	for _, k := range keysToRemove {
+		delete(o.ResourceConfigs, k)
+	}
+}
+
 // DisableVersions disables the versions entirely.
 func (o *ResourceConfig) DisableVersions(versions ...schema.GroupVersion) {
 	for _, version := range versions {

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
@@ -24,7 +24,7 @@ import (
 type APIResourceConfigSource interface {
 	VersionEnabled(version schema.GroupVersion) bool
 	ResourceEnabled(resource schema.GroupVersionResource) bool
-	AnyVersionForGroupEnabled(group string) bool
+	AnyResourceForGroupEnabled(group string) bool
 }
 
 var _ APIResourceConfigSource = &ResourceConfig{}
@@ -36,20 +36,6 @@ type ResourceConfig struct {
 
 func NewResourceConfig() *ResourceConfig {
 	return &ResourceConfig{GroupVersionConfigs: map[schema.GroupVersion]bool{}, ResourceConfigs: map[schema.GroupVersionResource]bool{}}
-}
-
-// DisableAll disables all group/versions. It does not modify individual resource enablement/disablement.
-func (o *ResourceConfig) DisableAll() {
-	for k := range o.GroupVersionConfigs {
-		o.GroupVersionConfigs[k] = false
-	}
-}
-
-// EnableAll enables all group/versions. It does not modify individual resource enablement/disablement.
-func (o *ResourceConfig) EnableAll() {
-	for k := range o.GroupVersionConfigs {
-		o.GroupVersionConfigs[k] = true
-	}
 }
 
 // DisableMatchingVersions disables all group/versions for which the matcher function returns true. It does not modify individual resource enablement/disablement.
@@ -97,6 +83,7 @@ func (o *ResourceConfig) EnableVersions(versions ...schema.GroupVersion) {
 	}
 }
 
+// TODO this must be removed and we enable/disable individual resources.
 func (o *ResourceConfig) VersionEnabled(version schema.GroupVersion) bool {
 	enabled, _ := o.GroupVersionConfigs[version]
 	return enabled
@@ -115,22 +102,30 @@ func (o *ResourceConfig) EnableResources(resources ...schema.GroupVersionResourc
 }
 
 func (o *ResourceConfig) ResourceEnabled(resource schema.GroupVersionResource) bool {
+	// if a resource is explicitly set, that takes priority over the preference of the version.
+	resourceEnabled, explicitlySet := o.ResourceConfigs[resource]
+	if explicitlySet {
+		return resourceEnabled
+	}
+
 	if !o.VersionEnabled(resource.GroupVersion()) {
 		return false
 	}
-	resourceEnabled, explicitlySet := o.ResourceConfigs[resource]
-	if !explicitlySet {
-		return true
-	}
-	return resourceEnabled
+	// they are enabled by default.
+	return true
 }
 
-func (o *ResourceConfig) AnyVersionForGroupEnabled(group string) bool {
+func (o *ResourceConfig) AnyResourceForGroupEnabled(group string) bool {
 	for version := range o.GroupVersionConfigs {
 		if version.Group == group {
 			if o.VersionEnabled(version) {
 				return true
 			}
+		}
+	}
+	for resource := range o.ResourceConfigs {
+		if resource.Group == group && o.ResourceEnabled(resource) {
+			return true
 		}
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
@@ -65,15 +65,18 @@ func TestDisabledResource(t *testing.T) {
 	config.EnableResources(g1v1rEnabled, g1v2rEnabled, g2v1rEnabled)
 	config.DisableResources(g1v1rDisabled, g1v2rDisabled, g2v1rDisabled)
 
-	// all resources under g1v1 are disabled because the group-version is disabled
+	// all resources not explicitly enabled under g1v1 are disabled because the group-version is disabled
 	if config.ResourceEnabled(g1v1rUnspecified) {
 		t.Errorf("expected disabled for %v, from %v", g1v1rUnspecified, config)
 	}
-	if config.ResourceEnabled(g1v1rEnabled) {
-		t.Errorf("expected disabled for %v, from %v", g1v1rEnabled, config)
+	if !config.ResourceEnabled(g1v1rEnabled) {
+		t.Errorf("expected enabled for %v, from %v", g1v1rEnabled, config)
 	}
 	if config.ResourceEnabled(g1v1rDisabled) {
 		t.Errorf("expected disabled for %v, from %v", g1v1rDisabled, config)
+	}
+	if config.ResourceEnabled(g1v1rUnspecified) {
+		t.Errorf("expected disabled for %v, from %v", g1v1rUnspecified, config)
 	}
 
 	// explicitly disabled resources in enabled group-versions are disabled
@@ -96,61 +99,6 @@ func TestDisabledResource(t *testing.T) {
 	}
 	if !config.ResourceEnabled(g2v1rEnabled) {
 		t.Errorf("expected enabled for %v, from %v", g2v1rEnabled, config)
-	}
-
-	// DisableAll() only disables to the group/version level for compatibility
-	// corresponds to --runtime-config=api/all=false
-	config.DisableAll()
-	if config.ResourceEnabled(g1v1rEnabled) {
-		t.Errorf("expected disabled for %v, from %v", g1v1rEnabled, config)
-	}
-	if config.ResourceEnabled(g1v2rEnabled) {
-		t.Errorf("expected disabled for %v, from %v", g1v2rEnabled, config)
-	}
-	if config.ResourceEnabled(g2v1rEnabled) {
-		t.Errorf("expected disabled for %v, from %v", g2v1rEnabled, config)
-	}
-
-	// DisableAll() only disables to the group/version level for compatibility
-	// corresponds to --runtime-config=api/all=false,g1/v1=true
-	config.DisableAll()
-	config.EnableVersions(g1v1)
-	if !config.ResourceEnabled(g1v1rEnabled) {
-		t.Errorf("expected enabled for %v, from %v", g1v1rEnabled, config)
-	}
-
-	// EnableAll() only enables to the group/version level for compatibility
-	config.EnableAll()
-
-	// all unspecified or enabled resources under all groups now enabled
-	if !config.ResourceEnabled(g1v1rUnspecified) {
-		t.Errorf("expected enabled for %v, from %v", g1v1rUnspecified, config)
-	}
-	if !config.ResourceEnabled(g1v1rEnabled) {
-		t.Errorf("expected enabled for %v, from %v", g1v1rEnabled, config)
-	}
-	if !config.ResourceEnabled(g1v2rUnspecified) {
-		t.Errorf("expected enabled for %v, from %v", g1v2rUnspecified, config)
-	}
-	if !config.ResourceEnabled(g1v2rEnabled) {
-		t.Errorf("expected enabled for %v, from %v", g1v2rEnabled, config)
-	}
-	if !config.ResourceEnabled(g2v1rUnspecified) {
-		t.Errorf("expected enabled for %v, from %v", g2v1rUnspecified, config)
-	}
-	if !config.ResourceEnabled(g2v1rEnabled) {
-		t.Errorf("expected enabled for %v, from %v", g2v1rEnabled, config)
-	}
-
-	// previously disabled resources are still disabled
-	if config.ResourceEnabled(g1v1rDisabled) {
-		t.Errorf("expected disabled for %v, from %v", g1v1rDisabled, config)
-	}
-	if config.ResourceEnabled(g1v2rDisabled) {
-		t.Errorf("expected disabled for %v, from %v", g1v2rDisabled, config)
-	}
-	if config.ResourceEnabled(g2v1rDisabled) {
-		t.Errorf("expected disabled for %v, from %v", g2v1rDisabled, config)
 	}
 }
 
@@ -194,11 +142,37 @@ func TestAnyVersionForGroupEnabled(t *testing.T) {
 
 			expectedResult: true,
 		},
+		{
+			name: "present, and one resource enabled",
+			creator: func() APIResourceConfigSource {
+				ret := NewResourceConfig()
+				ret.DisableVersions(schema.GroupVersion{Group: "one", Version: "version1"})
+				ret.EnableResources(schema.GroupVersionResource{Group: "one", Version: "version2", Resource: "foo"})
+				return ret
+			},
+			testGroup: "one",
+
+			expectedResult: true,
+		},
+		{
+			name: "present, and one resource under disabled version enabled",
+			creator: func() APIResourceConfigSource {
+				ret := NewResourceConfig()
+				ret.DisableVersions(schema.GroupVersion{Group: "one", Version: "version1"})
+				ret.EnableResources(schema.GroupVersionResource{Group: "one", Version: "version1", Resource: "foo"})
+				return ret
+			},
+			testGroup: "one",
+
+			expectedResult: true,
+		},
 	}
 
 	for _, tc := range tests {
-		if e, a := tc.expectedResult, tc.creator().AnyVersionForGroupEnabled(tc.testGroup); e != a {
-			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if e, a := tc.expectedResult, tc.creator().AnyResourceForGroupEnabled(tc.testGroup); e != a {
+				t.Errorf("expected %v, got %v", e, a)
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
@@ -240,7 +240,7 @@ func getAllResourcesAlias(resource schema.GroupResource) schema.GroupResource {
 
 func (s *DefaultStorageFactory) getStorageGroupResource(groupResource schema.GroupResource) schema.GroupResource {
 	for _, potentialStorageResource := range s.Overrides[groupResource].cohabitatingResources {
-		if s.APIResourceConfigSource.AnyVersionForGroupEnabled(potentialStorageResource.Group) {
+		if s.APIResourceConfigSource.AnyResourceForGroupEnabled(potentialStorageResource.Group) {
 			return potentialStorageResource
 		}
 	}


### PR DESCRIPTION
This is in preparation for the "beta APIs are off by default" implementation. To support that, we need an order of precedence that looks like 

1. a user specifying a resource enable/disable
2. a user specifying a version enable/disable
3. a user specifying an api stability enable/disable
4. a hardcoded resource enable/disable
5. a hardcoded version enable/disable

This is done by removing the per-resource preferences specified by the default when a stability level or version is specified by the user that overlaps.

```release-note
NONE
```