### PR TITLE
Remove SA token dependency in kube-addon-manager

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 9.1.6 (Tue February 24 2022 Spencer Peterson <spencerjp@google.com>)
+ - Update kubectl to v1.23.4.
+ - Wait for default ServiceAccount, but not token, per pull #108309.
+
 ### Version 9.1.5 (Mon April 19 2021 Spencer Peterson <spencerjp@google.com>)
  - Update baseimage to debian-base:v1.0.1.
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,8 +15,8 @@
 IMAGE=gcr.io/k8s-staging-addon-manager/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v9.1.5
-KUBECTL_VERSION?=v1.20.2
+VERSION=v9.1.6
+KUBECTL_VERSION?=v1.23.4
 
 BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):v1.0.1
 

--- a/cluster/addons/addon-manager/kube-addons-main.sh
+++ b/cluster/addons/addon-manager/kube-addons-main.sh
@@ -35,18 +35,14 @@ fi
 log INFO "== Kubernetes addon manager started at $(date -Is) with ADDON_CHECK_INTERVAL_SEC=${ADDON_CHECK_INTERVAL_SEC} =="
 
 # Wait for the default service account to be created in the kube-system namespace.
-token_found=""
-while [ -z "${token_found}" ]; do
+# shellcheck disable=SC2086
+# Disabling because "${KUBECTL_OPTS}" needs to allow for expansion here
+while ! ${KUBECTL} ${KUBECTL_OPTS} get --namespace="${SYSTEM_NAMESPACE}" serviceaccount default; do
+  log WRN "== Error getting default service account, retry in 0.5 second =="
   sleep 0.5
-  # shellcheck disable=SC2086
-  # Disabling because "${KUBECTL_OPTS}" needs to allow for expansion here
-  if ! token_found=$(${KUBECTL} ${KUBECTL_OPTS} get --namespace="${SYSTEM_NAMESPACE}" serviceaccount default -o go-template="{{with index .secrets 0}}{{.name}}{{end}}"); then
-    token_found="";
-    log WRN "== Error getting default service account, retry in 0.5 second =="
-  fi
 done
 
-log INFO "== Default service account in the ${SYSTEM_NAMESPACE} namespace has token ${token_found} =="
+log INFO "== Default service account in the ${SYSTEM_NAMESPACE} namespace exists =="
 
 # Create admission_control objects if defined before any other addon services. If the limits
 # are defined in a namespace other than default, we should still create the limits for the


### PR DESCRIPTION
Compatabile with pull #108309.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

SA tokens will no longer be populated; the addon manager's dependency on the default token must be removed.

Additionally bumps the kubectl version.

#### Special notes for your reviewer:

Tested with script and verified addon manager bootstrap functions as intended.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

