### PR TITLE
add check for colima docker socket as fall back

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -189,8 +189,8 @@ function kube::build::verify_prereqs() {
 
 function kube::build::docker_available_on_osx() {
   if [[ -z "${DOCKER_HOST}" ]]; then
-    if [[ -S "/var/run/docker.sock" ]] || [[ -S "${HOME}/.colima/docker.sock" ]]; then
-      kube::log::status "Using Docker for MacOS"
+    if [[ -S "/var/run/docker.sock" ]] || [[ -S "$(docker context inspect | jq -r '.[0].Endpoints.docker.Host' | awk -F 'unix://' '{print $2}')" ]]; then
+      kube::log::status "Using docker on macOS"
       return 0
     fi
 

--- a/build/common.sh
+++ b/build/common.sh
@@ -189,7 +189,7 @@ function kube::build::verify_prereqs() {
 
 function kube::build::docker_available_on_osx() {
   if [[ -z "${DOCKER_HOST}" ]]; then
-    if [[ -S "/var/run/docker.sock" ]]; then
+    if [[ -S "/var/run/docker.sock" ]] || [[ -S "${HOME}/.colima/docker.sock" ]]; then
       kube::log::status "Using Docker for MacOS"
       return 0
     fi

--- a/build/common.sh
+++ b/build/common.sh
@@ -189,7 +189,7 @@ function kube::build::verify_prereqs() {
 
 function kube::build::docker_available_on_osx() {
   if [[ -z "${DOCKER_HOST}" ]]; then
-    if [[ -S "/var/run/docker.sock" ]] || [[ -S "$(docker context inspect | jq -r '.[0].Endpoints.docker.Host' | awk -F 'unix://' '{print $2}')" ]]; then
+    if [[ -S "/var/run/docker.sock" ]] || [[ -S "$(docker context inspect --format  '{{.Endpoints.docker.Host}}' | awk -F 'unix://' '{print $2}')" ]]; then
       kube::log::status "Using docker on macOS"
       return 0
     fi


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I found this issue when I was trying to build a kind image
```
kind build node-image . --image kindest/node:1.24.0-alpha3
```
It tries to compile and it fails when I don't have Docker Desktop on macOS, but I'm using [colima]() which is a replacement for docker on macOS.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


