### PR TITLE
Automated cherry pick of #108639: unmark non-validated types as enums.

### DIFF
--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -2498,12 +2498,7 @@
           },
           "type": {
             "default": "",
-            "description": "Type of resource that this limit applies to.\n\nPossible enum values:\n - `\"Container\"` Limit that applies to all containers in a namespace\n - `\"PersistentVolumeClaim\"` Limit that applies to all persistent volume claims in a namespace\n - `\"Pod\"` Limit that applies to all pods in a namespace",
-            "enum": [
-              "Container",
-              "PersistentVolumeClaim",
-              "Pod"
-            ],
+            "description": "Type of resource that this limit applies to.",
             "type": "string"
           }
         },
@@ -2712,14 +2707,7 @@
           },
           "type": {
             "default": "",
-            "description": "Type of namespace controller condition.\n\nPossible enum values:\n - `\"NamespaceContentRemaining\"` contains information about resources remaining in a namespace.\n - `\"NamespaceDeletionContentFailure\"` contains information about namespace deleter errors during deletion of resources.\n - `\"NamespaceDeletionDiscoveryFailure\"` contains information about namespace deleter errors during resource discovery.\n - `\"NamespaceDeletionGroupVersionParsingFailure\"` contains information about namespace deleter errors parsing GV for legacy types.\n - `\"NamespaceFinalizersRemaining\"` contains information about which finalizers are on resources remaining in a namespace.",
-            "enum": [
-              "NamespaceContentRemaining",
-              "NamespaceDeletionContentFailure",
-              "NamespaceDeletionDiscoveryFailure",
-              "NamespaceDeletionGroupVersionParsingFailure",
-              "NamespaceFinalizersRemaining"
-            ],
+            "description": "Type of namespace controller condition.",
             "type": "string"
           }
         },
@@ -2850,14 +2838,7 @@
           },
           "type": {
             "default": "",
-            "description": "Node address type, one of Hostname, ExternalIP or InternalIP.\n\nPossible enum values:\n - `\"ExternalDNS\"` identifies a DNS name which resolves to an IP address which has the characteristics of a NodeExternalIP. The IP it resolves to may or may not be a listed NodeExternalIP address.\n - `\"ExternalIP\"` identifies an IP address which is, in some way, intended to be more usable from outside the cluster then an internal IP, though no specific semantics are defined. It may be a globally routable IP, though it is not required to be. External IPs may be assigned directly to an interface on the node, like a NodeInternalIP, or alternatively, packets sent to the external IP may be NAT'ed to an internal node IP rather than being delivered directly (making the IP less efficient for node-to-node traffic than a NodeInternalIP).\n - `\"Hostname\"` identifies a name of the node. Although every node can be assumed to have a NodeAddress of this type, its exact syntax and semantics are not defined, and are not consistent between different clusters.\n - `\"InternalDNS\"` identifies a DNS name which resolves to an IP address which has the characteristics of a NodeInternalIP. The IP it resolves to may or may not be a listed NodeInternalIP address.\n - `\"InternalIP\"` identifies an IP address which is assigned to one of the node's network interfaces. Every node should have at least one address of this type. An internal IP is normally expected to be reachable from every other node, but may not be visible to hosts outside the cluster. By default it is assumed that kube-apiserver can reach node internal IPs, though it is possible to configure clusters where this is not the case. NodeInternalIP is the default type of node IP, and does not necessarily imply that the IP is ONLY reachable internally. If a node has multiple internal IPs, no specific semantics are assigned to the additional IPs.",
-            "enum": [
-              "ExternalDNS",
-              "ExternalIP",
-              "Hostname",
-              "InternalDNS",
-              "InternalIP"
-            ],
+            "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
             "type": "string"
           }
         },
@@ -2913,14 +2894,7 @@
           },
           "type": {
             "default": "",
-            "description": "Type of node condition.\n\nPossible enum values:\n - `\"DiskPressure\"` means the kubelet is under pressure due to insufficient available disk.\n - `\"MemoryPressure\"` means the kubelet is under pressure due to insufficient available memory.\n - `\"NetworkUnavailable\"` means that network for the node is not correctly configured.\n - `\"PIDPressure\"` means the kubelet is under pressure due to insufficient available PID.\n - `\"Ready\"` means kubelet is healthy and ready to accept pods.",
-            "enum": [
-              "DiskPressure",
-              "MemoryPressure",
-              "NetworkUnavailable",
-              "PIDPressure",
-              "Ready"
-            ],
+            "description": "Type of node condition.",
             "type": "string"
           }
         },
