### PR TITLE
kubelet apiserver: be gentle closing connections on heartbeat failures

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -554,14 +554,14 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 		klog.InfoS("Standalone mode, no API client")
 
 	case kubeDeps.KubeClient == nil, kubeDeps.EventClient == nil, kubeDeps.HeartbeatClient == nil:
-		clientConfig, closeAllConns, err := buildKubeletClientConfig(ctx, s, nodeName)
+		clientConfig, onHeartbeatFailure, err := buildKubeletClientConfig(ctx, s, nodeName)
 		if err != nil {
 			return err
 		}
-		if closeAllConns == nil {
-			return errors.New("closeAllConns must be a valid function other than nil")
+		if onHeartbeatFailure == nil {
+			return errors.New("onHeartbeatFailure must be a valid function other than nil")
 		}
-		kubeDeps.OnHeartbeatFailure = closeAllConns
+		kubeDeps.OnHeartbeatFailure = onHeartbeatFailure
 
 		kubeDeps.KubeClient, err = clientset.NewForConfig(clientConfig)
 		if err != nil {
@@ -845,6 +845,7 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, nod
 		if err != nil {
 			return nil, nil, err
 		}
+		var onHeartbeatFailure func()
 		// Kubelet needs to be able to recover from stale http connections.
 		// HTTP2 has a mechanism to detect broken connections by sending periodical pings.
 		// HTTP1 only can have one persistent connection, and it will close all Idle connections
@@ -853,14 +854,15 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, nod
 		// setting the environment variable DISABLE_HTTP2.
 		if s := os.Getenv("DISABLE_HTTP2"); len(s) > 0 {
 			klog.InfoS("HTTP2 has been explicitly disabled, Kubelet will forcefully close active connections on heartbeat failures")
+			onHeartbeatFailure = closeAllConns
 		} else {
-			closeAllConns = func() { utilnet.CloseIdleConnectionsFor(transportConfig.Transport) }
+			onHeartbeatFailure = func() { utilnet.CloseIdleConnectionsFor(transportConfig.Transport) }
 		}
 
 		klog.V(2).InfoS("Starting client certificate rotation")
 		clientCertificateManager.Start()
 
-		return transportConfig, closeAllConns, nil
+		return transportConfig, onHeartbeatFailure, nil
 	}
 
 	if len(s.BootstrapKubeconfig) > 0 {
@@ -884,19 +886,19 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, nod
 	// once the Kubelet heartbeat fails. However, since there are many edge cases that we can't
 	// control, users can still opt-in to the previous behavior for closing the connections by
 	// setting the environment variable DISABLE_HTTP2.
-	var closeAllConns func()
+	var onHeartbeatFailure func()
 	if s := os.Getenv("DISABLE_HTTP2"); len(s) > 0 {
 		klog.InfoS("HTTP2 has been explicitly disabled, updating Kubelet client Dialer to forcefully close active connections on heartbeat failures")
-		closeAllConns, err = updateDialer(clientConfig)
+		onHeartbeatFailure, err = updateDialer(clientConfig)
 		if err != nil {
 			return nil, nil, err
 		}
 	} else {
-		closeAllConns = func() {
+		onHeartbeatFailure = func() {
 			utilnet.CloseIdleConnectionsFor(clientConfig.Transport)
 		}
 	}
-	return clientConfig, closeAllConns, nil
+	return clientConfig, onHeartbeatFailure, nil
 }
 
 // updateDialer instruments a restconfig with a dial. the returned function allows forcefully closing all active connections.

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -845,6 +845,17 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, nod
 		if err != nil {
 			return nil, nil, err
 		}
+		// Kubelet needs to be able to recover from stale http connections.
+		// HTTP2 has a mechanism to detect broken connections by sending periodical pings.
+		// HTTP1 only can have one persistent connection, and it will close all Idle connections
+		// once the Kubelet heartbeat fails. However, since there are many edge cases that we can't
+		// control, users can still opt-in to the previous behavior for closing the connections by
+		// setting the environment variable DISABLE_HTTP2.
+		if s := os.Getenv("DISABLE_HTTP2"); len(s) > 0 {
+			klog.InfoS("HTTP2 has been explicitly disabled, Kubelet will forcefully close active connections on heartbeat failures")
+		} else {
+			closeAllConns = func() { utilnet.CloseIdleConnectionsFor(transportConfig.Transport) }
+		}
 
 		klog.V(2).InfoS("Starting client certificate rotation")
 		clientCertificateManager.Start()


### PR DESCRIPTION
Follow up on https://github.com/kubernetes/kubernetes/pull/104844
Alternative to https://github.com/kubernetes/kubernetes/pull/107879

Kubelet was forcefully closing all connections (idle and active) on heartbeat failures https://github.com/kubernetes/kubernetes/pull/63492 
However, since https://github.com/kubernetes/kubernetes/pull/95981, all clients using HTTP2 use a health check by default that allows to detect stale connections without any additional logic.

In case users are disabling http2, by setting the environment variable DISABLE_HTTP2, the previous behavior is maintained.



/kind bug

```release-note
kubelet don't forcefully close active connections on heartbeat failures, using the http2 health check mechanism to detect broken connections. Users can force the previous behavior of the kubelet by setting the environment variable DISABLE_HTTP2.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
