### PR TITLE
Fix logging statement with missing parameter

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -222,7 +222,7 @@ func (c *codec) doEncode(obj runtime.Object, w io.Writer, memAlloc runtime.Memor
 				return encoder.EncodeWithAllocator(obj, w, memAlloc)
 			}
 		} else {
-			klog.V(4).Infof("a memory allocator was provided but the encoder %T doesn't implement the runtime.EncoderWithAllocator, using regular encoder.Encode method")
+			klog.V(4).Infof("a memory allocator was provided but the encoder %s doesn't implement the runtime.EncoderWithAllocator, using regular encoder.Encode method", c.encoder.Identifier())
 		}
 	}
 	switch obj := obj.(type) {


### PR DESCRIPTION
`kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go`
Line 225 has a logging statement with missing parameter, causing:

```bash
I0225 16:19:15.424936 1416311 versioning.go:225] a memory allocator was provided but the encoder %!T(MISSING) doesn't implement the runtime.EncoderWithAllocator, using regular encoder.Encode method
```

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>


#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108355

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
