### PR TITLE
Calculate CEL cost totals

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"regexp"
 	"strings"
@@ -46,6 +47,11 @@ var (
 	printerColumnDatatypes                = sets.NewString("integer", "number", "string", "boolean", "date")
 	customResourceColumnDefinitionFormats = sets.NewString("int32", "int64", "float", "double", "byte", "date", "date-time", "password")
 	openapiV3Types                        = sets.NewString("string", "number", "integer", "boolean", "array", "object")
+)
+
+const (
+	// StaticEstimatedCostLimit represents the largest-allowed static CEL cost on a per-expression basis.
+	StaticEstimatedCostLimit = 10000000
 )
 
 // ValidateCustomResourceDefinition statically validates
@@ -714,7 +720,7 @@ func validateCustomResourceDefinitionValidation(ctx context.Context, customResou
 			requireValidPropertyType: opts.requireValidPropertyType,
 		}
 
-		allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(schema, fldPath.Child("openAPIV3Schema"), openAPIV3Schema, true, &opts)...)
+		allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(schema, fldPath.Child("openAPIV3Schema"), openAPIV3Schema, true, &opts, rootCostInfo())...)
 
 		if opts.requireStructuralSchema {
 			if ss, err := structuralschema.NewStructural(schema); err != nil {
@@ -742,16 +748,101 @@ func validateCustomResourceDefinitionValidation(ctx context.Context, customResou
 	return allErrs
 }
 
+// unbounded uses nil to represent an unbounded cardinality value.
+var unbounded *uint64 = nil
+
+type costInfo struct {
+	// MaxCardinality represents a limit to the number of data elements that can exist for the current
+	// schema based on MaxProperties or MaxItems limits present on parent schemas, If all parent
+	// map and array schemas have MaxProperties or MaxItems limits declared MaxCardinality is
+	// an int pointer representing the product of these limits.  If least one parent map or list schema
+	// does not have a MaxProperties or MaxItems limits set, the MaxCardinality is nil, indicating
+	// that the parent schemas offer no bound to the number of times a data element for the current
+	// schema can exist.
+	MaxCardinality *uint64
+}
+
+// MultiplyByElementCost returns a costInfo where the MaxCardinality is multiplied by the
+// factor that the schema increases the cardinality of its children. If the costInfo's
+// MaxCardinality is unbounded (nil) or the factor that the schema increase the cardinality
+// is unbounded, the resulting costInfo's MaxCardinality is also unbounded.
+func (c *costInfo) MultiplyByElementCost(schema *apiextensions.JSONSchemaProps) costInfo {
+	result := costInfo{MaxCardinality: unbounded}
+	if schema == nil {
+		// nil schemas can be passed since we call MultiplyByElementCost
+		// before ValidateCustomResourceDefinitionOpenAPISchema performs its nil check
+		return result
+	}
+	if c.MaxCardinality == unbounded {
+		return result
+	}
+	maxElements := extractMaxElements(schema)
+	if maxElements == unbounded {
+		return result
+	}
+	result.MaxCardinality = uint64ptr(multiplyWithOverflowGuard(*c.MaxCardinality, *maxElements))
+	return result
+}
+
+// extractMaxElements returns the factor by which the schema increases the cardinality
+// (number of possible data elements) of its children.  If schema is a map and has
+// MaxProperties or an array has MaxItems, the int pointer of the max value is returned.
+// If schema is a map or array and does not have MaxProperties or MaxItems,
+// unbounded (nil) is returned to indicate that there is no limit to the possible
+// number of data elements imposed by the current schema.  If the schema is an object, 1 is
+// returned to indicate that there is no increase to the number of possible data elements
+// for its children.  Primitives do not have children, but 1 is returned for simplicity.
+func extractMaxElements(schema *apiextensions.JSONSchemaProps) *uint64 {
+	switch schema.Type {
+	case "object":
+		if schema.AdditionalProperties != nil {
+			if schema.MaxProperties != nil {
+				maxProps := uint64(zeroIfNegative(*schema.MaxProperties))
+				return &maxProps
+			}
+			return unbounded
+		}
+		// return 1 to indicate that all fields of an object exist at most one for
+		// each occurrence of the object they are fields of
+		return uint64ptr(1)
+	case "array":
+		if schema.MaxItems != nil {
+			maxItems := uint64(zeroIfNegative(*schema.MaxItems))
+			return &maxItems
+		}
+		return unbounded
+	default:
+		return uint64ptr(1)
+	}
+}
+
+func zeroIfNegative(v int64) int64 {
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+func uint64ptr(i uint64) *uint64 {
+	return &i
+}
+
+func rootCostInfo() costInfo {
+	rootCardinality := uint64(1)
+	return costInfo{
+		MaxCardinality: &rootCardinality,
+	}
+}
+
 var metaFields = sets.NewString("metadata", "kind", "apiVersion")
 
 // ValidateCustomResourceDefinitionOpenAPISchema statically validates
-func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSchemaProps, fldPath *field.Path, ssv specStandardValidator, isRoot bool, opts *validationOptions) field.ErrorList {
+func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSchemaProps, fldPath *field.Path, ssv specStandardValidator, isRoot bool, opts *validationOptions, nodeCostInfo costInfo) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if schema == nil {
 		return allErrs
 	}
-
 	allErrs = append(allErrs, ssv.validate(schema, fldPath)...)
 
 	if schema.UniqueItems == true {
@@ -780,7 +871,7 @@ func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 			// we have to forbid defaults inside additionalProperties because pruning without actual value is ambiguous
 			subSsv = ssv.withForbiddenDefaults("inside additionalProperties applying to object metadata")
 		}
-		allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(schema.AdditionalProperties.Schema, fldPath.Child("additionalProperties"), subSsv, false, opts)...)
+		allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(schema.AdditionalProperties.Schema, fldPath.Child("additionalProperties"), subSsv, false, opts, nodeCostInfo.MultiplyByElementCost(schema))...)
 	}
 
 	if len(schema.Properties) != 0 {
@@ -798,33 +889,33 @@ func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 					subSsv = subSsv.withForbiddenDefaults(fmt.Sprintf("in top-level %s", property))
 				}
 			}
