### PR TITLE
Forbid empty AppArmor localhost profile

### DIFF
--- a/pkg/apis/policy/validation/validation.go
+++ b/pkg/apis/policy/validation/validation.go
@@ -33,7 +33,6 @@ import (
 	core "k8s.io/kubernetes/pkg/apis/core"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/apis/policy"
-	"k8s.io/kubernetes/pkg/security/apparmor"
 	"k8s.io/kubernetes/pkg/security/podsecuritypolicy/seccomp"
 	psputil "k8s.io/kubernetes/pkg/security/podsecuritypolicy/util"
 )
@@ -138,13 +137,13 @@ func ValidatePodSecurityPolicySpecificAnnotations(annotations map[string]string,
 	allErrs := field.ErrorList{}
 
 	if p := annotations[v1.AppArmorBetaDefaultProfileAnnotationKey]; p != "" {
-		if err := apparmor.ValidateProfileFormat(p); err != nil {
+		if err := apivalidation.ValidateAppArmorProfileFormat(p); err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath.Key(v1.AppArmorBetaDefaultProfileAnnotationKey), p, err.Error()))
 		}
 	}
 	if allowed := annotations[v1.AppArmorBetaAllowedProfilesAnnotationKey]; allowed != "" {
 		for _, p := range strings.Split(allowed, ",") {
-			if err := apparmor.ValidateProfileFormat(p); err != nil {
+			if err := apivalidation.ValidateAppArmorProfileFormat(p); err != nil {
 				allErrs = append(allErrs, field.Invalid(fldPath.Key(v1.AppArmorBetaAllowedProfilesAnnotationKey), allowed, err.Error()))
 			}
 		}

--- a/pkg/security/apparmor/OWNERS
+++ b/pkg/security/apparmor/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-node-approvers
+  - tallclair
+reviewers:
+  - sig-node-reviewers
+  - tallclair
+labels:
+  - sig/node

--- a/pkg/security/apparmor/validate.go
+++ b/pkg/security/apparmor/validate.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
 	utilpath "k8s.io/utils/path"
 )
@@ -75,12 +76,12 @@ func (v *validator) Validate(pod *v1.Pod) error {
 	var retErr error
 	podutil.VisitContainers(&pod.Spec, podutil.AllContainers, func(container *v1.Container, containerType podutil.ContainerType) bool {
 		profile := GetProfileName(pod, container.Name)
-		retErr = ValidateProfileFormat(profile)
+		retErr = validation.ValidateAppArmorProfileFormat(profile)
 		if retErr != nil {
 			return false
 		}
-		// TODO(#64841): This would ideally be part of ValidateProfileFormat, but that is called for
-		// API validation, and this is tightening validation.
+		// TODO(#64841): This would ideally be part of validation.ValidateAppArmorProfileFormat, but
+		// that is called for API validation, and this is tightening validation.
 		if strings.HasPrefix(profile, v1.AppArmorBetaProfileNamePrefix) {
 			if strings.TrimSpace(strings.TrimPrefix(profile, v1.AppArmorBetaProfileNamePrefix)) == "" {
 				retErr = fmt.Errorf("invalid empty AppArmor profile name: %q", profile)
@@ -114,17 +115,6 @@ func validateHost() error {
 		return errors.New("AppArmor is not enabled on the host")
 	}
 
-	return nil
-}
-
-// ValidateProfileFormat checks the format of the profile.
-func ValidateProfileFormat(profile string) error {
-	if profile == "" || profile == v1.AppArmorBetaProfileRuntimeDefault || profile == v1.AppArmorBetaProfileNameUnconfined {
-		return nil
-	}
-	if !strings.HasPrefix(profile, v1.AppArmorBetaProfileNamePrefix) {
-		return fmt.Errorf("invalid AppArmor profile name: %q", profile)
-	}
 	return nil
 }
 

--- a/pkg/security/apparmor/validate_test.go
+++ b/pkg/security/apparmor/validate_test.go
@@ -109,6 +109,8 @@ func TestValidateValidHost(t *testing.T) {
 		{v1.AppArmorBetaProfileNamePrefix + "foo-container", true},
 		{v1.AppArmorBetaProfileNamePrefix + "/usr/sbin/ntpd", true},
 		{"docker-default", false},
+		{v1.AppArmorBetaProfileNamePrefix + "", false}, // Empty profile explicitly forbidden.
+		{v1.AppArmorBetaProfileNamePrefix + " ", false},
 	}
 
 	for _, test := range tests {

--- a/pkg/security/apparmor/validate_test.go
+++ b/pkg/security/apparmor/validate_test.go
@@ -46,29 +46,6 @@ func TestValidateHost(t *testing.T) {
 	assert.NoError(t, validateHost())
 }
 
-func TestValidateProfileFormat(t *testing.T) {
-	tests := []struct {
-		profile     string
-		expectValid bool
-	}{
-		{"", true},
-		{v1.AppArmorBetaProfileRuntimeDefault, true},
-		{v1.AppArmorBetaProfileNameUnconfined, true},
-		{"baz", false}, // Missing local prefix.
-		{v1.AppArmorBetaProfileNamePrefix + "/usr/sbin/ntpd", true},
-		{v1.AppArmorBetaProfileNamePrefix + "foo-bar", true},
-	}
-
-	for _, test := range tests {
-		err := ValidateProfileFormat(test.profile)
-		if test.expectValid {
-			assert.NoError(t, err, "Profile %s should be valid", test.profile)
-		} else {
-			assert.Error(t, err, fmt.Sprintf("Profile %s should not be valid", test.profile))
-		}
-	}
-}
-
 func TestValidateBadHost(t *testing.T) {
 	hostErr := errors.New("expected host error")
 	v := &validator{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/97966 removed the requirement that AppArmor profiles be pre-loaded, but in doing so opened up `localhost/` as a valid profile. When `localhost/` gets passed to the CRI runtime, it strips out the `localhost/` prefix before passing the empty string to runc, which then treats it as `unconfined`. The end result is that `localhost/` is equivalent to `unconfined`, and could be used to evade admission policies that explicitly forbid the use of unconfined.

Also adds a `pkg/security/apparmor/OWNERS` file (owned by sig-node), so AppArmor changes don't require top-level approval.

#### Special notes for your reviewer:

Note that this validation would ideally be done as part of API validation, but because of https://github.com/kubernetes/kubernetes/issues/64841 the Kubelet just performs the check on pod admission (to the node).

#### Does this PR introduce a user-facing change?

https://github.com/kubernetes/kubernetes/pull/97966 was only pushed out in an alpha release, so no user-facing changes are introduced here.

```release-note
NONE
```

/sig node
/assign @saschagrunert 
/cc @liggitt 