### PR TITLE
CEL MaxLength integration

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -1682,12 +1682,17 @@ func TestValidationExpressions(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for i := range tests {
+		i := i
+		t.Run(tests[i].name, func(t *testing.T) {
+			t.Parallel()
 			// set costBudget to maxInt64 for current test
+			tt := tests[i]
 			tt.costBudget = math.MaxInt64
-			for _, validRule := range tt.valid {
+			for j := range tt.valid {
+				validRule := tt.valid[j]
 				t.Run(validRule, func(t *testing.T) {
+					t.Parallel()
 					s := withRule(*tt.schema, validRule)
 					celValidator := NewValidator(&s, PerCallLimit)
 					if celValidator == nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -15,7 +15,34 @@
 package model
 
 import (
+	"time"
+
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+)
+
+const (
+	// the largest request that will be accepted is 3MB
+	// TODO(DangerOnTheRanger): wire in MaxRequestBodyBytes from apiserver/pkg/server/options/server_run_options.go to make this configurable
+	maxRequestSizeBytes = int64(3 * 1024 * 1024)
+	// OpenAPI duration strings follow RFC 3339, section 5.6 - see the comment on maxDatetimeSizeJSON
+	maxDurationSizeJSON = 32
+	// OpenAPI datetime strings follow RFC 3339, section 5.6, and the longest possible
+	// such string is 9999-12-31T23:59:59.999999999Z, which has length 30 - we add 2
+	// to allow for quotation marks
+	maxDatetimeSizeJSON = 32
+	// Golang allows a string of 0 to be parsed as a duration, so that plus 2 to account for
+	// quotation marks makes 3
+	minDurationSizeJSON = 3
+	// RFC 3339 dates require YYYY-MM-DD, and then we add 2 to allow for quotation marks
+	dateSizeJSON = 12
+	// RFC 3339 times require 2-digit 24-hour time at the very least plus a capital T at the start,
+	// e.g., T23, and we add 2 to allow for quotation marks as usual
+	minTimeSizeJSON = 5
+	// RFC 3339 datetimes require a full date (YYYY-MM-DD) and full time (HH:MM:SS), and we add 3 for
+	// quotation marks like always in addition to the capital T that separates the date and time
+	minDatetimeSizeJSON = 21
 )
 
 // SchemaDeclType converts the structural schema to a CEL declaration, or returns nil if the
@@ -44,7 +71,10 @@ func SchemaDeclType(s *schema.Structural, isResourceRoot bool) *DeclType {
 		// To validate requirements on both the int and string representation:
 		//  `type(intOrStringField) == int ? intOrStringField < 5 : double(intOrStringField.replace('%', '')) < 0.5
 		//
-		return DynType
+		dyn := newSimpleType("dyn", decls.Dyn, nil)
+		// handle x-kubernetes-int-or-string by returning the max length of the largest possible string
+		dyn.MaxElements = maxRequestSizeBytes - 2
+		return dyn
 	}
 
 	// We ignore XPreserveUnknownFields since we don't support validation rules on
@@ -61,8 +91,14 @@ func SchemaDeclType(s *schema.Structural, isResourceRoot bool) *DeclType {
 	case "array":
 		if s.Items != nil {
 			itemsType := SchemaDeclType(s.Items, s.Items.XEmbeddedResource)
+			var maxItems int64
+			if s.ValueValidation != nil && s.ValueValidation.MaxItems != nil {
+				maxItems = *s.ValueValidation.MaxItems
+			} else {
+				maxItems = estimateMaxArrayItemsPerRequest(s.Items)
+			}
 			if itemsType != nil {
-				return NewListType(itemsType)
+				return NewListType(itemsType, maxItems)
 			}
 		}
 		return nil
@@ -70,7 +106,13 @@ func SchemaDeclType(s *schema.Structural, isResourceRoot bool) *DeclType {
 		if s.AdditionalProperties != nil && s.AdditionalProperties.Structural != nil {
 			propsType := SchemaDeclType(s.AdditionalProperties.Structural, s.AdditionalProperties.Structural.XEmbeddedResource)
 			if propsType != nil {
-				return NewMapType(StringType, propsType)
+				var maxProperties int64
+				if s.ValueValidation != nil && s.ValueValidation.MaxProperties != nil {
+					maxProperties = *s.ValueValidation.MaxProperties
+				} else {
+					maxProperties = estimateMaxAdditionalPropertiesPerRequest(s.AdditionalProperties.Structural)
+				}
+				return NewMapType(StringType, propsType, maxProperties)
 			}
 			return nil
 		}
@@ -106,14 +148,34 @@ func SchemaDeclType(s *schema.Structural, isResourceRoot bool) *DeclType {
 		if s.ValueValidation != nil {
 			switch s.ValueValidation.Format {
 			case "byte":
-				return BytesType
+				byteWithMaxLength := newSimpleType("bytes", decls.Bytes, types.Bytes([]byte{}))
+				if s.ValueValidation.MaxLength != nil {
+					byteWithMaxLength.MaxElements = *s.ValueValidation.MaxLength
+				} else {
+					byteWithMaxLength.MaxElements = estimateMaxStringLengthPerRequest(s)
+				}
+				return byteWithMaxLength
 			case "duration":
-				return DurationType
+				durationWithMaxLength := newSimpleType("duration", decls.Duration, types.Duration{Duration: time.Duration(0)})
+				durationWithMaxLength.MaxElements = estimateMaxStringLengthPerRequest(s)
+				return durationWithMaxLength
 			case "date", "date-time":
-				return TimestampType
+				timestampWithMaxLength := newSimpleType("timestamp", decls.Timestamp, types.Timestamp{Time: time.Time{}})
+				timestampWithMaxLength.MaxElements = estimateMaxStringLengthPerRequest(s)
+				return timestampWithMaxLength
 			}
 		}
-		return StringType
+		strWithMaxLength := newSimpleType("string", decls.String, types.String(""))
+		if s.ValueValidation != nil && s.ValueValidation.MaxLength != nil {
+			// multiply the user-provided max length by 4 in the case of an otherwise-untyped string
+			// we do this because the OpenAPIv3 spec indicates that maxLength is specified in runes/code points,
+			// but we need to reason about length for things like request size, so we use bytes in this code (and an individual
+			// unicode code point can be up to 4 bytes long)
+			strWithMaxLength.MaxElements = *s.ValueValidation.MaxLength * 4
+		} else {
+			strWithMaxLength.MaxElements = estimateMaxStringLengthPerRequest(s)
+		}
+		return strWithMaxLength
 	case "boolean":
 		return BoolType
 	case "number":
@@ -137,8 +199,8 @@ func WithTypeAndObjectMeta(s *schema.Structural) *schema.Structural {
 		return s
 	}
 	result := &schema.Structural{
-		Generic: s.Generic,
-		Extensions: s.Extensions,
+		Generic:         s.Generic,
+		Extensions:      s.Extensions,
 		ValueValidation: s.ValueValidation,
 	}
 	props := make(map[string]schema.Structural, len(s.Properties))
@@ -151,11 +213,107 @@ func WithTypeAndObjectMeta(s *schema.Structural) *schema.Structural {
 	props["metadata"] = schema.Structural{
 		Generic: schema.Generic{Type: "object"},
 		Properties: map[string]schema.Structural{
-			"name": stringType,
+			"name":         stringType,
 			"generateName": stringType,
 		},
 	}
 	result.Properties = props
 
 	return result
+}
+
+// estimateMinSizeJSON estimates the minimum size in bytes of the given schema when serialized in JSON.
+// minLength/minProperties/minItems are not currently taken into account, so if these limits are set the
+// minimum size might be higher than what estimateMinSizeJSON returns.
+func estimateMinSizeJSON(s *schema.Structural) int64 {
+	if s == nil {
+		// minimum valid JSON token has length 1 (single-digit number like `0`)
+		return 1
+	}
+	switch s.Type {
+	case "boolean":
+		// true
+		return 4
+	case "number", "integer":
+		// 0
+		return 1
+	case "string":
+		if s.ValueValidation != nil {
+			switch s.ValueValidation.Format {
+			case "duration":
+				return minDurationSizeJSON
+			case "date":
+				return dateSizeJSON
+			case "date-time":
+				return minDatetimeSizeJSON
+			}
+		}
+		// ""
+		return 2
+	case "array":
+		// []
+		return 2
+	case "object":
+		// {}
+		objSize := int64(2)
+		// exclude optional fields since the request can omit them
+		if s.ValueValidation != nil {
+			for _, propName := range s.ValueValidation.Required {
+				if prop, ok := s.Properties[propName]; ok {
+					if prop.Default.Object != nil {
+						// exclude fields with a default, those are filled in server-side
+						continue
+					}
+					// add 4, 2 for quotations around the property name, 1 for the colon, and 1 for a comma
+					objSize += int64(len(propName)) + estimateMinSizeJSON(&prop) + 4
+				}
+			}
+		}
+		return objSize
+	}
+	if s.XIntOrString {
+		// 0
+		return 1
+	}
+	// this code should be unreachable, so return the safest possible value considering this can be used as
+	// a divisor
+	return 1
+}
+
+// estimateMaxArrayItemsPerRequest estimates the maximum number of array items with
+// the provided schema that can fit into a single request.
+func estimateMaxArrayItemsPerRequest(itemSchema *schema.Structural) int64 {
+	// subtract 2 to account for [ and ]
+	return (maxRequestSizeBytes - 2) / (estimateMinSizeJSON(itemSchema) + 1)
+}
+
+// estimateMaxStringLengthPerRequest estimates the maximum string length (in characters)
+// of a string compatible with the format requirements in the provided schema.
+// must only be called on schemas of type "string" or x-kubernetes-int-or-string: true
+func estimateMaxStringLengthPerRequest(s *schema.Structural) int64 {
+	if s.ValueValidation == nil || s.XIntOrString {
+		// subtract 2 to account for ""
+		return (maxRequestSizeBytes - 2)
+	}
+	switch s.ValueValidation.Format {
+	case "duration":
+		return maxDurationSizeJSON
+	case "date":
+		return dateSizeJSON
+	case "date-time":
+		return maxDatetimeSizeJSON
+	default:
+		// subtract 2 to account for ""
+		return (maxRequestSizeBytes - 2)
+	}
+}
+
+// estimateMaxAdditionalPropertiesPerRequest estimates the maximum number of additional properties
+// with the provided schema that can fit into a single request.
+func estimateMaxAdditionalPropertiesPerRequest(additionalPropertiesSchema *schema.Structural) int64 {
+	// 2 bytes for key + "" + colon + comma + smallest possible value, realistically the actual keys
+	// will all vary in length
+	keyValuePairSize := estimateMinSizeJSON(additionalPropertiesSchema) + 6
+	// subtract 2 to account for { and }
+	return (maxRequestSizeBytes - 2) / keyValuePairSize
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/types_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/types_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestTypes_ListType(t *testing.T) {
-	list := NewListType(StringType)
+	list := NewListType(StringType, -1)
 	if !list.IsList() {
 		t.Error("list type not identifiable as list")
 	}
@@ -43,7 +43,7 @@ func TestTypes_ListType(t *testing.T) {
 }
 
 func TestTypes_MapType(t *testing.T) {
-	mp := NewMapType(StringType, IntType)
+	mp := NewMapType(StringType, IntType, -1)
 	if !mp.IsMap() {
 		t.Error("map type not identifiable as map")
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -359,6 +359,9 @@ func NewConfig(codecs serializer.CodecFactory) *Config {
 		// A request body might be encoded in json, and is converted to
 		// proto when persisted in etcd, so we allow 2x as the largest request
 		// body size to be accepted and decoded in a write request.
+		// If this constant is changed, maxRequestSizeBytes in apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+		// should be changed to reflect the new value, if the two haven't
+		// been wired together already somehow.
 		MaxRequestBodyBytes: int64(3 * 1024 * 1024),
 
 		// Default to treating watch as a long-running operation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR extracts the OpenAPIv3 `maxLength` property (or its equivalent for non-string datatypes) when given by the user and estimating it otherwise before reporting the total expression cost from `cel.Compile`; each expression passed through `Compile` now has a static cost returned with it. The final piece of the puzzle (which will be in  https://github.com/kubernetes/kubernetes/pull/108612) will be to then use those costs to determine what to run and what not to run for the sake of apiserver performance. Part of #107573.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

da68d7bb21fe42f53c7357073dbf66a21328e61b can be ignored/does not need to be reviewed; that commit is purely from running `./hack/pin-dependency.sh github.com/google/cel-go 9ef90eddf66efeea82f81bf35326ca85f99f859e` and then running `update-vendor.sh`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
