### PR TITLE
CSI inline volumes should support fsGroup

### DIFF
--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -1201,6 +1201,24 @@ func Test_csiMountMgr_supportsFSGroup(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "driverPolicy is ReadWriteOnceWithFSTypeFSGroupPolicy with CSI inline volume",
+			args: args{
+				fsGroup:      new(int64),
+				fsType:       "ext4",
+				driverPolicy: storage.ReadWriteOnceWithFSTypeFSGroupPolicy,
+			},
+			fields: fields{
+				spec: volume.NewSpecFromVolume(&api.Volume{
+					VolumeSource: api.VolumeSource{
+						CSI: &api.CSIVolumeSource{
+							Driver: testDriver,
+						},
+					},
+				}),
+			},
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig storage

#### What this PR does / why we need it:

Today, any volume without a PV spec is not able to apply fsGroup.
This policy is a bit too restrictive, as it means CSI Inline Volumes are
not accessible to non-root users. These volumes are always mounted
with RWO AccessMode and should be able to support fsGroup.

#### Which issue(s) this PR fixes:

Fixes #89290

#### Special notes for your reviewer:

/cc @gnufied @jsafrane @pohly @msau42 

Simple test using the hostpath driver with a slightly modified `examples/csi-app-inline.yaml`:
```
root@ubuntu2110:/workspace/csi-driver-host-path# cat examples/csi-app-inline.yaml
kind: Pod
apiVersion: v1
metadata:
  name: my-csi-app-inline
spec:
  securityContext:
    fsGroup: 1000
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: topology.hostpath.csi/node
            operator: Exists
  containers:
    - name: my-frontend
      image: busybox
      volumeMounts:
      - mountPath: "/data"
        name: my-csi-volume
      command: [ "sleep", "1000000" ]
  volumes:
    - name: my-csi-volume
      csi:
        driver: hostpath.csi.k8s.io
        fsType: ext4
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl apply -f examples/csi-app-inline.yaml
pod/my-csi-app-inline created
root@ubuntu2110:/workspace/csi-driver-host-path# grep SetupAt /tmp/kubelet.log
I0311 23:03:24.821360 3190213 csi_mounter.go:291] kubernetes.io/csi: mounter.SetupAt fsGroup [1000] applied successfully to csi-531e4596b9ce78763a7e2ab028e238d4b1f5b3e81a4561c04d0a94d9daf530ea
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl exec -it pod/my-csi-app-inline -- /bin/sh
/ # touch /data/test
/ # ls -la /data
total 8
drwxrwsr-x    2 root     1000          4096 Mar 11 23:04 .
drwxr-xr-x    1 root     root          4096 Mar 11 23:03 ..
-rw-r--r--    1 root     1000             0 Mar 11 23:04 test
```

And with runAsGroup / runAsUser included in the SecurityContext:
```
root@ubuntu2110:/workspace/csi-driver-host-path# head examples/csi-app-inline.yaml
kind: Pod
apiVersion: v1
metadata:
  name: my-csi-app-inline
spec:
  securityContext:
    fsGroup: 1000
    runAsGroup: 1000
    runAsUser: 1000
  affinity:
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl apply -f examples/csi-app-inline.yaml
pod/my-csi-app-inline created
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl exec -it pod/my-csi-app-inline -- /bin/sh
/ $ touch /data/test
/ $ ls -l /data
total 0
-rw-r--r--    1 1000     1000             0 Mar 12 00:09 test
/ $ id
uid=1000 gid=1000 groups=1000
```

#### Does this PR introduce a user-facing change?

```release-note
Fix to allow fsGroup to be applied for CSI Inline Volumes
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

