### PR TITLE
Update TopologyManager algorithm for selecting "best" non-preferred hint

### DIFF
--- a/pkg/kubelet/cm/topologymanager/policy_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_test.go
@@ -615,6 +615,220 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 				Preferred:        false,
 			},
 		},
+		{
+			name: "bestNonPreferredAffinityCount (1)",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1, 2, 3),
+								Preferred:        false,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource2": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(0, 1),
+				Preferred:        false,
+			},
+		},
+		{
+			name: "bestNonPreferredAffinityCount (2)",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1, 2, 3),
+								Preferred:        false,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource2": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 3),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(0, 3),
+				Preferred:        false,
+			},
+		},
+		{
+			name: "bestNonPreferredAffinityCount (3)",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1, 2, 3),
+								Preferred:        false,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource2": {
+							{
+								NUMANodeAffinity: NewTestBitMask(1, 2),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(1, 2),
+				Preferred:        false,
+			},
+		},
+		{
+			name: "bestNonPreferredAffinityCount (4)",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1, 2, 3),
+								Preferred:        false,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource2": {
+							{
+								NUMANodeAffinity: NewTestBitMask(2, 3),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(2, 3),
+				Preferred:        false,
+			},
+		},
+		{
+			name: "bestNonPreferredAffinityCount (5)",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1, 2, 3),
+								Preferred:        false,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource2": {
+							{
+								NUMANodeAffinity: NewTestBitMask(1, 2),
+								Preferred:        false,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(2, 3),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(1, 2),
+				Preferred:        false,
+			},
+		},
+		{
+			name: "bestNonPreferredAffinityCount (6)",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1, 2, 3),
+								Preferred:        false,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource2": {
+							{
+								NUMANodeAffinity: NewTestBitMask(1, 2, 3),
+								Preferred:        false,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(1, 2),
+								Preferred:        false,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(1, 3),
+								Preferred:        false,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(2, 3),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(1, 2),
+				Preferred:        false,
+			},
+		},
 	}
 }
 

--- a/pkg/kubelet/cm/topologymanager/policy_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 )
 
 type policyMergeTestCase struct {
@@ -1117,5 +1118,285 @@ func testPolicyMerge(policy Policy, tcases []policyMergeTestCase, t *testing.T) 
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Errorf("%v: Expected Topology Hint to be %v, got %v:", tc.name, tc.expected, actual)
 		}
