### PR TITLE
Support ExtenderName in FakeExtender

### DIFF
--- a/pkg/scheduler/extender_test.go
+++ b/pkg/scheduler/extender_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -58,10 +58,12 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			},
 			extenders: []st.FakeExtender{
 				{
-					Predicates: []st.FitPredicate{st.TruePredicateExtender},
+					ExtenderName: "FakeExtender1",
+					Predicates:   []st.FitPredicate{st.TruePredicateExtender},
 				},
 				{
-					Predicates: []st.FitPredicate{st.ErrorPredicateExtender},
+					ExtenderName: "FakeExtender2",
+					Predicates:   []st.FitPredicate{st.ErrorPredicateExtender},
 				},
 			},
 			nodes:      []string{"node1", "node2"},
@@ -76,10 +78,12 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			},
 			extenders: []st.FakeExtender{
 				{
-					Predicates: []st.FitPredicate{st.TruePredicateExtender},
+					ExtenderName: "FakeExtender1",
+					Predicates:   []st.FitPredicate{st.TruePredicateExtender},
 				},
 				{
-					Predicates: []st.FitPredicate{st.FalsePredicateExtender},
+					ExtenderName: "FakeExtender2",
+					Predicates:   []st.FitPredicate{st.FalsePredicateExtender},
 				},
 			},
 			nodes:      []string{"node1", "node2"},
@@ -94,10 +98,12 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			},
 			extenders: []st.FakeExtender{
 				{
-					Predicates: []st.FitPredicate{st.TruePredicateExtender},
+					ExtenderName: "FakeExtender1",
+					Predicates:   []st.FitPredicate{st.TruePredicateExtender},
 				},
 				{
-					Predicates: []st.FitPredicate{st.Node1PredicateExtender},
+					ExtenderName: "FakeExtender2",
+					Predicates:   []st.FitPredicate{st.Node1PredicateExtender},
 				},
 			},
 			nodes: []string{"node1", "node2"},
@@ -116,10 +122,12 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			},
 			extenders: []st.FakeExtender{
 				{
-					Predicates: []st.FitPredicate{st.Node2PredicateExtender},
+					ExtenderName: "FakeExtender1",
+					Predicates:   []st.FitPredicate{st.Node2PredicateExtender},
 				},
 				{
-					Predicates: []st.FitPredicate{st.Node1PredicateExtender},
+					ExtenderName: "FakeExtender2",
+					Predicates:   []st.FitPredicate{st.Node1PredicateExtender},
 				},
 			},
 			nodes:      []string{"node1", "node2"},
