### PR TITLE
endpointslice: don't try to update topology cache if node informer error

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -539,6 +539,7 @@ func (c *Controller) checkNodeTopologyDistribution() {
 	nodes, err := c.nodeLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("Error listing Nodes: %v", err)
+		return
 	}
 	c.topologyCache.SetNodes(nodes)
 	serviceKeys := c.topologyCache.GetOverloadedServices()


### PR DESCRIPTION
Subtle bug, if there is an error listing from the informer just return and don't try to update the cache without data

/kind bug
```release-note
NONE
```
