### PR TITLE
Set zone label selector for preprovisioned AWS in-tree tests

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1781,7 +1781,7 @@ func (a *awsDriver) PrepareTest(f *framework.Framework) (*storageframework.PerTe
 
 func (a *awsDriver) CreateVolume(config *storageframework.PerTestConfig, volType storageframework.TestVolType) storageframework.TestVolume {
 	zone := getInlineVolumeZone(config.Framework)
-	if volType == storageframework.InlineVolume {
+	if volType == storageframework.InlineVolume || volType == storageframework.PreprovisionedPV {
 		// PD will be created in framework.TestContext.CloudConfig.Zone zone,
 		// so pods should be also scheduled there.
 		config.ClientNodeSelection = e2epod.NodeSelection{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it: 

In the pre-provisioned PV test case I am seeing errors like 
`
Mar 11 16:15:21.495: INFO: At 2022-03-11 16:08:43 -0800 PST - event for aws-injector: {attachdetach-controller } FailedAttachVolume: AttachVolume.Attach failed for volume "aws-cxcq7" : error attaching EBS volume "vol-018a9cdf1bd834427" to instance "i-083014d02bf4a3544": "InvalidVolume.ZoneMismatch: The volume 'vol-018a9cdf1bd834427' is not in the same availability zone as instance 'i-083014d02bf4a3544'\n\tstatus code: 400, request id: 3e1a0970-4f22-45c8-ae84-4c3f5a53a0e1"
`
because the test creates a volume in zone C but then scheduler puts the pod in zone A.

I am not sure if I am passing arguments incorrectly or something but anyway I would expect this to "just work" like the inline volume case no matter the composition of my node pool (e.g. I have 1 node in zone A and one in zone C)
```
ginkgo --nodes=1 --focus=\[Driver:.aws\] --skip=\[Disruptive\] ./e2e.test -- --provider=aws --node-os-distro=custom
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
@gnufied git blame says you wrote this clause a while ago so you may have better understanding of it, does it make sense to set zone label selector for preprovisioned PV like for inline?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
