### PR TITLE
tests: Enables a few Conformance tests for Windows (part 2)

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1852,16 +1852,6 @@
     as RestartAlways.
   release: v1.12
   file: test/e2e/common/node/init_container.go
-- testname: Kubelet, hostAliases
-  codename: '[sig-node] Kubelet when scheduling a busybox Pod with hostAliases should
-    write entries to /etc/hosts [LinuxOnly] [NodeConformance] [Conformance]'
-  description: Create a Pod with hostAliases and a container with command to output
-    /etc/hosts entries. Pod's logs MUST have matching entries of specified hostAliases
-    to the output of /etc/hosts entries. Kubernetes mounts the /etc/hosts file into
-    its containers, however, mounting individual files is not supported on Windows
-    Containers. For this reason, this test is marked LinuxOnly.
-  release: v1.13
-  file: test/e2e/common/node/kubelet.go
 - testname: Kubelet, log output, default
   codename: '[sig-node] Kubelet when scheduling a busybox command in a pod should
     print the output to logs [NodeConformance] [Conformance]'
@@ -1890,6 +1880,14 @@
     set to true. The Pod then tries to write to the /file on the root, write operation
     to the root filesystem MUST fail as expected. This test is marked LinuxOnly since
     Windows does not support creating containers with read-only access.
+  release: v1.13
+  file: test/e2e/common/node/kubelet.go
+- testname: Kubelet, hostAliases
+  codename: '[sig-node] Kubelet when scheduling an agnhost Pod with hostAliases should
+    write entries to /etc/hosts [NodeConformance] [Conformance]'
+  description: Create a Pod with hostAliases and a container with command to output
+    /etc/hosts entries. Pod's logs MUST have matching entries of specified hostAliases
+    to the output of /etc/hosts entries.
   release: v1.13
   file: test/e2e/common/node/kubelet.go
 - testname: Kubelet, managed etc hosts

--- a/test/e2e/common/node/kubelet.go
+++ b/test/e2e/common/node/kubelet.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo"
@@ -136,55 +137,39 @@ var _ = SIGDescribe("Kubelet", func() {
 			gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("Error deleting Pod %v", err))
 		})
 	})
-	ginkgo.Context("when scheduling a busybox Pod with hostAliases", func() {
-		podName := "busybox-host-aliases" + string(uuid.NewUUID())
+	ginkgo.Context("when scheduling an agnhost Pod with hostAliases", func() {
+		podName := "agnhost-host-aliases" + string(uuid.NewUUID())
 
 		/*
 			Release: v1.13
 			Testname: Kubelet, hostAliases
 			Description: Create a Pod with hostAliases and a container with command to output /etc/hosts entries. Pod's logs MUST have matching entries of specified hostAliases to the output of /etc/hosts entries.
-			Kubernetes mounts the /etc/hosts file into its containers, however, mounting individual files is not supported on Windows Containers. For this reason, this test is marked LinuxOnly.
 		*/
-		framework.ConformanceIt("should write entries to /etc/hosts [LinuxOnly] [NodeConformance]", func() {
-			podClient.CreateSync(&v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: podName,
+		framework.ConformanceIt("should write entries to /etc/hosts [NodeConformance]", func() {
+			pod := e2epod.NewAgnhostPod(f.Namespace.Name, podName, nil, nil, nil, "etc-hosts")
+			// Don't restart the Pod since it is expected to exit
+			pod.Spec.RestartPolicy = v1.RestartPolicyNever
+			pod.Spec.HostAliases = []v1.HostAlias{
+				{
+					IP:        "123.45.67.89",
+					Hostnames: []string{"foo", "bar"},
 				},
-				Spec: v1.PodSpec{
-					// Don't restart the Pod since it is expected to exit
-					RestartPolicy: v1.RestartPolicyNever,
-					Containers: []v1.Container{
-						{
-							Image:   framework.BusyBoxImage,
-							Name:    podName,
-							Command: []string{"/bin/sh", "-c", "cat /etc/hosts; sleep 6000"},
-						},
-					},
-					HostAliases: []v1.HostAlias{
-						{
-							IP:        "123.45.67.89",
-							Hostnames: []string{"foo", "bar"},
-						},
-					},
-				},
-			})
+			}
 
-			gomega.Eventually(func() error {
-				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(context.TODO())
-				if err != nil {
-					return err
-				}
-				defer rc.Close()
-				buf := new(bytes.Buffer)
-				buf.ReadFrom(rc)
-				hostsFileContent := buf.String()
+			pod = podClient.Create(pod)
+			ginkgo.By("Waiting for pod completion")
+			err := e2epod.WaitForPodNoLongerRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+			framework.ExpectNoError(err)
 
-				if !strings.Contains(hostsFileContent, "123.45.67.89\tfoo\tbar") {
-					return fmt.Errorf("expected hosts file to contain entries from HostAliases. Got:\n%+v", hostsFileContent)
-				}
+			rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(context.TODO())
+			framework.ExpectNoError(err)
+			defer rc.Close()
+			buf := new(bytes.Buffer)
+			buf.ReadFrom(rc)
+			hostsFileContent := buf.String()
 
-				return nil
-			}, time.Minute, time.Second*4).Should(gomega.BeNil())
+			errMsg := fmt.Sprintf("expected hosts file to contain entries from HostAliases. Got:\n%+v", hostsFileContent)
+			framework.ExpectEqual(true, strings.Contains(hostsFileContent, "123.45.67.89\tfoo\tbar"), errMsg)
 		})
 	})
 	ginkgo.Context("when scheduling a read only busybox container", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/sig testing
/sig windows

/kind feature
/priority important-soon
/milestone v1.24

#### What this PR does / why we need it:

Some of these tests could not be run previously, especially on Windows Docker containers. But now, by using Windows Containerd, we can finally run them:

- /etc/hosts related tests: These were not supported because it required single file mappings, which is possible in Containerd.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
