### PR TITLE
Don't decorate admission for audit when audit is disabled

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/audit.go
@@ -43,7 +43,7 @@ var _ ValidationInterface = &auditHandler{}
 // Validate function must be instance of privateAnnotationsGetter or
 // AnnotationsGetter, otherwise an error is returned.
 func WithAudit(i Interface, ae *auditinternal.Event) Interface {
-	if i == nil {
+	if i == nil || ae == nil {
 		return i
 	}
 	return &auditHandler{Interface: i, ae: ae}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

No need to wrap the admission interface to capture audit logs when auditing isn't enabled. We already short-circuit at the function that does the bulk of the work ([logAnnotations](https://github.com/kubernetes/kubernetes/blob/a37b6fc8b488a07839e6426e5d7ce4a5165cfe73/staging/src/k8s.io/apiserver/pkg/admission/audit.go#L91)), but this just moves the short-circuiting logic earlier.

#### Which issue(s) this PR fixes:
I doubt it fixes it, but I spotted this when looking at https://github.com/kubernetes/kubernetes/issues/103760

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
