### PR TITLE
Mark pod-infra-container-image flag as deprecated

### DIFF
--- a/pkg/kubelet/config/flags.go
+++ b/pkg/kubelet/config/flags.go
@@ -54,9 +54,8 @@ func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ContainerRuntime, "container-runtime", s.ContainerRuntime, "The container runtime to use. Possible value: 'remote'.")
 	fs.MarkDeprecated("container-runtime", "will be removed in 1.27 as the only valid value is 'remote'")
 	fs.StringVar(&s.RuntimeCgroups, "runtime-cgroups", s.RuntimeCgroups, "Optional absolute name of cgroups to create and run the runtime in.")
-
-	// Docker-specific settings.
 	fs.StringVar(&s.PodSandboxImage, "pod-infra-container-image", s.PodSandboxImage, fmt.Sprintf("Specified image will not be pruned by the image garbage collector. CRI implementations have their own configuration to set this image."))
+	fs.MarkDeprecated("pod-infra-container-image", "will be removed in 1.27. Image garbage collector will get sandbox image information from CRI.")
 
 	// Image credential provider settings.
 	fs.StringVar(&s.ImageCredentialProviderConfigFile, "image-credential-provider-config", s.ImageCredentialProviderConfigFile, "The path to the credential provider plugin config file.")


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation
/sig node
/cc @adisky @endocrimes @dims 

#### What this PR does / why we need it:
`pod-infra-container-image` is only used for preventing the GC of the pause image since the dockershim removal.
It will be soon replaced by image pinning. There is already a PR for this feature for containerd: https://github.com/containerd/containerd/pull/6456.

It makes sense to deprecate the flag and plan to remove it in kubernetes 1.27, which should be enough time for operators to adopt newer CRI versions supporting image pinning.

#### Which issue(s) this PR fixes:
Refs #106893

#### Special notes for your reviewer:
n/a

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
--pod-infra-container-image kubelet flag is deprecated and will be removed in future releases
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
