### PR TITLE
Support CEL CRD validation expressions that reference existing object state.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -968,10 +968,6 @@ func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 					if cr.TransitionRule {
 						if uncorrelatablePath := ssv.forbidOldSelfValidations(); uncorrelatablePath != nil {
 							allErrs = append(allErrs, field.Invalid(fldPath.Child("x-kubernetes-validations").Index(i).Child("rule"), schema.XValidations[i].Rule, fmt.Sprintf("oldSelf cannot be used on the uncorrelatable portion of the schema within %v", uncorrelatablePath)))
-						} else {
-							// todo: remove when transition rule validation is implemented
-							allErrs = append(allErrs, field.Invalid(fldPath.Child("x-kubernetes-validations").Index(i).Child("rule"), schema.XValidations[i].Rule, "validation of rules containing oldSelf is not yet implemented"))
-
 						}
 					}
 				}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -787,8 +787,7 @@ func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 		for property, jsonSchema := range schema.Properties {
 			subSsv := ssv
 
-			// defensively assumes that a future map type is uncorrelatable
-			if schema.XMapType != nil && (*schema.XMapType != "granular" && *schema.XMapType != "atomic") {
+			if !cel.MapIsCorrelatable(schema.XMapType) {
 				subSsv = subSsv.withForbidOldSelfValidations(fldPath)
 			}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -59,13 +59,6 @@ func immutable(path ...string) validationMatch {
 func forbidden(path ...string) validationMatch {
 	return validationMatch{path: field.NewPath(path[0], path[1:]...), errorType: field.ErrorTypeForbidden}
 }
-func notImplemented(path ...string) validationMatch {
-	return validationMatch{
-		path:      field.NewPath(path[0], path[1:]...),
-		errorType: field.ErrorTypeInvalid,
-		contains:  "not yet implemented",
-	}
-}
 
 func (v validationMatch) matches(err *field.Error) bool {
 	return err.Type == v.errorType && err.Field == v.path.String() && strings.Contains(err.Error(), v.contains)
@@ -7668,9 +7661,6 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: []validationMatch{
-				notImplemented("spec.validation.openAPIV3Schema.properties[value].x-kubernetes-validations[0].rule"),
-			},
 		},
 		{
 			name: "allow transition rule on list defaulting to type atomic",
@@ -7691,9 +7681,6 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 						},
 					},
 				},
-			},
-			expectedErrors: []validationMatch{
-				notImplemented("spec.validation.openAPIV3Schema.properties[value].x-kubernetes-validations[0].rule"),
 			},
 		},
 		{
@@ -7742,9 +7729,6 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: []validationMatch{
-				notImplemented("spec.validation.openAPIV3Schema.properties[value].x-kubernetes-validations[0].rule"),
-			},
 		},
 		{
 			name: "allow transition rule on element of list of type map",
@@ -7771,9 +7755,6 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 						},
 					},
 				},
-			},
-			expectedErrors: []validationMatch{
-				notImplemented("spec.validation.openAPIV3Schema.properties[value].items.x-kubernetes-validations[0].rule"),
 			},
 		},
 		{
@@ -7802,9 +7783,6 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: []validationMatch{
-				notImplemented("spec.validation.openAPIV3Schema.properties[value].x-kubernetes-validations[0].rule"),
-			},
 		},
 		{
 			name: "allow transition rule on element of map of type granular",
@@ -7826,9 +7804,6 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 						},
 					},
 				},
-			},
-			expectedErrors: []validationMatch{
-				notImplemented("spec.validation.openAPIV3Schema.properties[value].properties[subfield].x-kubernetes-validations[0].rule"),
 			},
 		},
 		{
@@ -7877,9 +7852,6 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: []validationMatch{
-				notImplemented("spec.validation.openAPIV3Schema.properties[value].properties[subfield].x-kubernetes-validations[0].rule"),
-			},
 		},
 		{
 			name: "allow transition rule on map of type granular",
@@ -7897,9 +7869,6 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: []validationMatch{
-				notImplemented("spec.validation.openAPIV3Schema.properties[value].x-kubernetes-validations[0].rule"),
-			},
 		},
 		{
 			name: "allow transition rule on map defaulting to type granular",
@@ -7915,9 +7884,6 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 						},
 					},
 				},
