### PR TITLE
kubeadm: reuse found crictl path for exec

### DIFF
--- a/cmd/kubeadm/app/util/runtime/runtime.go
+++ b/cmd/kubeadm/app/util/runtime/runtime.go
@@ -46,18 +46,19 @@ type ContainerRuntime interface {
 
 // CRIRuntime is a struct that interfaces with the CRI
 type CRIRuntime struct {
-	exec      utilsexec.Interface
-	criSocket string
+	exec       utilsexec.Interface
+	criSocket  string
+	crictlPath string
 }
 
 // NewContainerRuntime sets up and returns a ContainerRuntime struct
 func NewContainerRuntime(execer utilsexec.Interface, criSocket string) (ContainerRuntime, error) {
-	toolName := "crictl"
-	runtime := &CRIRuntime{execer, criSocket}
-	if _, err := execer.LookPath(toolName); err != nil {
+	const toolName = "crictl"
+	crictlPath, err := execer.LookPath(toolName)
+	if err != nil {
 		return nil, errors.Wrapf(err, "%s is required by the container runtime", toolName)
 	}
-	return runtime, nil
+	return &CRIRuntime{execer, criSocket, crictlPath}, nil
 }
 
 // Socket returns the CRI socket endpoint
@@ -65,9 +66,14 @@ func (runtime *CRIRuntime) Socket() string {
 	return runtime.criSocket
 }
 
+// crictl creates a crictl command for the provided args.
+func (runtime *CRIRuntime) crictl(args ...string) utilsexec.Cmd {
+	return runtime.exec.Command(runtime.crictlPath, append([]string{"-r", runtime.Socket()}, args...)...)
+}
+
 // IsRunning checks if runtime is running
 func (runtime *CRIRuntime) IsRunning() error {
-	if out, err := runtime.exec.Command("crictl", "-r", runtime.criSocket, "info").CombinedOutput(); err != nil {
+	if out, err := runtime.crictl("info").CombinedOutput(); err != nil {
 		return errors.Wrapf(err, "container runtime is not running: output: %s, error", string(out))
 	}
 	return nil
@@ -75,7 +81,7 @@ func (runtime *CRIRuntime) IsRunning() error {
 
 // ListKubeContainers lists running k8s CRI pods
 func (runtime *CRIRuntime) ListKubeContainers() ([]string, error) {
-	out, err := runtime.exec.Command("crictl", "-r", runtime.criSocket, "pods", "-q").CombinedOutput()
+	out, err := runtime.crictl("pods", "-q").CombinedOutput()
 	if err != nil {
 		return nil, errors.Wrapf(err, "output: %s, error", string(out))
 	}
@@ -88,12 +94,12 @@ func (runtime *CRIRuntime) ListKubeContainers() ([]string, error) {
 func (runtime *CRIRuntime) RemoveContainers(containers []string) error {
 	errs := []error{}
 	for _, container := range containers {
-		out, err := runtime.exec.Command("crictl", "-r", runtime.criSocket, "stopp", container).CombinedOutput()
+		out, err := runtime.crictl("stopp", container).CombinedOutput()
 		if err != nil {
 			// don't stop on errors, try to remove as many containers as possible
 			errs = append(errs, errors.Wrapf(err, "failed to stop running pod %s: output: %s, error", container, string(out)))
 		} else {
-			out, err = runtime.exec.Command("crictl", "-r", runtime.criSocket, "rmp", container).CombinedOutput()
+			out, err = runtime.crictl("rmp", container).CombinedOutput()
 			if err != nil {
 				errs = append(errs, errors.Wrapf(err, "failed to remove running container %s: output: %s, error", container, string(out)))
 			}
@@ -107,7 +113,7 @@ func (runtime *CRIRuntime) PullImage(image string) error {
 	var err error
 	var out []byte
 	for i := 0; i < constants.PullImageRetry; i++ {
-		out, err = runtime.exec.Command("crictl", "-r", runtime.criSocket, "pull", image).CombinedOutput()
+		out, err = runtime.crictl("pull", image).CombinedOutput()
 		if err == nil {
 			return nil
 		}
@@ -117,7 +123,7 @@ func (runtime *CRIRuntime) PullImage(image string) error {
 
 // ImageExists checks to see if the image exists on the system
 func (runtime *CRIRuntime) ImageExists(image string) (bool, error) {
-	err := runtime.exec.Command("crictl", "-r", runtime.criSocket, "inspecti", image).Run()
+	err := runtime.crictl("inspecti", image).Run()
 	return err == nil, nil
 }
 


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now re-use the crictl tool path within the `ContainerRuntime` when
exec'ing into it. This allows introducing a convenience function to
create the crictl command and re-use it where necessary.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
cc @fabriziopandini @neolit123 @SataQiu
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
