### PR TITLE
Makefile: abort if symlinks in CWD

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -62,6 +62,15 @@ endif
 # This controls the verbosity of the build.  Higher numbers mean more output.
 KUBE_VERBOSE ?= 1
 
+# Having symlinks in the CWD confuses Go.  The Go team hopes to fix this, but
+# a trivial fix turned out to be insufficient.
+#     https://github.com/golang/go/issues/50807
+ifneq ($(shell pwd),$(shell pwd -P))
+    $(warning The current directory appears to have symlinks, which confuses Go.  Try:)
+    $(warning `    cd $(shell pwd -P)  # cd $$(pwd -P))
+    $(error Aborting)
+endif
+
 define ALL_HELP_INFO
 # Build code.
 #


### PR DESCRIPTION
I'm peeling some obvious commits off my workspaces branch.

This does not have USER impact but it may have developer impact.  If the path to you git repo includes a symlink, it will now ask you to change to the non-symlink directory.

```
$ make
Makefile:69: The current directory appears to have symlinks, which confuses Go.  Try:
Makefile:70: `    cd /home/thockin/src/go/src/k8s.io/kubernetes  # cd $(pwd -P)
Makefile:71: *** Aborting.  Stop.
```

/kind bug
/kind cleanup

```release-note
NONE
```