-			},
-			expectedErrors: []validationMatch{
-				notImplemented("spec.validation.openAPIV3Schema.properties[value].x-kubernetes-validations[0].rule"),
 			},
 		},
 		{
@@ -7941,9 +7907,6 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: []validationMatch{
-				notImplemented("spec.validation.openAPIV3Schema.properties[value].properties[subfield].x-kubernetes-validations[0].rule"),
-			},
 		},
 		{
 			name: "allow transition rule on map of type atomic",
@@ -7960,9 +7923,6 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 						},
 					},
 				},
-			},
-			expectedErrors: []validationMatch{
-				notImplemented("spec.validation.openAPIV3Schema.properties[value].x-kubernetes-validations[0].rule"),
 			},
 		},
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/celcoststability_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/celcoststability_test.go
@@ -1098,7 +1098,7 @@ func TestCelCostStability(t *testing.T) {
 							t.Fatal("expected non nil validator")
 						}
 						ctx := context.TODO()
-						errs, remainingBudegt := celValidator.Validate(ctx, field.NewPath("root"), &s, tt.obj, RuntimeCELCostBudget)
+						errs, remainingBudegt := celValidator.Validate(ctx, field.NewPath("root"), &s, tt.obj, nil, RuntimeCELCostBudget)
 						for _, err := range errs {
 							t.Errorf("unexpected error: %v", err)
 						}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/maplist.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/maplist.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cel
