### PR TITLE
Change level for klog.Fatal in kubectl

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -89,10 +89,11 @@ func DefaultBehaviorOnFatal() {
 	fatalErrHandler = fatal
 }
 
-// fatal prints the message (if provided) and then exits. If V(6) or greater,
-// klog.Fatal is invoked for extended information.
+// fatal prints the message (if provided) and then exits. If V(99) or greater,
+// klog.Fatal is invoked for extended information. This is intended for maintainer
+// debugging and out of a reasonable range for users.
 func fatal(msg string, code int) {
-	if klog.V(6).Enabled() {
+	if klog.V(99).Enabled() {
 		klog.FatalDepth(2, msg)
 	}
 	if len(msg) > 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR changes the level we print stack traces when kubectl has a non zero exit code. This is only useful for maintainers debugging issues and is set to a range outside of normal usage.

#### Special notes for your reviewer:

ref: https://github.com/kubernetes/kubernetes/pull/94663

/assign @liggitt 

#### Does this PR introduce a user-facing change?

```release-note
kubectl stack traces will now only print at -v=99 and not -v=6
```
