### PR TITLE
Automated cherry pick of #107413: kube-proxy: fix duplicate port opening

### DIFF
--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -1587,7 +1587,15 @@ COMMIT
 -A KUBE-SERVICES -m comment --comment "kubernetes service nodeports; NOTE: this must be the last rule in this chain" -m addrtype --dst-type LOCAL -j KUBE-NODEPORTS
 COMMIT
 `
-
+	assert.Equal(t, []*netutils.LocalPort{
+		{
+			Description: "nodePort for ns1/svc1:p80",
+			IP:          "",
+			IPFamily:    netutils.IPv4,
+			Port:        svcNodePort,
+			Protocol:    netutils.TCP,
+		},
+	}, fp.portMapper.(*fakePortOpener).openPorts)
 	assertIPTablesRulesEqual(t, expected, fp.iptablesData.String())
 }
 


### PR DESCRIPTION
Cherry pick of #107413 on release-1.23.

#107413: kube-proxy: fix duplicate port opening

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```