### PR TITLE
Automated cherry pick of #108138: Revert v1beta1 PodDisruptionBudget select patchStrategy

### DIFF
--- a/staging/src/k8s.io/api/policy/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/policy/v1beta1/generated.proto
@@ -144,7 +144,6 @@ message PodDisruptionBudgetSpec {
   // A null selector selects no pods.
   // An empty selector ({}) also selects no pods, which differs from standard behavior of selecting all pods.
   // In policy/v1, an empty selector will select all pods in the namespace.
-  // +patchStrategy=replace
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 

--- a/staging/src/k8s.io/api/policy/v1beta1/types.go
+++ b/staging/src/k8s.io/api/policy/v1beta1/types.go
@@ -36,9 +36,8 @@ type PodDisruptionBudgetSpec struct {
 	// A null selector selects no pods.
 	// An empty selector ({}) also selects no pods, which differs from standard behavior of selecting all pods.
 	// In policy/v1, an empty selector will select all pods in the namespace.
-	// +patchStrategy=replace
 	// +optional
-	Selector *metav1.LabelSelector `json:"selector,omitempty" patchStrategy:"replace" protobuf:"bytes,2,opt,name=selector"`
+	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,2,opt,name=selector"`
 
 	// An eviction is allowed if at most "maxUnavailable" pods selected by
 	// "selector" are unavailable after the eviction, i.e. even in absence of


### PR DESCRIPTION
Cherry pick of #108138 on release-1.22.

#108138: Revert v1beta1 PodDisruptionBudget select patchStrategy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in 1.21 in v1beta1 PodDisruptionBudget handling of "strategic merge patch"-type API requests for the `selector` field. Prior to 1.21, these requests would merge `matchLabels` content and replace `matchExpressions` content. In 1.21, patch requests touching the `selector` field started replacing the entire selector. This is consistent with server-side apply and the v1 PodDisruptionBudget behavior, but should not have been changed for v1beta1.
```
