### PR TITLE
Automated cherry pick of #108410: fix dryrun when ca file exists

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs.go
@@ -18,7 +18,6 @@ package phases
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -28,6 +27,7 @@ import (
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -197,20 +197,6 @@ func runCerts(c workflow.RunData) error {
 	}
 
 	fmt.Printf("[certs] Using certificateDir folder %q\n", data.CertificateWriteDir())
-
-	// If using an external CA while dryrun, copy CA cert to dryrun dir for later use
-	if data.ExternalCA() && data.DryRun() {
-		externalCAFile := filepath.Join(data.Cfg().CertificatesDir, kubeadmconstants.CACertName)
-		fileInfo, _ := os.Stat(externalCAFile)
-		contents, err := os.ReadFile(externalCAFile)
-		if err != nil {
-			return err
-		}
-		err = os.WriteFile(filepath.Join(data.CertificateWriteDir(), kubeadmconstants.CACertName), contents, fileInfo.Mode())
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -230,7 +216,21 @@ func runCAPhase(ca *certsphase.KubeadmCert) func(c workflow.RunData) error {
 		if cert, err := pkiutil.TryLoadCertFromDisk(data.CertificateDir(), ca.BaseName); err == nil {
 			certsphase.CheckCertificatePeriodValidity(ca.BaseName, cert)
 
+			// If CA Cert existed while dryrun, copy CA Cert to dryrun dir for later use
+			if data.DryRun() {
+				err := phases.CopyFile(filepath.Join(data.CertificateDir(), kubeadmconstants.CACertName), filepath.Join(data.CertificateWriteDir(), kubeadmconstants.CACertName))
+				if err != nil {
+					return errors.Wrapf(err, "could not copy %s to dry run directory %s", kubeadmconstants.CACertName, data.CertificateWriteDir())
+				}
+			}
 			if _, err := pkiutil.TryLoadKeyFromDisk(data.CertificateDir(), ca.BaseName); err == nil {
+				// If CA Key existed while dryrun, copy CA Key to dryrun dir for later use
+				if data.DryRun() {
+					err := phases.CopyFile(filepath.Join(data.CertificateDir(), kubeadmconstants.CAKeyName), filepath.Join(data.CertificateWriteDir(), kubeadmconstants.CAKeyName))
+					if err != nil {
+						return errors.Wrapf(err, "could not copy %s to dry run directory %s", kubeadmconstants.CAKeyName, data.CertificateWriteDir())
+					}
+				}
 				fmt.Printf("[certs] Using existing %s certificate authority\n", ca.BaseName)
 				return nil
 			}

--- a/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
@@ -18,12 +18,12 @@ package phases
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -137,15 +137,9 @@ func runKubeConfigFile(kubeConfigFileName string) func(workflow.RunData) error {
 			fmt.Printf("[kubeconfig] External CA mode: Using user provided %s\n", kubeConfigFileName)
 			// If using an external CA while dryrun, copy kubeconfig files to dryrun dir for later use
 			if data.DryRun() {
-				externalCAFile := filepath.Join(kubeadmconstants.KubernetesDir, kubeConfigFileName)
-				fileInfo, _ := os.Stat(externalCAFile)
-				contents, err := os.ReadFile(externalCAFile)
+				err := phases.CopyFile(filepath.Join(kubeadmconstants.KubernetesDir, kubeConfigFileName), filepath.Join(data.KubeConfigDir(), kubeConfigFileName))
 				if err != nil {
-					return err
-				}
-				err = os.WriteFile(filepath.Join(data.KubeConfigDir(), kubeConfigFileName), contents, fileInfo.Mode())
-				if err != nil {
-					return err
+					return errors.Wrapf(err, "could not copy %s to dry run directory %s", kubeConfigFileName, data.KubeConfigDir())
 				}
 			}
 			return nil

--- a/cmd/kubeadm/app/cmd/phases/util.go
+++ b/cmd/kubeadm/app/cmd/phases/util.go
@@ -17,6 +17,8 @@ limitations under the License.
 package phases
 
 import (
+	"os"
+
 	"k8s.io/component-base/version"
 
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
@@ -30,4 +32,15 @@ func SetKubernetesVersion(cfg *kubeadmapiv1.ClusterConfiguration) {
 		return
 	}
 	cfg.KubernetesVersion = version.Get().String()
+}
+
+// CopyFile copy file from src to dest.
+func CopyFile(src, dest string) error {
+	fileInfo, _ := os.Stat(src)
+	contents, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(dest, contents, fileInfo.Mode())
+	return err
 }


### PR DESCRIPTION
Cherry pick of #108410 on release-1.23.

#108410: fix dryrun when ca file exists

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```