### PR TITLE
Update tests to have namespace set in req context

### DIFF
--- a/pkg/registry/core/namespace/storage/storage_test.go
+++ b/pkg/registry/core/namespace/storage/storage_test.go
@@ -74,7 +74,7 @@ func TestCreateSetsFields(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.store.DestroyFunc()
 	namespace := validNewNamespace()
-	ctx := genericapirequest.NewContext()
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
 	_, err := storage.Create(ctx, namespace, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -152,7 +152,7 @@ func TestDeleteNamespaceWithIncompleteFinalizers(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.store.DestroyFunc()
 	key := "namespaces/foo"
-	ctx := genericapirequest.NewContext()
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
 	now := metav1.Now()
 	namespace := &api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -188,7 +188,7 @@ func TestUpdateDeletingNamespaceWithIncompleteMetadataFinalizers(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.store.DestroyFunc()
 	key := "namespaces/foo"
-	ctx := genericapirequest.NewContext()
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
 	now := metav1.Now()
 	namespace := &api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -223,7 +223,7 @@ func TestUpdateDeletingNamespaceWithIncompleteSpecFinalizers(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.store.DestroyFunc()
 	key := "namespaces/foo"
-	ctx := genericapirequest.NewContext()
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
 	now := metav1.Now()
 	namespace := &api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -257,7 +257,7 @@ func TestUpdateDeletingNamespaceWithCompleteFinalizers(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.store.DestroyFunc()
 	key := "namespaces/foo"
-	ctx := genericapirequest.NewContext()
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
 	now := metav1.Now()
 	namespace := &api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -298,7 +298,7 @@ func TestFinalizeDeletingNamespaceWithCompleteFinalizers(t *testing.T) {
 	defer storage.store.DestroyFunc()
 	defer finalizeStorage.store.DestroyFunc()
 	key := "namespaces/foo"
-	ctx := genericapirequest.NewContext()
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
 	now := metav1.Now()
 	namespace := &api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -341,7 +341,7 @@ func TestFinalizeDeletingNamespaceWithIncompleteMetadataFinalizers(t *testing.T)
 	defer storage.store.DestroyFunc()
 	defer finalizeStorage.store.DestroyFunc()
 	key := "namespaces/foo"
-	ctx := genericapirequest.NewContext()
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
 	now := metav1.Now()
 	namespace := &api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -377,7 +377,7 @@ func TestDeleteNamespaceWithCompleteFinalizers(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.store.DestroyFunc()
 	key := "namespaces/foo"
-	ctx := genericapirequest.NewContext()
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
 	now := metav1.Now()
 	namespace := &api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -579,7 +579,7 @@ func TestDeleteWithGCFinalizers(t *testing.T) {
 
 	for _, test := range tests {
 		key := "namespaces/" + test.name
-		ctx := genericapirequest.NewContext()
+		ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
 		namespace := &api.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       test.name,

--- a/pkg/registry/core/persistentvolume/storage/storage_test.go
+++ b/pkg/registry/core/persistentvolume/storage/storage_test.go
@@ -169,7 +169,7 @@ func TestUpdateStatus(t *testing.T) {
 	storage, statusStorage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	ctx := genericapirequest.NewContext()
+	ctx := genericapirequest.NewDefaultContext()
 	key, _ := storage.KeyFunc(ctx, "foo")
 	pvStart := validNewPersistentVolume("foo")
 	err := storage.Storage.Create(ctx, key, pvStart, nil, 0, false)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -3803,6 +3803,9 @@ func TestNamedCreaterWithGenerateName(t *testing.T) {
 	client := http.Client{}
 
 	simple := &genericapitesting.Simple{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+		},
 		Other: "bar",
 	}
 	data, err := runtime.Encode(testCodec, simple)
@@ -3914,6 +3917,9 @@ func TestCreate(t *testing.T) {
 	client := http.Client{}
 
 	simple := &genericapitesting.Simple{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+		},
 		Other: "bar",
 	}
 	data, err := runtime.Encode(testCodec, simple)
@@ -3975,6 +3981,9 @@ func TestCreateYAML(t *testing.T) {
 
 	// yaml encoder
 	simple := &genericapitesting.Simple{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+		},
 		Other: "bar",
 	}
 	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), "application/yaml")
@@ -4044,6 +4053,9 @@ func TestCreateInNamespace(t *testing.T) {
 	client := http.Client{}
 
 	simple := &genericapitesting.Simple{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "other",
+		},
 		Other: "bar",
 	}
 	data, err := runtime.Encode(testCodec, simple)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This updates tests that make requests that call into admission.
* For apiextensions-apiserver, the namespace is set
  to metav1.NamespaceNone since the CRD created and
  worked with is a cluster scoped CRD.
* For most tests in register/storage, the namespace
  is set to NamespaceDefault or NamespaceNone based
  on if the resource is cluster scoped (namespaces)
  or namespace scoped (pvs).
* Endpoints tests now have a namespace specified in
  the expected object - NamespaceDefault or other
  based on the test.

Please see https://github.com/kubernetes/kubernetes/pull/94637 for more details, specifically https://github.com/kubernetes/kubernetes/pull/94637#issuecomment-1005018002
#### Which issue(s) this PR fixes:
In reference to https://github.com/kubernetes/kubernetes/pull/94637

#### Special notes for your reviewer:
I've tested these changes out wrt https://github.com/kubernetes/kubernetes/pull/94637 and the tests pass.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/assign @liggitt 
/sig api-machinery