### PR TITLE
Fix golang 1.18 sha1 issues

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -51,5 +51,9 @@ make generated_files
 go install ./cmd/...
 ./hack/install-etcd.sh
 
+  # Temporary fix for https://github.com/kubernetes/kubernetes/issues/108910
+  GODEBUG=x509sha1=1
+  export GODEBUG
+
 make test-cmd
 make test-integration


### PR DESCRIPTION
```release-note
NONE
```

let's have the CI working until we figure out if is a golang problem or we need to adapt the code

https://prow.k8s.io/?repo=kubernetes%2Fkubernetes&type=presubmit&job=pull-kubernetes-integration

https://github.com/kubernetes/kubernetes/issues/108910#issuecomment-1076156850


Full credit to @MadhavJivrajani https://github.com/kubernetes/kubernetes/issues/108910#issuecomment-1076091591