### PR TITLE
Automated cherry pick of #108149: fix: do not return early in the node informer when there is

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -749,10 +749,6 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 		UpdateFunc: func(prev, obj interface{}) {
 			prevNode := prev.(*v1.Node)
 			newNode := obj.(*v1.Node)
-			if newNode.Labels[v1.LabelTopologyZone] ==
-				prevNode.Labels[v1.LabelTopologyZone] {
-				return
-			}
 			az.updateNodeCaches(prevNode, newNode)
 		},
 		DeleteFunc: func(obj interface{}) {


### PR DESCRIPTION
Cherry pick of #108149 on release-1.23.

#108149: fix: do not return early in the node informer when there is

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
fix a 1.23 regression: do not return early in the node informer when there is no change of the topology label.
```