### PR TITLE
increase Azure ACR credential provider timeout

### DIFF
--- a/pkg/credentialprovider/azure/azure_acr_helper.go
+++ b/pkg/credentialprovider/azure/azure_acr_helper.go
@@ -81,7 +81,7 @@ const dockerTokenLoginUsernameGUID = "00000000-0000-0000-0000-000000000000"
 
 var client = &http.Client{
 	Transport: utilnet.SetTransportDefaults(&http.Transport{}),
-	Timeout:   time.Second * 10,
+	Timeout:   time.Second * 60,
 }
 
 func receiveChallengeFromLoginServer(serverAddress string) (*authDirective, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
increase Azure ACR credential provider timeout
from 1.22, connection timeout to ACR is set as 10s, which in some cases, 10s is not enough, would cause following timeout:
```
Feb 16 10:05:09 aks-pdweappool02-29359546-vmss000002 kubelet[28475]: E0216 10:05:09.652945   28475 azure_credentials.go:326] failed to receive challenge: error reaching registry endpoint https://xxx.azurecr.io/v2/, error: Get "https://xxx.azurecr.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)Feb 16 10:05:09 aks-pdweappool02-29359546-vmss000002 kubelet[28475]: E0216 10:05:09.652966   28475 azure_credentials.go:264] error getting credentials from ACR for xxx.azurecr.io error reaching registry endpoint https://xxx.azurecr.io/v2/, error: Get "https://xxx.azurecr.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

This PR increases timeout from 10s to 60s


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
increase Azure ACR credential provider timeout
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
increase Azure ACR credential provider timeout
```

/kind bug
/assign @feiskyer 
/priority important-soon
/sig cloud-provider
/area provider/azure
/triage accepted
