### PR TITLE
Improve unit test coverage in `pkg/util/netsh/`

### DIFF
--- a/pkg/util/netsh/netsh_test.go
+++ b/pkg/util/netsh/netsh_test.go
@@ -441,27 +441,43 @@ func TestCheckIPExists(t *testing.T) {
 
 func TestGetIP(t *testing.T) {
 	testcases := []struct {
+		name          string
 		showAddress   string
 		expectAddress string
 	}{
 		{
+			name:          "IP address displayed in Chinese",
 			showAddress:   "IP 地址:                           10.96.0.2",
 			expectAddress: "10.96.0.2",
 		},
 		{
+			name:          "IP address displayed in English",
 			showAddress:   "IP Address:                           10.96.0.3",
 			expectAddress: "10.96.0.3",
 		},
 		{
+			name:          "IP address without spaces",
 			showAddress:   "IP Address:10.96.0.4",
 			expectAddress: "10.96.0.4",
+		},
+		{
+			name:          "Only 'IP Address:' field exists",
+			showAddress:   "IP Address:",
+			expectAddress: "",
+		},
+		{
+			name:          "IP address without ':' separator",
+			showAddress:   "IP Address10.6.9.2",
+			expectAddress: "",
 		},
 	}
 
 	for _, tc := range testcases {
-		address := getIP(tc.showAddress)
-		if address != tc.expectAddress {
-			t.Errorf("expected address=%q, got %q", tc.expectAddress, address)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			address := getIP(tc.showAddress)
+			if address != tc.expectAddress {
+				t.Errorf("expected address=%q, got %q", tc.expectAddress, address)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Improve unit test code coverage and readability in `pkg/util/netsh/`

Run test coverage command:
```
go test -cover ./pkg/util/netsh
```
Befor:
```
ok      k8s.io/kubernetes/pkg/util/netsh        0.842s  coverage: 98.5% of statements
```

After:
```
ok      k8s.io/kubernetes/pkg/util/netsh        0.997s  coverage: 100.0% of statements
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #97355

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
