### PR TITLE
Make use of `k8s.io/utils/pointer.Duration`

### DIFF
--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller_test.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller_test.go
@@ -17,37 +17,37 @@ limitations under the License.
 package ttlafterfinished
 
 import (
-	"k8s.io/klog/v2"
 	"strings"
 	"testing"
 	"time"
 
-	batch "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/pointer"
 )
 
-func newJob(completionTime, failedTime metav1.Time, ttl *int32) *batch.Job {
-	j := &batch.Job{
+func newJob(completionTime, failedTime metav1.Time, ttl *int32) *batchv1.Job {
+	j := &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{Kind: "Job"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foobar",
 			Namespace: metav1.NamespaceDefault,
 		},
-		Spec: batch.JobSpec{
+		Spec: batchv1.JobSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"foo": "bar"},
 			},
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"foo": "bar",
 					},
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{Image: "foo/bar"},
 					},
 				},
@@ -56,12 +56,12 @@ func newJob(completionTime, failedTime metav1.Time, ttl *int32) *batch.Job {
 	}
 
 	if !completionTime.IsZero() {
-		c := batch.JobCondition{Type: batch.JobComplete, Status: v1.ConditionTrue, LastTransitionTime: completionTime}
+		c := batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue, LastTransitionTime: completionTime}
 		j.Status.Conditions = append(j.Status.Conditions, c)
 	}
 
 	if !failedTime.IsZero() {
-		c := batch.JobCondition{Type: batch.JobFailed, Status: v1.ConditionTrue, LastTransitionTime: failedTime}
+		c := batchv1.JobCondition{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, LastTransitionTime: failedTime}
 		j.Status.Conditions = append(j.Status.Conditions, c)
 	}
 
@@ -70,11 +70,6 @@ func newJob(completionTime, failedTime metav1.Time, ttl *int32) *batch.Job {
 	}
 
 	return j
-}
-
-func durationPointer(n int) *time.Duration {
-	s := time.Duration(n) * time.Second
-	return &s
 }
 
 func TestTimeLeft(t *testing.T) {
@@ -110,7 +105,7 @@ func TestTimeLeft(t *testing.T) {
 			completionTime:   now,
 			ttl:              pointer.Int32(0),
 			since:            &now.Time,
-			expectedTimeLeft: durationPointer(0),
+			expectedTimeLeft: pointer.Duration(0 * time.Second),
 			expectedExpireAt: now.Time,
 		},
 		{
@@ -118,7 +113,7 @@ func TestTimeLeft(t *testing.T) {
 			completionTime:   now,
 			ttl:              pointer.Int32(10),
 			since:            &now.Time,
-			expectedTimeLeft: durationPointer(10),
+			expectedTimeLeft: pointer.Duration(10 * time.Second),
 			expectedExpireAt: now.Add(10 * time.Second),
 		},
 		{
@@ -126,7 +121,7 @@ func TestTimeLeft(t *testing.T) {
 			completionTime:   metav1.NewTime(now.Add(-10 * time.Second)),
 			ttl:              pointer.Int32(15),
 			since:            &now.Time,
-			expectedTimeLeft: durationPointer(5),
+			expectedTimeLeft: pointer.Duration(5 * time.Second),
 			expectedExpireAt: now.Add(5 * time.Second),
 		},
 		{
@@ -141,7 +136,7 @@ func TestTimeLeft(t *testing.T) {
 			failedTime:       now,
 			ttl:              pointer.Int32(0),
 			since:            &now.Time,
-			expectedTimeLeft: durationPointer(0),
+			expectedTimeLeft: pointer.Duration(0 * time.Second),
 			expectedExpireAt: now.Time,
 		},
 		{
@@ -149,7 +144,7 @@ func TestTimeLeft(t *testing.T) {
 			failedTime:       now,
 			ttl:              pointer.Int32(10),
 			since:            &now.Time,
-			expectedTimeLeft: durationPointer(10),
+			expectedTimeLeft: pointer.Duration(10 * time.Second),
 			expectedExpireAt: now.Add(10 * time.Second),
 		},
 		{
@@ -157,7 +152,7 @@ func TestTimeLeft(t *testing.T) {
 			failedTime:       metav1.NewTime(now.Add(-10 * time.Second)),
 			ttl:              pointer.Int32(15),
 			since:            &now.Time,
-			expectedTimeLeft: durationPointer(5),
+			expectedTimeLeft: pointer.Duration(5 * time.Second),
 			expectedExpireAt: now.Add(5 * time.Second),
 		},
 	}


### PR DESCRIPTION
/kind cleanup

`k8s.io/utils/pointer.Duration` was recently introduced with https://github.com/kubernetes/utils/pull/233. We can now make use of this helper func.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
