### PR TITLE
Makefile: add a DBG variable

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -73,6 +73,8 @@ define ALL_HELP_INFO
 #   GOFLAGS: Extra flags to pass to 'go' when building.
 #   GOLDFLAGS: Extra linking flags passed to 'go' when building.
 #   GOGCFLAGS: Additional go compile flags passed to 'go' when building.
+#   DBG: If set to "1", build with optimizations disabled for easier
+#     debugging.  Any other value is ignored.
 #
 # Example:
 #   make

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -803,15 +803,20 @@ kube::golang::build_binaries() {
     # build_binaries_for_platform.
     local goflags goldflags goasmflags gogcflags gotags
 
-    goasmflags="-trimpath=${KUBE_ROOT}"
+    # This is $(pwd) because we use run-in-gopath to build.  Once that is
+    # excised, this can become ${KUBE_ROOT}.
+    local trimroot # two lines to appease shellcheck SC2155
+    trimroot=$(pwd)
 
-    gogcflags="-trimpath=${KUBE_ROOT} ${GOGCFLAGS:-}"
+    goasmflags="all=-trimpath=${trimroot}"
+
+    gogcflags="all=-trimpath=${trimroot} ${GOGCFLAGS:-}"
     if [[ "${DBG:-}" == 1 ]]; then
         # Debugging - disable optimizations and inlining.
         gogcflags="${gogcflags} -N -l"
     fi
 
-    goldflags="$(kube::version::ldflags) ${GOLDFLAGS:-}"
+    goldflags="all=$(kube::version::ldflags) ${GOLDFLAGS:-}"
     if [[ "${DBG:-}" != 1 ]]; then
         # Not debugging - disable symbols and DWARF.
         goldflags="${goldflags} -s -w"


### PR DESCRIPTION
Now `make DBG=1` will produce binaries with no optimizaions and no inlining, but with symbols and DWARF information.

This also sets the various compile flags to use "all=" syntax.  Otherwise things like trimpath only apply to the CLI-listed packages and nothing else (which seems egregiously wrong).

Worth noting: this builds tools (like codegens) with debugging too.  We could make it more sophisticated if that seems a problem (e.g.  a different flag or value)

To discuss: "DBG" vs "KUBE_DBG" vs `make debug` vs ...

/kind cleanup

```release-note
NONE
```
