### PR TITLE
Flip CSIMigrationRBD flag to be beta and off by default

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -152,6 +152,7 @@ const (
 
 	// owner: @humblec
 	// alpha: v1.23
+	// beta: v1.25
 	//
 	// Enables the RBD in-tree driver to RBD CSI Driver  migration feature.
 	CSIMigrationRBD featuregate.Feature = "CSIMigrationRBD"
@@ -844,7 +845,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	CSIMigrationPortworx: {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires Portworx CSI driver)
 
-	CSIMigrationRBD: {Default: false, PreRelease: featuregate.Alpha}, // Off by default (requires RBD CSI driver)
+	CSIMigrationRBD: {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires RBD CSI driver)
 
 	CSIMigrationvSphere: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


/kind feature

```release-note
Promote CSIMigrationRBD to Beta (off by default since it requires installation of the Ceph CSI RBD Driver)
The in-tree Ceph RBD plugin "kubernetes.io/rbd" is now deprecated and is targeted for removal in 1.28 . Users should enable CSIMigration + CSIMigrationRBD features and install the Ceph CSI RBD  Driver (https://github.com/ceph/ceph-csi) to avoid disruption to existing Pod and PVC objects at that time.
Users should start using the Ceph CSI RBD Driver directly for any new volumes.

```

Additional Note:

We have user report here https://github.com/kubernetes/kubernetes/issues/107849 where this feature was tested and claimed everything works as expected.

Reference issue # https://github.com/kubernetes/kubernetes/pull/108632

Note for reviewer:
Please let me know if any specific checklist has to be completed before promoting the feature to Beta. 
