### PR TITLE
Restore volume.specs in ASW even if nodes are not in volume.nodesAtta…

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -479,6 +479,8 @@ func (adc *attachDetachController) populateDesiredStateOfWorld() error {
 				if err != nil {
 					klog.Errorf("Failed to update volume spec for node %s: %v", nodeName, err)
 				}
+			} else {
+				adc.actualStateOfWorld.SetVolumeSpec(volumeName, volumeSpec)
 			}
 		}
 	}

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -137,6 +137,9 @@ type ActualStateOfWorld interface {
 
 	// GetNodesToUpdateStatusFor returns the map of nodeNames to nodeToUpdateStatusFor
 	GetNodesToUpdateStatusFor() map[types.NodeName]nodeToUpdateStatusFor
+
+	// SetVolumeSpec set volumeSpec for specified attachedVolume
+	SetVolumeSpec(volumeName v1.UniqueVolumeName, volumeSpec *volume.Spec)
 }
 
 // AttachedVolume represents a volume that is attached to a node.
@@ -694,4 +697,16 @@ func getAttachedVolume(
 		},
 		MountedByNode:       nodeAttachedTo.mountedByNode,
 		DetachRequestedTime: nodeAttachedTo.detachRequestedTime}
+}
+
+func (asw *actualStateOfWorld) SetVolumeSpec(volumeName v1.UniqueVolumeName, volumeSpec *volume.Spec) {
+	asw.Lock()
+	defer asw.Unlock()
+
+	if volumeObj, volumeExists := asw.attachedVolumes[volumeName]; volumeExists {
+		if volumeObj.spec == nil {
+			volumeObj.spec = volumeSpec
+			asw.attachedVolumes[volumeName] = volumeObj
+		}
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
As mentioned in the issue, before ADcontroller starts, the pod has been evicted and recreated on another node, but has not been successfully detached from the old node nor attached to the new node. So `attachVolume.nodesAttachedTo` in ASW has only old nodes, no new nodes. `adc.actualStateOfWorld.GetAttachState` checking the attach status of volume/pod.nodename in ASW will return false. Volume.spec is not updated and is always nil.

#### Which issue(s) this PR fixes:
Fixes #108221

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: