### PR TITLE
Disable watermarks

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -54,6 +54,7 @@ type ServerRunOptions struct {
 	Metrics                 *metrics.Options
 	Logs                    *logs.Options
 	Traces                  *genericoptions.TracingOptions
+	Watermark               *genericoptions.WatermarkMaintenanceOptions
 
 	AllowPrivileged           bool
 	EnableLogsHandler         bool
@@ -107,6 +108,7 @@ func NewServerRunOptions() *ServerRunOptions {
 		Metrics:                 metrics.NewOptions(),
 		Logs:                    logs.NewOptions(),
 		Traces:                  genericoptions.NewTracingOptions(),
+		Watermark:               genericoptions.NewWatermarkMaintenanceOptions(),
 
 		EnableLogsHandler:                 true,
 		EventTTL:                          1 * time.Hour,
@@ -157,6 +159,7 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 	s.Metrics.AddFlags(fss.FlagSet("metrics"))
 	s.Logs.AddFlags(fss.FlagSet("logs"))
 	s.Traces.AddFlags(fss.FlagSet("traces"))
+	s.Watermark.AddFlags(fss.FlagSet("metrics"))
 
 	// Note: the weird ""+ in below lines seems to be the only way to get gofmt to
 	// arrange these text blocks sensibly. Grrr.

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -308,10 +308,13 @@ func TestAddFlags(t *testing.T) {
 		},
 		EnableLogsHandler:       false,
 		EnableAggregatorRouting: true,
-		ProxyClientKeyFile:      "/var/run/kubernetes/proxy.key",
-		ProxyClientCertFile:     "/var/run/kubernetes/proxy.crt",
-		Metrics:                 &metrics.Options{},
-		Logs:                    logs.NewOptions(),
+		Watermark: &apiserveroptions.WatermarkMaintenanceOptions{
+			Enable: true,
+		},
+		ProxyClientKeyFile:  "/var/run/kubernetes/proxy.key",
+		ProxyClientCertFile: "/var/run/kubernetes/proxy.crt",
+		Metrics:             &metrics.Options{},
+		Logs:                logs.NewOptions(),
 		Traces: &apiserveroptions.TracingOptions{
 			ConfigFile: "/var/run/kubernetes/tracing_config.yaml",
 		},

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -476,6 +476,11 @@ func buildGenericConfig(
 		genericConfig.FlowControl, lastErr = BuildPriorityAndFairness(s, clientgoExternalClient, versionedInformers)
 	}
 
+	err = s.Watermark.ApplyTo(genericConfig)
+	if err != nil {
+		lastErr = fmt.Errorf("failed to initialize watermark: %v", err)
+		return
+	}
 	return
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
@@ -80,7 +80,7 @@ func WithPriorityAndFairness(
 		return handler
 	}
 
-	recordWaitingW := recordWaitingWatermark(watermarkEnabled)
+	recordWaitingW := recordWaitingWatermarkAtomic(watermarkEnabled)
 	recordInFlightW := recordMaxInFlightWatermarkAtomic(watermarkEnabled)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -289,7 +289,7 @@ func WithPriorityAndFairness(
 	})
 }
 
-func recordWaitingWatermark(watermarkEnabled bool) func(bool, int32) {
+func recordWaitingWatermarkAtomic(watermarkEnabled bool) func(bool, int32) {
 	if !watermarkEnabled {
 		return func(bool, int32) {}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -176,7 +177,7 @@ func newApfHandlerWithFilter(t *testing.T, flowControlFilter utilflowcontrol.Int
 		}))
 		apfHandler.ServeHTTP(w, r)
 		postExecute()
-		if atomicReadOnlyExecuting != 0 {
+		if atomic.LoadInt32(&atomicReadOnlyExecuting) != 0 {
 			t.Errorf("Wanted %d requests executing, got %d", 0, atomicReadOnlyExecuting)
 		}
 	}), requestInfoFactory)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/watermark_maintenance.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/watermark_maintenance.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+	"k8s.io/apiserver/pkg/server"
+)
+
+type WatermarkMaintenanceOptions struct {
+	Enable bool
+}
+
+func NewWatermarkMaintenanceOptions() *WatermarkMaintenanceOptions {
+	return &WatermarkMaintenanceOptions{Enable: true}
+}
+
+func (o *WatermarkMaintenanceOptions) WithEnableOpt(enable bool) {
+	o.Enable = enable
+}
+
+func (o *WatermarkMaintenanceOptions) Validate() []error {
+	return nil
+}
+
+func (o *WatermarkMaintenanceOptions) AddFlags(fs *pflag.FlagSet) {
+	if o == nil {
+		return
+	}
+
+	fs.BoolVar(&o.Enable, "enable-watermark-maintenance", o.Enable,
+		"Set to false if you want to turn off priority-and-fairness and max-in-flight watermarks and it's maintenance")
+}
+
+func (o *WatermarkMaintenanceOptions) ApplyTo(c *server.Config) error {
+	c.EnableWatermarkMaintenance = o.Enable
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds a new API server option `enable-watermark-maintenance`. It provides an option to disable
watermark maintenance for `priority-and-fairness` and `max-in-flight` filters. This is caused by a recent investigation by @jerpeter1 when watermark maintenance burning cycles when you simply import the `k8s.io/apiserver` package. For now, i see that we are using 8-20% of CPU usage in operators. This option will allow disabling maintenance when it's not needed. By default, it turned on and will not provide breaking change.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added new flag enable-watermark-maintenance which accepts bool value. It disables maintaining watermarks for priority-and-fairnes and max-in-flight filters, which can save CPU in non api-server Kubernetes applications which are using k8s.io packages. Default value is true
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
