### PR TITLE
Automated cherry pick of #107997: cronjob_controllerv2: do not filter jobs to be reconciled by

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -231,13 +231,9 @@ func (jm *ControllerV2) resolveControllerRef(namespace string, controllerRef *me
 }
 
 func (jm *ControllerV2) getJobsToBeReconciled(cronJob *batchv1.CronJob) ([]*batchv1.Job, error) {
-	var jobSelector labels.Selector
-	if len(cronJob.Spec.JobTemplate.Labels) == 0 {
-		jobSelector = labels.Everything()
-	} else {
-		jobSelector = labels.Set(cronJob.Spec.JobTemplate.Labels).AsSelector()
-	}
-	jobList, err := jm.jobLister.Jobs(cronJob.Namespace).List(jobSelector)
+	// list all jobs: there may be jobs with labels that don't match the template anymore,
+	// but that still have a ControllerRef to the given cronjob
+	jobList, err := jm.jobLister.Jobs(cronJob.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry pick of #107997 on release-1.23.

#107997: cronjob_controllerv2: do not filter jobs to be reconciled by

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes regression in 1.21 default configurations where a bug in CronJob Controller V2 where it would lose track of jobs upon job template labels change.
```