### PR TITLE
Update publishing-bot rules for Go 1.17.8 / 1.16.15

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -24,17 +24,17 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/code-generator
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/code-generator
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
   - source:
       branch: release-1.23
       dir: staging/src/k8s.io/code-generator
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
 
 - destination: apimachinery
   library: true
@@ -52,17 +52,17 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apimachinery
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/apimachinery
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
   - source:
       branch: release-1.23
       dir: staging/src/k8s.io/apimachinery
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
 
 - destination: api
   library: true
@@ -86,7 +86,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/api
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
       - repository: apimachinery
         branch: release-1.21
@@ -94,7 +94,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/api
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -102,7 +102,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/api
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -141,7 +141,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/client-go
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
       - repository: apimachinery
         branch: release-1.21
@@ -155,7 +155,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/client-go
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
       - repository: apimachinery
         branch: release-1.22
@@ -169,7 +169,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/client-go
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -210,7 +210,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/component-base
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -222,7 +222,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-base
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -234,7 +234,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-base
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -273,7 +273,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/component-helpers
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -285,7 +285,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-helpers
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -297,7 +297,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-helpers
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -340,7 +340,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apiserver
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -354,7 +354,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apiserver
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -368,7 +368,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apiserver
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -420,7 +420,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -438,7 +438,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -456,7 +456,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -522,7 +522,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -545,7 +545,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -568,7 +568,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -631,7 +631,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/sample-controller
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -650,7 +650,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-controller
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -669,7 +669,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/sample-controller
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -730,7 +730,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -750,7 +750,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -770,7 +770,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -821,7 +821,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/metrics
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -835,7 +835,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/metrics
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -849,7 +849,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/metrics
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -890,7 +890,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.21
@@ -902,7 +902,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.22
@@ -914,7 +914,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: api
       branch: release-1.23
@@ -957,7 +957,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.21
@@ -971,7 +971,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.22
@@ -985,7 +985,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1030,7 +1030,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1044,7 +1044,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1058,7 +1058,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1103,7 +1103,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kubelet
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1117,7 +1117,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubelet
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1131,7 +1131,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubelet
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1176,7 +1176,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1190,7 +1190,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1204,7 +1204,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1253,7 +1253,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/controller-manager
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1269,7 +1269,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/controller-manager
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1285,7 +1285,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/controller-manager
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1344,7 +1344,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1364,7 +1364,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1384,7 +1384,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1451,7 +1451,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1473,7 +1473,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1495,7 +1495,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1540,7 +1540,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1550,7 +1550,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1560,7 +1560,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1593,7 +1593,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1603,7 +1603,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1613,7 +1613,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1636,17 +1636,17 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/mount-utils
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/mount-utils
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
   - source:
       branch: release-1.23
       dir: staging/src/k8s.io/mount-utils
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
 
 - destination: legacy-cloud-providers
   library: true
@@ -1704,7 +1704,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1728,7 +1728,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1754,7 +1754,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1793,17 +1793,17 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cri-api
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/cri-api
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
   - source:
       branch: release-1.23
       dir: staging/src/k8s.io/cri-api
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
 
 - destination: kubectl
   library: true
@@ -1855,7 +1855,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kubectl
     name: release-1.21
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1877,7 +1877,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubectl
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1899,7 +1899,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubectl
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1940,7 +1940,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/pod-security-admission
     name: release-1.22
-    go: 1.16.14
+    go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1956,7 +1956,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/pod-security-admission
     name: release-1.23
-    go: 1.17.7
+    go: 1.17.8
     dependencies:
     - repository: api
       branch: release-1.23


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Update publishing-bot rules for Go 1.17.8 / 1.16.15

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2450

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assign @xmudrii  @saschagrunert @palnabarun @Verolop @dims @nikhita 
cc @kubernetes/release-engineering 