@@ -3440,11 +3414,6 @@
           },
           "type": {
             "default": "",
-            "description": "\n\n\nPossible enum values:\n - `\"FileSystemResizePending\"` - controller resize is finished and a file system resize is pending on node\n - `\"Resizing\"` - a user trigger resize of pvc has been started",
-            "enum": [
-              "FileSystemResizePending",
-              "Resizing"
-            ],
             "type": "string"
           }
         },
@@ -3985,13 +3954,7 @@
           },
           "type": {
             "default": "",
-            "description": "Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions\n\nPossible enum values:\n - `\"ContainersReady\"` indicates whether all containers in the pod are ready.\n - `\"Initialized\"` means that all init containers in the pod have started successfully.\n - `\"PodScheduled\"` represents status of the scheduling process for this pod.\n - `\"Ready\"` means the pod is able to service requests and should be added to the load balancing pools of all matching services.",
-            "enum": [
-              "ContainersReady",
-              "Initialized",
-              "PodScheduled",
-              "Ready"
-            ],
+            "description": "Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
             "type": "string"
           }
         },
@@ -4110,13 +4073,7 @@
         "properties": {
           "conditionType": {
             "default": "",
-            "description": "ConditionType refers to a condition in the pod's condition list with matching type.\n\nPossible enum values:\n - `\"ContainersReady\"` indicates whether all containers in the pod are ready.\n - `\"Initialized\"` means that all init containers in the pod have started successfully.\n - `\"PodScheduled\"` represents status of the scheduling process for this pod.\n - `\"Ready\"` means the pod is able to service requests and should be added to the load balancing pools of all matching services.",
-            "enum": [
-              "ContainersReady",
-              "Initialized",
-              "PodScheduled",
-              "Ready"
-            ],
+            "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -2499,11 +2499,6 @@
           },
           "type": {
             "default": "",
-            "description": "\n\n\nPossible enum values:\n - `\"FileSystemResizePending\"` - controller resize is finished and a file system resize is pending on node\n - `\"Resizing\"` - a user trigger resize of pvc has been started",
-            "enum": [
-              "FileSystemResizePending",
-              "Resizing"
-            ],
             "type": "string"
           }
         },
@@ -2800,13 +2795,7 @@
         "properties": {
           "conditionType": {
             "default": "",
-            "description": "ConditionType refers to a condition in the pod's condition list with matching type.\n\nPossible enum values:\n - `\"ContainersReady\"` indicates whether all containers in the pod are ready.\n - `\"Initialized\"` means that all init containers in the pod have started successfully.\n - `\"PodScheduled\"` represents status of the scheduling process for this pod.\n - `\"Ready\"` means the pod is able to service requests and should be added to the load balancing pools of all matching services.",
-            "enum": [
-              "ContainersReady",
-              "Initialized",
-              "PodScheduled",
-              "Ready"
-            ],
+            "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -209,12 +209,7 @@
           },
           "type": {
             "default": "",
-            "description": "Type of job condition, Complete or Failed.\n\nPossible enum values:\n - `\"Complete\"` means the job has completed its execution.\n - `\"Failed\"` means the job has failed its execution.\n - `\"Suspended\"` means the job has been suspended.",
-            "enum": [
-              "Complete",
-              "Failed",
-              "Suspended"
-            ],
+            "description": "Type of job condition, Complete or Failed.",
             "type": "string"
           }
         },