-			allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(&jsonSchema, fldPath.Child("properties").Key(property), subSsv, false, opts)...)
+			allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(&jsonSchema, fldPath.Child("properties").Key(property), subSsv, false, opts, nodeCostInfo.MultiplyByElementCost(schema))...)
 		}
 	}
 
-	allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(schema.Not, fldPath.Child("not"), ssv, false, opts)...)
+	allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(schema.Not, fldPath.Child("not"), ssv, false, opts, nodeCostInfo.MultiplyByElementCost(schema))...)
 
 	if len(schema.AllOf) != 0 {
 		for i, jsonSchema := range schema.AllOf {
-			allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(&jsonSchema, fldPath.Child("allOf").Index(i), ssv, false, opts)...)
+			allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(&jsonSchema, fldPath.Child("allOf").Index(i), ssv, false, opts, nodeCostInfo.MultiplyByElementCost(schema))...)
 		}
 	}
 
 	if len(schema.OneOf) != 0 {
 		for i, jsonSchema := range schema.OneOf {
-			allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(&jsonSchema, fldPath.Child("oneOf").Index(i), ssv, false, opts)...)
+			allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(&jsonSchema, fldPath.Child("oneOf").Index(i), ssv, false, opts, nodeCostInfo.MultiplyByElementCost(schema))...)
 		}
 	}
 
 	if len(schema.AnyOf) != 0 {
 		for i, jsonSchema := range schema.AnyOf {
-			allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(&jsonSchema, fldPath.Child("anyOf").Index(i), ssv, false, opts)...)
+			allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(&jsonSchema, fldPath.Child("anyOf").Index(i), ssv, false, opts, nodeCostInfo.MultiplyByElementCost(schema))...)
 		}
 	}
 
 	if len(schema.Definitions) != 0 {
 		for definition, jsonSchema := range schema.Definitions {
-			allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(&jsonSchema, fldPath.Child("definitions").Key(definition), ssv, false, opts)...)
+			allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(&jsonSchema, fldPath.Child("definitions").Key(definition), ssv, false, opts, nodeCostInfo.MultiplyByElementCost(schema))...)
 		}
 	}
 
