### PR TITLE
Support shell completion for the type/name form

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
@@ -38,7 +38,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -135,7 +135,7 @@ func NewCmdAnnotate(parent string, f cmdutil.Factory, ioStreams genericclioption
 		Short:                 i18n.T("Update the annotations on a resource"),
 		Long:                  annotateLong + "\n\n" + cmdutil.SuggestAPIResources(parent),
 		Example:               annotateExample,
-		ValidArgsFunction:     util.ResourceTypeAndNameCompletionFunc(f),
+		ValidArgsFunction:     completion.ResourceTypeAndNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
@@ -17,11 +17,8 @@ limitations under the License.
 package apiresources
 
 import (
-	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"os"
 	"sort"
 	"strings"
 
@@ -277,39 +274,4 @@ func (s sortableResource) compareValues(i, j int) (string, string) {
 		return s.resources[i].APIResource.Kind, s.resources[j].APIResource.Kind
 	}
 	return s.resources[i].APIGroup, s.resources[j].APIGroup
-}
-
-// CompGetResourceList returns the list of api resources which begin with `toComplete`.
-func CompGetResourceList(f cmdutil.Factory, cmd *cobra.Command, toComplete string) []string {
-	buf := new(bytes.Buffer)
-	streams := genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: ioutil.Discard}
-	o := NewAPIResourceOptions(streams)
-
-	// Get the list of resources
-	o.Output = "name"
-	o.Cached = true
-	o.Verbs = []string{"get"}
-	// TODO:Should set --request-timeout=5s
-
-	// Ignore errors as the output may still be valid
-	o.RunAPIResources(cmd, f)
-
-	// Resources can be a comma-separated list.  The last element is then
-	// the one we should complete.  For example if toComplete=="pods,secre"
-	// we should return "pods,secrets"
-	prefix := ""
-	suffix := toComplete
-	lastIdx := strings.LastIndex(toComplete, ",")
-	if lastIdx != -1 {
-		prefix = toComplete[0 : lastIdx+1]
-		suffix = toComplete[lastIdx+1:]
-	}
-	var comps []string
-	resources := strings.Split(buf.String(), "\n")
-	for _, res := range resources {
-		if res != "" && strings.HasPrefix(res, suffix) {
-			comps = append(comps, fmt.Sprintf("%s%s", prefix, res))
-		}
-	}
-	return comps
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_edit_last_applied.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_edit_last_applied.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/cmd/util/editor"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -67,7 +67,7 @@ func NewCmdApplyEditLastApplied(f cmdutil.Factory, ioStreams genericclioptions.I
 		Short:                 i18n.T("Edit latest last-applied-configuration annotations of a resource/object"),
 		Long:                  applyEditLastAppliedLong,
 		Example:               applyEditLastAppliedExample,
-		ValidArgsFunction:     util.ResourceTypeAndNameCompletionFunc(f),
+		ValidArgsFunction:     completion.ResourceTypeAndNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, args, cmd))
 			cmdutil.CheckErr(o.Run())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 	"sigs.k8s.io/yaml"
