### PR TITLE
Revert "golang: Update to 1.18 from 1.18rc1"

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.24.0-go1.18-bullseye.0
+v1.24.0-go1.18rc1-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -91,7 +91,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
 readonly __default_debian_iptables_version=bullseye-v1.1.0
-readonly __default_go_runner_version=v2.3.1-go1.18-bullseye.0
+readonly __default_go_runner_version=v2.3.1-go1.18rc1-bullseye.0
 readonly __default_setcap_version=bullseye-v1.0.0
 
 # These are the base images for the Docker-wrapped binaries.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -80,7 +80,7 @@ dependencies:
 
   # Golang
   - name: "golang: upstream version"
-    version: 1.18
+    version: 1.18rc1
     refPaths:
     - path: build/build-image/cross/VERSION
     - path: staging/publishing/rules.yaml
@@ -97,7 +97,7 @@ dependencies:
     version: 1.18
     refPaths:
     - path: build/build-image/cross/VERSION
-    # TODO(dims): Uncomment once images are updated to go1.18
+    # TODO(go118): Uncomment once ready to transition presubmits to go118
     #- path: hack/lib/golang.sh
     #  match: minimum_go_version=go([0-9]+\.[0-9]+)
 
@@ -108,7 +108,7 @@ dependencies:
       match: 'GOLANG_VERSION\?=\d+.\d+(alpha|beta|rc)?\.?(\d+)?'
 
   - name: "k8s.gcr.io/kube-cross: dependents"
-    version: v1.24.0-go1.18-bullseye.0
+    version: v1.24.0-go1.18rc1-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -138,7 +138,7 @@ dependencies:
       match: configs\[DebianIptables\] = Config{list\.BuildImageRegistry, "debian-iptables", "[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"}
 
   - name: "k8s.gcr.io/go-runner: dependents"
-    version: v2.3.1-go1.18-bullseye.0
+    version: v2.3.1-go1.18rc1-bullseye.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -480,7 +480,6 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(GOFLAGS='' go version)"
   local minimum_go_version
-  # TODO(dims): Need to switch this to 1.18 once we update images to newer go version
   minimum_go_version=go1.17.0
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     kube::log::usage_from_stdin <<EOF

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,7 +7,7 @@ recursive-delete-patterns:
 - BUILD.bazel
 - "*/BUILD.bazel"
 - Gopkg.toml
-default-go-version: 1.18
+default-go-version: 1.18rc1
 rules:
 - destination: code-generator
   branches:

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -16,7 +16,7 @@ REGISTRY ?= k8s.gcr.io/e2e-test-images
 GOARM ?= 7
 DOCKER_CERT_BASE_PATH ?=
 QEMUVERSION=v5.1.0-2
-GOLANG_VERSION=1.18
+GOLANG_VERSION=1.18rc1
 export
 
 ifndef WHAT


### PR DESCRIPTION
This reverts commit d8f1da5ecbfe082622018540355da328cea71836.

/sig testing
/sig release
/priority critical-urgent
/kind regression
```release-note
NONE
```


Multiple jobs seems to start failing since this ??

https://github.com/kubernetes/kubernetes/issues/108916
https://github.com/kubernetes/kubernetes/issues/108910