### PR TITLE
migrate nginx to k8s.gcr.io image

### DIFF
--- a/test/e2e/common/node/podtemplates.go
+++ b/test/e2e/common/node/podtemplates.go
@@ -70,7 +70,7 @@ var _ = SIGDescribe("PodTemplates", func() {
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
-						{Name: "nginx", Image: "nginx"},
+						{Name: "nginx", Image: imageutils.GetE2EImage(imageutils.Nginx)},
 					},
 				},
 			},

--- a/test/e2e/framework/.import-restrictions
+++ b/test/e2e/framework/.import-restrictions
@@ -242,6 +242,7 @@ rules:
       - k8s.io/kubernetes/pkg/scheduler/internal/cache
   - selectorRegexp: k8s[.]io/kubernetes/test/
     allowedPrefixes:
+      - k8s.io/kubernetes/test/e2e/common
       - k8s.io/kubernetes/test/e2e/framework
       - k8s.io/kubernetes/test/e2e/framework/auth
       - k8s.io/kubernetes/test/e2e/framework/ginkgowrapper

--- a/test/e2e/framework/manifest/manifest.go
+++ b/test/e2e/framework/manifest/manifest.go
@@ -23,11 +23,12 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
+	commonutils "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2etestfiles "k8s.io/kubernetes/test/e2e/framework/testfiles"
 )
@@ -75,8 +76,8 @@ func StatefulSetFromManifest(fileName, ns string) (*appsv1.StatefulSet, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	json, err := utilyaml.ToJSON(data)
+	statefulsetYaml := commonutils.SubstituteImageName(string(data))
+	json, err := utilyaml.ToJSON([]byte(statefulsetYaml))
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/framework/manifest/manifest.go
+++ b/test/e2e/framework/manifest/manifest.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"

--- a/test/e2e/storage/flexvolume_online_resize.go
+++ b/test/e2e/storage/flexvolume_online_resize.go
@@ -36,6 +36,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 var _ = utils.SIGDescribe("Mounted flexvolume volume expand [Slow] [Feature:ExpandInUsePersistentVolumes]", func() {
@@ -221,7 +222,7 @@ func makeNginxPod(ns string, nodeSelector map[string]string, pvclaims []*v1.Pers
 			Containers: []v1.Container{
 				{
 					Name:  "write-pod",
-					Image: "nginx",
+					Image: imageutils.GetE2EImage(imageutils.Nginx),
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "http-server",

--- a/test/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.15-alpine
+        image: {{.NginxImageNew}}
         ports:
         - containerPort: 80
           name: web


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`test/e2e/common/node/podtemplates.go` change may be not needed. (Update it by the way. It has no side effect, I think)

#### Which issue(s) this PR fixes:

part of #108562

#### Special notes for your reviewer:
Only replaced nginx images in this PR.
Some other image has no alternative image: https://github.com/kubernetes/kubernetes/issues/108562#issuecomment-1061385476

#### Does this PR introduce a user-facing change?

```release-note
NONE
```