### PR TITLE
Notify resourcequota admission controller to stop before apiserver shutdown

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -65,6 +65,7 @@ func createAggregatorConfig(
 	// most of the config actually remains the same.  We only need to mess with a couple items related to the particulars of the aggregator
 	genericConfig := kubeAPIServerConfig
 	genericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
+	genericConfig.PreShutdownHooks = map[string]genericapiserver.PreShutdownHookConfigEntry{}
 	genericConfig.RESTOptionsGetter = nil
 	// prevent generic API server from installing the OpenAPI handler. Aggregator server
 	// has its own customized OpenAPI handler.
@@ -118,8 +119,9 @@ func createAggregatorConfig(
 		},
 	}
 
-	// we need to clear the poststarthooks so we don't add them multiple times to all the servers (that fails)
+	// we need to clear the poststarthooks & preshutdownhooks so we don't add them multiple times to all the servers (that fails)
 	aggregatorConfig.GenericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
+	aggregatorConfig.GenericConfig.PreShutdownHooks = map[string]genericapiserver.PreShutdownHookConfigEntry{}
 
 	return aggregatorConfig, nil
 }

--- a/cmd/kube-apiserver/app/apiextensions.go
+++ b/cmd/kube-apiserver/app/apiextensions.go
@@ -50,6 +50,7 @@ func createAPIExtensionsConfig(
 	// most of the config actually remains the same.  We only need to mess with a couple items related to the particulars of the apiextensions
 	genericConfig := kubeAPIServerConfig
 	genericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
+	genericConfig.PreShutdownHooks = map[string]genericapiserver.PreShutdownHookConfigEntry{}
 	genericConfig.RESTOptionsGetter = nil
 
 	// override genericConfig.AdmissionControl with apiextensions' scheme,
@@ -94,8 +95,9 @@ func createAPIExtensionsConfig(
 		},
 	}
 
-	// we need to clear the poststarthooks so we don't add them multiple times to all the servers (that fails)
+	// we need to clear the poststarthooks & preshutdownhooks so we don't add them multiple times to all the servers (that fails)
 	apiextensionsConfig.GenericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
+	apiextensionsConfig.GenericConfig.PreShutdownHooks = map[string]genericapiserver.PreShutdownHookConfigEntry{}
 
 	return apiextensionsConfig, nil
 }

--- a/plugin/pkg/admission/gc/gc_admission_test.go
+++ b/plugin/pkg/admission/gc/gc_admission_test.go
@@ -115,7 +115,7 @@ func newGCPermissionsEnforcement() (*gcPermissionsEnforcement, error) {
 		whiteList: whiteList,
 	}
 
