### PR TITLE
remove TODOs from http package and prober

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -52,7 +52,6 @@ var ProberResults = metrics.NewCounterVec(
 // probe (AddPod). The worker periodically probes its assigned container and caches the results. The
 // manager use the cached probe results to set the appropriate Ready state in the PodStatus when
 // requested (UpdatePodStatus). Updating probe parameters is not currently supported.
-// TODO: Move liveness probing out of the runtime, to here.
 type Manager interface {
 	// AddPod creates new probe workers for every container probe. This should be called for every
 	// pod created.

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -261,9 +261,7 @@ func (w *worker) doProbe() (keepGoing bool) {
 		}
 	}
 
-	// TODO: in order for exec probes to correctly handle downward API env, we must be able to reconstruct
-	// the full container environment here, OR we must make a call to the CRI in order to get those environment
-	// values from the running container.
+	// Note, exec probe does NOT have access to pod environment variables or downward API
 	result, err := w.probeManager.prober.probe(w.probeType, w.pod, status, w.container, w.containerID)
 	if err != nil {
 		// Prober error, throw away the result.

--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -51,9 +51,10 @@ func NewWithTLSConfig(config *tls.Config, followNonLocalRedirects bool) Prober {
 	// We do not want the probe use node's local proxy set.
 	transport := utilnet.SetTransportDefaults(
 		&http.Transport{
-			TLSClientConfig:   config,
-			DisableKeepAlives: true,
-			Proxy:             http.ProxyURL(nil),
+			TLSClientConfig:    config,
+			DisableKeepAlives:  true,
+			Proxy:              http.ProxyURL(nil),
+			DisableCompression: true, // removes Accept-Encoding header
 		})
 	return httpProber{transport, followNonLocalRedirects}
 }
@@ -68,9 +69,8 @@ type httpProber struct {
 	followNonLocalRedirects bool
 }
 
-// Probe returns a ProbeRunner capable of running an HTTP check.
+// Probe returns a probing result. The only case the err will not be nil is when there is a problem reading the response body.
 func (pr httpProber) Probe(url *url.URL, headers http.Header, timeout time.Duration) (probe.Result, string, error) {
-	pr.transport.DisableCompression = true // removes Accept-Encoding header
 	client := &http.Client{
 		Timeout:       timeout,
 		Transport:     pr.transport,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area kubelet
/sig node

#### What this PR does / why we need it:

This is a clean up of old workaround with three http connection pools that was fixed in https://github.com/golang/go/issues/22091. Also removed a few old TODOs.

#### Special notes for your reviewer:

I was looking at something else in this code and found that these old TODOs will unlikely be fixed, and the workaround with three http pools is unnatural and not needed any longer. Just a simple clean up.

```release-note
NONE
```
