### PR TITLE
agnhost: support --delay-shutdown flag for the net and netexec subcommands

### DIFF
--- a/test/images/agnhost/net/main.go
+++ b/test/images/agnhost/net/main.go
@@ -24,7 +24,10 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -38,9 +41,10 @@ var (
 	// flags for the command line. See usage args below for
 	// descriptions.
 	flags struct {
-		Serve   string
-		Runner  string
-		Options string
+		Serve         string
+		Runner        string
+		Options       string
+		DelayShutdown int
 	}
 	// runners is a map from runner name to runner instance.
 	runners = makeRunnerMap()
@@ -79,11 +83,23 @@ func init() {
 			"HTTP requests.")
 	CmdNet.Flags().StringVar(&flags.Runner, "runner", "", "Runner to execute (available:"+legalRunners+")")
 	CmdNet.Flags().StringVar(&flags.Options, "options", "", "JSON options to the Runner")
+	CmdNet.Flags().IntVar(&flags.DelayShutdown, "delay-shutdown", 0, "Number of seconds to delay shutdown when receiving SIGTERM.")
 }
 
 func main(cmd *cobra.Command, args []string) {
 	if flags.Runner == "" && flags.Serve == "" {
 		log.Fatalf("Must set either --runner or --serve, see --help")
+	}
+
+	if flags.DelayShutdown > 0 {
+		termCh := make(chan os.Signal, 1)
+		signal.Notify(termCh, syscall.SIGTERM)
+		go func() {
+			<-termCh
+			log.Printf("Sleeping %d seconds before terminating...", flags.DelayShutdown)
+			time.Sleep(time.Duration(flags.DelayShutdown) * time.Second)
+			os.Exit(0)
+		}()
 	}
 
 	log.SetFlags(log.Flags() | log.Lshortfile)


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a --delay-shutdown flag to the net and netexec subcommand in the agnhost test image used in e2e tests. This will be specifically useful for tests in https://github.com/kubernetes/kubernetes/pull/108691, where we need a webserver that receives SIGTERM but continues to serve traffic.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
