### PR TITLE
[WIP] returns scores of each plugin and extender from prioritizeNodes

### DIFF
--- a/pkg/scheduler/generic_scheduler_test.go
+++ b/pkg/scheduler/generic_scheduler_test.go
@@ -22,12 +22,12 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1371,7 +1371,15 @@ func Test_prioritizeNodesPluginToNodeScores(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			assert.Equal(t, test.wantPluginToNodeScores, scoreMap)
+			for i := range scoreMap {
+				sort.Slice(scoreMap[i], func(j, k int) bool {
+					return scoreMap[i][j].Name < scoreMap[i][k].Name
+				})
+			}
+
+			if diff := cmp.Diff(test.wantPluginToNodeScores, scoreMap); diff != "" {
+				t.Errorf("returned score map (-want,+got):\n%s", diff)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR changes `prioritizeNodes` method to return scores of each plugin and extender.

Currently, only the summed scores for each Node is returned from `prioritizeNodes`. 
We need information on what score each plugin/extender returned to show scores of plugins and extenders in event messages. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Part of https://github.com/kubernetes/kubernetes/issues/107556

#### Special notes for your reviewer:

I implemented this feature in https://github.com/kubernetes/kubernetes/pull/107984, but https://github.com/kubernetes/kubernetes/pull/107984 is big and difficult to review because of that. Therefore, I'm splitting https://github.com/kubernetes/kubernetes/pull/107984 into multiple PRs. This PR is one of them.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