@@ -77,7 +78,7 @@ func NewCmdApplyViewLastApplied(f cmdutil.Factory, ioStreams genericclioptions.I
 		Short:                 i18n.T("View the latest last-applied-configuration annotations of a resource/object"),
 		Long:                  applyViewLastAppliedLong,
 		Example:               applyViewLastAppliedExample,
-		ValidArgsFunction:     util.ResourceTypeAndNameCompletionFunc(f),
+		ValidArgsFunction:     completion.ResourceTypeAndNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(cmd, f, args))
 			cmdutil.CheckErr(options.Validate(cmd))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -105,7 +105,7 @@ func NewCmdAttach(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 		Short:                 i18n.T("Attach to a running container"),
 		Long:                  i18n.T("Attach to a process that is already running inside an existing container."),
 		Example:               attachExample,
-		ValidArgsFunction:     util.PodResourceNameCompletionFunc(f),
+		ValidArgsFunction:     completion.PodResourceNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
@@ -105,7 +105,7 @@ func NewCmdAttach(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 		Short:                 i18n.T("Attach to a running container"),
 		Long:                  i18n.T("Attach to a process that is already running inside an existing container."),
 		Example:               attachExample,
-		ValidArgsFunction:     util.ResourceNameCompletionFunc(f, "pod"),
+		ValidArgsFunction:     util.PodResourceNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
@@ -34,6 +34,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -107,7 +108,7 @@ func NewCmdAutoscale(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *
 		Short:                 i18n.T("Auto-scale a deployment, replica set, stateful set, or replication controller"),
 		Long:                  autoscaleLong,
 		Example:               autoscaleExample,
-		ValidArgsFunction:     util.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
+		ValidArgsFunction:     completion.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -42,7 +42,7 @@ func NewCmdConfigDeleteCluster(out io.Writer, configAccess clientcmd.ConfigAcces
 		Short:                 i18n.T("Delete the specified cluster from the kubeconfig"),
 		Long:                  i18n.T("Delete the specified cluster from the kubeconfig."),
 		Example:               deleteClusterExample,
-		ValidArgsFunction:     util.ClusterCompletionFunc,
+		ValidArgsFunction:     completion.ClusterCompletionFunc,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(runDeleteCluster(out, configAccess, cmd))
 		},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -42,7 +42,7 @@ func NewCmdConfigDeleteContext(out, errOut io.Writer, configAccess clientcmd.Con
 		Short:                 i18n.T("Delete the specified context from the kubeconfig"),
 		Long:                  i18n.T("Delete the specified context from the kubeconfig."),
 		Example:               deleteContextExample,
-		ValidArgsFunction:     util.ContextCompletionFunc,
+		ValidArgsFunction:     completion.ContextCompletionFunc,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(runDeleteContext(out, errOut, configAccess, cmd))
 		},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -65,7 +65,7 @@ func NewCmdConfigDeleteUser(streams genericclioptions.IOStreams, configAccess cl
 		Short:                 i18n.T("Delete the specified user from the kubeconfig"),
 		Long:                  i18n.T("Delete the specified user from the kubeconfig."),
 		Example:               deleteUserExample,
-		ValidArgsFunction:     util.UserCompletionFunc,
+		ValidArgsFunction:     completion.UserCompletionFunc,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/rename_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/rename_context.go
@@ -25,7 +25,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -68,7 +68,7 @@ func NewCmdConfigRenameContext(out io.Writer, configAccess clientcmd.ConfigAcces
 		Short:                 renameContextShort,
 		Long:                  renameContextLong,
 		Example:               renameContextExample,
-		ValidArgsFunction:     util.ContextCompletionFunc,
+		ValidArgsFunction:     completion.ContextCompletionFunc,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(cmd, args, out))
 			cmdutil.CheckErr(options.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_context.go
@@ -27,7 +27,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cliflag "k8s.io/component-base/cli/flag"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -62,7 +62,7 @@ func NewCmdConfigSetContext(out io.Writer, configAccess clientcmd.ConfigAccess) 
 		Short:                 i18n.T("Set a context entry in kubeconfig"),
 		Long:                  setContextLong,
 		Example:               setContextExample,
-		ValidArgsFunction:     util.ContextCompletionFunc,
+		ValidArgsFunction:     completion.ContextCompletionFunc,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd))
 			name, exists, err := options.run()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/use_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/use_context.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -53,7 +53,7 @@ func NewCmdConfigUseContext(out io.Writer, configAccess clientcmd.ConfigAccess) 
 		Aliases:               []string{"use"},
 		Long:                  `Set the current-context in a kubeconfig file.`,
 		Example:               useContextExample,
-		ValidArgsFunction:     util.ContextCompletionFunc,
+		ValidArgsFunction:     completion.ContextCompletionFunc,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd))
 			cmdutil.CheckErr(options.run())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -32,8 +32,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/cmd/exec"
-	"k8s.io/kubectl/pkg/cmd/get"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -102,20 +102,20 @@ func NewCmdCp(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.C
 			if len(args) == 0 {
 				if strings.IndexAny(toComplete, "/.~") == 0 {
 					// Looks like a path, do nothing
-				} else if strings.Index(toComplete, ":") != -1 {
+				} else if strings.Contains(toComplete, ":") {
 					// TODO: complete remote files in the pod
 				} else if idx := strings.Index(toComplete, "/"); idx > 0 {
 					// complete <namespace>/<pod>
 					namespace := toComplete[:idx]
 					template := "{{ range .items }}{{ .metadata.namespace }}/{{ .metadata.name }}: {{ end }}"
-					comps = get.CompGetFromTemplate(&template, f, namespace, cmd, []string{"pod"}, toComplete)
+					comps = completion.CompGetFromTemplate(&template, f, namespace, cmd, []string{"pod"}, toComplete)
 				} else {
 					// Complete namespaces followed by a /
-					for _, ns := range get.CompGetResource(f, cmd, "namespace", toComplete) {
+					for _, ns := range completion.CompGetResource(f, cmd, "namespace", toComplete) {
 						comps = append(comps, fmt.Sprintf("%s/", ns))
 					}
 					// Complete pod names followed by a :
-					for _, pod := range get.CompGetResource(f, cmd, "pod", toComplete) {
+					for _, pod := range completion.CompGetResource(f, cmd, "pod", toComplete) {
 						comps = append(comps, fmt.Sprintf("%s:", pod))
 					}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
@@ -29,10 +29,10 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	rbacclientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
-	"k8s.io/kubectl/pkg/cmd/get"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -109,7 +109,7 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, ioStreams genericclioptio
 	cmdutil.CheckErr(cmd.RegisterFlagCompletionFunc(
 		"clusterrole",
 		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return get.CompGetResource(f, cmd, "clusterrole", toComplete), cobra.ShellCompDirectiveNoFileComp
+			return completion.CompGetResource(f, cmd, "clusterrole", toComplete), cobra.ShellCompDirectiveNoFileComp
 		}))
 
 	return cmd

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token.go
@@ -33,7 +33,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/templates"
 	"k8s.io/kubectl/pkg/util/term"
 	"k8s.io/utils/pointer"
@@ -115,7 +115,7 @@ func NewCmdCreateToken(f cmdutil.Factory, ioStreams genericclioptions.IOStreams)
 		Short:                 "Request a service account token",
 		Long:                  tokenLong,
 		Example:               tokenExample,
-		ValidArgsFunction:     util.ResourceNameCompletionFunc(f, "serviceaccount"),
+		ValidArgsFunction:     completion.ResourceNameCompletionFunc(f, "serviceaccount"),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := o.Complete(f, cmd, args); err != nil {
 				cmdutil.CheckErr(err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -36,7 +36,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	cmdwait "k8s.io/kubectl/pkg/cmd/wait"
 	"k8s.io/kubectl/pkg/rawhttp"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -141,7 +141,7 @@ func NewCmdDelete(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 		Short:                 i18n.T("Delete resources by file names, stdin, resources and names, or by resources and label selector"),
 		Long:                  deleteLong,
 		Example:               deleteExample,
-		ValidArgsFunction:     util.ResourceTypeAndNameCompletionFunc(f),
+		ValidArgsFunction:     completion.ResourceTypeAndNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			o, err := deleteFlags.ToOptions(nil, streams)
 			cmdutil.CheckErr(err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/describe"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -107,7 +107,7 @@ func NewCmdDescribe(parent string, f cmdutil.Factory, streams genericclioptions.
 		Short:                 i18n.T("Show details of a specific resource or group of resources"),
 		Long:                  describeLong + "\n\n" + cmdutil.SuggestAPIResources(parent),
 		Example:               describeExample,
-		ValidArgsFunction:     util.ResourceTypeAndNameCompletionFunc(f),
+		ValidArgsFunction:     completion.ResourceTypeAndNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Run())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -34,7 +34,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/drain"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -69,7 +69,7 @@ func NewCmdCordon(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 		Short:                 i18n.T("Mark node as unschedulable"),
 		Long:                  cordonLong,
 		Example:               cordonExample,
-		ValidArgsFunction:     util.ResourceNameCompletionFunc(f, "node"),
+		ValidArgsFunction:     completion.ResourceNameCompletionFunc(f, "node"),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.RunCordonOrUncordon(true))
@@ -98,7 +98,7 @@ func NewCmdUncordon(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *c
 		Short:                 i18n.T("Mark node as schedulable"),
 		Long:                  uncordonLong,
 		Example:               uncordonExample,
-		ValidArgsFunction:     util.ResourceNameCompletionFunc(f, "node"),
+		ValidArgsFunction:     completion.ResourceNameCompletionFunc(f, "node"),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.RunCordonOrUncordon(false))
@@ -184,7 +184,7 @@ func NewCmdDrain(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 		Short:                 i18n.T("Drain node in preparation for maintenance"),
 		Long:                  drainLong,
 		Example:               drainExample,
-		ValidArgsFunction:     util.ResourceNameCompletionFunc(f, "node"),
+		ValidArgsFunction:     completion.ResourceNameCompletionFunc(f, "node"),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.RunDrain())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/cmd/util/editor"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -77,7 +77,7 @@ func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		Short:                 i18n.T("Edit a resource on the server"),
 		Long:                  editLong,
 		Example:               editExample,
-		ValidArgsFunction:     util.ResourceTypeAndNameCompletionFunc(f),
+		ValidArgsFunction:     completion.ResourceTypeAndNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, args, cmd))
 			cmdutil.CheckErr(o.Run())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/interrupt"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -89,7 +89,7 @@ func NewCmdExec(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		Short:                 i18n.T("Execute a command in a container"),
 		Long:                  i18n.T("Execute a command in a container."),
 		Example:               execExample,
-		ValidArgsFunction:     util.PodResourceNameCompletionFunc(f),
+		ValidArgsFunction:     completion.PodResourceNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			argsLenAtDash := cmd.ArgsLenAtDash()
 			cmdutil.CheckErr(options.Complete(f, cmd, args, argsLenAtDash))
@@ -101,7 +101,7 @@ func NewCmdExec(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 	cmdutil.AddJsonFilenameFlag(cmd.Flags(), &options.FilenameOptions.Filenames, "to use to exec into the resource")
 	// TODO support UID
 	cmdutil.AddContainerVarFlags(cmd, &options.ContainerName, options.ContainerName)
-	cmdutil.CheckErr(cmd.RegisterFlagCompletionFunc("container", util.ContainerCompletionFunc(f)))
+	cmdutil.CheckErr(cmd.RegisterFlagCompletionFunc("container", completion.ContainerCompletionFunc(f)))
 
 	cmd.Flags().BoolVarP(&options.Stdin, "stdin", "i", options.Stdin, "Pass stdin to the container")
 	cmd.Flags().BoolVarP(&options.TTY, "tty", "t", options.TTY, "Stdin is a TTY")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -89,7 +89,7 @@ func NewCmdExec(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		Short:                 i18n.T("Execute a command in a container"),
 		Long:                  i18n.T("Execute a command in a container."),
 		Example:               execExample,
-		ValidArgsFunction:     util.ResourceNameCompletionFunc(f, "pod"),
+		ValidArgsFunction:     util.PodResourceNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			argsLenAtDash := cmd.ArgsLenAtDash()
 			cmdutil.CheckErr(options.Complete(f, cmd, args, argsLenAtDash))
@@ -101,6 +101,8 @@ func NewCmdExec(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 	cmdutil.AddJsonFilenameFlag(cmd.Flags(), &options.FilenameOptions.Filenames, "to use to exec into the resource")
 	// TODO support UID
 	cmdutil.AddContainerVarFlags(cmd, &options.ContainerName, options.ContainerName)
+	cmdutil.CheckErr(cmd.RegisterFlagCompletionFunc("container", util.ContainerCompletionFunc(f)))
+
 	cmd.Flags().BoolVarP(&options.Stdin, "stdin", "i", options.Stdin, "Pass stdin to the container")
 	cmd.Flags().BoolVarP(&options.TTY, "tty", "t", options.TTY, "Stdin is a TTY")
 	cmd.Flags().BoolVarP(&options.Quiet, "quiet", "q", options.Quiet, "Only print output from the remote session")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -137,7 +138,7 @@ func NewCmdExposeService(f cmdutil.Factory, streams genericclioptions.IOStreams)
 		Short:                 i18n.T("Take a replication controller, service, deployment or pod and expose it as a new Kubernetes service"),
 		Long:                  exposeLong,
 		Example:               exposeExample,
-		ValidArgsFunction:     util.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
+		ValidArgsFunction:     completion.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd))
 			cmdutil.CheckErr(o.RunExpose(cmd, args))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -17,14 +17,11 @@ limitations under the License.
 package get
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -45,7 +42,6 @@ import (
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	watchtools "k8s.io/client-go/tools/watch"
-	"k8s.io/kubectl/pkg/cmd/apiresources"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/rawhttp"
 	"k8s.io/kubectl/pkg/scheme"
@@ -163,7 +159,7 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericclioptions.IOStr
 		Short:                 i18n.T("Display one or many resources"),
 		Long:                  getLong + "\n\n" + cmdutil.SuggestAPIResources(parent),
 		Example:               getExample,
-		ValidArgsFunction:     ResourceTypeAndNameCompletionFunc(f, nil, true),
+		// ValidArgsFunction is set when this function is called so that we have access to the util package
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate(cmd))
@@ -850,141 +846,4 @@ func multipleGVKsRequested(infos []*resource.Info) bool {
 		}
 	}
 	return false
-}
-
-// CompGetResource gets the list of the resource specified which begin with `toComplete`.
-func CompGetResource(f cmdutil.Factory, cmd *cobra.Command, resourceName string, toComplete string) []string {
-	template := "{{ range .items  }}{{ .metadata.name }} {{ end }}"
-	return CompGetFromTemplate(&template, f, "", cmd, []string{resourceName}, toComplete)
-}
-
-// CompGetContainers gets the list of containers of the specified pod which begin with `toComplete`.
-func CompGetContainers(f cmdutil.Factory, cmd *cobra.Command, podName string, toComplete string) []string {
-	template := "{{ range .spec.initContainers }}{{ .name }} {{end}}{{ range .spec.containers  }}{{ .name }} {{ end }}"
-	return CompGetFromTemplate(&template, f, "", cmd, []string{"pod", podName}, toComplete)
-}
-
-// CompGetFromTemplate executes a Get operation using the specified template and args and returns the results
-// which begin with `toComplete`.
-func CompGetFromTemplate(template *string, f cmdutil.Factory, namespace string, cmd *cobra.Command, args []string, toComplete string) []string {
-	buf := new(bytes.Buffer)
-	streams := genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: ioutil.Discard}
-	o := NewGetOptions("kubectl", streams)
-
-	// Get the list of names of the specified resource
-	o.PrintFlags.TemplateFlags.GoTemplatePrintFlags.TemplateArgument = template
-	format := "go-template"
-	o.PrintFlags.OutputFormat = &format
-
-	// Do the steps Complete() would have done.
-	// We cannot actually call Complete() or Validate() as these function check for
-	// the presence of flags, which, in our case won't be there
-	if namespace != "" {
-		o.Namespace = namespace
-		o.ExplicitNamespace = true
-	} else {
-		var err error
-		o.Namespace, o.ExplicitNamespace, err = f.ToRawKubeConfigLoader().Namespace()
-		if err != nil {
-			return nil
-		}
-	}
-
-	o.ToPrinter = func(mapping *meta.RESTMapping, outputObjects *bool, withNamespace bool, withKind bool) (printers.ResourcePrinterFunc, error) {
-		printer, err := o.PrintFlags.ToPrinter()
-		if err != nil {
-			return nil, err
-		}
-		return printer.PrintObj, nil
-	}
-
-	o.Run(f, cmd, args)
-
-	var comps []string
-	resources := strings.Split(buf.String(), " ")
-	for _, res := range resources {
-		if res != "" && strings.HasPrefix(res, toComplete) {
-			comps = append(comps, res)
-		}
-	}
-	return comps
-}
-
-// ResourceTypeAndNameCompletionFunc Returns a completion function that completes resource types
-// and resource names that match the toComplete prefix.  It supports the <type>/<name> form.
-func ResourceTypeAndNameCompletionFunc(f cmdutil.Factory, allowedTypes []string, allowRepeat bool) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		var comps []string
-		directive := cobra.ShellCompDirectiveNoFileComp
-
-		if len(args) > 0 && !strings.Contains(args[0], "/") {
-			// The first argument is of the form <type> (e.g., pods)
-			// All following arguments should be a resource name.
-			if allowRepeat || len(args) == 1 {
-				comps = CompGetResource(f, cmd, args[0], toComplete)
-
-				// Remove choices already on the command-line
-				if len(args) > 1 {
-					comps = cmdutil.Difference(comps, args[1:])
-				}
-			}
-		} else {
-			slashIdx := strings.Index(toComplete, "/")
-			if slashIdx == -1 {
-				if len(args) == 0 {
-					// We are completing the first argument.  We default to the normal
-					// <type> form (not the form <type>/<name>).
-					// So we suggest resource types and let the shell add a space after
-					// the completion.
-					if len(allowedTypes) == 0 {
-						comps = apiresources.CompGetResourceList(f, cmd, toComplete)
-					} else {
-						for _, c := range allowedTypes {
-							if strings.HasPrefix(c, toComplete) {
-								comps = append(comps, c)
-							}
-						}
-					}
-				} else {
-					// Here we know the first argument contains a / (<type>/<name>).
-					// All other arguments must also use that form.
-					if allowRepeat {
-						// Since toComplete does not already contain a / we know we are completing a
-						// resource type. Disable adding a space after the completion, and add the /
-						directive |= cobra.ShellCompDirectiveNoSpace
-
-						if len(allowedTypes) == 0 {
-							typeComps := apiresources.CompGetResourceList(f, cmd, toComplete)
-							for _, c := range typeComps {
-								comps = append(comps, fmt.Sprintf("%s/", c))
-							}
-						} else {
-							for _, c := range allowedTypes {
-								if strings.HasPrefix(c, toComplete) {
-									comps = append(comps, fmt.Sprintf("%s/", c))
-								}
-							}
-						}
-					}
-				}
-			} else {
-				// We are completing an argument of the form <type>/<name>
-				// and since the / is already present, we are completing the resource name.
-				if allowRepeat || len(args) == 0 {
-					resourceType := toComplete[:slashIdx]
-					toComplete = toComplete[slashIdx+1:]
-					nameComps := CompGetResource(f, cmd, resourceType, toComplete)
-					for _, c := range nameComps {
-						comps = append(comps, fmt.Sprintf("%s/%s", resourceType, c))
-					}
-
-					// Remove choices already on the command-line.
-					if len(args) > 0 {
-						comps = cmdutil.Difference(comps, args[0:])
-					}
-				}
-			}
-		}
-		return comps, directive
-	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -139,7 +139,7 @@ func NewCmdLabel(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 		Short:                 i18n.T("Update the labels on a resource"),
 		Long:                  fmt.Sprintf(labelLong, validation.LabelValueMaxLength),
 		Example:               labelExample,
-		ValidArgsFunction:     util.ResourceTypeAndNameCompletionFunc(f),
+		ValidArgsFunction:     completion.ResourceTypeAndNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -152,7 +153,7 @@ func NewCmdLogs(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		Short:                 i18n.T("Print the logs for a container in a pod"),
 		Long:                  logsLong,
 		Example:               logsExample,
-		ValidArgsFunction:     util.PodResourceNameAndContainerCompletionFunc(f),
+		ValidArgsFunction:     completion.PodResourceNameAndContainerCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -115,7 +115,7 @@ func NewCmdPatch(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 		Short:                 i18n.T("Update fields of a resource"),
 		Long:                  patchLong,
 		Example:               patchExample,
-		ValidArgsFunction:     util.ResourceTypeAndNameCompletionFunc(f),
+		ValidArgsFunction:     completion.ResourceTypeAndNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -109,7 +109,7 @@ func NewCmdPortForward(f cmdutil.Factory, streams genericclioptions.IOStreams) *
 		Short:                 i18n.T("Forward one or more local ports to a pod"),
 		Long:                  portforwardLong,
 		Example:               portforwardExample,
-		ValidArgsFunction:     util.ResourceNameCompletionFunc(f, "pod"),
+		ValidArgsFunction:     util.PodResourceNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(opts.Complete(f, cmd, args))
 			cmdutil.CheckErr(opts.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -41,6 +41,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -109,7 +110,7 @@ func NewCmdPortForward(f cmdutil.Factory, streams genericclioptions.IOStreams) *
 		Short:                 i18n.T("Forward one or more local ports to a pod"),
 		Long:                  portforwardLong,
 		Example:               portforwardExample,
-		ValidArgsFunction:     util.PodResourceNameCompletionFunc(f),
+		ValidArgsFunction:     completion.PodResourceNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(opts.Complete(f, cmd, args))
 			cmdutil.CheckErr(opts.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
@@ -27,7 +27,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -84,7 +84,7 @@ func NewCmdRolloutHistory(f cmdutil.Factory, streams genericclioptions.IOStreams
 		Short:                 i18n.T("View rollout history"),
 		Long:                  historyLong,
 		Example:               historyExample,
-		ValidArgsFunction:     util.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
+		ValidArgsFunction:     completion.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause.go
@@ -30,7 +30,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -84,7 +84,7 @@ func NewCmdRolloutPause(f cmdutil.Factory, streams genericclioptions.IOStreams) 
 		Short:                 i18n.T("Mark the provided resource as paused"),
 		Long:                  pauseLong,
 		Example:               pauseExample,
-		ValidArgsFunction:     util.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
+		ValidArgsFunction:     completion.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go
@@ -29,7 +29,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -91,7 +91,7 @@ func NewCmdRolloutRestart(f cmdutil.Factory, streams genericclioptions.IOStreams
 		Short:                 i18n.T("Restart a resource"),
 		Long:                  restartLong,
 		Example:               restartExample,
-		ValidArgsFunction:     util.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
+		ValidArgsFunction:     completion.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_resume.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_resume.go
@@ -30,7 +30,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -88,7 +88,7 @@ func NewCmdRolloutResume(f cmdutil.Factory, streams genericclioptions.IOStreams)
 		Short:                 i18n.T("Resume a paused resource"),
 		Long:                  resumeLong,
 		Example:               resumeExample,
-		ValidArgsFunction:     util.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
+		ValidArgsFunction:     completion.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
@@ -37,7 +37,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/interrupt"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -103,7 +103,7 @@ func NewCmdRolloutStatus(f cmdutil.Factory, streams genericclioptions.IOStreams)
 		Short:                 i18n.T("Show the status of the rollout"),
 		Long:                  statusLong,
 		Example:               statusExample,
-		ValidArgsFunction:     util.SpecifiedResourceTypeAndNameNoRepeatCompletionFunc(f, validArgs),
+		ValidArgsFunction:     completion.SpecifiedResourceTypeAndNameNoRepeatCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_undo.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_undo.go
@@ -27,7 +27,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -88,7 +88,7 @@ func NewCmdRolloutUndo(f cmdutil.Factory, streams genericclioptions.IOStreams) *
 		Short:                 i18n.T("Undo a previous rollout"),
 		Long:                  undoLong,
 		Example:               undoExample,
-		ValidArgsFunction:     util.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
+		ValidArgsFunction:     completion.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scale"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -114,7 +114,7 @@ func NewCmdScale(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 		Short:                 i18n.T("Set a new size for a deployment, replica set, or replication controller"),
 		Long:                  scaleLong,
 		Example:               scaleExample,
-		ValidArgsFunction:     util.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
+		ValidArgsFunction:     completion.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate(cmd))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/explain"
-	"k8s.io/kubectl/pkg/util"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -38,6 +37,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -109,7 +109,7 @@ func NewCmdTaint(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 		Short:                 i18n.T("Update the taints on one or more nodes"),
 		Long:                  fmt.Sprintf(taintLong, validation.DNS1123SubdomainMaxLength, validation.LabelValueMaxLength),
 		Example:               taintExample,
-		ValidArgsFunction:     util.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
+		ValidArgsFunction:     completion.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(f, cmd, args))
 			cmdutil.CheckErr(options.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -29,7 +29,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/metricsutil"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
@@ -82,7 +82,7 @@ func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericclioptio
 		Short:                 i18n.T("Display resource (CPU/memory) usage of nodes"),
 		Long:                  topNodeLong,
 		Example:               topNodeExample,
-		ValidArgsFunction:     util.ResourceNameCompletionFunc(f, "node"),
+		ValidArgsFunction:     completion.ResourceNameCompletionFunc(f, "node"),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -30,7 +30,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/metricsutil"
-	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
@@ -100,7 +100,7 @@ func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericclioptions
 		Short:                 i18n.T("Display resource (CPU/memory) usage of pods"),
 		Long:                  topPodLong,
 		Example:               topPodExample,
-		ValidArgsFunction:     util.ResourceNameCompletionFunc(f, "pod"),
+		ValidArgsFunction:     completion.ResourceNameCompletionFunc(f, "pod"),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/util/completion/completion_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion/completion_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package completion
 
 import (
 	"net/http"

--- a/staging/src/k8s.io/kubectl/pkg/util/completion_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion_test.go
@@ -127,6 +127,25 @@ func TestResourceTypeAndNameCompletionFuncRepeating(t *testing.T) {
 	checkCompletion(t, comps, []string{"foo"}, directive, cobra.ShellCompDirectiveNoFileComp)
 }
 
+func TestResourceTypeAndNameCompletionFuncJointForm(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := ResourceTypeAndNameCompletionFunc(tf)
+	comps, directive := compFunc(cmd, []string{}, "pod/b")
+	checkCompletion(t, comps, []string{"pod/bar"}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
+
+func TestResourceTypeAndNameCompletionFuncJointFormRepeating(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := ResourceTypeAndNameCompletionFunc(tf)
+	comps, directive := compFunc(cmd, []string{"pod/bar"}, "pod/")
+	// The other pods should be completed, but not the already specified ones
+	checkCompletion(t, comps, []string{"pod/foo"}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
+
 func TestSpecifiedResourceTypeAndNameCompletionFuncNoArgs(t *testing.T) {
 	tf, cmd := prepareCompletionTest()
 	addPodsToFactory(tf)
@@ -155,6 +174,24 @@ func TestSpecifiedResourceTypeAndNameCompletionFuncRepeating(t *testing.T) {
 	checkCompletion(t, comps, []string{"foo"}, directive, cobra.ShellCompDirectiveNoFileComp)
 }
 
+func TestSpecifiedResourceTypeAndNameCompletionFuncJointFormOneArg(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := SpecifiedResourceTypeAndNameCompletionFunc(tf, []string{"pod"})
+	comps, directive := compFunc(cmd, []string{}, "pod/b")
+	checkCompletion(t, comps, []string{"pod/bar"}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
+
+func TestSpecifiedResourceTypeAndNameCompletionFuncJointFormRepeating(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := SpecifiedResourceTypeAndNameCompletionFunc(tf, []string{"pod"})
+	comps, directive := compFunc(cmd, []string{"pod/bar"}, "pod/")
+	// The other pods should be completed, but not the already specified ones
+	checkCompletion(t, comps, []string{"pod/foo"}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
 func TestSpecifiedResourceTypeAndNameCompletionNoRepeatFuncOneArg(t *testing.T) {
 	tf, cmd := prepareCompletionTest()
 	addPodsToFactory(tf)
@@ -170,6 +207,25 @@ func TestSpecifiedResourceTypeAndNameCompletionNoRepeatFuncMultiArg(t *testing.T
 
 	compFunc := SpecifiedResourceTypeAndNameNoRepeatCompletionFunc(tf, []string{"pod"})
 	comps, directive := compFunc(cmd, []string{"pod", "bar"}, "")
+	// There should not be any more pods shown as this function should not repeat the completion
+	checkCompletion(t, comps, []string{}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
+
+func TestSpecifiedResourceTypeAndNameCompletionNoRepeatFuncJointFormOneArg(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := SpecifiedResourceTypeAndNameNoRepeatCompletionFunc(tf, []string{"pod"})
+	comps, directive := compFunc(cmd, []string{}, "pod/b")
+	checkCompletion(t, comps, []string{"pod/bar"}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
+
+func TestSpecifiedResourceTypeAndNameCompletionNoRepeatFuncJointFormMultiArg(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := SpecifiedResourceTypeAndNameNoRepeatCompletionFunc(tf, []string{"pod"})
+	comps, directive := compFunc(cmd, []string{"pod/bar"}, "pod/")
 	// There should not be any more pods shown as this function should not repeat the completion
 	checkCompletion(t, comps, []string{}, directive, cobra.ShellCompDirectiveNoFileComp)
 }
@@ -192,7 +248,65 @@ func TestResourceNameCompletionFuncTooManyArgs(t *testing.T) {
 	checkCompletion(t, comps, []string{}, directive, cobra.ShellCompDirectiveNoFileComp)
 }
 
-func TestPodResourceNameAndContainerCompletionFuncNoArgs(t *testing.T) {
+func TestResourceNameCompletionFuncJointFormNoArgs(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := ResourceNameCompletionFunc(tf, "pod")
+	comps, directive := compFunc(cmd, []string{}, "pod/b")
+	// The <type>/<name> should NOT be supported by this function
+	checkCompletion(t, comps, []string{}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
+
+func TestPodResourceNameCompletionFuncNoArgsPodName(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := PodResourceNameCompletionFunc(tf)
+	comps, directive := compFunc(cmd, []string{}, "b")
+	checkCompletion(t, comps, []string{"bar"}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
+
+func TestPodResourceNameCompletionFuncNoArgsResources(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := PodResourceNameCompletionFunc(tf)
+	comps, directive := compFunc(cmd, []string{}, "d")
+	checkCompletion(
+		t, comps, []string{"daemonsets/", "deployments/"},
+		directive, cobra.ShellCompDirectiveNoFileComp|cobra.ShellCompDirectiveNoSpace)
+}
+
+func TestPodResourceNameCompletionFuncTooManyArgs(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := PodResourceNameCompletionFunc(tf)
+	comps, directive := compFunc(cmd, []string{"pod-name"}, "")
+	checkCompletion(t, comps, []string{}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
+
+func TestPodResourceNameCompletionFuncJointFormNoArgs(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := PodResourceNameCompletionFunc(tf)
+	comps, directive := compFunc(cmd, []string{}, "pod/b")
+	// The <type>/<name> SHOULD be supported by this function
+	checkCompletion(t, comps, []string{"pod/bar"}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
+
+func TestPodResourceNameCompletionFuncJointFormTooManyArgs(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := PodResourceNameCompletionFunc(tf)
+	comps, directive := compFunc(cmd, []string{"pod/name"}, "pod/b")
+	checkCompletion(t, comps, []string{}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
+
+func TestPodResourceNameAndContainerCompletionFuncNoArgsPodName(t *testing.T) {
 	tf, cmd := prepareCompletionTest()
 	addPodsToFactory(tf)
 
@@ -201,12 +315,42 @@ func TestPodResourceNameAndContainerCompletionFuncNoArgs(t *testing.T) {
 	checkCompletion(t, comps, []string{"bar"}, directive, cobra.ShellCompDirectiveNoFileComp)
 }
 
+func TestPodResourceNameAndContainerCompletionFuncNoArgsResources(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := PodResourceNameAndContainerCompletionFunc(tf)
+	comps, directive := compFunc(cmd, []string{}, "s")
+	checkCompletion(
+		t, comps, []string{"services/", "statefulsets/"},
+		directive, cobra.ShellCompDirectiveNoFileComp|cobra.ShellCompDirectiveNoSpace)
+
+}
+
 func TestPodResourceNameAndContainerCompletionFuncTooManyArgs(t *testing.T) {
 	tf, cmd := prepareCompletionTest()
 	addPodsToFactory(tf)
 
 	compFunc := PodResourceNameAndContainerCompletionFunc(tf)
 	comps, directive := compFunc(cmd, []string{"pod-name", "container-name"}, "")
+	checkCompletion(t, comps, []string{}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
+
+func TestPodResourceNameAndContainerCompletionFuncJointFormNoArgs(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := PodResourceNameAndContainerCompletionFunc(tf)
+	comps, directive := compFunc(cmd, []string{}, "pod/b")
+	checkCompletion(t, comps, []string{"pod/bar"}, directive, cobra.ShellCompDirectiveNoFileComp)
+}
+
+func TestPodResourceNameAndContainerCompletionFuncJointFormTooManyArgs(t *testing.T) {
+	tf, cmd := prepareCompletionTest()
+	addPodsToFactory(tf)
+
+	compFunc := PodResourceNameAndContainerCompletionFunc(tf)
+	comps, directive := compFunc(cmd, []string{"pod/pod-name", "container-name"}, "")
 	checkCompletion(t, comps, []string{}, directive, cobra.ShellCompDirectiveNoFileComp)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2150,6 +2150,7 @@ k8s.io/kubectl/pkg/scale
 k8s.io/kubectl/pkg/scheme
 k8s.io/kubectl/pkg/util
 k8s.io/kubectl/pkg/util/certificate
+k8s.io/kubectl/pkg/util/completion
 k8s.io/kubectl/pkg/util/deployment
 k8s.io/kubectl/pkg/util/event
 k8s.io/kubectl/pkg/util/fieldpath


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/sig cli

#### What this PR does / why we need it:

In https://github.com/kubernetes/kubernetes/pull/106755#issuecomment-1047252647 @brianpursley brought up the fact that the shell completion logic did not handle the `<type>/<name>` format for the specification of resources.

Following his suggestion and guidance, this PR adds the necessary logic to:
1.  support shell completion for the `<type>/<name>` format for all commands that support it
1. teaches the 'kubectl exec' command how to complete its `--container/-c` flag
1. for commands that work on pods, suggest completion choices of resource types that contain pods (see examples below)

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubectl/issues/1180
Fixes #94927
Supersedes #106755

#### Special notes for your reviewer:

This could have been 3 different PRs but 2 of these would have been very small so I chose to submit them all as one, to facilitate the review effort (testing everything at once).  But I can split them if required.

I feel most user-facing behaviour changes are straight-forward and should not cause any surprise to users.
The one change that is more surprising and needs special attention is the fact that for the commands:
- attach
- exec
- logs
- port-forward

completion choices will now include resource types, not just pod names.  For example:
```
$ kubectl port-forward <TAB>
bar-pod-fc87855b6-8rmqt                              baz-pod-fc87855b6-8rmqt
daemonsets/           pods/                          services/
deployments/          replicasets/                   statefulsets/
jobs/                 replicationcontrollers/        test-pod-fc87855b6-8rmqt
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl now supports shell completion for the <type>/<name> format for specifying resources.

kubectl now provides shell completion for container names following the --container/-c flag of the exec command.

kubectl's shell completion now suggests resource types for commands that only apply to pods.
```

#### Examples of improvements
<details>
<summary>The new completion of containers for ' kubectl exec'</summary>

```
# NEW: container completion (normal form)
kubectl exec httpbin-777f4d8df9-zd9gd -c is<TAB>
kubectl exec httpbin-777f4d8df9-zd9gd -c istio-proxy

# NEW: container completion (type/name form)
kubectl exec deploy/httpbin -c is<TAB>
kubectl exec deploy/httpbin -c istio-proxy
```
</details>

<details>
<summary>Commands that accept any resource type</summary>

- annotate
- apply edit-last-applied
- apply view-last-applied
- delete
- describe
- edit
- get
- label
- patch

```
# NEW: completion for the 'name' in the type/name form
kubectl get deployments.apps/ht<TAB>
kubectl get deployments.apps/httpbin

# NEW: completion for the 'type' in the type/name form
kubectl get deployments.apps/httpbin dep<TAB>
kubectl get deployments.apps/httpbin deployments.apps/
```
</details>
<details>
<summary>Commands that accept a subset of resource types</summary>

- autoscale
- expose
- rollout history
- rollout pause
- rollout restart
- rollout resume
- rollout status
- rollout undo
- scale
- taint

```
# NEW: completion for the 'name' in the type/name form
kubectl expose deployment/<TAB>
kubectl expose deployment/httpbin

# NEW: completion for the 'type' in the type/name form
kubectl expose deployment/httpbin p<TAB>
kubectl expose deployment/httpbin pod/
```
</details>

<details>
<summary>Commands that apply to resource types that contain pods</summary>

- attach
- exec
- logs
- port-foward

```
# NEW: Completes a pod name AND resource types that contain pods
kubectl exec <TAB>
bar-pod-fc87855b6-8rmqt                              baz-pod-fc87855b6-8rmqt
daemonsets/           pods/                          services/
deployments/          replicasets/                   statefulsets/
jobs/                 replicationcontrollers/        test-pod-fc87855b6-8rmqt

# NEW: When a '/' is found, does completion for 'name' for the type/name form
kubectl exec deploy/ht<TAB>
kubectl exec deploy/httpbin
```
</details>

<details>
<summary>Commands that accept container names</summary>

- logs

```
# NEW: Completes a pod name AND resource types that contain pods
kubectl logs p<TAB>
php-apache-d4cf67d68-l2fv8          pods/

# NEW: When a '/' is found, does completion for 'name' for the type/name form
kubectl logs deploy/ht<TAB>
kubectl logs deploy/httpbin

# NEW: completion of container name with the type/name form
kubectl logs deploy/httpbin is<TAB>
kubectl logs deploy/httpbin istio-proxy
```
</details>

/cc @brianpursley @eddiezane 