@@ -838,17 +929,17 @@ func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 			subSsv = subSsv.withForbidOldSelfValidations(fldPath)
 		}
 
-		allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(schema.Items.Schema, fldPath.Child("items"), subSsv, false, opts)...)
+		allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(schema.Items.Schema, fldPath.Child("items"), subSsv, false, opts, nodeCostInfo.MultiplyByElementCost(schema))...)
 		if len(schema.Items.JSONSchemas) != 0 {
 			for i, jsonSchema := range schema.Items.JSONSchemas {
-				allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(&jsonSchema, fldPath.Child("items").Index(i), subSsv, false, opts)...)
+				allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(&jsonSchema, fldPath.Child("items").Index(i), subSsv, false, opts, nodeCostInfo.MultiplyByElementCost(schema))...)
 			}
 		}
 	}
 
 	if schema.Dependencies != nil {
 		for dependency, jsonSchemaPropsOrStringArray := range schema.Dependencies {
-			allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(jsonSchemaPropsOrStringArray.Schema, fldPath.Child("dependencies").Key(dependency), ssv, false, opts)...)
+			allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(jsonSchemaPropsOrStringArray.Schema, fldPath.Child("dependencies").Key(dependency), ssv, false, opts, nodeCostInfo.MultiplyByElementCost(schema))...)
 		}
 	}
 
