### PR TITLE
Add e2e tests for credential provider 

### DIFF
--- a/test/e2e/imagecredentialprovider/credential_provider.go
+++ b/test/e2e/imagecredentialprovider/credential_provider.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentialprovider
+
+import (
+	"github.com/onsi/ginkgo"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+)
+
+// SIGDescribe annotates the test with the SIG label.
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[sig-cloud-provider][sig-node][sig-auth] "+text, body)
+}
+
+/*
+These tests assumes external gcp credential provider is installed and configured on k8s node.
+however they won't fail unless in tree gcp credential provider is removed or disabled.
+Currently to make sure external credential provider is used for tests both below feature gates needs to be enabled in kubelet
+KubeletCredentialProviders, DisableKubeletCloudCredentialProviders
+*/
+
+var _ = SIGDescribe("ImageCredentialProvider [Feature: KubeletCredentialProviders]", func() {
+	f := framework.NewDefaultFramework("image-credential-provider")
+	var podClient *framework.PodClient
+
+	ginkgo.BeforeEach(func() {
+		podClient = f.PodClient()
+	})
+
+	/*
+		Release: v1.24
+		Testname: Test kubelet image credential provider
+		Description: Create Pod with image from private registry, image credentials fetched from external credential provider by kubelet.
+	*/
+	ginkgo.It("should be able to create pod with image credentials fetched from external credential provider ", func() {
+		privateimage := imageutils.GetConfig(imageutils.AgnhostPrivate)
+		name := "pod-auth-image-" + string(uuid.NewUUID())
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:            "container-auth-image",
+						Image:           privateimage.GetE2EImage(),
+						ImagePullPolicy: v1.PullAlways,
+					},
+				},
+			},
+		}
+		podClient.Create(pod)
+		err := e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+		framework.ExpectNoError(err)
+	})
+
+	/*
+		Release: v1.24
+		Testname: Test kubelet image credential provider
+		Description: Create Pod with unauthenticated image, pod should be created even if kubelet fails to fetch credentials.
+	*/
+	ginkgo.It("should be able to create pod with unauthenticated image even if failed to get image credentials from external credential provider", func() {
+		image := imageutils.GetConfig(imageutils.Agnhost)
+		name := "pod-unauth-image-" + string(uuid.NewUUID())
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:            "container-unauth-image",
+						Image:           image.GetE2EImage(),
+						ImagePullPolicy: v1.PullAlways,
+					},
+				},
+			},
+		}
+		podClient.Create(pod)
+		err := e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+		framework.ExpectNoError(err)
+	})
+})


### PR DESCRIPTION
Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add e2e tests for kubelet credential provider 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2133-kubelet-credential-providers
```
