### PR TITLE
Expose the version of Kustomize that Kubectl embeds

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -328,12 +328,16 @@ kube::test::if_has_string() {
   local match=$2
 
   if grep -q "${match}" <<< "${message}"; then
+    echo -n "${green}"
     echo "Successful"
+    echo -n "${reset}"
     echo "message:${message}"
     echo "has:${match}"
     return 0
   else
+    echo -n "${bold}${red}"
     echo "FAIL!"
+    echo -n "${reset}"
     echo "message:${message}"
     echo "has not:${match}"
     caller
@@ -346,13 +350,17 @@ kube::test::if_has_not_string() {
   local match=$2
 
   if grep -q "${match}" <<< "${message}"; then
+    echo -n "${bold}${red}"
     echo "FAIL!"
+    echo -n "${reset}"
     echo "message:${message}"
     echo "has:${match}"
     caller
     return 1
   else
+    echo -n "${green}"
     echo "Successful"
+    echo -n "${reset}"
     echo "message:${message}"
     echo "has not:${match}"
     return 0
@@ -362,11 +370,16 @@ kube::test::if_has_not_string() {
 kube::test::if_empty_string() {
   local match=$1
   if [ -n "${match}" ]; then
+    echo -n "${bold}${red}"
+    echo "FAIL!"
     echo "${match} is not empty"
+    echo -n "${reset}"
     caller
     return 1
   else
+    echo -n "${green}"
     echo "Successful"
+    echo -n "${reset}"
     return 0
   fi
 }

--- a/hack/update-kustomize.sh
+++ b/hack/update-kustomize.sh
@@ -55,9 +55,19 @@ fi
 ./hack/update-internal-modules.sh
 ./hack/lint-dependencies.sh
 
+sed -i '' -e "s/const kustomizeVersion.*$/const kustomizeVersion = \"${LATEST_KUSTOMIZE}\"/" staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+
 echo -e "\n${color_blue}Committing changes${color_norm}"
 git add .
 git commit -a -m "Update kubectl kustomize to kyaml/$LATEST_KYAML, cmd/config/$LATEST_CONFIG, api/$LATEST_API, kustomize/$LATEST_KUSTOMIZE"
+
+echo -e "\n${color_blue:?}Verifying kubectl kustomize version${color_norm:?}"
+make WHAT=cmd/kubectl
+
+if [[ $(_output/bin/kubectl version --client -o json | jq -r '.kustomizeVersion') != "$LATEST_KUSTOMIZE" ]]; then
+  echo -e "${color_red:?}Unexpected kubectl kustomize version${color_norm:?}"
+  exit 1
+fi
 
 echo -e "\n${color_green:?}Update successful${color_norm:?}"
 echo "Note: If any of the integration points changed, you may need to update them manually."

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
@@ -34,10 +35,14 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
+// TODO(knverey): remove this hardcoding once kubectl being built with module support makes BuildInfo available.
+const kustomizeVersion = "v4.4.1"
+
 // Version is a struct for version information
 type Version struct {
-	ClientVersion *apimachineryversion.Info `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
-	ServerVersion *apimachineryversion.Info `json:"serverVersion,omitempty" yaml:"serverVersion,omitempty"`
+	ClientVersion    *apimachineryversion.Info `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
+	KustomizeVersion string                    `json:"kustomizeVersion,omitempty" yaml:"kustomizeVersion,omitempty"`
+	ServerVersion    *apimachineryversion.Info `json:"serverVersion,omitempty" yaml:"serverVersion,omitempty"`
 }
 
 var (
@@ -116,32 +121,32 @@ func (o *Options) Validate(args []string) error {
 // Run executes version command
 func (o *Options) Run() error {
 	var (
-		serverVersion *apimachineryversion.Info
-		serverErr     error
-		versionInfo   Version
+		serverErr   error
+		versionInfo Version
 	)
 
-	clientVersion := version.Get()
-	versionInfo.ClientVersion = &clientVersion
+	versionInfo.ClientVersion = func() *apimachineryversion.Info { v := version.Get(); return &v }()
+	versionInfo.KustomizeVersion = getKustomizeVersion()
 
 	if !o.ClientOnly && o.discoveryClient != nil {
 		// Always request fresh data from the server
 		o.discoveryClient.Invalidate()
-		serverVersion, serverErr = o.discoveryClient.ServerVersion()
-		versionInfo.ServerVersion = serverVersion
+		versionInfo.ServerVersion, serverErr = o.discoveryClient.ServerVersion()
 	}
 
 	switch o.Output {
 	case "":
 		if o.Short {
-			fmt.Fprintf(o.Out, "Client Version: %s\n", clientVersion.GitVersion)
-			if serverVersion != nil {
-				fmt.Fprintf(o.Out, "Server Version: %s\n", serverVersion.GitVersion)
+			fmt.Fprintf(o.Out, "Client Version: %s\n", versionInfo.ClientVersion.GitVersion)
+			fmt.Fprintf(o.Out, "Kustomize Version: %s\n", versionInfo.KustomizeVersion)
+			if versionInfo.ServerVersion != nil {
+				fmt.Fprintf(o.Out, "Server Version: %s\n", versionInfo.ServerVersion.GitVersion)
 			}
 		} else {
-			fmt.Fprintf(o.Out, "Client Version: %#v\n", clientVersion)
-			if serverVersion != nil {
-				fmt.Fprintf(o.Out, "Server Version: %#v\n", *serverVersion)
+			fmt.Fprintf(o.Out, "Client Version: %#v\n", *versionInfo.ClientVersion)
+			fmt.Fprintf(o.Out, "Kustomize Version: %s\n", versionInfo.KustomizeVersion)
+			if versionInfo.ServerVersion != nil {
+				fmt.Fprintf(o.Out, "Server Version: %#v\n", *versionInfo.ServerVersion)
 			}
 		}
 	case "yaml":
@@ -162,11 +167,24 @@ func (o *Options) Run() error {
 		return fmt.Errorf("VersionOptions were not validated: --output=%q should have been rejected", o.Output)
 	}
 
-	if serverVersion != nil {
-		if err := printVersionSkewWarning(o.ErrOut, clientVersion, *serverVersion); err != nil {
+	if versionInfo.ServerVersion != nil {
+		if err := printVersionSkewWarning(o.ErrOut, *versionInfo.ClientVersion, *versionInfo.ServerVersion); err != nil {
 			return err
 		}
 	}
 
 	return serverErr
+}
+
+func getKustomizeVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return kustomizeVersion
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == "sigs.k8s.io/kustomize/kustomize/v4" {
+			return dep.Version
+		}
+	}
+	return kustomizeVersion
 }

--- a/test/cmd/version.sh
+++ b/test/cmd/version.sh
@@ -66,6 +66,21 @@ run_kubectl_version_tests() {
   kube::test::version::yaml_object_to_file "" "${TEMP}/client_server_yaml_version_test"
   kube::test::version::diff_assert "${TEMP}/client_server_json_version_test" "eq" "${TEMP}/client_server_yaml_version_test" "--output json/yaml has identical information"
 
+  kube::log::status "Testing kubectl version: contains semantic version of embedded kustomize"
+  output_message=$(kubectl version)
+  kube::test::if_has_not_string "${output_message}" "Kustomize Version\: unknown" "kustomize version should not be unknown"
+  kube::test::if_has_string "${output_message}" "Kustomize Version\: v[[:digit:]][[:digit:]]*\.[[:digit:]][[:digit:]]*\.[[:digit:]][[:digit:]]*" "kubectl kustomize version should have a reasonable value"
+
+  kube::log::status "Testing kubectl version: all output formats include kustomize version"
+  output_message=$(kubectl version --client)
+  kube::test::if_has_string "${output_message}" "Kustomize Version" "kustomize version should be printed when --client is specified"
+  output_message=$(kubectl version --short)
+  kube::test::if_has_string "${output_message}" "Kustomize Version" "kustomize version should be printed when --short is specified"
+  output_message=$(kubectl version -o yaml)
+  kube::test::if_has_string "${output_message}" "kustomizeVersion" "kustomize version should be printed when -o yaml is used"
+  output_message=$(kubectl version -o json)
+  kube::test::if_has_string "${output_message}" "kustomizeVersion" "kustomize version should be printed when -o json is used"
+
   set +o nounset
   set +o errexit
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/kustomize/issues/1424. **This is the top feature request on Kustomize by upvotes** and has also been requested directly on the kubectl and oc repos.

/cc @natasha41575 

#### Special notes for your reviewer:

_**Updated to match the implementation agreed to at the Mar 23 SIG CLI meeting**_

This PR extracts the current Kustomize version from the root go.mod and sets an ldflag that embeds the version into Kustomize's Provenance code (the same code that drives standalone `kustomize version`). It then uses that information to expose Kustomize version info in `kubectl version`. It also adds a sanity check to the Kustomize update script, ensuring that the version output matches what the update executor intended.

Alternatives considered:
- Embedding the Kustomize version inside the client section of `kubectl version`: https://github.com/kubernetes/kubernetes/pull/108947
- Introduce `kubectl version --kustomize` to expose this info specifically. Would be clean to implement, but not consistent with anything else I'm aware of, and probably unintuitive.
- Having the Kustomize release process directly embed the version, or having the kubectl update process embed it in the kubectl integration code (https://github.com/kubernetes/kubernetes/commit/3dba87f527171ad0f6f2c0666ffe81d3359902fb). Both of those would cause potentially inaccurate output for other CLIs importing kustomize and kubectl CLI code respectively.
- `kubectl kustomize version` (https://github.com/kubernetes/kubernetes/commit/1e7c1db436e5b0aaaf556b2f684a6059e53af5fb). It was pointed out at today's SIG meeting that the version also applies to `kubectl apply -k`, not just `kubectl kustomize`. 

#### Output

<details>

<summary>Expand to show output samples</summary>

```bash
༶ _output/bin/kubectl version
Client Version: version.Info{Major:"1", Minor:"24+", GitVersion:"v1.24.0-alpha.4.14+b85880aac7a987-dirty", GitCommit:"b85880aac7a9879f70b4d124e0f92826a00eeb0a", GitTreeState:"dirty", BuildDate:"2022-03-23T22:57:37Z", GoVersion:"go1.17.6", Compiler:"gc", Platform:"darwin/arm64"}
Kustomize Version: v4.4.1
Server Version: # not relevant / unchanged

༶ _output/bin/kubectl version --client
Client Version: version.Info{Major:"1", Minor:"24+", GitVersion:"v1.24.0-alpha.4.14+b85880aac7a987-dirty", GitCommit:"b85880aac7a9879f70b4d124e0f92826a00eeb0a", GitTreeState:"dirty", BuildDate:"2022-03-23T22:57:37Z", GoVersion:"go1.17.6", Compiler:"gc", Platform:"darwin/arm64"}
Kustomize Version: v4.4.1

༶ _output/bin/kubectl version --client -o yaml
clientVersion:
  buildDate: "2022-03-23T22:57:37Z"
  compiler: gc
  gitCommit: b85880aac7a9879f70b4d124e0f92826a00eeb0a
  gitTreeState: dirty
  gitVersion: v1.24.0-alpha.4.14+b85880aac7a987-dirty
  goVersion: go1.17.6
  major: "1"
  minor: 24+
  platform: darwin/arm64
kustomizeVersion: v4.4.1

༶ _output/bin/kubectl version --client -o json
{
  "clientVersion": {
    "major": "1",
    "minor": "24+",
    "gitVersion": "v1.24.0-alpha.4.14+b85880aac7a987-dirty",
    "gitCommit": "b85880aac7a9879f70b4d124e0f92826a00eeb0a",
    "gitTreeState": "dirty",
    "buildDate": "2022-03-23T22:57:37Z",
    "goVersion": "go1.17.6",
    "compiler": "gc",
    "platform": "darwin/arm64"
  },
  "kustomizeVersion": "v4.4.1"
}

༶ _output/bin/kubectl version --short
Client Version: v1.24.0-alpha.4.14+b85880aac7a987-dirty
Kustomize Version: v4.4.1
Server Version: v1.22.4
```
</details>

#### Does this PR introduce a user-facing change?

```release-note
`kubectl version` now includes information on the embedded version of Kustomize
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
