### PR TITLE
Move kubectl wait to informers with a cache to avoid hanging due to objects disappearing from the cluster

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -329,8 +329,6 @@ func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error
 	}
 	if initObjGetErr != nil {
 		// TODO this could do something slightly fancier if we wish
-		fmt.Println("unknown error getting object initially")
-		fmt.Println(initObjGetErr)
 		return info.Object, false, initObjGetErr
 	}
 	resourceLocation := ResourceLocation{
@@ -340,7 +338,6 @@ func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error
 	}
 	if uid, ok := o.UIDMap[resourceLocation]; ok {
 		if gottenObj.GetUID() != uid {
-			fmt.Println("UID did not match on first check")
 			return gottenObj, true, nil
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -379,23 +379,19 @@ func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error
 		return false, nil
 	}
 
-	var result runtime.Object
 	intr := interrupt.New(nil, cancel)
 	err := intr.Run(func() error {
-		ev, err := watchtools.UntilWithSync(ctx, lw, &unstructured.Unstructured{}, preconditionFunc, Wait{errOut: o.ErrOut}.IsDeleted)
-		if ev != nil {
-			result = ev.Object
-		}
+		_, err := watchtools.UntilWithSync(ctx, lw, &unstructured.Unstructured{}, preconditionFunc, Wait{errOut: o.ErrOut}.IsDeleted)
 		return err
 	})
 	if err != nil {
 		if err == wait.ErrWaitTimeout {
-			return result, false, errWaitTimeoutWithName
+			return gottenObj, false, errWaitTimeoutWithName
 		}
-		return result, false, err
+		return gottenObj, false, err
 	}
 
-	return result, true, nil
+	return gottenObj, true, nil
 }
 
 // Wait has helper methods for handling watches, including error handling.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -319,7 +319,7 @@ func TestWaitForDeletion(t *testing.T) {
 						count++
 						fakeWatch := watch.NewRaceFreeFake()
 						go func() {
-							time.Sleep(100 * time.Millisecond)
+							time.Sleep(1 * time.Second)
 							fakeWatch.Stop()
 						}()
 						return true, fakeWatch, nil
@@ -416,7 +416,7 @@ func TestWaitForDeletion(t *testing.T) {
 						count++
 						fakeWatch := watch.NewRaceFreeFake()
 						go func() {
-							time.Sleep(100 * time.Millisecond)
+							time.Sleep(1 * time.Second)
 							fakeWatch.Stop()
 						}()
 						return true, fakeWatch, nil
@@ -774,7 +774,7 @@ func TestWaitForCondition(t *testing.T) {
 						count++
 						fakeWatch := watch.NewRaceFreeFake()
 						go func() {
-							time.Sleep(100 * time.Millisecond)
+							time.Sleep(1 * time.Second)
 							fakeWatch.Stop()
 						}()
 						return true, fakeWatch, nil
@@ -1320,7 +1320,7 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 			o := &WaitOptions{
 				ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(infos...),
 				DynamicClient:  fakeClient,
-				Timeout:        1 * time.Millisecond,
+				Timeout:        1 * time.Second,
 
 				Printer: printers.NewDiscardingPrinter(),
 				ConditionFn: JSONPathWait{
@@ -1497,7 +1497,7 @@ func TestWaitForJSONPathCondition(t *testing.T) {
 						count++
 						fakeWatch := watch.NewRaceFreeFake()
 						go func() {
-							time.Sleep(100 * time.Millisecond)
+							time.Sleep(1 * time.Second)
 							fakeWatch.Stop()
 						}()
 						return true, fakeWatch, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This moves the `kubectl wait` set of functions to using informers with cache updates for waiting on resources to reach a specified state. It prevents wait from hanging due to resources disappearing and outputs a descriptive error message when a resource it is waiting on disappears.

Example output:
```
☸  context: minikube (namespace: default) in ~/tmp 
❯ devkc wait --for=condition=ready pod --all --timeout=15s
pod/nginx-deployment-9456bbbf9-f9k7k condition met
pod/nginx-deployment-9456bbbf9-k2fhr condition met
pod/nginx-deployment-9456bbbf9-l886q condition met
pod/nginx-deployment-9456bbbf9-qsgqh condition met
pod/nginx-deployment-9456bbbf9-sjfdp condition met
pod/nginx-deployment-9456bbbf9-w85zc condition met
Error from server (NotFound): pods "nginx-deployment-9456bbbf9-zs5vq" not found

☸  context: minikube (namespace: default) in ~/tmp 
❯ devkc wait --for=condition=ready pod --all --timeout=15s
pod/nginx-deployment-9456bbbf9-f9k7k condition met
pod/nginx-deployment-9456bbbf9-l886q condition met
pod/nginx-deployment-9456bbbf9-sjfdp condition met
Error from server (NotFound): pods "nginx-deployment-9456bbbf9-k2fhr" not found

☸  context: minikube (namespace: default) in ~/tmp 
❯ devkc wait --for=condition=ready pod --all --timeout=15s
pod/nginx-deployment-9456bbbf9-f9k7k condition met
```

#### Which issue(s) this PR fixes:
Fixes kubernetes/kubectl#1120

#### Special notes for your reviewer:
I had to bump all the timeouts in the tests up to at least 1 second due to how the informer and caching works. From what I can tell on my local testing it doesn't actually increase testing time that significantly (2 seconds for me) but just fyi.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

cleared release note since this is reverted in https://github.com/kubernetes/kubernetes/pull/110922, original release note was:
```
kubectl wait no longer hangs on resources that have disappeared from the cluster
```