### PR TITLE
Support for in-tree PV Deletion protection finalizer

### DIFF
--- a/pkg/controller/volume/persistentvolume/delete_test.go
+++ b/pkg/controller/volume/persistentvolume/delete_test.go
@@ -187,6 +187,17 @@ func TestDeleteSync(t *testing.T) {
 				return testSyncVolume(ctrl, reactor, test)
 			},
 		},
+		{
+			// TODO: Change the expectedVolumes to novolumes after HonorPVReclaimPolicy is enabled by default.
+			// delete success - volume has deletion timestamp before doDelete() starts
+			"8-13 - volume has deletion timestamp and processed",
+			volumesWithFinalizers(withVolumeDeletionTimestamp(newVolumeArray("volume8-13", "1Gi", "uid8-13", "claim8-13", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty, pvutil.AnnBoundByController)), []string{pvutil.PVDeletionInTreeProtectionFinalizer}),
+			volumesWithFinalizers(withVolumeDeletionTimestamp(newVolumeArray("volume8-13", "1Gi", "uid8-13", "claim8-13", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, classEmpty, pvutil.AnnBoundByController)), []string{pvutil.PVDeletionInTreeProtectionFinalizer}),
+			noclaims,
+			noclaims,
+			noevents, noerrors,
+			wrapTestWithReclaimCalls(operationDelete, []error{nil}, testSyncVolume),
+		},
 	}
 	runSyncTests(t, tests, []*storage.StorageClass{}, []*v1.Pod{})
 }

--- a/pkg/controller/volume/persistentvolume/util/util.go
+++ b/pkg/controller/volume/persistentvolume/util/util.go
@@ -78,6 +78,9 @@ const (
 
 	//PVDeletionProtectionFinalizer is the finalizer added by the external-provisioner on the PV
 	PVDeletionProtectionFinalizer = "external-provisioner.volume.kubernetes.io/finalizer"
+
+	// PVDeletionInTreeProtectionFinalizer is the finalizer added to protect PV deletion for in-tree volumes.
+	PVDeletionInTreeProtectionFinalizer = "kubernetes.io/pv-controller"
 )
 
 // IsDelayBindingProvisioning checks if claim provisioning with selected-node annotation

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -801,6 +801,7 @@ const (
 	// owner: @deepakkinni @xing-yang
 	// kep: http://kep.k8s.io/2680
 	// alpha: v1.23
+	// beta: v1.24
 	//
 	// Honor Persistent Volume Reclaim Policy when it is "Delete" irrespective of PV-PVC
 	// deletion ordering.
@@ -943,7 +944,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	JobMutableNodeSchedulingDirectives:             {Default: true, PreRelease: featuregate.Beta},
 	IdentifyPodOS:                                  {Default: false, PreRelease: featuregate.Alpha},
 	PodAndContainerStatsFromCRI:                    {Default: false, PreRelease: featuregate.Alpha},
-	HonorPVReclaimPolicy:                           {Default: false, PreRelease: featuregate.Alpha},
+	HonorPVReclaimPolicy:                           {Default: false, PreRelease: featuregate.Beta},
 	RecoverVolumeExpansionFailure:                  {Default: false, PreRelease: featuregate.Alpha},
 	GRPCContainerProbe:                             {Default: false, PreRelease: featuregate.Alpha},
 	LegacyServiceAccountTokenNoAutoGeneration:      {Default: true, PreRelease: featuregate.Beta},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig storage

#### What this PR does / why we need it:
Support for in-tree volume deletion protection as a part of https://github.com/kubernetes/enhancements/issues/2644

#### Which issue(s) this PR fixes:
Fixes # https://github.com/kubernetes/enhancements/issues/2644

#### Special notes for your reviewer:

Testing done:
1. Verified that the new finalizer `kubernetes.io/pv-controller` is present on the PV
```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: pvc-2f355c16-1c7d-445c-8620-38d2b002118a
  uid: 6ba5d724-7e4d-4bf7-99f1-2cd9cbc3512f
  resourceVersion: '169754'
  creationTimestamp: '2022-03-03T23:04:37Z'
  annotations:
    kubernetes.io/createdby: vsphere-volume-dynamic-provisioner
    pv.kubernetes.io/bound-by-controller: 'yes'
    pv.kubernetes.io/provisioned-by: kubernetes.io/vsphere-volume
  finalizers:
    - kubernetes.io/pv-controller
    - kubernetes.io/pv-protection
status:
  phase: Bound
spec:
  capacity:
    storage: 1Gi
  vsphereVolume:
    volumePath: >-
      [vsanDatastore]
      6a492162-5521-98f4-6007-0200406001ba/kubernetes-dynamic-pvc-2f355c16-1c7d-445c-8620-38d2b002118a.vmdk
    fsType: ext4
    storagePolicyName: vSAN Default Storage Policy
    storagePolicyID: aa6d5a82-1c88-45da-85d3-3d74b91a5bad
  accessModes:
    - ReadWriteOnce
  claimRef:
    kind: PersistentVolumeClaim
    namespace: default
    name: vcp-pvc-1
    uid: 2f355c16-1c7d-445c-8620-38d2b002118a
    apiVersion: v1
    resourceVersion: '169688'
  persistentVolumeReclaimPolicy: Delete
  storageClassName: vcp-sc
  volumeMode: Filesystem
```

2. Verified that deleting the pv first followed by deleting the PVC results in the disk being removed from the underlying storage.

#### Does this PR introduce a user-facing change?
```release-note
Support in-tree PV deletion protection finalizer.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/3181
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>