### PR TITLE
Fix function name of `IsNodeExist` error

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/errors.go
@@ -97,8 +97,8 @@ func IsNotFound(err error) bool {
 	return isErrCode(err, ErrCodeKeyNotFound)
 }
 
-// IsNodeExist returns true if and only if err is an node already exist error.
-func IsNodeExist(err error) bool {
+// IsExist returns true if and only if err is "key" already exists error.
+func IsExist(err error) bool {
 	return isErrCode(err, ErrCodeKeyExists)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/errors/storage.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/errors/storage.go
@@ -56,7 +56,7 @@ func InterpretGetError(err error, qualifiedResource schema.GroupResource, name s
 // operation into the appropriate API error.
 func InterpretCreateError(err error, qualifiedResource schema.GroupResource, name string) error {
 	switch {
-	case storage.IsNodeExist(err):
+	case storage.IsExist(err):
 		return errors.NewAlreadyExists(qualifiedResource, name)
 	case storage.IsUnreachable(err):
 		return errors.NewServerTimeout(qualifiedResource, "create", 2) // TODO: make configurable or handled at a higher level
@@ -71,7 +71,7 @@ func InterpretCreateError(err error, qualifiedResource schema.GroupResource, nam
 // operation into the appropriate API error.
 func InterpretUpdateError(err error, qualifiedResource schema.GroupResource, name string) error {
 	switch {
-	case storage.IsConflict(err), storage.IsNodeExist(err), storage.IsInvalidObj(err):
+	case storage.IsConflict(err), storage.IsExist(err), storage.IsInvalidObj(err):
 		return errors.NewConflict(qualifiedResource, name, err)
 	case storage.IsUnreachable(err):
 		return errors.NewServerTimeout(qualifiedResource, "update", 2) // TODO: make configurable or handled at a higher level
@@ -92,7 +92,7 @@ func InterpretDeleteError(err error, qualifiedResource schema.GroupResource, nam
 		return errors.NewNotFound(qualifiedResource, name)
 	case storage.IsUnreachable(err):
 		return errors.NewServerTimeout(qualifiedResource, "delete", 2) // TODO: make configurable or handled at a higher level
-	case storage.IsConflict(err), storage.IsNodeExist(err), storage.IsInvalidObj(err):
+	case storage.IsConflict(err), storage.IsExist(err), storage.IsInvalidObj(err):
 		return errors.NewConflict(qualifiedResource, name, err)
 	case storage.IsInternalError(err):
 		return errors.NewInternalError(err)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -187,7 +187,7 @@ func TestCreateWithKeyExist(t *testing.T) {
 	key, _ := testPropogateStore(ctx, t, store, obj)
 	out := &example.Pod{}
 	err := store.Create(ctx, key, obj, out, 0)
-	if err == nil || !storage.IsNodeExist(err) {
+	if err == nil || !storage.IsExist(err) {
 		t.Errorf("expecting key exists error, but get: %s", err)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The function name `IsNodeExist` is  misleading, in fact it indicates the key already exists error, but not node exists error.
Thus, this PR is to make the function name more correctly.

#### Special notes for your reviewer:
Serveral use references of this function have modified accordingly.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```