### PR TITLE
Windows gmsa e2e: Don't assume bash is avaliable for webhook deployment

### DIFF
--- a/test/e2e/windows/gmsa_full.go
+++ b/test/e2e/windows/gmsa_full.go
@@ -44,23 +44,22 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"path"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
-
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 const (
@@ -77,7 +76,6 @@ const (
 	gmsaCustomResourceName = "gmsa-e2e"
 
 	// gmsaWebhookDeployScriptURL is the URL of the deploy script for the GMSA webook
-	// TODO(wk8): we should pin versions.
 	gmsaWebhookDeployScriptURL = "https://raw.githubusercontent.com/kubernetes-sigs/windows-gmsa/master/admission-webhook/deploy/deploy-gmsa-webhook.sh"
 
 	// output from the nltest /query command should have this in it
@@ -107,15 +105,8 @@ var _ = SIGDescribe("[Feature:Windows] GMSA Full [Serial] [Slow]", func() {
 			ginkgo.By("retrieving the contents of the GMSACredentialSpec custom resource manifest from the node")
 			crdManifestContents := retrieveCRDManifestFileContents(f, node)
 
-			ginkgo.By("downloading the GMSA webhook deploy script")
-			deployScriptPath, err := downloadFile(gmsaWebhookDeployScriptURL)
-			defer func() { os.Remove(deployScriptPath) }()
-			if err != nil {
-				framework.Failf(err.Error())
-			}
-
 			ginkgo.By("deploying the GMSA webhook")
-			webhookCleanUp, err := deployGmsaWebhook(f, deployScriptPath)
+			webhookCleanUp, err := deployGmsaWebhook(f)
 			defer webhookCleanUp()
 			if err != nil {
 				framework.Failf(err.Error())
@@ -184,15 +175,8 @@ var _ = SIGDescribe("[Feature:Windows] GMSA Full [Serial] [Slow]", func() {
 			ginkgo.By("retrieving the contents of the GMSACredentialSpec custom resource manifest from the node")
 			crdManifestContents := retrieveCRDManifestFileContents(f, node)
 
-			ginkgo.By("downloading the GMSA webhook deploy script")
-			deployScriptPath, err := downloadFile(gmsaWebhookDeployScriptURL)
-			defer func() { os.Remove(deployScriptPath) }()
-			if err != nil {
-				framework.Failf(err.Error())
-			}
-
 			ginkgo.By("deploying the GMSA webhook")
-			webhookCleanUp, err := deployGmsaWebhook(f, deployScriptPath)
+			webhookCleanUp, err := deployGmsaWebhook(f)
 			defer webhookCleanUp()
 			if err != nil {
 				framework.Failf(err.Error())
@@ -236,6 +220,7 @@ var _ = SIGDescribe("[Feature:Windows] GMSA Full [Serial] [Slow]", func() {
 				}
 				return strings.Contains(output, "This is a test file.")
 			}, 1*time.Minute, 1*time.Second).Should(gomega.BeTrue())
+
 		})
 	})
 })
@@ -315,40 +300,81 @@ func retrieveCRDManifestFileContents(f *framework.Framework, node v1.Node) strin
 // deployGmsaWebhook deploys the GMSA webhook, and returns a cleanup function
 // to be called when done with testing, that removes the temp files it's created
 // on disks as well as the API resources it's created.
-func deployGmsaWebhook(f *framework.Framework, deployScriptPath string) (func(), error) {
-	cleanUpFunc := func() {}
-
-	tempDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		return cleanUpFunc, fmt.Errorf("unable to create temp dir: %w", err)
-	}
-
-	manifestsFile := path.Join(tempDir, "manifests.yml")
-	name := "gmsa-webhook"
-	namespace := f.Namespace.Name + "-webhook"
-	certsDir := path.Join(tempDir, "certs")
+func deployGmsaWebhook(f *framework.Framework) (func(), error) {
+	deployerName := "webhook-deployer"
+	deployerNamespace := f.Namespace.Name
+	webHookName := "gmsa-webhook"
+	webHookNamespace := deployerNamespace + "-webhook"
 
 	// regardless of whether the deployment succeeded, let's do a best effort at cleanup
-	cleanUpFunc = func() {
-		framework.RunKubectl(f.Namespace.Name, "delete", "--filename", manifestsFile)
-		framework.RunKubectl(f.Namespace.Name, "delete", "CustomResourceDefinition", "gmsacredentialspecs.windows.k8s.io")
-		framework.RunKubectl(f.Namespace.Name, "delete", "CertificateSigningRequest", fmt.Sprintf("%s.%s", name, namespace))
-		os.RemoveAll(tempDir)
+	cleanUpFunc := func() {
+		framework.Logf("Best effort clean up of the webhook:\n")
+		stdout, err := framework.RunKubectl("", "delete", "CustomResourceDefinition", "gmsacredentialspecs.windows.k8s.io")
+		framework.Logf("stdout:%s\nerror:%s", stdout, err)
+
+		stdout, err = framework.RunKubectl("", "delete", "CertificateSigningRequest", fmt.Sprintf("%s.%s", webHookName, webHookNamespace))
+		framework.Logf("stdout:%s\nerror:%s", stdout, err)
+
+		stdout, err = runKubectlExecInNamespace(deployerNamespace, deployerName, "--", "kubectl", "delete", "-f", "/manifests.yml")
+		framework.Logf("stdout:%s\nerror:%s", stdout, err)
 	}
 
-	cmd := exec.Command("bash", deployScriptPath,
-		"--file", manifestsFile,
-		"--name", name,
-		"--namespace", namespace,
-		"--certs-dir", certsDir,
-		"--tolerate-master")
+	// ensure the deployer has ability to approve certificatesigningrequests to install the webhook
+	s := createServiceAccount(f)
+	bindClusterRBACRoleToServiceAccount(f, s, "cluster-admin")
 
-	output, err := cmd.CombinedOutput()
+	installSteps := []string{
+		"echo \"@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing/\" >> /etc/apk/repositories",
+		"&& apk add kubectl@testing gettext openssl",
+		"&& apk add --update coreutils",
+		fmt.Sprintf("&& curl %s > gmsa.sh", gmsaWebhookDeployScriptURL),
+		"&& chmod +x gmsa.sh",
+		fmt.Sprintf("&& ./gmsa.sh --file %s --name %s --namespace %s --certs-dir %s --tolerate-master", "/manifests.yml", webHookName, webHookNamespace, "certs"),
+		"&& /agnhost pause",
+	}
+	installCommand := strings.Join(installSteps, " ")
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployerName,
+			Namespace: deployerNamespace,
+		},
+		Spec: v1.PodSpec{
+			ServiceAccountName: s,
+			NodeSelector: map[string]string{
+				"kubernetes.io/os": "linux",
+			},
+			Containers: []v1.Container{
+				{
+					Name:    deployerName,
+					Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+					Command: []string{"bash", "-c"},
+					Args:    []string{installCommand},
+				},
+			},
+			Tolerations: []v1.Toleration{
+				{
+					Operator: v1.TolerationOpExists,
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+	f.PodClient().CreateSync(pod)
+
+	// Wait for the Webhook deployment to become ready. The deployer pod takes a few seconds to initialize and create resources
+	err := waitForDeployment(func() (*appsv1.Deployment, error) {
+		return f.ClientSet.AppsV1().Deployments(webHookNamespace).Get(context.TODO(), webHookName, metav1.GetOptions{})
+	}, 10*time.Second, f.Timeouts.PodStart)
 	if err == nil {
-		framework.Logf("GMSA webhook successfully deployed, output:\n%s", string(output))
+		framework.Logf("GMSA webhook successfully deployed")
 	} else {
-		err = fmt.Errorf("unable to deploy GMSA webhook, output:\n%s: %w", string(output), err)
+		err = fmt.Errorf("GMSA webhook did not become ready: %w", err)
 	}
+
+	// Dump deployer logs
+	logs, _ := e2epod.GetPodLogs(f.ClientSet, deployerNamespace, deployerName, deployerName)
+	framework.Logf("GMSA deployment logs:\n%s", logs)
 
 	return cleanUpFunc, err
 }
@@ -419,7 +445,7 @@ func createRBACRoleForGmsa(f *framework.Framework) (string, func(), error) {
 
 // createServiceAccount creates a service account, and returns its name.
 func createServiceAccount(f *framework.Framework) string {
-	accountName := f.Namespace.Name + "-sa"
+	accountName := f.Namespace.Name + "-sa-" + string(uuid.NewUUID())
 	account := &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      accountName,
@@ -453,6 +479,28 @@ func bindRBACRoleToServiceAccount(f *framework.Framework, serviceAccountName, rb
 		},
 	}
 	f.ClientSet.RbacV1().RoleBindings(f.Namespace.Name).Create(context.TODO(), binding, metav1.CreateOptions{})
+}
+
+func bindClusterRBACRoleToServiceAccount(f *framework.Framework, serviceAccountName, rbacRoleName string) {
+	binding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      f.Namespace.Name + "-rbac-binding",
+			Namespace: f.Namespace.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccountName,
+				Namespace: f.Namespace.Name,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     rbacRoleName,
+		},
+	}
+	f.ClientSet.RbacV1().ClusterRoleBindings().Create(context.TODO(), binding, metav1.CreateOptions{})
 }
 
 // createPodWithGmsa creates a pod using the test GMSA cred spec, and returns its name.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Assuming bash is installed when running the e2e tests fails when running inside the conformance image. This provides a way to deploy the webhook that isn't dependent on the tools installed in the local machine running `e2e.test`.  

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108816

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows
/assign @marosset @knabben @ixinqi @claudiubelu 