### PR TITLE
Fix nodes volumesAttached status not being updated

### DIFF
--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -675,7 +675,6 @@ func (asw *actualStateOfWorld) GetVolumesToReportAttachedForNode(nodeName types.
 	asw.Lock()
 	defer asw.Unlock()
 
-	var attachedVolumes []v1.AttachedVolume
 	nodeToUpdateObj, ok := asw.nodesToUpdateStatusFor[nodeName]
 	if !ok {
 		return false, nil
@@ -684,7 +683,7 @@ func (asw *actualStateOfWorld) GetVolumesToReportAttachedForNode(nodeName types.
 		return false, nil
 	}
 
-	attachedVolumes = asw.getAttachedVolumeFromUpdateObject(nodeToUpdateObj.volumesToReportAsAttached)
+	volumesToReportAttached := asw.getAttachedVolumeFromUpdateObject(nodeToUpdateObj.volumesToReportAsAttached)
 	// When GetVolumesToReportAttached is called by node status updater, the current status
 	// of this node will be updated, so set the flag statusUpdateNeeded to false indicating
 	// the current status is already updated.
@@ -692,7 +691,7 @@ func (asw *actualStateOfWorld) GetVolumesToReportAttachedForNode(nodeName types.
 		klog.Errorf("Failed to update statusUpdateNeeded field when getting volumes: %v", err)
 	}
 
-	return true, attachedVolumes
+	return true, volumesToReportAttached
 }
 
 func (asw *actualStateOfWorld) GetNodesToUpdateStatusFor() map[types.NodeName]nodeToUpdateStatusFor {

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -202,7 +202,7 @@ func (rc *reconciler) reconcile() {
 			}
 
 			// Update Node Status to indicate volume is no longer safe to mount.
-			err = rc.nodeStatusUpdater.UpdateNodeStatuses()
+			err = rc.nodeStatusUpdater.UpdateNodeStatusForNode(attachedVolume.NodeName)
 			if err != nil {
 				// Skip detaching this volume if unable to update node status
 				klog.ErrorS(err, "UpdateNodeStatuses failed while attempting to report volume as attached", "volume", attachedVolume)

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -205,7 +205,7 @@ func (rc *reconciler) reconcile() {
 			err = rc.nodeStatusUpdater.UpdateNodeStatusForNode(attachedVolume.NodeName)
 			if err != nil {
 				// Skip detaching this volume if unable to update node status
-				klog.ErrorS(err, "UpdateNodeStatuses failed while attempting to report volume as attached", "volume", attachedVolume)
+				klog.ErrorS(err, "UpdateNodeStatusForNode failed while attempting to report volume as attached", "volume", attachedVolume)
 				continue
 			}
 

--- a/pkg/controller/volume/attachdetach/statusupdater/fake_node_status_updater.go
+++ b/pkg/controller/volume/attachdetach/statusupdater/fake_node_status_updater.go
@@ -18,6 +18,7 @@ package statusupdater
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func NewFakeNodeStatusUpdater(returnError bool) NodeStatusUpdater {
@@ -31,6 +32,14 @@ type fakeNodeStatusUpdater struct {
 }
 
 func (fnsu *fakeNodeStatusUpdater) UpdateNodeStatuses() error {
+	if fnsu.returnError {
+		return fmt.Errorf("fake error on update node status")
+	}
+
+	return nil
+}
+
+func (fnsu *fakeNodeStatusUpdater) UpdateNodeStatusForNode(nodeName types.NodeName) error {
 	if fnsu.returnError {
 		return fmt.Errorf("fake error on update node status")
 	}

--- a/pkg/controller/volume/attachdetach/statusupdater/node_status_updater.go
+++ b/pkg/controller/volume/attachdetach/statusupdater/node_status_updater.go
@@ -19,6 +19,7 @@ limitations under the License.
 package statusupdater
 
 import (
+	"fmt"
 	"k8s.io/klog/v2"
 
 	"k8s.io/api/core/v1"
@@ -36,6 +37,8 @@ type NodeStatusUpdater interface {
 	// Gets a list of node statuses that should be updated from the actual state
 	// of the world and updates them.
 	UpdateNodeStatuses() error
+	// Update any pending status change for the given node
+	UpdateNodeStatusForNode(nodeName types.NodeName) error
 }
 
 // NewNodeStatusUpdater returns a new instance of NodeStatusUpdater.
@@ -57,40 +60,65 @@ type nodeStatusUpdater struct {
 }
 
 func (nsu *nodeStatusUpdater) UpdateNodeStatuses() error {
+	var nodeIssues int
 	// TODO: investigate right behavior if nodeName is empty
 	// kubernetes/kubernetes/issues/37777
 	nodesToUpdate := nsu.actualStateOfWorld.GetVolumesToReportAttached()
 	for nodeName, attachedVolumes := range nodesToUpdate {
-		nodeObj, err := nsu.nodeLister.Get(string(nodeName))
-		if errors.IsNotFound(err) {
-			// If node does not exist, its status cannot be updated.
-			// Do nothing so that there is no retry until node is created.
-			klog.V(2).Infof(
-				"Could not update node status. Failed to find node %q in NodeInformer cache. Error: '%v'",
-				nodeName,
-				err)
-			continue
-		} else if err != nil {
-			// For all other errors, log error and reset flag statusUpdateNeeded
-			// back to true to indicate this node status needs to be updated again.
-			klog.V(2).Infof("Error retrieving nodes from node lister. Error: %v", err)
-			nsu.actualStateOfWorld.SetNodeStatusUpdateNeeded(nodeName)
-			continue
+		err := nsu.processNodeVolumes(nodeName, attachedVolumes)
+		if err != nil {
+			nodeIssues += 1
 		}
+	}
+	if nodeIssues > 0 {
+		return fmt.Errorf("unable to update %d nodes", nodeIssues)
+	}
+	return nil
+}
 
-		if err := nsu.updateNodeStatus(nodeName, nodeObj, attachedVolumes); err != nil {
-			// If update node status fails, reset flag statusUpdateNeeded back to true
-			// to indicate this node status needs to be updated again
-			nsu.actualStateOfWorld.SetNodeStatusUpdateNeeded(nodeName)
+func (nsu *nodeStatusUpdater) UpdateNodeStatusForNode(nodeName types.NodeName) error {
+	needsUpdate, attachedVolumes := nsu.actualStateOfWorld.GetVolumesToReportAttachedForNode(nodeName)
+	if !needsUpdate {
+		return nil
+	}
+	return nsu.processNodeVolumes(nodeName, attachedVolumes)
+}
 
-			klog.V(2).Infof(
-				"Could not update node status for %q; re-marking for update. %v",
-				nodeName,
-				err)
+func (nsu *nodeStatusUpdater) processNodeVolumes(nodeName types.NodeName, attachedVolumes []v1.AttachedVolume) error {
+	nodeObj, err := nsu.nodeLister.Get(string(nodeName))
+	if errors.IsNotFound(err) {
+		// If node does not exist, its status cannot be updated.
+		// Do nothing so that there is no retry until node is created.
+		klog.V(2).Infof(
+			"Could not update node status. Failed to find node %q in NodeInformer cache. Error: '%v'",
+			nodeName,
+			err)
+		return nil
+	} else if err != nil {
+		// For all other errors, log error and reset flag statusUpdateNeeded
+		// back to true to indicate this node status needs to be updated again.
+		klog.V(2).Infof("Error retrieving nodes from node lister. Error: %v", err)
+		nsu.actualStateOfWorld.SetNodeStatusUpdateNeeded(nodeName)
+		return err
+	}
 
-			// We currently always return immediately on error
-			return err
-		}
+	err = nsu.updateNodeStatus(nodeName, nodeObj, attachedVolumes)
+	if errors.IsNotFound(err) {
+		klog.V(2).Infof(
+			"Could not update node status for %q; node does not exist - skipping",
+			nodeName)
+		return nil
+	} else if err != nil {
+		// If update node status fails, reset flag statusUpdateNeeded back to true
+		// to indicate this node status needs to be updated again
+		nsu.actualStateOfWorld.SetNodeStatusUpdateNeeded(nodeName)
+
+		klog.V(2).Infof(
+			"Could not update node status for %q; re-marking for update. %v",
+			nodeName,
+			err)
+
+		return err
 	}
 	return nil
 }

--- a/pkg/controller/volume/attachdetach/statusupdater/node_status_updater.go
+++ b/pkg/controller/volume/attachdetach/statusupdater/node_status_updater.go
@@ -104,6 +104,8 @@ func (nsu *nodeStatusUpdater) processNodeVolumes(nodeName types.NodeName, attach
 
 	err = nsu.updateNodeStatus(nodeName, nodeObj, attachedVolumes)
 	if errors.IsNotFound(err) {
+		// If node does not exist, its status cannot be updated.
+		// Do nothing so that there is no retry until node is created.
 		klog.V(2).Infof(
 			"Could not update node status for %q; node does not exist - skipping",
 			nodeName)

--- a/pkg/controller/volume/attachdetach/statusupdater/node_status_updater_test.go
+++ b/pkg/controller/volume/attachdetach/statusupdater/node_status_updater_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statusupdater
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache"
+	controllervolumetesting "k8s.io/kubernetes/pkg/controller/volume/attachdetach/testing"
+	volumetesting "k8s.io/kubernetes/pkg/volume/testing"
+	"testing"
+)
+
+// setupNodeStatusUpdate creates all the needed objects for testing.
+// the initial environment has 2 nodes with no volumes attached
+// and adds one volume to attach to each node to the actual state of the world
+func setupNodeStatusUpdate(ctx context.Context, t *testing.T) (cache.ActualStateOfWorld, *fake.Clientset, NodeStatusUpdater) {
+	testNode1 := corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testnode-1",
+		},
+		Status: corev1.NodeStatus{},
+	}
+	testNode2 := corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testnode-2",
+		},
+		Status: corev1.NodeStatus{},
+	}
+	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
+	asw := cache.NewActualStateOfWorld(volumePluginMgr)
+	fakeKubeClient := fake.NewSimpleClientset(&testNode1, &testNode2)
+	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
+	nodeInformer := informerFactory.Core().V1().Nodes()
+	nsu := NewNodeStatusUpdater(fakeKubeClient, nodeInformer.Lister(), asw)
+
+	err := nodeInformer.Informer().GetStore().Add(&testNode1)
+	if err != nil {
+		t.Fatalf(".Informer().GetStore().Add failed. Expected: <no error> Actual: <%v>", err)
+	}
+	err = nodeInformer.Informer().GetStore().Add(&testNode2)
+	if err != nil {
+		t.Fatalf(".Informer().GetStore().Add failed. Expected: <no error> Actual: <%v>", err)
+	}
+
+	volumeName1 := corev1.UniqueVolumeName("volume-name-1")
+	volumeName2 := corev1.UniqueVolumeName("volume-name-2")
+	volumeSpec1 := controllervolumetesting.GetTestVolumeSpec(string(volumeName1), volumeName1)
+	volumeSpec2 := controllervolumetesting.GetTestVolumeSpec(string(volumeName2), volumeName2)
+
+	nodeName1 := types.NodeName("testnode-1")
+	nodeName2 := types.NodeName("testnode-2")
+	devicePath := "fake/device/path"
+
+	_, err = asw.AddVolumeNode(volumeName1, volumeSpec1, nodeName1, devicePath, true)
+	if err != nil {
+		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", err)
+	}
+	_, err = asw.AddVolumeNode(volumeName2, volumeSpec2, nodeName2, devicePath, true)
+	if err != nil {
+		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", err)
+	}
+
+	return asw, fakeKubeClient, nsu
+}
+
+// TestNodeStatusUpdater_UpdateNodeStatuses_TwoNodesUpdate calls setup
+// calls UpdateNodeStatuses()
+// check that asw.GetVolumesToReportAttached reports nothing left to attach
+// checks that each node status.volumesAttached is of length 1 and contains the correct volume
+func TestNodeStatusUpdater_UpdateNodeStatuses_TwoNodesUpdate(t *testing.T) {
+	ctx := context.Background()
+	asw, fakeKubeClient, nsu := setupNodeStatusUpdate(ctx, t)
+
+	err := nsu.UpdateNodeStatuses()
+	if err != nil {
+		t.Fatalf("UpdateNodeStatuses failed. Expected: <no error> Actual: <%v>", err)
+	}
+
+	needToReport := asw.GetVolumesToReportAttached()
+	if len(needToReport) != 0 {
+		t.Fatalf("len(asw.GetVolumesToReportAttached()) Expected: <0> Actual: <%v>", len(needToReport))
+	}
+
+	node, err := fakeKubeClient.CoreV1().Nodes().Get(ctx, "testnode-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Nodes().Get failed. Expected: <no error> Actual: <%v>", err)
+	}
+	if len(node.Status.VolumesAttached) != 1 {
+		t.Fatalf("len(node.Status.VolumesAttached) Expected: <1> Actual: <%v>", len(node.Status.VolumesAttached))
+	}
+	if node.Status.VolumesAttached[0].Name != "volume-name-1" {
+		t.Fatalf("volumeName Expected: <volume-name-1> Actual: <%s>", node.Status.VolumesAttached[0].Name)
+	}
+
+	node, err = fakeKubeClient.CoreV1().Nodes().Get(ctx, "testnode-2", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Nodes().Get failed. Expected: <no error> Actual: <%v>", err)
+	}
+	if len(node.Status.VolumesAttached) != 1 {
+		t.Fatalf("len(node.Status.VolumesAttached) Expected: <1> Actual: <%v>", len(node.Status.VolumesAttached))
+	}
+	if node.Status.VolumesAttached[0].Name != "volume-name-2" {
+		t.Fatalf("volumeName Expected: <volume-name-2> Actual: <%s>", node.Status.VolumesAttached[0].Name)
+	}
+}
+
+func TestNodeStatusUpdater_UpdateNodeStatuses_FailureInFirstUpdate(t *testing.T) {
+	ctx := context.Background()
+	asw, fakeKubeClient, nsu := setupNodeStatusUpdate(ctx, t)
+
+	var failedNode string
+	failedOnce := false
+	failureErr := fmt.Errorf("test generated error")
+	fakeKubeClient.PrependReactor("patch", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		patchAction := action.(core.PatchAction)
+		if !failedOnce {
+			failedNode = patchAction.GetName()
+			failedOnce = true
+			return true, nil, failureErr
+		}
+		return false, nil, nil
+	})
+
+	err := nsu.UpdateNodeStatuses()
+	if errors.Is(err, failureErr) {
+		t.Fatalf("UpdateNodeStatuses failed. Expected: <test generated error> Actual: <%v>", err)
+	}
+
+	needToReport := asw.GetVolumesToReportAttached()
+	if len(needToReport) != 1 {
+		t.Fatalf("len(asw.GetVolumesToReportAttached()) Expected: <1> Actual: <%v>", len(needToReport))
+	}
+	if _, ok := needToReport[types.NodeName(failedNode)]; !ok {
+		t.Fatalf("GetVolumesToReportAttached() did not report correct node Expected: <%s> Actual: <%v>", failedNode, needToReport)
+	}
+
+	nodes, err := fakeKubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Nodes().List failed. Expected: <no error> Actual: <%v>", err)
+	}
+
+	if len(nodes.Items) != 2 {
+		t.Fatalf("len(nodes.Items) Expected: <2> Actual: <%v>", len(nodes.Items))
+	}
+
+	for _, node := range nodes.Items {
+		if node.Name == failedNode {
+			if len(node.Status.VolumesAttached) != 0 {
+				t.Fatalf("len(node.Status.VolumesAttached) Expected: <0> Actual: <%v>", len(node.Status.VolumesAttached))
+			}
+		} else {
+			if len(node.Status.VolumesAttached) != 1 {
+				t.Fatalf("len(node.Status.VolumesAttached) Expected: <1> Actual: <%v>", len(node.Status.VolumesAttached))
+			}
+		}
+	}
+}
+
+// TestNodeStatusUpdater_UpdateNodeStatusForNode calls setup
+// calls UpdateNodeStatusesForNode on testnode-1
+// check that asw.GetVolumesToReportAttached reports testnode-2 needs to be reported
+// checks that testnode-1 status.volumesAttached is of length 1 and contains the correct volume
+func TestNodeStatusUpdater_UpdateNodeStatusForNode(t *testing.T) {
+	ctx := context.Background()
+	asw, fakeKubeClient, nsu := setupNodeStatusUpdate(ctx, t)
+
+	err := nsu.UpdateNodeStatusForNode("testnode-1")
+	if err != nil {
+		t.Fatalf("UpdateNodeStatuses failed. Expected: <no error> Actual: <%v>", err)
+	}
+
+	needToReport := asw.GetVolumesToReportAttached()
+	if len(needToReport) != 1 {
+		t.Fatalf("len(asw.GetVolumesToReportAttached()) Expected: <1> Actual: <%v>", len(needToReport))
+	}
+	if _, ok := needToReport["testnode-2"]; !ok {
+		t.Fatalf("GetVolumesToReportAttached() did not report correct node Expected: <testnode-2> Actual: <%v>", needToReport)
+	}
+
+	node, err := fakeKubeClient.CoreV1().Nodes().Get(ctx, "testnode-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Nodes().Get failed. Expected: <no error> Actual: <%v>", err)
+	}
+	if len(node.Status.VolumesAttached) != 1 {
+		t.Fatalf("len(node.Status.VolumesAttached) Expected: <1> Actual: <%v>", len(node.Status.VolumesAttached))
+	}
+	if node.Status.VolumesAttached[0].Name != "volume-name-1" {
+		t.Fatalf("volumeName Expected: <volume-name-1> Actual: <%s>", node.Status.VolumesAttached[0].Name)
+	}
+}


### PR DESCRIPTION
/kind bug

Fixes #107973 

The UpdateNodeStatuses code stops too early in case there is an error when calling updateNodeStatus. It will return immediately which means any remaining node won't have its update status put back to true.

Looking at the call sites for UpdateNodeStatuses, it appears this is not the only issue. If the lister call fails with anything but a Not Found error, it's silently ignored which is wrong in the detach path.
Also the reconciler detach path calls UpdateNodeStatuses but the real intent is to only update the node currently processed in the loop and not proceed with the detach call if there is an error updating that specify node volumesAttached property. With the current implementation, it will not proceed if there is an error updating another node (which is not completely bad but not ideal) and worse it will proceed if there is a lister error on that node which means the node volumesAttached property won't have been updated.

To fix those issues, introduce the following changes:
- [node_status_updater] introduce UpdateNodeStatusForNode which does what UpdateNodeStatuses does but only for the provided node
- [node_status_updater] if the node lister call fails for anything but a Not Found error, we will return an error, not ignore it
- [node_status_updater] if the update of a node volumesAttached properties fails we continue processing the other nodes
- [actual_state_of_world] introduce GetVolumesToReportAttachedForNode which does what GetVolumesToReportAttached but for the node whose name is provided it returns a bool which indicates if the node in question needs an update as well as the volumesAttached list. It is used by UpdateNodeStatusForNode
- [reconciler] use UpdateNodeStatusForNode in the detach loop

```release-note
Fix a bug in attachdetach controller that didn't properly handle kube-apiserver errors leading to stuck attachments/detachments.
```