### PR TITLE
Increase timeout for stats/summary check

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -411,7 +411,7 @@ func recent(d time.Duration) types.GomegaMatcher {
 	}, gomega.And(
 		gomega.BeTemporally(">=", time.Now().Add(-d)),
 		// Now() is the test start time, not the match time, so permit a few extra minutes.
-		gomega.BeTemporally("<", time.Now().Add(2*time.Minute))))
+		gomega.BeTemporally("<", time.Now().Add(3*time.Minute))))
 }
 
 func recordSystemCgroupProcesses() {


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
Increase the time threshold for /stats/summary matchers.

#### Which issue(s) this PR fixes:
Addresses https://github.com/kubernetes/kubernetes/issues/107412. Will let it sink for a few days and close the issue if the flakiness is gone.

#### Special notes for your reviewer:
Looking at the logs, the time differences is very small (a couple of seconds). I've increased the timeout period a minute. Tested a local run, it works.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

