### PR TITLE
storage: etcd: remove a duplicate test case

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -1357,20 +1357,6 @@ func TestList(t *testing.T) {
 			expectRV:       "1",
 		},
 		{
-			name:   "test List with limit at old resource version and match=Exact",
-			prefix: "/two-level/",
-			pred: storage.SelectionPredicate{
-				Label: labels.Everything(),
-				Field: fields.Everything(),
-				Limit: 1,
-			},
-			expectedOut:    []*example.Pod{},
-			expectContinue: false,
-			rv:             "1",
-			rvMatch:        metav1.ResourceVersionMatchExact,
-			expectRV:       "1",
-		},
-		{
 			name:          "test List with limit when paging disabled",
 			disablePaging: true,
 			prefix:        "/two-level/",


### PR DESCRIPTION
This test case was a duplicate of the previous one.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind cleanup
/sig api-machinery
/cc @stts @liggitt 

```release-note
NONE
```

```docs

```
