### PR TITLE
Remove unused `--dockershim-checkpoint-dir` e2e.test flag

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -82,8 +82,7 @@ type TestContextType struct {
 	Host               string
 	BearerToken        string `datapolicy:"token"`
 	// TODO: Deprecating this over time... instead just use gobindata_util.go , see #23987.
-	RepoRoot                string
-	DockershimCheckpointDir string
+	RepoRoot string
 	// ListImages will list off all images that are used then quit
 	ListImages bool
 
@@ -312,7 +311,6 @@ func RegisterCommonFlags(flags *flag.FlagSet) {
 	flags.StringVar(&TestContext.SystemdServices, "systemd-services", "docker", "The comma separated list of systemd services the framework will dump logs for.")
 	flags.BoolVar(&TestContext.DumpSystemdJournal, "dump-systemd-journal", false, "Whether to dump the full systemd journal.")
 	flags.StringVar(&TestContext.ImageServiceEndpoint, "image-service-endpoint", "", "The image service endpoint of cluster VM instances.")
-	flags.StringVar(&TestContext.DockershimCheckpointDir, "dockershim-checkpoint-dir", "/var/lib/dockershim/sandbox", "The directory for dockershim to store sandbox checkpoints.")
 	// TODO: remove the node-role.kubernetes.io/master taint in 1.25 or later.
 	// The change will likely require an action for some users that do not
 	// use k8s originated tools like kubeadm or kOps for creating clusters


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/cc @adisky @endocrimes @dims

#### What this PR does / why we need it:
https://github.com/kubernetes/test-infra/pull/107179 removed all usages of the `--dockershim-checkpoint-dir` flag in tests, so there's no need to keep it anymore.

#### Which issue(s) this PR fixes:
Refs #106893

#### Special notes for your reviewer:
n/a

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
