### PR TITLE
Handle Non-graceful Node Shutdown

### DIFF
--- a/pkg/controller/podgc/gc_controller_test.go
+++ b/pkg/controller/podgc/gc_controller_test.go
@@ -27,13 +27,16 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/util/workqueue"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/testutil"
+	"k8s.io/kubernetes/pkg/features"
 	testingclock "k8s.io/utils/clock/testing"
 )
 
@@ -444,6 +447,157 @@ func TestGCUnscheduledTerminating(t *testing.T) {
 			if pass := compareStringSetToList(test.deletedPodNames, deletedPodNames); !pass {
 				t.Errorf("[%v]pod's deleted expected and actual did not match.\n\texpected: %v\n\tactual: %v, test: %v",
 					i, test.deletedPodNames.List(), deletedPodNames, test.name)
+			}
+		})
+	}
+}
+
+func TestGCTerminating(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeOutOfServiceVolumeDetach, true)()
+	type node struct {
+		name           string
+		readyCondition v1.ConditionStatus
+		taints         []v1.Taint
+	}
+
+	type nameToPodConfig struct {
+		name              string
+		phase             v1.PodPhase
+		deletionTimeStamp *metav1.Time
+		nodeName          string
+	}
+
+	testCases := []struct {
+		name            string
+		pods            []nameToPodConfig
+		nodes           []node
+		deletedPodNames sets.String
+	}{
+		{
+			name: "pods have deletion timestamp set and the corresponding nodes are not ready",
+			nodes: []node{
+				{name: "worker-0", readyCondition: v1.ConditionFalse},
+				{name: "worker-1", readyCondition: v1.ConditionFalse},
+			},
+			pods: []nameToPodConfig{
+				{name: "a", deletionTimeStamp: &metav1.Time{}, nodeName: "worker-0"},
+				{name: "b", deletionTimeStamp: &metav1.Time{}, nodeName: "worker-1"},
+			},
+			deletedPodNames: sets.NewString(),
+		},
+
+		{
+			name: "some pods have deletion timestamp and/or phase set and some of the corresponding nodes have an" +
+				"outofservice taint that are not ready",
+			nodes: []node{
+				// terminated pods on this node should be force deleted
+				{name: "worker-0", readyCondition: v1.ConditionFalse, taints: []v1.Taint{{Key: v1.TaintNodeOutOfService,
+					Effect: v1.TaintEffectNoExecute}}},
+				// terminated pods on this node should not be force deleted
+				{name: "worker-1", readyCondition: v1.ConditionFalse},
+				// terminated pods on this node should not be force deleted
+				{name: "worker-2", readyCondition: v1.ConditionTrue},
+				// terminated pods on this node should be force deleted
+				{name: "worker-3", readyCondition: v1.ConditionFalse, taints: []v1.Taint{{Key: v1.TaintNodeOutOfService,
+					Effect: v1.TaintEffectNoSchedule}}},
+				// terminated pods on this node should be force deleted
+				{name: "worker-4", readyCondition: v1.ConditionFalse, taints: []v1.Taint{{Key: v1.TaintNodeOutOfService,
+					Effect: v1.TaintEffectPreferNoSchedule}}},
+				// terminated pods on this node should be force deleted
+				{name: "worker-5", readyCondition: v1.ConditionFalse, taints: []v1.Taint{{Key: v1.TaintNodeOutOfService,
+					Value: "any-value", Effect: v1.TaintEffectNoExecute}}},
+			},
+			pods: []nameToPodConfig{
+				// pods a1, b1, c1, d1 and e1 are on node worker-0
+				{name: "a1", nodeName: "worker-0"},
+				{name: "b1", deletionTimeStamp: &metav1.Time{}, nodeName: "worker-0"},
+				{name: "c1", phase: v1.PodPending, nodeName: "worker-0"},
+				{name: "d1", phase: v1.PodRunning, nodeName: "worker-0"},
+				{name: "e1", phase: v1.PodUnknown, nodeName: "worker-0"},
+
+				// pods a2, b2, c2, d2 and e2 are on node worker-1
+				{name: "a2", nodeName: "worker-1"},
+				{name: "b2", deletionTimeStamp: &metav1.Time{}, nodeName: "worker-1"},
+				{name: "c2", phase: v1.PodPending, nodeName: "worker-1"},
+				{name: "d2", phase: v1.PodRunning, nodeName: "worker-1"},
+				{name: "e2", phase: v1.PodUnknown, nodeName: "worker-1"},
+
+				// pods a3, b3, c3, d3 and e3 are on node worker-2
+				{name: "a3", nodeName: "worker-2"},
+				{name: "b3", deletionTimeStamp: &metav1.Time{}, nodeName: "worker-2"},
+				{name: "c3", phase: v1.PodPending, nodeName: "worker-2"},
+				{name: "d3", phase: v1.PodRunning, nodeName: "worker-2"},
+				{name: "e3", phase: v1.PodUnknown, nodeName: "worker-2"},
+
+				// pods a4, b4, c4, d4 and e4 are on node worker-3
+				{name: "a4", nodeName: "worker-3"},
+				{name: "b4", deletionTimeStamp: &metav1.Time{}, nodeName: "worker-3"},
+				{name: "c4", phase: v1.PodPending, nodeName: "worker-3"},
+				{name: "d4", phase: v1.PodRunning, nodeName: "worker-3"},
+				{name: "e4", phase: v1.PodUnknown, nodeName: "worker-3"},
+
+				// pods a5, b5, c5, d5 and e5 are on node worker-4
+				{name: "a5", nodeName: "worker-3"},
+				{name: "b5", deletionTimeStamp: &metav1.Time{}, nodeName: "worker-4"},
+				{name: "c5", phase: v1.PodPending, nodeName: "worker-4"},
+				{name: "d5", phase: v1.PodRunning, nodeName: "worker-4"},
+				{name: "e5", phase: v1.PodUnknown, nodeName: "worker-4"},
+
+				// pods a6, b6, c6, d6 and e6 are on node worker-5
+				{name: "a6", nodeName: "worker-5"},
+				{name: "b6", deletionTimeStamp: &metav1.Time{}, nodeName: "worker-5"},
+				{name: "c6", phase: v1.PodPending, nodeName: "worker-5"},
+				{name: "d6", phase: v1.PodRunning, nodeName: "worker-5"},
+				{name: "e6", phase: v1.PodUnknown, nodeName: "worker-5"},
+			},
+			deletedPodNames: sets.NewString("b1", "b4", "b5", "b6"),
+		},
+	}
+	for i, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{*testutil.NewNode("node-a")}})
+			gcc, podInformer, nodeInformer := NewFromClient(client, -1)
+			deletedPodNames := make([]string, 0)
+			var lock sync.Mutex
+			gcc.deletePod = func(_, name string) error {
+				lock.Lock()
+				defer lock.Unlock()
+				deletedPodNames = append(deletedPodNames, name)
+				return nil
+			}
+			creationTime := time.Unix(0, 0)
+			for _, node := range test.nodes {
+				creationTime = creationTime.Add(2 * time.Hour)
+				nodeInformer.Informer().GetStore().Add(&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: node.name, CreationTimestamp: metav1.Time{Time: creationTime}},
+					Spec: v1.NodeSpec{
+						Taints: node.taints,
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: node.readyCondition,
+							},
+						},
+					},
+				})
+			}
+
+			for _, pod := range test.pods {
+				creationTime = creationTime.Add(1 * time.Hour)
+				podInformer.Informer().GetStore().Add(&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: pod.name, CreationTimestamp: metav1.Time{Time: creationTime},
+						DeletionTimestamp: pod.deletionTimeStamp},
+					Status: v1.PodStatus{Phase: pod.phase},
+					Spec:   v1.PodSpec{NodeName: pod.nodeName},
+				})
+			}
+
+			gcc.gc(context.TODO())
+			if pass := compareStringSetToList(test.deletedPodNames, deletedPodNames); !pass {
+				t.Errorf("[%v]pod's deleted expected and actual did not match.\n\texpected: %v\n\tactual: %v",
+					i, test.deletedPodNames.List(), deletedPodNames)
 			}
 		})
 	}

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -180,6 +180,7 @@ func NewAttachDetachController(
 		adc.actualStateOfWorld,
 		adc.attacherDetacher,
 		adc.nodeStatusUpdater,
+		adc.nodeLister,
 		recorder)
 
 	csiTranslator := csitrans.New()

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -844,12 +844,20 @@ const (
 	//
 	// Enable MinDomains in Pod Topology Spread.
 	MinDomainsInPodTopologySpread featuregate.Feature = "MinDomainsInPodTopologySpread"
+
 	// owner: @aojea
 	// kep: http://kep.k8s.io/3070
 	// alpha: v1.24
 	//
 	// Subdivide the ClusterIP range for dynamic and static IP allocation.
 	ServiceIPStaticSubrange featuregate.Feature = "ServiceIPStaticSubrange"
+
+	// owner: @xing-yang @sonasingh46
+	// kep: http://kep.k8s.io/2268
+	// alpha: v1.24
+	//
+	// Allow pods to failover to a different node in case of non graceful node shutdown
+	NodeOutOfServiceVolumeDetach featuregate.Feature = "NodeOutOfServiceVolumeDetach"
 )
 
 func init() {
@@ -973,7 +981,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	LegacyServiceAccountTokenNoAutoGeneration:      {Default: true, PreRelease: featuregate.Beta},
 	MinDomainsInPodTopologySpread:                  {Default: false, PreRelease: featuregate.Alpha},
 	ServiceIPStaticSubrange:                        {Default: false, PreRelease: featuregate.Alpha},
-
+	NodeOutOfServiceVolumeDetach:                   {Default: false, PreRelease: featuregate.Alpha},
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
 	genericfeatures.AdvancedAuditing:                    {Default: true, PreRelease: featuregate.GA},

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -164,3 +164,13 @@ func GetNodeIP(client clientset.Interface, name string) net.IP {
 	}
 	return nodeIP
 }
