### PR TITLE
Update ineligible_endpoints.yaml to include Log endpoints

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -418,3 +418,9 @@
 - endpoint: replaceAutoscalingV2NamespacedHorizontalPodAutoscalerStatus
   reason: optional feature
   link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: logFileHandler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/issues/108675
+- endpoint: logFileListHandler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/issues/108675


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Add Log endpoints  to `logFileListHandler` and `logFileHandler` to ineligible_endpoint.yaml as it:
- should be considered an operational tool, not related to application consistency across distros. 

**Special notes for your reviewer:**
As of 1.22 APISnoop [Ineligible endpoints](https://apisnoop.cncf.io/conformance-progress/ineligible-endpoints) are pulled from the community owned `inelegible_endpoint.yaml` file
**Which issue(s) this PR fixes:**
Fixes #108675 

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig architecture
/area conformance