### PR TITLE
Fix:[Flake] [sig-node] Restart [Serial] [Slow] [Disruptive] Kubelet hould correctly account for terminated pods after restart

### DIFF
--- a/test/e2e_node/container_manager_test.go
+++ b/test/e2e_node/container_manager_test.go
@@ -28,6 +28,9 @@ import (
 	"strings"
 	"time"
 
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	testutils "k8s.io/kubernetes/test/utils"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -196,6 +198,9 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 						},
 					},
 				})
+				if err := e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, podName, "Ready", 120*time.Second, testutils.PodRunningReady); err != nil {
+					framework.ExpectNoError(err, fmt.Sprintf("Pod %v could not enter running/ready", podName))
+				}
 				var (
 					ngPids []int
 					err    error
@@ -212,7 +217,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 					}
 
 					return nil
-				}, 2*time.Minute, time.Second*4).Should(gomega.BeNil())
+				}, 30*time.Second, time.Second*4).Should(gomega.BeNil())
 
 			})
 			ginkgo.It("burstable container's oom-score-adj should be between [2, 1000)", func(ctx context.Context) {
@@ -238,6 +243,9 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 						},
 					},
 				})
+				if err := e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, podName, "Ready", 120*time.Second, testutils.PodRunningReady); err != nil {
+					framework.ExpectNoError(err, fmt.Sprintf("Pod %v could not enter running/ready", podName))
+				}
 				var (
 					wsPids []int
 					err    error
@@ -253,7 +261,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 						}
 					}
 					return nil
-				}, 2*time.Minute, time.Second*4).Should(gomega.BeNil())
+				}, 30*time.Second, time.Second*4).Should(gomega.BeNil())
 
 				// TODO: Test the oom-score-adj logic for burstable more accurately.
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
See https://github.com/kubernetes/kubernetes/issues/108775#issuecomment-1075999859
https://github.com/kubernetes/kubernetes/issues/108775#issuecomment-1076045749

We check the pid of container after the pod becomes running, so we could prevent getting other pid with same name, which would make the test to end prematurely
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/108775

#### Special notes for your reviewer:
/cc @ehashman @SergeyKanzhelev 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
