### PR TITLE
Automated cherry pick of #108123: Fix incorrect parameters in EndpointsEqualBeyondHash

### DIFF
--- a/pkg/controller/util/endpoint/controller_utils.go
+++ b/pkg/controller/util/endpoint/controller_utils.go
@@ -281,11 +281,13 @@ func (sl portsInOrder) Less(i, j int) bool {
 // but excludes equality checks that would have already been covered with
 // endpoint hashing (see hashEndpoint func for more info).
 func EndpointsEqualBeyondHash(ep1, ep2 *discovery.Endpoint) bool {
-	if stringPtrChanged(ep1.NodeName, ep1.NodeName) {
+	// To prevent updating all EndpointSlices on upgrade, the equal check ignores difference of NodeName and Zone if the
+	// existing value is nil and the new value is non-nil.
+	if ep1.NodeName != nil && ep2.NodeName != nil && *ep1.NodeName != *ep2.NodeName {
 		return false
 	}
 
-	if stringPtrChanged(ep1.Zone, ep1.Zone) {
+	if ep1.Zone != nil && ep2.Zone != nil && *ep1.Zone != *ep2.Zone {
 		return false
 	}
 
@@ -318,17 +320,6 @@ func objectRefPtrChanged(ref1, ref2 *v1.ObjectReference) bool {
 		return true
 	}
 	if ref1 != nil && ref2 != nil && !apiequality.Semantic.DeepEqual(*ref1, *ref2) {
-		return true
-	}
-	return false
-}
-
-// stringPtrChanged returns true if a set of string pointers have different values.
-func stringPtrChanged(ptr1, ptr2 *string) bool {
-	if (ptr1 == nil) != (ptr2 == nil) {
-		return true
-	}
-	if ptr1 != nil && ptr2 != nil && *ptr1 != *ptr2 {
 		return true
 	}
 	return false

--- a/pkg/controller/util/endpoint/controller_utils_test.go
+++ b/pkg/controller/util/endpoint/controller_utils_test.go
@@ -23,11 +23,13 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 func TestDetermineNeededServiceUpdates(t *testing.T) {
@@ -659,6 +661,165 @@ func Test_podChanged(t *testing.T) {
 			}
 			if labelsChanged != tc.labelsChanged {
 				t.Errorf("Expected labelsChanged to be %t, got %t", tc.labelsChanged, labelsChanged)
+			}
+		})
+	}
+}
+
+func TestEndpointsEqualBeyondHash(t *testing.T) {
+	tests := []struct {
+		name     string
+		ep1      *discovery.Endpoint
+		ep2      *discovery.Endpoint
+		expected bool
+	}{
+		{
+			name: "No change",
+			ep1: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+				NodeName:  utilpointer.StringPtr("node-1"),
+			},
+			ep2: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+				NodeName:  utilpointer.StringPtr("node-1"),
+			},
+			expected: true,
+		},
+		{
+			name: "NodeName changed from nil",
+			ep1: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+			},
+			ep2: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+				NodeName:  utilpointer.StringPtr("node-2"),
+			},
+			expected: true,
+		},
+		{
+			name: "NodeName changed",
+			ep1: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+				NodeName:  utilpointer.StringPtr("node-1"),
+			},
+			ep2: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+				NodeName:  utilpointer.StringPtr("node-2"),
+			},
+			expected: false,
+		},
+		{
+			name: "Zone changed from nil",
+			ep1: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+			},
+			ep2: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+				Zone:      utilpointer.StringPtr("zone-2"),
+			},
+			expected: true,
+		},
+		{
+			name: "Zone changed",
+			ep1: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+				Zone:      utilpointer.StringPtr("zone-1"),
+			},
+			ep2: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+				Zone:      utilpointer.StringPtr("zone-2"),
+			},
+			expected: false,
+		},
+		{
+			name: "Ready condition changed",
+			ep1: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+				Zone:      utilpointer.StringPtr("zone-1"),
+				NodeName:  utilpointer.StringPtr("node-1"),
+			},
+			ep2: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(false),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+				Zone:      utilpointer.StringPtr("zone-1"),
+				NodeName:  utilpointer.StringPtr("node-1"),
+			},
+			expected: false,
+		},
+		{
+			name: "Pod name changed",
+			ep1: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
+				Zone:      utilpointer.StringPtr("zone-1"),
+				NodeName:  utilpointer.StringPtr("node-1"),
+			},
+			ep2: &discovery.Endpoint{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.1"},
+				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
+				Zone:      utilpointer.StringPtr("zone-1"),
+				NodeName:  utilpointer.StringPtr("node-1"),
+			},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EndpointsEqualBeyondHash(tt.ep1, tt.ep2); got != tt.expected {
+				t.Errorf("EndpointsEqualBeyondHash() = %v, want %v", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #108123 on release-1.23.

#108123: Fix incorrect parameters in EndpointsEqualBeyondHash

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```