### PR TITLE
Open ingress  nginx e2e test

### DIFF
--- a/test/e2e/framework/testfiles/testfiles.go
+++ b/test/e2e/framework/testfiles/testfiles.go
@@ -81,12 +81,12 @@ func Read(filePath string) ([]byte, error) {
 	}
 	// Here we try to generate an error that points test authors
 	// or users in the right direction for resolving the problem.
-	error := fmt.Sprintf("Test file %q was not found.\n", filePath)
+	err := fmt.Sprintf("Test file %q was not found.\n", filePath)
 	for _, filesource := range filesources {
-		error += filesource.DescribeFiles()
-		error += "\n"
+		err += filesource.DescribeFiles()
+		err += "\n"
 	}
-	return nil, errors.New(error)
+	return nil, errors.New(err)
 }
 
 // Exists checks whether a file could be read. Unexpected errors

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -484,22 +484,13 @@ var _ = common.SIGDescribe("Loadbalancing: L7", func() {
 			jig.Class = "nginx"
 			nginxController = &e2eingress.NginxIngressController{Ns: ns, Client: jig.Client}
 
-			// TODO: This test may fail on other platforms. We can simply skip it
-			// but we want to allow easy testing where a user might've hand
-			// configured firewalls.
-			if framework.ProviderIs("gce", "gke") {
-				framework.ExpectNoError(gce.GcloudComputeResourceCreate("firewall-rules", fmt.Sprintf("ingress-80-443-%v", ns), framework.TestContext.CloudConfig.ProjectID, "--allow", "tcp:80,tcp:443", "--network", framework.TestContext.CloudConfig.Network))
-			} else {
-				framework.Logf("WARNING: Not running on GCE/GKE, cannot create firewall rules for :80, :443. Assuming traffic can reach the external ips of all nodes in cluster on those ports.")
-			}
+			framework.ExpectNoError(gce.GcloudComputeResourceCreate("firewall-rules", fmt.Sprintf("ingress-80-443-%v", ns), framework.TestContext.CloudConfig.ProjectID, "--allow", "tcp:80,tcp:443", "--network", framework.TestContext.CloudConfig.Network))
 
 			nginxController.Init()
 		})
 
 		ginkgo.AfterEach(func() {
-			if framework.ProviderIs("gce", "gke") {
-				framework.ExpectNoError(gce.GcloudComputeResourceDelete("firewall-rules", fmt.Sprintf("ingress-80-443-%v", ns), framework.TestContext.CloudConfig.ProjectID))
-			}
+			framework.ExpectNoError(gce.GcloudComputeResourceDelete("firewall-rules", fmt.Sprintf("ingress-80-443-%v", ns), framework.TestContext.CloudConfig.ProjectID))
 			if ginkgo.CurrentGinkgoTestDescription().Failed {
 				e2eingress.DescribeIng(ns)
 			}

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -481,7 +481,6 @@ var _ = common.SIGDescribe("Loadbalancing: L7", func() {
 		ginkgo.BeforeEach(func() {
 			e2eskipper.SkipUnlessProviderIs("gce", "gke")
 			ginkgo.By("Initializing nginx controller")
-			jig.Class = "nginx"
 			nginxController = &e2eingress.NginxIngressController{Ns: ns, Client: jig.Client}
 
 			framework.ExpectNoError(gce.GcloudComputeResourceCreate("firewall-rules", fmt.Sprintf("ingress-80-443-%v", ns), framework.TestContext.CloudConfig.ProjectID, "--allow", "tcp:80,tcp:443", "--network", framework.TestContext.CloudConfig.Network))

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -479,11 +479,6 @@ var _ = common.SIGDescribe("Loadbalancing: L7", func() {
 		var nginxController *e2eingress.NginxIngressController
 
 		ginkgo.BeforeEach(func() {
-			// Skip until nginx-ingress controller works against kubernetes 1.22+
-			// Those versions no longer server ingress v1beta1
-			// xref: https://github.com/kubernetes/ingress-nginx/issues/7145
-			e2eskipper.Skipf("Skipping because nginx-controller requires ingress/v1beta1 API")
-
 			e2eskipper.SkipUnlessProviderIs("gce", "gke")
 			ginkgo.By("Initializing nginx controller")
 			jig.Class = "nginx"

--- a/test/e2e/testing-manifests/embed.go
+++ b/test/e2e/testing-manifests/embed.go
@@ -22,7 +22,7 @@ import (
 	e2etestfiles "k8s.io/kubernetes/test/e2e/framework/testfiles"
 )
 
-//go:embed cluster-dns flexvolume guestbook kubectl sample-device-plugin.yaml scheduling/nvidia-driver-installer.yaml statefulset storage-csi
+//go:embed cluster-dns flexvolume guestbook ingress kubectl sample-device-plugin.yaml scheduling/nvidia-driver-installer.yaml statefulset storage-csi
 var e2eTestingManifestsFS embed.FS
 
 func GetE2ETestingManifestsFS() e2etestfiles.EmbeddedFileSource {

--- a/test/e2e/testing-manifests/ingress/http/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/http/ing.yaml
@@ -2,6 +2,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: echomap
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
 spec:
   # kubemci requires a default backend.
   defaultBackend:

--- a/test/e2e/testing-manifests/ingress/nginx/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/nginx/rc.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: k8s.gcr.io/ingress-nginx/controller:v0.46.0
+      - image: k8s.gcr.io/ingress-nginx/controller:v1.1.1
         args:
         - /nginx-ingress-controller
         - --election-id=ingress-controller-leader


### PR DESCRIPTION
- Open Nginx e2e test
`ingress-nginx` has dropped v1beta1 from ingress nginx and migrated to v1, pls see: https://github.com/kubernetes/ingress-nginx/pull/7156

- Embedded ingress into the golang test executable files
pls see the bug here: https://github.com/kubernetes/kubernetes/issues/108324 for the details

- Rename variable `error` to `err`
`error` is the keyword in golang

- Remove duplicated check on the provider
The test has skipped if the provided is not "gce" or "gke", there is no need to check it again.
pls see the code here, 
https://github.com/kubernetes/kubernetes/blob/016b96ca3896d27b37c5b2d6e223fb3320a0fdec/test/e2e/network/ingress.go#L487

- fix: ingress should tell which ingress class is used
or else IP address of ingress will not get filled.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug



#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108324

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
