### PR TITLE
feat: prepare KMS data encryption for migration to AES-GCM

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes.go
@@ -96,7 +96,7 @@ func NewCBCTransformer(block cipher.Block) value.Transformer {
 }
 
 var (
-	errInvalidBlockSize    = fmt.Errorf("the stored data is not a multiple of the block size")
+	ErrInvalidBlockSize    = fmt.Errorf("the stored data is not a multiple of the block size")
 	errInvalidPKCS7Data    = errors.New("invalid PKCS7 data (empty or not padded)")
 	errInvalidPKCS7Padding = errors.New("invalid padding on input")
 )
@@ -110,7 +110,7 @@ func (t *cbc) TransformFromStorage(ctx context.Context, data []byte, dataCtx val
 	data = data[blockSize:]
 
 	if len(data)%blockSize != 0 {
-		return nil, false, errInvalidBlockSize
+		return nil, false, ErrInvalidBlockSize
 	}
 
 	result := make([]byte, len(data))

--- a/test/integration/controlplane/transformation/transformation_testcase.go
+++ b/test/integration/controlplane/transformation/transformation_testcase.go
@@ -50,6 +50,12 @@ const (
 	testNamespace            = "secret-encryption-test"
 	testSecret               = "test-secret"
 	metricsPrefix            = "apiserver_storage_"
+
+	// precomputed key and secret for use with AES GCM
+	// this looks exactly the same as the AES CBC secret but with a different value
+	futureAESGCMKey = "e0/+tts8FS254BZimFZWtUsOCOUDSkvzB72PyimMlkY="
+	futureSecret    = "azhzAAoMCgJ2MRIGU2VjcmV0En4KXwoLdGVzdC1zZWNyZXQSABoWc2VjcmV0LWVuY3J5cHRpb24tdGVzdCIAKiQ3MmRmZTVjNC0xNDU2LTQyMzktYjFlZC1hZGZmYTJmMWY3YmEyADgAQggI5Jy/7wUQAHoAEhMKB2FwaV9rZXkSCPCfpJfwn5C8GgZPcGFxdWUaACIA"
+	futureSecretVal = "\xf0\x9f\xa4\x97\xf0\x9f\x90\xbc"
 )
 
 type unSealSecret func(ctx context.Context, cipherText []byte, dataCtx value.Context, config apiserverconfigv1.ProviderConfiguration) ([]byte, error)
@@ -237,6 +243,19 @@ func (e *transformTest) readRawRecordFromETCD(path string) (*clientv3.GetRespons
 	response, err := etcdClient.Get(context.Background(), path, clientv3.WithPrefix())
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve secret from etcd %v", err)
+	}
+
+	return response, nil
+}
+
+func (e *transformTest) writeRawRecordToETCD(path string, data []byte) (*clientv3.PutResponse, error) {
+	_, etcdClient, err := integration.GetEtcdClients(e.kubeAPIServer.ServerOpts.Etcd.StorageConfig.Transport)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create etcd client: %v", err)
+	}
+	response, err := etcdClient.Put(context.Background(), path, string(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to write secret to etcd %v", err)
 	}
 
 	return response, nil


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>
Co-authored-by: Monis Khan <mok@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This change updates the KMS envelope encryption to be able to use AES-GCM to encrypt data using the DEK instead of AES-CBC. To allow for downgrades and HA upgrades, this functionality is only used on reads.

In the next release we will be able to use AES-GCM for writes. Backwards compatibility with previously encrypted resources will be retained by falling back to AES-CBC on reads.

xref https://github.com/kubernetes/kubernetes/issues/81127

This PR is a rebased version of https://github.com/kubernetes/kubernetes/pull/86124 on master. All credits to @enj! 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
