### PR TITLE
Add warning when diff command includes invalid argument

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -201,6 +201,8 @@ func (d *DiffProgram) getCommand(args ...string) (string, exec.Cmd) {
 			for i := 1; i < len(diffCommand); i++ {
 				if isValidChar(diffCommand[i]) {
 					args = append(args, diffCommand[i])
+				} else {
+					klog.Warningf("invalid argument is ignored: %s, only Alphanumeric (case-insensitive), dash and equal are allowed", diffCommand[i])
 				}
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently `kubectl diff` command ignores invalid arguments in `KUBECTL_EXTERNAL_DIFF`
without raising any error or warning. That brings about confusion for the user
whether passed parameter is used or not.

This PR adds simple warning for the ignored parameters.

#### Which issue(s) this PR fixes:
Fixes kubernetes/kubectl#1178

#### Does this PR introduce a user-facing change?
```release-note
Returns warning message if KUBECTL_EXTERNAL_DIFF includes invalid arguments
```