@@ -2026,13 +2021,7 @@
         "properties": {
           "conditionType": {
             "default": "",
-            "description": "ConditionType refers to a condition in the pod's condition list with matching type.\n\nPossible enum values:\n - `\"ContainersReady\"` indicates whether all containers in the pod are ready.\n - `\"Initialized\"` means that all init containers in the pod have started successfully.\n - `\"PodScheduled\"` represents status of the scheduling process for this pod.\n - `\"Ready\"` means the pod is able to service requests and should be added to the load balancing pools of all matching services.",
-            "enum": [
-              "ContainersReady",
-              "Initialized",
-              "PodScheduled",
-              "Ready"
-            ],
+            "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__batch__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1beta1_openapi.json
@@ -1828,13 +1828,7 @@
         "properties": {
           "conditionType": {
             "default": "",
-            "description": "ConditionType refers to a condition in the pod's condition list with matching type.\n\nPossible enum values:\n - `\"ContainersReady\"` indicates whether all containers in the pod are ready.\n - `\"Initialized\"` means that all init containers in the pod have started successfully.\n - `\"PodScheduled\"` represents status of the scheduling process for this pod.\n - `\"Ready\"` means the pod is able to service requests and should be added to the load balancing pools of all matching services.",
-            "enum": [
-              "ContainersReady",
-              "Initialized",
-              "PodScheduled",
-              "Ready"
-            ],
+            "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
             "type": "string"
           }
         },

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -289,7 +289,6 @@ type UncountedTerminatedPods struct {
 	Failed []types.UID `json:"failed,omitempty" protobuf:"bytes,2,rep,name=failed,casttype=k8s.io/apimachinery/pkg/types.UID"`
 }
 
-// +enum
 type JobConditionType string
 
 // These are valid conditions of a job.

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -291,7 +291,7 @@ type UncountedTerminatedPods struct {
 
 type JobConditionType string
 
-// These are valid conditions of a job.
+// These are built-in conditions of a job.
 const (
 	// JobSuspended means the job has been suspended.
 	JobSuspended JobConditionType = "Suspended"

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2636,7 +2636,7 @@ const (
 // PodConditionType is a valid value for PodCondition.Type
 type PodConditionType string
 
-// These are valid conditions of pod.
+// These are built-in conditions of pod. An application may use a custom condition not listed here.
 const (
 	// ContainersReady indicates whether all containers in the pod are ready.
 	ContainersReady PodConditionType = "ContainersReady"
@@ -5055,8 +5055,8 @@ const (
 
 type NodeConditionType string
 
-// These are valid conditions of node. Currently, we don't have enough information to decide
-// node condition. In the future, we will add more. The proposed set of conditions are:
+// These are valid but not exhaustive conditions of node. A cloud provider may set a condition not listed here.
+// The built-in set of conditions are:
 // NodeReachable, NodeLive, NodeReady, NodeSchedulable, NodeRunnable.
 const (
 	// NodeReady means kubelet is healthy and ready to accept pods.
@@ -5093,7 +5093,7 @@ type NodeCondition struct {
 
 type NodeAddressType string
 
-// These are valid address type of node.
+// These are built-in addresses type of node. A cloud provider may set a type not listed here.
 const (
 	// NodeHostName identifies a name of the node. Although every node can be assumed
 	// to have a NodeAddress of this type, its exact syntax and semantics are not
@@ -5265,7 +5265,7 @@ const (
 
 type NamespaceConditionType string
 
-// These are valid conditions of a namespace.
+// These are built-in conditions of a namespace.
 const (
 	// NamespaceDeletionDiscoveryFailure contains information about namespace deleter errors during resource discovery.
 	NamespaceDeletionDiscoveryFailure NamespaceConditionType = "NamespaceDeletionDiscoveryFailure"
@@ -5753,7 +5753,8 @@ type EventList struct {
 // List holds a list of objects, which may not be known by the server.
 type List metav1.List
 
-// LimitType is a type of object that is limited
+// LimitType is a type of object that is limited. It can be Pod, Container, PersistentVolumeClaim or
+// a fully qualified resource name.
 type LimitType string
 
 const (

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -522,7 +522,6 @@ type PersistentVolumeClaimSpec struct {
 }
 
 // PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
-// +enum
 type PersistentVolumeClaimConditionType string
 
 const (
@@ -2635,7 +2634,6 @@ const (
 )
 
 // PodConditionType is a valid value for PodCondition.Type
-// +enum
 type PodConditionType string
 
 // These are valid conditions of pod.
@@ -5055,7 +5053,6 @@ const (
 	NodeTerminated NodePhase = "Terminated"
 )
 
-// +enum
 type NodeConditionType string
 
 // These are valid conditions of node. Currently, we don't have enough information to decide
@@ -5094,7 +5091,6 @@ type NodeCondition struct {
 	Message string `json:"message,omitempty" protobuf:"bytes,6,opt,name=message"`
 }
 
-// +enum
 type NodeAddressType string
 
 // These are valid address type of node.
@@ -5267,7 +5263,6 @@ const (
 	NamespaceTerminatingCause metav1.CauseType = "NamespaceTerminating"
 )
 
-// +enum
 type NamespaceConditionType string
 
 // These are valid conditions of a namespace.
@@ -5759,7 +5754,6 @@ type EventList struct {
 type List metav1.List
 
 // LimitType is a type of object that is limited
-// +enum
 type LimitType string
 
 const (


### PR DESCRIPTION
Cherry pick of #108639 on release-1.23.

#108639: unmark non-validated types as enums.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.23 regression in published openAPI that incorrectly identified some fields as enum values
```
