### PR TITLE
Fix test:A set of valid responses are returned for both pod and service Proxy

### DIFF
--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -58,7 +58,7 @@ const (
 	// We have seen one of these calls take just over 15 seconds, so putting this at 30.
 	proxyHTTPCallTimeout = 30 * time.Second
 	podRetryPeriod       = 1 * time.Second
-	podRetryTimeout      = 1 * time.Minute
+	podRetryTimeout      = 2 * time.Minute
 
 	requestRetryPeriod  = 10 * time.Millisecond
 	requestRetryTimeout = 1 * time.Minute


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

```
[It] A set of valid responses are returned for both pod and service ProxyWithPath [Conformance]
  /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:633
Feb 26 23:58:33.859: INFO: Creating pod...
Feb 26 23:58:33.878: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:34.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:35.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:36.907: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:37.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:38.885: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:39.884: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:40.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:41.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:42.884: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:43.891: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:44.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:45.887: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:46.884: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:47.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:48.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:49.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:50.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:51.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:52.884: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:53.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:54.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:55.885: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:56.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:57.884: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:58.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:58:59.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:00.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:01.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:02.888: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:03.889: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:04.885: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:05.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:06.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:07.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:08.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:09.887: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:10.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:11.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:12.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:13.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:14.889: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:15.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:16.893: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:17.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:18.884: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:19.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:20.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:21.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:22.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:23.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:24.884: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:25.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:26.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:27.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:28.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:29.882: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:30.892: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:31.883: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:32.910: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:33.886: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:33.890: INFO: Pod Quantity: 1 Status: Pending
Feb 26 23:59:33.890: FAIL: Pod didn't start within time out period
Unexpected error:
    <*errors.errorString | 0xc000190250>: {
        s: "timed out waiting for the condition",
    }
    timed out waiting for the condition
occurred
Full Stack Trace
k8s.io/kubernetes/test/e2e/network.glob..func24.1.4()
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:314 +0x5c5
k8s.io/kubernetes/test/e2e.RunE2ETests(0x23bf257)
	_output/local/go/src/k8s.io/kubernetes/test/e2e/e2e.go:130 +0x687
k8s.io/kubernetes/test/e2e.TestE2E(0x2336919)
	_output/local/go/src/k8s.io/kubernetes/test/e2e/e2e_test.go:136 +0x19
testing.tRunner(0xc000186000, 0x709de30)
	/usr/local/go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1306 +0x35a
[AfterEach] version v1
  /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:186
```

```
Feb 26 17:47:43.263: INFO: Pod Quantity: 1 Status: Pending
Feb 26 17:47:44.244: INFO: Pod Quantity: 1 Status: Pending
Feb 26 17:47:45.201: INFO: Pod Quantity: 1 Status: Pending
Feb 26 17:47:46.195: INFO: Pod Quantity: 1 Status: Pending
Feb 26 17:47:46.198: INFO: Pod Quantity: 1 Status: Pending
Feb 26 17:47:46.199: FAIL: Pod didn't start within time out period
Unexpected error:
    <*errors.errorString | 0xc00023a2a0>: {
        s: "timed out waiting for the condition",
    }
    timed out waiting for the condition
occurred
Full Stack Trace
k8s.io/kubernetes/test/e2e/network.glob..func23.1.5()
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:400 +0x5c5
k8s.io/kubernetes/test/e2e.RunE2ETests(0xc0005877b0)
	_output/local/go/src/k8s.io/kubernetes/test/e2e/e2e.go:133 +0x697
k8s.io/kubernetes/test/e2e.TestE2E(0x2371919)
	_output/local/go/src/k8s.io/kubernetes/test/e2e/e2e_test.go:136 +0x19
testing.tRunner(0xc000adb860, 0x7155480)
	/usr/local/go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1306 +0x35a
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://storage.googleapis.com/k8s-triage/index.html?date=2022-03-01&test=A%20set%20of%20valid%20responses%20are%20returned%20for%20both%20pod%20and%20service%20Proxy

reported by clayton on slack

#### Special notes for your reviewer:
@SergeyKanzhelev @ehashman 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
