### PR TITLE
[Release-1.11] Add item length check in legacyPrinterToTable

### DIFF
--- a/pkg/printers/humanreadable.go
+++ b/pkg/printers/humanreadable.go
@@ -649,7 +649,7 @@ func (h *HumanReadablePrinter) legacyPrinterToTable(obj runtime.Object, handler 
 		if err != nil {
 			return nil, err
 		}
-		for len(data) > 0 {
+		for len(data) > 0 && i < len(items) {
 			cells, remainder := tabbedLineToCells(data, len(table.ColumnDefinitions))
 			table.Rows = append(table.Rows, metav1beta1.TableRow{
 				Cells:  cells,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Item length should be always equal to data buffer.
`tabbedLineToCells` parses buffer according to `\n` and
if resource itself exceptionally contains `\n`, api server
panicks with index out of range error.

Instead panicking, this PR gracefully handles 
equality check.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
