### PR TITLE
Server Side Field Validation Support For Kubectl

### DIFF
--- a/hack/testdata/invalid-deployment-unknown-and-duplicate-fields.yaml
+++ b/hack/testdata/invalid-deployment-unknown-and-duplicate-fields.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: invalid-nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  replicas: 4
+  foo: bar
+  baz: baq
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -124,7 +124,16 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) (err er
 	}
 
 	o.validator = func() (validation.Schema, error) {
-		return f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
+		directive, err := cmdutil.GetValidationDirective(cmd)
+		if err != nil {
+			return nil, err
+		}
+		dynamicClient, err := f.DynamicClient()
+		if err != nil {
+			return nil, err
+		}
+		verifier := resource.NewQueryParamVerifier(dynamicClient, f.OpenAPIGetter(), resource.QueryParamFieldValidation)
+		return f.Validator(directive, verifier)
 	}
 
 	// build the printer

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
@@ -54,6 +54,10 @@ type Helper struct {
 	// FieldManager is the name associated with the actor or entity that is making
 	// changes.
 	FieldManager string
+
+	// FieldValidation is the directive used to indicate how the server should perform
+	// field validation (Ignore, Warn, or Strict)
+	FieldValidation string
 }
 
 // NewHelper creates a Helper from a ResourceMapping
