### PR TITLE
[WIP] fix: scheduler v1beta3 doesn't append out-of-tree plugins correctly

### DIFF
--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -91,31 +91,30 @@ clientConnection:
   kubeconfig: "%s"
 profiles:
 - plugins:
-    multiPoint:
+    preFilter:
       enabled:
-      - name: DefaultBinder
-      - name: PrioritySort
-      - name: DefaultPreemption
-      - name: VolumeBinding
       - name: NodeResourcesFit
       - name: NodePorts
+      disabled:
+      - name: "*"
+    filter:
+      enabled:
+      - name: NodeResourcesFit
+      - name: NodePorts
+      disabled:
+      - name: "*"
+    preScore:
+      enabled:
       - name: InterPodAffinity
       - name: TaintToleration
       disabled:
       - name: "*"
-    preFilter:
-      disabled:
-      - name: VolumeBinding
-      - name: InterPodAffinity
-    filter:
-      disabled:
-      - name: VolumeBinding
+    score:
+      enabled:
       - name: InterPodAffinity
       - name: TaintToleration
-    score:
       disabled:
-      - name: VolumeBinding
-      - name: NodeResourcesFit
+      - name: "*"
 `, configKubeconfig)), os.FileMode(0600)); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -29,7 +29,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/util/feature"
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/component-base/featuregate"
@@ -39,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/testing/defaults"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 func TestSetup(t *testing.T) {
@@ -154,6 +157,44 @@ profiles:
 		t.Fatal(err)
 	}
 
+	// out-of-tree plugin config v1ta3
+	outOfTreePluginConfigFilev1beta3 := filepath.Join(tmpDir, "outOfTreePluginv1beta3.yaml")
+	if err := os.WriteFile(outOfTreePluginConfigFilev1beta3, []byte(fmt.Sprintf(`
+apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: "%s"
+profiles:
+- plugins:
+    preFilter:
+      enabled:
+      - name: Foo
+    filter:
+      enabled:
+      - name: Foo
+`, configKubeconfig)), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
+	// plugin config
+	outOfTreePluginConfigFilev1beta2 := filepath.Join(tmpDir, "outOfTreePluginv1beta2.yaml")
+	if err := os.WriteFile(outOfTreePluginConfigFilev1beta2, []byte(fmt.Sprintf(`
+apiVersion: kubescheduler.config.k8s.io/v1beta2
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: "%s"
+profiles:
+- plugins:
+    preFilter:
+      enabled:
+      - name: Foo
+    filter:
+      enabled:
+      - name: Foo
+`, configKubeconfig)), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
 	// multiple profiles config
 	multiProfilesConfig := filepath.Join(tmpDir, "multi-profiles.yaml")
 	if err := os.WriteFile(multiProfilesConfig, []byte(fmt.Sprintf(`
@@ -211,6 +252,7 @@ leaderElection:
 	testcases := []struct {
 		name               string
 		flags              []string
+		registryOptions    []Option
 		restoreFeatures    map[featuregate.Feature]bool
 		wantPlugins        map[string]*config.Plugins
 		wantLeaderElection *componentbaseconfig.LeaderElectionConfiguration
@@ -331,6 +373,56 @@ leaderElection:
 			},
 		},
 		{
+			name: "out-of-tree component configuration v1beta2",
+			flags: []string{
+				"--config", outOfTreePluginConfigFilev1beta2,
+				"--kubeconfig", configKubeconfig,
+			},
+			registryOptions: []Option{WithPlugin("Foo", newFoo)},
+			wantPlugins: map[string]*config.Plugins{
+				"default-scheduler": {
+					Bind: defaults.PluginsV1beta2.Bind,
+					Filter: config.PluginSet{
+						Enabled: append(defaults.PluginsV1beta2.Filter.Enabled, config.Plugin{Name: "Foo"}),
+					},
+					PreFilter: config.PluginSet{
+						Enabled: append(defaults.PluginsV1beta2.PreFilter.Enabled, config.Plugin{Name: "Foo"}),
+					},
+					PostFilter: defaults.PluginsV1beta2.PostFilter,
+					PreScore:   defaults.PluginsV1beta2.PreScore,
+					QueueSort:  defaults.PluginsV1beta2.QueueSort,
+					Score:      defaults.PluginsV1beta2.Score,
+					Reserve:    defaults.PluginsV1beta2.Reserve,
+					PreBind:    defaults.PluginsV1beta2.PreBind,
+				},
+			},
+		},
+		{
+			name: "out-of-tree component configuration v1beta3",
+			flags: []string{
+				"--config", outOfTreePluginConfigFilev1beta3,
+				"--kubeconfig", configKubeconfig,
+			},
+			registryOptions: []Option{WithPlugin("Foo", newFoo)},
+			wantPlugins: map[string]*config.Plugins{
+				"default-scheduler": {
+					Bind: defaults.ExpandedPluginsV1beta3.Bind,
+					Filter: config.PluginSet{
+						Enabled: append(defaults.ExpandedPluginsV1beta3.Filter.Enabled, config.Plugin{Name: "Foo"}),
+					},
+					PreFilter: config.PluginSet{
+						Enabled: append(defaults.ExpandedPluginsV1beta3.PreFilter.Enabled, config.Plugin{Name: "Foo"}),
+					},
+					PostFilter: defaults.ExpandedPluginsV1beta3.PostFilter,
+					PreScore:   defaults.ExpandedPluginsV1beta3.PreScore,
+					QueueSort:  defaults.ExpandedPluginsV1beta3.QueueSort,
+					Score:      defaults.ExpandedPluginsV1beta3.Score,
+					Reserve:    defaults.ExpandedPluginsV1beta3.Reserve,
+					PreBind:    defaults.ExpandedPluginsV1beta3.PreBind,
+				},
+			},
+		},
+		{
 			name: "leader election CLI args, along with --config arg",
 			flags: []string{
 				"--leader-elect=false",
@@ -437,7 +529,7 @@ leaderElection:
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			_, sched, err := Setup(ctx, opts)
+			_, sched, err := Setup(ctx, opts, tc.registryOptions...)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -461,4 +553,30 @@ leaderElection:
 			}
 		})
 	}
