### PR TITLE
e2e: do not parse resourceVersion

### DIFF
--- a/test/e2e/apimachinery/protocol.go
+++ b/test/e2e/apimachinery/protocol.go
@@ -19,13 +19,14 @@ package apimachinery
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 
@@ -34,7 +35,6 @@ import (
 
 var _ = SIGDescribe("client-go should negotiate", func() {
 	f := framework.NewDefaultFramework("protocol")
-	f.SkipNamespaceCreation = true
 
 	for _, s := range []string{
 		"application/json",
@@ -44,17 +44,28 @@ var _ = SIGDescribe("client-go should negotiate", func() {
 	} {
 		accept := s
 		g.It(fmt.Sprintf("watch and report errors with accept %q", accept), func() {
+			g.By("creating an object for which we will watch")
+			ns := f.Namespace.Name
+			client := f.ClientSet.CoreV1().ConfigMaps(ns)
+			configMapName := "e2e-client-go-test-negotiation"
+			testConfigMap := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: configMapName}}
+			before, err := client.List(context.TODO(), metav1.ListOptions{})
+			framework.ExpectNoError(err)
+			_, err = client.Create(context.TODO(), testConfigMap, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			opts := metav1.ListOptions{
+				ResourceVersion: before.ResourceVersion,
+				FieldSelector:   fields.SelectorFromSet(fields.Set{"metadata.name": configMapName}).String(),
+			}
+
+			g.By("watching for changes on the object")
 			cfg, err := framework.LoadConfig()
 			framework.ExpectNoError(err)
 
 			cfg.AcceptContentTypes = accept
 
 			c := kubernetes.NewForConfigOrDie(cfg)
-			svcs, err := c.CoreV1().Services("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
-			framework.ExpectNoError(err)
-			rv, err := strconv.Atoi(svcs.ResourceVersion)
-			framework.ExpectNoError(err)
-			w, err := c.CoreV1().Services("default").Watch(context.TODO(), metav1.ListOptions{ResourceVersion: strconv.Itoa(rv - 1)})
+			w, err := c.CoreV1().ConfigMaps(ns).Watch(context.TODO(), opts)
 			framework.ExpectNoError(err)
 			defer w.Stop()
 


### PR DESCRIPTION
This test wishes to observe a watch event. In order to do this in the
past, the test chose a well-known `Service` object, fetched it, and did
arithmetic on the returned `resourceVersion` in order to start a watch
that was guaranteed to see an event. It is not valid to parse the
`resourceVersion` as an integer or to do arithmetic on it, so in order
to make the test conformant to an appropriate use of the API it now:

 - creates a namespace
 - fetches the current `resourceVersion`
 - creates an object
 - watches from the previous `resourceVersion` that was read

This ensures that an event is seen by the watch, but uses the publically
supported API.

`ConfigMap`s are used instead of `Service`s as they do not require a
valid `spec` for creation and make the test terser.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
/kind cleanup
/sig api-machinery

```release-note
NONE
```

```docs

```

/assign @liggitt @smarterclayton @deads2k @sttts 