### PR TITLE
Reintroduce response status and header on kubectl verbose debug

### DIFF
--- a/staging/src/k8s.io/client-go/transport/round_trippers.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers.go
@@ -72,7 +72,7 @@ func HTTPWrappersForConfig(config *Config, rt http.RoundTripper) (http.RoundTrip
 func DebugWrappers(rt http.RoundTripper) http.RoundTripper {
 	switch {
 	case bool(klog.V(9).Enabled()):
-		rt = NewDebuggingRoundTripper(rt, DebugCurlCommand, DebugDetailedTiming, DebugResponseHeaders)
+		rt = NewDebuggingRoundTripper(rt, DebugCurlCommand, DebugURLTiming, DebugDetailedTiming, DebugResponseHeaders)
 	case bool(klog.V(8).Enabled()):
 		rt = NewDebuggingRoundTripper(rt, DebugJustURL, DebugRequestHeaders, DebugResponseStatus, DebugResponseHeaders)
 	case bool(klog.V(7).Enabled()):


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
Back in time, `kubectl -v=9` returned a lot of information, including response status and response header.

This was part of the debug timing verbosity: https://github.com/kubernetes/client-go/blob/release-1.22/transport/round_trippers.go#L453-L454

After a bunch of changes, this information is not part anymore of the `DebugURLTiming` but wasn't also changed on the DebugWrappers constructor, which means "-v=9" is now less verbose than "-v=8" as it contains the timing measures, but not essential information as response status and headers.

This PR re-adds this behavior for  "-v=9"




#### Does this PR introduce a user-facing change?
```release-note
Re-adds response status and headers on verbose kubectl responses
```

#### More information
* In v1.22 with kubectl -v=9:
```
I0303 20:01:26.592295   22890 loader.go:372] Config loaded from file:  /Users/rkatz/.kube/config
I0303 20:01:26.593216   22890 round_trippers.go:435] curl -v -XGET  -H "Accept: application/json, */*" -H "User-Agent: kubectl-22.7/v1.22.7 (darwin/amd64) kubernetes/b56e432" -H "Authorization: Bearer <masked>" 'https://abla?timeout=32s'
I0303 20:01:27.616843   22890 round_trippers.go:454] GET https://aabla?timeout=32s 403 Forbidden in 1023 milliseconds
I0303 20:01:27.616894   22890 round_trippers.go:460] Response Headers:
I0303 20:01:27.616921   22890 round_trippers.go:463]     Content-Type: text/plain
I0303 20:01:27.616932   22890 round_trippers.go:463]     Content-Length: 0
I0303 20:01:27.616940   22890 round_trippers.go:463]     Audit-Id: e648efab-bdeb-4266-a5e4-d5909cd46e61
I0303 20:01:27.616950   22890 round_trippers.go:463]     Cache-Control: no-cache, private
I0303 20:01:27.616958   22890 round_trippers.go:463]     Access-Control-Expose-Headers: connection,content-length,audit-id
I0303 20:01:27.616968   22890 round_trippers.go:463]     Strict-Transport-Security: max-age=31536000; includeSubDomains
I0303 20:01:27.616977   22890 round_trippers.go:463]     Date: Thu, 03 Mar 2022 23:01:27 GMT
```

* In v1.23
```
I0303 20:01:53.579926   22905 loader.go:372] Config loaded from file:  /Users/rkatz/.kube/config
I0303 20:01:53.580768   22905 round_trippers.go:466] curl -v -XGET  -H "Accept: application/json, */*" -H "User-Agent: kubectl/v1.23.0 (darwin/amd64) kubernetes/ab69524" -H "Authorization: Bearer <masked>" 'https://abla?timeout=32s'
I0303 20:01:53.707277   22905 round_trippers.go:495] HTTP Trace: DNS Lookup for abla resolved to [{XXXX }]
I0303 20:01:53.919425   22905 round_trippers.go:510] HTTP Trace: Dial to tcp:XXXX:443 succeed
I0303 20:01:54.564936   22905 round_trippers.go:570] HTTP Statistics: DNSLookup 126 ms Dial 212 ms TLSHandshake 426 ms ServerProcessing 218 ms Duration 984 ms
I0303 20:01:54.564964   22905 round_trippers.go:577] Response Headers:
I0303 20:01:54.564975   22905 round_trippers.go:580]     Content-Length: 0
I0303 20:01:54.564983   22905 round_trippers.go:580]     Audit-Id: f3715963-d778-44d9-b1df-353195ab8145
I0303 20:01:54.564991   22905 round_trippers.go:580]     Cache-Control: no-cache, private
I0303 20:01:54.564998   22905 round_trippers.go:580]     Access-Control-Expose-Headers: connection,content-length,audit-id
I0303 20:01:54.565005   22905 round_trippers.go:580]     Strict-Transport-Security: max-age=31536000; includeSubDomains
I0303 20:01:54.565013   22905 round_trippers.go:580]     Date: Thu, 03 Mar 2022 23:01:54 GMT
I0303 20:01:54.565020   22905 round_trippers.go:580]     Content-Type: text/plain
```

* With this PR:
```
I0303 20:19:00.629090   38507 loader.go:372] Config loaded from file:  /Users/rkatz/.kube/config
I0303 20:19:00.630078   38507 round_trippers.go:466] curl -v -XGET  -H "User-Agent: kubectl/v1.24.0 (darwin/amd64) kubernetes/8c1dc25" -H "Authorization: Bearer <masked>" -H "Accept: application/json, */*" 'https://abla?timeout=32s'
I0303 20:19:00.630093   38507 round_trippers.go:469] Request Headers:
I0303 20:19:00.630103   38507 round_trippers.go:473]     Accept: application/json, */*
I0303 20:19:00.630109   38507 round_trippers.go:473]     User-Agent: kubectl/v1.24.0 (darwin/amd64) kubernetes/8c1dc25
I0303 20:19:00.630115   38507 round_trippers.go:473]     Authorization: Bearer <masked>
I0303 20:19:00.779570   38507 round_trippers.go:495] HTTP Trace: DNS Lookup for abla resolved to [{XXXX }]
I0303 20:19:00.992442   38507 round_trippers.go:510] HTTP Trace: Dial to tcp:XXXXX:443 succeed
I0303 20:19:01.662791   38507 round_trippers.go:570] HTTP Statistics: DNSLookup 149 ms Dial 212 ms TLSHandshake 428 ms ServerProcessing 240 ms Duration 1032 ms
I0303 20:19:01.662822   38507 round_trippers.go:574] Response Status: 403 Forbidden in 1032 milliseconds
I0303 20:19:01.662832   38507 round_trippers.go:577] Response Headers:
I0303 20:19:01.662841   38507 round_trippers.go:580]     Audit-Id: eefcddef-696d-42f0-8d40-371543c825b3
I0303 20:19:01.662848   38507 round_trippers.go:580]     Cache-Control: no-cache, private
I0303 20:19:01.662855   38507 round_trippers.go:580]     Access-Control-Expose-Headers: connection,content-length,audit-id
I0303 20:19:01.662863   38507 round_trippers.go:580]     Strict-Transport-Security: max-age=31536000; includeSubDomains
I0303 20:19:01.662870   38507 round_trippers.go:580]     Date: Thu, 03 Mar 2022 23:19:01 GMT
I0303 20:19:01.662877   38507 round_trippers.go:580]     Content-Type: text/plain
I0303 20:19:01.662884   38507 round_trippers.go:580]     Content-Length: 0
```
