### PR TITLE
Makefile: clean up static/nonstatic build output

### DIFF
--- a/build/root/Makefile.generated_files
+++ b/build/root/Makefile.generated_files
@@ -67,7 +67,8 @@ $(META_DIR)/$(GO_PKGDEPS_FILE): FORCE
 	if [[ "$(DBG_CODEGEN)" == 1 ]]; then          \
 	    echo "DBG: calculating Go dependencies";  \
 	fi
-	hack/run-in-gopath.sh go install ./hack/make-rules/helpers/go2make
+	KUBE_BUILD_PLATFORMS="" \
+	    hack/make-rules/build.sh hack/make-rules/helpers/go2make
 	hack/run-in-gopath.sh go2make                       \
 	    k8s.io/kubernetes/...                           \
 	    --prune  k8s.io/kubernetes/staging              \
@@ -205,7 +206,8 @@ $(PRERELEASE_LIFECYCLE_FILES): $(PRERELEASE_LIFECYCLE_GEN)
 # newer than the binary, and try to "rebuild" it over and over.  So we touch
 # it, and make is happy.
 $(PRERELEASE_LIFECYCLE_GEN): $(GODEPS_k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/prerelease-lifecycle-gen)
-	KUBE_BUILD_PLATFORMS="" hack/make-rules/build.sh ./vendor/k8s.io/code-generator/cmd/prerelease-lifecycle-gen
+	KUBE_BUILD_PLATFORMS="" \
+	    hack/make-rules/build.sh vendor/k8s.io/code-generator/cmd/prerelease-lifecycle-gen
 	touch $@
 
 
@@ -299,7 +301,8 @@ $(DEEPCOPY_FILES): $(DEEPCOPY_GEN)
 # newer than the binary, and try to "rebuild" it over and over.  So we touch
 # it, and make is happy.
 $(DEEPCOPY_GEN): $(GODEPS_k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/deepcopy-gen)
-	KUBE_BUILD_PLATFORMS="" hack/make-rules/build.sh ./vendor/k8s.io/code-generator/cmd/deepcopy-gen
+	KUBE_BUILD_PLATFORMS="" \
+	    hack/make-rules/build.sh vendor/k8s.io/code-generator/cmd/deepcopy-gen
 	touch $@
 
 
@@ -399,7 +402,8 @@ $(DEFAULTER_FILES): $(DEFAULTER_GEN)
 # newer than the binary, and try to "rebuild" it over and over.  So we touch
 # it, and make is happy.
 $(DEFAULTER_GEN): $(GODEPS_k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/defaulter-gen)
-	KUBE_BUILD_PLATFORMS="" hack/make-rules/build.sh ./vendor/k8s.io/code-generator/cmd/defaulter-gen
+	KUBE_BUILD_PLATFORMS="" \
+	    hack/make-rules/build.sh vendor/k8s.io/code-generator/cmd/defaulter-gen
 	touch $@
 
 
@@ -512,7 +516,8 @@ $(CONVERSION_FILES): $(CONVERSION_GEN)
 # newer than the binary, and try to rebuild it over and over.  So we touch it,
 # and make is happy.
 $(CONVERSION_GEN): $(GODEPS_k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/conversion-gen)
-	KUBE_BUILD_PLATFORMS="" hack/make-rules/build.sh ./vendor/k8s.io/code-generator/cmd/conversion-gen
+	KUBE_BUILD_PLATFORMS="" \
+	    hack/make-rules/build.sh vendor/k8s.io/code-generator/cmd/conversion-gen
 	touch $@
 
 
@@ -636,5 +641,6 @@ gen_openapi: $(OPENAPI_GEN) $(KUBE_OPENAPI_OUTFILE) $(AGGREGATOR_OPENAPI_OUTFILE
 # newer than the binary, and try to "rebuild" it over and over.  So we touch
 # it, and make is happy.
 $(OPENAPI_GEN): $(GODEPS_k8s.io/kubernetes/vendor/k8s.io/kube-openapi/cmd/openapi-gen)
-	KUBE_BUILD_PLATFORMS="" hack/make-rules/build.sh ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
+	KUBE_BUILD_PLATFORMS="" \
+	    hack/make-rules/build.sh vendor/k8s.io/kube-openapi/cmd/openapi-gen
 	touch $@


### PR DESCRIPTION
Slightly nicer output when building

before:

```
$ make generated_files
+++ [0226 13:42:17] Building go targets for linux/amd64:
    hack/make-rules/helpers/go2make
> non-static build: k8s.io/kubernetes/hack/make-rules/helpers/go2make
```

after:

```
$ make generated_files
+++ [0226 14:30:08] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
```

or:

```
$ make all WHAT="cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo"
+++ [0227 10:30:27] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0227 10:30:31] Building go targets for linux/amd64
    k8s.io/kubernetes/cmd/kubectl (static)
    k8s.io/kubernetes/test/e2e/e2e.test (test)
    k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/ginkgo (non-static)
```

The "Building go targets..." lines are once per invocation of build.sh.  I don't love it but it's better than before?  TGhe alternative would be to emit one "Building go target" for each target, but we don't call `go build` once per binary, so the timestamps are kind of a lie.

/kind cleanup
```release-note
NONE
```
