### PR TITLE
fix bugs of container cpu shares when cpu request set to zero

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -142,9 +142,9 @@ func (m *kubeGenericRuntimeManager) calculateLinuxResources(cpuRequest, cpuLimit
 	// If request is not specified, but limit is, we want request to default to limit.
 	// API server does this for new containers, but we repeat this logic in Kubelet
 	// for containers running on existing Kubernetes clusters.
-	if cpuRequest == nil && !cpuLimit.IsZero() {
+	if cpuRequest == nil {
 		cpuShares = int64(cm.MilliCPUToShares(cpuLimit.MilliValue()))
-	} else if cpuRequest != nil {
+	} else {
 		// if cpuRequest.Amount is nil, then MilliCPUToShares will return the minimal number
 		// of CPU shares.
 		cpuShares = int64(cm.MilliCPUToShares(cpuRequest.MilliValue()))

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -142,7 +142,7 @@ func (m *kubeGenericRuntimeManager) calculateLinuxResources(cpuRequest, cpuLimit
 	// If request is not specified, but limit is, we want request to default to limit.
 	// API server does this for new containers, but we repeat this logic in Kubelet
 	// for containers running on existing Kubernetes clusters.
-	if cpuRequest == nil {
+	if cpuRequest == nil && cpuLimit != nil {
 		cpuShares = int64(cm.MilliCPUToShares(cpuLimit.MilliValue()))
 	} else {
 		// if cpuRequest.Amount is nil, then MilliCPUToShares will return the minimal number

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -260,6 +260,29 @@ func TestCalculateLinuxResources(t *testing.T) {
 				MemoryLimitInBytes: 0,
 			},
 		},
+		{
+			name:   "RequestNilCPU",
+			cpuLim: resource.MustParse("2"),
+			memLim: resource.MustParse("0"),
+			expected: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuQuota:           200000,
+				CpuShares:          2048,
+				MemoryLimitInBytes: 0,
+			},
+		},
+		{
+			name:   "RequestZeroCPU",
+			cpuReq: resource.MustParse("0"),
+			cpuLim: resource.MustParse("2"),
+			memLim: resource.MustParse("0"),
+			expected: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuQuota:           200000,
+				CpuShares:          2,
+				MemoryLimitInBytes: 0,
+			},
+		},
 	}
 	for _, test := range tests {
 		linuxContainerResources := m.calculateLinuxResources(&test.cpuReq, &test.cpuLim, &test.memLim)

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -229,18 +229,23 @@ func TestCalculateLinuxResources(t *testing.T) {
 
 	assert.NoError(t, err)
 
+	generateResourceQuantity := func(str string) *resource.Quantity {
+		quantity := resource.MustParse(str)
+		return &quantity
+	}
+
 	tests := []struct {
 		name     string
-		cpuReq   resource.Quantity
-		cpuLim   resource.Quantity
-		memLim   resource.Quantity
+		cpuReq   *resource.Quantity
+		cpuLim   *resource.Quantity
+		memLim   *resource.Quantity
 		expected *runtimeapi.LinuxContainerResources
 	}{
 		{
 			name:   "Request128MBLimit256MB",
-			cpuReq: resource.MustParse("1"),
-			cpuLim: resource.MustParse("2"),
-			memLim: resource.MustParse("128Mi"),
+			cpuReq: generateResourceQuantity("1"),
+			cpuLim: generateResourceQuantity("2"),
+			memLim: generateResourceQuantity("128Mi"),
 			expected: &runtimeapi.LinuxContainerResources{
 				CpuPeriod:          100000,
 				CpuQuota:           200000,
@@ -250,9 +255,9 @@ func TestCalculateLinuxResources(t *testing.T) {
 		},
 		{
 			name:   "RequestNoMemory",
-			cpuReq: resource.MustParse("2"),
-			cpuLim: resource.MustParse("8"),
-			memLim: resource.MustParse("0"),
+			cpuReq: generateResourceQuantity("2"),
+			cpuLim: generateResourceQuantity("8"),
+			memLim: generateResourceQuantity("0"),
 			expected: &runtimeapi.LinuxContainerResources{
 				CpuPeriod:          100000,
 				CpuQuota:           800000,
@@ -262,8 +267,8 @@ func TestCalculateLinuxResources(t *testing.T) {
 		},
 		{
 			name:   "RequestNilCPU",
-			cpuLim: resource.MustParse("2"),
-			memLim: resource.MustParse("0"),
+			cpuLim: generateResourceQuantity("2"),
+			memLim: generateResourceQuantity("0"),
 			expected: &runtimeapi.LinuxContainerResources{
 				CpuPeriod:          100000,
 				CpuQuota:           200000,
@@ -273,9 +278,9 @@ func TestCalculateLinuxResources(t *testing.T) {
 		},
 		{
 			name:   "RequestZeroCPU",
-			cpuReq: resource.MustParse("0"),
-			cpuLim: resource.MustParse("2"),
-			memLim: resource.MustParse("0"),
+			cpuReq: generateResourceQuantity("0"),
+			cpuLim: generateResourceQuantity("2"),
+			memLim: generateResourceQuantity("0"),
 			expected: &runtimeapi.LinuxContainerResources{
 				CpuPeriod:          100000,
 				CpuQuota:           200000,
@@ -285,7 +290,7 @@ func TestCalculateLinuxResources(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		linuxContainerResources := m.calculateLinuxResources(&test.cpuReq, &test.cpuLim, &test.memLim)
+		linuxContainerResources := m.calculateLinuxResources(test.cpuReq, test.cpuLim, test.memLim)
 		assert.Equal(t, test.expected, linuxContainerResources)
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
@@ -21,6 +21,7 @@ package kuberuntime
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	resourcehelper "k8s.io/kubernetes/pkg/api/v1/resource"
 )
@@ -41,7 +42,11 @@ func (m *kubeGenericRuntimeManager) convertOverheadToLinuxResources(pod *v1.Pod)
 
 func (m *kubeGenericRuntimeManager) calculateSandboxResources(pod *v1.Pod) *runtimeapi.LinuxContainerResources {
 	req, lim := resourcehelper.PodRequestsAndLimitsWithoutOverhead(pod)
-	return m.calculateLinuxResources(req.Cpu(), lim.Cpu(), lim.Memory())
+	var cpuRequest *resource.Quantity
+	if _, cpuRequestExists := req[v1.ResourceCPU]; cpuRequestExists {
+		cpuRequest = req.Cpu()
+	}
+	return m.calculateLinuxResources(cpuRequest, lim.Cpu(), lim.Memory())
 }
 
 func (m *kubeGenericRuntimeManager) applySandboxResources(pod *v1.Pod, config *runtimeapi.PodSandboxConfig) error {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
For container resources, if limits are specified, but requests are not, default requests are set to limits in API server, and kubelet repeat this logic for containers running on existing Kubernetes cluster, but it works with some mistake for cpu. 
Actually, if cpu request is set to zero (instead of not specified), kubelet will also consider it as equal to limits, and set cpu shares as to limit instead of 2 (minShares). 
This is unexpected, think that if we have 2 containers, one with requests set as:

    limits:
        cpu: "4"
      requests:
        cpu: "2"

and the other with requests set as:

    limits:
        cpu: "4"
      requests:
        cpu: "0"

the cpu shares (in container level cgroup) for first one would be set as 2048 while the latter as 4096
but the expected cpu shares would be 2048 and 2 instead

**Special notes for your reviewer**:

I have one PR before #100986, but it's too out-of-date, so I open a new one rebased on current master

**Does this PR introduce a user-facing change?**:

```release-note
fix relative cpu priority for pods where containers explicitly request zero cpu by giving the lowest priority instead of falling back to the cpu limit to avoid possible cpu starvation of other pods
```


