### PR TITLE
Update sig-cli OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -177,31 +177,29 @@ aliases:
   # - wgliang
 
   sig-cli-maintainers:
-    - deads2k
-    - janetkuo
-    - seans3
-    - monopole
     - apelisse
-    - soltysh
-    - pwittrock
-    - eddiezane
     - brianpursley
+    - deads2k
+    - eddiezane
     - KnVerey
+    - pwittrock
+    - seans3
+    - soltysh
   # emeritus:
   # - adohe
   # - brendandburns
   # - droot
+  # - janetkuo
   # - mengqiy
+  # - monopole
   # - smarterclayton
-  sig-cli:
+  sig-cli-reviewers:
     - brianpursley
+    - dougsland
+    - eddiezane
+    - KnVerey
     - seans3
     - soltysh
-    - pwittrock
-    - eddiezane
-    - dougsland
-    - rikatz
-    - KnVerey
   sig-testing-reviewers:
     - bentheelder
     - cblecker

--- a/cmd/clicheck/OWNERS
+++ b/cmd/clicheck/OWNERS
@@ -3,4 +3,4 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers

--- a/cmd/kubectl-convert/OWNERS
+++ b/cmd/kubectl-convert/OWNERS
@@ -3,7 +3,7 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers
 labels:
   - area/kubectl
   - sig/cli

--- a/cmd/kubectl/OWNERS
+++ b/cmd/kubectl/OWNERS
@@ -3,7 +3,7 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers
 labels:
   - area/kubectl
   - sig/cli

--- a/hack/testdata/OWNERS
+++ b/hack/testdata/OWNERS
@@ -3,4 +3,4 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers

--- a/hack/verify-flags/OWNERS
+++ b/hack/verify-flags/OWNERS
@@ -3,4 +3,4 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers

--- a/pkg/kubectl/OWNERS
+++ b/pkg/kubectl/OWNERS
@@ -3,7 +3,7 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers
 labels:
   - area/kubectl
   - sig/cli

--- a/pkg/printers/OWNERS
+++ b/pkg/printers/OWNERS
@@ -5,4 +5,4 @@ approvers:
   - sig-cli-maintainers
 reviewers:
   - smarterclayton
-  - sig-cli
+  - sig-cli-reviewers

--- a/staging/src/k8s.io/component-base/cli/OWNERS
+++ b/staging/src/k8s.io/component-base/cli/OWNERS
@@ -7,6 +7,6 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers
 labels:
   - sig/cli

--- a/staging/src/k8s.io/component-base/term/OWNERS
+++ b/staging/src/k8s.io/component-base/term/OWNERS
@@ -6,6 +6,6 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers
 labels:
   - sig/cli

--- a/staging/src/k8s.io/kubectl/OWNERS
+++ b/staging/src/k8s.io/kubectl/OWNERS
@@ -3,7 +3,7 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers
 labels:
   - area/kubectl
   - sig/cli

--- a/staging/src/k8s.io/kubectl/pkg/util/i18n/translations/kubectl/OWNERS
+++ b/staging/src/k8s.io/kubectl/pkg/util/i18n/translations/kubectl/OWNERS
@@ -3,4 +3,4 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers

--- a/test/cmd/OWNERS
+++ b/test/cmd/OWNERS
@@ -3,4 +3,4 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers

--- a/test/e2e/kubectl/OWNERS
+++ b/test/e2e/kubectl/OWNERS
@@ -3,6 +3,6 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers
 labels:
   - sig/cli

--- a/test/fixtures/pkg/kubectl/OWNERS
+++ b/test/fixtures/pkg/kubectl/OWNERS
@@ -3,4 +3,4 @@
 approvers:
   - sig-cli-maintainers
 reviewers:
-  - sig-cli
+  - sig-cli-reviewers


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR cleans up the SIG-CLI OWNERS files.

Thank you to @janetkuo, @monopole, and @rikatz for your great work. Please let us know if you'd ever like to rejoin us over in CLI world.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```