@@ -957,6 +1048,11 @@ func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 				allErrs = append(allErrs, field.InternalError(fldPath.Child("x-kubernetes-validations"), err))
 			} else {
 				for i, cr := range compResults {
+					expressionCost := getExpressionCost(cr, nodeCostInfo)
+					if expressionCost > StaticEstimatedCostLimit {
+						costErrorMsg := getCostErrorMessage(expressionCost, StaticEstimatedCostLimit)
+						allErrs = append(allErrs, field.Forbidden(fldPath.Child("x-kubernetes-validations").Index(i).Child("rule"), costErrorMsg))
+					}
 					if cr.Error != nil {
 						if cr.Error.Type == cel.ErrorTypeRequired {
 							allErrs = append(allErrs, field.Required(fldPath.Child("x-kubernetes-validations").Index(i).Child("rule"), cr.Error.Detail))
@@ -979,6 +1075,36 @@ func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 	}
 
 	return allErrs
+}
+
+// multiplyWithOverflowGuard returns the product of baseCost and cardinality unless that product
+// would exceed math.MaxUint, in which case math.MaxUint is returned.
+func multiplyWithOverflowGuard(baseCost, cardinality uint64) uint64 {
+	if baseCost == 0 {
+		// an empty rule can return 0, so guard for that here
+		return 0
+	} else if math.MaxUint/baseCost < cardinality {
+		return math.MaxUint
+	}
+	return baseCost * cardinality
+}
+
+func getExpressionCost(cr cel.CompilationResult, cardinalityCost costInfo) uint64 {
+	if cardinalityCost.MaxCardinality != unbounded {
+		return multiplyWithOverflowGuard(cr.MaxCost, *cardinalityCost.MaxCardinality)
+	}
+	return multiplyWithOverflowGuard(cr.MaxCost, cr.MaxCardinality)
+}
+
+func getCostErrorMessage(expressionCost, costLimit uint64) string {
+	exceedFactor := float64(expressionCost) / float64(StaticEstimatedCostLimit)
+	if exceedFactor > 100.0 {
+		// if exceedFactor is greater than 2 orders of magnitude, the rule is likely O(n^2) or worse
+		// and will probably never validate without some set limits
+		// also in such cases the cost estimation is generally large enough to not add any value
+		return fmt.Sprintf("CEL rule exceeded budget by more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are used)")
+	}
+	return fmt.Sprintf("CEL rule exceeded budget by factor of %.1fx (try adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are used)", exceedFactor)
 }
 
 var newlineMatcher = regexp.MustCompile(`[\n\r]+`) // valid newline chars in CEL grammar

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
@@ -64,6 +64,9 @@ type CompilationResult struct {
 	TransitionRule bool
 	// Represents the worst-case cost of the compiled expression in terms of CEL's cost units, as used by cel.EstimateCost.
 	MaxCost uint64
+	// MaxCardinality represents the worse case number of times this validation rule could be invoked if contained under an
+	// unbounded map or list in an OpenAPIv3 schema.
+	MaxCardinality uint64
 }
 
 // Compile compiles all the XValidations rules (without recursing into the schema) and returns a slice containing a
@@ -120,14 +123,15 @@ func Compile(s *schema.Structural, isResourceRoot bool, perCallLimit uint64) ([]
 	estimator := newCostEstimator(root)
 	// compResults is the return value which saves a list of compilation results in the same order as x-kubernetes-validations rules.
 	compResults := make([]CompilationResult, len(celRules))
+	maxCardinality := celmodel.MaxCardinality(s)
 	for i, rule := range celRules {
-		compResults[i] = compileRule(rule, env, perCallLimit, estimator)
+		compResults[i] = compileRule(rule, env, perCallLimit, estimator, maxCardinality)
 	}
 
 	return compResults, nil
 }
 
-func compileRule(rule apiextensions.ValidationRule, env *cel.Env, perCallLimit uint64, estimator *library.CostEstimator) (compilationResult CompilationResult) {
+func compileRule(rule apiextensions.ValidationRule, env *cel.Env, perCallLimit uint64, estimator *library.CostEstimator, maxCardinality uint64) (compilationResult CompilationResult) {
 	if len(strings.TrimSpace(rule.Rule)) == 0 {
 		// include a compilation result, but leave both program and error nil per documented return semantics of this
 		// function
@@ -174,6 +178,7 @@ func compileRule(rule apiextensions.ValidationRule, env *cel.Env, perCallLimit u
 		return
 	}
 	compilationResult.MaxCost = costEst.Max
+	compilationResult.MaxCardinality = maxCardinality
 	compilationResult.Program = prog
 	return
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
@@ -18,7 +18,6 @@ package cel
 
 import (
 	"fmt"
-	"math"
 	"strings"
 	"testing"
 
@@ -1078,8 +1077,7 @@ func genMapWithCustomItemRule(item *schema.Structural, rule string) func(maxProp
 // if expectedCostExceedsLimit is non-zero. Typically, only expectedCost or expectedCostExceedsLimit is non-zero, not both.
 func schemaChecker(schema *schema.Structural, expectedCost uint64, expectedCostExceedsLimit uint64, t *testing.T) func(t *testing.T) {
 	return func(t *testing.T) {
-		// TODO(DangerOnTheRanger): if perCallLimit in compilation.go changes, this needs to change as well
-		compilationResults, err := Compile(schema, false, uint64(math.MaxInt64))
+		compilationResults, err := Compile(schema, false, PerCallLimit)
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
 		}

--- a/test/integration/apiserver/crd_validation_expressions_test.go
+++ b/test/integration/apiserver/crd_validation_expressions_test.go
@@ -751,11 +751,13 @@ var structuralSchemaWithValidators = []byte(`
           },
 		  "assocList": {
 			"type": "array",
+			"maxItems": 10,
 			"items": {
 			  "type": "object",
+			  "maxProperties": 12,
 			  "properties": {
-			    "k": { "type": "string" },
-			    "v": { "type": "string" }
+			    "k": { "type": "string", "maxLength": 3},
+			    "v": { "type": "string", "maxLength": 3}
 			  },
 			  "required": ["k"]
 			},
@@ -1006,12 +1008,13 @@ var structuralSchemaWithDefaultMapKeyTransitionRule = []byte(`
               "k2"
             ],
             "x-kubernetes-list-type": "map",
+            "maxItems": 100,
             "items": {
               "type": "object",
               "properties": {
                 "k1": { "type": "string" },
                 "k2": { "type": "string", "default": "DEFAULT" },
-                "v": { "type": "string" }
+                "v": { "type": "string", "maxLength": 200 }
               },
 			  "required": ["k1"],
 		      "x-kubernetes-validations": [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR is a part of #107573, and adds support at the CRD level for CEL expression cost calculation as per [the KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2876-crd-validation-expression-language), and emits an error message if the CRD CEL cost limit is exceeded. This PR builds off of #108419 by taking into account `maxLength` and associated fields when calculating the total maximum cost for a CRD's CEL expressions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
