### PR TITLE
Promote replaceCoreV1NamespacedPodTemplate test - +1 endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1927,6 +1927,13 @@
     when listed by its label selector.
   release: v1.19
   file: test/e2e/common/node/podtemplates.go
+- testname: PodTemplate, replace
+  codename: '[sig-node] PodTemplates should replace a pod template [Conformance]'
+  description: Attempt to create a PodTemplate which MUST succeed. Attempt to replace
+    the PodTemplate to include a new annotation which MUST succeed. The annotation
+    MUST be found in the new PodTemplate.
+  release: v1.24
+  file: test/e2e/common/node/podtemplates.go
 - testname: PodTemplate lifecycle
   codename: '[sig-node] PodTemplates should run the lifecycle of PodTemplates [Conformance]'
   description: Attempt to create a PodTemplate. Patch the created PodTemplate. Fetching

--- a/test/e2e/common/node/podtemplates.go
+++ b/test/e2e/common/node/podtemplates.go
@@ -164,7 +164,14 @@ var _ = SIGDescribe("PodTemplates", func() {
 
 	})
 
-	ginkgo.It("should replace a pod template", func() {
+	/*
+	   Release: v1.24
+	   Testname: PodTemplate, replace
+	   Description: Attempt to create a PodTemplate which MUST succeed.
+	   Attempt to replace the PodTemplate to include a new annotation
+	   which MUST succeed. The annotation MUST be found in the new PodTemplate.
+	*/
+	framework.ConformanceIt("should replace a pod template", func() {
 		ptClient := f.ClientSet.CoreV1().PodTemplates(f.Namespace.Name)
 		ptName := "podtemplate-" + utilrand.String(5)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoint:
- replaceCoreV1NamespacedPodTemplate

**Which issue(s) this PR fixes:**
Fixes #108285 
**Testgrid Link:**
Promotion PR should be ready to Merge on 14 March 2022 if there was no faking on the [Testgid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should%20replace%20a%20pod%20template&graph-metrics=test-duration-minutes) .

**Special notes for your reviewer:**
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance
