### PR TITLE
Automated cherry pick of #108209: increase Azure ACR credential provider timeout

### DIFF
--- a/pkg/credentialprovider/azure/azure_acr_helper.go
+++ b/pkg/credentialprovider/azure/azure_acr_helper.go
@@ -80,7 +80,7 @@ const dockerTokenLoginUsernameGUID = "00000000-0000-0000-0000-000000000000"
 
 var client = &http.Client{
 	Transport: utilnet.SetTransportDefaults(&http.Transport{}),
-	Timeout:   time.Second * 10,
+	Timeout:   time.Second * 60,
 }
 
 func receiveChallengeFromLoginServer(serverAddress string) (*authDirective, error) {


### PR DESCRIPTION
Cherry pick of #108209 on release-1.22.

#108209: increase Azure ACR credential provider timeout

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.