### PR TITLE
integration framework: log number of leaked goroutines

### DIFF
--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -172,12 +172,30 @@ func EtcdMain(tests func() int) {
 	// Bail out early when -help was given as parameter.
 	flag.Parse()
 
+	before := runtime.NumGoroutine()
 	stop, err := startEtcd()
 	if err != nil {
 		klog.Fatalf("cannot run integration tests: unable to start etcd: %v", err)
 	}
 	result := tests()
 	stop() // Don't defer this. See os.Exit documentation.
+
+	// Log the number of goroutines leaked.
+	// TODO: we should work on reducing this as much as possible.
+	var dg int
+	for i := 0; i < 10; i++ {
+		// Leave some room for goroutines we can not get rid of
+		// like k8s.io/klog/v2.(*loggingT).flushDaemon()
+		// TODO: adjust this number based on a more exhaustive analysis.
+		if dg = runtime.NumGoroutine() - before; dg <= 4 {
+			os.Exit(result)
+		}
+		// Allow goroutines to schedule and die off.
+		runtime.Gosched()
+		time.Sleep(100 * time.Millisecond)
+	}
+	after := runtime.NumGoroutine()
+	klog.Infof("unexpected number of goroutines: before: %d after %d", before, after)
 	os.Exit(result)
 }
 


### PR DESCRIPTION

/kind flake
```release-note
NONE
```

Since it will not be easy to avoid the integration framework to leak goroutines due to the complexity of the shutdown process and the way we are setting up the apiserver for testing, at least keep track on how good or bad we are doing

https://github.com/kubernetes/kubernetes/pull/108060#issuecomment-1053672987
