### PR TITLE
kubelet: Pod admission should exclude terminated terminal pods

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -973,7 +973,7 @@ func (kl *Kubelet) filterOutInactivePods(pods []*v1.Pod) []*v1.Pod {
 		}
 
 		// terminal pods are considered inactive UNLESS they are actively terminating
-		if kl.isAdmittedPodTerminal(p) && !kl.podWorkers.IsPodTerminationRequested(p.UID) {
+		if kl.isAdmittedPodTerminal(p) && !kl.podWorkers.IsPodTerminating(p.UID) {
 			continue
 		}
 


### PR DESCRIPTION
The previous change to exclude pods that are actively terminating from admission was too broad, which meant that when the kubelet reported a pod as terminal by setting Succeeded or Failed phase but was still in the process of cleaning up resources a newly scheduled pod could be rejected because of the fully terminated pod.

Instead, the admission check should exclude terminal pods that are not actively terminating.

Fixes #106884

/hold

Waiting for an e2e from bobby

#### What type of PR is this?

/kind bug
/kind regression

```release-note
The kubelet was incorrectly rejecting pods after scheduling because it was waiting for pods to be fully terminated before accepting new pods that consumed the same resources as the old pod. Instead, the kubelet should only consider pods that still have running containers as consuming resources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```