### PR TITLE
Remove unused `--container-runtime` e2e.test flag

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -108,7 +108,6 @@ type TestContextType struct {
 	EtcdUpgradeStorage          string
 	EtcdUpgradeVersion          string
 	GCEUpgradeScript            string
-	ContainerRuntime            string
 	ContainerRuntimeEndpoint    string
 	ContainerRuntimeProcessName string
 	ContainerRuntimePidFile     string
@@ -307,7 +306,6 @@ func RegisterCommonFlags(flags *flag.FlagSet) {
 	flags.StringVar(&TestContext.ReportPrefix, "report-prefix", "", "Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
 	flags.StringVar(&TestContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
 	flags.Var(cliflag.NewMapStringBool(&TestContext.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features.")
-	flags.StringVar(&TestContext.ContainerRuntime, "container-runtime", "remote", "The container runtime of cluster VM instances (remote).")
 	flags.StringVar(&TestContext.ContainerRuntimeEndpoint, "container-runtime-endpoint", "unix:///var/run/containerd/containerd.sock", "The container runtime endpoint of cluster VM instances.")
 	flags.StringVar(&TestContext.ContainerRuntimeProcessName, "container-runtime-process-name", "dockerd", "The name of the container runtime process.")
 	flags.StringVar(&TestContext.ContainerRuntimePidFile, "container-runtime-pid-file", "/var/run/docker.pid", "The pid file of the container runtime.")
@@ -483,12 +481,6 @@ func AfterReadingAllFlags(t *TestContextType) {
 		// We need to support that, changing it would break those usages.
 		Logf("The --provider flag is not set. Continuing as if --provider=skeleton had been used.")
 		TestContext.Provider = "skeleton"
-	}
-
-	// Make sure that container runtime is valid
-	if TestContext.ContainerRuntime != "remote" {
-		klog.Errorf("Unsupported CRI container runtime: %q", TestContext.ContainerRuntime)
-		os.Exit(1)
 	}
 
 	var err error

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -162,7 +162,7 @@ func TestE2eNode(t *testing.T) {
 				klog.Exitf("chroot %q failed: %v", rootfs, err)
 			}
 		}
-		if _, err := system.ValidateSpec(*spec, framework.TestContext.ContainerRuntime); len(err) != 0 {
+		if _, err := system.ValidateSpec(*spec, "remote"); len(err) != 0 {
 			klog.Exitf("system validation failed: %v", err)
 		}
 		return

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -274,10 +274,6 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		cmdArgs = append(cmdArgs, "--hostname-override", framework.TestContext.NodeName)
 	}
 
-	if framework.TestContext.ContainerRuntime != "" {
-		cmdArgs = append(cmdArgs, "--container-runtime", framework.TestContext.ContainerRuntime)
-	}
-
 	if framework.TestContext.ContainerRuntimeEndpoint != "" {
 		cmdArgs = append(cmdArgs, "--container-runtime-endpoint", framework.TestContext.ContainerRuntimeEndpoint)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/cc @adisky @endocrimes @dims

#### What this PR does / why we need it:
https://github.com/kubernetes/test-infra/pull/24918 removed all usages of the `--container-runtime` flag in tests, so there's no need to keep it anymore.

#### Which issue(s) this PR fixes:
Refs #106893

#### Special notes for your reviewer:
n/a

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
