### PR TITLE
Implement page size progressing for rare selectors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -1783,6 +1783,67 @@ func TestListContinuation(t *testing.T) {
 	recorder.resetReads()
 }
 
+func TestListPaginationRareObject(t *testing.T) {
+	etcdClient := testserver.RunEtcd(t, nil)
+	codec := apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)
+	transformer := &prefixTransformer{prefix: []byte(defaultTestPrefix)}
+	recorder := &clientRecorder{KV: etcdClient.KV}
+	etcdClient.KV = recorder
+	store := newStore(etcdClient, codec, newPod, "", schema.GroupResource{Resource: "pods"}, transformer, true, NewDefaultLeaseManagerConfig())
+	ctx := context.Background()
+
+	podCount := 1000
+	var pods []*example.Pod
+	for i := 0; i < podCount; i++ {
+		key := fmt.Sprintf("/one-level/pod-%d", i)
+		obj := &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod-%d", i)}}
+		storedObj := &example.Pod{}
+		err := store.Create(ctx, key, obj, storedObj, 0)
+		if err != nil {
+			t.Fatalf("Set failed: %v", err)
+		}
+		pods = append(pods, storedObj)
+	}
+
+	out := &example.PodList{}
+	options := storage.ListOptions{
+		Predicate: storage.SelectionPredicate{
+			Limit: 1,
+			Label: labels.Everything(),
+			Field: fields.OneTermEqualSelector("metadata.name", "pod-999"),
+			GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, error) {
+				pod := obj.(*example.Pod)
+				return nil, fields.Set{"metadata.name": pod.Name}, nil
+			},
+		},
+		Recursive: true,
+	}
+	if err := store.GetList(ctx, "/", options, out); err != nil {
+		t.Fatalf("Unable to get initial list: %v", err)
+	}
+	if len(out.Continue) != 0 {
+		t.Errorf("Unexpected continuation token set")
+	}
+	if len(out.Items) != 1 || !reflect.DeepEqual(&out.Items[0], pods[999]) {
+		t.Fatalf("Unexpected first page: %#v", out.Items)
+	}
+	if transformer.reads != uint64(podCount) {
+		t.Errorf("unexpected reads: %d", transformer.reads)
+	}
+	// We expect that kube-apiserver will be increasing page sizes
+	// if not full pages are received, so we should see significantly less
+	// than 1000 pages (which would be result of talking to etcd with page size
+	// copied from pred.Limit).
+	// The expected number of calls is n+1 where n is the smallest n so that:
+	// pageSize + pageSize * 2 + pageSize * 4 + ... + pageSize * 2^n >= podCount.
+	// For pageSize = 1, podCount = 1000, we get n+1 = 10, 2 ^ 10 = 1024.
+	if recorder.reads != 10 {
+		t.Errorf("unexpected reads: %d", recorder.reads)
+	}
+	transformer.resetReads()
+	recorder.resetReads()
+}
+
 type clientRecorder struct {
 	reads uint64
 	clientv3.KV


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It tries to solve problem described in https://github.com/kubernetes/kubernetes/pull/94303#issue-687908212 with solution mentioned described https://github.com/kubernetes/kubernetes/pull/94303#issuecomment-688090991:

**Problem statement**
Currently kube-apiserver <-> etcd communication is using the same limit as passed in pred.Limit, from the client. If this is paired with field/label selector that filters for rare objects (common example is fieldSelector=spec.NodeName=X for pods in large clusters, where we can have O(100k) pods and usually O(100) pods on a given node) this will lead to a significant number of etcd round trips. In practice we have seen that with ~120k objects in the system we started seeing that requests were failing to fit in 1m request timeout, even if the result size is O(100).

**Solution**
Decupling kube-apiserver <-> etcd page limit and k8s API call page limit. This PR implements very naive method (described in https://github.com/kubernetes/kubernetes/pull/94303#issuecomment-688090991) that doubles internal page size, each time we do not fill the entire response (possible only when field/label selectors/predicates are set).

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
/hold
So far I only unit tested this, I would like to start some real cluster and play with this to validate performance gain before we submit this.

There is another change happening in this area in https://github.com/kubernetes/kubernetes/issues/108258. While that effort is going to enforce pagination for all requests (even without page size set), there is still room for this PR which will improve performance of API calls when #108258 is disabled (which is going to be a default).


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

/assign @wojtek-t 
/cc @jpbetz @smarterclayton @ptabor 