### PR TITLE
Remove delay on first invocation of ItemExponentialFailureRateLimiter::When

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters_test.go
@@ -24,6 +24,9 @@ import (
 func TestItemExponentialFailureRateLimiter(t *testing.T) {
 	limiter := NewItemExponentialFailureRateLimiter(1*time.Millisecond, 1*time.Second)
 
+	if e, a := 0*time.Millisecond, limiter.When("one"); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
 	if e, a := 1*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
@@ -36,17 +39,14 @@ func TestItemExponentialFailureRateLimiter(t *testing.T) {
 	if e, a := 8*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := 16*time.Millisecond, limiter.When("one"); e != a {
-		t.Errorf("expected %v, got %v", e, a)
-	}
 	if e, a := 5, limiter.NumRequeues("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	if e, a := 1*time.Millisecond, limiter.When("two"); e != a {
+	if e, a := 0*time.Millisecond, limiter.When("two"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := 2*time.Millisecond, limiter.When("two"); e != a {
+	if e, a := 1*time.Millisecond, limiter.When("two"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 	if e, a := 2, limiter.NumRequeues("two"); e != a {
@@ -57,7 +57,7 @@ func TestItemExponentialFailureRateLimiter(t *testing.T) {
 	if e, a := 0, limiter.NumRequeues("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := 1*time.Millisecond, limiter.When("one"); e != a {
+	if e, a := 0*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -68,7 +68,7 @@ func TestItemExponentialFailureRateLimiterOverFlow(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		limiter.When("one")
 	}
-	if e, a := 32*time.Millisecond, limiter.When("one"); e != a {
+	if e, a := 16*time.Millisecond, limiter.When("one"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -83,7 +83,7 @@ func TestItemExponentialFailureRateLimiterOverFlow(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		limiter.When("two")
 	}
-	if e, a := 4*time.Minute, limiter.When("two"); e != a {
+	if e, a := 2*time.Minute, limiter.When("two"); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:


Optionally add one or more of the following kinds if applicable:
-->
/kind cleanup

#### What this PR does / why we need it:

When using this rate limiter with an empty queue I was seeing delays when
adding a new item with `AddRateLimited`. This is odd as I would expect delays
only on subsquent additions after a failure.

This change removes the delay on the first invocation of `When`.

#### Special notes for your reviewer:
👋

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
