### PR TITLE
Fix incorrect test cases to cover code that needs to be tested in `TestValidateIPSet`

### DIFF
--- a/pkg/util/ipset/ipset_test.go
+++ b/pkg/util/ipset/ipset_test.go
@@ -927,7 +927,7 @@ func TestValidateIPSet(t *testing.T) {
 		{ // case[3]
 			ipset: &IPSet{
 				Name:       "bar",
-				SetType:    BitmapPort,
+				SetType:    HashIPPort,
 				HashFamily: ProtocolFamilyIPV6,
 				HashSize:   0,
 				MaxElem:    2048,
@@ -938,7 +938,7 @@ func TestValidateIPSet(t *testing.T) {
 		{ // case[4]
 			ipset: &IPSet{
 				Name:       "baz",
-				SetType:    BitmapPort,
+				SetType:    HashIPPort,
 				HashFamily: ProtocolFamilyIPV6,
 				HashSize:   1024,
 				MaxElem:    -1,


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Wrong test cases:
https://github.com/kubernetes/kubernetes/blob/5bafc8306a7b622e292746aec8a9e9212b755071/pkg/util/ipset/ipset_test.go#L927-L948
According to the testcases desc field, we can see that case[3] is the test `wrong hash size number`
case[4] is to test `wrong hash max elem number`
However, when building the test case, the value set by the `IPSet.SetType` fields is `BitmapPort`, 
https://github.com/kubernetes/kubernetes/blob/5bafc8306a7b622e292746aec8a9e9212b755071/pkg/util/ipset/ipset_test.go#L930
https://github.com/kubernetes/kubernetes/blob/5bafc8306a7b622e292746aec8a9e9212b755071/pkg/util/ipset/ipset_test.go#L941
which does not conform to the description of the `desc` field.
And this will cause the test to jump directly to verifying the `PortRange` of `BitmapPort`. At this time, `PortRange == ""`, so it will definitely return `false`, 
https://github.com/kubernetes/kubernetes/blob/5bafc8306a7b622e292746aec8a9e9212b755071/pkg/util/ipset/ipset.go#L107-L109
and the verified HashSize and MaxElem part code that needs to be tested is not tested.
https://github.com/kubernetes/kubernetes/blob/5bafc8306a7b622e292746aec8a9e9212b755071/pkg/util/ipset/ipset.go#L112-L121 


#### When we modified the code, the test coverage increased from `85.0%` to `87.2%` and the code that verified the HashSize and MaxElem part code  that was not covered previously was covered.
Run command:
```
go test -cover ./pkg/util/ipset/
```
Befor：
```
ok      k8s.io/kubernetes/pkg/util/ipset        0.919s  coverage: 85.0% of statements
```

After：
```
ok      k8s.io/kubernetes/pkg/util/ipset        (cached)        coverage: 87.2% of statements
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig testing