+
+import (
+	"fmt"
+	"hash/maphash"
+
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+)
+
+// mapList provides a "lookup by key" operation for lists (arrays) with x-kubernetes-list-type=map.
+type mapList interface {
+	// get returns the unique element having identical values, for all
+	// x-kubernetes-list-map-keys, to the provided object. If no such unique element exists, or
+	// if the provided object isn't itself a valid mapList element, get returns nil.
+	get(interface{}) interface{}
+}
+
+type keyStrategy interface {
+	// CompositeKeyFor returns a composite key for the provided object, if possible, and a
+	// boolean that indicates whether or not a key could be generated for the provided object.
+	CompositeKeyFor(map[string]interface{}) (interface{}, bool)
+}
+
+// singleKeyStrategy is a cheaper strategy for associative lists that have exactly one key.
+type singleKeyStrategy struct {
+	key     string
+	defawlt interface{} // default is a keyword
+}
+
+// CompositeKeyFor directly returns the value of the single key (or its default value, if absent) to
+// use as a composite key.
+func (ks *singleKeyStrategy) CompositeKeyFor(obj map[string]interface{}) (interface{}, bool) {
+	v, ok := obj[ks.key]
+	if !ok {
+		v = ks.defawlt // substitute default value
+	}
+
+	switch v.(type) {
+	case bool, float64, int64, string:
+		return v, true
+	default:
+		return nil, false // non-scalar
+	}
+}
+
+// hashKeyStrategy computes a hash of all key values.
+type hashKeyStrategy struct {
+	sts    *schema.Structural
+	hasher maphash.Hash
+}
+
+// CompositeKeyFor returns a hash computed from the values (or default values, if absent) of all
+// keys.
+func (ks *hashKeyStrategy) CompositeKeyFor(obj map[string]interface{}) (interface{}, bool) {
+	const keyDelimiter = "\x00" // 0 byte should never appear in the hash input except as delimiter
+
+	ks.hasher.Reset()
+	for _, key := range ks.sts.XListMapKeys {
+		v, ok := obj[key]
+		if !ok {
+			v = ks.sts.Properties[key].Default.Object
+		}
+
+		switch v.(type) {
+		case bool:
+			fmt.Fprintf(&ks.hasher, keyDelimiter+"%t", v)
+		case float64:
+			fmt.Fprintf(&ks.hasher, keyDelimiter+"%f", v)
+		case int64:
+			fmt.Fprintf(&ks.hasher, keyDelimiter+"%d", v)
+		case string:
+			fmt.Fprintf(&ks.hasher, keyDelimiter+"%q", v)
+		default:
+			return nil, false // values must be scalars
+		}
+	}
+	return ks.hasher.Sum64(), true
+}
+
+// emptyMapList is a mapList containing no elements.
+type emptyMapList struct{}
+
+func (emptyMapList) get(interface{}) interface{} {
+	return nil
+}
+
+type mapListImpl struct {
+	sts      *schema.Structural
+	ks       keyStrategy
+	elements map[interface{}][]interface{} // composite key -> bucket
+}
+
+func (a *mapListImpl) get(obj interface{}) interface{} {
+	mobj, ok := obj.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	key, ok := a.ks.CompositeKeyFor(mobj)
+	if !ok {
+		return nil
+	}
+
+	// Scan bucket to handle key collisions and duplicate key sets:
+	var match interface{}
+	for _, element := range a.elements[key] {
+		all := true
+		for _, key := range a.sts.XListMapKeys {
+			va, ok := element.(map[string]interface{})[key]
+			if !ok {
+				va = a.sts.Properties[key].Default.Object
+			}
+
+			vb, ok := mobj[key]
+			if !ok {
+				vb = a.sts.Properties[key].Default.Object
+			}
+
+			all = all && (va == vb)
+		}
+
+		if !all {
+			continue
+		}
+
+		if match != nil {
+			// Duplicate key set / more than one element matches. This condition should
+			// have generated a validation error elsewhere.
+			return nil
+		}
+		match = element
+	}
+	return match // can be nil
+}
+
+func makeKeyStrategy(sts *schema.Structural) keyStrategy {
+	if len(sts.XListMapKeys) == 1 {
+		key := sts.XListMapKeys[0]
+		return &singleKeyStrategy{
+			key:     key,
+			defawlt: sts.Properties[key].Default.Object,
+		}
+	}
+
+	return &hashKeyStrategy{
+		sts: sts,
+	}
+}
+
+// makeMapList returns a queryable interface over the provided x-kubernetes-list-type=map
+// elements. If the provided schema is _not_ an array with x-kubernetes-list-type=map, returns an
+// empty mapList.
+func makeMapList(sts *schema.Structural, ks keyStrategy, items []interface{}) (rv mapList) {
+	if sts.Type != "array" || sts.XListType == nil || *sts.XListType != "map" || len(sts.XListMapKeys) == 0 || len(items) == 0 {
+		return emptyMapList{}
+	}
+
+	elements := make(map[interface{}][]interface{}, len(items))
+
+	for _, item := range items {
+		mitem, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if key, ok := ks.CompositeKeyFor(mitem); ok {
+			elements[key] = append(elements[key], mitem)
+		}
+	}
+
+	return &mapListImpl{
+		sts:      sts,
+		ks:       ks,
+		elements: elements,
+	}
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/maplist_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/maplist_test.go
@@ -1,0 +1,434 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cel
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+)
+
+func TestMapList(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		sts         schema.Structural
+		keyStrategy keyStrategy
+		items       []interface{}
+		query       interface{}
+		expected    interface{}
+	}{
+		{
+			name: "default list type",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+			},
+			query:    map[string]interface{}{},
+			expected: nil,
+		},
+		{
+			name: "non list type",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "map",
+				},
+			},
+			query:    map[string]interface{}{},
+			expected: nil,
+		},
+		{
+			name: "non-map list type",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+				Extensions: schema.Extensions{
+					XListType: &listTypeSet,
+				},
+			},
+			query:    map[string]interface{}{},
+			expected: nil,
+		},
+		{
+			name: "no keys",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+				Extensions: schema.Extensions{
+					XListType: &listTypeMap,
+				},
+			},
+			query:    map[string]interface{}{},
+			expected: nil,
+		},
+		{
+			name: "single key",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+				Extensions: schema.Extensions{
+					XListType:    &listTypeMap,
+					XListMapKeys: []string{"k"},
+				},
+			},
+			items: []interface{}{
+				map[string]interface{}{
+					"k":  "a",
+					"v1": "a",
+				},
+				map[string]interface{}{
+					"k":  "b",
+					"v1": "b",
+				},
+			},
+			query: map[string]interface{}{
+				"k":  "b",
+				"v1": "B",
+			},
+			expected: map[string]interface{}{
+				"k":  "b",
+				"v1": "b",
+			},
+		},
+		{
+			name: "single key with faked composite key collision",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+				Extensions: schema.Extensions{
+					XListType:    &listTypeMap,
+					XListMapKeys: []string{"k"},
+				},
+			},
+			keyStrategy: collisionfulKeyStrategy{},
+			items: []interface{}{
+				map[string]interface{}{
+					"k":  "a",
+					"v1": "a",
+				},
+				map[string]interface{}{
+					"k":  "b",
+					"v1": "b",
+				},
+			},
+			query: map[string]interface{}{
+				"k":  "b",
+				"v1": "B",
+			},
+			expected: map[string]interface{}{
+				"k":  "b",
+				"v1": "b",
+			},
+		},
+		{
+			name: "single key with default",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+				Extensions: schema.Extensions{
+					XListType:    &listTypeMap,
+					XListMapKeys: []string{"k"},
+				},
+				Properties: map[string]schema.Structural{
+					"k": {
+						Generic: schema.Generic{
+							Default: schema.JSON{Object: "a"},
+						},
+					},
+				},
+			},
+			items: []interface{}{
+				map[string]interface{}{
+					"v1": "a",
+				},
+				map[string]interface{}{
+					"k":  "b",
+					"v1": "b",
+				},
+			},
+			query: map[string]interface{}{
+				"k":  "a",
+				"v1": "A",
+			},
+			expected: map[string]interface{}{
+				"v1": "a",
+			},
+		},
+		{
+			name: "single key with defaulted key missing from query",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+				Extensions: schema.Extensions{
+					XListType:    &listTypeMap,
+					XListMapKeys: []string{"k"},
+				},
+				Properties: map[string]schema.Structural{
+					"k": {
+						Generic: schema.Generic{
+							Default: schema.JSON{Object: "a"},
+						},
+					},
+				},
+			},
+			items: []interface{}{
+				map[string]interface{}{
+					"v1": "a",
+				},
+			},
+			query: map[string]interface{}{
+				"v1": "A",
+			},
+			expected: map[string]interface{}{
+				"v1": "a",
+			},
+		},
+		{
+			name: "single key ignoring non-map query",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+				Extensions: schema.Extensions{
+					XListType:    &listTypeMap,
+					XListMapKeys: []string{"k"},
+				},
+			},
+			items: []interface{}{
+				map[string]interface{}{
+					"k":  "a",
+					"v1": "a",
+				},
+			},
+			query:    42,
+			expected: nil,
+		},
+		{
+			name: "single key ignoring unkeyable query",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+				Extensions: schema.Extensions{
+					XListType:    &listTypeMap,
+					XListMapKeys: []string{"k"},
+				},
+			},
+			items: []interface{}{
+				map[string]interface{}{
+					"k":  "a",
+					"v1": "a",
+				},
+			},
+			query: map[string]interface{}{
+				"k": map[string]interface{}{
+					"keys": "must",
+					"be":   "scalars",
+				},
+				"v1": "A",
+			},
+			expected: nil,
+		},
+		{
+			name: "ignores item of invalid type",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+				Extensions: schema.Extensions{
+					XListType:    &listTypeMap,
+					XListMapKeys: []string{"k"},
+				},
+			},
+			items: []interface{}{
+				map[string]interface{}{
+					"k":  "a",
+					"v1": "a",
+				},
+				5,
+			},
+			query: map[string]interface{}{
+				"k":  "a",
+				"v1": "A",
+			},
+			expected: map[string]interface{}{
+				"k":  "a",
+				"v1": "a",
+			},
+		},
+		{
+			name: "ignores items with duplicated key",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+				Extensions: schema.Extensions{
+					XListType:    &listTypeMap,
+					XListMapKeys: []string{"k"},
+				},
+			},
+			items: []interface{}{
+				map[string]interface{}{
+					"k":  "a",
+					"v1": "a",
+				},
+				map[string]interface{}{
+					"k":  "a",
+					"v1": "b",
+				},
+			},
+			query: map[string]interface{}{
+				"k":  "a",
+				"v1": "A",
+			},
+			expected: nil,
+		},
+		{
+			name: "multiple keys with defaults missing from query",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+				Extensions: schema.Extensions{
+					XListType:    &listTypeMap,
+					XListMapKeys: []string{"kb", "kf", "ki", "ks"},
+				},
+				Properties: map[string]schema.Structural{
+					"kb": {
+						Generic: schema.Generic{
+							Default: schema.JSON{Object: true},
+						},
+					},
+					"kf": {
+						Generic: schema.Generic{
+							Default: schema.JSON{Object: float64(2.0)},
+						},
+					},
+					"ki": {
+						Generic: schema.Generic{
+							Default: schema.JSON{Object: int64(42)},
+						},
+					},
+					"ks": {
+						Generic: schema.Generic{
+							Default: schema.JSON{Object: "hello"},
+						},
+					},
+				},
+			},
+			items: []interface{}{
+				map[string]interface{}{
+					"v1": "a",
+				},
+			},
+			query: map[string]interface{}{
+				"v1": "A",
+			},
+			expected: map[string]interface{}{
+				"v1": "a",
+			},
+		},
+		{
+			name: "multiple keys with defaults ignores item with nil value for key",
+			sts: schema.Structural{
+				Generic: schema.Generic{
+					Type: "array",
+				},
+				Extensions: schema.Extensions{
+					XListType:    &listTypeMap,
+					XListMapKeys: []string{"kb", "kf", "ki", "ks"},
+				},
+				Properties: map[string]schema.Structural{
+					"kb": {
+						Generic: schema.Generic{
+							Default: schema.JSON{Object: true},
+						},
+					},
+					"kf": {
+						Generic: schema.Generic{
+							Default: schema.JSON{Object: float64(2.0)},
+						},
+					},
+					"ki": {
+						Generic: schema.Generic{
+							Default: schema.JSON{Object: int64(42)},
+						},
+					},
+					"ks": {
+						Generic: schema.Generic{
+							Default: schema.JSON{Object: "hello"},
+						},
+					},
+				},
+			},
+			items: []interface{}{
+				map[string]interface{}{
+					"kb": nil,
+					"kf": float64(2.0),
+					"ki": int64(42),
+					"ks": "hello",
+					"v1": "a",
+				},
+				map[string]interface{}{
+					"kb": false,
+					"kf": float64(2.0),
+					"ki": int64(42),
+					"ks": "hello",
+					"v1": "b",
+				},
+			},
+			query: map[string]interface{}{
+				"kb": false,
+				"kf": float64(2.0),
+				"ki": int64(42),
+				"ks": "hello",
+				"v1": "B",
+			},
+			expected: map[string]interface{}{
+				"kb": false,
+				"kf": float64(2.0),
+				"ki": int64(42),
+				"ks": "hello",
+				"v1": "b",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ks := tc.keyStrategy
+			if ks == nil {
+				ks = makeKeyStrategy(&tc.sts)
+			}
+			actual := makeMapList(&tc.sts, ks, tc.items).get(tc.query)
+			if !reflect.DeepEqual(tc.expected, actual) {
+				t.Errorf("got: %v, expected %v", actual, tc.expected)
+			}
+		})
+	}
+}
+
+type collisionfulKeyStrategy struct{}
+
+func (collisionfulKeyStrategy) CompositeKeyFor(obj map[string]interface{}) (interface{}, bool) {
+	return 7, true
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting/validation.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/kube-openapi/pkg/validation/strfmt"
+	kubeopenapivalidate "k8s.io/kube-openapi/pkg/validation/validate"
+
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
 	schemaobjectmeta "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta"
@@ -29,8 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/kube-openapi/pkg/validation/strfmt"
-	kubeopenapivalidate "k8s.io/kube-openapi/pkg/validation/validate"
 )
 
 // ValidateDefaults checks that default values validate and are properly pruned.
