### PR TITLE
test: bump nfs-provisioner to 3.0.1

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -218,7 +218,7 @@ func initImageConfigs(list RegistryList) (map[int]Config, map[int]Config) {
 	configs[JessieDnsutils] = Config{list.PromoterE2eRegistry, "jessie-dnsutils", "1.5"}
 	configs[Kitten] = Config{list.PromoterE2eRegistry, "kitten", "1.5"}
 	configs[Nautilus] = Config{list.PromoterE2eRegistry, "nautilus", "1.5"}
-	configs[NFSProvisioner] = Config{list.SigStorageRegistry, "nfs-provisioner", "v2.2.2"}
+	configs[NFSProvisioner] = Config{list.SigStorageRegistry, "nfs-provisioner", "v3.0.1"}
 	configs[Nginx] = Config{list.PromoterE2eRegistry, "nginx", "1.14-2"}
 	configs[NginxNew] = Config{list.PromoterE2eRegistry, "nginx", "1.15-2"}
 	configs[NodePerfNpbEp] = Config{list.PromoterE2eRegistry, "node-perf/npb-ep", "1.2"}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

This updates the nfs-provisioner image used in storage tests to the first version built for multiple architectures.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @mkumatag 