### PR TITLE
Print kubectl debug messages received when starting a container

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -742,7 +742,7 @@ func (o *DebugOptions) waitForContainer(ctx context.Context, ns, podName, contai
 				return true, nil
 			}
 			if !o.Quiet && s.State.Waiting != nil && s.State.Waiting.Message != "" {
-				fmt.Fprintf(o.ErrOut, "Container %s: %s\n", containerName, s.State.Waiting.Message)
+				fmt.Fprintf(o.ErrOut, "Warning: container %s: %s\n", containerName, s.State.Waiting.Message)
 			}
 			return false, nil
 		})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -357,7 +357,7 @@ func (o *DebugOptions) Run(f cmdutil.Factory, cmd *cobra.Command) error {
 			opts.Config = config
 			opts.AttachFunc = attach.DefaultAttachFunc
 
-			if err := handleAttachPod(ctx, f, o.podClient, debugPod.Namespace, debugPod.Name, containerName, opts); err != nil {
+			if err := o.handleAttachPod(ctx, f, debugPod.Namespace, debugPod.Name, containerName, opts); err != nil {
 				return err
 			}
 		}
@@ -701,7 +701,7 @@ func containerNameToRef(pod *corev1.Pod) map[string]*corev1.Container {
 }
 
 // waitForContainer watches the given pod until the container is running
-func waitForContainer(ctx context.Context, podClient corev1client.PodsGetter, ns, podName, containerName string) (*corev1.Pod, error) {
+func (o *DebugOptions) waitForContainer(ctx context.Context, ns, podName, containerName string) (*corev1.Pod, error) {
 	// TODO: expose the timeout
 	ctx, cancel := watchtools.ContextWithOptionalTimeout(ctx, 0*time.Second)
 	defer cancel()
@@ -710,11 +710,11 @@ func waitForContainer(ctx context.Context, podClient corev1client.PodsGetter, ns
 	lw := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = fieldSelector
-			return podClient.Pods(ns).List(ctx, options)
+			return o.podClient.Pods(ns).List(ctx, options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.FieldSelector = fieldSelector
-			return podClient.Pods(ns).Watch(ctx, options)
+			return o.podClient.Pods(ns).Watch(ctx, options)
 		},
 	}
 
@@ -722,6 +722,7 @@ func waitForContainer(ctx context.Context, podClient corev1client.PodsGetter, ns
 	var result *corev1.Pod
 	err := intr.Run(func() error {
 		ev, err := watchtools.UntilWithSync(ctx, lw, &corev1.Pod{}, nil, func(ev watch.Event) (bool, error) {
+			klog.V(2).Infof("watch received event %q with object %T", ev.Type, ev.Object)
 			switch ev.Type {
 			case watch.Deleted:
 				return false, errors.NewNotFound(schema.GroupResource{Resource: "pods"}, "")
@@ -740,6 +741,9 @@ func waitForContainer(ctx context.Context, podClient corev1client.PodsGetter, ns
 			if s.State.Running != nil || s.State.Terminated != nil {
 				return true, nil
 			}
+			if !o.Quiet && s.State.Waiting != nil && s.State.Waiting.Message != "" {
+				fmt.Fprintf(o.ErrOut, "Container %s: %s\n", containerName, s.State.Waiting.Message)
+			}
 			return false, nil
 		})
 		if ev != nil {
@@ -751,8 +755,8 @@ func waitForContainer(ctx context.Context, podClient corev1client.PodsGetter, ns
 	return result, err
 }
 
-func handleAttachPod(ctx context.Context, f cmdutil.Factory, podClient corev1client.PodsGetter, ns, podName, containerName string, opts *attach.AttachOptions) error {
-	pod, err := waitForContainer(ctx, podClient, ns, podName, containerName)
+func (o *DebugOptions) handleAttachPod(ctx context.Context, f cmdutil.Factory, ns, podName, containerName string, opts *attach.AttachOptions) error {
+	pod, err := o.waitForContainer(ctx, ns, podName, containerName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This provides feedback to the user, for example that the server is unable to pull the debug container image, for example:

```
$ kubectl debug -it --image=bogus shared      
Defaulting debug container name to debugger-rfdmp.
Container debugger-rfdmp: rpc error: code = Unknown desc = failed to pull and unpack image "docker.io/library/bogus:latest": failed to resolve reference "docker.io/library/bogus:latest": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
Container debugger-rfdmp: Back-off pulling image "bogus"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108135

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
