### PR TITLE
endpoint slice controller: handle pods with nodes not present

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -539,6 +539,7 @@ func (c *Controller) checkNodeTopologyDistribution() {
 	nodes, err := c.nodeLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("Error listing Nodes: %v", err)
+		return
 	}
 	c.topologyCache.SetNodes(nodes)
 	serviceKeys := c.topologyCache.GetOverloadedServices()


### PR DESCRIPTION
/kind bug

The endpoint slice controller doesn't handle well the case where a Pod exist but not its Node.
There are several situations when a Pod can exist but not its Node ,commonly, this happens when the node is removed, the node can not be present for several reasons, it can be temporary or permanent.
For permanent situation, there is a PodGC controller, that runs periodically and cleans up the Pods without a Node
https://github.com/kubernetes/kubernetes/blob/a1ac74224eac04dae21fcee2b32f8e914111ec9f/pkg/controller/podgc/gc_controller.go#L42-L48
For temporal situations, we should check when the Node is back and sync the corresponding services.




```release-note
endpoint slices: skip Pods associated to Nodes that are not present in the API.
```

Fixes: #107927