### PR TITLE
apimachinery/unstructured: handle nil as the slice zero value

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -132,6 +132,9 @@ func NestedStringSlice(obj map[string]interface{}, fields ...string) ([]string, 
 	if !found || err != nil {
 		return nil, found, err
 	}
+	if val == nil {
+		return nil, true, nil
+	}
 	m, ok := val.([]interface{})
 	if !ok {
 		return nil, false, fmt.Errorf("%v accessor error: %v is of the type %T, expected []interface{}", jsonPath(fields), val, val)
@@ -153,6 +156,9 @@ func NestedSlice(obj map[string]interface{}, fields ...string) ([]interface{}, b
 	val, found, err := NestedFieldNoCopy(obj, fields...)
 	if !found || err != nil {
 		return nil, found, err
+	}
+	if val == nil {
+		return nil, true, nil
 	}
 	_, ok := val.([]interface{})
 	if !ok {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -225,3 +225,78 @@ func TestSetNestedMap(t *testing.T) {
 	assert.Len(t, obj["x"].(map[string]interface{})["z"], 1)
 	assert.Equal(t, obj["x"].(map[string]interface{})["z"].(map[string]interface{})["b"], "bar")
 }
+
+func TestNestedSlice(t *testing.T) {
+	target := []interface{}{"foo", map[string]interface{}{"bar": "baz"}}
+
+	obj := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": target,
+			"c": "not-a-slice",
+			"d": nil, // nil is the zero value of a slice
+		},
+	}
+
+	// case 1: field exists and is a slice
+	res, exists, err := NestedSlice(obj, "a", "b")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Equal(t, target, res)
+	// Result is a deep copy, changing it does not change the original
+	res[1].(map[string]interface{})["bar"] = "qux"
+	assert.Equal(t, target[1].(map[string]interface{})["bar"], "baz")
+
+	// case 2: field does not exist
+	res, exists, err = NestedSlice(obj, "x")
+	assert.False(t, exists)
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+
+	// case 3: field is not a slice
+	res, exists, err = NestedSlice(obj, "a", "c")
+	assert.False(t, exists)
+	assert.Error(t, err)
+	assert.Nil(t, res)
+
+	// case 4: field is nil
+	res, exists, err = NestedSlice(obj, "a", "d")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+}
+
+func TestNestedStringSlice(t *testing.T) {
+	target := []interface{}{"foo", "bar"}
+
+	obj := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": target,
+			"c": "not-a-slice",
+			"d": nil, // nil is the zero value of a slice
+		},
+	}
+
+	// case 1: field exists and is a slice
+	res, exists, err := NestedSlice(obj, "a", "b")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Equal(t, target, res)
+
+	// case 2: field does not exist
+	res, exists, err = NestedSlice(obj, "x")
+	assert.False(t, exists)
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+
+	// case 3: field is not a slice
+	res, exists, err = NestedSlice(obj, "a", "c")
+	assert.False(t, exists)
+	assert.Error(t, err)
+	assert.Nil(t, res)
+
+	// case 4: field is nil
+	res, exists, err = NestedSlice(obj, "a", "d")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

I found this while investigating an error similar to
<https://github.com/strimzi/strimzi-kafka-operator/issues/4737>.

The scenario is to submit some object (like a CRD) to the API and then
immediately `kubectl wait` on a condition. This races against the
controller that initializes the `status` structs. If `wait` encounters
an empty list of conditions, it errors out with

```log
error: .status.conditions accessor error: <nil> is of the type <nil>, expected []interface{}
```

from the type assertion in `NestedSlice`. `nil` is the [zero value of
slices](https://go.dev/ref/spec#Slice_types).

Handle this case by passing "empty" (nil) slices through as found.
Add tests to verify the behavior of these helpers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes strimzi/strimzi-kafka-operator#4737

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
