### PR TITLE
e2e: Fix ResourceConsumer unstable request interval

### DIFF
--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -227,16 +227,16 @@ func (rc *ResourceConsumer) makeConsumeCPURequests() {
 	defer ginkgo.GinkgoRecover()
 	rc.stopWaitGroup.Add(1)
 	defer rc.stopWaitGroup.Done()
-	sleepTime := time.Duration(0)
+	tick := time.After(time.Duration(0))
 	millicores := 0
 	for {
 		select {
 		case millicores = <-rc.cpu:
 			framework.Logf("RC %s: setting consumption to %v millicores in total", rc.name, millicores)
-		case <-time.After(sleepTime):
+		case <-tick:
 			framework.Logf("RC %s: sending request to consume %d millicores", rc.name, millicores)
 			rc.sendConsumeCPURequest(millicores)
-			sleepTime = rc.sleepTime
+			tick = time.After(rc.sleepTime)
 		case <-rc.stopCPU:
 			framework.Logf("RC %s: stopping CPU consumer", rc.name)
 			return
@@ -248,16 +248,16 @@ func (rc *ResourceConsumer) makeConsumeMemRequests() {
 	defer ginkgo.GinkgoRecover()
 	rc.stopWaitGroup.Add(1)
 	defer rc.stopWaitGroup.Done()
-	sleepTime := time.Duration(0)
+	tick := time.After(time.Duration(0))
 	megabytes := 0
 	for {
 		select {
 		case megabytes = <-rc.mem:
 			framework.Logf("RC %s: setting consumption to %v MB in total", rc.name, megabytes)
-		case <-time.After(sleepTime):
+		case <-tick:
 			framework.Logf("RC %s: sending request to consume %d MB", rc.name, megabytes)
 			rc.sendConsumeMemRequest(megabytes)
-			sleepTime = rc.sleepTime
+			tick = time.After(rc.sleepTime)
 		case <-rc.stopMem:
 			framework.Logf("RC %s: stopping mem consumer", rc.name)
 			return
@@ -269,16 +269,16 @@ func (rc *ResourceConsumer) makeConsumeCustomMetric() {
 	defer ginkgo.GinkgoRecover()
 	rc.stopWaitGroup.Add(1)
 	defer rc.stopWaitGroup.Done()
-	sleepTime := time.Duration(0)
+	tick := time.After(time.Duration(0))
 	delta := 0
 	for {
 		select {
 		case delta = <-rc.customMetric:
 			framework.Logf("RC %s: setting bump of metric %s to %d in total", rc.name, customMetricName, delta)
-		case <-time.After(sleepTime):
+		case <-tick:
 			framework.Logf("RC %s: sending request to consume %d of custom metric %s", rc.name, delta, customMetricName)
 			rc.sendConsumeCustomMetric(delta)
-			sleepTime = rc.sleepTime
+			tick = time.After(rc.sleepTime)
 		case <-rc.stopCustomMetric:
 			framework.Logf("RC %s: stopping metric consumer", rc.name)
 			return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Setting a new consumption target in `autoscaling.ResourceConsumer` (a call e.g. to `rc.ConsumeCPU(...)`) caused the internal sleep duration between consumption requests to reset. The next consumption would then get delayed, starting after a gap of 0-30s.

This bug is not visible in the current e2e tests, because they only loosely validate the scaling behavior – waiting a long time for the number of replicas to eventually reach a given target. Even if the gap in the resource consumption causes a bad recommendation, then that only makes the test to run a bit longer. However, it impacts the tests I'm about to add for #102369, as they will validate exactly *how* the target is reached.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
