### PR TITLE
test/e2e/framework: include the new control plane taint for "--non-blocking-taints"

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -316,7 +316,8 @@ func RegisterCommonFlags(flags *flag.FlagSet) {
 	flags.BoolVar(&TestContext.DumpSystemdJournal, "dump-systemd-journal", false, "Whether to dump the full systemd journal.")
 	flags.StringVar(&TestContext.ImageServiceEndpoint, "image-service-endpoint", "", "The image service endpoint of cluster VM instances.")
 	flags.StringVar(&TestContext.DockershimCheckpointDir, "dockershim-checkpoint-dir", "/var/lib/dockershim/sandbox", "The directory for dockershim to store sandbox checkpoints.")
-	flags.StringVar(&TestContext.NonblockingTaints, "non-blocking-taints", `node-role.kubernetes.io/master`, "Nodes with taints in this comma-delimited list will not block the test framework from starting tests.")
+	// Expect the test suite to work with both the new and legacy non-blocking control plane taints by default
+	flags.StringVar(&TestContext.NonblockingTaints, "non-blocking-taints", `node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master`, "Nodes with taints in this comma-delimited list will not block the test framework from starting tests. The default taint 'node-role.kubernetes.io/master' is DEPRECATED and will be removed from the list in a future release.")
 
 	flags.BoolVar(&TestContext.ListImages, "list-images", false, "If true, will show list of images used for runnning tests.")
 	flags.BoolVar(&TestContext.ListConformanceTests, "list-conformance-tests", false, "If true, will show list of conformance tests.")


### PR DESCRIPTION
partial backport of:
https://github.com/kubernetes/kubernetes/pull/107533/files#diff-c017e0c5e68c14cb966137bc87de3d3ab8475dc25f9b5fdb47a2b8174830054f

Include both the new and legacy control plane taints
as default arguments for the e2e tests suite.

This allows kubeadm and clusters managed by other tools to skew their tests
if they are in the process of migrating from the legacy
to new taint.

Without this change the kubeadm 1.24 tests on 1.23 k8s would fail.
Including both taints to be non-blocking is not a breaking change to 1.23 clusters.

```
Feb 24 17:02:11.284: INFO: 	-> Node kinder-xony-control-plane-1 [[[ Ready=true, Network(available)=false, Taints=[{node-role.kubernetes.io/master  NoSchedule <nil>} {node-role.kubernetes.io/control-plane  NoSchedule <nil>}], NonblockingTaints=node-role.kubernetes.io/master ]]]
Feb 24 17:02:11.284: INFO: 	-> Node kinder-xony-control-plane-2 [[[ Ready=true, Network(available)=false, Taints=[{node-role.kubernetes.io/master  NoSchedule <nil>} {node-role.kubernetes.io/control-plane  NoSchedule <nil>}], NonblockingTaints=node-role.kubernetes.io/master ]]]
Feb 24 17:02:11.284: INFO: 	-> Node kinder-xony-control-plane-3 [[[ Ready=true, Network(available)=false, Taints=[{node-role.kubernetes.io/master  NoSchedule <nil>} {node-role.kubernetes.io/control-plane  NoSchedule <nil>}], NonblockingTaints=node-role.kubernetes.io/master ]]]
Feb 24 17:02:11.284: INFO: ==== node wait: 2 out of 5 nodes are ready, max notReady allowed 0.  Need 3 more before starting.
Feb 24 17:02:11.284: FAIL: Unexpected error:
    <*errors.errorString | 0xc0002b82a0>: {
        s: "timed out waiting for the condition",
    }
    timed out waiting for the condition
occurred
```

https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-latest-on-1-23
