### PR TITLE
Automated cherry pick of #108366 (release-1.22): Delay writing a terminal phase until the pod is terminated

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1496,15 +1496,26 @@ func (kl *Kubelet) Run(updates <-chan kubetypes.PodUpdate) {
 }
 
 // syncPod is the transaction script for the sync of a single pod (setting up)
-// a pod. The reverse (teardown) is handled in syncTerminatingPod and
-// syncTerminatedPod. If syncPod exits without error, then the pod runtime
-// state is in sync with the desired configuration state (pod is running).
-// If syncPod exits with a transient error, the next invocation of syncPod
-// is expected to make progress towards reaching the runtime state.
+// a pod. This method is reentrant and expected to converge a pod towards the
+// desired state of the spec. The reverse (teardown) is handled in
+// syncTerminatingPod and syncTerminatedPod. If syncPod exits without error,
+// then the pod runtime state is in sync with the desired configuration state
+// (pod is running). If syncPod exits with a transient error, the next
+// invocation of syncPod is expected to make progress towards reaching the
+// runtime state. syncPod exits with isTerminal when the pod was detected to
+// have reached a terminal lifecycle phase due to container exits (for
+// RestartNever or RestartOnFailure) and the next method invoked will by
+// syncTerminatingPod.
 //
 // Arguments:
 //
-// o - the SyncPodOptions for this invocation
+// updateType - whether this is a create (first time) or an update, should
+//   only be used for metrics since this method must be reentrant
+// pod - the pod that is being set up
+// mirrorPod - the mirror pod known to the kubelet for this pod, if any
+// podStatus - the most recent pod status observed for this pod which can
+//   be used to determine the set of actions that should be taken during
+//   this loop of syncPod
 //
 // The workflow is:
 // * If the pod is being created, record pod worker start latency
@@ -1512,7 +1523,9 @@ func (kl *Kubelet) Run(updates <-chan kubetypes.PodUpdate) {
 // * If the pod is being seen as running for the first time, record pod
 //   start latency
 // * Update the status of the pod in the status manager
-// * Kill the pod if it should not be running due to soft admission
+// * Stop the pod's containers if it should not be running due to soft
+//   admission
+// * Ensure any background tracking for a runnable pod is started
 // * Create a mirror pod if the pod is a static pod, and does not
 //   already have a mirror pod
 // * Create the data directories for the pod if they do not exist
@@ -1526,10 +1539,12 @@ func (kl *Kubelet) Run(updates <-chan kubetypes.PodUpdate) {
 //
 // This operation writes all events that are dispatched in order to provide
 // the most accurate information possible about an error situation to aid debugging.
-// Callers should not throw an event if this operation returns an error.
-func (kl *Kubelet) syncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) error {
+// Callers should not write an event if this operation returns an error.
+func (kl *Kubelet) syncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (isTerminal bool, err error) {
 	klog.V(4).InfoS("syncPod enter", "pod", klog.KObj(pod), "podUID", pod.UID)
-	defer klog.V(4).InfoS("syncPod exit", "pod", klog.KObj(pod), "podUID", pod.UID)
+	defer func() {
+		klog.V(4).InfoS("syncPod exit", "pod", klog.KObj(pod), "podUID", pod.UID, "isTerminal", isTerminal)
+	}()
 
 	// Latency measurements for the main workflow are relative to the
 	// first time the pod was seen by the API server.
@@ -1561,9 +1576,15 @@ func (kl *Kubelet) syncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	for _, ipInfo := range apiPodStatus.PodIPs {
 		podStatus.IPs = append(podStatus.IPs, ipInfo.IP)
 	}
-
 	if len(podStatus.IPs) == 0 && len(apiPodStatus.PodIP) > 0 {
 		podStatus.IPs = []string{apiPodStatus.PodIP}
+	}
+
+	// If the pod is terminal, we don't need to continue to setup the pod
+	if apiPodStatus.Phase == v1.PodSucceeded || apiPodStatus.Phase == v1.PodFailed {
+		kl.statusManager.SetPodStatus(pod, apiPodStatus)
+		isTerminal = true
+		return isTerminal, nil
 	}
 
 	// If the pod should not be running, we request the pod's containers be stopped. This is not the same
@@ -1614,13 +1635,13 @@ func (kl *Kubelet) syncPod(ctx context.Context, updateType kubetypes.SyncPodType
 			// Return an error to signal that the sync loop should back off.
 			syncErr = fmt.Errorf("pod cannot be run: %s", runnable.Message)
 		}
-		return syncErr
+		return false, syncErr
 	}
 
 	// If the network plugin is not ready, only start the pod if it uses the host network
 	if err := kl.runtimeState.networkErrors(); err != nil && !kubecontainer.IsHostNetworkPod(pod) {
 		kl.recorder.Eventf(pod, v1.EventTypeWarning, events.NetworkNotReady, "%s: %v", NetworkNotReadyErrorMsg, err)
-		return fmt.Errorf("%s: %v", NetworkNotReadyErrorMsg, err)
+		return false, fmt.Errorf("%s: %v", NetworkNotReadyErrorMsg, err)
 	}
 
 	// Create Cgroups for the pod and apply resource parameters
@@ -1667,7 +1688,7 @@ func (kl *Kubelet) syncPod(ctx context.Context, updateType kubetypes.SyncPodType
 				}
 				if err := pcm.EnsureExists(pod); err != nil {
 					kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedToCreatePodContainer, "unable to ensure pod container exists: %v", err)
-					return fmt.Errorf("failed to ensure that the pod: %v cgroups exist and are correctly applied: %v", pod.UID, err)
+					return false, fmt.Errorf("failed to ensure that the pod: %v cgroups exist and are correctly applied: %v", pod.UID, err)
 				}
 			}
 		}
