### PR TITLE
Automated cherry pick of #105706: Upgrade etcd to 3.5.1

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -78,7 +78,7 @@ dependencies:
 
   # etcd
   - name: "etcd"
-    version: 3.5.0
+    version: 3.5.1
     refPaths:
     - path: cluster/gce/manifests/etcd.manifest
       match: etcd_docker_tag|etcd_version
@@ -93,7 +93,7 @@ dependencies:
       match: const etcdImage
 
   - name: "etcd-image"
-    version: 3.5.0
+    version: 3.5.1
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: BUNDLED_ETCD_VERSIONS\?|LATEST_ETCD_VERSION\?

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -212,7 +212,7 @@ HEAPSTER_MACHINE_TYPE=${HEAPSTER_MACHINE_TYPE:-}
 NUM_ADDITIONAL_NODES=${NUM_ADDITIONAL_NODES:-}
 ADDITIONAL_MACHINE_TYPE=${ADDITIONAL_MACHINE_TYPE:-}
 
-# Set etcd image (e.g. k8s.gcr.io/etcd) and version (e.g. v3.5.0-0) if you need
+# Set etcd image (e.g. k8s.gcr.io/etcd) and version (e.g. v3.5.1-0) if you need
 # non-default version.
 export ETCD_IMAGE=${TEST_ETCD_IMAGE:-}
 export ETCD_DOCKER_REPOSITORY=${TEST_ETCD_DOCKER_REPOSITORY:-}

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -18,7 +18,7 @@
     {
     "name": "etcd-container",
     {{security_context}}
-    "image": "{{ pillar.get('etcd_docker_repository', 'k8s.gcr.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.0-rc.0-0') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'k8s.gcr.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.1-0') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}
@@ -34,7 +34,7 @@
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
       },
       { "name": "TARGET_VERSION",
-        "value": "{{ pillar.get('etcd_version', '3.5.0-rc.0') }}"
+        "value": "{{ pillar.get('etcd_version', '3.5.1') }}"
       },
       {
         "name": "DO_NOT_MOVE_BINARIES",

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -170,8 +170,8 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.5.0-0
-export ETCD_VERSION=3.5.0
+export ETCD_IMAGE=3.5.1-0
+export ETCD_VERSION=3.5.1
 
 # Upgrade master with updated kube envs
 "${KUBE_ROOT}/cluster/gce/upgrade.sh" -M -l

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -15,7 +15,7 @@
 # Build the etcd image
 #
 # Usage:
-# 	[BUNDLED_ETCD_VERSIONS=3.0.17 3.1.12 3.2.24 3.3.17 3.4.13 3.5.0] [REGISTRY=k8s.gcr.io] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
+# 	[BUNDLED_ETCD_VERSIONS=3.0.17 3.1.12 3.2.24 3.3.17 3.4.13 3.5.1] [REGISTRY=k8s.gcr.io] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
 #
 # The image contains different etcd versions to simplify
 # upgrades. Thus be careful when removing any versions from here.
@@ -26,10 +26,10 @@
 # Except from etcd-$(version) and etcdctl-$(version) binaries, we also
 # need etcd and etcdctl binaries for backward compatibility reasons.
 # That binary will be set to the last version from $(BUNDLED_ETCD_VERSIONS).
-BUNDLED_ETCD_VERSIONS?=3.0.17 3.1.12 3.2.24 3.3.17 3.4.13 3.5.0
+BUNDLED_ETCD_VERSIONS?=3.0.17 3.1.12 3.2.24 3.3.17 3.4.13 3.5.1
 
 # LATEST_ETCD_VERSION identifies the most recent etcd version available.
-LATEST_ETCD_VERSION?=3.5.0
+LATEST_ETCD_VERSION?=3.5.1
 
 # REVISION provides a version number for this image and all it's bundled
 # artifacts. It should start at zero for each LATEST_ETCD_VERSION and increment

--- a/cluster/images/etcd/migrate/options.go
+++ b/cluster/images/etcd/migrate/options.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	supportedEtcdVersions = []string{"3.0.17", "3.1.12", "3.2.24", "3.3.17", "3.4.13", "3.5.0"}
+	supportedEtcdVersions = []string{"3.0.17", "3.1.12", "3.2.24", "3.3.17", "3.4.13", "3.5.1"}
 )
 
 const (

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -286,7 +286,7 @@ const (
 	MinExternalEtcdVersion = "3.2.18"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.5.0-0"
+	DefaultEtcdVersion = "3.5.1-0"
 
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"
@@ -467,8 +467,8 @@ var (
 		19: "3.4.13-0",
 		20: "3.4.13-0",
 		21: "3.4.13-0",
-		22: "3.5.0-0",
-		23: "3.5.0-0",
+		22: "3.5.1-0",
+		23: "3.5.1-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.5.0}
+ETCD_VERSION=${ETCD_VERSION:-3.5.1}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 export KUBE_INTEGRATION_ETCD_URL="http://${ETCD_HOST}:${ETCD_PORT}"

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
@@ -26,4 +26,4 @@ spec:
         imagePullPolicy: Never
         args: [ "--etcd-servers=http://localhost:2379" ]
       - name: etcd
-        image: quay.io/coreos/etcd:v3.5.0
+        image: quay.io/coreos/etcd:v3.5.1

--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -34,7 +34,7 @@ import (
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 )
 
-const etcdImage = "3.5.0-0"
+const etcdImage = "3.5.1-0"
 
 // EtcdUpgrade upgrades etcd on GCE.
 func EtcdUpgrade(targetStorage, targetVersion string) error {


### PR DESCRIPTION
Cherry pick of #105706 on release-1.22.

#105706: Upgrade etcd to 3.5.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.