### PR TITLE
support blank lines between yaml documents

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -327,6 +327,20 @@ func (r *YAMLReader) Read() ([]byte, error) {
 				}
 			}
 			if buffer.Len() != 0 {
+				// If we only have one byte in buffer, check if it is a blank line
+				if buffer.Len() == 1 {
+					ru, _, err := buffer.ReadRune()
+					if err != nil {
+						return nil, err
+					}
+					if err := buffer.UnreadRune(); err != nil {
+						return nil, err
+					}
+					// If line is blank, continue adding to the buffer
+					if ru == '\n' {
+						continue
+					}
+				}
 				return buffer.Bytes(), nil
 			}
 			if err == io.EOF {

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -245,6 +245,33 @@ stuff: 3
 	}
 }
 
+func TestDecodeSeparatorWithBlankLine(t *testing.T) {
+	y := `
+---
+stuff: 1
+
+---
+stuff: 2
+`
+	s := NewYAMLToJSONDecoder(bytes.NewReader([]byte(y)))
+
+	obj := generic{}
+	if err := s.Decode(&obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fmt.Sprintf("%#v", obj) != `yaml.generic{"stuff":1}` {
+		t.Errorf("unexpected object: %#v", obj)
+	}
+
+	obj = generic{}
+	if err := s.Decode(&obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fmt.Sprintf("%#v", obj) != `yaml.generic{"stuff":2}` {
+		t.Errorf("unexpected object: %#v", obj)
+	}
+}
+
 func TestDecodeBrokenYAML(t *testing.T) {
 	s := NewYAMLOrJSONDecoder(bytes.NewReader([]byte(`---
 stuff: 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
This PR allows for more graceful handling of a yaml streams, which contain blank lines between their documents or at the start of the stream. 

More specifically this handles the following two cases:

1. document starts with an empty line followed by the yaml document separator

	  ```text
	  
	  ---
	  stuff: 1
	  ```
	  
	  This case can happen quite often as CRDs generated by `controller-gen` will take this form, which is also what the original issue mainly concerns

2. blank line between end of document 1 and separator. E.g.

	  ```text
	  
	  ---
	  end: of-document-1
	  
	  ---
	  start: of-document-2
	  ```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/apimachinery/issues/133

#### Special notes for your reviewer:

Some considerations which went into the proposed solution:
* I did not want to directly check the `line` variable if it is a `\n` character, as I think this would be quite inefficient as the `if-clause` would need to be run on every single line. So while we do have a bit more than one check now, the check will only be run when encountering a yaml separator
* Making use of the length of the buffer and only peaking one rune into it, saves us the trouble of reading the through the whole buffer
* This solution also has the nice touch that it retains the `\n` characters in the buffer. Additionally it can handle 1..n blank lines in between separators

Yeah other than that, this is my first contribution and I am happy for any feedback. Maybe this can be done even simpler, but this was the smartest solution I could come up with :) 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
