### PR TITLE
WIP: Discovery: Use openAPI etag to invalidate cache and remove TTL

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -22,7 +22,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/spf13/pflag"
 
@@ -282,10 +281,9 @@ func (f *ConfigFlags) toDiscoveryClient() (discovery.CachedDiscoveryInterface, e
 	if f.CacheDir != nil {
 		cacheDir = *f.CacheDir
 	}
-	httpCacheDir := filepath.Join(cacheDir, "http")
 	discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(cacheDir, "discovery"), config.Host)
 
-	return diskcached.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, time.Duration(6*time.Hour))
+	return diskcached.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir)
 }
 
 // ToRESTMapper returns a mapper.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
@@ -602,7 +601,7 @@ func (f *TestFactory) DiscoveryClient() (discovery.CachedDiscoveryInterface, err
 	fakeClient := f.Client.(*fake.RESTClient)
 
 	cacheDir := filepath.Join("", ".kube", "cache", "discovery")
-	cachedClient, err := diskcached.NewCachedDiscoveryClientForConfig(f.ClientConfigVal, cacheDir, "", time.Duration(10*time.Minute))
+	cachedClient, err := diskcached.NewCachedDiscoveryClientForConfig(f.ClientConfigVal, cacheDir)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/apiserver/print_test.go
+++ b/test/integration/apiserver/print_test.go
@@ -24,7 +24,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
@@ -169,7 +168,7 @@ func TestServerSidePrint(t *testing.T) {
 		os.Remove(cacheDir)
 	}()
 
-	cachedClient, err := diskcached.NewCachedDiscoveryClientForConfig(restConfig, cacheDir, "", time.Duration(10*time.Minute))
+	cachedClient, err := diskcached.NewCachedDiscoveryClientForConfig(restConfig, cacheDir)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Discovery has TTL to invalidate cache in pre-determined periods. However,
most of the resources are not changed frequently and that creates
unnecessary API Server requests and even rarely user can not see immediately
the resource newly created because cache is not invalidated properly.

This PR removes TTL and instead relies on openAPI etag value.
It stores etag value on local file(and also in memory). Per kubectl/client-go
invocation, it asks openapi(v2/v3) endpoint by sending it's own etag value.
If the etag sent is up to date, openapi endpoint just returns 304(not modified)
status code without returning anything. Thanks to that, we can safely use
local cached files.

If something has been changed, openapi endpoint returns 200
with the latest etag value. In that case, we invalidate cache and
update our local etag value to the latest one.

This PR supports both `openapi/v3` and `openapi/v2` with v3 has higher priority.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
According to that change, `Fresh` function is lost it's meaning. And `Invalidate` function can be skipped entirely in internal usage(although user might still want to invalidate local cache?), because we know that we always have latest version.

If user has an option disabling openapi(v2/v3) endpoints, this PR will not work and always request to server. Is there any use case to disable openapi?

#### Does this PR introduce a user-facing change?
```release-note
Remove ttl and httpcachedir fields from NewCachedDiscoveryClientForConfig.
```
