### PR TITLE
there is no need for gci-docker-version and gci-ensure-gke-docker - t…

### DIFF
--- a/cluster/gce/gci/helper.sh
+++ b/cluster/gce/gci/helper.sh
@@ -23,10 +23,4 @@ function ensure-gci-metadata-files {
   if [[ ! -f "${KUBE_TEMP}/gci-update.txt" ]]; then
     echo -n "update_disabled" > "${KUBE_TEMP}/gci-update.txt"
   fi
-  if [[ ! -f "${KUBE_TEMP}/gci-ensure-gke-docker.txt" ]]; then
-    echo -n "true" > "${KUBE_TEMP}/gci-ensure-gke-docker.txt"
-  fi
-  if [[ ! -f "${KUBE_TEMP}/gci-docker-version.txt" ]]; then
-    echo -n "${GCI_DOCKER_VERSION:-}" > "${KUBE_TEMP}/gci-docker-version.txt"
-  fi
 }

--- a/cluster/gce/gci/master-helper.sh
+++ b/cluster/gce/gci/master-helper.sh
@@ -86,8 +86,6 @@ function replicate-master-instance() {
   echo "${master_certs}" > "${KUBE_TEMP}/kube-master-certs.yaml"
   get-metadata "${existing_master_zone}" "${existing_master_name}" cluster-name > "${KUBE_TEMP}/cluster-name.txt"
   get-metadata "${existing_master_zone}" "${existing_master_name}" gci-update-strategy > "${KUBE_TEMP}/gci-update.txt"
-  get-metadata "${existing_master_zone}" "${existing_master_name}" gci-ensure-gke-docker > "${KUBE_TEMP}/gci-ensure-gke-docker.txt"
-  get-metadata "${existing_master_zone}" "${existing_master_name}" gci-docker-version > "${KUBE_TEMP}/gci-docker-version.txt"
   get-metadata "${existing_master_zone}" "${existing_master_name}" cluster-location > "${KUBE_TEMP}/cluster-location.txt"
 
   create-master-instance-internal "${REPLICA_NAME}"
@@ -158,8 +156,6 @@ function create-master-instance-internal() {
   metadata="${metadata},cluster-location=${KUBE_TEMP}/cluster-location.txt"
   metadata="${metadata},cluster-name=${KUBE_TEMP}/cluster-name.txt"
   metadata="${metadata},gci-update-strategy=${KUBE_TEMP}/gci-update.txt"
-  metadata="${metadata},gci-ensure-gke-docker=${KUBE_TEMP}/gci-ensure-gke-docker.txt"
-  metadata="${metadata},gci-docker-version=${KUBE_TEMP}/gci-docker-version.txt"
   metadata="${metadata},kube-master-certs=${KUBE_TEMP}/kube-master-certs.yaml"
   metadata="${metadata},cluster-location=${KUBE_TEMP}/cluster-location.txt"
   metadata="${metadata},kube-master-internal-route=${KUBE_ROOT}/cluster/gce/gci/kube-master-internal-route.sh"

--- a/cluster/gce/gci/node-helper.sh
+++ b/cluster/gce/gci/node-helper.sh
@@ -28,8 +28,6 @@ function get-node-instance-metadata-from-file {
   metadata+="cluster-location=${KUBE_TEMP}/cluster-location.txt,"
   metadata+="cluster-name=${KUBE_TEMP}/cluster-name.txt,"
   metadata+="gci-update-strategy=${KUBE_TEMP}/gci-update.txt,"
-  metadata+="gci-ensure-gke-docker=${KUBE_TEMP}/gci-ensure-gke-docker.txt,"
-  metadata+="gci-docker-version=${KUBE_TEMP}/gci-docker-version.txt,"
   metadata+="shutdown-script=${KUBE_ROOT}/cluster/gce/gci/shutdown.sh,"
   metadata+="${NODE_EXTRA_METADATA}"
   echo "${metadata}"


### PR DESCRIPTION
…hose are not used by COS or any of scripts

/kind cleanup
/sig node
/assign @bsdnet 

The only reference to one of these is being removed here: https://github.com/kubernetes/kubernetes/pull/108192

@bsdnet to re-confirm those are not real COS metadata keys.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