+	}
+}
+
+func TestMaxOfMinAffinityCounts(t *testing.T) {
+	tcases := []struct {
+		hints    [][]TopologyHint
+		expected int
+	}{
+		{
+			[][]TopologyHint{},
+			0,
+		},
+		{
+			[][]TopologyHint{
+				{
+					TopologyHint{NewTestBitMask(), true},
+				},
+			},
+			0,
+		},
+		{
+			[][]TopologyHint{
+				{
+					TopologyHint{NewTestBitMask(0), true},
+				},
+			},
+			1,
+		},
+		{
+			[][]TopologyHint{
+				{
+					TopologyHint{NewTestBitMask(0, 1), true},
+				},
+			},
+			2,
+		},
+		{
+			[][]TopologyHint{
+				{
+					TopologyHint{NewTestBitMask(0, 1), true},
+					TopologyHint{NewTestBitMask(0, 1, 2), true},
+				},
+			},
+			2,
+		},
+		{
+			[][]TopologyHint{
+				{
+					TopologyHint{NewTestBitMask(0, 1), true},
+					TopologyHint{NewTestBitMask(0, 1, 2), true},
+				},
+				{
+					TopologyHint{NewTestBitMask(0, 1, 2), true},
+				},
+			},
+			3,
+		},
+		{
+			[][]TopologyHint{
+				{
+					TopologyHint{NewTestBitMask(0, 1), true},
+					TopologyHint{NewTestBitMask(0, 1, 2), true},
+				},
+				{
+					TopologyHint{NewTestBitMask(0, 1, 2), true},
+					TopologyHint{NewTestBitMask(0, 1, 2, 3), true},
+				},
+			},
+			3,
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run("", func(t *testing.T) {
+			result := maxOfMinAffinityCounts(tc.hints)
+			if result != tc.expected {
+				t.Errorf("Expected result to be %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestCompareHints(t *testing.T) {
+	tcases := []struct {
+		description                   string
+		bestNonPreferredAffinityCount int
+		current                       *TopologyHint
+		candidate                     *TopologyHint
+		expected                      string
+	}{
+		{
+			"candidate.NUMANodeAffinity.Count() == 0 (1)",
+			-1,
+			nil,
+			&TopologyHint{bitmask.NewEmptyBitMask(), false},
+			"current",
+		},
+		{
+			"candidate.NUMANodeAffinity.Count() == 0 (2)",
+			-1,
+			&TopologyHint{NewTestBitMask(), true},
+			&TopologyHint{NewTestBitMask(), false},
+			"current",
+		},
+		{
+			"current == nil (1)",
+			-1,
+			nil,
+			&TopologyHint{NewTestBitMask(0), true},
+			"candidate",
+		},
+		{
+			"current == nil (2)",
+			-1,
+			nil,
+			&TopologyHint{NewTestBitMask(0), false},
+			"candidate",
+		},
+		{
+			"!current.Preferred && candidate.Preferred",
+			-1,
+			&TopologyHint{NewTestBitMask(0), false},
+			&TopologyHint{NewTestBitMask(0), true},
+			"candidate",
+		},
+		{
+			"current.Preferred && !candidate.Preferred",
+			-1,
+			&TopologyHint{NewTestBitMask(0), true},
+			&TopologyHint{NewTestBitMask(0), false},
+			"current",
+		},
+		{
+			"current.Preferred && candidate.Preferred (1)",
+			-1,
+			&TopologyHint{NewTestBitMask(0), true},
+			&TopologyHint{NewTestBitMask(0), true},
+			"current",
+		},
+		{
+			"current.Preferred && candidate.Preferred (2)",
+			-1,
+			&TopologyHint{NewTestBitMask(0, 1), true},
+			&TopologyHint{NewTestBitMask(0), true},
+			"candidate",
+		},
+		{
+			"current.Preferred && candidate.Preferred (3)",
+			-1,
+			&TopologyHint{NewTestBitMask(0), true},
+			&TopologyHint{NewTestBitMask(0, 1), true},
+			"current",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (1.1)",
+			1,
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			"current",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (1.2)",
+			1,
+			&TopologyHint{NewTestBitMask(1, 2), false},
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			"candidate",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (1.3)",
+			1,
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			&TopologyHint{NewTestBitMask(1, 2), false},
+			"current",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (2.1)",
+			2,
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			&TopologyHint{NewTestBitMask(0), false},
+			"current",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (2.2)",
+			2,
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			"current",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (2.3)",
+			2,
+			&TopologyHint{NewTestBitMask(1, 2), false},
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			"candidate",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (2.4)",
+			2,
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			&TopologyHint{NewTestBitMask(1, 2), false},
+			"current",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (3a)",
+			2,
+			&TopologyHint{NewTestBitMask(0), false},
+			&TopologyHint{NewTestBitMask(0, 1, 2), false},
+			"current",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (3b)",
+			2,
+			&TopologyHint{NewTestBitMask(0), false},
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			"candidate",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (3ca.1)",
+			3,
+			&TopologyHint{NewTestBitMask(0), false},
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			"candidate",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (3ca.2)",
+			3,
+			&TopologyHint{NewTestBitMask(0), false},
+			&TopologyHint{NewTestBitMask(1, 2), false},
+			"candidate",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (3ca.3)",
+			4,
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			&TopologyHint{NewTestBitMask(1, 2, 3), false},
+			"candidate",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (3cb)",
+			4,
+			&TopologyHint{NewTestBitMask(1, 2, 3), false},
+			&TopologyHint{NewTestBitMask(0, 1), false},
+			"current",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (3cc.1)",
+			4,
+			&TopologyHint{NewTestBitMask(0, 1, 2), false},
+			&TopologyHint{NewTestBitMask(0, 1, 2), false},
+			"current",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (3cc.2)",
+			4,
+			&TopologyHint{NewTestBitMask(0, 1, 2), false},
+			&TopologyHint{NewTestBitMask(1, 2, 3), false},
+			"current",
+		},
+		{
+			"!current.Preferred && !candidate.Preferred (3cc.3)",
+			4,
+			&TopologyHint{NewTestBitMask(1, 2, 3), false},
+			&TopologyHint{NewTestBitMask(0, 1, 2), false},
+			"candidate",
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := compareHints(tc.bestNonPreferredAffinityCount, tc.current, tc.candidate)
+			if result != tc.current && result != tc.candidate {
+				t.Errorf("Expected result to be either 'current' or 'candidate' hint")
+			}
+			if tc.expected == "current" && result != tc.current {
+				t.Errorf("Expected result to be %v, got %v", tc.current, result)
+			}
+			if tc.expected == "candidate" && result != tc.candidate {
+				t.Errorf("Expected result to be %v, got %v", tc.candidate, result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
For the 'single-numa' and 'restricted' `TopologyManager` policies, pods are only
admitted if all of their containers have perfect alignment across the set of
resources they are requesting. The `best-effort` policy, on the other hand,
will prefer allocations that have perfect alignment, but fall back to a
non-preferred alignment if perfect alignment can't be achieved.

The existing algorithm of how to choose the best hint from the set of
"non-preferred" hints is fairly naive and often results in choosing a
sub-optimal hint. It works fine in cases where all resources would end up
coming from a single NUMA node (even if its not the same NUMA nodes), but
breaks down as soon as multiple NUMA nodes are required for the "best"
alignment.  We will never be able to achieve perfect alignment with these
non-preferred hints, but we should try and do something more intelligent than
simply choosing the hint with the narrowest mask.

In an ideal world, we would have the `TopologyManager` return a set of
"resource-relative" hints (as opposed to a common hint for all resources as is
done today). Each resource-relative hint would indicate how many other
resources could be aligned to it on a given NUMA node, and a  hint provider
would use this information to allocate its resources in the most aligned way
possible. There are likely some edge cases to consider here, but such an
algorithm would allow us to do partial-perfect-alignment of "some" resources,
even if all resources could not be perfectly aligned.

Unfortunately, supporting something like this would require a major redesign to
how the `TopologyManager` interacts with its hint providers (as well as how
those hint providers make decisions based on the hints they get back).

That said, we can still do better than the naive algorithm we have today, and
this patch provides a mechanism to do so.

We start by looking at the set of hints passed into the `TopologyManager` for
each resource and generate a list of the minimum number of NUMA nodes
required to satisfy an allocation for a given resource. In other words, each entry
in this list contains the `minNUMAAffinity.Count()` for a given resource.

Once we have this list, we find the *maximum* `minNUMAAffinity.Count()` from
the list and mark that as the `bestNonPreferredAffinityCount` that we would like
to have associated with whatever "bestHint" we ultimately generate. The intuition
being that we would like to (at the very least) get alignment for those resources
that *require* multiple NUMA nodes to satisfy their allocation. If we can't
quite get there, then we should try to come as close to it as possible.

For example, consider a machine where we have 8 NUMA nodes with 32
CPUs per NUMA node and 2 GPUs attached *only* to each *odd* numbered
NUMA node (e.g. the [DGX-A100 server](https://www.microway.com/hpc-tech-tips/dgx-a100-review-throughput-and-hardware-summary/) provided by NVIDIA).

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-ffa260be-7fff-2db0-fc3d-bd12073d1cad"><div dir="ltr" style="margin-left:0pt;" align="left">

Socket | Numa Node | CPU(s) | GPU(s)
-- | -- | -- | --
0 | 0 | 0-15,128-143 |  
0 | 1 | 16-31,144-159 | /dev/nvidia2, /dev/nvidia3
0 | 2 | 32-47,160-175 |  
0 | 3 | 48-63,176-191 | /dev/nvidia0, /dev/nvidia1
1 | 4 | 64-79,192-207 |  
1 | 5 | 80-95,208-223 | /dev/nvidia6, /dev/nvidia7
1 | 6 | 96-111,224-239 |  
1 | 7 | 112-127,240-255 | /dev/nvidia4, /dev/nvidia5

</div></b>

Assuming a machine with no resources allocated yet, if a user were to request 32
CPUs (which can fit on one NUMA node) and 4 GPUs (which *requires* at least 2
NUMA nodes), then you would expect one of the following affinity masks to win out
as the "best" affinity mask since it encodes the alignment required for all 4 GPUs
to be allocated (even though the 32 CPUs only require a single NUMA node):
```
Bits:  7 6 5 4 3 2 1 0
      {0 0 0 0 1 0 1 0}
      {0 0 1 0 0 0 1 0}
      {1 0 0 0 0 0 1 0}
      {0 0 1 0 1 0 0 0}
      {1 0 0 0 1 0 0 0}
      {1 0 1 0 0 0 0 0}
```
However, with the existing algorithm, none of these affinity masks will be
considered, and a naive result of `{00000010}` will be returned since that is the
"narrowest" alignment that the allocation of all CPUs with some subset of GPUs
can be satisfied with. In effect, the old algorithm lets the "least" constrained
resource influence the hint generation more heavily when what we actually want
is the "more" constrained resource to influence the hint generation more heavily.

To achieve this, the new algorithm proceeds as follows once
we have calculated the `bestNonPreferredAffinityCount` as described above:

If the mergedHint and bestHint are both non-preferred, then try and find a hint
whose affinity count is as close to (but not higher than) the
`bestNonPreferredAffinityCount` as possible. To do this we need to consider the
following cases and react accordingly:
```
  1. bestHint.NUMANodeAffinity.Count() >  bestNonPreferredAffinityCount
  2. bestHint.NUMANodeAffinity.Count() == bestNonPreferredAffinityCount
  3. bestHint.NUMANodeAffinity.Count() <  bestNonPreferredAffinityCount
```
For case (1), the current bestHint is larger than the
`bestNonPreferredAffinityCount`, so updating to any narrower `mergeHint` is
preferred over staying where we are.

For case (2), the current `bestHint` is equal to the
`bestNonPreferredAffinityCount`, so we would like to stick with what we have
*unless* the current `mergedHint` is also equal to
`bestNonPreferredAffinityCount` and it is narrower.

For case (3), the current `bestHint` is less than
`bestNonPreferredAffinityCount`, so we would like to creep back up to
`bestNonPreferredAffinityCount` as close as we can. There are three cases to
consider here:
```
  3a. mergedHint.NUMANodeAffinity.Count() >  bestNonPreferredAffinityCount
  3b. mergedHint.NUMANodeAffinity.Count() == bestNonPreferredAffinityCount
  3c. mergedHint.NUMANodeAffinity.Count() <  bestNonPreferredAffinityCount
```
For case (3a), we just want to stick with the current `bestHint` because
choosing a new hint that is greater than `bestNonPreferredAffinityCount` would
be counter-productive.

For case (3b), we want to immediately update `bestHint` to the current
`mergedHint`, making it now equal to `bestNonPreferredAffinityCount`.

For case (3c), we know that *both* the current `bestHint` and the current
`mergedHint` are less than `bestNonPreferredAffinityCount`, so we want to
choose one that brings us back up as close to `bestNonPreferredAffinityCount`
as possible. There are three cases to consider here:
```
  3ca. mergedHint.NUMANodeAffinity.Count() >  bestHint.NUMANodeAffinity.Count()
  3cb. mergedHint.NUMANodeAffinity.Count() <  bestHint.NUMANodeAffinity.Count()
  3cc. mergedHint.NUMANodeAffinity.Count() == bestHint.NUMANodeAffinity.Count()
```
For case (3ca), we want to immediately update `bestHint` to `mergedHint`
because that will bring us closer to the (higher) value of
`bestNonPreferredAffinityCount`.

For case (3cb), we want to stick with the current `bestHint` because choosing
the current `mergedHint` would strictly move us further away from the
`bestNonPreferredAffinityCount`.

Finally, for case (3cc), we know that the current `bestHint` and the current
`mergedHint` are equal, so we simply choose the narrower of the 2.

This PR implements this algorithm for the case where we must choose from a set
of non-preferred hints and provides a set of unit-tests to verify its
correctness.

#### Does this PR introduce a user-facing change?
```release-note
Improved algorithm for selecting "best" non-preferred hint in the TopologyManager
```