-	genericPluginInitializer := initializer.New(nil, nil, fakeAuthorizer{}, nil)
+	genericPluginInitializer := initializer.New(nil, nil, fakeAuthorizer{}, nil, nil)
 	fakeDiscoveryClient := &fakediscovery.FakeDiscovery{Fake: &coretesting.Fake{}}
 	fakeDiscoveryClient.Resources = []*metav1.APIResourceList{
 		{

--- a/plugin/pkg/admission/limitranger/admission_test.go
+++ b/plugin/pkg/admission/limitranger/admission_test.go
@@ -790,7 +790,7 @@ func newHandlerForTest(c clientset.Interface) (*LimitRanger, informers.SharedInf
 	if err != nil {
 		return nil, f, err
 	}
-	pluginInitializer := genericadmissioninitializer.New(c, f, nil, nil)
+	pluginInitializer := genericadmissioninitializer.New(c, f, nil, nil, nil)
 	pluginInitializer.Initialize(handler)
 	err = admission.ValidateInitialization(handler)
 	return handler, f, err

--- a/plugin/pkg/admission/namespace/autoprovision/admission_test.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission_test.go
@@ -41,7 +41,7 @@ import (
 func newHandlerForTest(c clientset.Interface) (admission.MutationInterface, informers.SharedInformerFactory, error) {
 	f := informers.NewSharedInformerFactory(c, 5*time.Minute)
 	handler := NewProvision()
-	pluginInitializer := genericadmissioninitializer.New(c, f, nil, nil)
+	pluginInitializer := genericadmissioninitializer.New(c, f, nil, nil, nil)
 	pluginInitializer.Initialize(handler)
 	err := admission.ValidateInitialization(handler)
 	return handler, f, err

--- a/plugin/pkg/admission/namespace/exists/admission_test.go
+++ b/plugin/pkg/admission/namespace/exists/admission_test.go
@@ -39,7 +39,7 @@ import (
 func newHandlerForTest(c kubernetes.Interface) (admission.ValidationInterface, informers.SharedInformerFactory, error) {
 	f := informers.NewSharedInformerFactory(c, 5*time.Minute)
 	handler := NewExists()
-	pluginInitializer := genericadmissioninitializer.New(c, f, nil, nil)
+	pluginInitializer := genericadmissioninitializer.New(c, f, nil, nil, nil)
 	pluginInitializer.Initialize(handler)
 	err := admission.ValidateInitialization(handler)
 	return handler, f, err

--- a/plugin/pkg/admission/podnodeselector/admission_test.go
+++ b/plugin/pkg/admission/podnodeselector/admission_test.go
@@ -198,7 +198,7 @@ func TestHandles(t *testing.T) {
 func newHandlerForTest(c kubernetes.Interface) (*Plugin, informers.SharedInformerFactory, error) {
 	f := informers.NewSharedInformerFactory(c, 5*time.Minute)
 	handler := NewPodNodeSelector(nil)
-	pluginInitializer := genericadmissioninitializer.New(c, f, nil, nil)
+	pluginInitializer := genericadmissioninitializer.New(c, f, nil, nil, nil)
 	pluginInitializer.Initialize(handler)
 	err := admission.ValidateInitialization(handler)
 	return handler, f, err

--- a/plugin/pkg/admission/podtolerationrestriction/admission_test.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission_test.go
@@ -356,7 +356,7 @@ func newHandlerForTest(c kubernetes.Interface) (*Plugin, informers.SharedInforme
 		return nil, nil, err
 	}
 	handler := NewPodTolerationsPlugin(pluginConfig)
-	pluginInitializer := genericadmissioninitializer.New(c, f, nil, nil)
+	pluginInitializer := genericadmissioninitializer.New(c, f, nil, nil, nil)
 	pluginInitializer.Initialize(handler)
 	err = admission.ValidateInitialization(handler)
 	return handler, f, err

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -99,13 +99,14 @@ func createHandlerWithConfig(kubeClient kubernetes.Interface, informerFactory in
 	}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 
-	handler, err := resourcequota.NewResourceQuota(config, 5, stopCh)
+	handler, err := resourcequota.NewResourceQuota(config, 5)
 	if err != nil {
 		return nil, err
 	}
 	handler.SetExternalKubeClientSet(kubeClient)
 	handler.SetExternalKubeInformerFactory(informerFactory)
 	handler.SetQuotaConfiguration(quotaConfiguration)
+	handler.SetShutdownSignal(stopCh)
 
 	return handler, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer.go
@@ -29,6 +29,7 @@ type pluginInitializer struct {
 	externalInformers informers.SharedInformerFactory
 	authorizer        authorizer.Authorizer
 	featureGates      featuregate.FeatureGate
+	stopCh            <-chan struct{}
 }
 
 // New creates an instance of admission plugins initializer.
@@ -39,12 +40,14 @@ func New(
 	extInformers informers.SharedInformerFactory,
 	authz authorizer.Authorizer,
 	featureGates featuregate.FeatureGate,
+	stopCh <-chan struct{},
 ) pluginInitializer {
 	return pluginInitializer{
 		externalClient:    extClientset,
 		externalInformers: extInformers,
 		authorizer:        authz,
 		featureGates:      featureGates,
+		stopCh:            stopCh,
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer.go
@@ -70,6 +70,10 @@ func (i pluginInitializer) Initialize(plugin admission.Interface) {
 	if wants, ok := plugin.(WantsAuthorizer); ok {
 		wants.SetAuthorizer(i.authorizer)
 	}
+
+	if wants, ok := plugin.(WantsShutdownSignal); ok {
+		wants.SetShutdownSignal(i.stopCh)
+	}
 }
 
 var _ admission.PluginInitializer = pluginInitializer{}

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer_test.go
@@ -32,7 +32,7 @@ import (
 // TestWantsAuthorizer ensures that the authorizer is injected
 // when the WantsAuthorizer interface is implemented by a plugin.
 func TestWantsAuthorizer(t *testing.T) {
-	target := initializer.New(nil, nil, &TestAuthorizer{}, nil)
+	target := initializer.New(nil, nil, &TestAuthorizer{}, nil, nil)
 	wantAuthorizerAdmission := &WantAuthorizerAdmission{}
 	target.Initialize(wantAuthorizerAdmission)
 	if wantAuthorizerAdmission.auth == nil {
@@ -44,7 +44,7 @@ func TestWantsAuthorizer(t *testing.T) {
 // when the WantsExternalKubeClientSet interface is implemented by a plugin.
 func TestWantsExternalKubeClientSet(t *testing.T) {
 	cs := &fake.Clientset{}
-	target := initializer.New(cs, nil, &TestAuthorizer{}, nil)
+	target := initializer.New(cs, nil, &TestAuthorizer{}, nil, nil)
 	wantExternalKubeClientSet := &WantExternalKubeClientSet{}
 	target.Initialize(wantExternalKubeClientSet)
 	if wantExternalKubeClientSet.cs != cs {
@@ -57,7 +57,7 @@ func TestWantsExternalKubeClientSet(t *testing.T) {
 func TestWantsExternalKubeInformerFactory(t *testing.T) {
 	cs := &fake.Clientset{}
 	sf := informers.NewSharedInformerFactory(cs, time.Duration(1)*time.Second)
-	target := initializer.New(cs, sf, &TestAuthorizer{}, nil)
+	target := initializer.New(cs, sf, &TestAuthorizer{}, nil, nil)
 	wantExternalKubeInformerFactory := &WantExternalKubeInformerFactory{}
 	target.Initialize(wantExternalKubeInformerFactory)
 	if wantExternalKubeInformerFactory.sf != sf {

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/interfaces.go
@@ -59,3 +59,9 @@ type WantsFeatures interface {
 	InspectFeatureGates(featuregate.FeatureGate)
 	admission.InitializationValidator
 }
+
+// WantsShutdownSignal defines a function which sets stop chan for admission plugins that need it.
+type WantsShutdownSignal interface {
+	SetShutdownSignal(<-chan struct{})
+	admission.InitializationValidator
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
@@ -53,7 +53,7 @@ func newHandlerForTestWithClock(c clientset.Interface, cacheClock clock.Clock) (
 	if err != nil {
 		return nil, f, err
 	}
-	pluginInitializer := kubeadmission.New(c, f, nil, nil)
+	pluginInitializer := kubeadmission.New(c, f, nil, nil, nil)
 	pluginInitializer.Initialize(handler)
 	err = admission.ValidateInitialization(handler)
 	return handler, f, err

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
@@ -109,7 +109,7 @@ func newAdmissionWaiter(a admission.Attributes) *admissionWaiter {
 // NewQuotaEvaluator configures an admission controller that can enforce quota constraints
 // using the provided registry.  The registry must have the capability to handle group/kinds that
 // are persisted by the server this admission controller is intercepting
-func NewQuotaEvaluator(quotaAccessor QuotaAccessor, ignoredResources map[schema.GroupResource]struct{}, quotaRegistry quota.Registry, lockAcquisitionFunc func([]corev1.ResourceQuota) func(), config *resourcequotaapi.Configuration, workers int, stopCh <-chan struct{}) Evaluator {
+func NewQuotaEvaluator(quotaAccessor QuotaAccessor, ignoredResources map[schema.GroupResource]struct{}, quotaRegistry quota.Registry, lockAcquisitionFunc func([]corev1.ResourceQuota) func(), config *resourcequotaapi.Configuration, workers int) Evaluator {
 	// if we get a nil config, just create an empty default.
 	if config == nil {
 		config = &resourcequotaapi.Configuration{}
@@ -128,7 +128,6 @@ func NewQuotaEvaluator(quotaAccessor QuotaAccessor, ignoredResources map[schema.
 		inProgress: sets.String{},
 
 		workers: workers,
-		stopCh:  stopCh,
 		config:  config,
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/hooks.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/hooks.go
@@ -73,6 +73,10 @@ type PostStartHookConfigEntry struct {
 	originatingStack string
 }
 
+type PreShutdownHookConfigEntry struct {
+	hook PreShutdownHookFunc
+}
+
 type preShutdownHookEntry struct {
 	hook PreShutdownHookFunc
 }

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -71,7 +71,7 @@ func TestQuota(t *testing.T) {
 	admissionCh := make(chan struct{})
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{QPS: -1, Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
 	config := &resourcequotaapi.Configuration{}
-	admission, err := resourcequota.NewResourceQuota(config, 5, admissionCh)
+	admission, err := resourcequota.NewResourceQuota(config, 5)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -80,6 +80,7 @@ func TestQuota(t *testing.T) {
 	admission.SetExternalKubeInformerFactory(internalInformers)
 	qca := quotainstall.NewQuotaConfigurationForAdmission()
 	admission.SetQuotaConfiguration(qca)
+	admission.SetShutdownSignal(admissionCh)
 	defer close(admissionCh)
 
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
@@ -305,7 +306,7 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 		},
 	}
 	qca := quotainstall.NewQuotaConfigurationForAdmission()
-	admission, err := resourcequota.NewResourceQuota(config, 5, admissionCh)
+	admission, err := resourcequota.NewResourceQuota(config, 5)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -313,6 +314,7 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 	externalInformers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
 	admission.SetExternalKubeInformerFactory(externalInformers)
 	admission.SetQuotaConfiguration(qca)
+	admission.SetShutdownSignal(admissionCh)
 	defer close(admissionCh)
 
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
@@ -434,7 +436,7 @@ func TestQuotaLimitService(t *testing.T) {
 		},
 	}
 	qca := quotainstall.NewQuotaConfigurationForAdmission()
-	admission, err := resourcequota.NewResourceQuota(config, 5, admissionCh)
+	admission, err := resourcequota.NewResourceQuota(config, 5)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -442,6 +444,7 @@ func TestQuotaLimitService(t *testing.T) {
 	externalInformers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
 	admission.SetExternalKubeInformerFactory(externalInformers)
 	admission.SetQuotaConfiguration(qca)
+	admission.SetShutdownSignal(admissionCh)
 	defer close(admissionCh)
 
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We didn't have a way to close the channel in resourcequota controller because the channel was created by it's own admission, so goroutines leaked in resourcequota controller

This PR added a new interface `WantsShutdownSignal` to set the stop channel, and any admission requires the signal to exit gracefully can implement this interface.

The stop channel defined in generic `AdmissionOptions.ApplyTo`, will be used by `genericInitializer` to set the stop channel. This channel is closed before apiserver shutdown by `Config.AddPreShutdownHook`

Also removed the `stopCh` from `QuotaAdmission` since it's only used by its own controller `quotaEvaluator`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108388

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