@@ -134,6 +142,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			},
 			extenders: []st.FakeExtender{
 				{
+					ExtenderName: "FakeExtender1",
 					Predicates:   []st.FitPredicate{st.TruePredicateExtender},
 					Prioritizers: []st.PriorityConfig{{Function: st.ErrorPrioritizerExtender, Weight: 10}},
 					Weight:       1,
@@ -155,11 +164,13 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			},
 			extenders: []st.FakeExtender{
 				{
+					ExtenderName: "FakeExtender1",
 					Predicates:   []st.FitPredicate{st.TruePredicateExtender},
 					Prioritizers: []st.PriorityConfig{{Function: st.Node1PrioritizerExtender, Weight: 10}},
 					Weight:       1,
 				},
 				{
+					ExtenderName: "FakeExtender2",
 					Predicates:   []st.FitPredicate{st.TruePredicateExtender},
 					Prioritizers: []st.PriorityConfig{{Function: st.Node2PrioritizerExtender, Weight: 10}},
 					Weight:       5,
@@ -182,6 +193,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			},
 			extenders: []st.FakeExtender{
 				{
+					ExtenderName: "FakeExtender1",
 					Predicates:   []st.FitPredicate{st.TruePredicateExtender},
 					Prioritizers: []st.PriorityConfig{{Function: st.Node1PrioritizerExtender, Weight: 10}},
 					Weight:       1,
@@ -211,6 +223,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			},
 			extenders: []st.FakeExtender{
 				{
+					ExtenderName: "FakeExtender1",
 					Predicates:   []st.FitPredicate{st.ErrorPredicateExtender},
 					Prioritizers: []st.PriorityConfig{{Function: st.ErrorPrioritizerExtender, Weight: 10}},
 					UnInterested: true,
@@ -238,11 +251,13 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			},
 			extenders: []st.FakeExtender{
 				{
-					Predicates: []st.FitPredicate{st.ErrorPredicateExtender},
-					Ignorable:  true,
+					ExtenderName: "FakeExtender1",
+					Predicates:   []st.FitPredicate{st.ErrorPredicateExtender},
+					Ignorable:    true,
 				},
 				{
-					Predicates: []st.FitPredicate{st.Node1PredicateExtender},
+					ExtenderName: "FakeExtender2",
+					Predicates:   []st.FitPredicate{st.Node1PredicateExtender},
 				},
 			},
 			nodes:      []string{"node1", "node2"},

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -227,7 +227,10 @@ func TestPostFilter(t *testing.T) {
 				"node1": framework.NewStatus(framework.Unschedulable),
 				"node2": framework.NewStatus(framework.Unschedulable),
 			},
-			extender:   &st.FakeExtender{Predicates: []st.FitPredicate{st.Node1PredicateExtender}},
+			extender: &st.FakeExtender{
+				ExtenderName: "FakeExtender1",
+				Predicates:   []st.FitPredicate{st.Node1PredicateExtender},
+			},
 			wantResult: framework.NewPostFilterResultWithNominatedNode("node1"),
 			wantStatus: framework.NewStatus(framework.Success),
 		},
@@ -1506,8 +1509,14 @@ func TestPreempt(t *testing.T) {
 			},
 			nodeNames: []string{"node1", "node2", "node3"},
 			extenders: []*st.FakeExtender{
-				{Predicates: []st.FitPredicate{st.TruePredicateExtender}},
-				{Predicates: []st.FitPredicate{st.Node1PredicateExtender}},
+				{
+					ExtenderName: "FakeExtender1",
+					Predicates:   []st.FitPredicate{st.TruePredicateExtender},
+				},
+				{
+					ExtenderName: "FakeExtender2",
+					Predicates:   []st.FitPredicate{st.Node1PredicateExtender},
+				},
 			},
 			registerPlugin: st.RegisterPluginAsExtensions(noderesources.Name, nodeResourcesFitFunc, "Filter", "PreFilter"),
 			want:           framework.NewPostFilterResultWithNominatedNode("node1"),
@@ -1523,7 +1532,10 @@ func TestPreempt(t *testing.T) {
 			},
 			nodeNames: []string{"node1", "node2", "node3"},
 			extenders: []*st.FakeExtender{
-				{Predicates: []st.FitPredicate{st.FalsePredicateExtender}},
+				{
+					ExtenderName: "FakeExtender1",
+					Predicates:   []st.FitPredicate{st.FalsePredicateExtender},
+				},
 			},
 			registerPlugin: st.RegisterPluginAsExtensions(noderesources.Name, nodeResourcesFitFunc, "Filter", "PreFilter"),
 			want:           nil,
@@ -1539,8 +1551,15 @@ func TestPreempt(t *testing.T) {
 			},
 			nodeNames: []string{"node1", "node2", "node3"},
 			extenders: []*st.FakeExtender{
-				{Predicates: []st.FitPredicate{st.ErrorPredicateExtender}, Ignorable: true},
-				{Predicates: []st.FitPredicate{st.Node1PredicateExtender}},
+				{
+					Predicates:   []st.FitPredicate{st.ErrorPredicateExtender},
+					Ignorable:    true,
+					ExtenderName: "FakeExtender1",
+				},
+				{
+					Predicates:   []st.FitPredicate{st.Node1PredicateExtender},
+					ExtenderName: "FakeExtender2",
+				},
 			},
 			registerPlugin: st.RegisterPluginAsExtensions(noderesources.Name, nodeResourcesFitFunc, "Filter", "PreFilter"),
 			want:           framework.NewPostFilterResultWithNominatedNode("node1"),
@@ -1556,8 +1575,15 @@ func TestPreempt(t *testing.T) {
 			},
 			nodeNames: []string{"node1", "node2"},
 			extenders: []*st.FakeExtender{
-				{Predicates: []st.FitPredicate{st.Node1PredicateExtender}, UnInterested: true},
-				{Predicates: []st.FitPredicate{st.TruePredicateExtender}},
+				{
+					ExtenderName: "FakeExtender1",
+					Predicates:   []st.FitPredicate{st.Node1PredicateExtender},
+					UnInterested: true,
+				},
+				{
+					ExtenderName: "FakeExtender2",
+					Predicates:   []st.FitPredicate{st.TruePredicateExtender},
+				},
 			},
 			registerPlugin: st.RegisterPluginAsExtensions(noderesources.Name, nodeResourcesFitFunc, "Filter", "PreFilter"),
 			// sum of priorities of all victims on node1 is larger than node2, node2 is chosen.

--- a/pkg/scheduler/generic_scheduler_test.go
+++ b/pkg/scheduler/generic_scheduler_test.go
@@ -285,7 +285,8 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 			name: "error",
 			extenders: []st.FakeExtender{
 				{
-					Predicates: []st.FitPredicate{st.ErrorPredicateExtender},
+					ExtenderName: "FakeExtender1",
+					Predicates:   []st.FitPredicate{st.ErrorPredicateExtender},
 				},
 			},
 			nodes:                 makeNodeList([]string{"a"}),
@@ -296,7 +297,8 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 			name: "success",
 			extenders: []st.FakeExtender{
 				{
-					Predicates: []st.FitPredicate{st.TruePredicateExtender},
+					ExtenderName: "FakeExtender1",
+					Predicates:   []st.FitPredicate{st.TruePredicateExtender},
 				},
 			},
 			nodes:                 makeNodeList([]string{"a"}),
@@ -309,6 +311,7 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 			name: "unschedulable",
 			extenders: []st.FakeExtender{
 				{
+					ExtenderName: "FakeExtender1",
 					Predicates: []st.FitPredicate{func(pod *v1.Pod, node *v1.Node) *framework.Status {
 						if node.Name == "a" {
 							return framework.NewStatus(framework.Success)
@@ -329,6 +332,7 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 			name: "unschedulable and unresolvable",
 			extenders: []st.FakeExtender{
 				{
+					ExtenderName: "FakeExtender1",
 					Predicates: []st.FitPredicate{func(pod *v1.Pod, node *v1.Node) *framework.Status {
 						if node.Name == "a" {
 							return framework.NewStatus(framework.Success)
@@ -353,6 +357,7 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 			name: "extender may overwrite the statuses",
 			extenders: []st.FakeExtender{
 				{
+					ExtenderName: "FakeExtender1",
 					Predicates: []st.FitPredicate{func(pod *v1.Pod, node *v1.Node) *framework.Status {
 						if node.Name == "a" {
 							return framework.NewStatus(framework.Success)
@@ -379,6 +384,7 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 			name: "multiple extenders",
 			extenders: []st.FakeExtender{
 				{
+					ExtenderName: "FakeExtender1",
 					Predicates: []st.FitPredicate{func(pod *v1.Pod, node *v1.Node) *framework.Status {
 						if node.Name == "a" {
 							return framework.NewStatus(framework.Success)
@@ -390,6 +396,7 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 					}},
 				},
 				{
+					ExtenderName: "FakeExtender1",
 					Predicates: []st.FitPredicate{func(pod *v1.Pod, node *v1.Node) *framework.Status {
 						if node.Name == "a" {
 							return framework.NewStatus(framework.Success)

--- a/pkg/scheduler/testing/fake_extender.go
+++ b/pkg/scheduler/testing/fake_extender.go
@@ -143,6 +143,9 @@ func (pl *node2PrioritizerPlugin) ScoreExtensions() framework.ScoreExtensions {
 
 // FakeExtender is a data struct which implements the Extender interface.
 type FakeExtender struct {
+	// ExtenderName indicates this fake extender's name.
+	// Note that extender name should be unique.
+	ExtenderName     string
 	Predicates       []FitPredicate
 	Prioritizers     []PriorityConfig
 	Weight           int64
@@ -155,9 +158,15 @@ type FakeExtender struct {
 	CachedNodeNameToInfo map[string]*framework.NodeInfo
 }
 
+const defaultFakeExtenderName = "defaultFakeExtender"
+
 // Name returns name of the extender.
 func (f *FakeExtender) Name() string {
-	return "FakeExtender"
+	if f.ExtenderName == "" {
+		// If ExtenderName is unset, use default name.
+		return defaultFakeExtenderName
+	}
+	return f.ExtenderName
 }
 
 // IsIgnorable returns a bool value indicating whether internal errors can be ignored.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The name of Extender should be unique. There is no way to specify FakeExtender's name and all FakeExtender's name is "FakeExtender". This PR supports ExtenderName in FakeExtender to allow to specify FakeExtender's name.

Currently, There are no issue with this because in k/k no one is using `Name()` func on Extender. 
But, #107984 adds top 3 score of node in event message and will use `Name()` method on Extender to get Extender's name for event messages. Therefore, #107984 needs the way to specify FakeExtender's name for unit tests.

(I implemented this feature in #107984, but #107984 is big and difficult to review because of that. Therefore, I'm considering splitting #107984 into multiple PRs. This PR is one of them.)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
