### PR TITLE
Use errors.As to detect wrapping in StatusCause

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -96,8 +96,8 @@ func HasStatusCause(err error, name metav1.CauseType) bool {
 // StatusCause returns the named cause from the provided error if it exists and
 // the error unwraps to the type APIStatus. Otherwise it returns false.
 func StatusCause(err error, name metav1.CauseType) (metav1.StatusCause, bool) {
-	var status APIStatus
-	if errors.As(err, &status) && status.Status().Details != nil {
+	status, ok := err.(APIStatus)
+	if (ok || errors.As(err, &status)) && status.Status().Details != nil {
 		for _, cause := range status.Status().Details.Causes {
 			if cause.Type == name {
 				return cause, true
@@ -757,7 +757,8 @@ func IsRequestEntityTooLargeError(err error) bool {
 // and may be the result of another HTTP actor.
 // It supports wrapped errors and returns false when the error is nil.
 func IsUnexpectedServerError(err error) bool {
-	if status := APIStatus(nil); errors.As(err, &status) && status.Status().Details != nil {
+	status, ok := err.(APIStatus)
+	if (ok || errors.As(err, &status)) && status.Status().Details != nil {
 		for _, cause := range status.Status().Details.Causes {
 			if cause.Type == metav1.CauseTypeUnexpectedServerResponse {
 				return true
@@ -770,8 +771,8 @@ func IsUnexpectedServerError(err error) bool {
 // IsUnexpectedObjectError determines if err is due to an unexpected object from the master.
 // It supports wrapped errors and returns false when the error is nil.
 func IsUnexpectedObjectError(err error) bool {
-	uoe := &UnexpectedObjectError{}
-	return err != nil && errors.As(err, &uoe)
+	uoe, ok := err.(*UnexpectedObjectError)
+	return err != nil && (ok || errors.As(err, &uoe))
 }
 
 // SuggestsClientDelay returns true if this error suggests a client delay as well as the
@@ -780,7 +781,8 @@ func IsUnexpectedObjectError(err error) bool {
 // request delay without retry.
 // It supports wrapped errors and returns false when the error is nil.
 func SuggestsClientDelay(err error) (int, bool) {
-	if t := APIStatus(nil); errors.As(err, &t) && t.Status().Details != nil {
+	t, ok := err.(APIStatus)
+	if (ok || errors.As(err, &t)) && t.Status().Details != nil {
 		switch t.Status().Reason {
 		// this StatusReason explicitly requests the caller to delay the action
 		case metav1.StatusReasonServerTimeout:
@@ -798,14 +800,14 @@ func SuggestsClientDelay(err error) (int, bool) {
 // It supports wrapped errors and returns StatusReasonUnknown when
 // the error is nil or doesn't have a status.
 func ReasonForError(err error) metav1.StatusReason {
-	if status := APIStatus(nil); errors.As(err, &status) {
+	if status, ok := err.(APIStatus); ok || errors.As(err, &status) {
 		return status.Status().Reason
 	}
 	return metav1.StatusReasonUnknown
 }
 
 func reasonAndCodeForError(err error) (metav1.StatusReason, int32) {
-	if status := APIStatus(nil); errors.As(err, &status) {
+	if status, ok := err.(APIStatus); ok || errors.As(err, &status) {
 		return status.Status().Reason, status.Status().Code
 	}
 	return metav1.StatusReasonUnknown, 0

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors_test.go
@@ -657,3 +657,49 @@ func TestStatusCauseSupportsWrappedErrors(t *testing.T) {
 		t.Errorf("expected cause when nested, got %v: %#v", ok, cause)
 	}
 }
+
+func BenchmarkIsAlreadyExistsWrappedErrors(b *testing.B) {
+	err := NewAlreadyExists(schema.GroupResource{}, "")
+	wrapped := fmt.Errorf("once: %w", err)
+
+	b.Run("Nil", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			IsAlreadyExists(nil)
+		}
+	})
+
+	b.Run("Bare", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			IsAlreadyExists(err)
+		}
+	})
+
+	b.Run("Wrapped", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			IsAlreadyExists(wrapped)
+		}
+	})
+}
+
+func BenchmarkIsNotFoundWrappedErrors(b *testing.B) {
+	err := NewNotFound(schema.GroupResource{}, "")
+	wrapped := fmt.Errorf("once: %w", err)
+
+	b.Run("Nil", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			IsNotFound(nil)
+		}
+	})
+
+	b.Run("Bare", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			IsNotFound(err)
+		}
+	})
+
+	b.Run("Wrapped", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			IsNotFound(wrapped)
+		}
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Two functions in this package, `StatusCause` and `HasStatusCause`, do not handle wrapped errors. With this, the entire package handles wrapped errors consistently.

#### Which issue(s) this PR fixes:

Fixes #108528

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Users of these functions will have already done their own unwrapping and are unaffected.

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

