### PR TITLE
Rename SupportsSELinux to SELinuxRelabel

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -175,7 +175,7 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 		// If the volume supports SELinux and it has not been
 		// relabeled already and it is not a read-only volume,
 		// relabel it and mark it as labeled
-		if vol.Mounter.GetAttributes().Managed && vol.Mounter.GetAttributes().SupportsSELinux && !vol.SELinuxLabeled {
+		if vol.Mounter.GetAttributes().Managed && vol.Mounter.GetAttributes().SELinuxRelabel && !vol.SELinuxLabeled {
 			vol.SELinuxLabeled = true
 			relabelVolume = true
 		}

--- a/pkg/volume/awsebs/aws_ebs.go
+++ b/pkg/volume/awsebs/aws_ebs.go
@@ -350,9 +350,9 @@ var _ volume.Mounter = &awsElasticBlockStoreMounter{}
 
 func (b *awsElasticBlockStoreMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        b.readOnly,
-		Managed:         !b.readOnly,
-		SupportsSELinux: true,
+		ReadOnly:       b.readOnly,
+		Managed:        !b.readOnly,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -239,9 +239,9 @@ var _ volume.Mounter = &azureFileMounter{}
 
 func (b *azureFileMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        b.readOnly,
-		Managed:         !b.readOnly,
-		SupportsSELinux: false,
+		ReadOnly:       b.readOnly,
+		Managed:        !b.readOnly,
+		SELinuxRelabel: false,
 	}
 }
 

--- a/pkg/volume/azuredd/azure_mounter.go
+++ b/pkg/volume/azuredd/azure_mounter.go
@@ -56,9 +56,9 @@ func (m *azureDiskMounter) GetAttributes() volume.Attributes {
 		readOnly = *volumeSource.ReadOnly
 	}
 	return volume.Attributes{
-		ReadOnly:        readOnly,
-		Managed:         !readOnly,
-		SupportsSELinux: true,
+		ReadOnly:       readOnly,
+		Managed:        !readOnly,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/cephfs/cephfs.go
+++ b/pkg/volume/cephfs/cephfs.go
@@ -206,9 +206,9 @@ var _ volume.Mounter = &cephfsMounter{}
 
 func (cephfsVolume *cephfsMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        cephfsVolume.readonly,
-		Managed:         false,
-		SupportsSELinux: false,
+		ReadOnly:       cephfsVolume.readonly,
+		Managed:        false,
+		SELinuxRelabel: false,
 	}
 }
 

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -371,9 +371,9 @@ type cinderVolume struct {
 
 func (b *cinderVolumeMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        b.readOnly,
-		Managed:         !b.readOnly,
-		SupportsSELinux: true,
+		ReadOnly:       b.readOnly,
+		Managed:        !b.readOnly,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -157,9 +157,9 @@ var _ volume.Mounter = &configMapVolumeMounter{}
 
 func (sv *configMapVolume) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        true,
-		Managed:         true,
-		SupportsSELinux: true,
+		ReadOnly:       true,
+		Managed:        true,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -352,9 +352,9 @@ func (c *csiMountMgr) podServiceAccountTokenAttrs() (map[string]string, error) {
 
 func (c *csiMountMgr) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        c.readOnly,
-		Managed:         !c.readOnly,
-		SupportsSELinux: c.supportsSELinux,
+		ReadOnly:       c.readOnly,
+		Managed:        !c.readOnly,
+		SELinuxRelabel: c.supportsSELinux,
 	}
 }
 

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -153,9 +153,9 @@ var _ volume.Mounter = &downwardAPIVolumeMounter{}
 // downward API volumes are always ReadOnlyManaged
 func (d *downwardAPIVolume) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        true,
-		Managed:         true,
-		SupportsSELinux: true,
+		ReadOnly:       true,
+		Managed:        true,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -219,9 +219,9 @@ type emptyDir struct {
 
 func (ed *emptyDir) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        false,
-		Managed:         true,
-		SupportsSELinux: true,
+		ReadOnly:       false,
+		Managed:        true,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -364,9 +364,9 @@ var _ volume.Mounter = &fcDiskMounter{}
 
 func (b *fcDiskMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        b.readOnly,
-		Managed:         !b.readOnly,
-		SupportsSELinux: true,
+		ReadOnly:       b.readOnly,
+		Managed:        !b.readOnly,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/flexvolume/mounter-defaults.go
+++ b/pkg/volume/flexvolume/mounter-defaults.go
@@ -45,9 +45,9 @@ func (f *mounterDefaults) SetUpAt(dir string, mounterArgs volume.MounterArgs) er
 func (f *mounterDefaults) GetAttributes() volume.Attributes {
 	klog.V(5).Info(logPrefix(f.plugin), "using default GetAttributes")
 	return volume.Attributes{
-		ReadOnly:        f.readOnly,
-		Managed:         !f.readOnly,
-		SupportsSELinux: f.flexVolume.plugin.capabilities.SELinuxRelabel,
+		ReadOnly:       f.readOnly,
+		Managed:        !f.readOnly,
+		SELinuxRelabel: f.flexVolume.plugin.capabilities.SELinuxRelabel,
 	}
 }
 

--- a/pkg/volume/flocker/flocker.go
+++ b/pkg/volume/flocker/flocker.go
@@ -214,9 +214,9 @@ type flockerVolumeMounter struct {
 
 func (b *flockerVolumeMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        b.readOnly,
-		Managed:         false,
-		SupportsSELinux: false,
+		ReadOnly:       b.readOnly,
+		Managed:        false,
+		SELinuxRelabel: false,
 	}
 }
 

--- a/pkg/volume/gcepd/gce_pd.go
+++ b/pkg/volume/gcepd/gce_pd.go
@@ -354,9 +354,9 @@ var _ volume.Mounter = &gcePersistentDiskMounter{}
 
 func (b *gcePersistentDiskMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        b.readOnly,
-		Managed:         !b.readOnly,
-		SupportsSELinux: true,
+		ReadOnly:       b.readOnly,
+		Managed:        !b.readOnly,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -161,9 +161,9 @@ var _ volume.Mounter = &gitRepoVolumeMounter{}
 
 func (b *gitRepoVolumeMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        false,
-		Managed:         true,
-		SupportsSELinux: true, // xattr change should be okay, TODO: double check
+		ReadOnly:       false,
+		Managed:        true,
+		SELinuxRelabel: true, // xattr change should be okay, TODO: double check
 	}
 }
 

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -251,9 +251,9 @@ var _ volume.Mounter = &glusterfsMounter{}
 
 func (b *glusterfsMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        b.readOnly,
-		Managed:         false,
-		SupportsSELinux: false,
+		ReadOnly:       b.readOnly,
+		Managed:        false,
+		SELinuxRelabel: false,
 	}
 }
 

--- a/pkg/volume/hostpath/host_path.go
+++ b/pkg/volume/hostpath/host_path.go
@@ -212,9 +212,9 @@ var _ volume.Mounter = &hostPathMounter{}
 
 func (b *hostPathMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        b.readOnly,
-		Managed:         false,
-		SupportsSELinux: false,
+		ReadOnly:       b.readOnly,
+		Managed:        false,
+		SELinuxRelabel: false,
 	}
 }
 

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -346,9 +346,9 @@ var _ volume.Mounter = &iscsiDiskMounter{}
 
 func (b *iscsiDiskMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        b.readOnly,
-		Managed:         !b.readOnly,
-		SupportsSELinux: true,
+		ReadOnly:       b.readOnly,
+		Managed:        !b.readOnly,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -504,9 +504,9 @@ var _ volume.Mounter = &localVolumeMounter{}
 
 func (m *localVolumeMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        m.readOnly,
-		Managed:         !m.readOnly,
-		SupportsSELinux: true,
+		ReadOnly:       m.readOnly,
+		Managed:        !m.readOnly,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -18,10 +18,11 @@ package nfs
 
 import (
 	"fmt"
-	netutil "k8s.io/utils/net"
 	"os"
 	"runtime"
 	"time"
+
+	netutil "k8s.io/utils/net"
 
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
@@ -232,9 +233,9 @@ var _ volume.Mounter = &nfsMounter{}
 
 func (nfsMounter *nfsMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        nfsMounter.readOnly,
-		Managed:         false,
-		SupportsSELinux: false,
+		ReadOnly:       nfsMounter.readOnly,
+		Managed:        false,
+		SELinuxRelabel: false,
 	}
 }
 

--- a/pkg/volume/portworx/portworx.go
+++ b/pkg/volume/portworx/portworx.go
@@ -18,10 +18,11 @@ package portworx
 
 import (
 	"fmt"
+	"os"
+
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
 	utilstrings "k8s.io/utils/strings"
-	"os"
 
 	volumeclient "github.com/libopenstorage/openstorage/api/client/volume"
 	v1 "k8s.io/api/core/v1"
@@ -287,9 +288,9 @@ var _ volume.Mounter = &portworxVolumeMounter{}
 
 func (b *portworxVolumeMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        b.readOnly,
-		Managed:         !b.readOnly,
-		SupportsSELinux: false,
+		ReadOnly:       b.readOnly,
+		Managed:        !b.readOnly,
+		SELinuxRelabel: false,
 	}
 }
 

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -168,9 +168,9 @@ var _ volume.Mounter = &projectedVolumeMounter{}
 
 func (sv *projectedVolume) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        true,
-		Managed:         true,
-		SupportsSELinux: true,
+		ReadOnly:       true,
+		Managed:        true,
+		SELinuxRelabel: true,
 	}
 
 }

--- a/pkg/volume/quobyte/quobyte.go
+++ b/pkg/volume/quobyte/quobyte.go
@@ -225,9 +225,9 @@ var _ volume.Mounter = &quobyteMounter{}
 
 func (mounter *quobyteMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        mounter.readOnly,
-		Managed:         false,
-		SupportsSELinux: false,
+		ReadOnly:       mounter.readOnly,
+		Managed:        false,
+		SELinuxRelabel: false,
 	}
 }
 

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -19,17 +19,10 @@ package rbd
 import (
 	"context"
 	"fmt"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/kubernetes/pkg/features"
 	"os"
 	"path/filepath"
 	"regexp"
 	dstrings "strings"
-
-	"k8s.io/klog/v2"
-	"k8s.io/mount-utils"
-	utilexec "k8s.io/utils/exec"
-	utilstrings "k8s.io/utils/strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -37,10 +30,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
 	volutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/volumepathhandler"
+	"k8s.io/mount-utils"
+	utilexec "k8s.io/utils/exec"
+	utilstrings "k8s.io/utils/strings"
 )
 
 var (
@@ -832,9 +831,9 @@ var _ volume.Mounter = &rbdMounter{}
 
 func (rbd *rbd) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        rbd.ReadOnly,
-		Managed:         !rbd.ReadOnly,
-		SupportsSELinux: true,
+		ReadOnly:       rbd.ReadOnly,
+		Managed:        !rbd.ReadOnly,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -162,9 +162,9 @@ var _ volume.Mounter = &secretVolumeMounter{}
 
 func (sv *secretVolume) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        true,
-		Managed:         true,
-		SupportsSELinux: true,
+		ReadOnly:       true,
+		Managed:        true,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/storageos/storageos.go
+++ b/pkg/volume/storageos/storageos.go
@@ -328,9 +328,9 @@ var _ volume.Mounter = &storageosMounter{}
 
 func (b *storageosMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly:        b.readOnly,
-		Managed:         !b.readOnly,
-		SupportsSELinux: true,
+		ReadOnly:       b.readOnly,
+		Managed:        !b.readOnly,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -686,9 +686,9 @@ func getUniqueVolumeName(spec *Spec) (string, error) {
 
 func (_ *FakeVolume) GetAttributes() Attributes {
 	return Attributes{
-		ReadOnly:        false,
-		Managed:         true,
-		SupportsSELinux: true,
+		ReadOnly:       false,
+		Managed:        true,
+		SELinuxRelabel: true,
 	}
 }
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -115,9 +115,9 @@ type Metrics struct {
 
 // Attributes represents the attributes of this mounter.
 type Attributes struct {
-	ReadOnly        bool
-	Managed         bool
-	SupportsSELinux bool
+	ReadOnly       bool
+	Managed        bool
+	SELinuxRelabel bool
 }
 
 // MounterArgs provides more easily extensible arguments to Mounter

--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -208,8 +208,8 @@ type vsphereVolumeMounter struct {
 
 func (b *vsphereVolumeMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		SupportsSELinux: true,
-		Managed:         true,
+		SELinuxRelabel: true,
+		Managed:        true,
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig storage

#### What this PR does / why we need it:
The field `SupportsSELinux` in fact says that the container runtime should relabel a volume when running a container with it, it does not say that the volume supports SELinux. For example, NFS can support SELinux, but we don't want NFS volumes relabeled, because they can be shared among several Pods.

This is just internal cleanup, nobody should use the `Attributes` struct outside of k/k.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
