### PR TITLE
apiserver: use endpoint lease reconciler as default

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -177,9 +177,10 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 
 	fs.IntVar(&s.MasterCount, "apiserver-count", s.MasterCount,
 		"The number of apiservers running in the cluster, must be a positive number. (In use when --endpoint-reconciler-type=master-count is enabled.)")
+	fs.MarkDeprecated("apiserver-count", "apiserver-count is deprecated and will be removed in a future version.")
 
 	fs.StringVar(&s.EndpointReconcilerType, "endpoint-reconciler-type", string(s.EndpointReconcilerType),
-		"Use an endpoint reconciler ("+strings.Join(reconcilers.AllTypes.Names(), ", ")+")")
+		"Use an endpoint reconciler ("+strings.Join(reconcilers.AllTypes.Names(), ", ")+") master-count is deprecated, and will be removed in a future version.")
 
 	fs.IntVar(&s.IdentityLeaseDurationSeconds, "identity-lease-duration-seconds", s.IdentityLeaseDurationSeconds,
 		"The duration of kube-apiserver lease in seconds, must be a positive number. (In use when the APIServerIdentity feature gate is enabled.)")

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -274,9 +274,9 @@ func (c *Config) createEndpointReconciler() reconcilers.EndpointReconciler {
 	klog.Infof("Using reconciler: %v", c.ExtraConfig.EndpointReconcilerType)
 	switch c.ExtraConfig.EndpointReconcilerType {
 	// there are numerous test dependencies that depend on a default controller
-	case "", reconcilers.MasterCountReconcilerType:
+	case reconcilers.MasterCountReconcilerType:
 		return c.createMasterCountReconciler()
-	case reconcilers.LeaseEndpointReconcilerType:
+	case "", reconcilers.LeaseEndpointReconcilerType:
 		return c.createLeaseReconciler()
 	case reconcilers.NoneEndpointReconcilerType:
 		return c.createNoneReconciler()


### PR DESCRIPTION
The apiserver owns and manages the kubernetes.default service.

It has 3 different options to reconcile the endpoints that belong to
that service:

- None: endpoints are handled by an external party.
- MasterCount: legacy, it reconciles based on the endpoints generated
and a flag specifying the number of master on the cluster.
- [Lease: default since 1.11,](https://github.com/kubernetes/kubernetes/issues/57617) each apiserver writes a lease in etcd
and renews periodically, the endpoints are generated based on the
existing leases.

It seems that when the default was set for the lease reconciler, the
controlplane code wasn't updated and kept using the master count
reconciler.

This also starts the deprecation of the master count reconciler in
favor of the lease reconciler.

The master count has different problems that are solved by the lease reconciler and
is more complex to adapt to adapt and evolve, per example, use of dual-stack addresses on the
apiserver or reconciliation of the endpoints if they were externally modified.

/kind bug
/kind cleanup
/kind deprecation

```release-note
kube-apiserver: the --master-count flag and --endpoint-reconciler-type=master-count reconciler are deprecated in favor of the lease reconciler
```

