### PR TITLE
code cleanup around the load balance timeout variables

### DIFF
--- a/test/e2e/framework/service/const.go
+++ b/test/e2e/framework/service/const.go
@@ -48,13 +48,12 @@ const (
 	// on AWS. A few minutes is typical, so use 10m.
 	LoadBalancerLagTimeoutAWS = 10 * time.Minute
 
-	// LoadBalancerCreateTimeoutDefault is the default time to wait for a load balancer to be created/modified.
-	// TODO: once support ticket 21807001 is resolved, reduce this timeout back to something reasonable
-	// Hideen - use GetServiceLoadBalancerCreateTimeout function instead.
-	loadBalancerCreateTimeoutDefault = 15 * time.Minute
-	// LoadBalancerCreateTimeoutLarge is the maximum time to wait for a load balancer to be created/modified.
-	// Hideen - use GetServiceLoadBalancerCreateTimeout function instead.
-	loadBalancerCreateTimeoutLarge = 45 * time.Minute
+	// loadBalancerCreationTimeoutDefault is the default time to wait for a load balancer to be created/modified.
+	// Hideen - use GetServiceLoadBalancerCreationTimeout function instead.
+	loadBalancerCreationTimeoutDefault = 15 * time.Minute
+	// loadBalancerCreationTimeoutLarge is the maximum time to wait for a load balancer to be created/modified.
+	// Hideen - use GetServiceLoadBalancerCreationTimeout function instead.
+	loadBalancerCreationTimeoutLarge = 45 * time.Minute
 
 	// LoadBalancerPropagationTimeoutDefault is the default time to wait for pods to
 	// be targeted by load balancers.

--- a/test/e2e/framework/service/resource.go
+++ b/test/e2e/framework/service/resource.go
@@ -104,9 +104,9 @@ func GetServiceLoadBalancerCreationTimeout(cs clientset.Interface) time.Duration
 	nodes, err := e2enode.GetReadySchedulableNodes(cs)
 	framework.ExpectNoError(err)
 	if len(nodes.Items) > LargeClusterMinNodesNumber {
-		return loadBalancerCreateTimeoutLarge
+		return loadBalancerCreationTimeoutLarge
 	}
-	return loadBalancerCreateTimeoutDefault
+	return loadBalancerCreationTimeoutDefault
 }
 
 // GetServiceLoadBalancerPropagationTimeout returns a timeout value for propagating a load balancer of a service.


### PR DESCRIPTION
- remove the comment about the internal ticket number.
- fix the typo, the method is `GetServiceLoadBalancerCreationTimeout` instead of `GetServiceLoadBalancerCreateTimeout`.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```



/sig testing