### PR TITLE
use `sync.Map` in CycleState for better performance

### DIFF
--- a/pkg/scheduler/framework/cycle_state.go
+++ b/pkg/scheduler/framework/cycle_state.go
@@ -41,18 +41,18 @@ type StateKey string
 // StateData stored by one plugin can be read, altered, or deleted by another plugin.
 // CycleState does not provide any data protection, as all plugins are assumed to be
 // trusted.
+// Note: CycleState uses a sync.Map to back the storage. It's aimed to optimize for the "write once and read many times" scenarios.
+// It is the recommended pattern used in all in-tree plugins - plugin-specific state is written once in PreFilter/PreScore and afterwards read many times in Filter/Score.
 type CycleState struct {
-	mx      sync.RWMutex
-	storage map[StateKey]StateData
+	// storage is keyed with StateKey, and valued with StateData.
+	storage sync.Map
 	// if recordPluginMetrics is true, PluginExecutionDuration will be recorded for this cycle.
 	recordPluginMetrics bool
 }
 
 // NewCycleState initializes a new CycleState and returns its pointer.
 func NewCycleState() *CycleState {
-	return &CycleState{
-		storage: make(map[StateKey]StateData),
-	}
+	return &CycleState{}
 }
 
 // ShouldRecordPluginMetrics returns whether PluginExecutionDuration metrics should be recorded.
@@ -78,36 +78,32 @@ func (c *CycleState) Clone() *CycleState {
 		return nil
 	}
 	copy := NewCycleState()
-	for k, v := range c.storage {
-		copy.Write(k, v.Clone())
-	}
+	c.storage.Range(func(k, v interface{}) bool {
+		copy.storage.Store(k, v.(StateData).Clone())
+		return true
+	})
+
 	return copy
 }
 
 // Read retrieves data with the given "key" from CycleState. If the key is not
 // present an error is returned.
