### PR TITLE
Copy recordPluginMetrics in CycleState.Clone

### DIFF
--- a/pkg/scheduler/framework/cycle_state.go
+++ b/pkg/scheduler/framework/cycle_state.go
@@ -82,6 +82,7 @@ func (c *CycleState) Clone() *CycleState {
 		copy.storage.Store(k, v.(StateData).Clone())
 		return true
 	})
+	copy.recordPluginMetrics = c.recordPluginMetrics
 
 	return copy
 }

--- a/pkg/scheduler/framework/cycle_state_test.go
+++ b/pkg/scheduler/framework/cycle_state_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -31,44 +32,120 @@ func (f *fakeData) Clone() StateData {
 	return copy
 }
 
-func TestCycleStateClone(t *testing.T) {
-	var key StateKey = "key"
-	data1 := "value1"
-	data2 := "value2"
+var key StateKey = "fakedata_key"
 
-	state := NewCycleState()
-	originalValue := &fakeData{
-		data: data1,
-	}
-	state.Write(key, originalValue)
-	stateCopy := state.Clone()
-
-	valueCopy, err := stateCopy.Read(key)
-	if err != nil {
-		t.Errorf("failed to read copied value: %v", err)
-	}
-	if v, ok := valueCopy.(*fakeData); ok && v.data != data1 {
-		t.Errorf("clone failed, got %q, expected %q", v.data, data1)
-	}
-
-	originalValue.data = data2
-	original, err := state.Read(key)
-	if err != nil {
-		t.Errorf("failed to read original value: %v", err)
-	}
-	if v, ok := original.(*fakeData); ok && v.data != data2 {
-		t.Errorf("original value should change, got %q, expected %q", v.data, data2)
-	}
-
-	if v, ok := valueCopy.(*fakeData); ok && v.data != data1 {
-		t.Errorf("cloned copy should not change, got %q, expected %q", v.data, data1)
-	}
+// createCycleStateWithFakeData creates *CycleState with fakeData.
+// The given data is used in stored fakeData.
+func createCycleStateWithFakeData(data string, recordPluginMetrics bool) *CycleState {
+	c := NewCycleState()
+	c.Write(key, &fakeData{
+		data: data,
+	})
+	c.SetRecordPluginMetrics(recordPluginMetrics)
+	return c
 }
 
-func TestCycleStateCloneNil(t *testing.T) {
-	var state *CycleState
-	stateCopy := state.Clone()
-	if stateCopy != nil {
-		t.Errorf("clone expected to be nil")
+// isCycleStateEqual returns whether two CycleState, which has fakeData in storage, is equal or not.
+// And if they are not equal, returns message which shows why not equal.
+func isCycleStateEqual(a, b *CycleState) (bool, string) {
+	if a == nil && b == nil {
+		return true, ""
+	}
+	if a == nil || b == nil {
+		return false, fmt.Sprintf("one CycleState is nil, but another one is not nil. A: %v, B: %v", a, b)
+	}
+
+	if a.recordPluginMetrics != b.recordPluginMetrics {
+		return false, fmt.Sprintf("CycleState A and B have a different recordPluginMetrics. A: %v, B: %v", a.recordPluginMetrics, b.recordPluginMetrics)
+	}
+
+	var msg string
+	isEqual := true
+	countA := 0
+	a.storage.Range(func(k, v1 interface{}) bool {
+		countA++
+		v2, ok := b.storage.Load(k)
+		if !ok {
+			isEqual = false
+			msg = fmt.Sprintf("CycleState B doesn't have the data which CycleState A has. key: %v, data: %v", k, v1)
+			return false
+		}
+
+		typed1, ok1 := v1.(*fakeData)
+		typed2, ok2 := v2.(*fakeData)
+		if !ok1 || !ok2 {
+			isEqual = false
+			msg = fmt.Sprintf("CycleState has the data which is not type *fakeData.")
+			return false
+		}
+
+		if typed1.data != typed2.data {
+			isEqual = false
+			msg = fmt.Sprintf("CycleState B has a different data on key %v. A: %v, B: %v", k, typed1.data, typed2.data)
+			return false
+		}
+
+		return true
+	})
+
+	if !isEqual {
+		return false, msg
+	}
+
+	countB := 0
+	b.storage.Range(func(k, _ interface{}) bool {
+		countB++
+		return true
+	})
+
+	if countA != countB {
+		return false, fmt.Sprintf("two Cyclestates have different numbers of data. A: %v, B: %v", countA, countB)
+	}
+
+	return true, ""
+}
+
+func TestCycleStateClone(t *testing.T) {
+	tests := []struct {
+		name            string
+		state           *CycleState
+		wantClonedState *CycleState
+	}{
+		{
+			name:            "clone with recordPluginMetrics true",
+			state:           createCycleStateWithFakeData("data", true),
+			wantClonedState: createCycleStateWithFakeData("data", true),
+		},
+		{
+			name:            "clone with recordPluginMetrics false",
+			state:           createCycleStateWithFakeData("data", false),
+			wantClonedState: createCycleStateWithFakeData("data", false),
+		},
+		{
+			name:            "clone with nil CycleState",
+			state:           nil,
+			wantClonedState: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := tt.state
+			stateCopy := state.Clone()
+
+			if isEqual, msg := isCycleStateEqual(stateCopy, tt.wantClonedState); !isEqual {
+				t.Errorf("unexpected cloned state: %v", msg)
+			}
+
+			if state == nil || stateCopy == nil {
+				// not need to run the rest check in this case.
+				return
+			}
+
+			stateCopy.Write(key, &fakeData{data: "modified"})
+			if isEqual, _ := isCycleStateEqual(state, stateCopy); isEqual {
+				t.Errorf("the change for a cloned state should not affect the original state.")
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We currently don't copy `recordPluginMetrics` field in CycleState.Clone() so `recordPluginMetrics` in the copied CycleCtate is always false. 
But if we do so, for example, the following part will always be `false`. Is this the expected behavior..?
https://github.com/kubernetes/kubernetes/blob/1007f4974d299991c5cb840dd3ce8f1cc58fbdce/pkg/scheduler/framework/runtime/framework.go#L632

Ref: https://github.com/kubernetes/kubernetes/pull/108724#discussion_r827738293

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a bug where metrics are not recorded during Preemption(PostFilter).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
