### PR TITLE
Do not assume a namespace for cluster-scoped custom resources of kind "Namespace" and their subresources

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
@@ -55,6 +55,9 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{"GET", "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"GET", "/api/v1/namespaces/other/pods", "list", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 
+		{"GET", "/apis/stable.example.com/v1/namespaces/example", "get", "apis", "stable.example.com", "v1", "", "namespaces", "", "example", []string{"namespaces", "example"}},
+		{"GET", "/apis/stable.example.com/v1/namespaces/other/namespaces/example", "get", "apis", "stable.example.com", "v1", "other", "namespaces", "", "example", []string{"namespaces", "example"}},
+
 		// special verbs
 		{"GET", "/api/v1/proxy/namespaces/other/pods/foo", "proxy", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"GET", "/api/v1/proxy/namespaces/other/pods/foo/subpath/not/a/subresource", "proxy", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo", "subpath", "not", "a", "subresource"}},
@@ -64,23 +67,35 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{"GET", "/api/v1/watch/namespaces/other/pods", "watch", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 		{"GET", "/api/v1/namespaces/other/pods?watch=1", "watch", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 		{"GET", "/api/v1/namespaces/other/pods?watch=0", "list", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
+		// watch cluster-scoped CRs
+		{"GET", "/apis/stable.example.com/v1/namespaces?watch=true", "watch", "apis", "stable.example.com", "v1", "", "namespaces", "", "", []string{"namespaces"}},
+		{"GET", "/apis/stable.example.com/v1/namespaces/other/namespaces?watch=true", "watch", "apis", "stable.example.com", "v1", "other", "namespaces", "", "", []string{"namespaces"}},
+		// watch namespace-scoped CRs in all namespaces
+		{"GET", "/apis/stable.example.com/v1/namespaces?watch=true", "watch", "apis", "stable.example.com", "v1", namespaceAll, "namespaces", "", "", []string{"namespaces"}},
 
 		// subresource identification
 		{"GET", "/api/v1/namespaces/other/pods/foo/status", "get", "api", "", "v1", "other", "pods", "status", "foo", []string{"pods", "foo", "status"}},
 		{"GET", "/api/v1/namespaces/other/pods/foo/proxy/subpath", "get", "api", "", "v1", "other", "pods", "proxy", "foo", []string{"pods", "foo", "proxy", "subpath"}},
 		{"PUT", "/api/v1/namespaces/other/finalize", "update", "api", "", "v1", "other", "namespaces", "finalize", "other", []string{"namespaces", "other", "finalize"}},
 		{"PUT", "/api/v1/namespaces/other/status", "update", "api", "", "v1", "other", "namespaces", "status", "other", []string{"namespaces", "other", "status"}},
+		{"GET", "/apis/stable.example.com/v1/namespaces/example/status", "get", "apis", "stable.example.com", "v1", "", "namespaces", "status", "example", []string{"namespaces", "example", "status"}},
+		{"GET", "/apis/stable.example.com/v1/namespaces/other/namespaces/example/status", "get", "apis", "stable.example.com", "v1", "other", "namespaces", "status", "example", []string{"namespaces", "example", "status"}},
 
 		// verb identification
 		{"PATCH", "/api/v1/namespaces/other/pods/foo", "patch", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"DELETE", "/api/v1/namespaces/other/pods/foo", "delete", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"POST", "/api/v1/namespaces/other/pods", "create", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
+		{"POST", "/apis/stable.example.com/v1/namespaces", "create", "apis", "stable.example.com", "v1", "", "namespaces", "", "", []string{"namespaces"}},
+		{"POST", "/apis/stable.example.com/v1/namespaces/other/namespaces", "create", "apis", "stable.example.com", "v1", "other", "namespaces", "", "", []string{"namespaces"}},
+
 
 		// deletecollection verb identification
 		{"DELETE", "/api/v1/nodes", "deletecollection", "api", "", "v1", "", "nodes", "", "", []string{"nodes"}},
 		{"DELETE", "/api/v1/namespaces", "deletecollection", "api", "", "v1", "", "namespaces", "", "", []string{"namespaces"}},
 		{"DELETE", "/api/v1/namespaces/other/pods", "deletecollection", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 		{"DELETE", "/apis/extensions/v1/namespaces/other/pods", "deletecollection", "api", "extensions", "v1", "other", "pods", "", "", []string{"pods"}},
+		{"DELETE", "/apis/stable.example.com/v1/namespaces", "deletecollection", "apis", "stable.example.com", "v1", "", "namespaces", "", "", []string{"namespaces"}},
+		{"DELETE", "/apis/stable.example.com/v1/namespaces/other/namespaces", "deletecollection", "apis", "stable.example.com", "v1", "other", "namespaces", "", "", []string{"namespaces"}},
 
 		// api group identification
 		{"POST", "/apis/extensions/v1/namespaces/other/pods", "create", "api", "extensions", "v1", "other", "pods", "", "", []string{"pods"}},

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
@@ -54,8 +54,9 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{"HEAD", "/api/v1/pods", "list", "api", "", "v1", namespaceAll, "pods", "", "", []string{"pods"}},
 		{"GET", "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"GET", "/api/v1/namespaces/other/pods", "list", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
-
+		// resource path test for a cluster-scoped "namespaces.stable.example.com" resource named "example"
 		{"GET", "/apis/stable.example.com/v1/namespaces/example", "get", "apis", "stable.example.com", "v1", "", "namespaces", "", "example", []string{"namespaces", "example"}},
+		// resource path test for a namespaced "namespaces.stable.example.com" resource named "example" in namespace "other"
 		{"GET", "/apis/stable.example.com/v1/namespaces/other/namespaces/example", "get", "apis", "stable.example.com", "v1", "other", "namespaces", "", "example", []string{"namespaces", "example"}},
 
 		// special verbs
@@ -67,10 +68,11 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{"GET", "/api/v1/watch/namespaces/other/pods", "watch", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 		{"GET", "/api/v1/namespaces/other/pods?watch=1", "watch", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 		{"GET", "/api/v1/namespaces/other/pods?watch=0", "list", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
-		// watch cluster-scoped CRs
+		// watch cluster-scoped "namespaces.stable.example.com" CRs
 		{"GET", "/apis/stable.example.com/v1/namespaces?watch=true", "watch", "apis", "stable.example.com", "v1", "", "namespaces", "", "", []string{"namespaces"}},
+		// watch namespaced "namespaces.stable.example.com" CRs in namespace "other"
 		{"GET", "/apis/stable.example.com/v1/namespaces/other/namespaces?watch=true", "watch", "apis", "stable.example.com", "v1", "other", "namespaces", "", "", []string{"namespaces"}},
-		// watch namespace-scoped CRs in all namespaces
+		// watch namespaced "namespaces.stable.example.com" CRs in all namespaces
 		{"GET", "/apis/stable.example.com/v1/namespaces?watch=true", "watch", "apis", "stable.example.com", "v1", namespaceAll, "namespaces", "", "", []string{"namespaces"}},
 
 		// subresource identification
@@ -78,23 +80,28 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{"GET", "/api/v1/namespaces/other/pods/foo/proxy/subpath", "get", "api", "", "v1", "other", "pods", "proxy", "foo", []string{"pods", "foo", "proxy", "subpath"}},
 		{"PUT", "/api/v1/namespaces/other/finalize", "update", "api", "", "v1", "other", "namespaces", "finalize", "other", []string{"namespaces", "other", "finalize"}},
 		{"PUT", "/api/v1/namespaces/other/status", "update", "api", "", "v1", "other", "namespaces", "status", "other", []string{"namespaces", "other", "status"}},
+		// get the status subresource of a cluster-scoped resource "example" of group "namespaces.stable.example.com"
 		{"GET", "/apis/stable.example.com/v1/namespaces/example/status", "get", "apis", "stable.example.com", "v1", "", "namespaces", "status", "example", []string{"namespaces", "example", "status"}},
+		// get the status subresource of a namespaced resource "example" of group "namespaces.stable.example.com" in namespace "other"
 		{"GET", "/apis/stable.example.com/v1/namespaces/other/namespaces/example/status", "get", "apis", "stable.example.com", "v1", "other", "namespaces", "status", "example", []string{"namespaces", "example", "status"}},
 
 		// verb identification
 		{"PATCH", "/api/v1/namespaces/other/pods/foo", "patch", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"DELETE", "/api/v1/namespaces/other/pods/foo", "delete", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"POST", "/api/v1/namespaces/other/pods", "create", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
+		// create a new cluster-scoped resource in the group "namespaces.stable.example.com"
 		{"POST", "/apis/stable.example.com/v1/namespaces", "create", "apis", "stable.example.com", "v1", "", "namespaces", "", "", []string{"namespaces"}},
+		// create a new namespaced resource of the group "namespaces.stable.example.com" in namespace "other"
 		{"POST", "/apis/stable.example.com/v1/namespaces/other/namespaces", "create", "apis", "stable.example.com", "v1", "other", "namespaces", "", "", []string{"namespaces"}},
-
 
 		// deletecollection verb identification
 		{"DELETE", "/api/v1/nodes", "deletecollection", "api", "", "v1", "", "nodes", "", "", []string{"nodes"}},
 		{"DELETE", "/api/v1/namespaces", "deletecollection", "api", "", "v1", "", "namespaces", "", "", []string{"namespaces"}},
 		{"DELETE", "/api/v1/namespaces/other/pods", "deletecollection", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 		{"DELETE", "/apis/extensions/v1/namespaces/other/pods", "deletecollection", "api", "extensions", "v1", "other", "pods", "", "", []string{"pods"}},
+		// delete a collection of cluster-scoped resources in the group "namespaces.stable.example.com"
 		{"DELETE", "/apis/stable.example.com/v1/namespaces", "deletecollection", "apis", "stable.example.com", "v1", "", "namespaces", "", "", []string{"namespaces"}},
+		// delete a collection of namespaced resources of the group "namespaces.stable.example.com" in namespace "other"
 		{"DELETE", "/apis/stable.example.com/v1/namespaces/other/namespaces", "deletecollection", "apis", "stable.example.com", "v1", "other", "namespaces", "", "", []string{"namespaces"}},
 
 		// api group identification


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
This PR proposes a fix for the API handling of cluster-scoped custom resources with a plural name of `namespaces` as reported in #97397. Currently, `apiserver` erroneously fills a namespace for such resources in the associated `request.RequestInfo`. For instance currently, for cluster-scoped `namespaces.stable.example.com` resources, a `kubectl get namespaces.stable.example.com` successfully lists CRs under this group but for a specific resource `example` existing in this group, a `kubectl get namespaces.stable.example.com example` fails with a 404, because `apiserver` thinks it's a namespaced resource. 

We have also hit this issue while working on a [custom resource](https://github.com/crossplane-contrib/provider-jet-azure/pull/145#discussion_r814024344). Please note that we also cannot handle custom resources with a plural name corresponding to a namespace subresource properly, such as the following one:
```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: status.stable.example.com
spec:
  group: stable.example.com
  versions:
    - name: v1
      served: true
      storage: true
      schema:
        openAPIV3Schema:
          type: object
          properties:
            spec:
              type: object
              properties:
                cronSpec:
                  type: string
                image:
                  type: string
                replicas:
                  type: integer
  scope: Namespaced
  names:
    plural: status
    singular: statu
    kind: Statu
```

When you try (against Kubernetes `v1.23.1`) to create a CR under this group, it fails:
```bash
> kubectl create -f - <<EOF
apiVersion: "stable.example.com/v1"
kind: Statu
metadata:
  name: example
  namespace: crossplane-system
spec:
  cronSpec: "* * * * */5"
  image: my-awesome-cron-image
EOF

Error from server (NotFound): error when creating "STDIN": the server could not find the requested resource (post status.stable.example.com)
```

This PR does not fix these issues with subresource-named plural names. Although these are related with #97397, they have a little bit of different mechanics. I think we can open a new issue for such CRDs.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #97397

#### Special notes for your reviewer:
Tested this PR using the following CRD and CR manifests:
```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: namespaces.stable.example.com
spec:
  group: stable.example.com
  versions:
    - name: v1
      served: true
      storage: true
      schema:
        openAPIV3Schema:
          type: object
          properties:
            spec:
              type: object
              properties:
                cronSpec:
                  type: string
                image:
                  type: string
                replicas:
                  type: integer
      subresources:
        status: {}
  scope: Cluster
  names:
    plural: namespaces
    singular: namespace
    kind: Namespace
```

```yaml
apiVersion: "stable.example.com/v1"
kind: Namespace
metadata:
  name: example
spec:
  cronSpec: "* * * * */5"
  image: my-awesome-cron-image
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