+}
+
+// Simulates an out-of-tree plugin.
+type foo struct{}
+
+var _ framework.PreFilterPlugin = &foo{}
+var _ framework.FilterPlugin = &foo{}
+
+func (*foo) Name() string {
+	return "Foo"
+}
+
+func newFoo(_ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
+	return &foo{}, nil
+}
+
+func (*foo) PreFilter(_ context.Context, _ *framework.CycleState, _ *v1.Pod) *framework.Status {
+	return nil
+}
+
+func (*foo) PreFilterExtensions() framework.PreFilterExtensions {
+	return nil
+}
+
+func (*foo) Filter(_ context.Context, _ *framework.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+	return nil
 }

--- a/pkg/scheduler/apis/config/v1beta3/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1beta3/default_plugins.go
@@ -27,9 +27,24 @@ import (
 // getDefaultPlugins returns the default set of plugins.
 func getDefaultPlugins() *v1beta3.Plugins {
 	plugins := &v1beta3.Plugins{
-		MultiPoint: v1beta3.PluginSet{
+		QueueSort: v1beta3.PluginSet{
 			Enabled: []v1beta3.Plugin{
 				{Name: names.PrioritySort},
+			},
+		},
+		PreFilter: v1beta3.PluginSet{
+			Enabled: []v1beta3.Plugin{
+				{Name: names.NodeAffinity, Weight: pointer.Int32(2)},
+				{Name: names.NodePorts},
+				{Name: names.NodeResourcesFit, Weight: pointer.Int32(1)},
+				{Name: names.VolumeRestrictions},
+				{Name: names.VolumeBinding},
+				{Name: names.PodTopologySpread},
+				{Name: names.InterPodAffinity},
+			},
+		},
+		Filter: v1beta3.PluginSet{
+			Enabled: []v1beta3.Plugin{
 				{Name: names.NodeUnschedulable},
 				{Name: names.NodeName},
 				{Name: names.TaintToleration, Weight: pointer.Int32(3)},
@@ -43,16 +58,66 @@ func getDefaultPlugins() *v1beta3.Plugins {
 				{Name: names.AzureDiskLimits},
 				{Name: names.VolumeBinding},
 				{Name: names.VolumeZone},
-				{Name: names.PodTopologySpread, Weight: pointer.Int32(2)},
-				{Name: names.InterPodAffinity, Weight: pointer.Int32(2)},
+				{Name: names.PodTopologySpread},
+				{Name: names.InterPodAffinity},
+			},
+		},
+		PostFilter: v1beta3.PluginSet{
+			Enabled: []v1beta3.Plugin{
 				{Name: names.DefaultPreemption},
-				{Name: names.NodeResourcesBalancedAllocation, Weight: pointer.Int32(1)},
-				{Name: names.ImageLocality, Weight: pointer.Int32(1)},
+			},
+		},
+		PreScore: v1beta3.PluginSet{
+			Enabled: []v1beta3.Plugin{
+				{Name: names.TaintToleration, Weight: pointer.Int32(3)},
+				{Name: names.NodeAffinity, Weight: pointer.Int32(2)},
+				{Name: names.PodTopologySpread},
+				{Name: names.InterPodAffinity},
+			},
+		},
+		Score: v1beta3.PluginSet{
+			Enabled: []v1beta3.Plugin{
+				// Weight is tripled because:
+				// - This is a score coming from user preference.
+				// - Usage of node tainting to group nodes in the cluster is increasing becoming a use-case
+				// for many user workloads
+				{Name: names.TaintToleration, Weight: pointer.Int32Ptr(3)},
+				// Weight is doubled because:
+				// - This is a score coming from user preference.
+				{Name: names.NodeAffinity, Weight: pointer.Int32Ptr(2)},
+				{Name: names.NodeResourcesFit, Weight: pointer.Int32Ptr(1)},
+				// Weight is tripled because:
+				// - This is a score coming from user preference.
+				// - Usage of node tainting to group nodes in the cluster is increasing becoming a use-case
+				//	 for many user workloads
+				{Name: names.VolumeBinding, Weight: pointer.Int32Ptr(1)},
+				// Weight is doubled because:
+				// - This is a score coming from user preference.
+				// - It makes its signal comparable to NodeResourcesLeastAllocated.
+				{Name: names.PodTopologySpread, Weight: pointer.Int32Ptr(2)},
+				// Weight is doubled because:
+				// - This is a score coming from user preference.
+				{Name: names.InterPodAffinity, Weight: pointer.Int32Ptr(2)},
+				{Name: names.NodeResourcesBalancedAllocation, Weight: pointer.Int32Ptr(1)},
+				{Name: names.ImageLocality, Weight: pointer.Int32Ptr(1)},
+			},
+		},
+		Reserve: v1beta3.PluginSet{
+			Enabled: []v1beta3.Plugin{
+				{Name: names.VolumeBinding},
+			},
+		},
+		PreBind: v1beta3.PluginSet{
+			Enabled: []v1beta3.Plugin{
+				{Name: names.VolumeBinding},
+			},
+		},
+		Bind: v1beta3.PluginSet{
+			Enabled: []v1beta3.Plugin{
 				{Name: names.DefaultBinder},
 			},
 		},
 	}
-
 	return plugins
 }
 

--- a/pkg/scheduler/apis/config/v1beta3/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1beta3/default_plugins_test.go
@@ -37,9 +37,24 @@ func TestApplyFeatureGates(t *testing.T) {
 		{
 			name: "Feature gates disabled",
 			wantConfig: &v1beta3.Plugins{
-				MultiPoint: v1beta3.PluginSet{
+				QueueSort: v1beta3.PluginSet{
 					Enabled: []v1beta3.Plugin{
 						{Name: names.PrioritySort},
+					},
+				},
+				PreFilter: v1beta3.PluginSet{
+					Enabled: []v1beta3.Plugin{
+						{Name: names.NodeAffinity, Weight: pointer.Int32(2)},
+						{Name: names.NodePorts},
+						{Name: names.NodeResourcesFit, Weight: pointer.Int32(1)},
+						{Name: names.VolumeRestrictions},
+						{Name: names.VolumeBinding},
+						{Name: names.PodTopologySpread},
+						{Name: names.InterPodAffinity},
+					},
+				},
+				Filter: v1beta3.PluginSet{
+					Enabled: []v1beta3.Plugin{
 						{Name: names.NodeUnschedulable},
 						{Name: names.NodeName},
 						{Name: names.TaintToleration, Weight: pointer.Int32(3)},
@@ -53,11 +68,62 @@ func TestApplyFeatureGates(t *testing.T) {
 						{Name: names.AzureDiskLimits},
 						{Name: names.VolumeBinding},
 						{Name: names.VolumeZone},
-						{Name: names.PodTopologySpread, Weight: pointer.Int32(2)},
-						{Name: names.InterPodAffinity, Weight: pointer.Int32(2)},
+						{Name: names.PodTopologySpread},
+						{Name: names.InterPodAffinity},
+					},
+				},
+				PostFilter: v1beta3.PluginSet{
+					Enabled: []v1beta3.Plugin{
 						{Name: names.DefaultPreemption},
-						{Name: names.NodeResourcesBalancedAllocation, Weight: pointer.Int32(1)},
-						{Name: names.ImageLocality, Weight: pointer.Int32(1)},
+					},
+				},
+				PreScore: v1beta3.PluginSet{
+					Enabled: []v1beta3.Plugin{
+						{Name: names.TaintToleration, Weight: pointer.Int32(3)},
+						{Name: names.NodeAffinity, Weight: pointer.Int32(2)},
+						{Name: names.PodTopologySpread},
+						{Name: names.InterPodAffinity},
+					},
+				},
+				Score: v1beta3.PluginSet{
+					Enabled: []v1beta3.Plugin{
+						// Weight is tripled because:
+						// - This is a score coming from user preference.
+						// - Usage of node tainting to group nodes in the cluster is increasing becoming a use-case
+						// for many user workloads
+						{Name: names.TaintToleration, Weight: pointer.Int32Ptr(3)},
+						// Weight is doubled because:
+						// - This is a score coming from user preference.
+						{Name: names.NodeAffinity, Weight: pointer.Int32Ptr(2)},
+						{Name: names.NodeResourcesFit, Weight: pointer.Int32Ptr(1)},
+						// Weight is tripled because:
+						// - This is a score coming from user preference.
+						// - Usage of node tainting to group nodes in the cluster is increasing becoming a use-case
+						//	 for many user workloads
+						{Name: names.VolumeBinding, Weight: pointer.Int32Ptr(1)},
+						// Weight is doubled because:
+						// - This is a score coming from user preference.
+						// - It makes its signal comparable to NodeResourcesLeastAllocated.
+						{Name: names.PodTopologySpread, Weight: pointer.Int32Ptr(2)},
+						// Weight is doubled because:
+						// - This is a score coming from user preference.
+						{Name: names.InterPodAffinity, Weight: pointer.Int32Ptr(2)},
+						{Name: names.NodeResourcesBalancedAllocation, Weight: pointer.Int32Ptr(1)},
+						{Name: names.ImageLocality, Weight: pointer.Int32Ptr(1)},
+					},
+				},
+				Reserve: v1beta3.PluginSet{
+					Enabled: []v1beta3.Plugin{
+						{Name: names.VolumeBinding},
+					},
+				},
+				PreBind: v1beta3.PluginSet{
+					Enabled: []v1beta3.Plugin{
+						{Name: names.VolumeBinding},
+					},
+				},
+				Bind: v1beta3.PluginSet{
+					Enabled: []v1beta3.Plugin{
 						{Name: names.DefaultBinder},
 					},
 				},

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -330,16 +330,16 @@ func NewFramework(r Registry, profile *config.KubeSchedulerProfile, opts ...Opti
 		fillEventToPluginMap(p, options.clusterEventMap)
 	}
 
-	// initialize plugins per individual extension points
-	for _, e := range f.getExtensionPoints(profile.Plugins) {
-		if err := updatePluginList(e.slicePtr, *e.plugins, pluginsMap); err != nil {
+	// initialize multiPoint plugins to their expanded extension points
+	if len(profile.Plugins.MultiPoint.Enabled) > 0 {
+		if err := f.expandMultiPointPlugins(profile, pluginsMap); err != nil {
 			return nil, err
 		}
 	}
 
-	// initialize multiPoint plugins to their expanded extension points
-	if len(profile.Plugins.MultiPoint.Enabled) > 0 {
-		if err := f.expandMultiPointPlugins(profile, pluginsMap); err != nil {
+	// initialize plugins per individual extension points
+	for _, e := range f.getExtensionPoints(profile.Plugins) {
+		if err := updatePluginList(e.slicePtr, *e.plugins, pluginsMap); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -330,16 +330,16 @@ func NewFramework(r Registry, profile *config.KubeSchedulerProfile, opts ...Opti
 		fillEventToPluginMap(p, options.clusterEventMap)
 	}
 
-	// initialize multiPoint plugins to their expanded extension points
-	if len(profile.Plugins.MultiPoint.Enabled) > 0 {
-		if err := f.expandMultiPointPlugins(profile, pluginsMap); err != nil {
+	// initialize plugins per individual extension points
+	for _, e := range f.getExtensionPoints(profile.Plugins) {
+		if err := updatePluginList(e.slicePtr, *e.plugins, pluginsMap); err != nil {
 			return nil, err
 		}
 	}
 
-	// initialize plugins per individual extension points
-	for _, e := range f.getExtensionPoints(profile.Plugins) {
-		if err := updatePluginList(e.slicePtr, *e.plugins, pluginsMap); err != nil {
+	// initialize multiPoint plugins to their expanded extension points
+	if len(profile.Plugins.MultiPoint.Enabled) > 0 {
+		if err := f.expandMultiPointPlugins(profile, pluginsMap); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind regression
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

After introducing multipoint in v1beta3, out-of-tree plugin is placed at the beginning instead of the end of finalized plugin list, this behavior is regression comparing to v1beta1 and v1beta2.  

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108083

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
