### PR TITLE
Automated cherry pick of #107763: e2e: Wait for kube-root-ca.crt to be created

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -248,6 +248,9 @@ func (f *Framework) BeforeEach() {
 			ginkgo.By("Waiting for a default service account to be provisioned in namespace")
 			err = WaitForDefaultServiceAccountInNamespace(f.ClientSet, namespace.Name)
 			ExpectNoError(err)
+			ginkgo.By("Waiting for kube-root-ca.crt to be provisioned in namespace")
+			err = WaitForKubeRootCAInNamespace(f.ClientSet, namespace.Name)
+			ExpectNoError(err)
 		} else {
 			Logf("Skipping waiting for service account")
 		}


### PR DESCRIPTION
Cherry pick of #107763 on release-1.23.

#107763: e2e: Wait for kube-root-ca.crt to be created

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
e2e tests wait for kube-root-ca.crt to be populated in namespaces for use with projected service account tokens, reducing delays starting those test pods and errors in the logs.
```