### PR TITLE
Make daemon.NodeShouldRunDaemonPod function public

### DIFF
--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -2397,7 +2397,7 @@ func TestNodeShouldRunDaemonPod(t *testing.T) {
 					manager.podNodeIndex.Add(p)
 				}
 				c.ds.Spec.UpdateStrategy = *strategy
-				shouldRun, shouldContinueRunning := manager.nodeShouldRunDaemonPod(node, c.ds)
+				shouldRun, shouldContinueRunning := NodeShouldRunDaemonPod(node, c.ds)
 
 				if shouldRun != c.shouldRun {
 					t.Errorf("[%v] strategy: %v, predicateName: %v expected shouldRun: %v, got: %v", i, c.ds.Spec.UpdateStrategy.Type, c.predicateName, c.shouldRun, shouldRun)

--- a/pkg/controller/daemon/update.go
+++ b/pkg/controller/daemon/update.go
@@ -528,7 +528,7 @@ func (dsc *DaemonSetsController) updatedDesiredNodeCounts(ds *apps.DaemonSet, no
 	var desiredNumberScheduled int
 	for i := range nodeList {
 		node := nodeList[i]
-		wantToRun, _ := dsc.nodeShouldRunDaemonPod(node, ds)
+		wantToRun, _ := NodeShouldRunDaemonPod(node, ds)
 		if !wantToRun {
 			continue
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR makes the `NodeShouldRunDaemonPod` function from `k8s.io/kubernetes/pkg/controller/daemon` public.

I want to use that function in Cluster Autoscaler repository to better handle daemonsets during scale-ups. Currently the component uses only the scheduler logic to handle daemonsets which can lead to incorrect scale-up decisions.

#### Does this PR introduce a user-facing change?

NONE
