### PR TITLE
client-go: chain the error returned by rate limiter

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -504,7 +504,9 @@ func (r *Request) tryThrottleWithInfo(ctx context.Context, retryInfo string) err
 	now := time.Now()
 
 	err := r.rateLimiter.Wait(ctx)
-
+	if err != nil {
+		err = fmt.Errorf("client rate limiter Wait returned an error: %w", err)
+	}
 	latency := time.Since(now)
 
 	var message string

--- a/test/integration/client/cert_rotation_test.go
+++ b/test/integration/client/cert_rotation_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"math"
 	"math/big"
 	"os"
@@ -135,7 +136,9 @@ func TestCertRotationContinuousRequests(t *testing.T) {
 	for range time.Tick(time.Second) {
 		_, err := client.CoreV1().ServiceAccounts("default").List(ctx, v1.ListOptions{})
 		if err != nil {
-			if err == ctx.Err() {
+			// client may wrap the context.Canceled error, so we can't
+			// do 'err == ctx.Err()', instead use 'errors.Is'.
+			if errors.Is(err, context.Canceled) {
 				return
 			}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
We often see error from client-go `Request` 
```
[error] failed to create the reconcile looper: failed to retrieve all IP pools: context deadline exceeded
```
one source of the `context deadline exceeded` error could be the rate limiter `Wait`:
https://github.com/kubernetes/kubernetes/blob/9918aa1e035a00bc7c0f16a05e1b222650b3eabc/staging/src/k8s.io/client-go/rest/request.go#L952-L954

This PR chains the error from rate limiter `Wait` method so the log gives us more context to pin point the origin of error.


#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
