### PR TITLE
[Kubeadm] Add param of dns-image-repository for dns container image

### DIFF
--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -447,6 +447,6 @@ func (i *ImagesList) Run(out io.Writer, printer output.Printer) error {
 func AddImagesCommonConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiv1.ClusterConfiguration, cfgPath *string, featureGatesString *string) {
 	options.AddKubernetesVersionFlag(flagSet, &cfg.KubernetesVersion)
 	options.AddFeatureGatesStringFlag(flagSet, featureGatesString)
-	options.AddImageMetaFlags(flagSet, &cfg.ImageRepository)
+	options.AddImageMetaFlags(flagSet, &cfg.ImageRepository, &cfg.DNS.ImageRepository)
 	options.AddConfigFlag(flagSet, cfgPath)
 }

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -166,7 +166,7 @@ func newCmdInit(out io.Writer, initOptions *initOptions) *cobra.Command {
 	AddInitOtherFlags(cmd.Flags(), initOptions)
 	initOptions.bto.AddTokenFlag(cmd.Flags())
 	initOptions.bto.AddTTLFlag(cmd.Flags())
-	options.AddImageMetaFlags(cmd.Flags(), &initOptions.externalClusterCfg.ImageRepository)
+	options.AddImageMetaFlags(cmd.Flags(), &initOptions.externalClusterCfg.ImageRepository, &initOptions.externalClusterCfg.DNS.ImageRepository)
 
 	// defines additional flag that are not used by the init command but that could be eventually used
 	// by the sub-commands automatically generated for phases

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -53,6 +53,9 @@ const (
 	// ImageRepository sets the container registry to pull control plane images from.
 	ImageRepository = "image-repository"
 
+	// ImageRepository sets the dns container registry to pull dns images from.
+	DnsImageRepoSitory = "dns-image-repository"
+
 	// KubeconfigDir flag sets the path where to save the kubeconfig file.
 	KubeconfigDir = "kubeconfig-dir"
 

--- a/cmd/kubeadm/app/cmd/options/generic.go
+++ b/cmd/kubeadm/app/cmd/options/generic.go
@@ -60,8 +60,9 @@ func AddControlPlanExtraArgsFlags(fs *pflag.FlagSet, apiServerExtraArgs, control
 }
 
 // AddImageMetaFlags adds the --image-repository flag to the given flagset
-func AddImageMetaFlags(fs *pflag.FlagSet, imageRepository *string) {
+func AddImageMetaFlags(fs *pflag.FlagSet, imageRepository, dnsImageRepository *string) {
 	fs.StringVar(imageRepository, ImageRepository, *imageRepository, "Choose a container registry to pull control plane images from")
+	fs.StringVar(dnsImageRepository, DnsImageRepoSitory, *dnsImageRepository, "Choose a container registry to pull dns images from")
 }
 
 // AddFeatureGatesStringFlag adds the --feature-gates flag to the given flagset


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

Optionally add one or more of the following kinds if applicable:


#### What this PR does / why we need it:  

Before v1.21.x we can use kubeadm to init a kubernetes master with image proxy  in one line of command,like  kubeadm init --image-repository k8s.proxy, we break this behavior sinnce v1.21.x,  it change `k8s.proxy/coredns/coredns:v1.8.6` to `k8s.proxy/coredns:v1.8.6`.

So we need to use config file to init k8s cluster when we use a image repository proxy.

This PR let the kubeadm appearing again for init a kubernetes master with image proxy  in one line of command . this is very convenient.

Before this PR:

```shell
$ go run cmd/kubeadm/kubeadm.go config images list --image-repository k8s.proxy
...
k8s.proxy/coredns:v1.8.6
``` 

After this PR:
```shell
$ go run cmd/kubeadm/kubeadm.go config images list --image-repository k8s.proxy --dns-image-repository  k8s.proxy/coredns
...
k8s.proxy/coredns/coredns:v1.8.6
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a param of `dns-image-repository` for coredns container image.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
I'm not sure about it.
```
