### PR TITLE
kubelet: set terminationMessagePath perms to 0660

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -445,26 +445,26 @@ func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerO
 				utilruntime.HandleError(fmt.Errorf("unable to set termination-log file permissions %q: %v", containerLogPath, err))
 			}
 
-			var containerUid, containerGid int
+			var containerUID, containerGID int
 			if container.SecurityContext != nil && container.SecurityContext.RunAsUser != nil {
-				containerUid = int(*container.SecurityContext.RunAsUser)
+				containerUID = int(*container.SecurityContext.RunAsUser)
 			} else if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil {
-				containerUid = int(*pod.Spec.SecurityContext.RunAsUser)
+				containerUID = int(*pod.Spec.SecurityContext.RunAsUser)
 			} else {
-				containerUid = 0
+				containerUID = 0
 			}
 
 			if container.SecurityContext != nil && container.SecurityContext.RunAsGroup != nil {
-				containerGid = int(*container.SecurityContext.RunAsGroup)
+				containerGID = int(*container.SecurityContext.RunAsGroup)
 			} else if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsGroup != nil {
-				containerGid = int(*pod.Spec.SecurityContext.RunAsGroup)
+				containerGID = int(*pod.Spec.SecurityContext.RunAsGroup)
 			} else {
-				containerGid = 0
+				containerGID = 0
 			}
 
 			if goruntime.GOOS != "windows" {
-				if err := os.Chown(containerLogPath, containerUid, containerGid); err != nil {
-					utilruntime.HandleError(fmt.Errorf("unable to chown termination-log file: %q: %v", containerLogPath, err))
+				if err := os.Chown(containerLogPath, containerUID, containerGID); err != nil {
+					utilruntime.HandleError(fmt.Errorf("unable to chown termination-log file: %q: %w", containerLogPath, err))
 				}
 			}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -336,7 +336,7 @@ func (m *kubeGenericRuntimeManager) generateContainerConfig(ctx context.Context,
 		Annotations: newContainerAnnotations(container, pod, restartCount, opts),
 		Devices:     makeDevices(opts),
 		CDIDevices:  makeCDIDevices(opts),
-		Mounts:      m.makeMounts(opts, container),
+		Mounts:      m.makeMounts(opts, container, pod),
 		LogPath:     containerLogsPath,
 		Stdin:       container.Stdin,
 		StdinOnce:   container.StdinOnce,
@@ -405,7 +405,7 @@ func makeCDIDevices(opts *kubecontainer.RunContainerOptions) []*runtimeapi.CDIDe
 }
 
 // makeMounts generates container volume mounts for kubelet runtime v1.
-func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerOptions, container *v1.Container) []*runtimeapi.Mount {
+func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerOptions, container *v1.Container, pod *v1.Pod) []*runtimeapi.Mount {
 	volumeMounts := []*runtimeapi.Mount{}
 
 	for idx := range opts.Mounts {
@@ -443,6 +443,29 @@ func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerO
 			// in the file no matter what the umask is.
 			if err := m.osInterface.Chmod(containerLogPath, 0660); err != nil {
 				utilruntime.HandleError(fmt.Errorf("unable to set termination-log file permissions %q: %v", containerLogPath, err))
+			}
+
+			var containerUid, containerGid int
+			if container.SecurityContext.RunAsUser != nil {
+				containerUid = int(*container.SecurityContext.RunAsUser)
+			} else if pod.Spec.SecurityContext.RunAsUser != nil {
+				containerUid = int(*pod.Spec.SecurityContext.RunAsUser)
+			} else {
+				containerUid = 0
+			}
+
+			if container.SecurityContext.RunAsGroup != nil {
+				containerGid = int(*container.SecurityContext.RunAsGroup)
+			} else if pod.Spec.SecurityContext.RunAsGroup != nil {
+				containerGid = int(*pod.Spec.SecurityContext.RunAsGroup)
+			} else {
+				containerGid = 0
+			}
+
+			if goruntime.GOOS != "windows" {
+				if err := os.Chown(containerLogPath, containerUid, containerGid); err != nil {
+					utilruntime.HandleError(fmt.Errorf("unable to chown termination-log file: %q: %v", containerLogPath, err))
+				}
 			}
 
 			// Volume Mounts fail on Windows if it is not of the form C:/

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -441,7 +441,7 @@ func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerO
 			// open(2) to create the file, so the final mode used is "mode &
 			// ~umask". But we want to make sure the specified mode is used
 			// in the file no matter what the umask is.
-			if err := m.osInterface.Chmod(containerLogPath, 0666); err != nil {
+			if err := m.osInterface.Chmod(containerLogPath, 0660); err != nil {
 				utilruntime.HandleError(fmt.Errorf("unable to set termination-log file permissions %q: %v", containerLogPath, err))
 			}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -446,17 +446,17 @@ func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerO
 			}
 
 			var containerUid, containerGid int
-			if container.SecurityContext.RunAsUser != nil {
+			if container.SecurityContext != nil && container.SecurityContext.RunAsUser != nil {
 				containerUid = int(*container.SecurityContext.RunAsUser)
-			} else if pod.Spec.SecurityContext.RunAsUser != nil {
+			} else if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil {
 				containerUid = int(*pod.Spec.SecurityContext.RunAsUser)
 			} else {
 				containerUid = 0
 			}
 
-			if container.SecurityContext.RunAsGroup != nil {
+			if container.SecurityContext != nil && container.SecurityContext.RunAsGroup != nil {
 				containerGid = int(*container.SecurityContext.RunAsGroup)
-			} else if pod.Spec.SecurityContext.RunAsGroup != nil {
+			} else if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsGroup != nil {
 				containerGid = int(*pod.Spec.SecurityContext.RunAsGroup)
 			} else {
 				containerGid = 0

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -66,7 +66,7 @@ func makeExpectedConfig(m *kubeGenericRuntimeManager, pod *v1.Pod, containerInde
 		Labels:      newContainerLabels(container, pod),
 		Annotations: newContainerAnnotations(container, pod, restartCount, opts),
 		Devices:     makeDevices(opts),
-		Mounts:      m.makeMounts(opts, container),
+		Mounts:      m.makeMounts(opts, container, pod),
 		LogPath:     containerLogsPath,
 		Stdin:       container.Stdin,
 		StdinOnce:   container.StdinOnce,

--- a/test/e2e/common/node/runtime.go
+++ b/test/e2e/common/node/runtime.go
@@ -137,6 +137,7 @@ while true; do sleep 1; done
 		ginkgo.Context("on terminated container", func() {
 			rootUser := int64(0)
 			nonRootUser := int64(10000)
+			nonRootGroup := int64(10000)
 			adminUserName := "ContainerAdministrator"
 			nonAdminUserName := "ContainerUser"
 
@@ -204,6 +205,7 @@ while true; do sleep 1; done
 					container.SecurityContext.WindowsOptions = &v1.WindowsSecurityContextOptions{RunAsUserName: &nonAdminUserName}
 				} else {
 					container.SecurityContext.RunAsUser = &nonRootUser
+					container.SecurityContext.RunAsGroup = &nonRootGroup
 				}
 				matchTerminationMessage(ctx, container, v1.PodSucceeded, gomega.Equal("DONE"))
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently, kubelet creates a world-readable and world-writeable empty files in `/var/lib/kubelet/pods/{podUID}/containers/{containerName}/{containerId}`. These are meant to be written by the process in containers when container is terminated.

Originally, this file was created with `0644`, then despite security concerns, it was changed to `0666` in https://github.com/kubernetes/kubernetes/issues/31839. This was completed to allow containers running as non-root to write termination messages. Later on, in 2019 this has been highlighted as a security vulnerability in Kubernetes Security Audit Report in https://github.com/kubernetes/kubernetes/issues/81116.

This PR changes termination log file mode to `0660` which is the best of both worlds - it removes world-writable file, yet still allows the container user and it's group to write the termination message.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related (fixes only part) #81116

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Change world-accessible permissions to owner and group only read/write for files created by kubelet '/var/lib/kubelet/pods/{podUID}/containers/busysleep/{containerId}'. 
Termination message file (by default `/dev/termination-log`) can now be written only by the container user and it's group.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

- [2019 Kubernetes Security Audit](https://github.com/kubernetes/sig-security/blob/6f1cec8878c705b67982e9b3bf3b52d6f19e17e0/sig-security-external-audit/security-audit-2019/findings/Kubernetes%20Final%20Report.pdf)

