### PR TITLE
handle fail path when getting pod count in podtopologyspread

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -1435,12 +1435,8 @@ func TestSingleConstraint(t *testing.T) {
 			},
 		},
 		{
-			// only node-a and node-y are considered, so pods spread as 2/~1~/~0~/3
-			// ps: '~num~' is a markdown symbol to denote a crossline through 'num'
-			// but in this unit test, we don't run NodeAffinity Predicate, so node-b and node-x are
-			// still expected to be fits;
-			// the fact that node-a fits can prove the underlying logic works
-			name: "incoming pod has nodeAffinity, pods spread as 2/~1~/~0~/3, hence node-a fits",
+			// only node-a and node-y are considered, so pods spread as 2/<excluded>/<excluded>/3
+			name: "incoming pod has nodeAffinity, pods spread as 2/<excluded>/<excluded>/3, hence node-a fits",
 			pod: st.MakePod().Name("p").Label("foo", "").
 				NodeAffinityIn("node", []string{"node-a", "node-y"}).
 				SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("foo").Obj(), nil).
@@ -1461,8 +1457,8 @@ func TestSingleConstraint(t *testing.T) {
 			},
 			wantStatusCode: map[string]framework.Code{
 				"node-a": framework.Success,
-				"node-b": framework.Success, // in real case, it's false
-				"node-x": framework.Success, // in real case, it's false
+				"node-b": framework.Unschedulable,
+				"node-x": framework.Unschedulable,
 				"node-y": framework.Unschedulable,
 			},
 		},
@@ -1485,17 +1481,16 @@ func TestSingleConstraint(t *testing.T) {
 			},
 		},
 		{
-			// In this unit test, NodeAffinity plugin is not involved, so node-b still fits
-			name: "incoming pod has nodeAffinity, pods spread as 0/~2~/0/1, hence node-a fits",
+			name: "incoming pod has nodeAffinity, pods spread as 0/<excluded>/0/1, hence node-a fits",
 			pod: st.MakePod().Name("p").Label("foo", "").
 				NodeAffinityNotIn("node", []string{"node-b"}).
 				SpreadConstraint(1, "zone", v1.DoNotSchedule, st.MakeLabelSelector().Exists("foo").Obj(), nil).
 				Obj(),
 			nodes: []*v1.Node{
 				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
-				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
-				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
-				st.MakeNode().Name("node-y").Label("zone", "zone2").Label("node", "node-y").Obj(),
+				st.MakeNode().Name("node-b").Label("zone", "zone2").Label("node", "node-b").Obj(),
+				st.MakeNode().Name("node-x").Label("zone", "zone3").Label("node", "node-x").Obj(),
+				st.MakeNode().Name("node-y").Label("zone", "zone3").Label("node", "node-y").Obj(),
 			},
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("p-b1").Node("node-b").Label("foo", "").Obj(),
@@ -1504,7 +1499,7 @@ func TestSingleConstraint(t *testing.T) {
 			},
 			wantStatusCode: map[string]framework.Code{
 				"node-a": framework.Success,
-				"node-b": framework.Success, // in real case, it's Unschedulable
+				"node-b": framework.Unschedulable,
 				"node-x": framework.Unschedulable,
 				"node-y": framework.Unschedulable,
 			},

--- a/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
@@ -37,6 +37,8 @@ const (
 	ErrReasonConstraintsNotMatch = "node(s) didn't match pod topology spread constraints"
 	// ErrReasonNodeLabelNotMatch is used when the node doesn't hold the required label.
 	ErrReasonNodeLabelNotMatch = ErrReasonConstraintsNotMatch + " (missing required label)"
+	// ErrNodeShouldBeFilteredOut is used when couldn't get matched Pod count from TpPairToMatchNum.
+	ErrNodeShouldBeFilteredOut = "node should be filtered out by PreFilter"
 )
 
 var systemDefaultConstraints = []v1.TopologySpreadConstraint{


### PR DESCRIPTION
Signed-off-by: kerthcet <kerthcet@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig scheduling

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
1. handle fail path when getting pod count in Filter phase
2. solve hard comments in test

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