@@ -1708,7 +1729,7 @@ func (kl *Kubelet) syncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	if err := kl.makePodDataDirs(pod); err != nil {
 		kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedToMakePodDataDirectories, "error making pod data directories: %v", err)
 		klog.ErrorS(err, "Unable to make pod data directories for pod", "pod", klog.KObj(pod))
-		return err
+		return false, err
 	}
 
 	// Volume manager will not mount volumes for terminating pods
@@ -1718,7 +1739,7 @@ func (kl *Kubelet) syncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		if err := kl.volumeManager.WaitForAttachAndMount(pod); err != nil {
 			kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedMountVolume, "Unable to attach or mount volumes: %v", err)
 			klog.ErrorS(err, "Unable to attach or mount volumes for pod; skipping pod", "pod", klog.KObj(pod))
-			return err
+			return false, err
 		}
 	}
 
@@ -1733,15 +1754,15 @@ func (kl *Kubelet) syncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		for _, r := range result.SyncResults {
 			if r.Error != kubecontainer.ErrCrashLoopBackOff && r.Error != images.ErrImagePullBackOff {
 				// Do not record an event here, as we keep all event logging for sync pod failures
-				// local to container runtime so we get better errors
-				return err
+				// local to container runtime, so we get better errors.
+				return false, err
 			}
 		}
 
-		return nil
+		return false, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 // syncTerminatingPod is expected to terminate all running containers in a pod. Once this method

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -925,6 +925,12 @@ func countRunningContainerStatus(status v1.PodStatus) int {
 	return runningContainers
 }
 
