### PR TITLE
Remove the restart kubelet check from the test.

### DIFF
--- a/test/e2e_node/lock_contention_linux_test.go
+++ b/test/e2e_node/lock_contention_linux_test.go
@@ -67,21 +67,9 @@ var _ = SIGDescribe("Lock contention [Slow] [Disruptive] [NodeSpecialFeature:Loc
 
 		ginkgo.By("verifying the kubelet is not healthy as there was a lock contention.")
 		// Once the lock is acquired, check if the kubelet is in healthy state or not.
-		// It should not be.
+		// It should not be as the lock contention forces the kubelet to stop.
 		gomega.Eventually(func() bool {
 			return kubeletHealthCheck(kubeletHealthCheckURL)
 		}, 10*time.Second, time.Second).Should(gomega.BeFalse())
-
-		ginkgo.By("releasing the lock on lock file i.e /var/run/kubelet.lock, triggering kubelet restart.")
-		// Release the lock.
-		err = unix.Flock(fd, unix.LOCK_UN)
-		framework.ExpectNoError(err)
-
-		// Releasing the lock triggers kubelet to re-acquire the lock and restart.
-		ginkgo.By("verifying the kubelet is healthy after restart.")
-		// Kubelet should report healthy state.
-		gomega.Eventually(func() bool {
-			return kubeletHealthCheck(kubeletHealthCheckURL)
-		}, 10*time.Second, time.Second).Should(gomega.BeTrue())
 	})
 })


### PR DESCRIPTION
Upon reconsidering as to the purpose of the test i.e to test the lock contention flags 
(--lock-file-contention and --lock-file), it makes sense that we test only the actual functionality 
which is the kubelet should stop once there is a lock contention.

In no way it is the responsiblity of the kubelet to restart, which would be the responsiblity 
of a higher system such as systemd. Hence the removal of the check for releasing the lock 
and checking for whether the kubelet is healthy again or not seem out of scope from kubelet's responsiblities.

Thanks to @adisky for this perspective. 

/cc @endocrimes @SergeyKanzhelev 

Signed-off-by: Imran Pochi <imran@kinvolk.io>

#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:

This PR addresses the failing [test](https://github.com/kubernetes/test-infra/blob/0d5895b49bf2ff2f3230f7f1969a92c29d1e0148/config/jobs/kubernetes/sig-node/containerd.yaml#L1315).

 https://k8s-testgrid.appspot.com/sig-node-kubelet#kubelet-gce-e2e-lock-contention

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108348

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
