### PR TITLE
Automated cherry pick of #108410: fix dryrun when ca file exists

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
@@ -18,9 +18,11 @@ package phases
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -132,6 +134,13 @@ func runKubeConfigFile(kubeConfigFileName string) func(workflow.RunData) error {
 		// if external CA mode, skip certificate authority generation
 		if data.ExternalCA() {
 			fmt.Printf("[kubeconfig] External CA mode: Using user provided %s\n", kubeConfigFileName)
+			// If using an external CA while dryrun, copy kubeconfig files to dryrun dir for later use
+			if data.DryRun() {
+				err := phases.CopyFile(filepath.Join(kubeadmconstants.KubernetesDir, kubeConfigFileName), filepath.Join(data.KubeConfigDir(), kubeConfigFileName))
+				if err != nil {
+					return errors.Wrapf(err, "could not copy %s to dry run directory %s", kubeConfigFileName, data.KubeConfigDir())
+				}
+			}
 			return nil
 		}
 

--- a/cmd/kubeadm/app/cmd/phases/util.go
+++ b/cmd/kubeadm/app/cmd/phases/util.go
@@ -17,7 +17,10 @@ limitations under the License.
 package phases
 
 import (
+	"os"
+
 	"k8s.io/component-base/version"
+
 	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 )
 
@@ -29,4 +32,15 @@ func SetKubernetesVersion(cfg *kubeadmapiv1beta2.ClusterConfiguration) {
 		return
 	}
 	cfg.KubernetesVersion = version.Get().String()
+}
+
+// CopyFile copy file from src to dest.
+func CopyFile(src, dest string) error {
+	fileInfo, _ := os.Stat(src)
+	contents, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(dest, contents, fileInfo.Mode())
+	return err
 }


### PR DESCRIPTION
Cherry pick of #108410 on release-1.21.

#108410: fix dryrun when ca file exists

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```