### PR TITLE
Pass audiences as extra user info

### DIFF
--- a/pkg/serviceaccount/jwt_test.go
+++ b/pkg/serviceaccount/jwt_test.go
@@ -374,6 +374,10 @@ func TestTokenGenerateAndValidate(t *testing.T) {
 			t.Errorf("%s: Expected userUID=%v, got %v", k, tc.ExpectedUserUID, resp.User.GetUID())
 			continue
 		}
+		if val := resp.User.GetExtra()["jwt/audiences"]; len(val) == 0 || val[0] != "api" {
+			t.Errorf("%s: Expected audiences=%v, got %v", k, map[string][]string{"jwt/audiences": auds}, resp.User.GetExtra())
+			continue
+		}
 		if !reflect.DeepEqual(resp.User.GetGroups(), tc.ExpectedGroups) {
 			t.Errorf("%s: Expected groups=%v, got %v", k, tc.ExpectedGroups, resp.User.GetGroups())
 			continue


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Let the JWT authenticator add the audiences of the used token to the
user-info as extra info. This allows apiservices to make use of
additional audiences on tokens for additional access control.

They will see the audiences then as part of the `X-EXTRA-` headers.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```