@@ -76,6 +80,13 @@ func (m *Helper) DryRun(dryRun bool) *Helper {
 // that is making changes in a create or update operation.
 func (m *Helper) WithFieldManager(fieldManager string) *Helper {
 	m.FieldManager = fieldManager
+	return m
+}
+
+// WithFieldValidation sets the field validation option to indicate
+// how the server should perform field validation (Ignore, Warn, or Strict).
+func (m *Helper) WithFieldValidation(validationDirective string) *Helper {
+	m.FieldValidation = validationDirective
 	return m
 }
 
@@ -206,6 +217,9 @@ func (m *Helper) CreateWithOptions(namespace string, modify bool, obj runtime.Ob
 	if m.FieldManager != "" {
 		options.FieldManager = m.FieldManager
 	}
+	if m.FieldValidation != "" {
+		options.FieldValidation = m.FieldValidation
+	}
 	if modify {
 		// Attempt to version the object based on client logic.
 		version, err := metadataAccessor.ResourceVersion(obj)
@@ -242,6 +256,9 @@ func (m *Helper) Patch(namespace, name string, pt types.PatchType, data []byte, 
 	if m.FieldManager != "" {
 		options.FieldManager = m.FieldManager
 	}
+	if m.FieldValidation != "" {
+		options.FieldValidation = m.FieldValidation
+	}
 	return m.RESTClient.Patch(pt).
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
@@ -261,6 +278,9 @@ func (m *Helper) Replace(namespace, name string, overwrite bool, obj runtime.Obj
 	}
 	if m.FieldManager != "" {
 		options.FieldManager = m.FieldManager
+	}
+	if m.FieldValidation != "" {
+		options.FieldValidation = m.FieldValidation
 	}
 
 	// Attempt to version the object based on client logic.

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier.go
@@ -62,6 +62,11 @@ type QueryParamVerifier struct {
 	queryParam    VerifiableQueryParam
 }
 
+// Verifier is the generic verifier interface used for testing QueryParamVerifier
+type Verifier interface {
+	HasSupport(gvk schema.GroupVersionKind) error
+}
+
 // VerifiableQueryParam is a query parameter who's enablement on the
 // apiserver can be determined by evaluating the OpenAPI for a specific
 // GVK.
@@ -72,6 +77,7 @@ const (
 	QueryParamFieldValidation VerifiableQueryParam = "fieldValidation"
 )
 
+// HasSupport checks if the given gvk supports the query param configured on v
 func (v *QueryParamVerifier) HasSupport(gvk schema.GroupVersionKind) error {
 	oapi, err := v.openAPIGetter.OpenAPISchema()
 	if err != nil {
@@ -90,7 +96,7 @@ func (v *QueryParamVerifier) HasSupport(gvk schema.GroupVersionKind) error {
 		}
 	}
 	if !supports {
-		return newParamUnsupportedError(gvk, v.queryParam)
+		return NewParamUnsupportedError(gvk, v.queryParam)
 	}
 	return nil
 }
@@ -100,7 +106,7 @@ type paramUnsupportedError struct {
 	param VerifiableQueryParam
 }
 
-func newParamUnsupportedError(gvk schema.GroupVersionKind, param VerifiableQueryParam) error {
+func NewParamUnsupportedError(gvk schema.GroupVersionKind, param VerifiableQueryParam) error {
 	return &paramUnsupportedError{
 		gvk:   gvk,
 		param: param,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -80,25 +80,27 @@ type ApplyOptions struct {
 
 	DeleteOptions *delete.DeleteOptions
 
-	ServerSideApply bool
-	ForceConflicts  bool
-	FieldManager    string
-	Selector        string
-	DryRunStrategy  cmdutil.DryRunStrategy
-	DryRunVerifier  *resource.QueryParamVerifier
-	Prune           bool
-	PruneResources  []prune.Resource
-	cmdBaseName     string
-	All             bool
-	Overwrite       bool
-	OpenAPIPatch    bool
-	PruneWhitelist  []string
+	ServerSideApply         bool
+	ForceConflicts          bool
+	FieldManager            string
+	Selector                string
+	DryRunStrategy          cmdutil.DryRunStrategy
+	DryRunVerifier          *resource.QueryParamVerifier
+	FieldValidationVerifier *resource.QueryParamVerifier
+	Prune                   bool
+	PruneResources          []prune.Resource
+	cmdBaseName             string
+	All                     bool
+	Overwrite               bool
+	OpenAPIPatch            bool
+	PruneWhitelist          []string
 
-	Validator     validation.Schema
-	Builder       *resource.Builder
-	Mapper        meta.RESTMapper
-	DynamicClient dynamic.Interface
-	OpenAPISchema openapi.Resources
+	ValidationDirective string
+	Validator           validation.Schema
+	Builder             *resource.Builder
+	Mapper              meta.RESTMapper
+	DynamicClient       dynamic.Interface
+	OpenAPISchema       openapi.Resources
 
 	Namespace        string
 	EnforceNamespace bool
@@ -238,6 +240,7 @@ func (flags *ApplyFlags) ToOptions(cmd *cobra.Command, baseName string, args []s
 	}
 
 	dryRunVerifier := resource.NewQueryParamVerifier(dynamicClient, flags.Factory.OpenAPIGetter(), resource.QueryParamDryRun)
+	fieldValidationVerifier := resource.NewQueryParamVerifier(dynamicClient, flags.Factory.OpenAPIGetter(), resource.QueryParamFieldValidation)
 	fieldManager := GetApplyFieldManagerFlag(cmd, serverSideApply)
 
 	// allow for a success message operation to be specified at print time
@@ -264,7 +267,12 @@ func (flags *ApplyFlags) ToOptions(cmd *cobra.Command, baseName string, args []s
 	}
 
 	openAPISchema, _ := flags.Factory.OpenAPISchema()
-	validator, err := flags.Factory.Validator(cmdutil.GetFlagBool(cmd, "validate"))
+
+	validationDirective, err := cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return nil, err
+	}
+	validator, err := flags.Factory.Validator(validationDirective, fieldValidationVerifier)
 	if err != nil {
 		return nil, err
 	}
@@ -308,14 +316,15 @@ func (flags *ApplyFlags) ToOptions(cmd *cobra.Command, baseName string, args []s
 		OpenAPIPatch:    flags.OpenAPIPatch,
 		PruneWhitelist:  flags.PruneWhitelist,
 
-		Recorder:         recorder,
-		Namespace:        namespace,
-		EnforceNamespace: enforceNamespace,
-		Validator:        validator,
-		Builder:          builder,
-		Mapper:           mapper,
-		DynamicClient:    dynamicClient,
-		OpenAPISchema:    openAPISchema,
+		Recorder:            recorder,
+		Namespace:           namespace,
+		EnforceNamespace:    enforceNamespace,
+		Validator:           validator,
+		ValidationDirective: validationDirective,
+		Builder:             builder,
+		Mapper:              mapper,
+		DynamicClient:       dynamicClient,
+		OpenAPISchema:       openAPISchema,
 
 		IOStreams: flags.IOStreams,
 
@@ -407,7 +416,6 @@ func (o *ApplyOptions) SetObjects(infos []*resource.Info) {
 
 // Run executes the `apply` command.
 func (o *ApplyOptions) Run() error {
-
 	if o.PreProcessorFn != nil {
 		klog.V(4).Infof("Running apply pre-processor function")
 		if err := o.PreProcessorFn(); err != nil {
@@ -472,7 +480,8 @@ func (o *ApplyOptions) applyOneObject(info *resource.Info) error {
 
 	helper := resource.NewHelper(info.Client, info.Mapping).
 		DryRun(o.DryRunStrategy == cmdutil.DryRunServer).
-		WithFieldManager(o.FieldManager)
+		WithFieldManager(o.FieldManager).
+		WithFieldValidation(o.ValidationDirective)
 
 	if o.DryRunStrategy == cmdutil.DryRunServer {
 		// Ensure the APIServer supports server-side dry-run for the resource,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_edit_last_applied.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_edit_last_applied.go
@@ -83,6 +83,7 @@ func NewCmdApplyEditLastApplied(f cmdutil.Factory, ioStreams genericclioptions.I
 	cmd.Flags().BoolVar(&o.WindowsLineEndings, "windows-line-endings", o.WindowsLineEndings,
 		"Defaults to the line ending native to your platform.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, FieldManagerClientSideApply)
+	cmdutil.AddValidateFlags(cmd)
 
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
@@ -213,6 +213,7 @@ func (c *CreateClusterRoleOptions) RunCreateRole() error {
 		if c.FieldManager != "" {
 			createOptions.FieldManager = c.FieldManager
 		}
+		createOptions.FieldValidation = c.ValidationDirective
 		if c.DryRunStrategy == cmdutil.DryRunServer {
 			if err := c.DryRunVerifier.HasSupport(clusterRole.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
@@ -59,9 +59,10 @@ type ClusterRoleBindingOptions struct {
 	FieldManager     string
 	CreateAnnotation bool
 
-	Client         rbacclientv1.RbacV1Interface
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resource.QueryParamVerifier
+	Client              rbacclientv1.RbacV1Interface
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
 
 	genericclioptions.IOStreams
 }
@@ -149,6 +150,10 @@ func (o *ClusterRoleBindingOptions) Complete(f cmdutil.Factory, cmd *cobra.Comma
 	o.PrintObj = func(obj runtime.Object) error {
 		return printer.PrintObj(obj, o.Out)
 	}
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -169,6 +174,7 @@ func (o *ClusterRoleBindingOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(clusterRoleBinding.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -96,9 +96,10 @@ type ConfigMapOptions struct {
 	Namespace        string
 	EnforceNamespace bool
 
-	Client         corev1client.CoreV1Interface
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resource.QueryParamVerifier
+	Client              corev1client.CoreV1Interface
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
 
 	genericclioptions.IOStreams
 }
@@ -194,6 +195,11 @@ func (o *ConfigMapOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 		return printer.PrintObj(obj, o.Out)
 	}
 
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -222,6 +228,7 @@ func (o *ConfigMapOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(configMap.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
@@ -60,14 +60,15 @@ type CreateCronJobOptions struct {
 	Command  []string
 	Restart  string
 
-	Namespace        string
-	EnforceNamespace bool
-	Client           batchv1client.BatchV1Interface
-	DryRunStrategy   cmdutil.DryRunStrategy
-	DryRunVerifier   *resource.QueryParamVerifier
-	Builder          *resource.Builder
-	FieldManager     string
-	CreateAnnotation bool
+	Namespace           string
+	EnforceNamespace    bool
+	Client              batchv1client.BatchV1Interface
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
+	Builder             *resource.Builder
+	FieldManager        string
+	CreateAnnotation    bool
 
 	genericclioptions.IOStreams
 }
@@ -160,6 +161,11 @@ func (o *CreateCronJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, a
 		return printer.PrintObj(obj, o.Out)
 	}
 
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -175,6 +181,7 @@ func (o *CreateCronJobOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(cronJob.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
@@ -72,9 +72,10 @@ type CreateDeploymentOptions struct {
 	FieldManager     string
 	CreateAnnotation bool
 
-	Client         appsv1client.AppsV1Interface
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resource.QueryParamVerifier
+	Client              appsv1client.AppsV1Interface
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
 
 	genericclioptions.IOStreams
 }
@@ -167,6 +168,11 @@ func (o *CreateDeploymentOptions) Complete(f cmdutil.Factory, cmd *cobra.Command
 		return printer.PrintObj(obj, o.Out)
 	}
 
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -191,6 +197,7 @@ func (o *CreateDeploymentOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(deploy.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
@@ -116,9 +116,10 @@ type CreateIngressOptions struct {
 	EnforceNamespace bool
 	CreateAnnotation bool
 
-	Client         networkingv1client.NetworkingV1Interface
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resource.QueryParamVerifier
+	Client              networkingv1client.NetworkingV1Interface
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
 
 	FieldManager string
 
@@ -208,6 +209,11 @@ func (o *CreateIngressOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, a
 	o.PrintObj = func(obj runtime.Object) error {
 		return printer.PrintObj(obj, o.Out)
 	}
+
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -254,6 +260,7 @@ func (o *CreateIngressOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(ingress.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
@@ -62,14 +62,15 @@ type CreateJobOptions struct {
 	From    string
 	Command []string
 
-	Namespace        string
-	EnforceNamespace bool
-	Client           batchv1client.BatchV1Interface
-	DryRunStrategy   cmdutil.DryRunStrategy
-	DryRunVerifier   *resource.QueryParamVerifier
-	Builder          *resource.Builder
-	FieldManager     string
-	CreateAnnotation bool
+	Namespace           string
+	EnforceNamespace    bool
+	Client              batchv1client.BatchV1Interface
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
+	Builder             *resource.Builder
+	FieldManager        string
+	CreateAnnotation    bool
 
 	genericclioptions.IOStreams
 }
@@ -155,6 +156,11 @@ func (o *CreateJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 		return printer.PrintObj(obj, o.Out)
 	}
 
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -207,6 +213,7 @@ func (o *CreateJobOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(job.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
@@ -52,10 +52,11 @@ type NamespaceOptions struct {
 	// Name of resource being created
 	Name string
 
-	DryRunStrategy   cmdutil.DryRunStrategy
-	DryRunVerifier   *resource.QueryParamVerifier
-	CreateAnnotation bool
-	FieldManager     string
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
+	CreateAnnotation    bool
+	FieldManager        string
 
 	Client *coreclient.CoreV1Client
 
@@ -140,6 +141,11 @@ func (o *NamespaceOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 	o.PrintObj = func(obj runtime.Object) error {
 		return printer.PrintObj(obj, o.Out)
 	}
+
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -155,6 +161,7 @@ func (o *NamespaceOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(namespace.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
@@ -70,9 +70,10 @@ type PodDisruptionBudgetOpts struct {
 	Namespace        string
 	EnforceNamespace bool
 
-	Client         *policyv1client.PolicyV1Client
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resourcecli.QueryParamVerifier
+	Client              *policyv1client.PolicyV1Client
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resourcecli.QueryParamVerifier
+	ValidationDirective string
 
 	genericclioptions.IOStreams
 }
@@ -165,6 +166,11 @@ func (o *PodDisruptionBudgetOpts) Complete(f cmdutil.Factory, cmd *cobra.Command
 		return printer.PrintObj(obj, o.Out)
 	}
 
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -217,6 +223,7 @@ func (o *PodDisruptionBudgetOpts) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(podDisruptionBudget.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
@@ -64,9 +64,10 @@ type PriorityClassOptions struct {
 	FieldManager     string
 	CreateAnnotation bool
 
-	Client         *schedulingv1client.SchedulingV1Client
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resource.QueryParamVerifier
+	Client              *schedulingv1client.SchedulingV1Client
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
 
 	genericclioptions.IOStreams
 }
@@ -149,6 +150,11 @@ func (o *PriorityClassOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, a
 		return printer.PrintObj(obj, o.Out)
 	}
 
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -168,6 +174,7 @@ func (o *PriorityClassOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(priorityClass.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
@@ -66,9 +66,10 @@ type QuotaOpts struct {
 	Namespace        string
 	EnforceNamespace bool
 
-	Client         *coreclient.CoreV1Client
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resourcecli.QueryParamVerifier
+	Client              *coreclient.CoreV1Client
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resourcecli.QueryParamVerifier
+	ValidationDirective string
 
 	genericclioptions.IOStreams
 }
@@ -155,6 +156,11 @@ func (o *QuotaOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []strin
 		return printer.PrintObj(obj, o.Out)
 	}
 
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -182,6 +188,7 @@ func (o *QuotaOpts) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(resourceQuota.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -136,16 +136,17 @@ type CreateRoleOptions struct {
 	Resources     []ResourceOptions
 	ResourceNames []string
 
-	DryRunStrategy   cmdutil.DryRunStrategy
-	DryRunVerifier   *resource.QueryParamVerifier
-	OutputFormat     string
-	Namespace        string
-	EnforceNamespace bool
-	Client           clientgorbacv1.RbacV1Interface
-	Mapper           meta.RESTMapper
-	PrintObj         func(obj runtime.Object) error
-	FieldManager     string
-	CreateAnnotation bool
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
+	OutputFormat        string
+	Namespace           string
+	EnforceNamespace    bool
+	Client              clientgorbacv1.RbacV1Interface
+	Mapper              meta.RESTMapper
+	PrintObj            func(obj runtime.Object) error
+	FieldManager        string
+	CreateAnnotation    bool
 
 	genericclioptions.IOStreams
 }
@@ -271,6 +272,11 @@ func (o *CreateRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args
 		return printer.PrintObj(obj, o.Out)
 	}
 
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
 	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return err
@@ -374,6 +380,7 @@ func (o *CreateRoleOptions) RunCreateRole() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(role.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
@@ -61,9 +61,10 @@ type RoleBindingOptions struct {
 	FieldManager     string
 	CreateAnnotation bool
 
-	Client         rbacclientv1.RbacV1Interface
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resource.QueryParamVerifier
+	Client              rbacclientv1.RbacV1Interface
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
 
 	genericclioptions.IOStreams
 }
@@ -149,6 +150,11 @@ func (o *RoleBindingOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, arg
 	o.PrintObj = func(obj runtime.Object) error {
 		return printer.PrintObj(obj, o.Out)
 	}
+
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -178,6 +184,7 @@ func (o *RoleBindingOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(roleBinding.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -112,9 +112,10 @@ type CreateSecretOptions struct {
 	Namespace        string
 	EnforceNamespace bool
 
-	Client         corev1client.CoreV1Interface
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resource.QueryParamVerifier
+	Client              corev1client.CoreV1Interface
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
 
 	genericclioptions.IOStreams
 }
@@ -212,6 +213,11 @@ func (o *CreateSecretOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, ar
 		return printer.PrintObj(obj, o.Out)
 	}
 
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -242,6 +248,7 @@ func (o *CreateSecretOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			err := o.DryRunVerifier.HasSupport(secret.GroupVersionKind())
 			if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go
@@ -108,9 +108,10 @@ type CreateSecretDockerRegistryOptions struct {
 	Namespace        string
 	EnforceNamespace bool
 
-	Client         corev1client.CoreV1Interface
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resource.QueryParamVerifier
+	Client              corev1client.CoreV1Interface
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
 
 	genericclioptions.IOStreams
 }
@@ -211,6 +212,11 @@ func (o *CreateSecretDockerRegistryOptions) Complete(f cmdutil.Factory, cmd *cob
 		return printer.PrintObj(obj, o.Out)
 	}
 
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -241,6 +247,7 @@ func (o *CreateSecretDockerRegistryOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			err := o.DryRunVerifier.HasSupport(secretDockerRegistry.GroupVersionKind())
 			if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go
@@ -69,9 +69,10 @@ type CreateSecretTLSOptions struct {
 	Namespace        string
 	EnforceNamespace bool
 
-	Client         corev1client.CoreV1Interface
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resource.QueryParamVerifier
+	Client              corev1client.CoreV1Interface
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
 
 	genericclioptions.IOStreams
 }
@@ -168,6 +169,11 @@ func (o *CreateSecretTLSOptions) Complete(f cmdutil.Factory, cmd *cobra.Command,
 		return printer.PrintObj(obj, o.Out)
 	}
 
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -198,6 +204,7 @@ func (o *CreateSecretTLSOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			err := o.DryRunVerifier.HasSupport(secretTLS.GroupVersionKind())
 			if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
@@ -74,9 +74,10 @@ type ServiceOptions struct {
 	Namespace        string
 	EnforceNamespace bool
 
-	Client         corev1client.CoreV1Interface
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resource.QueryParamVerifier
+	Client              corev1client.CoreV1Interface
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
 	genericclioptions.IOStreams
 }
 
@@ -129,6 +130,11 @@ func (o *ServiceOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 
 	o.PrintObj = func(obj runtime.Object) error {
 		return printer.PrintObj(obj, o.Out)
+	}
+
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -214,6 +220,7 @@ func (o *ServiceOptions) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			createOptions.DryRun = []string{metav1.DryRunAll}
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
@@ -51,11 +51,12 @@ type ServiceAccountOpts struct {
 	PrintFlags *genericclioptions.PrintFlags
 	PrintObj   func(obj runtime.Object) error
 	// Name of resource being created
-	Name             string
-	DryRunStrategy   cmdutil.DryRunStrategy
-	DryRunVerifier   *resource.QueryParamVerifier
-	CreateAnnotation bool
-	FieldManager     string
+	Name                string
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.QueryParamVerifier
+	ValidationDirective string
+	CreateAnnotation    bool
+	FieldManager        string
 
 	Namespace        string
 	EnforceNamespace bool
@@ -146,6 +147,11 @@ func (o *ServiceAccountOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, arg
 		return printer.PrintObj(obj, o.Out)
 	}
 
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -173,6 +179,7 @@ func (o *ServiceAccountOpts) Run() error {
 		if o.FieldManager != "" {
 			createOptions.FieldManager = o.FieldManager
 		}
+		createOptions.FieldValidation = o.ValidationDirective
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(serviceAccount.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
@@ -72,8 +72,6 @@ var (
 // NewCmdEdit creates the `edit` command
 func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	o := editor.NewEditOptions(editor.NormalEditMode, ioStreams)
-	o.ValidateOptions = cmdutil.ValidateOptions{EnableValidation: true}
-
 	cmd := &cobra.Command{
 		Use:                   "edit (RESOURCE/NAME | -f FILENAME)",
 		DisableFlagsInUseLine: true,
@@ -94,7 +92,7 @@ func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 
 	usage := "to use to edit the resource"
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
-	cmdutil.AddValidateOptionFlags(cmd, &o.ValidateOptions)
+	cmdutil.AddValidateFlags(cmd)
 	cmd.Flags().BoolVarP(&o.OutputPatch, "output-patch", "", o.OutputPatch, "Output the patch if the resource is edited.")
 	cmd.Flags().BoolVar(&o.WindowsLineEndings, "windows-line-endings", o.WindowsLineEndings,
 		"Defaults to the line ending native to your platform.")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -499,7 +499,7 @@ func (f *TestFactory) UnstructuredClientForMapping(mapping *meta.RESTMapping) (r
 }
 
 // Validator returns a validation schema
-func (f *TestFactory) Validator(validate bool) (validation.Schema, error) {
+func (f *TestFactory) Validator(validateDirective string, verifier *resource.QueryParamVerifier) (validation.Schema, error) {
 	return validation.NullSchema{}, nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/factory.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/factory.go
@@ -61,7 +61,7 @@ type Factory interface {
 	UnstructuredClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error)
 
 	// Returns a schema that can validate objects stored on disk.
-	Validator(validate bool) (validation.Schema, error)
+	Validator(validationDirective string, verifier *resource.QueryParamVerifier) (validation.Schema, error)
 	// OpenAPISchema returns the parsed openapi schema definition
 	OpenAPISchema() (openapi.Resources, error)
 	// OpenAPIGetter returns a getter for the openapi schema document

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
@@ -141,8 +142,14 @@ func (f *factoryImpl) UnstructuredClientForMapping(mapping *meta.RESTMapping) (r
 	return restclient.RESTClientFor(cfg)
 }
 
-func (f *factoryImpl) Validator(validate bool) (validation.Schema, error) {
-	if !validate {
+func (f *factoryImpl) Validator(validationDirective string, verifier *resource.QueryParamVerifier) (validation.Schema, error) {
+	// client-side schema validation is only performed
+	// when the validationDirective is strict.
+	// If the directive is warn, we rely on the ParamVerifyingSchema
+	// to ignore the client-side validation and provide a warning
+	// to the user that attempting warn validation when SS validation
+	// is unsupported is inert.
+	if validationDirective == metav1.FieldValidationIgnore {
 		return validation.NullSchema{}, nil
 	}
 
@@ -151,10 +158,11 @@ func (f *factoryImpl) Validator(validate bool) (validation.Schema, error) {
 		return nil, err
 	}
 
-	return validation.ConjunctiveSchema{
+	schema := validation.ConjunctiveSchema{
 		openapivalidation.NewSchemaValidation(resources),
 		validation.NoDoubleKeySchema{},
-	}, nil
+	}
+	return validation.NewParamVerifyingSchema(schema, verifier, string(validationDirective)), nil
 }
 
 // OpenAPISchema returns metadata and structural information about

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -399,11 +399,14 @@ func GetPodRunningTimeoutFlag(cmd *cobra.Command) (time.Duration, error) {
 }
 
 func AddValidateFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool("validate", true, "If true, use a schema to validate the input before sending it")
-}
-
-func AddValidateOptionFlags(cmd *cobra.Command, options *ValidateOptions) {
-	cmd.Flags().BoolVar(&options.EnableValidation, "validate", options.EnableValidation, "If true, use a schema to validate the input before sending it")
+	cmd.Flags().String(
+		"validate",
+		"strict",
+		`Must be one of: strict (or true), warn, ignore (or false).
+		"true" or "strict" will use a schema to validate the input and fail the request if invalid. It will perform server side validation if ServerSideFieldValidation is enabled on the api-server, but will fall back to less reliable client-side validation if not.
+		"warn" will warn about unknown or duplicate fields without blocking the request if server-side field validation is enabled on the API server, and behave as "ignore" otherwise.
+		"false" or "ignore" will not perform any schema validation, silently dropping any unknown or duplicate fields.`,
+	)
 }
 
 func AddFilenameOptionFlags(cmd *cobra.Command, options *resource.FilenameOptions, usage string) {
@@ -475,7 +478,7 @@ func AddSubresourceFlags(cmd *cobra.Command, subresource *string, usage string, 
 }
 
 type ValidateOptions struct {
-	EnableValidation bool
+	ValidationDirective string
 }
 
 // Merge converts the passed in object to JSON, merges the fragment into it using an RFC7396 JSON Merge Patch,
@@ -574,6 +577,30 @@ func GetForceConflictsFlag(cmd *cobra.Command) bool {
 
 func GetFieldManagerFlag(cmd *cobra.Command) string {
 	return GetFlagString(cmd, "field-manager")
+}
+
+func GetValidationDirective(cmd *cobra.Command) (string, error) {
+	var validateFlag = GetFlagString(cmd, "validate")
+	b, err := strconv.ParseBool(validateFlag)
+	if err != nil {
+		switch validateFlag {
+		case cmd.Flag("validate").NoOptDefVal:
+			return metav1.FieldValidationStrict, nil
+		case "strict":
+			return metav1.FieldValidationStrict, nil
+		case "warn":
+			return metav1.FieldValidationWarn, nil
+		case "ignore":
+			return metav1.FieldValidationIgnore, nil
+		default:
+			return metav1.FieldValidationStrict, fmt.Errorf(`invalid - validate option %q; must be one of: strict (or true), warn, ignore (or false)`, validateFlag)
+		}
+	}
+	// The flag was a boolean
+	if b {
+		return metav1.FieldValidationStrict, nil
+	}
+	return metav1.FieldValidationIgnore, nil
 }
 
 type DryRunStrategy int

--- a/staging/src/k8s.io/kubectl/pkg/util/openapi/validation/validation.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/openapi/validation/validation.go
@@ -43,12 +43,12 @@ func NewSchemaValidation(resources openapi.Resources) *SchemaValidation {
 // ValidateBytes will validates the object against using the Resources
 // object.
 func (v *SchemaValidation) ValidateBytes(data []byte) error {
-	obj, err := parse(data)
+	obj, err := Parse(data)
 	if err != nil {
 		return err
 	}
 
-	gvk, errs := getObjectKind(obj)
+	gvk, errs := GetObjectKind(obj)
 	if errs != nil {
 		return utilerrors.NewAggregate(errs)
 	}
@@ -71,7 +71,7 @@ func (v *SchemaValidation) validateList(object interface{}) []error {
 		return []error{errors.New("invalid object to validate")}
 	}
 	for _, item := range fields["items"].([]interface{}) {
-		if gvk, errs := getObjectKind(item); errs != nil {
+		if gvk, errs := GetObjectKind(item); errs != nil {
 			allErrors = append(allErrors, errs...)
 		} else {
 			allErrors = append(allErrors, v.validateResource(item, gvk)...)
@@ -90,7 +90,7 @@ func (v *SchemaValidation) validateResource(obj interface{}, gvk schema.GroupVer
 	return validation.ValidateModel(obj, resource, gvk.Kind)
 }
 
-func parse(data []byte) (interface{}, error) {
+func Parse(data []byte) (interface{}, error) {
 	var obj interface{}
 	out, err := yaml.ToJSON(data)
 	if err != nil {
@@ -102,7 +102,7 @@ func parse(data []byte) (interface{}, error) {
 	return obj, nil
 }
 
-func getObjectKind(object interface{}) (schema.GroupVersionKind, []error) {
+func GetObjectKind(object interface{}) (schema.GroupVersionKind, []error) {
 	var listErrors []error
 	fields, ok := object.(map[string]interface{})
 	if !ok || fields == nil {

--- a/staging/src/k8s.io/kubectl/pkg/validation/schema.go
+++ b/staging/src/k8s.io/kubectl/pkg/validation/schema.go
@@ -22,7 +22,11 @@ import (
 	"fmt"
 
 	ejson "github.com/exponent-io/jsonpath"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/klog/v2"
+	schemavalidation "k8s.io/kubectl/pkg/util/openapi/validation"
 )
 
 // Schema is an interface that knows how to validate an API object serialized to a byte array.
@@ -100,4 +104,51 @@ func (c ConjunctiveSchema) ValidateBytes(data []byte) error {
 		}
 	}
 	return utilerrors.NewAggregate(list)
+}
+
+func NewParamVerifyingSchema(s Schema, verifier resource.Verifier, directive string) Schema {
+	return &paramVerifyingSchema{
+		schema:    s,
+		verifier:  verifier,
+		directive: directive,
+	}
+}
+
+// paramVerifyingSchema only performs validation
+// based on the fieldValidation query param
+// being unsupported by the apiserver, because
+// server-side validation will be performed instead
+// of client-side validation.
+type paramVerifyingSchema struct {
+	schema    Schema
+	verifier  resource.Verifier
+	directive string
+}
+
+// ValidateBytes validates bytes per a ParamVerifyingSchema
+func (c *paramVerifyingSchema) ValidateBytes(data []byte) error {
+	obj, err := schemavalidation.Parse(data)
+	if err != nil {
+		return err
+	}
+
+	gvk, errs := schemavalidation.GetObjectKind(obj)
+	if errs != nil {
+		return utilerrors.NewAggregate(errs)
+	}
+
+	err = c.verifier.HasSupport(gvk)
+	if resource.IsParamUnsupportedError(err) {
+		switch c.directive {
+		case metav1.FieldValidationStrict:
+			return c.schema.ValidateBytes(data)
+		case metav1.FieldValidationWarn:
+			klog.Warningf("cannot perform warn validation if server-side field validation is unsupported, skipping validation")
+		default:
+			// can't be reached
+			klog.Warningf("unexpected field validation directive: %s, skipping validation", c.directive)
+		}
+		return nil
+	}
+	return err
 }

--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -72,18 +72,6 @@ run_kubectl_create_error_tests() {
   # Passing no arguments to create is an error
   ! kubectl create || exit 1
 
-  ## kubectl create should not panic on empty string lists in a template
-  ERROR_FILE="${KUBE_TEMP}/validation-error"
-  kubectl create -f hack/testdata/invalid-rc-with-empty-args.yaml "${kube_flags[@]}" 2> "${ERROR_FILE}" || true
-  # Post-condition: should get an error reporting the empty string
-  if grep -q "unknown object type \"nil\" in ReplicationController" "${ERROR_FILE}"; then
-    kube::log::status "\"kubectl create with empty string list returns error as expected: $(cat "${ERROR_FILE}")"
-  else
-    kube::log::status "\"kubectl create with empty string list returns unexpected error or non-error: $(cat "${ERROR_FILE}")"
-    exit 1
-  fi
-  rm "${ERROR_FILE}"
-
   # Posting a pod to namespaces should fail.  Also tests --raw forcing the post location
   grep -q 'the object provided is unrecognized (must be of type Namespace)' <<< "$( kubectl create "${kube_flags[@]}" --raw /api/v1/namespaces -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml --v=8 2>&1 )"
 

--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -154,6 +154,27 @@ run_kubectl_create_kustomization_directory_tests() {
   set +o errexit
 }
 
+has_one_of_error_message() {
+  local message=$1
+  local match1=$2
+  local match2=$3
+
+  if (grep -q "${match1}" <<< "${message}") || (grep -q "${match2}" <<< "${message}"); then
+    echo "Successful"
+    echo "message:${message}"
+    echo "has either:${match1}"
+    echo "or:${match2}"
+    return 0
+  else
+    echo "FAIL!"
+    echo "message:${message}"
+    echo "has neither:${match1}"
+    echo "nor:${match2}"
+    caller
+    return 1
+  fi
+}
+
 # Runs tests related to kubectl create --validate
 run_kubectl_create_validate_tests() {
   set -o nounset
@@ -165,7 +186,7 @@ run_kubectl_create_validate_tests() {
   kube::log::status "Testing kubectl create --validate=true"
   # create and verify
   output_message=$(! kubectl create -f hack/testdata/invalid-deployment-unknown-and-duplicate-fields.yaml --validate=true 2>&1)
-  kube::test::if_has_string "${output_message}" 'error validating data'
+  has_one_of_error_message "${output_message}" 'strict decoding error' 'error validating data'
 
   ## test  --validate=false
   kube::log::status "Testing kubectl create --validate=false"
@@ -179,7 +200,7 @@ run_kubectl_create_validate_tests() {
   kube::log::status "Testing kubectl create --validate=strict"
   # create and verify
   output_message=$(! kubectl create -f hack/testdata/invalid-deployment-unknown-and-duplicate-fields.yaml --validate=strict 2>&1)
-  kube::test::if_has_string "${output_message}" 'error validating data'
+  has_one_of_error_message "${output_message}" 'strict decoding error' 'error validating data'
 
   ## test --validate=warn
   kube::log::status "Testing kubectl create --validate=warn"
@@ -201,7 +222,7 @@ run_kubectl_create_validate_tests() {
   kube::log::status "Testing kubectl create"
   # create and verify
   output_message=$(! kubectl create -f hack/testdata/invalid-deployment-unknown-and-duplicate-fields.yaml 2>&1)
-  kube::test::if_has_string "${output_message}" 'error validating data'
+  has_one_of_error_message "${output_message}" 'strict decoding error' 'error validating data'
 
   ## test invalid validate value
   kube::log::status "Testing kubectl create --validate=foo"

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -573,6 +573,7 @@ runTests() {
   fi
   if kube::test::if_supports_resource "${deployments}"; then
     record_command run_kubectl_create_kustomization_directory_tests
+    record_command run_kubectl_create_validate_tests
   fi
 
   ######################

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -95,19 +95,19 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 
 		ginkgo.By("client-side validation (kubectl create and apply) rejects request with unknown properties when disallowed by the schema")
 		unknownCR := fmt.Sprintf(`{%s,"spec":{"foo":true}}`, meta)
-		if _, err := framework.RunKubectlInput(f.Namespace.Name, unknownCR, ns, "create", "-f", "-"); err == nil || !strings.Contains(err.Error(), `unknown field "foo"`) {
+		if _, err := framework.RunKubectlInput(f.Namespace.Name, unknownCR, ns, "create", "-f", "-"); err == nil || (!strings.Contains(err.Error(), `unknown field "foo"`) && !strings.Contains(err.Error(), `unknown field "spec.foo"`)) {
 			framework.Failf("unexpected no error when creating CR with unknown field: %v", err)
 		}
-		if _, err := framework.RunKubectlInput(f.Namespace.Name, unknownCR, ns, "apply", "-f", "-"); err == nil || !strings.Contains(err.Error(), `unknown field "foo"`) {
+		if _, err := framework.RunKubectlInput(f.Namespace.Name, unknownCR, ns, "apply", "-f", "-"); err == nil || (!strings.Contains(err.Error(), `unknown field "foo"`) && !strings.Contains(err.Error(), `unknown field "spec.foo"`)) {
 			framework.Failf("unexpected no error when applying CR with unknown field: %v", err)
 		}
 
 		ginkgo.By("client-side validation (kubectl create and apply) rejects request without required properties")
 		noRequireCR := fmt.Sprintf(`{%s,"spec":{"bars":[{"age":"10"}]}}`, meta)
-		if _, err := framework.RunKubectlInput(f.Namespace.Name, noRequireCR, ns, "create", "-f", "-"); err == nil || !strings.Contains(err.Error(), `missing required field "name"`) {
+		if _, err := framework.RunKubectlInput(f.Namespace.Name, noRequireCR, ns, "create", "-f", "-"); err == nil || (!strings.Contains(err.Error(), `missing required field "name"`) && !strings.Contains(err.Error(), `spec.bars[0].name: Required value`)) {
 			framework.Failf("unexpected no error when creating CR without required field: %v", err)
 		}
-		if _, err := framework.RunKubectlInput(f.Namespace.Name, noRequireCR, ns, "apply", "-f", "-"); err == nil || !strings.Contains(err.Error(), `missing required field "name"`) {
+		if _, err := framework.RunKubectlInput(f.Namespace.Name, noRequireCR, ns, "apply", "-f", "-"); err == nil || (!strings.Contains(err.Error(), `missing required field "name"`) && !strings.Contains(err.Error(), `spec.bars[0].name: Required value`)) {
 			framework.Failf("unexpected no error when applying CR without required field: %v", err)
 		}
 

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1071,7 +1071,9 @@ metadata:
 			framework.ExpectNotEqual(schema, nil, "retrieving a schema for the crd")
 
 			meta := fmt.Sprintf(metaPattern, crd.Crd.Spec.Names.Kind, crd.Crd.Spec.Group, crd.Crd.Spec.Versions[0].Name, "test-cr")
-			validArbitraryCR := fmt.Sprintf(`{%s,"spec":{"bars":[{"name":"test-bar"}],"extraProperty":"arbitrary-value"}}`, meta)
+
+			// unknown fields on the root are considered valid
+			validArbitraryCR := fmt.Sprintf(`{%s,"spec":{"bars":[{"name":"test-bar"}]},"extraProperty":"arbitrary-value"}`, meta)
 			err = createApplyCustomResource(validArbitraryCR, f.Namespace.Name, "test-cr", crd)
 			framework.ExpectNoError(err, "creating custom resource")
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Modifies the behavior of the kubectl `--validate` flag to support server-side field validation.

Changes the kubectl --validate flag from a bool to a string that accepts the values {true, strict, warn, false, ignore}
* true/strict - perform validation and error the request on any invalid fields in the ojbect. It will attempt to perform server-side validation if it is enabled on the apiserver, otherwise it will fall back to client-side validation.
* warn - perform server-side validation and warn on any invalid fields (but ultimately let the request succeed by dropping any invalid fields from the object). If validation is not available on the server, perform no validation.
* false/ignore - perform no validation, silently dropping invalid fields from the object.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This addresses the [kubectl flag](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2885-server-side-unknown-field-validation) portion of the beta graduation criteria of [KEP-2885](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2885-server-side-unknown-field-validation)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Changes the kubectl --validate flag from a bool to a string that accepts the values {true, strict, warn, false, ignore}
* true/strict - perform validation and error the request on any invalid fields in the ojbect. It will attempt to perform server-side validation if it is enabled on the apiserver, otherwise it will fall back to client-side validation.
* warn - perform server-side validation and warn on any invalid fields (but ultimately let the request succeed by dropping any invalid fields from the object). If validation is not available on the server, perform no validation.
* false/ignore - perform no validation, silently dropping invalid fields from the object.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2885-server-side-unknown-field-validation
```
