### PR TITLE
bump kube-addon-manager image version to 9.1.6

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 9.1.6 (Thu February 24 2022 Shihang Zhang <zshihang@google.com>)
+ - Clean up the wait check for service account (https://github.com/kubernetes/kubernetes/pull/108313)
+
 ### Version 9.1.5 (Mon April 19 2021 Spencer Peterson <spencerjp@google.com>)
  - Update baseimage to debian-base:v1.0.1.
 

--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -23,7 +23,7 @@ spec:
         - all
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: k8s.gcr.io/addon-manager/kube-addon-manager:v9.1.5
+    image: k8s.gcr.io/addon-manager/kube-addon-manager:v9.1.6
     command:
     - /bin/bash
     - -c

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/addon-manager/kube-addon-manager:v9.1.5
+    image: {{kube_docker_registry}}/addon-manager/kube-addon-manager:v9.1.6
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
unblock https://github.com/kubernetes/kubernetes/pull/108309

#### Does this PR introduce a user-facing change?
```release-note
`kube-addon-manager` image version is bumped to 9.1.6
```