### PR TITLE
Skip ESIPP e2e testcases when the provider is local

### DIFF
--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -768,7 +768,8 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 	// [LinuxOnly]: Windows does not support session affinity.
 	ginkgo.It("should have session affinity work for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters] [LinuxOnly]", func() {
 		// L4 load balancer affinity `ClientIP` is not supported on AWS ELB.
-		e2eskipper.SkipIfProviderIs("aws")
+		// local provider might not be configured to support external load balancer.
+		e2eskipper.SkipIfProviderIs("aws", "local")
 
 		svc := getServeHostnameService("affinity-lb-esipp")
 		svc.Spec.Type = v1.ServiceTypeLoadBalancer
@@ -780,7 +781,8 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 	// [LinuxOnly]: Windows does not support session affinity.
 	ginkgo.It("should be able to switch session affinity for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters] [LinuxOnly]", func() {
 		// L4 load balancer affinity `ClientIP` is not supported on AWS ELB.
-		e2eskipper.SkipIfProviderIs("aws")
+		// local provider might not be configured to support external load balancer.
+		e2eskipper.SkipIfProviderIs("aws", "local")
 
 		svc := getServeHostnameService("affinity-lb-esipp-transition")
 		svc.Spec.Type = v1.ServiceTypeLoadBalancer
@@ -792,7 +794,8 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 	// [LinuxOnly]: Windows does not support session affinity.
 	ginkgo.It("should have session affinity work for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters] [LinuxOnly]", func() {
 		// L4 load balancer affinity `ClientIP` is not supported on AWS ELB.
-		e2eskipper.SkipIfProviderIs("aws")
+		// local provider might not be configured to support external load balancer.
+		e2eskipper.SkipIfProviderIs("aws", "local")
 
 		svc := getServeHostnameService("affinity-lb")
 		svc.Spec.Type = v1.ServiceTypeLoadBalancer
@@ -804,7 +807,8 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 	// [LinuxOnly]: Windows does not support session affinity.
 	ginkgo.It("should be able to switch session affinity for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters] [LinuxOnly]", func() {
 		// L4 load balancer affinity `ClientIP` is not supported on AWS ELB.
-		e2eskipper.SkipIfProviderIs("aws")
+		// local provider might not be configured to support external load balancer.
+		e2eskipper.SkipIfProviderIs("aws", "local")
 
 		svc := getServeHostnameService("affinity-lb-transition")
 		svc.Spec.Type = v1.ServiceTypeLoadBalancer


### PR DESCRIPTION
local provider does not always support external load balancer, if those
testcases want to be covered by local provider, some extra setups are
needed, obviously, this is not implemented yet.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Run the testcase with local provider get the error like this, 

```
  Feb 21 14:10:51.090: Unexpected error:
      <*fmt.wrapError | 0xc000709620>: {
          msg: "timed out waiting for service \"affinity-lb-transition\" to have a load balancer: timed out waiting for the condition",
          err: <*errors.errorString | 0xc00019bad0>{
              s: "timed out waiting for the condition",
          },
      }
      timed out waiting for service "affinity-lb-transition" to have a load balancer: timed out waiting for the condition
```

It's actually failed with check here, 
https://github.com/kubernetes/kubernetes/blob/f0d5ea1e1d4d43cd5caac92800207fcd2a62538c/test/e2e/framework/service/jig.go#L582

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig testing