### PR TITLE
apimachinery: add cache for buffer reuse when encode

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/codec.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/codec.go
@@ -59,7 +59,8 @@ func Encode(e Encoder, obj Object) ([]byte, error) {
 	if err := e.Encode(obj, buf); err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+	bufClone := append([]byte(nil), buf.Bytes()...)
+	return bufClone, nil
 }
 
 // Decode is a convenience wrapper for decoding data into an Object.


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind regression
-->

#### What this PR does / why we need it:
Reuse buffer when codec do encode action

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
