### PR TITLE
Add CEL runtime cost into CR validation

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -946,7 +946,7 @@ func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 
 		structural, err := structuralschema.NewStructural(schema)
 		if err == nil {
-			compResults, err := cel.Compile(structural, isRoot)
+			compResults, err := cel.Compile(structural, isRoot, cel.PerCallLimit)
 			if err != nil {
 				allErrs = append(allErrs, field.InternalError(fldPath.Child("x-kubernetes-validations"), err))
 			} else {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
@@ -18,6 +18,7 @@ package cel
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -40,6 +41,14 @@ const (
 	// OldScopedVarName is the variable name assigned to the existing value of the locally scoped data element of a
 	// CEL validation expression.
 	OldScopedVarName = "oldSelf"
+
+	// PerCallLimit specify the actual cost limit per CEL validation call
+	//TODO: pick the number for PerCallLimit
+	PerCallLimit = uint64(math.MaxInt64)
+
+	// RuntimeCELCostBudget is the overall cost budget for runtime CEL validation cost per CustomResource
+	//TODO: pick the RuntimeCELCostBudget
+	RuntimeCELCostBudget = math.MaxInt64
 )
 
 // CompilationResult represents the cel compilation result for one rule
@@ -58,7 +67,8 @@ type CompilationResult struct {
 /// - non-nil Program, nil Error: The program was compiled successfully
 //  - nil Program, non-nil Error: Compilation resulted in an error
 //  - nil Program, nil Error: The provided rule was empty so compilation was not attempted
-func Compile(s *schema.Structural, isResourceRoot bool) ([]CompilationResult, error) {
+// perCallLimit was added for testing purpose only. Callers should always use const PerCallLimit as input.
+func Compile(s *schema.Structural, isResourceRoot bool, perCallLimit uint64) ([]CompilationResult, error) {
 	if len(s.Extensions.XValidations) == 0 {
 		return nil, nil
 	}
@@ -106,13 +116,13 @@ func Compile(s *schema.Structural, isResourceRoot bool) ([]CompilationResult, er
 	// compResults is the return value which saves a list of compilation results in the same order as x-kubernetes-validations rules.
 	compResults := make([]CompilationResult, len(celRules))
 	for i, rule := range celRules {
-		compResults[i] = compileRule(rule, env)
+		compResults[i] = compileRule(rule, env, perCallLimit)
 	}
 
 	return compResults, nil
 }
 
-func compileRule(rule apiextensions.ValidationRule, env *cel.Env) (compilationResult CompilationResult) {
+func compileRule(rule apiextensions.ValidationRule, env *cel.Env, perCallLimit uint64) (compilationResult CompilationResult) {
 	if len(strings.TrimSpace(rule.Rule)) == 0 {
 		// include a compilation result, but leave both program and error nil per documented return semantics of this
 		// function
@@ -141,7 +151,8 @@ func compileRule(rule apiextensions.ValidationRule, env *cel.Env) (compilationRe
 		}
 	}
 
-	prog, err := env.Program(ast, cel.EvalOptions(cel.OptOptimize))
+	// TODO: Ideally we could configure the per expression limit at validation time and set it to the remaining overall budget, but we would either need a way to pass in a limit at evaluation time or move program creation to validation time
+	prog, err := env.Program(ast, cel.EvalOptions(cel.OptOptimize, cel.OptTrackCost), cel.CostLimit(perCallLimit))
 	if err != nil {
 		compilationResult.Error = &Error{ErrorTypeInvalid, "program instantiation failed: " + err.Error()}
 		return

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
@@ -637,7 +637,7 @@ func TestCelCompilation(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			compilationResults, err := Compile(&tt.input, false)
+			compilationResults, err := Compile(&tt.input, false, PerCallLimit)
 			if err != nil {
 				t.Errorf("Expected no error, but got: %v", err)
 			}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting/validation.go
@@ -47,15 +47,17 @@ func ValidateDefaults(pth *field.Path, s *structuralschema.Structural, isResourc
 		}
 	}
 
-	return validate(pth, s, s, f, false, requirePrunedDefaults)
+	allErr, error, _ := validate(pth, s, s, f, false, requirePrunedDefaults, cel.RuntimeCELCostBudget)
+	return allErr, error
 }
 
 // validate is the recursive step func for the validation. insideMeta is true if s specifies
 // TypeMeta or ObjectMeta. The SurroundingObjectFunc f is used to validate defaults of
 // TypeMeta or ObjectMeta fields.
-func validate(pth *field.Path, s *structuralschema.Structural, rootSchema *structuralschema.Structural, f SurroundingObjectFunc, insideMeta, requirePrunedDefaults bool) (field.ErrorList, error) {
+func validate(pth *field.Path, s *structuralschema.Structural, rootSchema *structuralschema.Structural, f SurroundingObjectFunc, insideMeta, requirePrunedDefaults bool, costBudget int64) (allErrs field.ErrorList, error error, remainingCost int64) {
+	remainingCost = costBudget
 	if s == nil {
-		return nil, nil
+		return nil, nil, remainingCost
 	}
 
 	if s.XEmbeddedResource {
@@ -63,8 +65,6 @@ func validate(pth *field.Path, s *structuralschema.Structural, rootSchema *struc
 		f = NewRootObjectFunc().WithTypeMeta(metav1.TypeMeta{APIVersion: "validation/v1", Kind: "Validation"})
 		rootSchema = s
 	}
-
-	allErrs := field.ErrorList{}
 
 	if s.Default.Object != nil {
 		validator := kubeopenapivalidate.NewSchemaValidator(s.ToKubeOpenAPI(), nil, "", strfmt.Default)
@@ -75,7 +75,7 @@ func validate(pth *field.Path, s *structuralschema.Structural, rootSchema *struc
 				// this should never happen. f(s.Default.Object) only gives an error if f is the
 				// root object func, but the default value is not a map. But then we wouldn't be
 				// in this case.
-				return nil, fmt.Errorf("failed to validate default value inside metadata: %v", err)
+				return nil, fmt.Errorf("failed to validate default value inside metadata: %v", err), remainingCost
 			}
 
 			// check ObjectMeta/TypeMeta and everything else
@@ -85,8 +85,13 @@ func validate(pth *field.Path, s *structuralschema.Structural, rootSchema *struc
 				allErrs = append(allErrs, field.Invalid(pth.Child("default"), s.Default.Object, fmt.Sprintf("must result in valid metadata: %v", errs.ToAggregate())))
 			} else if errs := apiservervalidation.ValidateCustomResource(pth.Child("default"), s.Default.Object, validator); len(errs) > 0 {
 				allErrs = append(allErrs, errs...)
-			} else if celValidator := cel.NewValidator(s); celValidator != nil {
-				allErrs = append(allErrs, celValidator.Validate(pth.Child("default"), s, s.Default.Object)...)
+			} else if celValidator := cel.NewValidator(s, cel.PerCallLimit); celValidator != nil {
+				celErrs, rmCost := celValidator.Validate(pth.Child("default"), s, s.Default.Object, remainingCost)
+				remainingCost = rmCost
+				allErrs = append(allErrs, celErrs...)
+				if remainingCost < 0 {
+					return allErrs, nil, remainingCost
+				}
 			}
 		} else {
 			// check whether default is pruned
@@ -105,8 +110,13 @@ func validate(pth *field.Path, s *structuralschema.Structural, rootSchema *struc
 				allErrs = append(allErrs, errs...)
 			} else if errs := apiservervalidation.ValidateCustomResource(pth.Child("default"), s.Default.Object, validator); len(errs) > 0 {
 				allErrs = append(allErrs, errs...)
-			} else if celValidator := cel.NewValidator(s); celValidator != nil {
-				allErrs = append(allErrs, celValidator.Validate(pth.Child("default"), s, s.Default.Object)...)
+			} else if celValidator := cel.NewValidator(s, cel.PerCallLimit); celValidator != nil {
+				celErrs, rmCost := celValidator.Validate(pth.Child("default"), s, s.Default.Object, remainingCost)
+				remainingCost = rmCost
+				allErrs = append(allErrs, celErrs...)
+				if remainingCost < 0 {
+					return allErrs, nil, remainingCost
+				}
 			}
 		}
 	}
@@ -114,11 +124,15 @@ func validate(pth *field.Path, s *structuralschema.Structural, rootSchema *struc
 	// do not follow additionalProperties because defaults are forbidden there
 
 	if s.Items != nil {
-		errs, err := validate(pth.Child("items"), s.Items, rootSchema, f.Index(), insideMeta, requirePrunedDefaults)
-		if err != nil {
-			return nil, err
-		}
+		errs, err, rCost := validate(pth.Child("items"), s.Items, rootSchema, f.Index(), insideMeta, requirePrunedDefaults, remainingCost)
+		remainingCost = rCost
 		allErrs = append(allErrs, errs...)
+		if err != nil {
+			return nil, err, remainingCost
+		}
+		if remainingCost < 0 {
+			return allErrs, nil, remainingCost
+		}
 	}
 
 	for k, subSchema := range s.Properties {
@@ -126,12 +140,16 @@ func validate(pth *field.Path, s *structuralschema.Structural, rootSchema *struc
 		if s.XEmbeddedResource && (k == "metadata" || k == "apiVersion" || k == "kind") {
 			subInsideMeta = true
 		}
-		errs, err := validate(pth.Child("properties").Key(k), &subSchema, rootSchema, f.Child(k), subInsideMeta, requirePrunedDefaults)
-		if err != nil {
-			return nil, err
-		}
+		errs, err, rCost := validate(pth.Child("properties").Key(k), &subSchema, rootSchema, f.Child(k), subInsideMeta, requirePrunedDefaults, remainingCost)
+		remainingCost = rCost
 		allErrs = append(allErrs, errs...)
+		if err != nil {
+			return nil, err, remainingCost
+		}
+		if remainingCost < 0 {
+			return allErrs, nil, remainingCost
+		}
 	}
 
-	return allErrs, nil
+	return allErrs, nil, remainingCost
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting/validation_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaulting
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func jsonPtr(x interface{}) *apiextensions.JSON {
+	ret := apiextensions.JSON(x)
+	return &ret
+}
+
+func TestDefaultValidationWithCostBudget(t *testing.T) {
+	tests := []struct {
+		name  string
+		input apiextensions.CustomResourceValidation
+	}{
+		{
+			name: "default cel validation",
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						"embedded": {
+							Type: "object",
+							Properties: map[string]apiextensions.JSONSchemaProps{
+								"metadata": {
+									Type:              "object",
+									XEmbeddedResource: true,
+									Properties: map[string]apiextensions.JSONSchemaProps{
+										"name": {
+											Type: "string",
+											XValidations: apiextensions.ValidationRules{
+												{
+													Rule: "self == 'singleton'",
+												},
+											},
+											Default: jsonPtr("singleton"),
+										},
+									},
+								},
+							},
+						},
+						"value": {
+							Type: "string",
+							XValidations: apiextensions.ValidationRules{
+								{
+									Rule: "self.startsWith('kube')",
+								},
+							},
+							Default: jsonPtr("kube-everything"),
+						},
+						"object": {
+							Type: "object",
+							Properties: map[string]apiextensions.JSONSchemaProps{
+								"field1": {
+									Type: "integer",
+								},
+								"field2": {
+									Type: "integer",
+								},
+							},
+							XValidations: apiextensions.ValidationRules{
+								{
+									Rule: "self.field1 < self.field2",
+								},
+							},
+							Default: jsonPtr(map[string]interface{}{"field1": 1, "field2": 2}),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := tt.input.OpenAPIV3Schema
+			ss, err := structuralschema.NewStructural(schema)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			f := NewRootObjectFunc().WithTypeMeta(metav1.TypeMeta{APIVersion: "validation/v1", Kind: "Validation"})
+
+			// cost budget is large enough to pass all validation rules
+			allErrs, err, _ := validate(field.NewPath("test"), ss, ss, f, false, false, 10)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			for _, valErr := range allErrs {
+				t.Errorf("unexpected error: %v", valErr)
+			}
+
+			// cost budget exceeded for the first validation rule
+			allErrs, err, _ = validate(field.NewPath("test"), ss, ss, f, false, false, 0)
+			meet := 0
+			for _, er := range allErrs {
+				if er.Type == field.ErrorTypeInvalid && strings.Contains(er.Error(), "validation failed due to running out of cost budget, no further validation rules will be run") {
+					meet += 1
+				}
+			}
+			if meet != 1 {
+				t.Errorf("expected to get cost budget exceed error once but got %v cost budget exceed error", meet)
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// cost budget exceeded for the last validation rule
+			allErrs, err, _ = validate(field.NewPath("test"), ss, ss, f, false, false, 9)
+			meet = 0
+			for _, er := range allErrs {
+				if er.Type == field.ErrorTypeInvalid && strings.Contains(er.Error(), "validation failed due to running out of cost budget, no further validation rules will be run") {
+					meet += 1
+				}
+			}
+			if meet != 1 {
+				t.Errorf("expected to get cost budget exceed error once but got %v cost budget exceed error", meet)
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
@@ -19,6 +19,7 @@ package customresource
 import (
 	"context"
 
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -90,7 +91,8 @@ func (a statusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Obj
 
 		// validate x-kubernetes-validations rules
 		if celValidator, ok := a.customResourceStrategy.celValidators[v]; ok {
-			errs = append(errs, celValidator.Validate(nil, a.customResourceStrategy.structuralSchemas[v], u.Object)...)
+			err, _ := celValidator.Validate(nil, a.customResourceStrategy.structuralSchemas[v], u.Object, cel.RuntimeCELCostBudget)
+			errs = append(errs, err...)
 		}
 	}
 	return errs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is part of  https://github.com/kubernetes/kubernetes/issues/107573. Based on PR: https://github.com/google/cel-go/pull/494. Add runtime cost calculation of CEL into CR validation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added CEL runtime cost calculation into CustomerResource validation. CustomerResource validation will fail if runtime cost exceeds the budget.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
