### PR TITLE
job: validate job pod name against DNS subdomainName

### DIFF
--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -97,7 +97,7 @@ func ValidateJob(job *batch.Job, opts JobValidationOptions) field.ErrorList {
 		// The index could be maximum `.spec.completions-1`
 		// If we don't validate this here, the indexed job will fail to create pods later.
 		maximumPodHostname := fmt.Sprintf("%s-%d", job.ObjectMeta.Name, *job.Spec.Completions-1)
-		if errs := apimachineryvalidation.IsDNS1123Label(maximumPodHostname); len(errs) > 0 {
+		if errs := apivalidation.ValidatePodName(maximumPodHostname, false); len(errs) > 0 {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("name"), job.ObjectMeta.Name, fmt.Sprintf("will not able to create pod with invalid DNS label: %s", maximumPodHostname)))
 		}
 	}


### PR DESCRIPTION
At present the job pod name validation has been performed
against the RFC1123. This commit changes the validation of the
it against DNS subdomainname by making use of ValidatePodName
alias.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


/kind bug

-->
```release-note
NONE
```


