### PR TITLE
fix: exclude non-ready nodes from azure load balancer

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -1125,11 +1125,8 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 						if err != nil && !errors.Is(err, cloudprovider.InstanceNotFound) {
 							return nil, err
 						}
-
-						// If a node is not supposed to be included in the LB, it
-						// would not be in the `nodes` slice. We need to check the nodes that
-						// have been added to the LB's backendpool, find the unwanted ones and
-						// delete them from the pool.
+						// If the node appears in the local cache of nodes to exclude,
+						// delete it from the load balancer backend pool.
 						shouldExcludeLoadBalancer, err := az.ShouldNodeExcludedFromLoadBalancer(nodeName)
 						if err != nil {
 							klog.Errorf("ShouldNodeExcludedFromLoadBalancer(%s) failed with error: %v", nodeName, err)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression


#### What this PR does / why we need it:
fix: exclude non-ready nodes and deleted nodes from azure load balancers

Make sure that nodes that are not in the ready state and are not newly created (i.e. not having the "node.cloudprovider.kubernetes.io/uninitialized" taint) get removed from load balancers.                       
Also remove nodes that are being deleted from the cluster.

Ref: https://github.com/kubernetes-sigs/cloud-provider-azure/pull/1195

#### Which issue(s) this PR fixes:
Fixes #108283


/priority critical-urgent
/sig cloud-provider
/area provider/azure
cc @feiskyer
cc @nilo19 

```release-note
NONE