### PR TITLE
Add env var to verify-typecheck for serial execution

### DIFF
--- a/hack/verify-typecheck.sh
+++ b/hack/verify-typecheck.sh
@@ -34,8 +34,9 @@ make --no-print-directory -C "${KUBE_ROOT}" generated_files
 # that library doesn't work well with multiple modules.  Until that is done,
 # force this tooling to run in a fake GOPATH.
 ret=0
+TYPECHECK_SERIAL="${TYPECHECK_SERIAL:-false}"
 hack/run-in-gopath.sh \
-    go run test/typecheck/main.go "$@" || ret=$?
+    go run test/typecheck/main.go "$@" "--serial=$TYPECHECK_SERIAL" || ret=$?
 if [[ $ret -ne 0 ]]; then
   echo "!!! Type Check has failed. This may cause cross platform build failures." >&2
   echo "!!! Please see https://git.k8s.io/kubernetes/test/typecheck for more information." >&2


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This PR makes it possible to set serial execution for verify-typecheck.sh. This is needed bring down the memory usage of the [flaking job](https://github.com/kubernetes/test-infra/blob/4a346cf5c342eda25ff9bb56044439674be17a8b/config/jobs/kubernetes/sig-testing/verify.yaml#L126) that is getting oom killed. This is due to Go 1.17 requiring double the amount of memory for this (see https://github.com/golang/go/issues/49035).

#### Which issue(s) this PR fixes:

Ref https://github.com/kubernetes/kubernetes/issues/107702

#### Special notes for your reviewer:

I'm not sure if this is the best way to pass these along.

Another option is to make typecheck support an env var https://github.com/kubernetes/kubernetes/blob/4763d7529097c87f03a73ba9baf48f8ec1b2e1bb/test/typecheck/main.go#L42.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
