### PR TITLE
hack: Set GODEBUG=x509sha1=1

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -51,5 +51,10 @@ make generated_files
 go install ./cmd/...
 ./hack/install-etcd.sh
 
+# TODO(MadhavJivrajani): Temporary fix due to Go 1.18 changes.
+# Please see https://tip.golang.org/doc/go1.18#sha1
+GODEBUG=x509sha1=1
+export GODEBUG
+
 make test-cmd
 make test-integration

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -532,6 +532,12 @@ kube::golang::setup_env() {
   GOROOT=$(go env GOROOT)
   export GOROOT
 
+  # TODO(MadhavJivrajani): Temporary fix due to Go 1.18 changes.
+  # Please see https://tip.golang.org/doc/go1.18#sha1
+  GODEBUG=x509sha1=1
+  export GODEBUG
+
+
   # Unset GOBIN in case it already exists in the current session.
   unset GOBIN
 


### PR DESCRIPTION
Temporary fix due to changes introduced in
https://tip.golang.org/doc/go1.18#sha1

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
See #108910

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
