### PR TITLE
pkg/proxy/userspace/roundrobin: Make `lb.services` nil check standardized

### DIFF
--- a/pkg/proxy/userspace/roundrobin.go
+++ b/pkg/proxy/userspace/roundrobin.go
@@ -126,9 +126,9 @@ func (lb *LoadBalancerRR) ServiceHasEndpoints(svcPort proxy.ServicePortName) boo
 	lb.lock.RLock()
 	defer lb.lock.RUnlock()
 	state, exists := lb.services[svcPort]
-    if !exists || state == nil {
-        return false
-    }
+	if !exists || state == nil {
+		return false
+	}
 	return len(state.endpoints) > 0
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
As suggested in [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/userspace/roundrobin.go#L129-L130), some portions of the code contains the map checking for nil values in `lb.services` map, and others don't have. Even though we're never assigning nil values to this map, we should standardize the portions that does not have this check in `roundrobin` module.

Example:
```go
state, exists := lb.services[svcPort]
return exists && state != nil && len(state.endpoints) > 0
```
Should be like this:
```go
state, exists := lb.services[svcPort]
if !exists || state == nil {
      return false
}
return len(state.endpoints) > 0
```
#### Which issue(s) this PR fixes:
Fixes #108257

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
