### PR TITLE
Return a placeholder error for blocking failures and skip CEL validation.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -47,6 +47,9 @@ func required(path ...string) validationMatch {
 func invalid(path ...string) validationMatch {
 	return validationMatch{path: field.NewPath(path[0], path[1:]...), errorType: field.ErrorTypeInvalid}
 }
+func invalidtypecode(path ...string) validationMatch {
+	return validationMatch{path: field.NewPath(path[0], path[1:]...), errorType: field.ErrorTypeTypeInvalid}
+}
 func invalidIndex(index int, path ...string) validationMatch {
 	return validationMatch{path: field.NewPath(path[0], path[1:]...).Index(index), errorType: field.ErrorTypeInvalid}
 }
@@ -2101,7 +2104,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 			},
 			errors: []validationMatch{
 				invalid("spec", "validation", "openAPIV3Schema", "properties[a]", "default"),
-				invalid("spec", "validation", "openAPIV3Schema", "properties[c]", "default", "foo"),
+				invalidtypecode("spec", "validation", "openAPIV3Schema", "properties[c]", "default", "foo"),
 				invalid("spec", "validation", "openAPIV3Schema", "properties[d]", "default", "bad"),
 				// we also expected unpruned and valid defaults under x-kubernetes-preserve-unknown-fields. We could be more
 				// strict here, but want to encourage proper specifications by forbidding other defaults.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
@@ -95,7 +95,7 @@ func ValidateCustomResource(fldPath *field.Path, customResource interface{}, val
 				if i, ok := err.Value.(int64); ok {
 					max = i
 				}
-				allErrs = append(allErrs, field.TooMany(errPath, -1, int(max)))
+				allErrs = append(allErrs, field.TooMany(errPath, int(max), -1))
 
 			case openapierrors.TooManyPropertiesCode:
 				max := int64(-1)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
@@ -79,6 +79,27 @@ func ValidateCustomResource(fldPath *field.Path, customResource interface{}, val
 				}
 				allErrs = append(allErrs, field.NotSupported(errPath, err.Value, values))
 
+			case openapierrors.TooLongFailCode:
+				value := interface{}("")
+				if err.Value != nil {
+					value = err.Value
+				}
+				allErrs = append(allErrs, field.TooLongFail(errPath, value, err.Error()))
+
+			case openapierrors.TooManyPropertiesCode, openapierrors.MaxItemsFailCode:
+				value := interface{}("")
+				if err.Value != nil {
+					value = err.Value
+				}
+				allErrs = append(allErrs, field.TooManyFail(errPath, value, err.Error()))
+
+			case openapierrors.InvalidTypeCode:
+				value := interface{}("")
+				if err.Value != nil {
+					value = err.Value
+				}
+				allErrs = append(allErrs, field.TypeInvalid(errPath, value, err.Error()))
+
 			default:
 				value := interface{}("")
 				if err.Value != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
@@ -84,14 +84,25 @@ func ValidateCustomResource(fldPath *field.Path, customResource interface{}, val
 				if err.Value != nil {
 					value = err.Value
 				}
-				allErrs = append(allErrs, field.TooLongFail(errPath, value, err.Error()))
-
-			case openapierrors.TooManyPropertiesCode, openapierrors.MaxItemsFailCode:
-				value := interface{}("")
-				if err.Value != nil {
-					value = err.Value
+				max := int64(-1)
+				if i, ok := err.Value.(int64); ok {
+					max = i
 				}
-				allErrs = append(allErrs, field.TooManyFail(errPath, value, err.Error()))
+				allErrs = append(allErrs, field.TooLongMaxLength(errPath, value, int(max)))
+
+			case openapierrors.MaxItemsFailCode:
+				max := int64(-1)
+				if i, ok := err.Value.(int64); ok {
+					max = i
+				}
+				allErrs = append(allErrs, field.TooMany(errPath, -1, int(max)))
+
+			case openapierrors.TooManyPropertiesCode:
+				max := int64(-1)
+				if i, ok := err.Value.(int64); ok {
+					max = i
+				}
+				allErrs = append(allErrs, field.TooMany(errPath, -1, int(max)))
 
 			case openapierrors.InvalidTypeCode:
 				value := interface{}("")

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation_test.go
@@ -561,7 +561,7 @@ func TestValidateCustomResource(t *testing.T) {
 			},
 			failingObjects: []failingObject{
 				{object: map[string]interface{}{"fieldX": []interface{}{"a", "b", "c"}}, expectErrs: []string{
-					`fieldX: Too many: must have at most 3 items`,
+					`fieldX: Too many: 3: has too many items`,
 				}},
 			},
 		},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
@@ -99,8 +99,12 @@ func (a statusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Obj
 
 	// validate x-kubernetes-validations rules
 	if celValidator, ok := a.customResourceStrategy.celValidators[v]; ok {
-		err, _ := celValidator.Validate(ctx, nil, a.customResourceStrategy.structuralSchemas[v], uNew.Object, uOld.Object, cel.RuntimeCELCostBudget)
-		errs = append(errs, err...)
+		if has, err := hasBlockingErr(errs); has {
+			errs = append(errs, err)
+		} else {
+			err, _ := celValidator.Validate(ctx, nil, a.customResourceStrategy.structuralSchemas[v], uNew.Object, uOld.Object, cel.RuntimeCELCostBudget)
+			errs = append(errs, err...)
+		}
 	}
 	return errs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -123,6 +123,8 @@ const (
 	// ErrorTypeInternal is used to report other errors that are not related
 	// to user input.  See InternalError().
 	ErrorTypeInternal ErrorType = "InternalError"
+	// ErrorTypeTypeInvalid is for the value did not match the schema type for that field
+	ErrorTypeTypeInvalid ErrorType = "FieldValueTypeInvalid"
 )
 
 // String converts a ErrorType into its corresponding canonical error message.
@@ -146,9 +148,26 @@ func (t ErrorType) String() string {
 		return "Too many"
 	case ErrorTypeInternal:
 		return "Internal error"
+	case ErrorTypeTypeInvalid:
+		return "Invalid value"
 	default:
 		panic(fmt.Sprintf("unrecognized validation error: %q", string(t)))
 	}
+}
+
+// TooLongFail returns a *Error indicating "MaxLength exceed".
+func TooLongFail(field *Path, value interface{}, detail string) *Error {
+	return &Error{ErrorTypeTooLong, field.String(), value, detail}
+}
+
+// TooManyFail returns a *Error indicating "MaxItems/MaxProperties exceed"
+func TooManyFail(field *Path, value interface{}, detail string) *Error {
+	return &Error{ErrorTypeTooMany, field.String(), value, detail}
+}
+
+// TypeInvalid returns a *Error indicating "type is invalid"
+func TypeInvalid(field *Path, value interface{}, detail string) *Error {
+	return &Error{ErrorTypeTypeInvalid, field.String(), value, detail}
 }
 
 // NotFound returns a *Error indicating "value not found".  This is

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -167,16 +167,6 @@ func (t ErrorType) String() string {
 	}
 }
 
-// TooLongFail returns a *Error indicating "MaxLength exceed".
-func TooLongFail(field *Path, value interface{}, detail string) *Error {
-	return &Error{ErrorTypeTooLong, field.String(), value, detail}
-}
-
-// TooManyFail returns a *Error indicating "MaxItems/MaxProperties exceed"
-func TooManyFail(field *Path, value interface{}, detail string) *Error {
-	return &Error{ErrorTypeTooMany, field.String(), value, detail}
-}
-
 // TypeInvalid returns a *Error indicating "type is invalid"
 func TypeInvalid(field *Path, value interface{}, detail string) *Error {
 	return &Error{ErrorTypeTypeInvalid, field.String(), value, detail}

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -42,12 +42,24 @@ func (v *Error) Error() string {
 	return fmt.Sprintf("%s: %s", v.Field, v.ErrorBody())
 }
 
+type omitValueType struct{}
+
+var omitValue = omitValueType{}
+
 // ErrorBody returns the error message without the field name.  This is useful
 // for building nice-looking higher-level error reporting.
 func (v *Error) ErrorBody() string {
 	var s string
-	switch v.Type {
-	case ErrorTypeRequired, ErrorTypeForbidden, ErrorTypeTooLong, ErrorTypeInternal:
+	switch {
+	case v.Type == ErrorTypeRequired:
+		s = v.Type.String()
+	case v.Type == ErrorTypeForbidden:
+		s = v.Type.String()
+	case v.Type == ErrorTypeTooLong:
+		s = v.Type.String()
+	case v.Type == ErrorTypeInternal:
+		s = v.Type.String()
+	case v.BadValue == omitValue:
 		s = v.Type.String()
 	default:
 		value := v.BadValue
@@ -226,11 +238,40 @@ func TooLong(field *Path, value interface{}, maxLength int) *Error {
 	return &Error{ErrorTypeTooLong, field.String(), value, fmt.Sprintf("must have at most %d bytes", maxLength)}
 }
 
+// TooLongMaxLength returns a *Error indicating "too long".  This is used to
+// report that the given value is too long.  This is similar to
+// Invalid, but the returned error will not include the too-long
+// value. If maxLength is negative, no max length will be included in the message.
+func TooLongMaxLength(field *Path, value interface{}, maxLength int) *Error {
+	var msg string
+	if maxLength >= 0 {
+		msg = fmt.Sprintf("may not be longer than %d", maxLength)
+	} else {
+		msg = "value is too long"
+	}
+	return &Error{ErrorTypeTooLong, field.String(), value, msg}
+}
+
 // TooMany returns a *Error indicating "too many". This is used to
 // report that a given list has too many items. This is similar to TooLong,
 // but the returned error indicates quantity instead of length.
 func TooMany(field *Path, actualQuantity, maxQuantity int) *Error {
-	return &Error{ErrorTypeTooMany, field.String(), actualQuantity, fmt.Sprintf("must have at most %d items", maxQuantity)}
+	var msg string
+
+	if maxQuantity >= 0 {
+		msg = fmt.Sprintf("must have at most %d items", maxQuantity)
+	} else {
+		msg = "has too many items"
+	}
+
+	var actual interface{}
+	if actualQuantity >= 0 {
+		actual = actualQuantity
+	} else {
+		actual = omitValue
+	}
+
+	return &Error{ErrorTypeTooMany, field.String(), actual, msg}
 }
 
 // InternalError returns a *Error indicating "internal error".  This is used


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
If subtree contains blocking error(suck like OpenAPIv3 type/maxLength/maxItems/required/wrong type field validation failures ), skip CEL validation and return a placeholder error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Skip x-kubernetes-validations rules if having fundamental error against OpenAPIv3 schema.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
