### PR TITLE
apiserver: Remove the deprecated `--service-account-api-audiences` flag

### DIFF
--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -341,12 +341,6 @@ func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 			"and key set are served to relying parties from a URL other than the "+
 			"API server's external (as auto-detected or overridden with external-hostname). ")
 
-		// Deprecated in 1.13
-		fs.StringSliceVar(&o.APIAudiences, "service-account-api-audiences", o.APIAudiences, ""+
-			"Identifiers of the API. The service account token authenticator will validate that "+
-			"tokens used against the API are bound to at least one of these audiences.")
-		fs.MarkDeprecated("service-account-api-audiences", "Use --api-audiences")
-
 		fs.DurationVar(&o.ServiceAccounts.MaxExpiration, "service-account-max-token-expiration", o.ServiceAccounts.MaxExpiration, ""+
 			"The maximum validity duration of a token created by the service account token issuer. If an otherwise valid "+
 			"TokenRequest with a validity duration larger than this value is requested, a token will be issued with a validity duration of this value.")


### PR DESCRIPTION
/kind cleanup
/priority backlog

The deprecation happened in v1.13 with https://github.com/kubernetes/kubernetes/pull/70105.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
action required: API server's deprecated `--service-account-api-audiences` flag is now removed.  Use `--api-audiences` instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
