### PR TITLE
Skip scheduling pod that has been assigned node

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -733,7 +733,14 @@ func (sched *Scheduler) skipPodSchedule(fwk framework.Framework, pod *v1.Pod) bo
 		return true
 	}
 
-	// Case 2: pod that has been assumed could be skipped.
+	// Case 2: pod has been assigned node.
+	if len(pod.Spec.NodeName) != 0 {
+		fwk.EventRecorder().Eventf(pod, nil, v1.EventTypeWarning, "FailedScheduling", "Scheduling", "skip scheduling pod that has been assigned node: %s/%s", pod.Namespace, pod.Name)
+		klog.V(3).InfoS("Skip scheduling pod that has been assigned node", "pod", klog.KObj(pod))
+		return true
+	}
+
+	// Case 3: pod that has been assumed could be skipped.
 	// An assumed pod can be added again to the scheduling queue if it got an update event
 	// during its previous scheduling cycle but before getting assumed.
 	isAssumed, err := sched.Cache.IsAssumedPod(pod)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Typically, only Pods with no assigned nodes are added to the scheduler queue. But when the exception is encountered, as mentioned in the issue, the pod is already running and the scheduler is still scheduling the pod.
So, is it possible to check before scheduling and skip scheduling if a pod is already assigned a node.

#### Which issue(s) this PR fixes:
Fixes #108665

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: