### PR TITLE
ServerSideFieldValidation Beta Graduation

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -993,7 +993,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	genericfeatures.OpenAPIEnums:                        {Default: true, PreRelease: featuregate.Beta},
 	genericfeatures.CustomResourceValidationExpressions: {Default: false, PreRelease: featuregate.Alpha},
 	genericfeatures.OpenAPIV3:                           {Default: false, PreRelease: featuregate.Alpha},
-	genericfeatures.ServerSideFieldValidation:           {Default: false, PreRelease: featuregate.Alpha},
+	genericfeatures.ServerSideFieldValidation:           {Default: true, PreRelease: featuregate.Beta},
 	// features that enable backwards compatibility but are scheduled to be removed
 	// ...
 	HPAScaleToZero: {Default: false, PreRelease: featuregate.Alpha},

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -174,6 +174,7 @@ const (
 	// owner: @kevindelgado
 	// kep: http://kep.k8s.io/2885
 	// alpha: v1.23
+	// beta: v1.24
 	//
 	// Enables server-side field validation.
 	ServerSideFieldValidation featuregate.Feature = "ServerSideFieldValidation"
@@ -205,5 +206,5 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	OpenAPIEnums:                        {Default: true, PreRelease: featuregate.Beta},
 	CustomResourceValidationExpressions: {Default: false, PreRelease: featuregate.Alpha},
 	OpenAPIV3:                           {Default: false, PreRelease: featuregate.Alpha},
-	ServerSideFieldValidation:           {Default: false, PreRelease: featuregate.Alpha},
+	ServerSideFieldValidation:           {Default: true, PreRelease: featuregate.Beta},
 }

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -251,8 +251,8 @@
     works for CRD preserving unknown fields at the schema root [Conformance]'
   description: Register a custom resource definition with x-preserve-unknown-fields
     in the schema root. Attempt to create and apply a change a custom resource, via
-    kubectl; client-side validation MUST accept unknown properties. Attempt kubectl
-    explain; the output MUST show the custom resource KIND.
+    kubectl; kubectl validation MUST accept unknown properties. Attempt kubectl explain;
+    the output MUST show the custom resource KIND.
   release: v1.16
   file: test/e2e/apimachinery/crd_publish_openapi.go
 - testname: Custom Resource OpenAPI Publish, with x-preserve-unknown-fields in embedded
@@ -261,7 +261,7 @@
     works for CRD preserving unknown fields in an embedded object [Conformance]'
   description: Register a custom resource definition with x-preserve-unknown-fields
     in an embedded object. Attempt to create and apply a change a custom resource,
-    via kubectl; client-side validation MUST accept unknown properties. Attempt kubectl
+    via kubectl; kubectl validation MUST accept unknown properties. Attempt kubectl
     explain; the output MUST show that x-preserve-unknown-properties is used on the
     nested field.
   release: v1.16
@@ -271,12 +271,12 @@
     works for CRD with validation schema [Conformance]'
   description: Register a custom resource definition with a validating schema consisting
     of objects, arrays and primitives. Attempt to create and apply a change a custom
-    resource using valid properties, via kubectl; client-side validation MUST pass.
-    Attempt both operations with unknown properties and without required properties;
-    client-side validation MUST reject the operations. Attempt kubectl explain; the
-    output MUST explain the custom resource properties. Attempt kubectl explain on
-    custom resource properties; the output MUST explain the nested custom resource
-    properties.
+    resource using valid properties, via kubectl; kubectl validation MUST pass. Attempt
+    both operations with unknown properties and without required properties; kubectl
+    validation MUST reject the operations. Attempt kubectl explain; the output MUST
+    explain the custom resource properties. Attempt kubectl explain on custom resource
+    properties; the output MUST explain the nested custom resource properties. All
+    validation should be the same.
   release: v1.16
   file: test/e2e/apimachinery/crd_publish_openapi.go
 - testname: Custom Resource OpenAPI Publish, with x-preserve-unknown-fields in object
@@ -284,7 +284,7 @@
     works for CRD without validation schema [Conformance]'
   description: Register a custom resource definition with x-preserve-unknown-fields
     in the top level object. Attempt to create and apply a change a custom resource,
-    via kubectl; client-side validation MUST accept unknown properties. Attempt kubectl
+    via kubectl; kubectl validation MUST accept unknown properties. Attempt kubectl
     explain; the output MUST contain a valid DESCRIPTION stanza.
   release: v1.16
   file: test/e2e/apimachinery/crd_publish_openapi.go

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1001,7 +1001,7 @@ metadata:
 		return nil
 	}
 
-	ginkgo.Describe("Kubectl client-side validation", func() {
+	ginkgo.Describe("Kubectl validation", func() {
 		ginkgo.It("should create/apply a CR with unknown fields for CRD with no validation schema", func() {
 			ginkgo.By("create CRD with no validation schema")
 			crd, err := crd.CreateTestCRD(f)
@@ -1046,7 +1046,7 @@ metadata:
 			}
 		})
 
-		ginkgo.It("should create/apply a valid CR with arbitrary-extra properties for CRD with partially-specified validation schema", func() {
+		ginkgo.It("should create/apply an invalid/valid CR with arbitrary-extra properties for CRD with partially-specified validation schema", func() {
 			ginkgo.By("prepare CRD with partially-specified validation schema")
 			crd, err := crd.CreateTestCRD(f, func(crd *apiextensionsv1.CustomResourceDefinition) {
 				props := &apiextensionsv1.JSONSchemaProps{}
@@ -1071,6 +1071,15 @@ metadata:
 			framework.ExpectNotEqual(schema, nil, "retrieving a schema for the crd")
 
 			meta := fmt.Sprintf(metaPattern, crd.Crd.Spec.Names.Kind, crd.Crd.Spec.Group, crd.Crd.Spec.Versions[0].Name, "test-cr")
+
+			// XPreserveUnknownFields is defined on the root of the schema so unknown fields within the spec
+			// are still considered invalid
+			invalidArbitraryCR := fmt.Sprintf(`{%s,"spec":{"bars":[{"name":"test-bar"}],"extraProperty":"arbitrary-value"}}`, meta)
+			err = createApplyCustomResource(invalidArbitraryCR, f.Namespace.Name, "test-cr", crd)
+			framework.ExpectError(err, "creating custom resource")
+			if !strings.Contains(err.Error(), `unknown field "spec.extraProperty"`) {
+				framework.Failf("incorrect error from createApplyCustomResource: %v", err)
+			}
 
 			// unknown fields on the root are considered valid
 			validArbitraryCR := fmt.Sprintf(`{%s,"spec":{"bars":[{"name":"test-bar"}]},"extraProperty":"arbitrary-value"}`, meta)
@@ -2151,7 +2160,7 @@ func startLocalProxy() (srv *httptest.Server, logs *bytes.Buffer) {
 }
 
 // createApplyCustomResource asserts that given CustomResource be created and applied
-// without being rejected by client-side validation
+// without being rejected by kubectl validation
 func createApplyCustomResource(resource, namespace, name string, crd *crd.TestCrd) error {
 	ginkgo.By("successfully create CR")
 	if _, err := framework.RunKubectlInput(namespace, resource, "create", "--validate=true", "-f", "-"); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Sets the ServerSideFieldValidation feature gate to beta and on by default and adjusts tests accordingly

Follow up to https://github.com/kubernetes/kubernetes/pull/108350



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `ServerSideFieldValidation` feature has graduated to beta and is now enabled by default. Kubectl 1.24 and newer will use server-side validation instead of client-side validation when writing to API servers with the feature enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2885
```
