### PR TITLE
Automated cherry pick of #107997: cronjob_controllerv2: do not filter jobs to be reconciled by

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -224,13 +224,9 @@ func (jm *ControllerV2) resolveControllerRef(namespace string, controllerRef *me
 }
 
 func (jm *ControllerV2) getJobsToBeReconciled(cronJob *batchv1.CronJob) ([]*batchv1.Job, error) {
-	var jobSelector labels.Selector
-	if len(cronJob.Spec.JobTemplate.Labels) == 0 {
-		jobSelector = labels.Everything()
-	} else {
-		jobSelector = labels.Set(cronJob.Spec.JobTemplate.Labels).AsSelector()
-	}
-	jobList, err := jm.jobLister.Jobs(cronJob.Namespace).List(jobSelector)
+	// list all jobs: there may be jobs with labels that don't match the template anymore,
+	// but that still have a ControllerRef to the given cronjob
+	jobList, err := jm.jobLister.Jobs(cronJob.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/cronjob/cronjob_controllerv2_test.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/robfig/cron"
 
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -451,6 +451,36 @@ func TestControllerV2GetJobsToBeReconciled(t *testing.T) {
 				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "foo2", Namespace: "bar-ns"}},
 			},
 			expected: []*batchv1.Job{},
+		},
+		{
+			name: "test getting jobs whose labels do not match job template",
+			cronJob: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "foo-ns", Name: "fooer"},
+				Spec: batchv1.CronJobSpec{JobTemplate: batchv1.JobTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"key": "value"}},
+				}},
+			},
+			jobs: []runtime.Object{
+				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "foo-ns",
+					Name:            "foo-fooer-owner-ref",
+					Labels:          map[string]string{"key": "different-value"},
+					OwnerReferences: []metav1.OwnerReference{{Name: "fooer", Controller: &trueRef}}},
+				},
+				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "foo-ns",
+					Name:            "foo-other-owner-ref",
+					Labels:          map[string]string{"key": "different-value"},
+					OwnerReferences: []metav1.OwnerReference{{Name: "another-cronjob", Controller: &trueRef}}},
+				},
+			},
+			expected: []*batchv1.Job{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "foo-ns",
+					Name:            "foo-fooer-owner-ref",
+					Labels:          map[string]string{"key": "different-value"},
+					OwnerReferences: []metav1.OwnerReference{{Name: "fooer", Controller: &trueRef}}},
+			}},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Cherry pick of #107997 on release-1.21.

#107997: cronjob_controllerv2: do not filter jobs to be reconciled by

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes regression in 1.21 default configurations where a bug in CronJob Controller V2 where it would lose track of jobs upon job template labels change.
```