### PR TITLE
Makefile: Pass SHELL to sub-make

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -525,7 +525,7 @@ generated_files:
 	echo "$$GENERATED_FILES_HELP_INFO"
 else
 generated_files gen_openapi:
-	$(MAKE) -f Makefile.generated_files $@ CALLED_FROM_MAIN_MAKEFILE=1
+	$(MAKE) -f Makefile.generated_files $@ CALLED_FROM_MAIN_MAKEFILE=1 SHELL="$(SHELL)"
 endif
 
 define HELP_INFO

--- a/build/root/Makefile.generated_files
+++ b/build/root/Makefile.generated_files
@@ -33,9 +33,6 @@ ifeq ($(DBG_MAKEFILE),1)
 endif
 
 
-# It's necessary to set this because some environments don't link sh -> bash.
-SHELL := /usr/bin/env bash
-
 # Define variables so `make --warn-undefined-variables` works.
 DBG_CODEGEN ?=
 UPDATE_API_KNOWN_VIOLATIONS ?=


### PR DESCRIPTION
It turns out that:

a) SHELL does not automatically get passed down
b) we were resetting SHELL in the sub-make anyway

/kind bug
/kind cleanup
```release-note
NONE
```
