### PR TITLE
kubectl drain: Generic "declare a controller" message

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -190,7 +190,7 @@ func NewCmdDrain(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 			cmdutil.CheckErr(o.RunDrain())
 		},
 	}
-	cmd.Flags().BoolVar(&o.drainer.Force, "force", o.drainer.Force, "Continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet.")
+	cmd.Flags().BoolVar(&o.drainer.Force, "force", o.drainer.Force, "Continue even if there are pods that do not declare a controller.")
 	cmd.Flags().BoolVar(&o.drainer.IgnoreAllDaemonSets, "ignore-daemonsets", o.drainer.IgnoreAllDaemonSets, "Ignore DaemonSet-managed pods.")
 	cmd.Flags().BoolVar(&o.drainer.DeleteEmptyDirData, "delete-local-data", o.drainer.DeleteEmptyDirData, "Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained).")
 	cmd.Flags().MarkDeprecated("delete-local-data", "This option is deprecated and will be deleted. Use --delete-emptydir-data.")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
@@ -599,7 +599,7 @@ func TestDrain(t *testing.T) {
 			args:                  []string{"node", "--force"},
 			expectFatal:           false,
 			expectDelete:          true,
-			expectWarning:         "WARNING: deleting Pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet: default/bar",
+			expectWarning:         "WARNING: deleting Pods that declare no controller: default/bar",
 			expectOutputToContain: "node/node drained",
 		},
 		{

--- a/staging/src/k8s.io/kubectl/pkg/drain/filters.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/filters.go
@@ -33,8 +33,8 @@ const (
 	daemonSetWarning    = "ignoring DaemonSet-managed Pods"
 	localStorageFatal   = "Pods with local storage (use --delete-emptydir-data to override)"
 	localStorageWarning = "deleting Pods with local storage"
-	unmanagedFatal      = "Pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet (use --force to override)"
-	unmanagedWarning    = "deleting Pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet"
+	unmanagedFatal      = "Pods declare no controller (use --force to override)"
+	unmanagedWarning    = "deleting Pods that declare no controller"
 )
 
 // PodDelete informs filtering logic whether a pod should be deleted or not


### PR DESCRIPTION
When it initially landed in c6e9ad066e (#16698), the drain logic [looked in a created-by annotation for recognized kinds][1], so listing the set of recognized kinds was a clear approach.

Sometime later, the source moved into `ownerReferences`, but the hard-coded set of recognized controller kinds remained.

When 2f1108451f (#56864) removed the hard-coded set of recognized controller kinds, it should have also updated these messages to remove stale references to the previous hard-coded values.  This commit catches the message strings up with that commit.

/kind cleanup

```release-note
NONE
```

[1]: https://github.com/kubernetes/kubernetes/pull/16698/commits/c6e9ad066eff9378761da5804797a9eb5d4c6790#diff-211259b8a8ec42f105264c10897dad48029badb538684e60e43eaead68c3d219R216