### PR TITLE
test: support storage tests with non-standard kubelet root directory

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -77,7 +77,7 @@ type TestContextType struct {
 	KubeConfig         string
 	KubeContext        string
 	KubeAPIContentType string
-	KubeVolumeDir      string
+	KubeletRootDir     string
 	CertDir            string
 	Host               string
 	BearerToken        string `datapolicy:"token"`
@@ -337,7 +337,8 @@ func RegisterClusterFlags(flags *flag.FlagSet) {
 	flags.StringVar(&TestContext.KubeContext, clientcmd.FlagContext, "", "kubeconfig context to use/override. If unset, will use value from 'current-context'")
 	flags.StringVar(&TestContext.KubeAPIContentType, "kube-api-content-type", "application/vnd.kubernetes.protobuf", "ContentType used to communicate with apiserver")
 
-	flags.StringVar(&TestContext.KubeVolumeDir, "volume-dir", "/var/lib/kubelet", "Path to the directory containing the kubelet volumes.")
+	flags.StringVar(&TestContext.KubeletRootDir, "kubelet-root-dir", "/var/lib/kubelet", "The data directory of kubelet. Some tests (for example, CSI storage tests) deploy DaemonSets which need to know this value and cannot query it. Such tests only work in clusters where the data directory is the same on all nodes.")
+	flags.StringVar(&TestContext.KubeletRootDir, "volume-dir", "/var/lib/kubelet", "An alias for --kubelet-root-dir, kept for backwards compatibility.")
 	flags.StringVar(&TestContext.CertDir, "cert-dir", "", "Path to the directory containing the certs. Default is empty, which doesn't use certs.")
 	flags.StringVar(&TestContext.RepoRoot, "repo-root", "../../", "Root directory of kubernetes repository, for finding test files.")
 	// NOTE: Node E2E tests have this flag defined as well, but true by default.

--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -234,8 +234,8 @@ func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) 
 
 	// Confirm that the file can be accessed from a second
 	// pod using host_path with the same MCS label
-	volumeHostPath := fmt.Sprintf("%s/pods/%s/volumes/kubernetes.io~empty-dir/%s", framework.TestContext.KubeVolumeDir, foundPod.UID, volumeName)
-	ginkgo.By(fmt.Sprintf("confirming a container with the same label can read the file under --volume-dir=%s", framework.TestContext.KubeVolumeDir))
+	volumeHostPath := fmt.Sprintf("%s/pods/%s/volumes/kubernetes.io~empty-dir/%s", framework.TestContext.KubeletRootDir, foundPod.UID, volumeName)
+	ginkgo.By(fmt.Sprintf("confirming a container with the same label can read the file under --kubelet-root-dir=%s", framework.TestContext.KubeletRootDir))
 	pod = scTestPod(hostIPC, hostPID)
 	pod.Spec.NodeName = foundPod.Spec.NodeName
 	volumeMounts := []v1.VolumeMount{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Some storage tests deploy DaemonSets which hard-code /var/lib/kubelet as root
directory for kubelet registration and pod directory. To enable those tests in
clusters with some other directory, a new global parameter gets added and the
value defined there gets patched into the relevant places of a CSI driver's
YAML files.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92664

#### Special notes for your reviewer:

A global parameter is used because other tests might also need the same
information.


There are currently no Prow jobs which use a non-standard path. I verified manually that the new flag has the intended behavior:
```
# Without flags.
$ kubectl get pods --all-namespaces -o yaml | grep /var/lib/kubelet
                k:{"mountPath":"/var/lib/kubelet/plugins"}:
                k:{"mountPath":"/var/lib/kubelet/pods"}:
      - mountPath: /var/lib/kubelet/pods
      - mountPath: /var/lib/kubelet/plugins
      - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-hostpath-provisioning-8787/csi.sock
        path: /var/lib/kubelet/plugins/csi-hostpath-provisioning-8787
        path: /var/lib/kubelet/pods
        path: /var/lib/kubelet/plugins_registry
        path: /var/lib/kubelet/plugins

# With -kubelet-root=/var/lib/kubeletxxx
$ kubectl get pods --all-namespaces -o yaml | grep /var/lib/kubelet
                k:{"mountPath":"/var/lib/kubeletxxx/plugins"}:
                k:{"mountPath":"/var/lib/kubeletxxx/pods"}:
      - mountPath: /var/lib/kubeletxxx/pods
      - mountPath: /var/lib/kubeletxxx/plugins
      - --kubelet-registration-path=/var/lib/kubeletxxx/plugins/csi-hostpath-provisioning-4758/csi.sock
        path: /var/lib/kubeletxxx/plugins/csi-hostpath-provisioning-4758
        path: /var/lib/kubeletxxx/pods
        path: /var/lib/kubeletxxx/plugins_registry
        path: /var/lib/kubeletxxx/plugins
```



#### Does this PR introduce a user-facing change?

```release-note
The e2e.test binary supports a new `--kubelet-root` parameter to override the default `/var/lib/kubelet` path. CSI storage tests use this.
```
