### PR TITLE
Automated cherry pick of #107030: tests: Lowers the number of pods returned by

### DIFF
--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -68,7 +68,7 @@ func estimateMaximumPods(c clientset.Interface, min, max int32) int32 {
 		availablePods += 10
 	}
 	//avoid creating exactly max pods
-	availablePods = int32(float32(availablePods) * 0.8)
+	availablePods = int32(float32(availablePods) * 0.5)
 	// bound the top and bottom
 	if availablePods > max {
 		availablePods = max


### PR DESCRIPTION
Cherry pick of #107030 on release-1.23.

#107030: tests: Lowers the number of pods returned by

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

/sig testing
/sig windows
/sig apps

#### What this PR does / why we need it:

The Conformance test "should orphan pods created by rc if delete options say so" is spawning 80% of the Cluster's Pod Capacity (on a 2 node setup, with 30 Pods capacity each, it spawns 48 pods).

Because of this, tests that are running in parallel with this test has a higher chance to flake, causing them to timeout because they didn't get to spawn the necessary Pods within the expected 1 minute time.

Lowering the percentage should reduce the amount of flakes we see.

Sample test failures caused by running in parallel with this test can be seen here: https://github.com/kubernetes/kubernetes/issues/106750

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubernetes/issues/106750

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
