### PR TITLE
event driven replacement cycle scan

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -91,6 +91,7 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
+	"k8s.io/kubernetes/pkg/kubelet/inits"
 	"k8s.io/kubernetes/pkg/kubelet/kubeletconfig/configfiles"
 	kubeletmetrics "k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/server"
@@ -1185,6 +1186,8 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 }
 
 func startKubelet(k kubelet.Bootstrap, podCfg *config.PodConfig, kubeCfg *kubeletconfiginternal.KubeletConfiguration, kubeDeps *kubelet.Dependencies, enableServer bool) {
+	inits.SafeInitFuncs.DoInit()
+	k.InitHousekeeping()
 	// start the kubelet
 	go k.Run(podCfg.Updates())
 

--- a/hack/verify-mocks.sh
+++ b/hack/verify-mocks.sh
@@ -61,6 +61,10 @@ for file in $files; do
 done
 
 echo "diffing process started for ${#mock_files[@]} files"
+if [[ ${#mock_files[@]} == 0 ]]; then
+  echo "up to date"
+  exit 0
+fi
 ret=0
 for file in "${mock_files[@]}"; do
   diff -Naupr -B \

--- a/pkg/kubelet/container/container_gc.go
+++ b/pkg/kubelet/container/container_gc.go
@@ -78,10 +78,15 @@ func NewContainerGC(runtime Runtime, policy GCPolicy, sourcesReadyProvider Sourc
 }
 
 func (cgc *realContainerGC) GarbageCollect() error {
-	return cgc.runtime.GarbageCollect(cgc.policy, cgc.sourcesReadyProvider.AllReady(), false)
+	for {
+		err := cgc.runtime.GarbageCollect(cgc.policy, cgc.sourcesReadyProvider.AllReady(), false)
+		if err != nil {
+			return err
+		}
+	}
 }
 
 func (cgc *realContainerGC) DeleteAllUnusedContainers() error {
 	klog.InfoS("Attempting to delete unused containers")
-	return cgc.runtime.GarbageCollect(cgc.policy, cgc.sourcesReadyProvider.AllReady(), true)
+	return cgc.runtime.DirectGarbageCollect(cgc.policy, cgc.sourcesReadyProvider.AllReady(), true)
 }

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -140,6 +140,20 @@ func (mr *MockRuntimeMockRecorder) DeleteContainer(containerID interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContainer", reflect.TypeOf((*MockRuntime)(nil).DeleteContainer), containerID)
 }
 
+// DirectGarbageCollect mocks base method.
+func (m *MockRuntime) DirectGarbageCollect(gcPolicy container.GCPolicy, allSourcesReady, evictNonDeletedPods bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DirectGarbageCollect", gcPolicy, allSourcesReady, evictNonDeletedPods)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DirectGarbageCollect indicates an expected call of DirectGarbageCollect.
+func (mr *MockRuntimeMockRecorder) DirectGarbageCollect(gcPolicy, allSourcesReady, evictNonDeletedPods interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DirectGarbageCollect", reflect.TypeOf((*MockRuntime)(nil).DirectGarbageCollect), gcPolicy, allSourcesReady, evictNonDeletedPods)
+}
+
 // GarbageCollect mocks base method.
 func (m *MockRuntime) GarbageCollect(gcPolicy container.GCPolicy, allSourcesReady, evictNonDeletedPods bool) error {
 	m.ctrl.T.Helper()

--- a/pkg/kubelet/cribuffer/cribuffer.go
+++ b/pkg/kubelet/cribuffer/cribuffer.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cribuffer
+
+import (
+	"k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/util/observer"
+)
+
+type CriBufferProvider interface {
+	GetKubeletPods() []*container.Pod
+	GetKubeletRunningPods() []*container.Pod
+	observer.Observer
+}
+
+var CriBuffer CriBufferProvider

--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/cribuffer"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/util/sliceutils"
 )
@@ -222,10 +223,7 @@ func (im *realImageGCManager) detectImages(detectTime time.Time) (sets.String, e
 	if err != nil {
 		return imagesInUse, err
 	}
-	pods, err := im.runtime.GetPods(true)
-	if err != nil {
-		return imagesInUse, err
-	}
+	pods := cribuffer.CriBuffer.GetKubeletPods()
 
 	// Make a set of images in use by containers.
 	for _, pod := range pods {

--- a/pkg/kubelet/inits/inits.go
+++ b/pkg/kubelet/inits/inits.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inits
+
+type SafeInitDependent func()
+
+var SafeInitFuncs = &safeInitFuncs{}
+
+type safeInitFuncs []SafeInitDependent
+
+func (s *safeInitFuncs) DoInit() {
+	for _, initfunc := range *s {
+		initfunc()
+	}
+}
+
+func (s *safeInitFuncs) Regist(initfunc SafeInitDependent) {
+	*s = append(*s, initfunc)
+}

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -29,6 +29,7 @@ import (
 	core "k8s.io/client-go/testing"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/podworks"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
@@ -328,6 +329,8 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	kubelet.podWorkers.(*fakePodWorkers).setPodRuntimeBeRemoved(pod.UID)
 	kubelet.podManager.SetPods([]*v1.Pod{})
 
+	podworks.Observer.Notify(podworks.POD_TERMINATED, pod.UID)
+
 	assert.NoError(t, kubelet.volumeManager.WaitForUnmount(pod))
 	if actual := kubelet.volumeManager.GetMountedVolumesForPod(util.GetUniquePodName(pod)); len(actual) > 0 {
 		t.Fatalf("expected volume unmount to wait for no volumes: %v", actual)
@@ -519,6 +522,7 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 	// Remove pod
 	kubelet.podWorkers.(*fakePodWorkers).setPodRuntimeBeRemoved(pod.UID)
 	kubelet.podManager.SetPods([]*v1.Pod{})
+	podworks.Observer.Notify(podworks.POD_TERMINATED, pod.UID)
 
 	assert.NoError(t, waitForVolumeUnmount(kubelet.volumeManager, pod))
 

--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -93,12 +94,15 @@ func (m *kubeGenericRuntimeManager) toKubeContainer(c *runtimeapi.Container) (*k
 
 	annotatedInfo := getContainerInfoFromAnnotations(c.Annotations)
 	return &kubecontainer.Container{
-		ID:      kubecontainer.ContainerID{Type: m.runtimeName, ID: c.Id},
-		Name:    c.GetMetadata().GetName(),
-		ImageID: c.ImageRef,
-		Image:   c.Image.Image,
-		Hash:    annotatedInfo.Hash,
-		State:   toKubeContainerState(c.State),
+		ID:           kubecontainer.ContainerID{Type: m.runtimeName, ID: c.Id},
+		Name:         c.GetMetadata().GetName(),
+		ImageID:      c.ImageRef,
+		Image:        c.Image.Image,
+		Hash:         annotatedInfo.Hash,
+		State:        toKubeContainerState(c.State),
+		CreatedAt:    time.Unix(0, c.CreatedAt),
+		Labels:       c.Labels,
+		PodSandboxId: c.PodSandboxId,
 	}, nil
 }
 
@@ -112,8 +116,9 @@ func (m *kubeGenericRuntimeManager) sandboxToKubeContainer(s *runtimeapi.PodSand
 	}
 
 	return &kubecontainer.Container{
-		ID:    kubecontainer.ContainerID{Type: m.runtimeName, ID: s.Id},
-		State: kubecontainer.SandboxToContainerState(s.State),
+		ID:        kubecontainer.ContainerID{Type: m.runtimeName, ID: s.Id},
+		State:     kubecontainer.SandboxToContainerState(s.State),
+		CreatedAt: time.Unix(0, s.CreatedAt),
 	}, nil
 }
 

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -19,6 +19,7 @@ package kuberuntime
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -139,11 +140,12 @@ func TestToKubeContainer(t *testing.T) {
 			Type: runtimetesting.FakeRuntimeName,
 			ID:   "test-id",
 		},
-		Name:    "test-name",
-		ImageID: "test-image-ref",
-		Image:   "test-image",
-		Hash:    uint64(0x1234),
-		State:   kubecontainer.ContainerStateRunning,
+		Name:      "test-name",
+		ImageID:   "test-image-ref",
+		Image:     "test-image",
+		Hash:      uint64(0x1234),
+		State:     kubecontainer.ContainerStateRunning,
+		CreatedAt: time.Unix(0, c.CreatedAt),
 	}
 
 	_, _, m, err := createTestRuntimeManager()

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -358,9 +358,11 @@ func (m *kubeGenericRuntimeManager) GetPods(all bool) ([]*kubecontainer.Pod, err
 		podUID := kubetypes.UID(s.Metadata.Uid)
 		if _, ok := pods[podUID]; !ok {
 			pods[podUID] = &kubecontainer.Pod{
-				ID:        podUID,
-				Name:      s.Metadata.Name,
-				Namespace: s.Metadata.Namespace,
+				ID:         podUID,
+				Name:       s.Metadata.Name,
+				Namespace:  s.Metadata.Namespace,
+				Containers: []*kubecontainer.Container{},
+				Sandboxes:  []*kubecontainer.Container{},
 			}
 		}
 		p := pods[podUID]
@@ -1085,6 +1087,10 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(uid kubetypes.UID, name, namesp
 // GarbageCollect removes dead containers using the specified container gc policy.
 func (m *kubeGenericRuntimeManager) GarbageCollect(gcPolicy kubecontainer.GCPolicy, allSourcesReady bool, evictNonDeletedPods bool) error {
 	return m.containerGC.GarbageCollect(gcPolicy, allSourcesReady, evictNonDeletedPods)
+}
+
+func (m *kubeGenericRuntimeManager) DirectGarbageCollect(gcPolicy kubecontainer.GCPolicy, allSourcesReady bool, evictNonDeletedPods bool) error {
+	return m.containerGC.DirectGarbageCollect(gcPolicy, allSourcesReady, evictNonDeletedPods)
 }
 
 // UpdatePodCIDR is just a passthrough method to update the runtimeConfig of the shim

--- a/pkg/kubelet/pleg/pleg.go
+++ b/pkg/kubelet/pleg/pleg.go
@@ -18,6 +18,7 @@ package pleg
 
 import (
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/kubelet/cribuffer"
 )
 
 // PodLifeCycleEventType define the event type of pod life cycle events.
@@ -54,4 +55,5 @@ type PodLifecycleEventGenerator interface {
 	Start()
 	Watch() chan *PodLifecycleEvent
 	Healthy() (bool, error)
+	cribuffer.CriBufferProvider
 }

--- a/pkg/kubelet/pod/testing/mock_manager.go
+++ b/pkg/kubelet/pod/testing/mock_manager.go
@@ -238,6 +238,21 @@ func (mr *MockManagerMockRecorder) GetUIDTranslations() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUIDTranslations", reflect.TypeOf((*MockManager)(nil).GetUIDTranslations))
 }
 
+// GetUIDTranslationsByUID mocks base method.
+func (m *MockManager) GetUIDTranslationsByUID(arg0 types.UID) (map[types0.ResolvedPodUID]types0.MirrorPodUID, map[types0.MirrorPodUID]types0.ResolvedPodUID) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUIDTranslationsByUID", arg0)
+	ret0, _ := ret[0].(map[types0.ResolvedPodUID]types0.MirrorPodUID)
+	ret1, _ := ret[1].(map[types0.MirrorPodUID]types0.ResolvedPodUID)
+	return ret0, ret1
+}
+
+// GetUIDTranslationsByUID indicates an expected call of GetUIDTranslationsByUID.
+func (mr *MockManagerMockRecorder) GetUIDTranslationsByUID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUIDTranslationsByUID", reflect.TypeOf((*MockManager)(nil).GetUIDTranslationsByUID), arg0)
+}
+
 // IsMirrorPodOf mocks base method.
 func (m *MockManager) IsMirrorPodOf(arg0, arg1 *v1.Pod) bool {
 	m.ctrl.T.Helper()

--- a/pkg/kubelet/pod_syncdelay.go
+++ b/pkg/kubelet/pod_syncdelay.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
+	"k8s.io/kubernetes/pkg/kubelet/podworks"
+	"k8s.io/kubernetes/pkg/kubelet/status"
+	"k8s.io/kubernetes/pkg/util/observer"
+	"k8s.io/utils/clock"
+)
+
+const (
+	channelCapacity = 100
+)
+
+type podStatusRecord struct {
+	startTime             metav1.Time
+	activeDeadlineSeconds int64
+}
+
+type podSyncDelay struct {
+	podManager             kubepod.Manager
+	podStatusProvider      status.PodStatusProvider
+	queue                  workqueue.RateLimitingInterface
+	podsStatus             map[types.UID]podStatusRecord
+	fixActiveDeadlineEvent observer.SubjectEvent
+	eventChannel           chan types.UID
+	clock                  clock.WithTicker
+}
+
+type podUID types.UID
+
+func (u podUID) ForceFix() bool {
+	return true
+}
+
+func newPodSyncDelay(podManager kubepod.Manager, podStatusProvider status.PodStatusProvider, clock clock.WithTicker) *podSyncDelay {
+	syncDelay := &podSyncDelay{
+		podManager:        podManager,
+		podStatusProvider: podStatusProvider,
+		clock:             clock,
+		queue:             workqueue.NewRateLimitingQueueWithCustomClock(workqueue.DefaultControllerRateLimiter(), clock),
+		podsStatus:        make(map[types.UID]podStatusRecord),
+		eventChannel:      make(chan types.UID, channelCapacity),
+	}
+
+	syncDelay.fixActiveDeadlineEvent = observer.NewSubjectEvent(syncDelay.handleActiveDeadline, nil)
+	kubepod.Observer.Attach(kubepod.POD_MANAGER_CHANGED, syncDelay.podManagerChangedNotify, syncDelay.handlePodManagerChangedNotify)
+	podworks.Observer.Attach(podworks.POD_SYNC_DELAY, syncDelay.podSyncDelayNotify, syncDelay.handlePodSyncDelay)
+
+	go syncDelay.run()
+	return syncDelay
+}
+
+func (p *podSyncDelay) podManagerChangedNotify(se observer.SubjectEvent) {
+	p.queue.Add(se)
+}
+
+func (p *podSyncDelay) podSyncDelayNotify(se observer.SubjectEvent) {
+	e := se.Event.(podSyncDelayEvent)
+	duration := e.duration
+	e.duration = 0
+	se.Event = e
+
+	p.queue.AddAfter(se, duration)
+}
+
+func (p *podSyncDelay) handlePodSyncDelay(e interface{}) error {
+	event := e.(podSyncDelayEvent)
+	p.eventChannel <- event.poduid
+	return nil
+}
+
+func (p *podSyncDelay) handlePodManagerChangedNotify(e interface{}) error {
+	poduid := e.(types.UID)
+	p.activeDeadline(poduid)
+	return nil
+}
+
+func (p *podSyncDelay) activeDeadline(poduid types.UID) {
+	pod, exists := p.podManager.GetPodByUID(poduid)
+	if !exists {
+		delete(p.podsStatus, poduid)
+		return
+	}
+
+	if pod.Spec.ActiveDeadlineSeconds == nil {
+		return
+	}
+
+	// get the latest status to determine if it was started
+	podStatus, ok := p.podStatusProvider.GetPodStatus(pod.UID)
+	if !ok {
+		podStatus = pod.Status
+	}
+	// we have no start time so just return
+	if podStatus.StartTime.IsZero() {
+		return
+	}
+
+	status, okStatus := p.podsStatus[poduid]
+	if okStatus {
+		if !status.startTime.Equal(podStatus.StartTime) ||
+			status.activeDeadlineSeconds != *pod.Spec.ActiveDeadlineSeconds {
+			p.podsStatus[poduid] = podStatusRecord{
+				startTime:             *podStatus.StartTime,
+				activeDeadlineSeconds: *pod.Spec.ActiveDeadlineSeconds,
+			}
+		}
+	} else {
+		p.podsStatus[poduid] = podStatusRecord{
+			startTime:             *podStatus.StartTime,
+			activeDeadlineSeconds: *pod.Spec.ActiveDeadlineSeconds,
+		}
+	}
+
+	start := podStatus.StartTime.Time
+	duration := p.clock.Since(start)
+	allowedDuration := time.Duration(*pod.Spec.ActiveDeadlineSeconds) * time.Second
+	if duration >= allowedDuration {
+		p.eventChannel <- poduid
+		return
+	} else {
+		allowedDuration = allowedDuration - duration
+	}
+	p.fixActiveDeadlineEvent.Event = podUID(poduid)
+	p.queue.AddAfter(p.fixActiveDeadlineEvent, allowedDuration)
+}
+
+func (p *podSyncDelay) handleActiveDeadline(e interface{}) error {
+	poduid := types.UID(e.(podUID))
+	p.activeDeadline(poduid)
+	return nil
+}
+
+func (p *podSyncDelay) run() {
+	for p.execute() {
+	}
+}
+
+func (p *podSyncDelay) execute() bool {
+	item, quit := p.queue.Get()
+	if quit {
+		return false
+	}
+
+	defer p.queue.Done(item)
+
+	if se, ok := item.(observer.SubjectEvent); ok {
+		se.Handle()
+	}
+
+	return true
+}
+
+func (p *podSyncDelay) watch() chan types.UID {
+	return p.eventChannel
+}

--- a/pkg/kubelet/podworks/observer.go
+++ b/pkg/kubelet/podworks/observer.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podworks
+
+import (
+	"k8s.io/kubernetes/pkg/util/observer"
+)
+
+const (
+	POD_ADDED observer.SubjectEventType = iota
+	POD_TERMINATED
+	POD_FINISHED
+	POD_REMOVED
+	POD_SYNC_DELAY
+)
+
+var Observer = observer.NewObserver()

--- a/pkg/util/goroutinemap/exponentialbackoff/exponential_backoff.go
+++ b/pkg/util/goroutinemap/exponentialbackoff/exponential_backoff.go
@@ -45,6 +45,10 @@ type ExponentialBackoff struct {
 	durationBeforeRetry time.Duration
 }
 
+func (expBackoff *ExponentialBackoff) GetDuration() time.Duration {
+	return expBackoff.durationBeforeRetry
+}
+
 // SafeToRetry returns an error if the durationBeforeRetry period for the given
 // lastErrorTime has not yet expired. Otherwise it returns nil.
 func (expBackoff *ExponentialBackoff) SafeToRetry(operationName string) error {

--- a/pkg/util/mmap/doc.go
+++ b/pkg/util/mmap/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mmap has common methods for multilevel map.
+package mmap

--- a/pkg/util/mmap/mmap1.go
+++ b/pkg/util/mmap/mmap1.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mmap
+
+import (
+	"k8s.io/klog/v2"
+)
+
+type LEVEL int
+
+const (
+	LEVEL_0 LEVEL = iota
+	LEVEL_1
+	LEVEL_2
+	LEVEL_3
+	LEVEL_MAX
+)
+
+type VisitItemFunc func(v interface{}, k ...interface{}) (LEVEL, error)
+
+type AcceptValueFunc func(v interface{})
+
+type Mmaper interface {
+	GetLeafValues(f AcceptValueFunc, k ...interface{}) []interface{}
+	GetNextLevelKeys(k ...interface{}) []interface{}
+	GetLevelKeyNum(level LEVEL) int
+	Iterate(level LEVEL, f VisitItemFunc, k ...interface{}) error
+	Insert(v interface{}, k ...interface{}) bool
+	Delete(k ...interface{}) bool
+	Exist(k ...interface{}) bool
+	Num(k ...interface{}) int
+
+	getAll(f AcceptValueFunc) []interface{}
+	inner_iterate(level LEVEL, f VisitItemFunc, kbase ...interface{}) (LEVEL, error)
+}
+
+type Mmap1 struct {
+	m1 map[interface{}]interface{}
+}
+
+func NewMmap1() Mmaper {
+	return &Mmap1{make(map[interface{}]interface{})}
+}
+
+func (m *Mmap1) GetLeafValues(f AcceptValueFunc, k ...interface{}) []interface{} {
+	keynum := len(k)
+	if keynum > 1 {
+		klog.InfoS("Mmap1 GetLeafValues keynum should le 1", "keynum", keynum)
+		return []interface{}{}
+	}
+
+	locGet := false
+	if keynum == 0 {
+		locGet = true
+	}
+
+	if locGet {
+		return m.getAll(f)
+	}
+
+	if v, ok := m.m1[k[0]]; ok {
+		if f != nil {
+			f(v)
+		} else {
+			return []interface{}{v}
+		}
+	}
+
+	return []interface{}{}
+}
+
+func (m *Mmap1) GetNextLevelKeys(k ...interface{}) []interface{} {
+	keynum := len(k)
+	if keynum != 0 {
+		klog.InfoS("Mmap1 GetNextLevelKeys keynum should be 0", "keynum", keynum)
+		return []interface{}{}
+	}
+
+	rslt := make([]interface{}, 0, len(m.m1))
+	for k := range m.m1 {
+		rslt = append(rslt, k)
+	}
+	return rslt
+}
+
+func (m *Mmap1) GetLevelKeyNum(level LEVEL) int {
+	if level != LEVEL_1 {
+		klog.InfoS("Mmap1 GetLevelKeyNum level should eq LEVEL_1")
+		return 0
+	}
+
+	return len(m.m1)
+}
+
+func (m *Mmap1) Iterate(level LEVEL, f VisitItemFunc, k ...interface{}) error {
+	keynum := len(k)
+	if keynum > 1 {
+		klog.InfoS("Mmap1 Iterate keynum should le 1", "keynum", keynum)
+		return nil
+	}
+
+	if level != LEVEL_1 {
+		klog.InfoS("Mmap1 Iterate level should eq 1", "level", level)
+		return nil
+	}
+
+	locIterate := false
+	if keynum == 0 {
+		locIterate = true
+	}
+
+	if locIterate {
+		level, err := m.inner_iterate(level, f)
+		if level > LEVEL_1 {
+			return err
+		}
+		return nil
+	}
+
+	if v, ok := m.m1[k[0]]; ok {
+		continueLevel, err := f(v)
+		if continueLevel > LEVEL_1 {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Mmap1) inner_iterate(level LEVEL, f VisitItemFunc, kbase ...interface{}) (LEVEL, error) {
+	for k, v := range m.m1 {
+		keys := append(kbase, k)
+		continueLevel, err := f(v, keys...)
+
+		if continueLevel > LEVEL_1 {
+			return continueLevel, err
+		}
+	}
+
+	return LEVEL_0, nil
+}
+
+func (m *Mmap1) getAll(f AcceptValueFunc) []interface{} {
+	rslt := []interface{}{}
+	for _, v := range m.m1 {
+		if f != nil {
+			f(v)
+		} else {
+			rslt = append(rslt, v)
+		}
+	}
+
+	return rslt
+}
+
+func (m *Mmap1) Insert(v interface{}, k ...interface{}) bool {
+	if len(k) != 1 {
+		klog.InfoS("Mmap1 Insert keynum should be 1", "keynum", len(k))
+		return false
+	}
+
+	m.m1[k[0]] = v
+	return true
+}
+
+func (m *Mmap1) Delete(k ...interface{}) bool {
+	if len(k) != 1 {
+		klog.InfoS("Mmap1 Delete keynum should be 1", "keynum", len(k))
+		return false
+	}
+
+	delete(m.m1, k[0])
+
+	return true
+}
+
+func (m *Mmap1) Exist(k ...interface{}) bool {
+	if len(k) != 1 {
+		klog.InfoS("Mmap1 Exist keynum should be 1", "keynum", len(k))
+		return false
+	}
+
+	_, ok := m.m1[k[0]]
+
+	return ok
+}
+
+func (m *Mmap1) Num(k ...interface{}) int {
+	keynum := len(k)
+	if keynum != 0 {
+		klog.InfoS("Mmap1 Num keynum should be 0", "keynum", keynum)
+		return 0
+	}
+
+	return len(m.m1)
+}

--- a/pkg/util/mmap/mmap2.go
+++ b/pkg/util/mmap/mmap2.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mmap
+
+import (
+	"k8s.io/klog/v2"
+)
+
+type Mmap2 struct {
+	m2  map[interface{}]Mmaper
+	num int // leaf num
+}
+
+func NewMmap2() Mmaper {
+	return &Mmap2{
+		m2:  make(map[interface{}]Mmaper),
+		num: 0,
+	}
+}
+
+func (m *Mmap2) GetLeafValues(f AcceptValueFunc, k ...interface{}) []interface{} {
+	keynum := len(k)
+	if keynum > 2 {
+		klog.InfoS("Mmap2 GetLeafValues keynum should le 2", "keynum", keynum)
+		return []interface{}{}
+	}
+
+	locGet := false
+	if keynum == 0 {
+		locGet = true
+	}
+
+	if locGet {
+		return m.getAll(f)
+	}
+
+	lockey, keys := k[0], k[1:]
+	if m1, ok := m.m2[lockey]; ok {
+		return m1.GetLeafValues(f, keys...)
+	}
+
+	return []interface{}{}
+}
+
+func (m *Mmap2) GetNextLevelKeys(k ...interface{}) []interface{} {
+	keynum := len(k)
+	if keynum > 1 {
+		klog.InfoS("Mmap2 GetNextLevelKeys keynum should le 1", "keynum", keynum)
+		return []interface{}{}
+	}
+
+	locGet := false
+	if keynum == 0 {
+		locGet = true
+	}
+
+	if locGet {
+		rslt := make([]interface{}, 0, len(m.m2))
+		for k := range m.m2 {
+			rslt = append(rslt, k)
+		}
+		return rslt
+	}
+
+	lockey, keys := k[0], k[1:]
+	if m1, ok := m.m2[lockey]; ok {
+		return m1.GetNextLevelKeys(keys...)
+	}
+
+	return []interface{}{}
+}
+
+func (m *Mmap2) GetLevelKeyNum(level LEVEL) int {
+	if level > LEVEL_2 || level == LEVEL_0 {
+		klog.InfoS("Mmap2 GetLevelKeyNum level should le LEVEL_2")
+		return 0
+	}
+
+	locGet := false
+	if level == LEVEL_2 {
+		locGet = true
+	}
+
+	if locGet {
+		return len(m.m2)
+	}
+
+	rslt := 0
+	for _, m1 := range m.m2 {
+		rslt = rslt + m1.GetLevelKeyNum(level)
+	}
+	return rslt
+}
+
+func (m *Mmap2) Iterate(level LEVEL, f VisitItemFunc, k ...interface{}) error {
+	keynum := len(k)
+	if keynum > 2 {
+		klog.InfoS("Mmap2 Iterate keynum should le 2", "keynum", keynum)
+		return nil
+	}
+
+	if level > LEVEL_2 || level == LEVEL_0 {
+		klog.InfoS("Mmap2 Iterate level should le LEVEL_2")
+		return nil
+	}
+
+	locIterate := false
+	if keynum == 0 {
+		locIterate = true
+	}
+
+	if locIterate {
+		level, err := m.inner_iterate(level, f)
+		if level > LEVEL_2 {
+			return err
+		}
+		return nil
+	}
+
+	lockey, keys := k[0], k[1:]
+	if m1, ok := m.m2[lockey]; ok {
+		return m1.Iterate(level, f, keys...)
+	}
+
+	return nil
+}
+
+func (m *Mmap2) inner_iterate(level LEVEL, f VisitItemFunc, kbase ...interface{}) (LEVEL, error) {
+	locGet := false
+	if level == LEVEL_2 {
+		locGet = true
+	}
+
+	for k, m1 := range m.m2 {
+		keys := append(kbase, k)
+		var err error
+		var continueLevel LEVEL
+		if locGet {
+			continueLevel, err = f(m1, keys...)
+		} else {
+			continueLevel, err = m1.inner_iterate(level, f, keys...)
+		}
+
+		if continueLevel > LEVEL_2 {
+			return continueLevel, err
+		}
+	}
+
+	return LEVEL_0, nil
+}
+
+func (m *Mmap2) getAll(f AcceptValueFunc) []interface{} {
+	rslt := []interface{}{}
+	for _, m1 := range m.m2 {
+		vlist := m1.getAll(f)
+		if f == nil {
+			rslt = append(rslt, vlist...)
+		}
+	}
+
+	return rslt
+}
+
+func (m *Mmap2) Insert(v interface{}, k ...interface{}) bool {
+	keynum := len(k)
+	if keynum > 2 || keynum < 1 {
+		klog.InfoS("Mmap2 Insert keynum should le 2 and ge 1", "keynum", keynum)
+		return false
+	}
+
+	locInsert := false
+
+	if keynum == 1 { //1个参数时,v必须是*Mmap1,一个以上参数交给下级map检验
+		if !func(v interface{}) bool {
+			if _, ok := v.(*Mmap1); !ok {
+				return false
+			}
+			return true
+		}(v) {
+			klog.InfoS("Mmap2 Insert value must be *Mmap1, when has 1 arg")
+			return false
+		}
+
+		locInsert = true //本级操作
+	}
+
+	opok := false
+	lockey, keys := k[0], k[1:]
+	if m1, ok := m.m2[lockey]; ok {
+		m.num = m.num - m1.Num()
+		if locInsert {
+			m.m2[lockey] = v.(*Mmap1)
+			opok = true
+		} else {
+			opok = m1.Insert(v, keys...)
+		}
+		m.num = m.num + m.m2[lockey].Num()
+	} else {
+		if locInsert {
+			m.m2[lockey] = v.(*Mmap1)
+			opok = true
+		} else {
+			m1 := NewMmap1()
+			opok = m1.Insert(v, keys...)
+			m.m2[lockey] = m1
+		}
+		m.num = m.num + m.m2[lockey].Num()
+	}
+
+	return opok
+}
+
+func (m *Mmap2) Delete(k ...interface{}) bool {
+	keynum := len(k)
+	if keynum > 2 || keynum < 1 {
+		klog.InfoS("Mmap2 Delete keynum should le 2 and ge 1", "keynum", keynum)
+		return false
+	}
+
+	locDelete := false
+	if keynum == 1 {
+		locDelete = true
+	}
+
+	opok := true
+	lockey, keys := k[0], k[1:]
+	if m1, ok := m.m2[lockey]; ok {
+		m.num = m.num - m1.Num()
+		if locDelete {
+			delete(m.m2, lockey)
+			return true
+		}
+
+		opok = m1.Delete(keys...)
+		if m1.Num() == 0 {
+			delete(m.m2, lockey)
+		}
+		m.num = m.num + m1.Num()
+	}
+
+	return opok
+}
+
+func (m *Mmap2) Exist(k ...interface{}) bool {
+	keynum := len(k)
+	if keynum > 2 || keynum < 1 {
+		klog.InfoS("Mmap2 Exist keynum should le 2 and ge 1", "keynum", keynum)
+		return false
+	}
+
+	locExist := false
+	if keynum == 1 {
+		locExist = true
+	}
+
+	lockey, keys := k[0], k[1:]
+	if m1, ok := m.m2[lockey]; ok {
+		if locExist {
+			return ok
+		}
+		return m1.Exist(keys...)
+	}
+
+	return false
+}
+
+func (m *Mmap2) Num(k ...interface{}) int {
+	keynum := len(k)
+	if keynum > 1 {
+		klog.InfoS("Mmap2 Num keynum should le 1", "keynum", keynum)
+		return 0
+	}
+
+	locGet := false
+	if keynum == 0 {
+		locGet = true
+	}
+
+	if locGet {
+		return m.num
+	}
+
+	lockey, keys := k[0], k[1:]
+	if m1, ok := m.m2[lockey]; ok {
+		return m1.Num(keys...)
+	}
+
+	return 0
+}

--- a/pkg/util/mmap/mmap3.go
+++ b/pkg/util/mmap/mmap3.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mmap
+
+import (
+	"k8s.io/klog/v2"
+)
+
+type Mmap3 struct {
+	m3  map[interface{}]Mmaper
+	num int // leaf num
+}
+
+func NewMmap3() Mmaper {
+	return &Mmap3{
+		m3:  make(map[interface{}]Mmaper),
+		num: 0,
+	}
+}
+
+func (m *Mmap3) GetLeafValues(f AcceptValueFunc, k ...interface{}) []interface{} {
+	keynum := len(k)
+	if keynum > 3 {
+		klog.InfoS("Mmap3 GetLeafValues keynum should le 3", "keynum", keynum)
+		return []interface{}{}
+	}
+
+	locGet := false
+	if keynum == 0 {
+		locGet = true
+	}
+
+	if locGet {
+		return m.getAll(f)
+	}
+
+	lockey, keys := k[0], k[1:]
+	if m2, ok := m.m3[lockey]; ok {
+		return m2.GetLeafValues(f, keys...)
+	}
+
+	return []interface{}{}
+}
+
+func (m *Mmap3) GetNextLevelKeys(k ...interface{}) []interface{} {
+	keynum := len(k)
+	if keynum > 2 {
+		klog.InfoS("Mmap3 GetNextLevelKeys keynum should le 2", "keynum", keynum)
+		return []interface{}{}
+	}
+
+	locGet := false
+	if keynum == 0 {
+		locGet = true
+	}
+
+	if locGet {
+		rslt := make([]interface{}, 0, len(m.m3))
+		for k := range m.m3 {
+			rslt = append(rslt, k)
+		}
+		return rslt
+	}
+
+	lockey, keys := k[0], k[1:]
+	if m2, ok := m.m3[lockey]; ok {
+		return m2.GetNextLevelKeys(keys...)
+	}
+
+	return []interface{}{}
+}
+
+func (m *Mmap3) GetLevelKeyNum(level LEVEL) int {
+	if level > LEVEL_3 || level == LEVEL_0 {
+		klog.InfoS("Mmap3 GetLevelKeyNum level should le LEVEL_3 and not LEVEL_0")
+		return 0
+	}
+
+	locGet := false
+	if level == LEVEL_3 {
+		locGet = true
+	}
+
+	if locGet {
+		return len(m.m3)
+	}
+
+	rslt := 0
+	for _, m2 := range m.m3 {
+		rslt = rslt + m2.GetLevelKeyNum(level)
+	}
+	return rslt
+}
+
+func (m *Mmap3) Iterate(level LEVEL, f VisitItemFunc, k ...interface{}) error {
+	keynum := len(k)
+	if keynum > 3 {
+		klog.InfoS("Mmap3 Iterate keynum should le 3", "keynum", keynum)
+		return nil
+	}
+
+	if level > LEVEL_3 || level == LEVEL_0 {
+		klog.InfoS("Mmap3 Iterate level should le LEVEL_3 and not LEVEL_0")
+		return nil
+	}
+
+	locIterate := false
+	if keynum == 0 {
+		locIterate = true
+	}
+
+	if locIterate {
+		level, err := m.inner_iterate(level, f)
+		if level > LEVEL_3 {
+			return err
+		}
+		return nil
+	}
+
+	lockey, keys := k[0], k[1:]
+	if m2, ok := m.m3[lockey]; ok {
+		return m2.Iterate(level, f, keys...)
+	}
+
+	return nil
+}
+
+func (m *Mmap3) inner_iterate(level LEVEL, f VisitItemFunc, kbase ...interface{}) (LEVEL, error) {
+	locGet := false
+	if level == LEVEL_3 {
+		locGet = true
+	}
+
+	for k, m2 := range m.m3 {
+		keys := append(kbase, k)
+		var err error
+		var continueLevel LEVEL
+		if locGet {
+			continueLevel, err = f(m2, keys...)
+		} else {
+			continueLevel, err = m2.inner_iterate(level, f, keys...)
+		}
+
+		if continueLevel > LEVEL_3 {
+			return continueLevel, err
+		}
+	}
+
+	return LEVEL_0, nil
+}
+
+func (m *Mmap3) getAll(f AcceptValueFunc) []interface{} {
+	rslt := []interface{}{}
+	for _, m2 := range m.m3 {
+		vlist := m2.getAll(f)
+		if f == nil {
+			rslt = append(rslt, vlist...)
+		}
+	}
+
+	return rslt
+}
+
+func (m *Mmap3) Insert(v interface{}, k ...interface{}) bool {
+	keynum := len(k)
+	if keynum > 3 || keynum < 1 {
+		klog.InfoS("Mmap3 Insert keynum should le 3 and ge 1", "keynum", keynum)
+		return false
+	}
+
+	locInsert := false
+
+	if keynum == 1 { //1个参数时,v必须是*Mmap2,一个以上参数交给下级map检验
+		if !func(v interface{}) bool {
+			if _, ok := v.(*Mmap2); !ok {
+				return false
+			}
+			return true
+		}(v) {
+			klog.InfoS("Mmap3 Insert value must be *Mmap2, when has 1 arg")
+			return false
+		}
+
+		locInsert = true //本级操作
+	}
+
+	opok := false
+	lockey, keys := k[0], k[1:]
+	if m2, ok := m.m3[lockey]; ok {
+		m.num = m.num - m2.Num()
+		if locInsert {
+			m.m3[lockey] = v.(*Mmap2)
+			opok = true
+		} else {
+			opok = m2.Insert(v, keys...)
+		}
+		m.num = m.num + m.m3[lockey].Num()
+	} else {
+		if locInsert {
+			m.m3[lockey] = v.(*Mmap2)
+			opok = true
+		} else {
+			m2 := NewMmap2()
+			opok = m2.Insert(v, keys...)
+			m.m3[lockey] = m2
+		}
+		m.num = m.num + m.m3[lockey].Num()
+	}
+
+	return opok
+}
+
+func (m *Mmap3) Delete(k ...interface{}) bool {
+	keynum := len(k)
+	if keynum > 3 || keynum < 1 {
+		klog.InfoS("Mmap3 Delete keynum should le 3 and ge 1", "keynum", keynum)
+		return false
+	}
+
+	locDelete := false
+	if keynum == 1 {
+		locDelete = true
+	}
+
+	opok := true
+	lockey, keys := k[0], k[1:]
+	if m2, ok := m.m3[lockey]; ok {
+		m.num = m.num - m2.Num()
+		if locDelete {
+			delete(m.m3, lockey)
+			return true
+		}
+
+		opok = m2.Delete(keys...)
+		if m2.Num() == 0 {
+			delete(m.m3, lockey)
+		}
+		m.num = m.num + m2.Num()
+	}
+
+	return opok
+}
+
+func (m *Mmap3) Exist(k ...interface{}) bool {
+	keynum := len(k)
+	if keynum > 3 || keynum < 1 {
+		klog.InfoS("Mmap3 Exist keynum should le 3 and ge 1", "keynum", keynum)
+		return false
+	}
+
+	locExist := false
+	if keynum == 1 {
+		locExist = true
+	}
+
+	lockey, keys := k[0], k[1:]
+	if m2, ok := m.m3[lockey]; ok {
+		if locExist {
+			return ok
+		}
+		return m2.Exist(keys...)
+	}
+
+	return false
+}
+
+func (m *Mmap3) Num(k ...interface{}) int {
+	keynum := len(k)
+	if keynum > 2 {
+		klog.InfoS("Mmap3 Num keynum should le 2", "keynum", keynum)
+		return 0
+	}
+
+	locGet := false
+	if keynum == 0 {
+		locGet = true
+	}
+
+	if locGet {
+		return m.num
+	}
+
+	lockey, keys := k[0], k[1:]
+	if m2, ok := m.m3[lockey]; ok {
+		return m2.Num(keys...)
+	}
+
+	return 0
+}

--- a/pkg/util/mmap/mmap_test.go
+++ b/pkg/util/mmap/mmap_test.go
@@ -1,0 +1,318 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mmap
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMmap3(t *testing.T) {
+	m3 := NewMmap3()
+	m3.Insert("a", "1", "1.1", "1.1.1")
+	m3.Insert("b", "1", "1.1", "1.1.2")
+	m3.Insert("c", "1", "1.2", "1.2.1")
+	m3.Insert("d", "1", "1.2", "1.2.2")
+	m3.Insert("e", "2", "2.1", "2.1.1")
+	m3.Insert("f", "2", "2.1", "2.1.2")
+	m3.Insert("g", "2", "2.2", "2.2.1")
+	m3.Insert("h", "2", "2.2", "2.2.2")
+
+	if m3.Num() != 8 {
+		t.Errorf("m3.Num %v not accepted", m3.Num())
+	}
+
+	if !m3.Exist("1") {
+		t.Errorf("%#v not accepted", m3.Exist("1"))
+	}
+	if !m3.Exist("1", "1.1") {
+		t.Errorf("%#v not accepted", m3.Exist("1", "1.1"))
+	}
+	if !m3.Exist("2", "2.1", "2.1.2") {
+		t.Errorf("%#v not accepted", m3.Exist("2", "2.1", "2.1.2"))
+	}
+	if m3.Exist("2", "2.1", "2.1") {
+		t.Errorf("%#v not accepted", m3.Exist("2", "2.1", "2.1"))
+	}
+
+	if 2 != m3.GetLevelKeyNum(LEVEL_3) {
+		t.Errorf("%#v not accepted", m3.GetLevelKeyNum(LEVEL_3))
+	}
+	if 4 != m3.GetLevelKeyNum(LEVEL_2) {
+		t.Errorf("%#v not accepted", m3.GetLevelKeyNum(LEVEL_2))
+	}
+	if 8 != m3.GetLevelKeyNum(LEVEL_1) {
+		t.Errorf("%#v not accepted", m3.GetLevelKeyNum(LEVEL_1))
+	}
+	if 0 != m3.GetLevelKeyNum(LEVEL_0) {
+		t.Errorf("%#v not accepted", m3.GetLevelKeyNum(LEVEL_0))
+	}
+	if 0 != m3.GetLevelKeyNum(LEVEL(4)) {
+		t.Errorf("%#v not accepted", m3.GetLevelKeyNum(LEVEL(4)))
+	}
+
+	if !sliceEqual([]interface{}{"1", "2"}, m3.GetNextLevelKeys()) {
+		t.Errorf("%#v not accepted", m3.GetNextLevelKeys())
+	}
+
+	if !sliceEqual([]interface{}{"1.1", "1.2"}, m3.GetNextLevelKeys("1")) {
+		t.Errorf("%#v not accepted", m3.GetNextLevelKeys())
+	}
+
+	if !sliceEqual([]interface{}{"1.1.1", "1.1.2"}, m3.GetNextLevelKeys("1", "1.1")) {
+		t.Errorf("%#v not accepted", m3.GetNextLevelKeys())
+	}
+
+	if !sliceEqual([]interface{}{}, m3.GetNextLevelKeys("1", "1.1", "1.1.1")) {
+		t.Errorf("%#v not accepted", m3.GetNextLevelKeys())
+	}
+
+	var iterkeys []interface{}
+	f := func(v interface{}, k ...interface{}) (LEVEL, error) {
+		iterkeys = append(iterkeys, k[len(k)-1])
+		return LEVEL_0, nil
+	}
+
+	m3.Iterate(LEVEL_3, f)
+	if !sliceEqual([]interface{}{"1", "2"}, iterkeys) {
+		t.Errorf("%#v not accepted", iterkeys)
+	}
+
+	iterkeys = []interface{}{}
+	m3.Iterate(LEVEL_2, f)
+	if !sliceEqual([]interface{}{"1.1", "1.2", "2.1", "2.2"}, iterkeys) {
+		t.Errorf("%#v not accepted", iterkeys)
+	}
+
+	iterkeys = []interface{}{}
+	m3.Iterate(LEVEL_1, f)
+	if !sliceEqual([]interface{}{"1.1.1", "1.1.2", "1.2.1", "1.2.2", "2.1.1", "2.1.2", "2.2.1", "2.2.2"}, iterkeys) {
+		t.Errorf("%#v not accepted", iterkeys)
+	}
+
+	f1 := func(v interface{}, k ...interface{}) (LEVEL, error) {
+		str := k[0].(string)
+		if str == "1" {
+			return LEVEL_3, nil
+		}
+		iterkeys = append(iterkeys, k[len(k)-1])
+		return LEVEL_0, nil
+	}
+
+	iterkeys = []interface{}{}
+	if m3.Iterate(LEVEL_2, f1) != nil {
+		t.Errorf("%#v not accepted", m3.Iterate(LEVEL_2, f1))
+	}
+	if !sliceEqual([]interface{}{"2.1", "2.2"}, iterkeys) {
+		t.Errorf("%#v not accepted", iterkeys)
+	}
+
+	f2 := func(v interface{}, k ...interface{}) (LEVEL, error) {
+		str := k[0].(string)
+		if str == "1" {
+			return LEVEL_MAX, fmt.Errorf("f2 throw err")
+		}
+		iterkeys = append(iterkeys, k[len(k)-1])
+		return LEVEL_0, nil
+	}
+
+	iterkeys = []interface{}{}
+	if m3.Iterate(LEVEL_2, f2) == nil {
+		t.Errorf("nil not accepted")
+	}
+
+	f3 := func(v interface{}, k ...interface{}) (LEVEL, error) {
+		iterkeys = append(iterkeys, v)
+		return LEVEL_0, nil
+	}
+
+	iterkeys = []interface{}{}
+	if m3.Iterate(LEVEL_1, f3, "1") != nil {
+		t.Errorf("err %#v not accepted", m3.Iterate(LEVEL_1, f3, "1"))
+	}
+
+	if !sliceEqual([]interface{}{"a", "b", "c", "d"}, iterkeys) {
+		t.Errorf("%#v not accepted", iterkeys)
+	}
+
+	iterkeys = []interface{}{}
+	if m3.Iterate(LEVEL_1, f3, "1", "1.1") != nil {
+		t.Errorf("err %#v not accepted", m3.Iterate(LEVEL_1, f3, "1"))
+	}
+
+	if !sliceEqual([]interface{}{"a", "b"}, iterkeys) {
+		t.Errorf("%#v not accepted", iterkeys)
+	}
+
+	iterkeys = []interface{}{}
+	if m3.Iterate(LEVEL_1, f3, "1", "1.1", "1.1.1") != nil {
+		t.Errorf("err %#v not accepted", m3.Iterate(LEVEL_1, f3, "1"))
+	}
+
+	if !sliceEqual([]interface{}{"a"}, iterkeys) {
+		t.Errorf("%#v not accepted", iterkeys)
+	}
+
+	if m3.Iterate(LEVEL_1, f3, "1", "1.1", "1.1.3") != nil {
+		t.Errorf("err %#v not accepted", m3.Iterate(LEVEL_1, f3, "1"))
+	}
+
+	if m3.Iterate(LEVEL_1, f3, "1", "1.3") != nil {
+		t.Errorf("err %#v not accepted", m3.Iterate(LEVEL_1, f3, "1"))
+	}
+
+	if m3.Iterate(LEVEL_1, f3, "3") != nil {
+		t.Errorf("err %#v not accepted", m3.Iterate(LEVEL_1, f3, "1"))
+	}
+
+	if !sliceEqual([]interface{}{}, m3.GetLeafValues(nil, "1", "1.1", "1.1.1", "1.1.1.1")) {
+		t.Errorf("%#v not accepted", m3.GetLeafValues(nil, "1", "1.1", "1.1.1", "1.1.1.1"))
+	}
+
+	if !sliceEqual([]interface{}{"a"}, m3.GetLeafValues(nil, "1", "1.1", "1.1.1")) {
+		t.Errorf("%#v not accepted", m3.GetLeafValues(nil, "1", "1.1", "1.1.1"))
+	}
+
+	if !sliceEqual([]interface{}{"e", "f"}, m3.GetLeafValues(nil, "2", "2.1")) {
+		t.Errorf("%#v not accepted", m3.GetLeafValues(nil, "2", "2.1"))
+	}
+
+	if !sliceEqual([]interface{}{"a", "b", "c", "d"}, m3.GetLeafValues(nil, "1")) {
+		t.Errorf("%#v not accepted", m3.GetLeafValues(nil, "1"))
+	}
+
+	if !sliceEqual([]interface{}{"a", "b", "c", "d", "e", "f", "g", "h"}, m3.GetLeafValues(nil)) {
+		t.Errorf("%#v not accepted", m3.GetLeafValues(nil))
+	}
+
+	valueList := []string{}
+	valueFunc := func(v interface{}) {
+		valueList = append(valueList, v.(string))
+	}
+
+	if !sliceEqual([]interface{}{}, m3.GetLeafValues(valueFunc, "1")) {
+		t.Errorf("%#v not accepted", m3.GetLeafValues(valueFunc, "1"))
+	}
+	if !strSliceEqual([]string{"a", "b", "c", "d"}, valueList) {
+		t.Errorf("%#v not accepted", valueList)
+	}
+
+	//测试插入下级
+	m2 := NewMmap2()
+	m2.Insert("j", "3.1", "3.1.1")
+	m2.Insert("k", "3.1", "3.1.2")
+	m3.Insert(m2, "3")
+	if !sliceEqual([]interface{}{"j", "k"}, m3.GetLeafValues(nil, "3")) {
+		t.Errorf("%#v not accepted", m3.GetLeafValues(nil, "3"))
+	}
+
+	//测试插入下级,覆盖
+	m2_1 := NewMmap2()
+	m2_1.Insert("l", "3.2", "3.2.1")
+	m2_1.Insert("m", "3.2", "3.2.2")
+	m3.Insert(m2_1, "3")
+	if !sliceEqual([]interface{}{"l", "m"}, m3.GetLeafValues(nil, "3")) {
+		t.Errorf("%#v not accepted", m3.GetLeafValues(nil, "3"))
+	}
+
+	//测试插入下级,失败
+	m1 := NewMmap1()
+	if m3.Insert(m1, "4") {
+		t.Errorf("Mmap3 not insert Mmap1")
+	}
+
+	//测试删除下级
+	if !m3.Delete("3", "3.2", "3.2.3") {
+		t.Errorf("delete not exist,should true")
+	}
+	if !sliceEqual([]interface{}{"l", "m"}, m3.GetLeafValues(nil, "3")) {
+		t.Errorf("%#v not accepted", m3.GetLeafValues(nil, "3"))
+	}
+	if !m3.Delete("3", "3.2", "3.2.1") {
+		t.Errorf("delete exist,should true")
+	}
+	if !sliceEqual([]interface{}{"m"}, m3.GetLeafValues(nil, "3")) {
+		t.Errorf("%#v not accepted", m3.GetLeafValues(nil, "3"))
+	}
+	if !m3.Delete("3", "3.2") {
+		t.Errorf("delete exist,should true")
+	}
+	if !sliceEqual([]interface{}{}, m3.GetLeafValues(nil, "3")) {
+		t.Errorf("%#v not accepted", m3.GetLeafValues(nil, "3"))
+	}
+
+}
+
+func sliceEqual(s1, s2 []interface{}) bool {
+	for _, a := range s1 {
+		bfind := false
+		for _, b := range s2 {
+			if a == b {
+				bfind = true
+				break
+			}
+		}
+		if !bfind {
+			return false
+		}
+	}
+
+	for _, a := range s2 {
+		bfind := false
+		for _, b := range s1 {
+			if a == b {
+				bfind = true
+				break
+			}
+		}
+		if !bfind {
+			return false
+		}
+	}
+
+	return true
+}
+
+func strSliceEqual(s1, s2 []string) bool {
+	for _, a := range s1 {
+		bfind := false
+		for _, b := range s2 {
+			if a == b {
+				bfind = true
+				break
+			}
+		}
+		if !bfind {
+			return false
+		}
+	}
+
+	for _, a := range s2 {
+		bfind := false
+		for _, b := range s1 {
+			if a == b {
+				bfind = true
+				break
+			}
+		}
+		if !bfind {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/util/observer/doc.go
+++ b/pkg/util/observer/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package observer has common methods for event driven observer mode.
+package observer

--- a/pkg/util/observer/observer.go
+++ b/pkg/util/observer/observer.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package observer
+
+type SubjectEventType int
+type Notifier func(se SubjectEvent)
+type Handler func(enent interface{}) error
+
+type forceFixer interface {
+	ForceFix() bool
+}
+
+type CallBack struct {
+	Handler Handler
+}
+
+type SubjectEvent struct {
+	Cb    *CallBack //SubjectEvent需要可hash,func()不可hash
+	Event interface{}
+}
+
+func (s SubjectEvent) Handle() error {
+	return s.Cb.Handler(s.Event)
+}
+
+func (s SubjectEvent) ForceFix() bool {
+	if force, ok := s.Event.(forceFixer); ok {
+		return force.ForceFix()
+	}
+	return false
+}
+
+func NewSubjectEvent(h Handler, e interface{}) SubjectEvent {
+	return SubjectEvent{
+		Cb:    &CallBack{h},
+		Event: e,
+	}
+}
+
+type Observer interface {
+	Attach(SubjectEventType, Notifier, Handler)
+	AttachSubjectEvent(SubjectEventType, Notifier, SubjectEvent)
+	Notify(se SubjectEventType, enent interface{})
+}
+
+func NewObserver() Observer {
+	return &Registry{
+		observers: make(map[SubjectEventType][]RegistInfo),
+	}
+}
+
+type Registry struct {
+	observers map[SubjectEventType][]RegistInfo
+}
+
+func (r *Registry) Attach(et SubjectEventType, n Notifier, h Handler) {
+	r.observers[et] = append(r.observers[et],
+		RegistInfo{
+			se:       SubjectEvent{Cb: &CallBack{h}, Event: nil},
+			notifier: n,
+		})
+}
+
+func (r *Registry) AttachSubjectEvent(et SubjectEventType, n Notifier, se SubjectEvent) {
+	r.observers[et] = append(r.observers[et],
+		RegistInfo{
+			se:       se,
+			notifier: n,
+		})
+}
+
+func (r *Registry) Notify(et SubjectEventType, enent interface{}) {
+	if infos, ok := r.observers[et]; ok {
+		for _, o := range infos {
+			o.se.Event = enent
+			o.notifier(o.se)
+		}
+	}
+}
+
+type RegistInfo struct {
+	se       SubjectEvent
+	notifier Notifier
+}

--- a/pkg/volume/util/types/types.go
+++ b/pkg/volume/util/types/types.go
@@ -19,6 +19,7 @@ package types
 
 import (
 	"errors"
+	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -30,6 +31,8 @@ type UniquePodName types.UID
 
 // UniquePVCName defines the type to key pvc off
 type UniquePVCName types.UID
+
+type PodChangedFunc func(types.UID, time.Duration)
 
 // GeneratedOperations contains the operation that is created as well as
 // supporting functions required for the operation executor

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -269,7 +269,12 @@ func insert(q *waitForPriorityQueue, knownEntries map[t]*waitFor, entry *waitFor
 	// if the entry already exists, update the time only if it would cause the item to be queued sooner
 	existing, exists := knownEntries[entry.data]
 	if exists {
-		if existing.readyAt.After(entry.readyAt) {
+		isForceFix := false
+		if force, ok := entry.data.(forceFixer); ok {
+			isForceFix = force.ForceFix()
+		}
+
+		if isForceFix || existing.readyAt.After(entry.readyAt) {
 			existing.readyAt = entry.readyAt
 			heap.Fix(q, existing.index)
 		}
@@ -279,4 +284,8 @@ func insert(q *waitForPriorityQueue, knownEntries map[t]*waitFor, entry *waitFor
 
 	heap.Push(q, entry)
 	knownEntries[entry.data] = entry
+}
+
+type forceFixer interface {
+	ForceFix() bool
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/fake_delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/fake_delaying_queue.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"k8s.io/utils/clock"
+	"time"
+)
+
+type fake_delayingType struct {
+	*delayingType
+}
+
+func newFakeDelayingQueue(clock clock.WithTicker, q Interface, name string) *fake_delayingType {
+	return &fake_delayingType{
+		delayingType: newDelayingQueue(clock, q, name),
+	}
+}
+
+func NewFakeDelayingQueue() DelayingInterface {
+	return NewFakeDelayingQueueWithCustomClock(clock.RealClock{}, "")
+}
+
+func NewNamedFakeDelayingQueue(name string) DelayingInterface {
+	return NewFakeDelayingQueueWithCustomClock(clock.RealClock{}, name)
+}
+
+// NewDelayingQueueWithCustomClock constructs a new named workqueue
+// with ability to inject real or fake clock for testing purposes
+func NewFakeDelayingQueueWithCustomClock(clock clock.WithTicker, name string) DelayingInterface {
+	return newFakeDelayingQueue(clock, NewNamedFake(name), name)
+}
+
+func (q *fake_delayingType) AddAfter(item interface{}, _ time.Duration) {
+	q.Add(item)
+}

--- a/staging/src/k8s.io/client-go/util/workqueue/fake_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/fake_queue.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"k8s.io/utils/clock"
+	"sync"
+)
+
+type FakeType struct {
+	*Type
+	mutex sync.Mutex
+}
+
+func NewNamedFake(name string) *FakeType {
+	rc := clock.RealClock{}
+	return &FakeType{
+		Type: newQueue(
+			rc,
+			globalMetricsFactory.newQueueMetrics(name, rc),
+			defaultUnfinishedWorkUpdatePeriod,
+		),
+	}
+}
+
+func NewFakeType() *FakeType {
+	return NewNamedFake("")
+}
+
+func (q *FakeType) Add(item interface{}) {
+	q.mutex.Lock()
+	q.shuttingDown = false
+	q.Type.Add(item)
+	q.mutex.Unlock()
+}
+
+func (q *FakeType) Get() (item interface{}, shutdown bool) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	q.Type.ShutDown()
+	return q.Type.Get()
+}
+
+func (q *FakeType) ShutDown() {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	q.Type.ShutDown()
+}
+
+func (q *FakeType) ShuttingDown() bool {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	return q.Type.ShuttingDown()
+}

--- a/staging/src/k8s.io/client-go/util/workqueue/fake_rate_limiting_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/fake_rate_limiting_queue.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+func NewFakeRateLimitingQueue(rateLimiter RateLimiter) RateLimitingInterface {
+	return &rateLimitingType{
+		DelayingInterface: NewFakeDelayingQueue(),
+		rateLimiter:       rateLimiter,
+	}
+}

--- a/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package workqueue
 
+import (
+	"k8s.io/utils/clock"
+)
+
 // RateLimitingInterface is an interface that rate limits items being added to the queue.
 type RateLimitingInterface interface {
 	DelayingInterface
@@ -46,6 +50,13 @@ func NewRateLimitingQueue(rateLimiter RateLimiter) RateLimitingInterface {
 func NewNamedRateLimitingQueue(rateLimiter RateLimiter, name string) RateLimitingInterface {
 	return &rateLimitingType{
 		DelayingInterface: NewNamedDelayingQueue(name),
+		rateLimiter:       rateLimiter,
+	}
+}
+
+func NewRateLimitingQueueWithCustomClock(rateLimiter RateLimiter, clock clock.WithTicker) RateLimitingInterface {
+	return &rateLimitingType{
+		DelayingInterface: NewDelayingQueueWithCustomClock(clock, ""),
 		rateLimiter:       rateLimiter,
 	}
 }

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
@@ -258,7 +258,7 @@ func (r *FakeRuntimeService) StopPodSandbox(podSandboxID string) error {
 	if s, ok := r.Sandboxes[podSandboxID]; ok {
 		s.State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
 	} else {
-		return fmt.Errorf("pod sandbox %s not found", podSandboxID)
+		return fmt.Errorf("pod sandbox No such container %s not foud", podSandboxID)
 	}
 
 	return nil

--- a/test/e2e/framework/.import-restrictions
+++ b/test/e2e/framework/.import-restrictions
@@ -226,6 +226,8 @@ rules:
       - k8s.io/kubernetes/pkg/util/system
       - k8s.io/kubernetes/pkg/util/tail
       - k8s.io/kubernetes/pkg/util/taints
+      - k8s.io/kubernetes/pkg/util/mmap
+      - k8s.io/kubernetes/pkg/util/observer
       - k8s.io/kubernetes/pkg/volume
       - k8s.io/kubernetes/pkg/volume/util
       - k8s.io/kubernetes/pkg/volume/util/fs


### PR DESCRIPTION
Signed-off-by: yingchunliu-zte <liu.yingchun@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind  feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Change the cycle scan mode of modules such as containerGc, volume manager, housekeeping, status manager and syncpod to event-driven mode to improve CPU performance. When the system is in steady state, these modules will not consume CPU except for volumeManager's SyncPod.

PLEG provides events that drive the containerGC and provides a CRI buffer, while other modules no longer directly call the CRI to get a collection of all containers.

Podworkers provides POD_ ADDED, POD_ TERMINATED, POD_FINISHED events to drive modules such as volume manager and housekeeping.

Triggers the statusManager report the pod status to apiserver when the statusManager updateStatusInternal and podManager updates.

SourcesConfig provides ALL_ READY events to drive modules such as volume manager, housekeeping.

PodSyncdelay handles the eventization of syncpod and changes the 1s cycle scan to  delay events