+
+// IsNodeReady returns true if a node is ready; false otherwise.
+func IsNodeReady(node *v1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == v1.NodeReady {
+			return c.Status == v1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/pkg/util/taints/taints.go
+++ b/pkg/util/taints/taints.go
@@ -275,6 +275,16 @@ func TaintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 	return false
 }
 
+// TaintKeyExists checks if the given taint key exists in list of taints. Returns true if exists false otherwise.
+func TaintKeyExists(taints []v1.Taint, taintKeyToMatch string) bool {
+	for _, taint := range taints {
+		if taint.Key == taintKeyToMatch {
+			return true
+		}
+	}
+	return false
+}
+
 func TaintSetDiff(t1, t2 []v1.Taint) (taintsToAdd []*v1.Taint, taintsToRemove []*v1.Taint) {
 	for _, taint := range t1 {
 		if !TaintExists(t2, &taint) {

--- a/staging/src/k8s.io/api/core/v1/well_known_taints.go
+++ b/staging/src/k8s.io/api/core/v1/well_known_taints.go
@@ -45,4 +45,8 @@ const (
 	// TaintNodePIDPressure will be added when node has pid pressure
 	// and removed when node has enough pid.
 	TaintNodePIDPressure = "node.kubernetes.io/pid-pressure"
+
+	// TaintNodeOutOfService can be added when node is out of service in case of
+	// a non-graceful shutdown
+	TaintNodeOutOfService = "node.kubernetes.io/out-of-service"
 )


### PR DESCRIPTION
Signed-off-by: Ashutosh Kumar <sonasingh46@gmail.com>

Co-authored-by: Ashutosh Kumar <sonasingh46@gmail.com>


#### What type of PR is this?
Implements KEP https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2268-non-graceful-shutdown

/kind feature

#### What this PR does / why we need it:
This PR adds a feature to detach volume immediately and does not wait for the 6 min timeout in case of a non graceful shutdown of a node that has an `node.kubernetes.io/out-of-service` taint added manually.

Adds feature gate `NodeOutOfServiceVolumeDetach` for this feature which is disabled by default. 

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

Performed the following tests: 



Used kubernetes cluster created on vSphere infra and vSphere CSI driver. 
Kubernetes Version: 
```
# kubectl version
Client Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.3", GitCommit:"816c97ab8cff8a1c72eccca1026f7820e93e0d25", GitTreeState:"clean", BuildDate:"2022-01-25T21:25:17Z", GoVersion:"go1.17.6", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.3", GitCommit:"816c97ab8cff8a1c72eccca1026f7820e93e0d25", GitTreeState:"clean", BuildDate:"2022-01-25T21:19:12Z", GoVersion:"go1.17.6", Compiler:"gc", Platform:"linux/amd64"}
```

Kube-controller-image was based out on the current PR

##### Test 1:

```
1. Deployed the kube-controller-manager with current code changes and disabled 
the non graceful shutdown feature gate. (It is disabled by default)

2. Created a statefulset pod. 

3. Shutdown the node on which the pod is scheduled. Node is shutdown using the 
`Shut Down Guest OS` from vSphere UI ( This shutdown is a non graceful shutdown ) 

4. Observed that after 5 mins, the pod changed to `Terminating` state. 

5. Observed that even after 6 mins, ( i.e total 6+5 = 11 mins ) the pod is stuck in `Terminating` state
```

##### Test 2:

```
1. Deployed the kube-controller-manager with current code changes and disabled 
the non graceful shutdown feature gate. (It is disabled by default).

2. Created a statefulset pod. 

3. Shutdown the node on which the pod is scheduled. Node is shutdown using the 
`Shut Down Guest OS` from vSphere UI ( This shutdown is a non graceful shutdown ) 

4. Observed that after 5 mins, the pod changed to `Terminating` state. 

5. Deleted the pod using `kubectl delete pod <pod-name> --force --grace-period 0`

6. The pod immediately got scheduled to a different healthy node but was stuck in `ContainerCreating` 
state for 6 mins. The pod came into `Running` state after 6 mins. It had the following events: 
 ----     ------                  ----   ----                     -------
  Normal   Scheduled               6m10s  default-scheduler        Successfully assigned default/test-sts-0 to k8s-node-716-1644856168
  Warning  FailedAttachVolume      6m10s  attachdetach-controller  Multi-Attach error for volume "pvc-b83ddf01-3029-4666-aea5-f43c91d8ddf0" Volume is already exclusively attached to one node and can't be attached to another
  Warning  FailedMount             4m7s   kubelet                  Unable to attach or mount volumes: unmounted volumes=[test-volume], unattached volumes=[test-volume kube-api-access-48d69]: timed out waiting for the condition
  Warning  FailedMount             113s   kubelet                  Unable to attach or mount volumes: unmounted volumes=[test-volume], unattached volumes=[kube-api-access-48d69 test-volume]: timed out waiting for the condition
  Normal   SuccessfulAttachVolume  1s     attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-b83ddf01-3029-4666-aea5-f43c91d8ddf0"
  
```

##### Test 3:

```
1. Deployed the kube-controller-manager with current code changes and enabled the 
non graceful shutdown feature gate. The feature gate can be enabled by adding the 
following to kube-controller-manager manifest yaml.
spec:
  containers:
  - command:
    // Add the below line
    - --feature-gates=NodeOutOfServiceVolumeDetach=true

2. Created a statefulset pod. 

3. Shutdown the node on which the pod is scheduled. Node is shutdown using the 
`Shut Down Guest OS` from vSphere UI ( This shutdown is a non graceful shutdown ) 

4. Observed that after 5 mins, the pod changed to `Terminating` state. 

5. Taint the node on which the pod was scheduled using the command: 
kubectl taint nodes <node-name> node.kubernetes.io/out-of-service=value1:NoExecute

6. The pod immediately got scheduled to a different healthy and came into running state in next couple of seconds without waiting for the 6 mins detach timeout period.
  
```
#### Does this PR introduce a user-facing change?

```release-note
Non graceful node shutdown handling.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2268-non-graceful-shutdown

```
