### PR TITLE
Add test in scheduler/util/utils_test.go

### DIFF
--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -126,6 +126,7 @@ func DeletePod(cs kubernetes.Interface, pod *v1.Pod) error {
 
 // ClearNominatedNodeName internally submit a patch request to API server
 // to set each <pods[*].Status.NominatedNodeName> to "".
+// It make patch requests for all pods even if a patch for one pods fails
 func ClearNominatedNodeName(cs kubernetes.Interface, pods ...*v1.Pod) utilerrors.Aggregate {
 	var errs []error
 	for _, p := range pods {

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -125,7 +125,7 @@ func DeletePod(cs kubernetes.Interface, pod *v1.Pod) error {
 }
 
 // ClearNominatedNodeName internally submit a patch request to API server
-// to set each pods[*].Status.NominatedNodeName> to "".
+// to set each <pods[*].Status.NominatedNodeName> to "".
 func ClearNominatedNodeName(cs kubernetes.Interface, pods ...*v1.Pod) utilerrors.Aggregate {
 	var errs []error
 	for _, p := range pods {

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -324,11 +324,6 @@ func TestIsScalarResourceName(t *testing.T) {
 			want:         true,
 		},
 		{
-			name:         "Should be false with not HugePage resource name",
-			resourceName: "cpu",
-			want:         false,
-		},
-		{
 			name:         "Should be true with native resource name",
 			resourceName: "kubernetes.io/resource-foo",
 			want:         true,
@@ -337,6 +332,21 @@ func TestIsScalarResourceName(t *testing.T) {
 			name:         "Should be true with attachable volume resource name",
 			resourceName: "attachable-volumes-foo",
 			want:         true,
+		},
+		{
+			name:         "Should be false with not ScalarResource name",
+			resourceName: "cpu",
+			want:         false,
+		},
+		{
+			name:         "Should be false with not ScalarResource name",
+			resourceName: "memory",
+			want:         false,
+		},
+		{
+			name:         "Should be false with not ScalarResource name",
+			resourceName: "ephemeral-storage",
+			want:         false,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -154,11 +154,6 @@ func TestClearNominatedNodeName(t *testing.T) {
 			expectedPatchData:     `{"status":{"nominatedNodeName":null}}`,
 		},
 		{
-			name:                  "Should not make patch request if nominated node is already cleared",
-			pods:                  []*v1.Pod{},
-			expectedPatchRequests: 0,
-		},
-		{
 			name: "Should not be patched if NominatedNodeName is empty",
 			pods: []*v1.Pod{
 				{
@@ -198,12 +193,12 @@ func TestClearNominatedNodeName(t *testing.T) {
 				// If the pod name is "err", return an error.
 				if patch.GetName() == "err1" {
 					return true, nil, test.patchError
-				} 
+				}
 				actualPatchData = append(actualPatchData, string(patch.GetPatch()))
 				// For this test, we don't care about the result of the patched pod, just that we got the expected
 				// patch request, so just returning &v1.Pod{} here is OK because scheduler doesn't use the response.
 				return true, &v1.Pod{}, nil
-				
+
 			})
 
 			if err := ClearNominatedNodeName(cs, test.pods...); err != nil {

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -19,7 +19,6 @@ package util
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -207,16 +206,21 @@ func TestClearNominatedNodeName(t *testing.T) {
 
 			})
 
-			if err := ClearNominatedNodeName(cs, test.pods...); err != nil && !reflect.DeepEqual(err.Errors(), test.expectedPatchError.Errors()) {
-				t.Fatalf("ClearNominatedNodeName's error mismatch: Actual was %v, but expected %v", err.Errors(), test.expectedPatchError.Errors())
+			if err := ClearNominatedNodeName(cs, test.pods...); err != nil {
+				if diff := cmp.Diff(err, test.expectedPatchError); diff != "" {
+					t.Fatalf("ClearNominatedNodeName's error mismatch (-want,+got):\n%s", diff)
+				}
+
 			}
 
 			if actualPatchRequests != test.expectedPatchRequests {
 				t.Fatalf("Actual patch requests (%d) dos not equal expected patch requests (%d)", actualPatchRequests, test.expectedPatchRequests)
 			}
 
-			if test.expectedPatchRequests > 0 && !reflect.DeepEqual(actualPatchData, test.expectedPatchData) {
-				t.Fatalf("Patch data mismatch: Actual was %v, but expected %v", actualPatchData, test.expectedPatchData)
+			if test.expectedPatchRequests > 0 {
+				if diff := cmp.Diff(actualPatchData, test.expectedPatchData); diff != "" {
+					t.Fatalf("Patch data mismatch (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -128,7 +128,7 @@ func TestMoreImportantPod(t *testing.T) {
 
 func TestClearNominatedNodeName(t *testing.T) {
 	statusErr := &apierrors.StatusError{
-		ErrStatus: metav1.Status{Reason: metav1.StatusReasonUnknown},
+		ErrStatus: metav1.Status{Reason: metav1.StatusReasonUnknown, Message: "status error"},
 	}
 
 	tests := []struct {
@@ -207,8 +207,8 @@ func TestClearNominatedNodeName(t *testing.T) {
 
 			})
 
-			if err := ClearNominatedNodeName(cs, test.pods...); err != nil && err.Is(test.expectedPatchError) {
-				t.Fatalf("ClearNominatedNodeName's error mismatch: Actual was %v, but expected %v", err, test.expectedPatchError)
+			if err := ClearNominatedNodeName(cs, test.pods...); err != nil && !reflect.DeepEqual(err.Errors(), test.expectedPatchError.Errors()) {
+				t.Fatalf("ClearNominatedNodeName's error mismatch: Actual was %v, but expected %v", err.Errors(), test.expectedPatchError.Errors())
 			}
 
 			if actualPatchRequests != test.expectedPatchRequests {

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -339,11 +339,9 @@ func TestIsScalarResourceName(t *testing.T) {
 			want:         true,
 		},
 	}
-	{
-		for _, test := range tests {
-			if IsScalarResourceName(test.resourceName) != test.want {
-				t.Errorf("%s: expected: %t, got: %t", test.name, test.want, !test.want)
-			}
+	for _, test := range tests {
+		if IsScalarResourceName(test.resourceName) != test.want {
+			t.Errorf("%s: expected: %t, got: %t", test.name, test.want, !test.want)
 		}
 	}
 }

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -127,7 +127,6 @@ func TestMoreImportantPod(t *testing.T) {
 }
 
 func TestClearNominatedNodeName(t *testing.T) {
-	t.Parallel()
 	statusErr := &apierrors.StatusError{
 		ErrStatus: metav1.Status{Reason: metav1.StatusReasonUnknown},
 	}
@@ -300,7 +299,6 @@ func TestPatchPodStatus(t *testing.T) {
 }
 
 func TestIsScalarResourceName(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name         string
 		resourceName v1.ResourceName

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -176,8 +176,8 @@ func TestClearNominatedNodeName(t *testing.T) {
 					Status:     v1.PodStatus{NominatedNodeName: "node1"},
 				},
 				{
-					// In this test, the pod named "err1" returns an error in the patch.
-					ObjectMeta: metav1.ObjectMeta{Name: "err1"},
+					// In this test, the pod named "err" returns an error in the patch.
+					ObjectMeta: metav1.ObjectMeta{Name: "err"},
 					Status:     v1.PodStatus{NominatedNodeName: "node1"},
 				},
 			},

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -300,3 +300,50 @@ func TestDeletePod(t *testing.T) {
 		})
 	}
 }
+
+func TestIsScalarResourceName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		resourceName v1.ResourceName
+		want         bool
+	}{
+		{
+			name:         "Should be true with extended resources name",
+			resourceName: "example.com/foo",
+			want:         true,
+		},
+		{
+			name:         "Should be false with not extended resources name",
+			resourceName: "requests.foo",
+			want:         false,
+		},
+		{
+			name:         "Should be true with hugePage resource name",
+			resourceName: "hugepages-2Mi",
+			want:         true,
+		},
+		{
+			name:         "Should be false with not HugePage resource name",
+			resourceName: "cpu",
+			want:         false,
+		},
+		{
+			name:         "Should be true with native resource name",
+			resourceName: "kubernetes.io/resource-foo",
+			want:         true,
+		},
+		{
+			name:         "Should be true with attachable volume resource name",
+			resourceName: "attachable-volumes-foo",
+			want:         true,
+		},
+	}
+	{
+		for _, test := range tests {
+			if IsScalarResourceName(test.resourceName) != test.want {
+				t.Errorf("%s: expected: %t, got: %t", test.name, test.want, !test.want)
+			}
+		}
+	}
+}

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -303,46 +303,6 @@ func TestPatchPodStatus(t *testing.T) {
 	}
 }
 
-func TestDeletePod(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name string
-		pod  v1.Pod
-	}{
-		{
-			name: "Should delete pod successfully",
-			pod: v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns",
-					Name:      "pod1",
-				},
-				Spec: v1.PodSpec{
-					ImagePullSecrets: []v1.LocalObjectReference{{Name: "foo"}},
-				},
-			},
-		},
-	}
-	client := clientsetfake.NewSimpleClientset()
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := client.CoreV1().Pods(tc.pod.Namespace).Create(context.TODO(), &tc.pod, metav1.CreateOptions{})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			err = DeletePod(client, &tc.pod)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			targetPod, _ := client.CoreV1().Pods(tc.pod.Namespace).Get(context.TODO(), tc.pod.Name, metav1.GetOptions{})
-			if targetPod != nil {
-				t.Fatalf("failed to delete pod: %v", targetPod)
-			}
-		})
-	}
-}
-
 func TestIsScalarResourceName(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -198,12 +198,12 @@ func TestClearNominatedNodeName(t *testing.T) {
 				// If the pod name is "err", return an error.
 				if patch.GetName() == "err1" {
 					return true, nil, test.patchError
-				} else {
-					actualPatchData = append(actualPatchData, string(patch.GetPatch()))
-					// For this test, we don't care about the result of the patched pod, just that we got the expected
-					// patch request, so just returning &v1.Pod{} here is OK because scheduler doesn't use the response.
-					return true, &v1.Pod{}, nil
-				}
+				} 
+				actualPatchData = append(actualPatchData, string(patch.GetPatch()))
+				// For this test, we don't care about the result of the patched pod, just that we got the expected
+				// patch request, so just returning &v1.Pod{} here is OK because scheduler doesn't use the response.
+				return true, &v1.Pod{}, nil
+				
 			})
 
 			if err := ClearNominatedNodeName(cs, test.pods...); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add some tests in scheduler/util/utils_test.go to improve the test coverage.
Modified test cases for multiple pods.
- `TestClearNominatedNodeName `

Add new test because there was no test.
- `TestIsScalarResourceName `

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
