### PR TITLE
Remove deprecated StorageClass annotation "storageclass.beta.kubernetes.io/is-default-class"

### DIFF
--- a/pkg/apis/storage/util/helpers.go
+++ b/pkg/apis/storage/util/helpers.go
@@ -22,21 +22,12 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // marks a class as the default StorageClass
 const IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 
-// BetaIsDefaultStorageClassAnnotation is the beta version of IsDefaultStorageClassAnnotation.
-// TODO: remove Beta when no longer used
-const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
-
 // IsDefaultAnnotationText returns a pretty Yes/No String if
 // the annotation is set
-// TODO: remove Beta when no longer needed
 func IsDefaultAnnotationText(obj metav1.ObjectMeta) string {
 	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
 		return "Yes"
 	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
-		return "Yes"
-	}
-
 	return "No"
 }
 
@@ -47,9 +38,5 @@ func IsDefaultAnnotation(obj metav1.ObjectMeta) bool {
 	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
 		return true
 	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
-		return true
-	}
-
 	return false
 }

--- a/pkg/apis/storage/v1/util/helpers.go
+++ b/pkg/apis/storage/v1/util/helpers.go
@@ -24,34 +24,20 @@ import (
 // marks a class as the default StorageClass
 const IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 
-// BetaIsDefaultStorageClassAnnotation is the beta version of IsDefaultStorageClassAnnotation.
-// TODO: remove Beta when no longer used
-const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
-
 // IsDefaultAnnotationText returns a pretty Yes/No String if
 // the annotation is set
-// TODO: remove Beta when no longer needed
 func IsDefaultAnnotationText(obj metav1.ObjectMeta) string {
 	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
 		return "Yes"
 	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
-		return "Yes"
-	}
-
 	return "No"
 }
 
 // IsDefaultAnnotation returns a boolean if
 // the annotation is set
-// TODO: remove Beta when no longer needed
 func IsDefaultAnnotation(obj metav1.ObjectMeta) bool {
 	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
 		return true
 	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
-		return true
-	}
-
 	return false
 }

--- a/staging/src/k8s.io/kubectl/pkg/util/storage/storage.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/storage/storage.go
@@ -28,19 +28,12 @@ import (
 // marks a class as the default StorageClass
 const IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 
-// BetaIsDefaultStorageClassAnnotation is the beta version of IsDefaultStorageClassAnnotation.
-const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
-
 // IsDefaultAnnotationText returns a pretty Yes/No String if
 // the annotation is set
 func IsDefaultAnnotationText(obj metav1.ObjectMeta) string {
 	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
 		return "Yes"
 	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
-		return "Yes"
-	}
-
 	return "No"
 }
 

--- a/test/e2e/framework/pv/pv.go
+++ b/test/e2e/framework/pv/pv.go
@@ -49,10 +49,6 @@ const (
 	// marks a class as the default StorageClass
 	isDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 
-	// betaIsDefaultStorageClassAnnotation is the beta version of IsDefaultStorageClassAnnotation.
-	// TODO: remove Beta when no longer used
-	betaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
-
 	// volumeGidAnnotationKey is the of the annotation on the PersistentVolume
 	// object that specifies a supplemental GID.
 	// it is copied from k8s.io/kubernetes/pkg/volume/util VolumeGidAnnotationKey
@@ -826,15 +822,10 @@ func GetDefaultStorageClassName(c clientset.Interface) (string, error) {
 
 // isDefaultAnnotation returns a boolean if the default storage class
 // annotation is set
-// TODO: remove Beta when no longer needed
 func isDefaultAnnotation(obj metav1.ObjectMeta) bool {
 	if obj.Annotations[isDefaultStorageClassAnnotation] == "true" {
 		return true
 	}
-	if obj.Annotations[betaIsDefaultStorageClassAnnotation] == "true" {
-		return true
-	}
-
 	return false
 }
 

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -816,13 +816,11 @@ func updateDefaultStorageClass(c clientset.Interface, scName string, defaultStr 
 	framework.ExpectNoError(err)
 
 	if defaultStr == "" {
-		delete(sc.Annotations, storageutil.BetaIsDefaultStorageClassAnnotation)
 		delete(sc.Annotations, storageutil.IsDefaultStorageClassAnnotation)
 	} else {
 		if sc.Annotations == nil {
 			sc.Annotations = make(map[string]string)
 		}
-		sc.Annotations[storageutil.BetaIsDefaultStorageClassAnnotation] = defaultStr
 		sc.Annotations[storageutil.IsDefaultStorageClassAnnotation] = defaultStr
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/clean up

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
StorageClass annotation "storageclass.beta.kubernetes.io/is-default-class" is deprecated in 1.6 version and  "storageclass.kubernetes.io/is-default-class" should be used instead to mark a default storage class.

Related: https://github.com/kubernetes/kubernetes/pull/40088

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove deprecated StorageClass annotation `storageclass.beta.kubernetes.io/is-default-class` and use `storageclass.kubernetes.io/is-default-class` instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