+// PodCouldHaveRunningContainers returns true if the pod with the given UID could still have running
+// containers. This returns false if the pod has not yet been started or the pod is unknown.
+func (kl *Kubelet) PodCouldHaveRunningContainers(pod *v1.Pod) bool {
+	return kl.podWorkers.CouldHaveRunningContainers(pod.UID)
+}
+
 // PodResourcesAreReclaimed returns true if all required node-level resources that a pod was consuming have
 // been reclaimed by the kubelet.  Reclaiming resources is a prerequisite to deleting a pod from the API server.
 func (kl *Kubelet) PodResourcesAreReclaimed(pod *v1.Pod, status v1.PodStatus) bool {
@@ -1439,7 +1445,7 @@ func getPhase(spec *v1.PodSpec, info []v1.ContainerStatus) v1.PodPhase {
 }
 
 // generateAPIPodStatus creates the final API pod status for a pod, given the
-// internal pod status.
+// internal pod status. This method should only be called from within sync*Pod methods.
 func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.PodStatus) v1.PodStatus {
 	klog.V(3).InfoS("Generating pod status", "pod", klog.KObj(pod))
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -496,9 +496,9 @@ func TestDispatchWorkOfCompletedPod(t *testing.T) {
 	kubelet := testKubelet.kubelet
 	var got bool
 	kubelet.podWorkers = &fakePodWorkers{
-		syncPodFn: func(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) error {
+		syncPodFn: func(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, error) {
 			got = true
-			return nil
+			return false, nil
 		},
 		cache: kubelet.podCache,
 		t:     t,
@@ -575,9 +575,9 @@ func TestDispatchWorkOfActivePod(t *testing.T) {
 	kubelet := testKubelet.kubelet
 	var got bool
 	kubelet.podWorkers = &fakePodWorkers{
-		syncPodFn: func(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) error {
+		syncPodFn: func(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, error) {
 			got = true
-			return nil
+			return false, nil
 		},
 		cache: kubelet.podCache,
 		t:     t,
@@ -1226,8 +1226,11 @@ func TestCreateMirrorPod(t *testing.T) {
 		pod.Annotations[kubetypes.ConfigSourceAnnotationKey] = "file"
 		pods := []*v1.Pod{pod}
 		kl.podManager.SetPods(pods)
-		err := kl.syncPod(context.Background(), updateType, pod, nil, &kubecontainer.PodStatus{})
+		isTerminal, err := kl.syncPod(context.Background(), updateType, pod, nil, &kubecontainer.PodStatus{})
 		assert.NoError(t, err)
+		if isTerminal {
+			t.Fatalf("pod should not be terminal: %#v", pod)
+		}
 		podFullName := kubecontainer.GetPodFullName(pod)
 		assert.True(t, manager.HasPod(podFullName), "Expected mirror pod %q to be created", podFullName)
 		assert.Equal(t, 1, manager.NumOfPods(), "Expected only 1 mirror pod %q, got %+v", podFullName, manager.GetPods())
@@ -1258,8 +1261,11 @@ func TestDeleteOutdatedMirrorPod(t *testing.T) {
 
 	pods := []*v1.Pod{pod, mirrorPod}
 	kl.podManager.SetPods(pods)
-	err := kl.syncPod(context.Background(), kubetypes.SyncPodUpdate, pod, mirrorPod, &kubecontainer.PodStatus{})
+	isTerminal, err := kl.syncPod(context.Background(), kubetypes.SyncPodUpdate, pod, mirrorPod, &kubecontainer.PodStatus{})
 	assert.NoError(t, err)
+	if isTerminal {
+		t.Fatalf("pod should not be terminal: %#v", pod)
+	}
 	name := kubecontainer.GetPodFullName(pod)
 	creates, deletes := manager.GetCounts(name)
 	if creates != 1 || deletes != 1 {
@@ -1415,13 +1421,19 @@ func TestNetworkErrorsWithoutHostNetwork(t *testing.T) {
 	})
 
 	kubelet.podManager.SetPods([]*v1.Pod{pod})
-	err := kubelet.syncPod(context.Background(), kubetypes.SyncPodUpdate, pod, nil, &kubecontainer.PodStatus{})
+	isTerminal, err := kubelet.syncPod(context.Background(), kubetypes.SyncPodUpdate, pod, nil, &kubecontainer.PodStatus{})
 	assert.Error(t, err, "expected pod with hostNetwork=false to fail when network in error")
+	if isTerminal {
+		t.Fatalf("pod should not be terminal: %#v", pod)
+	}
 
 	pod.Annotations[kubetypes.ConfigSourceAnnotationKey] = kubetypes.FileSource
 	pod.Spec.HostNetwork = true
-	err = kubelet.syncPod(context.Background(), kubetypes.SyncPodUpdate, pod, nil, &kubecontainer.PodStatus{})
+	isTerminal, err = kubelet.syncPod(context.Background(), kubetypes.SyncPodUpdate, pod, nil, &kubecontainer.PodStatus{})
 	assert.NoError(t, err, "expected pod with hostNetwork=true to succeed when network in error")
+	if isTerminal {
+		t.Fatalf("pod should not be terminal: %#v", pod)
+	}
 }
 
 func TestFilterOutInactivePods(t *testing.T) {

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -323,6 +323,14 @@ func findContainerStatus(status *v1.PodStatus, containerID string) (containerSta
 
 }
 
+// TerminatePod ensures that the status of containers is properly defaulted at the end of the pod
+// lifecycle. As the Kubelet must reconcile with the container runtime to observe container status
+// there is always the possibility we are unable to retrieve one or more container statuses due to
+// garbage collection, admin action, or loss of temporary data on a restart. This method ensures
+// that any absent container status is treated as a failure so that we do not incorrectly describe
+// the pod as successful. If we have not yet initialized the pod in the presence of init containers,
+// the init container failure status is sufficient to describe the pod as failing, and we do not need
+// to override waiting containers (unless there is evidence the pod previously started those containers).
 func (m *manager) TerminatePod(pod *v1.Pod) {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()

--- a/pkg/kubelet/status/testing/fake_pod_deletion_safety.go
+++ b/pkg/kubelet/status/testing/fake_pod_deletion_safety.go
@@ -16,13 +16,18 @@ limitations under the License.
 
 package testing
 
-import "k8s.io/api/core/v1"
+import v1 "k8s.io/api/core/v1"
 
 // FakePodDeletionSafetyProvider is a fake PodDeletionSafetyProvider for test.
-type FakePodDeletionSafetyProvider struct{}
+type FakePodDeletionSafetyProvider struct {
+	Reclaimed  bool
+	HasRunning bool
+}
 
-// PodResourcesAreReclaimed implements PodDeletionSafetyProvider.
-// Always reports that all pod resources are reclaimed.
 func (f *FakePodDeletionSafetyProvider) PodResourcesAreReclaimed(pod *v1.Pod, status v1.PodStatus) bool {
-	return true
+	return f.Reclaimed
+}
+
+func (f *FakePodDeletionSafetyProvider) PodCouldHaveRunningContainers(pod *v1.Pod) bool {
+	return f.HasRunning
 }

--- a/pkg/kubelet/status/testing/mock_pod_status_provider.go
+++ b/pkg/kubelet/status/testing/mock_pod_status_provider.go
@@ -17,11 +17,158 @@ limitations under the License.
 package testing
 
 import (
-	"github.com/stretchr/testify/mock"
+	reflect "reflect"
 
-	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
+	gomock "github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/mock"
+	v1 "k8s.io/api/core/v1"
+	types "k8s.io/apimachinery/pkg/types"
 )
+
+// MockPodStatusProvider is a mock of PodStatusProvider interface
+type MockPodStatusProvider struct {
+	ctrl     *gomock.Controller
+	recorder *MockPodStatusProviderMockRecorder
+}
+
+// MockPodStatusProviderMockRecorder is the mock recorder for MockPodStatusProvider
+type MockPodStatusProviderMockRecorder struct {
+	mock *MockPodStatusProvider
+}
+
+// NewMockPodStatusProvider creates a new mock instance
+func NewMockPodStatusProvider(ctrl *gomock.Controller) *MockPodStatusProvider {
+	mock := &MockPodStatusProvider{ctrl: ctrl}
+	mock.recorder = &MockPodStatusProviderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockPodStatusProvider) EXPECT() *MockPodStatusProviderMockRecorder {
+	return m.recorder
+}
+
+// GetPodStatus mocks base method
+func (m *MockPodStatusProvider) GetPodStatus(uid types.UID) (v1.PodStatus, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPodStatus", uid)
+	ret0, _ := ret[0].(v1.PodStatus)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetPodStatus indicates an expected call of GetPodStatus
+func (mr *MockPodStatusProviderMockRecorder) GetPodStatus(uid interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodStatus", reflect.TypeOf((*MockPodStatusProvider)(nil).GetPodStatus), uid)
+}
+
+// MockPodDeletionSafetyProvider is a mock of PodDeletionSafetyProvider interface
+type MockPodDeletionSafetyProvider struct {
+	ctrl     *gomock.Controller
+	recorder *MockPodDeletionSafetyProviderMockRecorder
+}
+
+// MockPodDeletionSafetyProviderMockRecorder is the mock recorder for MockPodDeletionSafetyProvider
+type MockPodDeletionSafetyProviderMockRecorder struct {
+	mock *MockPodDeletionSafetyProvider
+}
+
+// NewMockPodDeletionSafetyProvider creates a new mock instance
+func NewMockPodDeletionSafetyProvider(ctrl *gomock.Controller) *MockPodDeletionSafetyProvider {
+	mock := &MockPodDeletionSafetyProvider{ctrl: ctrl}
+	mock.recorder = &MockPodDeletionSafetyProviderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockPodDeletionSafetyProvider) EXPECT() *MockPodDeletionSafetyProviderMockRecorder {
+	return m.recorder
+}
+
+// PodResourcesAreReclaimed mocks base method
+func (m *MockPodDeletionSafetyProvider) PodResourcesAreReclaimed(pod *v1.Pod, status v1.PodStatus) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PodResourcesAreReclaimed", pod, status)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// PodResourcesAreReclaimed indicates an expected call of PodResourcesAreReclaimed
+func (mr *MockPodDeletionSafetyProviderMockRecorder) PodResourcesAreReclaimed(pod, status interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PodResourcesAreReclaimed", reflect.TypeOf((*MockPodDeletionSafetyProvider)(nil).PodResourcesAreReclaimed), pod, status)
+}
+
+// PodCouldHaveRunningContainers mocks base method
+func (m *MockPodDeletionSafetyProvider) PodCouldHaveRunningContainers(pod *v1.Pod) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PodCouldHaveRunningContainers", pod)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// PodCouldHaveRunningContainers indicates an expected call of PodCouldHaveRunningContainers
+func (mr *MockPodDeletionSafetyProviderMockRecorder) PodCouldHaveRunningContainers(pod interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PodCouldHaveRunningContainers", reflect.TypeOf((*MockPodDeletionSafetyProvider)(nil).PodCouldHaveRunningContainers), pod)
+}
+
+// MockManager is a mock of Manager interface
+type MockManager struct {
+	ctrl     *gomock.Controller
+	recorder *MockManagerMockRecorder
+}
+
+// MockManagerMockRecorder is the mock recorder for MockManager
+type MockManagerMockRecorder struct {
+	mock *MockManager
+}
+
+// NewMockManager creates a new mock instance
+func NewMockManager(ctrl *gomock.Controller) *MockManager {
+	mock := &MockManager{ctrl: ctrl}
+	mock.recorder = &MockManagerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockManager) EXPECT() *MockManagerMockRecorder {
+	return m.recorder
+}
+
+// GetPodStatus mocks base method
+func (m *MockManager) GetPodStatus(uid types.UID) (v1.PodStatus, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPodStatus", uid)
+	ret0, _ := ret[0].(v1.PodStatus)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetPodStatus indicates an expected call of GetPodStatus
+func (mr *MockManagerMockRecorder) GetPodStatus(uid interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodStatus", reflect.TypeOf((*MockManager)(nil).GetPodStatus), uid)
+}
+
+// Start mocks base method
+func (m *MockManager) Start() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Start")
+}
+
+// Start indicates an expected call of Start
+func (mr *MockManagerMockRecorder) Start() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockManager)(nil).Start))
+}
+
+// SetPodStatus mocks base method
+func (m *MockManager) SetPodStatus(pod *v1.Pod, status v1.PodStatus) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetPodStatus", pod, status)
+}
 
 // MockStatusProvider mocks a PodStatusProvider.
 type MockStatusProvider struct {

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
@@ -204,274 +205,19 @@ var _ = SIGDescribe("Pods Extended", func() {
 
 		ginkgo.It("should never report success for a pending container", func() {
 			ginkgo.By("creating pods that should always exit 1 and terminating the pod after a random delay")
-
-			var reBug88766 = regexp.MustCompile(`rootfs_linux.*kubernetes\.io~(secret|projected).*no such file or directory`)
-
-			var (
-				lock sync.Mutex
-				errs []error
-
-				wg sync.WaitGroup
+			createAndTestPodRepeatedly(
+				3, 15,
+				podFastDeleteScenario{client: podClient.PodInterface, delayMs: 2000},
+				podClient.PodInterface,
 			)
-
-			r := prometheus.NewRegistry()
-			h := prometheus.NewSummaryVec(prometheus.SummaryOpts{
-				Name: "start_latency",
-				Objectives: map[float64]float64{
-					0.5:  0.05,
-					0.75: 0.025,
-					0.9:  0.01,
-					0.99: 0.001,
-				},
-			}, []string{"node"})
-			r.MustRegister(h)
-
-			const delay = 2000
-			const workers = 3
-			const pods = 15
-			var min, max time.Duration
-			for i := 0; i < workers; i++ {
-				wg.Add(1)
-				go func(i int) {
-					defer ginkgo.GinkgoRecover()
-					defer wg.Done()
-					for retries := 0; retries < pods; retries++ {
-						name := fmt.Sprintf("pod-submit-status-%d-%d", i, retries)
-						value := strconv.Itoa(time.Now().Nanosecond())
-						one := int64(1)
-						pod := &v1.Pod{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: name,
-								Labels: map[string]string{
-									"name": "foo",
-									"time": value,
-								},
-							},
-							Spec: v1.PodSpec{
-								RestartPolicy:                 v1.RestartPolicyNever,
-								TerminationGracePeriodSeconds: &one,
-								Containers: []v1.Container{
-									{
-										Name:  "busybox",
-										Image: imageutils.GetE2EImage(imageutils.BusyBox),
-										Command: []string{
-											"/bin/false",
-										},
-										Resources: v1.ResourceRequirements{
-											Requests: v1.ResourceList{
-												v1.ResourceCPU:    resource.MustParse("5m"),
-												v1.ResourceMemory: resource.MustParse("10Mi"),
-											},
-										},
-									},
-								},
-							},
-						}
-
-						// create the pod, capture the change events, then delete the pod
-						start := time.Now()
-						created := podClient.Create(pod)
-						ch := make(chan []watch.Event)
-						waitForWatch := make(chan struct{})
-						go func() {
-							defer ginkgo.GinkgoRecover()
-							defer close(ch)
-							w, err := podClient.Watch(context.TODO(), metav1.ListOptions{
-								ResourceVersion: created.ResourceVersion,
-								FieldSelector:   fmt.Sprintf("metadata.name=%s", pod.Name),
-							})
-							if err != nil {
-								framework.Logf("Unable to watch pod %s: %v", pod.Name, err)
-								return
-							}
-							defer w.Stop()
-							close(waitForWatch)
-							events := []watch.Event{
-								{Type: watch.Added, Object: created},
-							}
-							for event := range w.ResultChan() {
-								events = append(events, event)
-								if event.Type == watch.Error {
-									framework.Logf("watch error seen for %s: %#v", pod.Name, event.Object)
-								}
-								if event.Type == watch.Deleted {
-									framework.Logf("watch delete seen for %s", pod.Name)
-									break
-								}
-							}
-							ch <- events
-						}()
-
-						select {
-						case <-ch: // in case the goroutine above exits before establishing the watch
-						case <-waitForWatch: // when the watch is established
-						}
-						t := time.Duration(rand.Intn(delay)) * time.Millisecond
-						time.Sleep(t)
-						err := podClient.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
-						framework.ExpectNoError(err, "failed to delete pod")
-
-						var (
-							events []watch.Event
-							ok     bool
-						)
-						select {
-						case events, ok = <-ch:
-							if !ok {
-								continue
-							}
-							if len(events) < 2 {
-								framework.Fail("only got a single event")
-							}
-						case <-time.After(5 * time.Minute):
-							framework.Failf("timed out waiting for watch events for %s", pod.Name)
-						}
-
-						end := time.Now()
-
-						// check the returned events for consistency
-						var duration, completeDuration time.Duration
-						var hasContainers, hasTerminated, hasTerminalPhase, hasRunningContainers bool
-						verifyFn := func(event watch.Event) error {
-							var ok bool
-							pod, ok = event.Object.(*v1.Pod)
-							if !ok {
-								framework.Logf("Unexpected event object: %s %#v", event.Type, event.Object)
-								return nil
-							}
-
-							if len(pod.Status.InitContainerStatuses) != 0 {
-								return fmt.Errorf("pod %s on node %s had incorrect init containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status.InitContainerStatuses)
-							}
-							if len(pod.Status.ContainerStatuses) == 0 {
-								if hasContainers {
-									return fmt.Errorf("pod %s on node %s had incorrect containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status.ContainerStatuses)
-								}
-								return nil
-							}
-							hasContainers = true
-							if len(pod.Status.ContainerStatuses) != 1 {
-								return fmt.Errorf("pod %s on node %s had incorrect containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status.ContainerStatuses)
-							}
-							status := pod.Status.ContainerStatuses[0]
-							t := status.State.Terminated
-							if hasTerminated {
-								if status.State.Waiting != nil || status.State.Running != nil {
-									return fmt.Errorf("pod %s on node %s was terminated and then changed state: %#v", pod.Name, pod.Spec.NodeName, status)
-								}
-								if t == nil {
-									return fmt.Errorf("pod %s on node %s was terminated and then had termination cleared: %#v", pod.Name, pod.Spec.NodeName, status)
-								}
-							}
-							var hasNoStartTime bool
-							hasRunningContainers = status.State.Waiting == nil && status.State.Terminated == nil
-							if t != nil {
-								if !t.FinishedAt.Time.IsZero() {
-									if t.StartedAt.IsZero() {
-										hasNoStartTime = true
-									} else {
-										duration = t.FinishedAt.Sub(t.StartedAt.Time)
-									}
-									completeDuration = t.FinishedAt.Sub(pod.CreationTimestamp.Time)
-								}
-
-								defer func() { hasTerminated = true }()
-								switch {
-								case t.ExitCode == 1:
-									// expected
-								case t.ExitCode == 137 && (t.Reason == "ContainerStatusUnknown" || t.Reason == "Error"):
-									// expected, pod was force-killed after grace period
-								case t.ExitCode == 128 && (t.Reason == "StartError" || t.Reason == "ContainerCannotRun") && reBug88766.MatchString(t.Message):
-									// pod volume teardown races with container start in CRI, which reports a failure
-									framework.Logf("pod %s on node %s failed with the symptoms of https://github.com/kubernetes/kubernetes/issues/88766", pod.Name, pod.Spec.NodeName)
-								default:
-									data, _ := json.MarshalIndent(pod.Status, "", "  ")
-									framework.Logf("pod %s on node %s had incorrect final status:\n%s", pod.Name, pod.Spec.NodeName, string(data))
-									return fmt.Errorf("pod %s on node %s container unexpected exit code %d: start=%s end=%s reason=%s message=%s", pod.Name, pod.Spec.NodeName, t.ExitCode, t.StartedAt, t.FinishedAt, t.Reason, t.Message)
-								}
-								switch {
-								case duration > time.Hour:
-									// problem with status reporting
-									return fmt.Errorf("pod %s container %s on node %s had very long duration %s: start=%s end=%s", pod.Name, status.Name, pod.Spec.NodeName, duration, t.StartedAt, t.FinishedAt)
-								case hasNoStartTime:
-									// should never happen
-									return fmt.Errorf("pod %s container %s on node %s had finish time but not start time: end=%s", pod.Name, status.Name, pod.Spec.NodeName, t.FinishedAt)
-								}
-							}
-							if pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded {
-								hasTerminalPhase = true
-							} else {
-								if hasTerminalPhase {
-									return fmt.Errorf("pod %s on node %s was in a terminal phase and then reverted: %#v", pod.Name, pod.Spec.NodeName, pod.Status)
-								}
-							}
-							return nil
-						}
-
-						var eventErr error
-						for _, event := range events[1:] {
-							if err := verifyFn(event); err != nil {
-								eventErr = err
-								break
-							}
-						}
-						func() {
-							lock.Lock()
-							defer lock.Unlock()
-
-							if eventErr != nil {
-								errs = append(errs, eventErr)
-								return
-							}
-
-							if !hasTerminalPhase {
-								var names []string
-								for _, status := range pod.Status.ContainerStatuses {
-									if status.State.Running != nil {
-										names = append(names, status.Name)
-									}
-								}
-								switch {
-								case len(names) > 0:
-									errs = append(errs, fmt.Errorf("pod %s on node %s did not reach a terminal phase before being deleted but had running containers: phase=%s, running-containers=%s", pod.Name, pod.Spec.NodeName, pod.Status.Phase, strings.Join(names, ",")))
-								case pod.Status.Phase != v1.PodPending:
-									errs = append(errs, fmt.Errorf("pod %s on node %s was not Pending but has no running containers: phase=%s", pod.Name, pod.Spec.NodeName, pod.Status.Phase))
-								}
-							}
-							if hasRunningContainers {
-								data, _ := json.MarshalIndent(pod.Status.ContainerStatuses, "", "  ")
-								errs = append(errs, fmt.Errorf("pod %s on node %s had running or unknown container status before being deleted:\n%s", pod.Name, pod.Spec.NodeName, string(data)))
-							}
-						}()
-
-						if duration < min {
-							min = duration
-						}
-						if duration > max || max == 0 {
-							max = duration
-						}
-						h.WithLabelValues(pod.Spec.NodeName).Observe(end.Sub(start).Seconds())
-						framework.Logf("Pod %s on node %s timings total=%s t=%s run=%s execute=%s", pod.Name, pod.Spec.NodeName, end.Sub(start), t, completeDuration, duration)
-					}
-
-				}(i)
-			}
-
-			wg.Wait()
-
-			if len(errs) > 0 {
-				var messages []string
-				for _, err := range errs {
-					messages = append(messages, err.Error())
-				}
-				framework.Failf("%d errors:\n%v", len(errs), strings.Join(messages, "\n"))
-			}
-			values, _ := r.Gather()
-			var buf bytes.Buffer
-			for _, m := range values {
-				expfmt.MetricFamilyToText(&buf, m)
-			}
-			framework.Logf("Summary of latencies:\n%s", buf.String())
+		})
+		ginkgo.It("should never report container start when an init container fails", func() {
+			ginkgo.By("creating pods with an init container that always exit 1 and terminating the pod after a random delay")
+			createAndTestPodRepeatedly(
+				3, 15,
+				podFastDeleteScenario{client: podClient.PodInterface, delayMs: 2000, initContainer: true},
+				podClient.PodInterface,
+			)
 		})
 	})
 
@@ -552,3 +298,422 @@ var _ = SIGDescribe("Pods Extended", func() {
 		})
 	})
 })
+
+func createAndTestPodRepeatedly(workers, iterations int, scenario podScenario, podClient v1core.PodInterface) {
+	var (
+		lock sync.Mutex
+		errs []error
+
+		wg sync.WaitGroup
+	)
+
+	r := prometheus.NewRegistry()
+	h := prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Name: "latency",
+		Objectives: map[float64]float64{
+			0.5:  0.05,
+			0.75: 0.025,
+			0.9:  0.01,
+			0.99: 0.001,
+		},
+	}, []string{"node"})
+	r.MustRegister(h)
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer ginkgo.GinkgoRecover()
+			defer wg.Done()
+			for retries := 0; retries < iterations; retries++ {
+				pod := scenario.Pod(i, retries)
+
+				// create the pod, capture the change events, then delete the pod
+				start := time.Now()
+				created, err := podClient.Create(context.TODO(), pod, metav1.CreateOptions{})
+				framework.ExpectNoError(err, "failed to create pod")
+
+				ch := make(chan []watch.Event)
+				waitForWatch := make(chan struct{})
+				go func() {
+					defer ginkgo.GinkgoRecover()
+					defer close(ch)
+					w, err := podClient.Watch(context.TODO(), metav1.ListOptions{
+						ResourceVersion: created.ResourceVersion,
+						FieldSelector:   fmt.Sprintf("metadata.name=%s", pod.Name),
+					})
+					if err != nil {
+						framework.Logf("Unable to watch pod %s: %v", pod.Name, err)
+						return
+					}
+					defer w.Stop()
+					close(waitForWatch)
+					events := []watch.Event{
+						{Type: watch.Added, Object: created},
+					}
+					for event := range w.ResultChan() {
+						events = append(events, event)
+						if event.Type == watch.Error {
+							framework.Logf("watch error seen for %s: %#v", pod.Name, event.Object)
+						}
+						if scenario.IsLastEvent(event) {
+							framework.Logf("watch last event seen for %s", pod.Name)
+							break
+						}
+					}
+					ch <- events
+				}()
+
+				select {
+				case <-ch: // in case the goroutine above exits before establishing the watch
+				case <-waitForWatch: // when the watch is established
+				}
+
+				verifier, scenario, err := scenario.Action(pod)
+				framework.ExpectNoError(err, "failed to take action")
+
+				var (
+					events []watch.Event
+					ok     bool
+				)
+				select {
+				case events, ok = <-ch:
+					if !ok {
+						continue
+					}
+					if len(events) < 2 {
+						framework.Fail("only got a single event")
+					}
+				case <-time.After(5 * time.Minute):
+					framework.Failf("timed out waiting for watch events for %s", pod.Name)
+				}
+
+				end := time.Now()
+
+				var eventErr error
+				for _, event := range events[1:] {
+					if err := verifier.Verify(event); err != nil {
+						eventErr = err
+						break
+					}
+				}
+
+				total := end.Sub(start)
+
+				var lastPod *v1.Pod = pod
+				func() {
+					lock.Lock()
+					defer lock.Unlock()
+
+					if eventErr != nil {
+						errs = append(errs, eventErr)
+						return
+					}
+					pod, verifyErrs := verifier.VerifyFinal(scenario, total)
+					if pod != nil {
+						lastPod = pod
+					}
+					errs = append(errs, verifyErrs...)
+				}()
+
+				h.WithLabelValues(lastPod.Spec.NodeName).Observe(total.Seconds())
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	if len(errs) > 0 {
+		var messages []string
+		for _, err := range errs {
+			messages = append(messages, err.Error())
+		}
+		framework.Failf("%d errors:\n%v", len(errs), strings.Join(messages, "\n"))
+	}
+	values, _ := r.Gather()
+	var buf bytes.Buffer
+	for _, m := range values {
+		expfmt.MetricFamilyToText(&buf, m)
+	}
+	framework.Logf("Summary of latencies:\n%s", buf.String())
+}
+
+type podScenario interface {
+	Pod(worker, attempt int) *v1.Pod
+	Action(*v1.Pod) (podScenarioVerifier, string, error)
+	IsLastEvent(event watch.Event) bool
+}
+
+type podScenarioVerifier interface {
+	Verify(event watch.Event) error
+	VerifyFinal(scenario string, duration time.Duration) (*v1.Pod, []error)
+}
+
+type podFastDeleteScenario struct {
+	client  v1core.PodInterface
+	delayMs int
+
+	initContainer bool
+}
+
+func (s podFastDeleteScenario) Verifier(pod *v1.Pod) podScenarioVerifier {
+	return &podStartVerifier{}
+}
+
+func (s podFastDeleteScenario) IsLastEvent(event watch.Event) bool {
+	if event.Type == watch.Deleted {
+		return true
+	}
+	return false
+}
+
+func (s podFastDeleteScenario) Action(pod *v1.Pod) (podScenarioVerifier, string, error) {
+	t := time.Duration(rand.Intn(s.delayMs)) * time.Millisecond
+	scenario := fmt.Sprintf("t=%s", t)
+	time.Sleep(t)
+	return &podStartVerifier{pod: pod}, scenario, s.client.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+}
+
+func (s podFastDeleteScenario) Pod(worker, attempt int) *v1.Pod {
+	name := fmt.Sprintf("pod-terminate-status-%d-%d", worker, attempt)
+	value := strconv.Itoa(time.Now().Nanosecond())
+	one := int64(1)
+	if s.initContainer {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					"name": "foo",
+					"time": value,
+				},
+			},
+			Spec: v1.PodSpec{
+				RestartPolicy:                 v1.RestartPolicyNever,
+				TerminationGracePeriodSeconds: &one,
+				InitContainers: []v1.Container{
+					{
+						Name:  "fail",
+						Image: imageutils.GetE2EImage(imageutils.BusyBox),
+						Command: []string{
+							"/bin/false",
+						},
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("5m"),
+								v1.ResourceMemory: resource.MustParse("10Mi"),
+							},
+						},
+					},
+				},
+				Containers: []v1.Container{
+					{
+						Name:  "blocked",
+						Image: imageutils.GetE2EImage(imageutils.BusyBox),
+						Command: []string{
+							"/bin/true",
+						},
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("5m"),
+								v1.ResourceMemory: resource.MustParse("10Mi"),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"name": "foo",
+				"time": value,
+			},
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy:                 v1.RestartPolicyNever,
+			TerminationGracePeriodSeconds: &one,
+			Containers: []v1.Container{
+				{
+					Name:  "fail",
+					Image: imageutils.GetE2EImage(imageutils.BusyBox),
+					Command: []string{
+						"/bin/false",
+					},
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("5m"),
+							v1.ResourceMemory: resource.MustParse("10Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// podStartVerifier checks events for a given pod and looks for unexpected
+// transitions. It assumes one container running to completion.
+type podStartVerifier struct {
+	pod                  *v1.Pod
+	hasInitContainers    bool
+	hasContainers        bool
+	hasTerminated        bool
+	hasRunningContainers bool
+	hasTerminalPhase     bool
+	duration             time.Duration
+	completeDuration     time.Duration
+}
+
+var reBug88766 = regexp.MustCompile(`rootfs_linux.*kubernetes\.io~(secret|projected).*no such file or directory`)
+
+// Verify takes successive watch events for a given pod and returns an error if the status is unexpected.
+// This verifier works for any pod which has 0 init containers and 1 regular container.
+func (v *podStartVerifier) Verify(event watch.Event) error {
+	var ok bool
+	pod, ok := event.Object.(*v1.Pod)
+	if !ok {
+		framework.Logf("Unexpected event object: %s %#v", event.Type, event.Object)
+		return nil
+	}
+	v.pod = pod
+
+	if len(pod.Spec.InitContainers) > 0 {
+		if len(pod.Status.InitContainerStatuses) == 0 {
+			if v.hasInitContainers {
+				return fmt.Errorf("pod %s on node %s had incorrect init containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status.InitContainerStatuses)
+			}
+			return nil
+		}
+		v.hasInitContainers = true
+		if len(pod.Status.InitContainerStatuses) != 1 {
+			return fmt.Errorf("pod %s on node %s had incorrect init containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status.InitContainerStatuses)
+		}
+
+	} else {
+		if len(pod.Status.InitContainerStatuses) != 0 {
+			return fmt.Errorf("pod %s on node %s had incorrect init containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status.InitContainerStatuses)
+		}
+	}
+
+	if len(pod.Status.ContainerStatuses) == 0 {
+		if v.hasContainers {
+			return fmt.Errorf("pod %s on node %s had incorrect containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status.ContainerStatuses)
+		}
+		return nil
+	}
+	v.hasContainers = true
+	if len(pod.Status.ContainerStatuses) != 1 {
+		return fmt.Errorf("pod %s on node %s had incorrect containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status.ContainerStatuses)
+	}
+
+	if status := findContainerStatusInPod(pod, "blocked"); status != nil {
+		if (status.Started != nil && *status.Started == true) || status.LastTerminationState.Terminated != nil || status.State.Waiting == nil {
+			return fmt.Errorf("pod %s on node %s should not have started the blocked container: %#v", pod.Name, pod.Spec.NodeName, status)
+		}
+	}
+
+	status := findContainerStatusInPod(pod, "fail")
+	if status == nil {
+		return fmt.Errorf("pod %s on node %s had incorrect containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status)
+	}
+
+	t := status.State.Terminated
+	if v.hasTerminated {
+		if status.State.Waiting != nil || status.State.Running != nil {
+			return fmt.Errorf("pod %s on node %s was terminated and then changed state: %#v", pod.Name, pod.Spec.NodeName, status)
+		}
+		if t == nil {
+			return fmt.Errorf("pod %s on node %s was terminated and then had termination cleared: %#v", pod.Name, pod.Spec.NodeName, status)
+		}
+	}
+	var hasNoStartTime bool
+	v.hasRunningContainers = status.State.Waiting == nil && status.State.Terminated == nil
+	if t != nil {
+		if !t.FinishedAt.Time.IsZero() {
+			if t.StartedAt.IsZero() {
+				hasNoStartTime = true
+			} else {
+				v.duration = t.FinishedAt.Sub(t.StartedAt.Time)
+			}
+			v.completeDuration = t.FinishedAt.Sub(pod.CreationTimestamp.Time)
+		}
+
+		defer func() { v.hasTerminated = true }()
+		switch {
+		case t.ExitCode == 1:
+			// expected
+		case t.ExitCode == 137 && (t.Reason == "ContainerStatusUnknown" || t.Reason == "Error"):
+			// expected, pod was force-killed after grace period
+		case t.ExitCode == 128 && (t.Reason == "StartError" || t.Reason == "ContainerCannotRun") && reBug88766.MatchString(t.Message):
+			// pod volume teardown races with container start in CRI, which reports a failure
+			framework.Logf("pod %s on node %s failed with the symptoms of https://github.com/kubernetes/kubernetes/issues/88766", pod.Name, pod.Spec.NodeName)
+		default:
+			data, _ := json.MarshalIndent(pod.Status, "", "  ")
+			framework.Logf("pod %s on node %s had incorrect final status:\n%s", pod.Name, pod.Spec.NodeName, string(data))
+			return fmt.Errorf("pod %s on node %s container unexpected exit code %d: start=%s end=%s reason=%s message=%s", pod.Name, pod.Spec.NodeName, t.ExitCode, t.StartedAt, t.FinishedAt, t.Reason, t.Message)
+		}
+		switch {
+		case v.duration > time.Hour:
+			// problem with status reporting
+			return fmt.Errorf("pod %s container %s on node %s had very long duration %s: start=%s end=%s", pod.Name, status.Name, pod.Spec.NodeName, v.duration, t.StartedAt, t.FinishedAt)
+		case hasNoStartTime:
+			// should never happen
+			return fmt.Errorf("pod %s container %s on node %s had finish time but not start time: end=%s", pod.Name, status.Name, pod.Spec.NodeName, t.FinishedAt)
+		}
+	}
+	if pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded {
+		v.hasTerminalPhase = true
+	} else {
+		if v.hasTerminalPhase {
+			return fmt.Errorf("pod %s on node %s was in a terminal phase and then reverted: %#v", pod.Name, pod.Spec.NodeName, pod.Status)
+		}
+	}
+	return nil
+}
+
+func (v *podStartVerifier) VerifyFinal(scenario string, total time.Duration) (*v1.Pod, []error) {
+	var errs []error
+	pod := v.pod
+	if !v.hasTerminalPhase {
+		var names []string
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.State.Running != nil {
+				names = append(names, status.Name)
+			}
+		}
+		switch {
+		case len(names) > 0:
+			errs = append(errs, fmt.Errorf("pod %s on node %s did not reach a terminal phase before being deleted but had running containers: phase=%s, running-containers=%s", pod.Name, pod.Spec.NodeName, pod.Status.Phase, strings.Join(names, ",")))
+		case pod.Status.Phase != v1.PodPending:
+			errs = append(errs, fmt.Errorf("pod %s on node %s was not Pending but has no running containers: phase=%s", pod.Name, pod.Spec.NodeName, pod.Status.Phase))
+		}
+	}
+	if v.hasRunningContainers {
+		data, _ := json.MarshalIndent(pod.Status.ContainerStatuses, "", "  ")
+		errs = append(errs, fmt.Errorf("pod %s on node %s had running or unknown container status before being deleted:\n%s", pod.Name, pod.Spec.NodeName, string(data)))
+	}
+
+	framework.Logf("Pod %s on node %s %s total=%s run=%s execute=%s", pod.Name, pod.Spec.NodeName, scenario, total, v.completeDuration, v.duration)
+	return pod, errs
+}
+
+// findContainerStatusInPod finds a container status by its name in the provided pod
+func findContainerStatusInPod(pod *v1.Pod, containerName string) *v1.ContainerStatus {
+	for _, container := range pod.Status.InitContainerStatuses {
+		if container.Name == containerName {
+			return &container
+		}
+	}
+	for _, container := range pod.Status.ContainerStatuses {
+		if container.Name == containerName {
+			return &container
+		}
+	}
+	for _, container := range pod.Status.EphemeralContainerStatuses {
+		if container.Name == containerName {
+			return &container
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Cherry pick of https://github.com/kubernetes/kubernetes/pull/108366 on release-1.22.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a 1.22 regression that could incorrectly reject pods with OutOfCpu errors if they were rapidly scheduled after other pods were reported as complete in the API. The Kubelet now waits to report the phase of a pod as terminal in the API until all running containers are guaranteed to have stopped and no new containers can be started.  Short-lived pods may take slightly longer (~1s) to report Succeeded or Failed after this change.
```