### PR TITLE
[WIP] Update Etcd server image to 3.6.0-alpha.0-0

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -55,7 +55,7 @@ dependencies:
 
   # etcd
   - name: "etcd"
-    version: 3.5.1
+    version: 3.6.0-alpha.0
     refPaths:
     - path: cluster/gce/manifests/etcd.manifest
       match: etcd_docker_tag|etcd_version

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -18,7 +18,7 @@
     {
     "name": "etcd-container",
     {{security_context}}
-    "image": "{{ pillar.get('etcd_docker_repository', 'k8s.gcr.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.1-0') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'k8s.gcr.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.6.0-alpha.0-0') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}
@@ -34,7 +34,7 @@
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
       },
       { "name": "TARGET_VERSION",
-        "value": "{{ pillar.get('etcd_version', '3.5.1') }}"
+        "value": "{{ pillar.get('etcd_version', '3.6.0-alpha.0') }}"
       },
       {
         "name": "DO_NOT_MOVE_BINARIES",

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -170,8 +170,8 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.5.1-0
-export ETCD_VERSION=3.5.1
+export ETCD_IMAGE=3.6.0-alpha.0-0
+export ETCD_VERSION=3.6.0-alpha.0
 
 # Upgrade master with updated kube envs
 "${KUBE_ROOT}/cluster/gce/upgrade.sh" -M -l

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -320,7 +320,7 @@ const (
 	MinExternalEtcdVersion = "3.2.18"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.5.1-0"
+	DefaultEtcdVersion = "3.6.0-alpha.0-0"
 
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"
@@ -500,6 +500,7 @@ var (
 		21: "3.4.13-0",
 		22: "3.5.1-0",
 		23: "3.5.1-0",
+		24: "3.6.0-alpha.0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -500,7 +500,7 @@ var (
 		21: "3.4.13-0",
 		22: "3.5.1-0",
 		23: "3.5.1-0",
-		24: "3.6.0-alpha.0",
+		24: "3.6.0-alpha.0-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.5.1}
+ETCD_VERSION=${ETCD_VERSION:-3.6.0-alpha.0}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 # This is intentionally not called ETCD_LOG_LEVEL:

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
@@ -26,4 +26,4 @@ spec:
         imagePullPolicy: Never
         args: [ "--etcd-servers=http://localhost:2379" ]
       - name: etcd
-        image: quay.io/coreos/etcd:v3.5.1
+        image: quay.io/coreos/etcd:3.6.0-alpha.0

--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -34,7 +34,7 @@ import (
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 )
 
-const etcdImage = "3.5.1-0"
+const etcdImage = "3.6.0-alpha.0-0"
 
 // EtcdUpgrade upgrades etcd on GCE.
 func EtcdUpgrade(targetStorage, targetVersion string) error {

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -245,7 +245,7 @@ func initImageConfigs(list RegistryList) (map[int]Config, map[int]Config) {
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.2"}
 	configs[DebianIptables] = Config{list.BuildImageRegistry, "debian-iptables", "bullseye-v1.1.0"}
 	configs[EchoServer] = Config{list.PromoterE2eRegistry, "echoserver", "2.4"}
-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.1-0"}
+	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.6.0-alpha.0-0"}
 	configs[GlusterDynamicProvisioner] = Config{list.PromoterE2eRegistry, "glusterdynamic-provisioner", "v1.3"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-2"}
 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-2"}


### PR DESCRIPTION
Main reason for this PR is early testing and geting a signal from 100 node tests run. Before merging we need to make sure full v3.6.0  release will be ready before K8s 1.24 is cut.
/hold
/kind feature

```release-note
Update etcd version to 3.6.0-alpha.0
```
