### PR TITLE
[Release-1.11] Add item length check in legacyPrinterToTable

### DIFF
--- a/pkg/printers/humanreadable.go
+++ b/pkg/printers/humanreadable.go
@@ -650,6 +650,11 @@ func (h *HumanReadablePrinter) legacyPrinterToTable(obj runtime.Object, handler 
 			return nil, err
 		}
 		for len(data) > 0 {
+			if i >= len(items) {
+				// This should not happen but if it is, instead panicking with
+				// the out of bound error, We need to handle it gracefully.
+				break
+			}
 			cells, remainder := tabbedLineToCells(data, len(table.ColumnDefinitions))
 			table.Rows = append(table.Rows, metav1beta1.TableRow{
 				Cells:  cells,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Item length should be always equal to data buffer.
`tabbedLineToCells` parses buffer according to `\n` and
if resource itself exceptionally contains `\n`, api server
panicks with index out of range error.

Instead panicking, this PR gracefully handles 
equality check.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
