### PR TITLE
Automated cherry pick of #108002: kubeadm: fix the bug that 'kubeadm init --dry-run

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/dryrunclient.go
+++ b/cmd/kubeadm/app/util/apiclient/dryrunclient.go
@@ -25,11 +25,14 @@ import (
 
 	"github.com/pkg/errors"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientset "k8s.io/client-go/kubernetes"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
@@ -162,7 +165,19 @@ func NewDryRunClientWithOpts(opts DryRunClientOptions) clientset.Interface {
 		&core.SimpleReactor{
 			Verb:     "create",
 			Resource: "*",
-			Reaction: successfulModificationReactorFunc,
+			Reaction: func(action core.Action) (bool, runtime.Object, error) {
+				objAction, ok := action.(actionWithObject)
+				if obj := objAction.GetObject(); ok && obj != nil {
+					if secret, ok := obj.(*v1.Secret); ok {
+						if secret.Namespace == metav1.NamespaceSystem && strings.HasPrefix(secret.Name, bootstrapapi.BootstrapTokenSecretPrefix) {
+							// bypass bootstrap token secret create event so that it can be persisted to the backing data store
+							// this secret should be readable during the uploadcerts init phase if it has already been created
+							return false, nil, nil
+						}
+					}
+				}
+				return successfulModificationReactorFunc(action)
+			},
 		},
 		&core.SimpleReactor{
 			Verb:     "update",

--- a/cmd/kubeadm/app/util/apiclient/init_dryrun_test.go
+++ b/cmd/kubeadm/app/util/apiclient/init_dryrun_test.go
@@ -59,13 +59,6 @@ func TestHandleGetAction(t *testing.T) {
 			expectedObjectJSON: []byte(``),
 			expectedErr:        true, // we expect a NotFound error here
 		},
-		{
-			name:               "get kube-system secret bootstrap-token-abcdef",
-			action:             core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "secrets"}, "kube-system", "bootstrap-token-abcdef"),
-			expectedHandled:    true,
-			expectedObjectJSON: []byte(``),
-			expectedErr:        true, // we expect a NotFound error here
-		},
 		{ // an ask for a kubernetes service in the _kube-system_ ns should not be answered
 			name:               "get kube-system services",
 			action:             core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "services"}, "kube-system", "kubernetes"),
@@ -83,13 +76,6 @@ func TestHandleGetAction(t *testing.T) {
 		{ // an ask for an other node than the control-plane should not be answered
 			name:               "get other-node",
 			action:             core.NewRootGetAction(schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, "other-node"),
-			expectedHandled:    false,
-			expectedObjectJSON: []byte(``),
-			expectedErr:        false,
-		},
-		{ // an ask for a secret in any other ns than kube-system should not be answered
-			name:               "get default secret bootstrap-token-abcdef",
-			action:             core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "secrets"}, "default", "bootstrap-token-abcdef"),
 			expectedHandled:    false,
 			expectedObjectJSON: []byte(``),
 			expectedErr:        false,


### PR DESCRIPTION
Cherry pick of #108002 on release-1.23.

#108002: kubeadm: fix the bug that 'kubeadm init --dry-run

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```