-// This function is thread safe by acquiring an internal lock first.
+// This function is thread safe by using sync.Map.
 func (c *CycleState) Read(key StateKey) (StateData, error) {
-	c.mx.RLock()
-	defer c.mx.RUnlock()
-	if v, ok := c.storage[key]; ok {
-		return v, nil
+	if v, ok := c.storage.Load(key); ok {
+		return v.(StateData), nil
 	}
 	return nil, ErrNotFound
 }
 
 // Write stores the given "val" in CycleState with the given "key".
-// This function is thread safe by acquiring an internal lock first.
+// This function is thread safe by using sync.Map.
 func (c *CycleState) Write(key StateKey, val StateData) {
-	c.mx.Lock()
-	c.storage[key] = val
-	c.mx.Unlock()
+	c.storage.Store(key, val)
 }
 
 // Delete deletes data with the given key from CycleState.
-// This function is thread safe by acquiring an internal lock first.
+// This function is thread safe by using sync.Map.
 func (c *CycleState) Delete(key StateKey) {
-	c.mx.Lock()
-	delete(c.storage, key)
-	c.mx.Unlock()
+	c.storage.Delete(key)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:


This PR change to use sync.Map in CycleState for better performance. 
> The Map type is optimized for two common use cases: (1) when the entry for a given key is only ever written once but read many times, as in caches that only grow, or (2) when multiple goroutines read, write, and overwrite entries for disjoint sets of keys. In these two cases, use of a Map may significantly reduce lock contention compared to a Go map paired with a separate Mutex or RWMutex.
https://pkg.go.dev/sync#Map

In most of plugin, we write the result of calculation in PreFilter to CycleState once, and then we fetch the pre-calculated value from CycleState many times in Filter. So, our usecase is `(1)` in the above doc.

I run benchmark with scheduler_perf and the results show performance improvement from this change.

**Average of test results:**

**master** (a41f9e976da10af28169cbbfebbce5ad4ba965f0)

```
SchedulingThroughput: 416.66666666666663
scheduler_e2e_scheduling_duration_seconds: 7.813661890749998
scheduler_pod_scheduling_duration_seconds: 1705.1073021195007
scheduler_framework_extension_point_duration_seconds(Filter): 1.1003357337500002
scheduler_framework_extension_point_duration_seconds(Score): 1.9470813199999997
```


**this branch**

```
metrics average ((1 - this branch/master) * 100)
---
SchedulingThroughput: 416.66666666666663 (no diff)
scheduler_e2e_scheduling_duration_seconds: 6.875708032500001 (12% 🔥 )
scheduler_pod_scheduling_duration_seconds: 1475.0648149227504 (13% 🔥 )
scheduler_framework_extension_point_duration_seconds(Filter): 0.7749875659999999 (30% 🔥 )
scheduler_framework_extension_point_duration_seconds(Score): 1.7849141614999997 (8% 🔥 )
```

(I even doubt my benchmark results because the effect was greater than I thought 😲 😲 )

<details><summary>raw result of benchmark</summary><div>

Run with the following performance-config.yaml (ran the same test five times.)

```yaml
- name: SchedulingBasic
  workloadTemplate:
  - opcode: createNodes
    countParam: $initNodes
  - opcode: createPods
    countParam: $initPods
    podTemplatePath: config/pod-default.yaml
  - opcode: createPods
    countParam: $measurePods
    podTemplatePath: config/pod-default.yaml
    collectMetrics: true
  workloads:
  - name: 5000Nodes1-master
    params:
      initNodes: 5000
      initPods: 1000
      measurePods: 1000
  - name: 5000Nodes2-master
    params:
      initNodes: 5000
      initPods: 1000
      measurePods: 1000
  - name: 5000Nodes3-master
    params:
      initNodes: 5000
      initPods: 1000
      measurePods: 1000
  - name: 5000Nodes4-master
    params:
      initNodes: 5000
      initPods: 1000
      measurePods: 1000
  - name: 5000Nodes5-master
    params:
      initNodes: 5000
      initPods: 1000
      measurePods: 1000
```

Machine spec: Intel(R) Xeon(R) CPU @ 2.80GHz, 16 cores, 65GB RAM


<details><summary>details</summary><div>

```
gitpod /workspace/kubernetes (master) $ lscpu
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   46 bits physical, 48 bits virtual
CPU(s):                          16
On-line CPU(s) list:             0-15
Thread(s) per core:              2
Core(s) per socket:              8
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       GenuineIntel
CPU family:                      6
Model:                           85
Model name:                      Intel(R) Xeon(R) CPU @ 2.80GHz
Stepping:                        7
CPU MHz:                         2800.190
BogoMIPS:                        5600.38
Virtualization:                  VT-x
Hypervisor vendor:               KVM
Virtualization type:             full
L1d cache:                       256 KiB
L1i cache:                       256 KiB
L2 cache:                        8 MiB
L3 cache:                        33 MiB
NUMA node0 CPU(s):               0-15
Vulnerability Itlb multihit:     Not affected
Vulnerability L1tf:              Not affected
Vulnerability Mds:               Mitigation; Clear CPU buffers; SMT Host state unknown
Vulnerability Meltdown:          Not affected
Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl
Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:        Mitigation; Enhanced IBRS, IBPB conditional, RSB filling
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Mitigation; Clear CPU buffers; SMT Host state unknown
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss
                                  ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid tsc_known_fr
                                 eq pni pclmulqdq vmx ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand
                                  hypervisor lahf_lm abm 3dnowprefetch invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow v
                                 nmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx avx512f a
                                 vx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves ar
                                 at avx512_vnni md_clear arch_capabilities
gitpod /workspace/kubernetes (master) $  cat /proc/meminfo
MemTotal:       65855700 kB
MemFree:         1160784 kB
MemAvailable:   20296896 kB
Buffers:             176 kB
Cached:         17027316 kB
SwapCached:            0 kB
Active:          4414868 kB
Inactive:       52543704 kB
Active(anon):      46632 kB
Inactive(anon): 40193548 kB
Active(file):    4368236 kB
Inactive(file): 12350156 kB
Unevictable:      117568 kB
Mlocked:          117568 kB
SwapTotal:             0 kB
SwapFree:              0 kB
Dirty:             12548 kB
Writeback:             0 kB
AnonPages:      39959904 kB
Mapped:          2123744 kB
Shmem:            347760 kB
KReclaimable:    3258832 kB
Slab:            5209136 kB
SReclaimable:    3258832 kB
SUnreclaim:      1950304 kB
KernelStack:      159888 kB
PageTables:       838784 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:    32927848 kB
Committed_AS:   110760012 kB
VmallocTotal:   34359738367 kB
VmallocUsed:      189752 kB
VmallocChunk:          0 kB
Percpu:            53376 kB
HardwareCorrupted:     0 kB
AnonHugePages:     45056 kB
ShmemHugePages:        0 kB
ShmemPmdMapped:        0 kB
FileHugePages:         0 kB
FilePmdMapped:         0 kB
HugePages_Total:       0
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:               0 kB
DirectMap4k:     7512012 kB
DirectMap2M:    54353920 kB
DirectMap1G:     7340032 kB
```


</div></details>

**master**

```json
{
  "version": "v1",
  "dataItems": [
    {
      "data": {
        "Average": 333.3333333333333,
        "Perc50": 309,
        "Perc90": 398,
        "Perc95": 398,
        "Perc99": 398
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes1-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 6.19530365,
        "Perc50": 3.9230769230769234,
        "Perc90": 13.824,
        "Perc95": 21.4468085106383,
        "Perc99": 47.15789473684211
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_e2e_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes1-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 1315.9391675699999,
        "Perc50": 1312.4366471734893,
        "Perc90": 2310.487329434698,
        "Perc95": 2435.243664717349,
        "Perc99": 2535.04873294347
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_pod_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes1-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 0.7890571189999995,
        "Perc50": 0.6191596638655463,
        "Perc90": 1.4238095238095239,
        "Perc95": 2.0952380952380953,
        "Perc99": 6.133333333333334
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes1-master/namespace-2",
        "extension_point": "Filter"
      }
    },
    {
      "data": {
        "Average": 1.526279999,
        "Perc50": 0.9077844311377246,
        "Perc90": 2.791946308724832,
        "Perc95": 4.329411764705883,
        "Perc99": 14.222222222222223
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes1-master/namespace-2",
        "extension_point": "Score"
      }
    },
    {
      "data": {
        "Average": 333.3333333333333,
        "Perc50": 320,
        "Perc90": 362,
        "Perc95": 362,
        "Perc99": 362
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes2-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 6.728088687000001,
        "Perc50": 3.196172248803828,
        "Perc90": 7.368421052631579,
        "Perc95": 44.8,
        "Perc99": 69.81818181818183
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_e2e_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes2-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 1355.9785761780006,
        "Perc50": 1402.6763110307413,
        "Perc90": 2328.535262206148,
        "Perc95": 2444.267631103074,
        "Perc99": 2536.853526220615
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_pod_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes2-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 0.9620791129999998,
        "Perc50": 0.5199329983249581,
        "Perc90": 0.7879396984924623,
        "Perc95": 1.1764705882352942,
        "Perc99": 28.16
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes2-master/namespace-2",
        "extension_point": "Filter"
      }
    },
    {
      "data": {
        "Average": 1.5242814989999973,
        "Perc50": 0.6534854245880862,
        "Perc90": 1.4342857142857144,
        "Perc95": 2.314893617021277,
        "Perc99": 40.53333333333334
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes2-master/namespace-2",
        "extension_point": "Score"
      }
    },
    {
      "data": {
        "Average": 333.3333333333333,
        "Perc50": 312,
        "Perc90": 380,
        "Perc95": 380,
        "Perc99": 380
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes3-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 0.9905132030000007,
        "Perc50": 0.5180645161290323,
        "Perc90": 0.7761290322580646,
        "Perc95": 1.0363636363636364,
        "Perc99": 28.800000000000004
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes3-master/namespace-2",
        "extension_point": "Filter"
      }
    },
    {
      "data": {
        "Average": 1.4464014830000007,
        "Perc50": 0.6428223844282239,
        "Perc90": 1.36,
        "Perc95": 2.2974358974358977,
        "Perc99": 38.400000000000006
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes3-master/namespace-2",
        "extension_point": "Score"
      }
    },
    {
      "data": {
        "Average": 5.855873900999992,
        "Perc50": 3.1737089201877935,
        "Perc90": 6.782608695652174,
        "Perc95": 36.173913043478265,
        "Perc99": 64
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_e2e_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes3-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 1352.0473443360008,
        "Perc50": 1365.9701492537313,
        "Perc90": 2321.194029850746,
        "Perc95": 2440.5970149253735,
        "Perc99": 2536.119402985075
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_pod_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes3-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 333.3333333333333,
        "Perc50": 358,
        "Perc90": 375,
        "Perc95": 375,
        "Perc99": 375
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes4-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 5.900431178000002,
        "Perc50": 3.1695906432748537,
        "Perc90": 6.686567164179105,
        "Perc95": 37.760000000000005,
        "Perc99": 63.36
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_e2e_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes4-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 1439.435857698,
        "Perc50": 1406.8468468468468,
        "Perc90": 2329.3693693693695,
        "Perc95": 2444.6846846846847,
        "Perc99": 2536.936936936937
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_pod_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes4-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 0.9873334640000004,
        "Perc50": 0.5383915022761759,
        "Perc90": 0.7811836115326253,
        "Perc95": 1.0980392156862746,
        "Perc99": 28.444444444444446
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes4-master/namespace-2",
        "extension_point": "Filter"
      }
    },
    {
      "data": {
        "Average": 1.4224398640000002,
        "Perc50": 0.6396158463385354,
        "Perc90": 1.2981132075471697,
        "Perc95": 2.0210526315789474,
        "Perc99": 37.236363636363635
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes4-master/namespace-2",
        "extension_point": "Score"
      }
    },
    {
      "data": {
        "Average": 333.3333333333333,
        "Perc50": 341,
        "Perc90": 433,
        "Perc95": 433,
        "Perc99": 433
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes5-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 6.574950146999998,
        "Perc50": 3.152073732718894,
        "Perc90": 6.782608695652174,
        "Perc95": 44.160000000000004,
        "Perc99": 94.31578947368422
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_e2e_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes5-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 1357.0282626960013,
        "Perc50": 1241.2556053811659,
        "Perc90": 2289.3868921775897,
        "Perc95": 2424.6934460887946,
        "Perc99": 2532.938689217759
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_pod_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes5-master/namespace-2"
      }
    },
    {
      "data": {
        "Average": 0.6723600360000002,
        "Perc50": 0.5320754716981132,
        "Perc90": 0.7836477987421383,
        "Perc95": 1.142857142857143,
        "Perc99": 3.022222222222222
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes5-master/namespace-2",
        "extension_point": "Filter"
      }
    },
    {
      "data": {
        "Average": 1.8689224350000007,
        "Perc50": 0.6458128078817733,
        "Perc90": 1.3395348837209302,
        "Perc95": 2.0571428571428574,
        "Perc99": 47.78666666666667
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes5-master/namespace-2",
        "extension_point": "Score"
      }
    }
  ]
}
```

**this branch**

```json
{
  "version": "v1",
  "dataItems": [
    {
      "data": {
        "Average": 333.3333333333333,
        "Perc50": 355,
        "Perc90": 454,
        "Perc95": 454,
        "Perc99": 454
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes1-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 0.7205763349999995,
        "Perc50": 0.3168224299065421,
        "Perc90": 0.7022727272727274,
        "Perc95": 0.9435897435897437,
        "Perc99": 6.4
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes1-new/namespace-2",
        "extension_point": "Filter"
      }
    },
    {
      "data": {
        "Average": 1.2773007930000015,
        "Perc50": 0.6485678704856789,
        "Perc90": 1.4243902439024392,
        "Perc95": 2.3510204081632655,
        "Perc99": 30.720000000000002
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes1-new/namespace-2",
        "extension_point": "Score"
      }
    },
    {
      "data": {
        "Average": 5.656395587000007,
        "Perc50": 3.181065088757397,
        "Perc90": 7.2727272727272725,
        "Perc95": 33.422222222222224,
        "Perc99": 61.86666666666667
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_e2e_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes1-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 1145.1182191990008,
        "Perc50": 1168.770053475936,
        "Perc90": 2265.747126436782,
        "Perc95": 2412.8735632183907,
        "Perc99": 2530.574712643678
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_pod_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes1-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 333.3333333333333,
        "Perc50": 331,
        "Perc90": 481,
        "Perc95": 481,
        "Perc99": 481
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes2-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 5.355481164999994,
        "Perc50": 3.1591173054587687,
        "Perc90": 6.451612903225806,
        "Perc95": 35.2,
        "Perc99": 60.800000000000004
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_e2e_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes2-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 1183.7386822030003,
        "Perc50": 1178.470254957507,
        "Perc90": 2271.711711711712,
        "Perc95": 2415.855855855856,
        "Perc99": 2531.171171171171
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_pod_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes2-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 0.5033913410000005,
        "Perc50": 0.3145833333333333,
        "Perc90": 0.6897435897435897,
        "Perc95": 0.9435897435897437,
        "Perc99": 2.666666666666667
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes2-new/namespace-2",
        "extension_point": "Filter"
      }
    },
    {
      "data": {
        "Average": 1.5458305110000006,
        "Perc50": 0.6473358116480793,
        "Perc90": 1.3888,
        "Perc95": 2.47741935483871,
        "Perc99": 41.6
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes2-new/namespace-2",
        "extension_point": "Score"
      }
    },
    {
      "data": {
        "Average": 333.3333333333333,
        "Perc50": 371,
        "Perc90": 469,
        "Perc95": 469,
        "Perc99": 469
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes3-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 5.404177923999998,
        "Perc50": 3.172737955346651,
        "Perc90": 6.782608695652174,
        "Perc95": 32.72727272727273,
        "Perc99": 61.81818181818181
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_e2e_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes3-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 1143.6037961299996,
        "Perc50": 1117.257142857143,
        "Perc90": 2248.5644768856446,
        "Perc95": 2404.2822384428223,
        "Perc99": 2528.8564476885645
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_pod_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes3-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 0.6137249800000003,
        "Perc50": 0.3254716981132076,
        "Perc90": 0.7260000000000001,
        "Perc95": 1.0166666666666666,
        "Perc99": 2.7428571428571433
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes3-new/namespace-2",
        "extension_point": "Filter"
      }
    },
    {
      "data": {
        "Average": 1.4471905680000001,
        "Perc50": 0.6490566037735849,
        "Perc90": 1.434920634920635,
        "Perc95": 2.493023255813954,
        "Perc99": 39.38461538461539
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes3-new/namespace-2",
        "extension_point": "Score"
      }
    },
    {
      "data": {
        "Average": 333.3333333333333,
        "Perc50": 348,
        "Perc90": 430,
        "Perc95": 430,
        "Perc99": 430
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes4-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 5.386691297999999,
        "Perc50": 3.1737089201877935,
        "Perc90": 7.254237288135593,
        "Perc95": 22.666666666666668,
        "Perc99": 64
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_e2e_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes4-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 1226.542063555,
        "Perc50": 1201.7955112219452,
        "Perc90": 2276.186252771619,
        "Perc95": 2418.0931263858092,
        "Perc99": 2531.6186252771618
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_pod_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes4-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 0.632254053,
        "Perc50": 0.32177777777777783,
        "Perc90": 0.727710843373494,
        "Perc95": 1.1555555555555554,
        "Perc99": 4
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes4-new/namespace-2",
        "extension_point": "Filter"
      }
    },
    {
      "data": {
        "Average": 1.3028939189999995,
        "Perc50": 0.659557867360208,
        "Perc90": 1.458227848101266,
        "Perc95": 2.4000000000000004,
        "Perc99": 34.13333333333333
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes4-new/namespace-2",
        "extension_point": "Score"
      }
    },
    {
      "data": {
        "Average": 333.3333333333333,
        "Perc50": 329,
        "Perc90": 399,
        "Perc95": 399,
        "Perc99": 399
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes5-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 5.700086156000007,
        "Perc50": 3.139269406392694,
        "Perc90": 5.957446808510639,
        "Perc95": 39.04,
        "Perc99": 69.81818181818183
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_e2e_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes5-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 1201.2564986040002,
        "Perc50": 1180.2079002079001,
        "Perc90": 2258.823529411765,
        "Perc95": 2409.411764705882,
        "Perc99": 2529.8823529411766
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_pod_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes5-new/namespace-2"
      }
    },
    {
      "data": {
        "Average": 0.6300035549999992,
        "Perc50": 0.31341853035143774,
        "Perc90": 0.7165644171779141,
        "Perc95": 1.0612244897959184,
        "Perc99": 4
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes5-new/namespace-2",
        "extension_point": "Filter"
      }
    },
    {
      "data": {
        "Average": 1.5664408549999966,
        "Perc50": 0.6325802615933412,
        "Perc90": 1.2413793103448276,
        "Perc95": 2.1028571428571428,
        "Perc99": 44.218181818181826
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes5-new/namespace-2",
        "extension_point": "Score"
      }
    }
  ]
}
```

</div></details>

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CycleState is now optimized for "write once and read many times". 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
