### PR TITLE
Makefile: use errexit, pipefail, and nounset

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -30,7 +30,7 @@ endif
 #   clean: Clean up.
 
 # It's necessary to set this because some environments don't link sh -> bash.
-SHELL := /usr/bin/env bash
+SHELL := /usr/bin/env bash -o errexit -o pipefail -o nounset
 
 # Define variables so `make --warn-undefined-variables` works.
 PRINT_HELP ?=


### PR DESCRIPTION
I'm peeling some obvious commits off my workspaces branch.

This allows errors inside multi-statement shell blocks to cause builds to fail (as they were intended).  The normal build is unaffected.

/kind bug
/kind cleanup

```release-note
NONE
```

