### PR TITLE
test/integration: improve TestTransform

### DIFF
--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -1972,6 +1972,10 @@ func TestTransform(t *testing.T) {
 				rv = previousRV
 			}
 
+			ctx, cancel := context.WithTimeout(context.Background(), wait.ForeverTestTimeout)
+			t.Cleanup(func() {
+				cancel()
+			})
 			w, err := client.Get().
 				Resource(resource).NamespaceIfScoped(obj.GetNamespace(), len(obj.GetNamespace()) > 0).
 				SetHeader("Accept", tc.accept).
@@ -1981,7 +1985,7 @@ func TestTransform(t *testing.T) {
 					FieldSelector:   fields.OneTermEqualSelector("metadata.name", obj.GetName()).String(),
 				}, metav1.ParameterCodec).
 				Param("includeObject", string(tc.includeObject)).
-				Stream(context.TODO())
+				Stream(ctx)
 			if (tc.wantErr != nil) != (err != nil) {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -1417,6 +1417,12 @@ func TestTransform(t *testing.T) {
 	crdGVR := schema.GroupVersionResource{Group: fooCRD.Spec.Group, Version: fooCRD.Spec.Versions[0].Name, Resource: "foos"}
 	crclient := dynamicClient.Resource(crdGVR).Namespace(testNamespace)
 
+	previousList, err := crclient.List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("failed to list CRs before test: %v", err)
+	}
+	previousRV := previousList.GetResourceVersion()
+
 	testcases := []struct {
 		name          string
 		accept        string
@@ -1957,16 +1963,20 @@ func TestTransform(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			rv, _ := strconv.Atoi(obj.GetResourceVersion())
-			if rv < 1 {
-				rv = 1
+			var rv string
+			if obj.GetResourceVersion() == "" || obj.GetResourceVersion() == "0" {
+				// no object was created in the preamble to the test, so get recent data
+				rv = "0"
+			} else {
+				// we created an object, and need to list+watch from some time before the creation to see it
+				rv = previousRV
 			}
 
 			w, err := client.Get().
 				Resource(resource).NamespaceIfScoped(obj.GetNamespace(), len(obj.GetNamespace()) > 0).
 				SetHeader("Accept", tc.accept).
 				VersionedParams(&metav1.ListOptions{
-					ResourceVersion: strconv.Itoa(rv - 1),
+					ResourceVersion: rv,
 					Watch:           true,
 					FieldSelector:   fields.OneTermEqualSelector("metadata.name", obj.GetName()).String(),
 				}, metav1.ParameterCodec).


### PR DESCRIPTION
test/integration: use a known previous resourceVersion

ResourceVersion values are opaque and math should not be done on them.
The intent of this test was to watch from a resourceVersion before the
moment where the objects were created, and we can find such a version by
listing from the API server before the tests begin.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

test/integration: use a context with a deadline for streaming

Without such a context, this test would hang without data for 10
minutes, then panic.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/kind cleanup
```release-note
NONE
```

```docs

```

/cc @smarterclayton @liggitt @deads2k 
/sig api-machinery