### PR TITLE
fix: fix kube-scheduler KEP link

### DIFF
--- a/staging/src/k8s.io/kube-scheduler/README.md
+++ b/staging/src/k8s.io/kube-scheduler/README.md
@@ -1,6 +1,6 @@
 # kube-scheduler
 
-Implements [KEP 14 - Moving ComponentConfig API types to staging repos](https://git.k8s.io/enhancements/keps/sig-cluster-lifecycle/wgs/0014-20180707-componentconfig-api-types-to-staging.md#kube-scheduler-changes)
+Implements [KEP 115 - Moving ComponentConfig API types to staging repos](https://git.k8s.io/enhancements/keps/sig-cluster-lifecycle/wgs/115-componentconfig#kube-scheduler-changes)
 
 This repo provides external, versioned ComponentConfig API types for configuring the kube-scheduler.
 These external types can easily be vendored and used by any third-party tool writing Kubernetes


### PR DESCRIPTION

#### What type of PR is this?
fix kube-scheduler KEP link

/kind documentation

#### What this PR does / why we need it:
The KEP link in kube-scheduler [README](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kube-scheduler/README.md) is broken

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
