### PR TITLE
Add serathius to etcd image owners

### DIFF
--- a/cluster/images/etcd/OWNERS
+++ b/cluster/images/etcd/OWNERS
@@ -2,7 +2,9 @@
 
 reviewers:
   - jpbetz
+  - serathius
 approvers:
   - jpbetz
+  - serathius
 labels:
   - sig/api-machinery


### PR DESCRIPTION
I would like to propose myself as an etcd image owner. Existing owner (jpbetz@) is no longer actively working on etcd, nor reviewing PR for etcd upgrade in K8s. Without active owner for etcd image, all reviews are need to be done by top level approvers.

About my work on etcd:
* Proposed, and lead release of etcd v3.5.0 to Kubernetes https://github.com/kubernetes/kubernetes/issues/102294
* Heavily involved in Etcd v3.5.1 and v3.5.2 release, on both Etcd (https://github.com/etcd-io/etcd/issues/13518) and Kubernetes side (https://github.com/kubernetes/kubernetes/issues/106589#issuecomment-976380111)
* Etcd maintainer https://github.com/etcd-io/etcd/pull/13652

I hope that by having active image owner we can have etcd releases in Kubernetes delivered earlier and more effectivly.

/kind cleanup
```release-note
NONE
```