@@ -89,7 +90,7 @@ func validate(ctx context.Context, pth *field.Path, s *structuralschema.Structur
 			} else if errs := apiservervalidation.ValidateCustomResource(pth.Child("default"), s.Default.Object, validator); len(errs) > 0 {
 				allErrs = append(allErrs, errs...)
 			} else if celValidator := cel.NewValidator(s, cel.PerCallLimit); celValidator != nil {
-				celErrs, rmCost := celValidator.Validate(ctx, pth.Child("default"), s, s.Default.Object, remainingCost)
+				celErrs, rmCost := celValidator.Validate(ctx, pth.Child("default"), s, s.Default.Object, nil, remainingCost)
 				remainingCost = rmCost
 				allErrs = append(allErrs, celErrs...)
 				if remainingCost < 0 {
@@ -114,7 +115,7 @@ func validate(ctx context.Context, pth *field.Path, s *structuralschema.Structur
 			} else if errs := apiservervalidation.ValidateCustomResource(pth.Child("default"), s.Default.Object, validator); len(errs) > 0 {
 				allErrs = append(allErrs, errs...)
 			} else if celValidator := cel.NewValidator(s, cel.PerCallLimit); celValidator != nil {
-				celErrs, rmCost := celValidator.Validate(ctx, pth.Child("default"), s, s.Default.Object, remainingCost)
+				celErrs, rmCost := celValidator.Validate(ctx, pth.Child("default"), s, s.Default.Object, nil, remainingCost)
 				remainingCost = rmCost
 				allErrs = append(allErrs, celErrs...)
 				if remainingCost < 0 {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting/validation.go
@@ -90,7 +90,7 @@ func validate(ctx context.Context, pth *field.Path, s *structuralschema.Structur
 			} else if errs := apiservervalidation.ValidateCustomResource(pth.Child("default"), s.Default.Object, validator); len(errs) > 0 {
 				allErrs = append(allErrs, errs...)
 			} else if celValidator := cel.NewValidator(s, cel.PerCallLimit); celValidator != nil {
-				celErrs, rmCost := celValidator.Validate(ctx, pth.Child("default"), s, s.Default.Object, nil, remainingCost)
+				celErrs, rmCost := celValidator.Validate(ctx, pth.Child("default"), s, s.Default.Object, s.Default.Object, remainingCost)
 				remainingCost = rmCost
 				allErrs = append(allErrs, celErrs...)
 				if remainingCost < 0 {
@@ -115,7 +115,7 @@ func validate(ctx context.Context, pth *field.Path, s *structuralschema.Structur
 			} else if errs := apiservervalidation.ValidateCustomResource(pth.Child("default"), s.Default.Object, validator); len(errs) > 0 {
 				allErrs = append(allErrs, errs...)
 			} else if celValidator := cel.NewValidator(s, cel.PerCallLimit); celValidator != nil {
-				celErrs, rmCost := celValidator.Validate(ctx, pth.Child("default"), s, s.Default.Object, nil, remainingCost)
+				celErrs, rmCost := celValidator.Validate(ctx, pth.Child("default"), s, s.Default.Object, s.Default.Object, remainingCost)
 				remainingCost = rmCost
 				allErrs = append(allErrs, celErrs...)
 				if remainingCost < 0 {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"context"
 	"math/rand"
 	"os"
 	"strconv"
@@ -27,16 +28,19 @@ import (
 
 	kjson "sigs.k8s.io/json"
 
+	kubeopenapispec "k8s.io/kube-openapi/pkg/validation/spec"
+
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsfuzzer "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
-	kubeopenapispec "k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // TestRoundTrip checks the conversion to go-openapi types.
@@ -145,6 +149,7 @@ func stripIntOrStringType(x interface{}) interface{} {
 
 type failingObject struct {
 	object     interface{}
+	oldObject  interface{}
 	expectErrs []string
 }
 
@@ -153,6 +158,7 @@ func TestValidateCustomResource(t *testing.T) {
 		name           string
 		schema         apiextensions.JSONSchemaProps
 		objects        []interface{}
+		oldObjects     []interface{}
 		failingObjects []failingObject
 	}{
 		{name: "!nullable",
@@ -416,6 +422,119 @@ func TestValidateCustomResource(t *testing.T) {
 				}},
 			},
 		},
+		{name: "immutability transition rule",
+			schema: apiextensions.JSONSchemaProps{
+				Properties: map[string]apiextensions.JSONSchemaProps{
+					"field": {
+						Type: "string",
+						XValidations: []apiextensions.ValidationRule{
+							{
+								Rule: "self == oldSelf",
+							},
+						},
+					},
+				},
+			},
+			objects: []interface{}{
+				map[string]interface{}{"field": "x"},
+			},
+			oldObjects: []interface{}{
+				map[string]interface{}{"field": "x"},
+			},
+			failingObjects: []failingObject{
+				{
+					object:    map[string]interface{}{"field": "y"},
+					oldObject: map[string]interface{}{"field": "x"},
+					expectErrs: []string{
+						`field: Invalid value: "string": failed rule: self == oldSelf`,
+					}},
+			},
+		},
+		{name: "correlatable transition rule",
+			// Ensures a transition rule under a "listMap" is supported.
+			schema: apiextensions.JSONSchemaProps{
+				Properties: map[string]apiextensions.JSONSchemaProps{
+					"field": {
+						Type:         "array",
+						XListType:    &listMapType,
+						XListMapKeys: []string{"k1", "k2"},
+						Items: &apiextensions.JSONSchemaPropsOrArray{
+							Schema: &apiextensions.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiextensions.JSONSchemaProps{
+									"k1": {
+										Type: "string",
+									},
+									"k2": {
+										Type: "string",
+									},
+									"v1": {
+										Type: "number",
+										XValidations: []apiextensions.ValidationRule{
+											{
+												Rule: "self >= oldSelf",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			objects: []interface{}{
+				map[string]interface{}{"field": []interface{}{map[string]interface{}{"k1": "a", "k2": "b", "v1": 1.2}}},
+			},
+			oldObjects: []interface{}{
+				map[string]interface{}{"field": []interface{}{map[string]interface{}{"k1": "a", "k2": "b", "v1": 1.0}}},
+			},
+			failingObjects: []failingObject{
+				{
+					object:    map[string]interface{}{"field": []interface{}{map[string]interface{}{"k1": "a", "k2": "b", "v1": 0.9}}},
+					oldObject: map[string]interface{}{"field": []interface{}{map[string]interface{}{"k1": "a", "k2": "b", "v1": 1.0}}},
+					expectErrs: []string{
+						`field[0].v1: Invalid value: "number": failed rule: self >= oldSelf`,
+					}},
+			},
+		},
+		{name: "validation rule under non-correlatable field",
+			// The array makes the rule on the nested string non-correlatable
+			// for transition rule purposes. This test ensures that a rule that
+			// does NOT use oldSelf (is not a transition rule), still behaves
+			// as expected under a non-correlatable field.
+			schema: apiextensions.JSONSchemaProps{
+				Properties: map[string]apiextensions.JSONSchemaProps{
+					"field": {
+						Type: "array",
+						Items: &apiextensions.JSONSchemaPropsOrArray{
+							Schema: &apiextensions.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiextensions.JSONSchemaProps{
+									"x": {
+										Type: "string",
+										XValidations: []apiextensions.ValidationRule{
+											{
+												Rule: "self == 'x'",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			objects: []interface{}{
+				map[string]interface{}{"field": []interface{}{map[string]interface{}{"x": "x"}}},
+			},
+			failingObjects: []failingObject{
+				{
+					object: map[string]interface{}{"field": []interface{}{map[string]interface{}{"x": "y"}}},
+					expectErrs: []string{
+						`field[0].x: Invalid value: "string": failed rule: self == 'x'`,
+					}},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -423,13 +542,29 @@ func TestValidateCustomResource(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			for _, obj := range tt.objects {
+			structural, err := structuralschema.NewStructural(&tt.schema)
+			if err != nil {
+				t.Fatal(err)
+			}
+			celValidator := cel.NewValidator(structural, cel.PerCallLimit)
+			for i, obj := range tt.objects {
+				var oldObject interface{}
+				if len(tt.oldObjects) == len(tt.objects) {
+					oldObject = tt.oldObjects[i]
+				}
 				if errs := ValidateCustomResource(nil, obj, validator); len(errs) > 0 {
 					t.Errorf("unexpected validation error for %v: %v", obj, errs)
 				}
+				errs, _ := celValidator.Validate(context.TODO(), nil, structural, obj, oldObject, cel.RuntimeCELCostBudget)
+				if len(errs) > 0 {
+					t.Errorf(errs.ToAggregate().Error())
+				}
 			}
 			for i, failingObject := range tt.failingObjects {
-				if errs := ValidateCustomResource(nil, failingObject.object, validator); len(errs) == 0 {
+				errs := ValidateCustomResource(nil, failingObject.object, validator)
+				celErrs, _ := celValidator.Validate(context.TODO(), nil, structural, failingObject.object, failingObject.oldObject, cel.RuntimeCELCostBudget)
+				errs = append(errs, celErrs...)
+				if len(errs) == 0 {
 					t.Errorf("missing error for %v", failingObject.object)
 				} else {
 					sawErrors := sets.NewString()
@@ -505,3 +640,5 @@ func TestItemsProperty(t *testing.T) {
 		})
 	}
 }
+
+var listMapType = "map"

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
@@ -19,11 +19,12 @@ package customresource
 import (
 	"context"
 
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 type statusStrategy struct {
@@ -91,7 +92,7 @@ func (a statusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Obj
 	}
 	uOld, ok := old.(*unstructured.Unstructured)
 	if !ok {
-		return errs
+		uOld = nil // as a safety precaution, continue with validation if uOld self cannot be cast
 	}
 
 	v := obj.GetObjectKind().GroupVersionKind().Version

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
@@ -174,7 +174,7 @@ func (a customResourceStrategy) Validate(ctx context.Context, obj runtime.Object
 
 		// validate x-kubernetes-validations rules
 		if celValidator, ok := a.celValidators[v]; ok {
-			err, _ := celValidator.Validate(ctx, nil, a.structuralSchemas[v], u.Object, cel.RuntimeCELCostBudget)
+			err, _ := celValidator.Validate(ctx, nil, a.structuralSchemas[v], u.Object, nil, cel.RuntimeCELCostBudget)
 			errs = append(errs, err...)
 		}
 	}
@@ -227,7 +227,7 @@ func (a customResourceStrategy) ValidateUpdate(ctx context.Context, obj, old run
 
 	// validate x-kubernetes-validations rules
 	if celValidator, ok := a.celValidators[v]; ok {
-		err, _ := celValidator.Validate(ctx, nil, a.structuralSchemas[v], uNew.Object, cel.RuntimeCELCostBudget)
+		err, _ := celValidator.Validate(ctx, nil, a.structuralSchemas[v], uNew.Object, uOld.Object, cel.RuntimeCELCostBudget)
 		errs = append(errs, err...)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds support for CEL CRD validation expressions that reference the existing state of an object during CR updates.

#### Special notes for your reviewer:

https://github.com/kubernetes/enhancements/tree/787e5513d09096756c61aaba1916a73cb1dd348b/keps/sig-api-machinery/2876-crd-validation-expression-language#transition-rules

#### Does this PR introduce a user-facing change?

```release-note
CEL CRD validation expressions may now reference existing object state using the identifier `oldSelf`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/787e5513d09096756c61aaba1916a73cb1dd348b/keps/sig-api-machinery/2876-crd-validation-expression-language#transition-rules
```
