### PR TITLE
Makefile: remove superfluous @

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -86,7 +86,7 @@ endef
 .PHONY: all
 ifeq ($(PRINT_HELP),y)
 all:
-	@echo "$$ALL_HELP_INFO"
+	echo "$$ALL_HELP_INFO"
 else
 all: generated_files
 	hack/make-rules/build.sh $(WHAT)
@@ -101,7 +101,7 @@ endef
 .PHONY: ginkgo
 ifeq ($(PRINT_HELP),y)
 ginkgo:
-	@echo "$$GINKGO_HELP_INFO"
+	echo "$$GINKGO_HELP_INFO"
 else
 ginkgo:
 	hack/make-rules/build.sh vendor/github.com/onsi/ginkgo/ginkgo
@@ -122,7 +122,7 @@ endef
 .PHONY: verify
 ifeq ($(PRINT_HELP),y)
 verify:
-	@echo "$$VERIFY_HELP_INFO"
+	echo "$$VERIFY_HELP_INFO"
 else
 verify:
 	KUBE_VERIFY_GIT_BRANCH=$(BRANCH) hack/make-rules/verify.sh
@@ -137,7 +137,7 @@ endef
 .PHONY: quick-verify
 ifeq ($(PRINT_HELP),y)
 quick-verify:
-	@echo "$$QUICK_VERIFY_HELP_INFO"
+	echo "$$QUICK_VERIFY_HELP_INFO"
 else
 quick-verify:
 	QUICK=true SILENT=false hack/make-rules/verify.sh
@@ -152,7 +152,7 @@ endef
 .PHONY: update
 ifeq ($(PRINT_HELP),y)
 update:
-	@echo "$$UPDATE_HELP_INFO"
+	echo "$$UPDATE_HELP_INFO"
 else
 update: generated_files
 	CALLED_FROM_MAIN_MAKEFILE=1 hack/make-rules/update.sh
@@ -178,7 +178,7 @@ endef
 .PHONY: check test
 ifeq ($(PRINT_HELP),y)
 check test:
-	@echo "$$CHECK_TEST_HELP_INFO"
+	echo "$$CHECK_TEST_HELP_INFO"
 else
 check test: generated_files
 	hack/make-rules/test.sh $(WHAT) $(TESTS)
@@ -197,7 +197,7 @@ endef
 .PHONY: test-integration
 ifeq ($(PRINT_HELP),y)
 test-integration:
-	@echo "$$TEST_IT_HELP_INFO"
+	echo "$$TEST_IT_HELP_INFO"
 else
 test-integration: generated_files
 	hack/make-rules/test-integration.sh $(WHAT)
@@ -268,7 +268,7 @@ endef
 .PHONY: test-e2e-node
 ifeq ($(PRINT_HELP),y)
 test-e2e-node:
-	@echo "$$TEST_E2E_NODE_HELP_INFO"
+	echo "$$TEST_E2E_NODE_HELP_INFO"
 else
 test-e2e-node: ginkgo generated_files
 	hack/make-rules/test-e2e-node.sh
@@ -287,7 +287,7 @@ endef
 .PHONY: test-cmd
 ifeq ($(PRINT_HELP),y)
 test-cmd:
-	@echo "$$TEST_CMD_HELP_INFO"
+	echo "$$TEST_CMD_HELP_INFO"
 else
 test-cmd: generated_files
 	hack/make-rules/test-cmd.sh
@@ -304,7 +304,7 @@ endef
 .PHONY: clean
 ifeq ($(PRINT_HELP),y)
 clean:
-	@echo "$$CLEAN_HELP_INFO"
+	echo "$$CLEAN_HELP_INFO"
 else
 clean: clean_meta
 	build/make-clean.sh
@@ -320,7 +320,7 @@ endef
 .PHONY: clean_meta
 ifeq ($(PRINT_HELP),y)
 clean_meta:
-	@echo "$$CLEAN_META_HELP_INFO"
+	echo "$$CLEAN_META_HELP_INFO"
 else
 clean_meta:
 	rm -rf $(META_DIR)
@@ -336,7 +336,7 @@ endef
 .PHONY: clean_generated
 ifeq ($(PRINT_HELP),y)
 clean_generated:
-	@echo "$$CLEAN_GENERATED_HELP_INFO"
+	echo "$$CLEAN_GENERATED_HELP_INFO"
 else
 clean_generated:
 	find . -type f -name '$(GENERATED_FILE_PREFIX)*'  | xargs rm -f
@@ -357,7 +357,7 @@ endef
 .PHONY: vet
 ifeq ($(PRINT_HELP),y)
 vet:
-	@echo "$$VET_HELP_INFO"
+	echo "$$VET_HELP_INFO"
 else
 vet: generated_files
 	CALLED_FROM_MAIN_MAKEFILE=1 hack/make-rules/vet.sh $(WHAT)
@@ -376,7 +376,7 @@ endef
 .PHONY: release release-in-a-container
 ifeq ($(PRINT_HELP),y)
 release release-in-a-container:
-	@echo "$$RELEASE_HELP_INFO"
+	echo "$$RELEASE_HELP_INFO"
 else
 release release-in-a-container: KUBE_BUILD_CONFORMANCE = y
 release:
@@ -398,7 +398,7 @@ endef
 ifeq ($(PRINT_HELP),y)
 release-images: KUBE_BUILD_CONFORMANCE = y
 release-images:
-	@echo "$$RELEASE_IMAGES_HELP_INFO"
+	echo "$$RELEASE_IMAGES_HELP_INFO"
 else
 release-images:
 	build/release-images.sh
@@ -420,7 +420,7 @@ endef
 .PHONY: release-skip-tests quick-release
 ifeq ($(PRINT_HELP),y)
 release-skip-tests quick-release:
-	@echo "$$RELEASE_SKIP_TESTS_HELP_INFO"
+	echo "$$RELEASE_SKIP_TESTS_HELP_INFO"
 else
 release-skip-tests quick-release: KUBE_RELEASE_RUN_TESTS = n
 release-skip-tests quick-release: KUBE_FASTBUILD = true
@@ -441,7 +441,7 @@ endef
 .PHONY: quick-release-images
 ifeq ($(PRINT_HELP),y)
 quick-release-images:
-	@echo "$$QUICK_RELEASE_IMAGES_HELP_INFO"
+	echo "$$QUICK_RELEASE_IMAGES_HELP_INFO"
 else
 quick-release-images: KUBE_FASTBUILD = true
 quick-release-images:
@@ -459,7 +459,7 @@ endef
 .PHONY: package package-tarballs
 ifeq ($(PRINT_HELP),y)
 package package-tarballs:
-	@echo "$$PACKAGE_HELP_INFO"
+	echo "$$PACKAGE_HELP_INFO"
 else
 package-tarballs: KUBE_BUILD_CONFORMANCE = y
 package package-tarballs:
@@ -479,7 +479,7 @@ endef
 .PHONY: cross cross-in-a-container
 ifeq ($(PRINT_HELP),y)
 cross cross-in-a-container:
-	@echo "$$CROSS_HELP_INFO"
+	echo "$$CROSS_HELP_INFO"
 else
 cross cross-in-a-container: KUBE_BUILD_CONFORMANCE = y
 cross:
@@ -487,7 +487,7 @@ cross:
 cross-in-a-container: KUBE_OUTPUT_SUBPATH = $(OUT_DIR)/dockerized
 cross-in-a-container:
 ifeq (,$(wildcard /.dockerenv))
-	@echo -e "\nThe 'cross-in-a-container' target can only be used from within a docker container.\n"
+	echo -e "\nThe 'cross-in-a-container' target can only be used from within a docker container.\n"
 else
 	hack/make-rules/cross.sh
 endif
@@ -505,7 +505,7 @@ CMD_TARGET = $(filter-out %$(EXCLUDE_TARGET),$(notdir $(abspath $(wildcard cmd/*
 .PHONY: $(CMD_TARGET)
 ifeq ($(PRINT_HELP),y)
 $(CMD_TARGET):
-	@echo "$$CMD_HELP_INFO"
+	echo "$$CMD_HELP_INFO"
 else
 $(CMD_TARGET): generated_files
 	hack/make-rules/build.sh cmd/$@
@@ -520,7 +520,7 @@ endef
 .PHONY: generated_files
 ifeq ($(PRINT_HELP),y)
 generated_files:
-	@echo "$$GENERATED_FILES_HELP_INFO"
+	echo "$$GENERATED_FILES_HELP_INFO"
 else
 generated_files gen_openapi:
 	$(MAKE) -f Makefile.generated_files $@ CALLED_FROM_MAIN_MAKEFILE=1
@@ -535,7 +535,7 @@ endef
 .PHONY: help
 ifeq ($(PRINT_HELP),y)
 help:
-	@echo "$$HELP_INFO"
+	echo "$$HELP_INFO"
 else
 help:
 	hack/make-rules/make-help.sh


### PR DESCRIPTION
I'm peeling some obvious commits off my workspaces branch.

We already use `-s` when desired.

/kind cleanup

-->
```release-note
NONE
```
