### PR TITLE
Add maxLength/maxItems/maxProperties CEL extraction support/automatic maxLength calculation

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -23,6 +23,8 @@ import (
 )
 
 const (
+	// the largest request that will be accepted is 3MB
+	// TODO(DangerOnTheRanger): find out where this is originally declared so we don't have two constants
 	maxRequestSizeBytes = 3000000
 	// chosen as the numbers of digits of the largest 64-bit integer
 	// we add 4 to account for a unit (like ms) plus the quotation marks that will be used

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -26,9 +26,8 @@ const (
 	// the largest request that will be accepted is 3MB
 	// TODO(DangerOnTheRanger): find out where this is originally declared so we don't have two constants
 	maxRequestSizeBytes = 3000000
-	// chosen as the numbers of digits of the largest 64-bit integer
-	// we add 4 to account for a unit (like ms) plus the quotation marks that will be used
-	maxDurationSizeJSON = 23
+	// OpenAPI duration strings follow RFC 3339, section 5.6 - see the comment on maxDatetimeSizeJSON
+	maxDurationSizeJSON = 32
 	// OpenAPI datetime strings follow RFC 3339, section 5.6, and the longest possible
 	// such string is 9999-12-31T23:59:59.999999999Z, which has length 30 - we add 2
 	// to allow for quotation marks

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -76,14 +76,13 @@ func SchemaDeclType(s *schema.Structural, isResourceRoot bool) *DeclType {
 	case "array":
 		if s.Items != nil {
 			itemsType := SchemaDeclType(s.Items, s.Items.XEmbeddedResource)
-			var maxItems int64
+			maxItems := int64(-1)
 			if s.Items.ValueValidation != nil {
 				if s.Items.ValueValidation.MaxItems != nil {
 					maxItems = *s.Items.ValueValidation.MaxItems
-				} else {
-					maxItems = estimateMaxSizeJSON(s)
 				}
-			} else {
+			}
+			if maxItems == -1 {
 				maxItems = estimateMaxSizeJSON(s)
 			}
 			if itemsType != nil {
@@ -95,14 +94,13 @@ func SchemaDeclType(s *schema.Structural, isResourceRoot bool) *DeclType {
 		if s.AdditionalProperties != nil && s.AdditionalProperties.Structural != nil {
 			propsType := SchemaDeclType(s.AdditionalProperties.Structural, s.AdditionalProperties.Structural.XEmbeddedResource)
 			if propsType != nil {
-				var maxProperties int64
+				maxProperties := int64(-1)
 				if s.ValueValidation != nil {
 					if s.ValueValidation.MaxProperties != nil {
 						maxProperties = *s.ValueValidation.MaxProperties
-					} else {
-						maxProperties = estimateMaxSizeJSON(s)
 					}
-				} else {
+				}
+				if maxProperties == -1 {
 					maxProperties = estimateMaxSizeJSON(s)
 				}
 				return NewMapType(StringType, propsType, maxProperties)

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -89,10 +89,8 @@ func SchemaDeclType(s *schema.Structural, isResourceRoot bool) *DeclType {
 		if s.Items != nil {
 			itemsType := SchemaDeclType(s.Items, s.Items.XEmbeddedResource)
 			maxItems := int64(noMaxLength)
-			if s.Items.ValueValidation != nil {
-				if s.Items.ValueValidation.MaxItems != nil {
-					maxItems = *s.Items.ValueValidation.MaxItems
-				}
+			if s.Items.ValueValidation != nil && s.Items.ValueValidation.MaxItems != nil {
+				maxItems = *s.Items.ValueValidation.MaxItems
 			}
 			if maxItems == noMaxLength {
 				maxItems = estimateMaxSizeJSON(s)
@@ -107,10 +105,8 @@ func SchemaDeclType(s *schema.Structural, isResourceRoot bool) *DeclType {
 			propsType := SchemaDeclType(s.AdditionalProperties.Structural, s.AdditionalProperties.Structural.XEmbeddedResource)
 			if propsType != nil {
 				maxProperties := int64(noMaxLength)
-				if s.ValueValidation != nil {
-					if s.ValueValidation.MaxProperties != nil {
-						maxProperties = *s.ValueValidation.MaxProperties
-					}
+				if s.ValueValidation != nil && s.ValueValidation.MaxProperties != nil {
+					maxProperties = *s.ValueValidation.MaxProperties
 				}
 				if maxProperties == noMaxLength {
 					maxProperties = estimateMaxSizeJSON(s)
@@ -252,7 +248,8 @@ func estimateMinSizeJSON(s *schema.Structural) int64 {
 		// [],
 		return 3
 	case "object":
-		objSize := int64(3) // {},
+		// {},
+		objSize := int64(3)
 		// sum of all non-optional properties
 		if s.ValueValidation != nil {
 			for _, propName := range s.ValueValidation.Required {

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -230,7 +230,7 @@ func estimateMinSizeJSON(s *schema.Structural) int64 {
 		// 0,
 		return 2
 	case "string":
-		if s.ValueValidation != nil && s.ValueValidation.Format != "" && s.ValueValidation.Format != "byte" {
+		if s.ValueValidation != nil {
 			switch s.ValueValidation.Format {
 			case "duration":
 				return minDurationSizeJSON
@@ -274,7 +274,7 @@ func estimateMaxSizeJSON(s *schema.Structural) int64 {
 		// same case as a string without ValueValidation
 		return (maxRequestSizeBytes - 2)
 	case "string":
-		if s.ValueValidation != nil && s.ValueValidation.Format != "" && s.ValueValidation.Format != "byte" {
+		if s.ValueValidation != nil {
 			switch s.ValueValidation.Format {
 			case "duration":
 				return maxDurationSizeJSON

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -263,7 +263,7 @@ func estimateMinSizeJSON(s *schema.Structural) int64 {
 		}
 		return objSize
 	}
-	// TODO(DangerOnTheRanger): better error handling (We should never get here in normal operation)
+	// this code should be unreachable, but return noMaxLength just in case
 	return noMaxLength
 }
 
@@ -306,6 +306,6 @@ func estimateMaxSizeJSON(s *schema.Structural) int64 {
 			return noMaxLength
 		}
 	}
-	// TODO(DangerOnTheRanger): better error handling (We should never get here in normal operation)
+	// this code should be unreachable, but return noMaxLength just in case
 	return noMaxLength
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -220,10 +220,7 @@ func estimateMinSizeJSON(s *schema.Structural) int64 {
 	case "boolean":
 		// true,
 		return 5
-	case "number":
-		// 0,
-		return 2
-	case "integer":
+	case "number", "integer":
 		// 0,
 		return 2
 	case "string":

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -88,13 +88,13 @@ func SchemaDeclType(s *schema.Structural, isResourceRoot bool) *DeclType {
 	case "array":
 		if s.Items != nil {
 			itemsType := SchemaDeclType(s.Items, s.Items.XEmbeddedResource)
-			maxItems := int64(-1)
+			maxItems := int64(noMaxLength)
 			if s.Items.ValueValidation != nil {
 				if s.Items.ValueValidation.MaxItems != nil {
 					maxItems = *s.Items.ValueValidation.MaxItems
 				}
 			}
-			if maxItems == -1 {
+			if maxItems == noMaxLength {
 				maxItems = estimateMaxSizeJSON(s)
 			}
 			if itemsType != nil {
@@ -106,13 +106,13 @@ func SchemaDeclType(s *schema.Structural, isResourceRoot bool) *DeclType {
 		if s.AdditionalProperties != nil && s.AdditionalProperties.Structural != nil {
 			propsType := SchemaDeclType(s.AdditionalProperties.Structural, s.AdditionalProperties.Structural.XEmbeddedResource)
 			if propsType != nil {
-				maxProperties := int64(-1)
+				maxProperties := int64(noMaxLength)
 				if s.ValueValidation != nil {
 					if s.ValueValidation.MaxProperties != nil {
 						maxProperties = *s.ValueValidation.MaxProperties
 					}
 				}
-				if maxProperties == -1 {
+				if maxProperties == noMaxLength {
 					maxProperties = estimateMaxSizeJSON(s)
 				}
 				return NewMapType(StringType, propsType, maxProperties)
@@ -264,7 +264,7 @@ func estimateMinSizeJSON(s *schema.Structural) int64 {
 		return objSize
 	}
 	// TODO(DangerOnTheRanger): better error handling (We should never get here in normal operation)
-	return -1
+	return noMaxLength
 }
 
 // estimateMaxSizeJSON estimates the maximum number of elements that can fit in s considering request size
@@ -303,9 +303,9 @@ func estimateMaxSizeJSON(s *schema.Structural) int64 {
 		} else {
 			// this codepath executes in the case of non-map objects,
 			// but regular objects have no concept of maxProperties
-			return -1
+			return noMaxLength
 		}
 	}
 	// TODO(DangerOnTheRanger): better error handling (We should never get here in normal operation)
-	return -1
+	return noMaxLength
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -224,6 +224,7 @@ func estimateMinSizeJSON(s *schema.Structural) int64 {
 		return 2
 	case "string":
 		// "",
+		// TODO(DangerOnTheRanger): does an empty string constitute a valid date/datetime string?
 		return 3
 	case "array":
 		// [],
@@ -248,6 +249,14 @@ func estimateMinSizeJSON(s *schema.Structural) int64 {
 // constraints.
 func estimateMaxSizeJSON(s *schema.Structural) int64 {
 	switch s.Type {
+	case "boolean":
+		// false,
+		return 6
+	case "number", "integer":
+		// we're concerned with the theoretical largest number that could be written as a string given the
+		// request limit, not the largest 64-bit integer (which is significantly smaller), so this is the
+		// same case as a string without ValueValidation
+		return (maxRequestSizeBytes - 2)
 	case "string":
 		if s.ValueValidation != nil && s.ValueValidation.Format != "" && s.ValueValidation.Format != "byte" {
 			switch s.Type {

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -250,7 +250,7 @@ func estimateMinSizeJSON(s *schema.Structural) int64 {
 	case "object":
 		// {},
 		objSize := int64(3)
-		// sum of all non-optional properties
+		// exclude required fields since the request can omit them
 		if s.ValueValidation != nil {
 			for _, propName := range s.ValueValidation.Required {
 				prop := s.Properties[propName]

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -133,6 +133,12 @@ func SchemaDeclType(s *schema.Structural, isResourceRoot bool) *DeclType {
 				return DurationType
 			case "date", "date-time":
 				return TimestampType
+			case "":
+				if s.ValueValidation.MaxLength != nil {
+					strWithMaxLength := newSimpleType("string", decls.String, types.String(""))
+					strWithMaxLength.MaxLength = *s.ValueValidation.MaxLength
+					return strWithMaxLength
+				}
 			}
 		}
 		return StringType

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas_test.go
@@ -261,10 +261,30 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 	}
 	tests := []maxLengthTest{
 		{
-			Name: "numberArray",
-			InputSchema: arraySchema("integer", &schema.ValueValidation{
-				Format: "int64",
+			Name:        "booleanArray",
+			InputSchema: arraySchema("boolean", nil),
+			// expected JSON is [true,true,...], so our length should be (3000000 - 2) / 5
+			ExpectedMaxLength: 599999,
+		},
+		{
+			Name: "durationArray",
+			InputSchema: arraySchema("string", &schema.ValueValidation{
+				Format: "duration",
 			}),
+			// expected JSON is ["P1D","P1D",...] so our length should be (3000000 - 2) / 6
+			ExpectedMaxLength: 499999,
+		},
+		{
+			Name: "datetimeArray",
+			InputSchema: arraySchema("string", &schema.ValueValidation{
+				Format: "date-time",
+			}),
+			// expected JSON is ["2000-01-01T01:01:01","2000-01-01T01:01:01",...] so our length should be (3000000 - 2) / 22
+			ExpectedMaxLength: 136363,
+		},
+		{
+			Name:        "numberArray",
+			InputSchema: arraySchema("integer", nil),
 			// expected JSON is [0,0,...] so our length should be (3000000 - 2) / 2
 			ExpectedMaxLength: 1499999,
 		},
@@ -320,7 +340,7 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 			ExpectedMaxLength: 176470,
 		},
 		{
-			Name: "listWithLength",
+			Name: "arrayWithLength",
 			InputSchema: arraySchema("integer", &schema.ValueValidation{
 				Format:   "int64",
 				MaxItems: maxPtr(10),
@@ -332,8 +352,7 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 			Name: "stringWithLength",
 			InputSchema: &schema.Structural{
 				Generic: schema.Generic{
-					Type:    "string",
-					Default: schema.JSON{Object: "test-data"},
+					Type: "string",
 				},
 				ValueValidation: &schema.ValueValidation{
 					MaxLength: maxPtr(20),
@@ -360,6 +379,45 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 			},
 			// manually set by MaxProperties
 			ExpectedMaxLength: 15,
+		},
+		{
+			Name: "durationMaxSize",
+			InputSchema: &schema.Structural{
+				Generic: schema.Generic{
+					Type: "string",
+				},
+				ValueValidation: &schema.ValueValidation{
+					Format: "duration",
+				},
+			},
+			// should be exactly equal to maxDurationSizeJSON
+			ExpectedMaxLength: maxDurationSizeJSON,
+		},
+		{
+			Name: "dateSize",
+			InputSchema: &schema.Structural{
+				Generic: schema.Generic{
+					Type: "string",
+				},
+				ValueValidation: &schema.ValueValidation{
+					Format: "date",
+				},
+			},
+			// should be exactly equal to dateSizeJSON
+			ExpectedMaxLength: dateSizeJSON,
+		},
+		{
+			Name: "maxdatetimeSize",
+			InputSchema: &schema.Structural{
+				Generic: schema.Generic{
+					Type: "string",
+				},
+				ValueValidation: &schema.ValueValidation{
+					Format: "date-time",
+				},
+			},
+			// should be exactly equal to maxDatetimeSizeJSON
+			ExpectedMaxLength: maxDatetimeSizeJSON,
 		},
 	}
 	for _, testCase := range tests {

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas_test.go
@@ -318,7 +318,6 @@ func schemaWithMaxLengths() *schema.Structural {
 					Default: schema.JSON{Object: "test-data"},
 				},
 				ValueValidation: &schema.ValueValidation{
-					Format:    "byte",
 					MaxLength: maxPtr(20),
 				},
 			},

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas_test.go
@@ -239,6 +239,20 @@ func testSchema() *schema.Structural {
 	return ts
 }
 
+func arraySchema(arrayType string, validation *schema.ValueValidation) *schema.Structural {
+	return &schema.Structural{
+		Generic: schema.Generic{
+			Type: "array",
+		},
+		Items: &schema.Structural{
+			Generic: schema.Generic{
+				Type: arrayType,
+			},
+			ValueValidation: validation,
+		},
+	}
+}
+
 func TestEstimateMaxLengthJSON(t *testing.T) {
 	type maxLengthTest struct {
 		Name              string
@@ -248,34 +262,15 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 	tests := []maxLengthTest{
 		{
 			Name: "numberArray",
-			InputSchema: &schema.Structural{
-				Generic: schema.Generic{
-					Type: "array",
-				},
-				Items: &schema.Structural{
-					Generic: schema.Generic{
-						Type: "integer",
-					},
-					ValueValidation: &schema.ValueValidation{
-						Format: "int64",
-					},
-				},
-			},
+			InputSchema: arraySchema("integer", &schema.ValueValidation{
+				Format: "int64",
+			}),
 			// expected JSON is [0,0,...] so our length should be (3000000 - 2) / 2
 			ExpectedMaxLength: 1499999,
 		},
 		{
-			Name: "stringArray",
-			InputSchema: &schema.Structural{
-				Generic: schema.Generic{
-					Type: "array",
-				},
-				Items: &schema.Structural{
-					Generic: schema.Generic{
-						Type: "string",
-					},
-				},
-			},
+			Name:        "stringArray",
+			InputSchema: arraySchema("string", nil),
 			// expected JSON is ["","",...] so our length should be (3000000 - 2) / 3
 			ExpectedMaxLength: 999999,
 		},
@@ -326,21 +321,10 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 		},
 		{
 			Name: "listWithLength",
-			InputSchema: &schema.Structural{
-				Generic: schema.Generic{
-					Type:    "array",
-					Default: schema.JSON{Object: [5]int64{1, 2, 3, 4, 5}},
-				},
-				Items: &schema.Structural{
-					Generic: schema.Generic{
-						Type: "integer",
-					},
-					ValueValidation: &schema.ValueValidation{
-						Format:   "int64",
-						MaxItems: maxPtr(10),
-					},
-				},
-			},
+			InputSchema: arraySchema("integer", &schema.ValueValidation{
+				Format:   "int64",
+				MaxItems: maxPtr(10),
+			}),
 			// manually set by MaxItems
 			ExpectedMaxLength: 10,
 		},

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas_test.go
@@ -239,8 +239,8 @@ func testSchema() *schema.Structural {
 	return ts
 }
 
-func TestCELSchema(t *testing.T) {
-	ts := celSchema()
+func TestMaxLengths(t *testing.T) {
+	ts := schemaWithMaxLengths()
 	cust := SchemaDeclType(ts, true).MaybeAssignTypeName("CustomObject")
 	list, ok := cust.FindField("listWithLength")
 	if !ok {
@@ -272,7 +272,7 @@ func maxPtr(max int64) *int64 {
 	return &max
 }
 
-func celSchema() *schema.Structural {
+func schemaWithMaxLengths() *schema.Structural {
 	// Manual construction of a schema with the following definition:
 	//
 	// schema:

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/types.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/google/cel-go/cel"
@@ -31,7 +32,7 @@ import (
 )
 
 const (
-	noMaxLength = -1
+	noMaxLength = math.MaxInt
 )
 
 // NewListType returns a parameterized list type with a specified element type.
@@ -51,7 +52,7 @@ func NewMapType(key, elem *DeclType, maxProperties int64) *DeclType {
 		name:         "map",
 		KeyType:      key,
 		ElemType:     elem,
-		MaxLength: maxProperties,
+		MaxLength:    maxProperties,
 		exprType:     decls.NewMapType(key.ExprType(), elem.ExprType()),
 		defaultValue: NewMapValue(),
 	}
@@ -557,5 +558,5 @@ var (
 	ListType = NewListType(AnyType, noMaxLength)
 
 	// MapType is equivalent to the CEL 'map' type.
-	MapType = NewMapType(AnyType, AnyType, -1)
+	MapType = NewMapType(AnyType, AnyType, noMaxLength)
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/types_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/types_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestTypes_ListType(t *testing.T) {
-	list := NewListType(StringType)
+	list := NewListType(StringType, -1)
 	if !list.IsList() {
 		t.Error("list type not identifiable as list")
 	}
@@ -43,7 +43,7 @@ func TestTypes_ListType(t *testing.T) {
 }
 
 func TestTypes_MapType(t *testing.T) {
-	mp := NewMapType(StringType, IntType)
+	mp := NewMapType(StringType, IntType, -1)
 	if !mp.IsMap() {
 		t.Error("map type not identifiable as map")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Part of https://github.com/kubernetes/kubernetes/issues/107573, particularly laying the foundation for [resource constraints](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2876-crd-validation-expression-language#estimated-cost-limits) by extracting `maxLength` (or its equivalent for non-string datatypes) when given by the user, and estimating it otherwise. This PR intentionally introduces no observable change in behavior; a follow-up PR that uses this PR in conjunction with CEL's [CostEstimator](https://github.com/google/cel-go/blob/a29469fda231aa37802d476ef818e2224c25e157/checker/cost.go#L25-L37) will be written.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
