### PR TITLE
Automated cherry pick of #108000: azure_file: add namespace tests for InTree to CSI

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
@@ -129,9 +129,21 @@ func (t *azureFileCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume)
 			resourceGroup = v
 		}
 	}
-	namespace := defaultSecretNamespace
+
+	// Secret is required when mounting a volume but pod presence cannot be assumed - we should not try to read pod now.
+	namespace := ""
+	// Try to read SecretNamespace from source pv.
 	if azureSource.SecretNamespace != nil {
 		namespace = *azureSource.SecretNamespace
+	} else {
+		// Try to read namespace from ClaimRef which should be always present.
+		if pv.Spec.ClaimRef != nil {
+			namespace = pv.Spec.ClaimRef.Namespace
+		}
+	}
+
+	if len(namespace) == 0 {
+		return nil, fmt.Errorf("could not find a secret namespace in PersistentVolumeSource or ClaimRef")
 	}
 
 	volumeID := fmt.Sprintf(volumeIDTemplate, resourceGroup, accountName, azureSource.ShareName, pv.ObjectMeta.Name, namespace)


### PR DESCRIPTION
Cherry pick of #108000 on release-1.21.

#108000: azure_file: add namespace tests for InTree to CSI

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.