### PR TITLE
[WIP] New PortForwarder that better handles lost remote connections

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward2/portforward2.go
+++ b/staging/src/k8s.io/client-go/tools/portforward2/portforward2.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward2
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// TODO: Replace portforward.go with this
+// TODO: Create unit tests (adapt then from the existing unit tests)
+// TODO: Update e2e tests
+
+// PortForwardProtocolV1Name is the subprotocol used for port forwarding.
+const PortForwardProtocolV1Name = "portforward.k8s.io"
+
+// PortForwarder2 knows how to listen for local connections and forward them to a remote pod via an upgraded HTTP request.
+type PortForwarder2 struct {
+	dialer            httpstream.Dialer
+	addresses         []string
+	ports             []string
+	reconnect         bool
+	outWriter         io.Writer
+	errWriter         io.Writer
+	requestID         uint32
+	activeConnections sync.WaitGroup
+}
+
+// New creates a new PortForwarder2 for localhost.
+func New(dialer httpstream.Dialer, ports []string, outWriter io.Writer, errWriter io.Writer) *PortForwarder2 {
+	return NewOnAddresses(dialer, []string{"localhost"}, ports, outWriter, errWriter)
+}
+
+// NewOnAddresses creates a new PortForwarder2 with custom listen addresses.
+func NewOnAddresses(dialer httpstream.Dialer, addresses []string, ports []string, outWriter io.Writer, errWriter io.Writer) *PortForwarder2 {
+	return &PortForwarder2{
+		dialer:    dialer,
+		addresses: addresses,
+		ports:     ports,
+		outWriter: outWriter,
+		errWriter: errWriter,
+	}
+}
+
+// ForwardPorts starts port forwarding and continues until the provided context is cancelled.
+func (pf *PortForwarder2) ForwardPorts(ctx context.Context) error {
+	// Keep track of listeners, so they can be closed later
+	var listeners []net.Listener
+
+	// Create a new context, with cancel, so that we can cancel the listeners to stop gracefully
+	listenerContext, cancelListeners := context.WithCancel(ctx)
+
+	// Stop all listeners and wait for all active connections to close
+	defer func() {
+		cancelListeners()
+		for _, listener := range listeners {
+			if err := listener.Close(); err != nil {
+				pf.errorf("failed to close listener: %s", err) // Print the error, but don't fail during cleanup
+			}
+		}
+		pf.activeConnections.Wait()
+	}()
+
+	// Create a listener for each listenAddress/port combination
+	for _, a := range pf.addresses {
+		for _, p := range pf.ports {
+			listener, err := pf.listen(listenerContext, a, p)
+			if err != nil {
+				return err
+			}
+			listeners = append(listeners, listener)
+		}
+	}
+
+	// Wait for context to be done
+	<-listenerContext.Done()
+
+	return nil
+}
+
+func (pf *PortForwarder2) listen(ctx context.Context, address string, port string) (net.Listener, error) {
+	protocol, err := determineAddressProtocol(address)
+	if err != nil {
+		return nil, err
+	}
+
+	localPort, remotePort, err := parseLocalAndRemotePorts(port)
+	if err != nil {
+		return nil, err
+	}
+
+	addressWithPort := net.JoinHostPort(address, localPort)
+	listener, err := net.Listen(protocol, addressWithPort)
+	if err != nil {
+		return nil, fmt.Errorf("listen failed on %s: %s", addressWithPort, err)
+	}
+
+	listenerAddress := listener.Addr().String()
+	pf.printf("Forwarding from %s -> %s\n", listenerAddress, remotePort)
+
+	// Accept and handle connections
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					pf.errorf("accept failed: %s\n", err)
+					continue
+				}
+			}
+			go pf.handleConnection(ctx, conn, listenerAddress, remotePort)
+		}
+	}()
+
+	return listener, nil
+}
+
+func (pf *PortForwarder2) handleConnection(ctx context.Context, localConn net.Conn, listenerAddress string, remotePort string) {
+	defer localConn.Close()
+
+	// Increment the active connections WaitGroup, so if we need to stop we can wait for all in-flight connections to complete
+	pf.activeConnections.Add(1)
+	defer pf.activeConnections.Done()
+
+	// Each connection handled gets a unique, sequential request ID
+	requestID := atomic.AddUint32(&pf.requestID, 1)
+
+	// Print an informational message at the start and at the finish of each handled connection
+	pf.printf("[%d] Started handling connection forwarding from %s -> %s\n", requestID, listenerAddress, remotePort)
+	defer func() {
+		pf.printf("[%d] Finished handling connection forwarding from %s -> %s\n", requestID, listenerAddress, remotePort)
+	}()
+
+	// Helper function for displaying error messages
+	handleError := func(message string, err error) {
+		if err == nil {
+			pf.errorf("[%d] ERROR: %s\n", requestID, message)
+		} else {
+			pf.errorf("[%d] ERROR: %s: %s\n", requestID, message, err)
+		}
+	}
+
+	// Establish the remote connection
+	remoteConnection, _, err := pf.dialer.Dial(PortForwardProtocolV1Name)
+	if err != nil {
+		handleError("dial failed", err)
+		return
+	}
+	defer remoteConnection.Close()
+
+	// Create an error stream for the remote connection.  Immediately close it, because we will only read from it
+	remoteErrorStream, err := pf.createStream(remoteConnection, v1.StreamTypeError, remotePort, requestID)
+	if err != nil {
+		handleError("failed to create error stream", err)
+		return
+	}
+	remoteErrorStream.Close()
+
+	// Create a data stream for the remote connection
+	remoteDataStream, err := pf.createStream(remoteConnection, v1.StreamTypeData, remotePort, requestID)
+	if err != nil {
+		handleError("failed to create data stream", err)
+		return
+	}
+
+	// Read everything from the error stream
+	errorChan := make(chan struct{})
+	go func() {
+		defer close(errorChan)
+		message, err := ioutil.ReadAll(remoteErrorStream)
+		if err != nil {
+			handleError("failed to read from error stream", err)
+		} else if len(message) > 0 {
+			handleError(string(message), nil)
+		}
+	}()
+
+	// Read from remote to local
+	doneChan := make(chan struct{})
+	go func() {
+		defer close(doneChan)
+		bytesRead, err := io.Copy(localConn, remoteDataStream)
+		if err != nil {
+			handleError("failed to read from remote data stream", err)
+		}
+		klog.V(3).Infof("bytes read = %d", bytesRead)
+	}()
+
+	// Write from local to remote
+	go func() {
+		defer remoteDataStream.Close()
+		bytesWritten, err := io.Copy(remoteDataStream, localConn)
+		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			handleError("failed to write to remote data stream", err)
+		}
+		klog.V(3).Infof("bytes written = %d", bytesWritten)
+	}()
+
+	select {
+	case <-ctx.Done():
+		remoteDataStream.Reset() // Reset data stream to unblock io.Copy
+	case <-doneChan:
+	}
+
+	// Always wait for errorChan
+	<-errorChan
+}
+
+func (pf *PortForwarder2) createStream(connection httpstream.Connection, streamType string, port string, requestID uint32) (httpstream.Stream, error) {
+	headers := http.Header{}
+	headers.Set(v1.StreamType, streamType)
+	headers.Set(v1.PortHeader, port)
+	headers.Set(v1.PortForwardRequestIDHeader, fmt.Sprintf("%d", requestID))
+	return connection.CreateStream(headers)
+}
+
+func (pf *PortForwarder2) printf(format string, a ...interface{}) {
+	if pf.outWriter != nil {
+		fmt.Fprintf(pf.outWriter, format, a...)
+	}
+}
+
+func (pf *PortForwarder2) errorf(format string, a ...interface{}) {
+	if pf.errWriter != nil {
+		fmt.Fprintf(pf.outWriter, format, a...)
+	}
+}
+
+func determineAddressProtocol(address string) (string, error) {
+	if netutils.ParseIPSloppy(address).To4() != nil {
+		return "tcp4", nil
+	}
+	if netutils.ParseIPSloppy(address) != nil {
+		return "tcp6", nil
+	}
+	ips, err := net.LookupIP(address)
+	if err != nil {
+		return "", err
+	}
+	for _, ip := range ips {
+		if netutils.IsIPv4(ip) {
+			return "tcp4", nil
+		}
+		if netutils.IsIPv6(ip) {
+			return "tcp6", nil
+		}
+	}
+	return "", fmt.Errorf("unable to determine address protocol for %q", address)
+}
+
+func parseLocalAndRemotePorts(portString string) (string, string, error) {
+	// Split the local and remote ports and handle if only a single port is specified
+	parts := strings.Split(portString, ":")
+	var localString, remoteString string
+	if len(parts) == 1 {
+		localString = parts[0]
+		remoteString = parts[0]
+	} else if len(parts) == 2 {
+		localString = parts[0]
+		if localString == "" {
+			// support :5000
+			localString = "0"
+		}
+		remoteString = parts[1]
+	} else {
+		return "", "", fmt.Errorf("invalid port format")
+	}
+
+	// Make sure the local port can be parsed as a 16-bit unsigned int
+	localPort, err := strconv.ParseUint(localString, 10, 16)
+	if err != nil {
+		return "", "", fmt.Errorf("error parsing local port %q: %s", localString, err)
+	}
+
+	// Make sure the remote port can be parsed as a 16-bit unsigned int and is not 0
+	remotePort, err := strconv.ParseUint(remoteString, 10, 16)
+	if err != nil {
+		return "", "", fmt.Errorf("error parsing remote port %q: %s", remoteString, err)
+	}
+	if remotePort == 0 {
+		return "", "", fmt.Errorf("remote port must be > 0")
+	}
+
+	return strconv.FormatUint(localPort, 10), strconv.FormatUint(remotePort, 10), nil
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -19,8 +19,9 @@ package portforward
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/client-go/tools/portforward2"
 	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -36,7 +37,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
@@ -47,16 +47,14 @@ import (
 
 // PortForwardOptions contains all the options for running the port-forward cli command.
 type PortForwardOptions struct {
-	Namespace     string
-	PodName       string
-	RESTClient    *restclient.RESTClient
-	Config        *restclient.Config
-	PodClient     corev1client.PodsGetter
-	Address       []string
-	Ports         []string
-	PortForwarder portForwarder
-	StopChannel   chan struct{}
-	ReadyChannel  chan struct{}
+	Namespace  string
+	PodName    string
+	RESTClient *restclient.RESTClient
+	Config     *restclient.Config
+	PodClient  corev1client.PodsGetter
+	Address    []string
+	Ports      []string
+	genericclioptions.IOStreams
 }
 
 var (
@@ -98,11 +96,7 @@ const (
 )
 
 func NewCmdPortForward(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
-	opts := &PortForwardOptions{
-		PortForwarder: &defaultPortForwarder{
-			IOStreams: streams,
-		},
-	}
+	opts := &PortForwardOptions{IOStreams: streams}
 	cmd := &cobra.Command{
 		Use:                   "port-forward TYPE/NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]",
 		DisableFlagsInUseLine: true,
@@ -120,27 +114,6 @@ func NewCmdPortForward(f cmdutil.Factory, streams genericclioptions.IOStreams) *
 	cmd.Flags().StringSliceVar(&opts.Address, "address", []string{"localhost"}, "Addresses to listen on (comma separated). Only accepts IP addresses or localhost as a value. When localhost is supplied, kubectl will try to bind on both 127.0.0.1 and ::1 and will fail if neither of these addresses are available to bind.")
 	// TODO support UID
 	return cmd
-}
-
-type portForwarder interface {
-	ForwardPorts(method string, url *url.URL, opts PortForwardOptions) error
-}
-
-type defaultPortForwarder struct {
-	genericclioptions.IOStreams
-}
-
-func (f *defaultPortForwarder) ForwardPorts(method string, url *url.URL, opts PortForwardOptions) error {
-	transport, upgrader, err := spdy.RoundTripperFor(opts.Config)
-	if err != nil {
-		return err
-	}
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, method, url)
-	fw, err := portforward.NewOnAddresses(dialer, opts.Address, opts.Ports, opts.StopChannel, opts.ReadyChannel, f.Out, f.ErrOut)
-	if err != nil {
-		return err
-	}
-	return fw.ForwardPorts()
 }
 
 // splitPort splits port string which is in form of [LOCAL PORT]:REMOTE PORT
@@ -363,8 +336,6 @@ func (o *PortForwardOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, arg
 		return err
 	}
 
-	o.StopChannel = make(chan struct{}, 1)
-	o.ReadyChannel = make(chan struct{})
 	return nil
 }
 
@@ -378,33 +349,34 @@ func (o PortForwardOptions) Validate() error {
 		return fmt.Errorf("at least 1 PORT is required for port-forward")
 	}
 
-	if o.PortForwarder == nil || o.PodClient == nil || o.RESTClient == nil || o.Config == nil {
-		return fmt.Errorf("client, client config, restClient, and portforwarder must be provided")
+	if o.PodClient == nil || o.RESTClient == nil || o.Config == nil {
+		return fmt.Errorf("client, client config, and restClient must be provided")
 	}
 	return nil
 }
 
 // RunPortForward implements all the necessary functionality for port-forward cmd.
 func (o PortForwardOptions) RunPortForward() error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	fw := portforward2.NewOnAddresses(o, o.Address, o.Ports, o.Out, o.ErrOut)
+	return fw.ForwardPorts(ctx)
+}
+
+func (o PortForwardOptions) Dial(protocols ...string) (httpstream.Connection, string, error) {
 	pod, err := o.PodClient.Pods(o.Namespace).Get(context.TODO(), o.PodName, metav1.GetOptions{})
 	if err != nil {
-		return err
+		return nil, "", err
 	}
 
 	if pod.Status.Phase != corev1.PodRunning {
-		return fmt.Errorf("unable to forward port because pod is not running. Current status=%v", pod.Status.Phase)
+		return nil, "", fmt.Errorf("unable to forward port because pod is not running. Current status=%v", pod.Status.Phase)
 	}
 
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt)
-	defer signal.Stop(signals)
-
-	go func() {
-		<-signals
-		if o.StopChannel != nil {
-			close(o.StopChannel)
-		}
-	}()
+	transport, upgrader, err := spdy.RoundTripperFor(o.Config)
+	if err != nil {
+		return nil, "", err
+	}
 
 	req := o.RESTClient.Post().
 		Resource("pods").
@@ -412,5 +384,6 @@ func (o PortForwardOptions) RunPortForward() error {
 		Name(pod.Name).
 		SubResource("portforward")
 
-	return o.PortForwarder.ForwardPorts("POST", req.URL(), o)
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
+	return dialer.Dial(protocols...)
 }


### PR DESCRIPTION
This PR is still a work in progress, but comments are welcome.

I wanted to get some feedback on direction before doing the remaining work.

TODO: 
- [ ] Delete the current PortForwarder and rename this one (PortForwarder2) to be PortForwarder.  I just called this one PortForwarder2 for now.
- [ ] Create unit tests (adapt them from the existing unit tests)
- [ ] Update e2e tests

`kubectl port-forward` in this branch is wired up to use PortForwarder2 in case anyone wants to try it out.

#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:

`kubectl port-forward` has long had a problem where the forwarding session would become hung (prior to kubectl 1.23) or would exit (kubectl 1.23 and later) whenever the remote connection was lost.

The root cause of this problem is that PortForwarder dials the remote connection only one time and then uses that single connection forever, with no ability to reconnect if the remote connection is lost.

This PR is a rewrite of PortForwarder, preserving its existing functionality, while improving its resiliency and simplifying the code in many places (new version is about 25% less code)

The most important improvement is that this new PortForwarder will dial the remote connection for _each handled connection_ instead of only dialing it once and reusing it forever.  This has the following benefits:

1. If the remote connection is lost temporarily due to a network outage or even the pod being deleted and re-created, the port forwarding session will recover as soon as the pod is available again.

2. Since dial is called for each connection, it potentially allows for the dialer to implement client-side load balancing by connecting to a different pod in a deployment for each handled connection.  It doesn't do this right now (yet), but the dialer in the kubectl port-forward command could be changed to dial pods in a round-robin or random way for example (see `polymorphichelpers.attachablePodForObject` implementation where it takes only the first one currently)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/686

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl port-forward is now able to reconnect to the remote pod if the remote connection is lost
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
