### PR TITLE
wait for default service account instead of its token

### DIFF
--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,7 +15,7 @@
 IMAGE=gcr.io/k8s-staging-addon-manager/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v9.1.5
+VERSION=v9.1.6
 KUBECTL_VERSION?=v1.20.2
 
 BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):v1.0.1

--- a/cluster/addons/addon-manager/kube-addons-main.sh
+++ b/cluster/addons/addon-manager/kube-addons-main.sh
@@ -35,18 +35,14 @@ fi
 log INFO "== Kubernetes addon manager started at $(date -Is) with ADDON_CHECK_INTERVAL_SEC=${ADDON_CHECK_INTERVAL_SEC} =="
 
 # Wait for the default service account to be created in the kube-system namespace.
-token_found=""
-while [ -z "${token_found}" ]; do
+# shellcheck disable=SC2086
+# Disabling because "${KUBECTL_OPTS}" needs to allow for expansion here
+while ! ${KUBECTL} ${KUBECTL_OPTS} get --namespace="${SYSTEM_NAMESPACE}" serviceaccount default; do
+  log WRN "== Error getting default service account, retry in 0.5 second =="
   sleep 0.5
-  # shellcheck disable=SC2086
-  # Disabling because "${KUBECTL_OPTS}" needs to allow for expansion here
-  if ! token_found=$(${KUBECTL} ${KUBECTL_OPTS} get --namespace="${SYSTEM_NAMESPACE}" serviceaccount default -o go-template="{{with index .secrets 0}}{{.name}}{{end}}"); then
-    token_found="";
-    log WRN "== Error getting default service account, retry in 0.5 second =="
-  fi
 done
 
-log INFO "== Default service account in the ${SYSTEM_NAMESPACE} namespace has token ${token_found} =="
+log INFO "== Default service account in the ${SYSTEM_NAMESPACE} namespace =="
 
 # Create admission_control objects if defined before any other addon services. If the limits
 # are defined in a namespace other than default, we should still create the limits for the


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
addon manager only needs to wait for the creation of default service account not its token.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```