### PR TITLE
golang: Update to 1.18 from 1.18rc1

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.24.0-go1.18rc1-bullseye.0
+v1.24.0-go1.18-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -91,7 +91,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
 readonly __default_debian_iptables_version=bullseye-v1.1.0
-readonly __default_go_runner_version=v2.3.1-go1.18rc1-bullseye.0
+readonly __default_go_runner_version=v2.3.1-go1.18-bullseye.0
 readonly __default_setcap_version=bullseye-v1.0.0
 
 # These are the base images for the Docker-wrapped binaries.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -80,7 +80,7 @@ dependencies:
 
   # Golang
   - name: "golang: upstream version"
-    version: 1.18rc1
+    version: 1.18
     refPaths:
     - path: build/build-image/cross/VERSION
     - path: staging/publishing/rules.yaml
@@ -97,7 +97,7 @@ dependencies:
     version: 1.18
     refPaths:
     - path: build/build-image/cross/VERSION
-    # TODO(go118): Uncomment once ready to transition presubmits to go118
+    # TODO(dims): Uncomment once images are updated to go1.18
     #- path: hack/lib/golang.sh
     #  match: minimum_go_version=go([0-9]+\.[0-9]+)
 
@@ -108,7 +108,7 @@ dependencies:
       match: 'GOLANG_VERSION\?=\d+.\d+(alpha|beta|rc)?\.?(\d+)?'
 
   - name: "k8s.gcr.io/kube-cross: dependents"
-    version: v1.24.0-go1.18rc1-bullseye.0
+    version: v1.24.0-go1.18-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -138,7 +138,7 @@ dependencies:
       match: configs\[DebianIptables\] = Config{list\.BuildImageRegistry, "debian-iptables", "[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"}
 
   - name: "k8s.gcr.io/go-runner: dependents"
-    version: v2.3.1-go1.18rc1-bullseye.0
+    version: v2.3.1-go1.18-bullseye.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -480,6 +480,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(GOFLAGS='' go version)"
   local minimum_go_version
+  # TODO(dims): Need to switch this to 1.18 once we update images to newer go version
   minimum_go_version=go1.17.0
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     kube::log::usage_from_stdin <<EOF

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,7 +7,7 @@ recursive-delete-patterns:
 - BUILD.bazel
 - "*/BUILD.bazel"
 - Gopkg.toml
-default-go-version: 1.18rc1
+default-go-version: 1.18
 rules:
 - destination: code-generator
   branches:

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -16,7 +16,7 @@ REGISTRY ?= k8s.gcr.io/e2e-test-images
 GOARM ?= 7
 DOCKER_CERT_BASE_PATH ?=
 QEMUVERSION=v5.1.0-2
-GOLANG_VERSION=1.18rc1
+GOLANG_VERSION=1.18
 export
 
 ifndef WHAT


### PR DESCRIPTION
Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/area dependency

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We cannot ship rc1 ... code freeze is a week away. Let's switch to the 1.18 final release.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubernetes 1.24 bumped version of golang it is compiled with to go1.18, which introduced significant changes to its garbage collection algorithm. As a result, we observed an increase in memory usage for kube-apiserver in larger an heavily loaded clusters up to ~25% (with the benefit of API call latencies drop by up to 10x on 99th percentiles). If the memory increase is not acceptable for you you can mitigate by setting GOGC env variable (for our tests using GOGC=63 brings memory usage back to original value, although the exact value may depend on usage patterns on your cluster).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
