### PR TITLE
Script kubectl kustomize update process

### DIFF
--- a/hack/update-kustomize.sh
+++ b/hack/update-kustomize.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source hack/lib/util.sh
+
+kube::util::require-jq
+kube::util::ensure_clean_working_dir
+
+PUBLISHED_RELEASES=$(curl -sL 'http://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100' | jq '[ .[] | select(.draft == false and .prerelease == false) | { "tag_name": .tag_name, "published_at": .published_at } ]')
+
+LATEST_KYAML=$(echo "${PUBLISHED_RELEASES}" | jq -r '[ .[] | select(.tag_name | startswith("kyaml/v")) ] | sort_by(.published_at) | last | .tag_name | scan("\/(v[\\d.]+)") | .[0]')
+LATEST_CONFIG=$(echo "${PUBLISHED_RELEASES}" | jq -r '[ .[] | select(.tag_name | startswith("cmd/config/v")) ] | sort_by(.published_at) | last | .tag_name | scan("\/(v[\\d.]+)") | .[0]')
+LATEST_API=$(echo "${PUBLISHED_RELEASES}" | jq -r '[ .[] | select(.tag_name | startswith("api/v")) ] | sort_by(.published_at) | last | .tag_name | scan("\/(v[\\d.]+)") | .[0]')
+LATEST_KUSTOMIZE=$(echo "${PUBLISHED_RELEASES}" | jq -r '[ .[] | select(.tag_name | startswith("kustomize/v")) ] | sort_by(.published_at) | last | .tag_name | scan("\/(v[\\d.]+)") | .[0]')
+
+echo "----------------------------------------"
+echo "Latest kyaml: $LATEST_KYAML"
+echo "Latest cmd/config: $LATEST_CONFIG"
+echo "Latest api: $LATEST_API"
+echo "Latest kustomize: $LATEST_KUSTOMIZE"
+echo -e "----------------------------------------\n"
+read -p "Update kubectl kustomize to these versions? [y/N] " -n 1 -r
+echo
+
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  echo -e "\n${color_blue:?}Updating kubectl kustomize${color_norm:?}"
+else
+  echo -e "\n${color_red:?}Update aborted${color_norm:?}"
+  exit 1
+fi
+
+./hack/pin-dependency.sh sigs.k8s.io/kustomize/kyaml "$LATEST_KYAML"
+./hack/pin-dependency.sh sigs.k8s.io/kustomize/cmd/config "$LATEST_CONFIG"
+./hack/pin-dependency.sh sigs.k8s.io/kustomize/api "$LATEST_API"
+./hack/pin-dependency.sh sigs.k8s.io/kustomize/kustomize/v4 "$LATEST_KUSTOMIZE"
+
+./hack/update-vendor.sh
+./hack/update-internal-modules.sh
+./hack/lint-dependencies.sh
+
+echo -e "\n${color_blue}Committing changes${color_norm}"
+git add .
+git commit -a -m "Update kubectl kustomize to kyaml/$LATEST_KYAML, cmd/config/$LATEST_CONFIG, api/$LATEST_API, kustomize/$LATEST_KUSTOMIZE"
+
+echo -e "\n${color_green:?}Update successful${color_norm:?}"
+echo "Note: If any of the integration points changed, you may need to update them manually."
+echo "See https://github.com/kubernetes-sigs/kustomize/tree/master/releasing#update-kustomize-in-kubectl for more information"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR scripts the manual process outlined in the [Kustomize release docs](https://github.com/kubernetes-sigs/kustomize/tree/master/releasing#update-kustomize-in-kubectl). Demo: https://github.com/KnVerey/kubernetes/pull/1. I chose hack/ as the location for this script since it uses utilities from there and invokes several of that directory's scripts. Let me know if it belongs somewhere else.

#### Which issue(s) this PR fixes:

None, but this related to https://github.com/kubernetes-sigs/kustomize/issues/3952

#### Special notes for your reviewer:

This is split out of https://github.com/kubernetes/kubernetes/pull/108817. As discussed [here](https://github.com/kubernetes/kubernetes/pull/108817#discussion_r831325462), it is possible that a newer kyaml release will exist than the one we want to bring in. However, that is rare, and made even more unlikely by our typical release process. We can make the script accommodate version overrides in the future if needed, but Kustomize maintainers feel manual confirmation of the targeted versions is sufficient for the time being.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
