### PR TITLE
Rename unschedulableQ to unschedulablePods

### DIFF
--- a/cmd/kube-scheduler/app/config/config.go
+++ b/cmd/kube-scheduler/app/config/config.go
@@ -52,11 +52,11 @@ type Config struct {
 	// LeaderElection is optional.
 	LeaderElection *leaderelection.LeaderElectionConfig
 
-	// PodMaxUnschedulableQDuration is the maximum time a pod can stay in
-	// unschedulableQ. If a pod stays in unschedulableQ for longer than this
-	// value, the pod will be moved from unschedulableQ to backoffQ or activeQ.
-	// If this value is empty, the default value (60s) will be used.
-	PodMaxUnschedulableQDuration time.Duration
+	// PodMaxInUnschedulablePodsDuration is the maximum time a pod can stay in
+	// unschedulablePods. If a pod stays in unschedulablePods for longer than this
+	// value, the pod will be moved from unschedulablePods to backoffQ or activeQ.
+	// If this value is empty, the default value (5min) will be used.
+	PodMaxInUnschedulablePodsDuration time.Duration
 }
 
 type completedConfig struct {

--- a/cmd/kube-scheduler/app/options/deprecated.go
+++ b/cmd/kube-scheduler/app/options/deprecated.go
@@ -30,11 +30,11 @@ type DeprecatedOptions struct {
 	componentbaseconfig.ClientConnectionConfiguration
 	// Note that only the deprecated options (lock-object-name and lock-object-namespace) are populated here.
 	componentbaseconfig.LeaderElectionConfiguration
-	// PodMaxUnschedulableQDuration is the maximum time a pod can stay in
-	// unschedulableQ. If a pod stays in unschedulableQ for longer than this
-	// value, the pod will be moved from unschedulableQ to backoffQ or activeQ.
-	// If this value is empty, the default value (60s) will be used.
-	PodMaxUnschedulableQDuration time.Duration
+	// PodMaxInUnschedulablePodsDuration is the maximum time a pod can stay in
+	// unschedulablePods. If a pod stays in unschedulablePods for longer than this
+	// value, the pod will be moved from unschedulablePods to backoffQ or activeQ.
+	// If this value is empty, the default value (5min) will be used.
+	PodMaxInUnschedulablePodsDuration time.Duration
 }
 
 // AddFlags adds flags for the deprecated options.
@@ -51,5 +51,5 @@ func (o *DeprecatedOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.Int32Var(&o.Burst, "kube-api-burst", 100, "DEPRECATED: burst to use while talking with kubernetes apiserver. This parameter is ignored if a config file is specified in --config.")
 	fs.StringVar(&o.ResourceNamespace, "lock-object-namespace", "kube-system", "DEPRECATED: define the namespace of the lock object. Will be removed in favor of leader-elect-resource-namespace. This parameter is ignored if a config file is specified in --config.")
 	fs.StringVar(&o.ResourceName, "lock-object-name", "kube-scheduler", "DEPRECATED: define the name of the lock object. Will be removed in favor of leader-elect-resource-name. This parameter is ignored if a config file is specified in --config.")
-	fs.DurationVar(&o.PodMaxUnschedulableQDuration, "pod-max-unschedulableq-duration", 5*time.Minute, "DEPRECATED: the maximum time a pod can stay in unschedulableQ. If a pod stays in unschedulableQ for longer than this value, the pod will be moved from unschedulableQ to backoffQ or activeQ. This flag is deprecated and will be removed in 1.26")
+	fs.DurationVar(&o.PodMaxInUnschedulablePodsDuration, "pod-max-in-unschedulable-pods-duration", 5*time.Minute, "DEPRECATED: the maximum time a pod can stay in unschedulablePods. If a pod stays in unschedulablePods for longer than this value, the pod will be moved from unschedulablePods to backoffQ or activeQ. This flag is deprecated and will be removed in 1.26")
 }

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -80,7 +80,7 @@ func NewOptions() *Options {
 		Authentication: apiserveroptions.NewDelegatingAuthenticationOptions(),
 		Authorization:  apiserveroptions.NewDelegatingAuthorizationOptions(),
 		Deprecated: &DeprecatedOptions{
-			PodMaxUnschedulableQDuration: 5 * time.Minute,
+			PodMaxInUnschedulablePodsDuration: 5 * time.Minute,
 		},
 		LeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
 			LeaderElect:       true,
@@ -236,7 +236,7 @@ func (o *Options) ApplyTo(c *schedulerappconfig.Config) error {
 
 	// Apply value independently instead of using ApplyDeprecated() because it can't be configured via ComponentConfig.
 	if o.Deprecated != nil {
-		c.PodMaxUnschedulableQDuration = o.Deprecated.PodMaxUnschedulableQDuration
+		c.PodMaxInUnschedulablePodsDuration = o.Deprecated.PodMaxInUnschedulablePodsDuration
 	}
 
 	return nil

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -330,7 +330,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 		scheduler.WithFrameworkOutOfTreeRegistry(outOfTreeRegistry),
 		scheduler.WithPodMaxBackoffSeconds(cc.ComponentConfig.PodMaxBackoffSeconds),
 		scheduler.WithPodInitialBackoffSeconds(cc.ComponentConfig.PodInitialBackoffSeconds),
-		scheduler.WithPodMaxUnschedulableQDuration(cc.PodMaxUnschedulableQDuration),
+		scheduler.WithPodMaxInUnschedulablePodsDuration(cc.PodMaxInUnschedulablePodsDuration),
 		scheduler.WithExtenders(cc.ComponentConfig.Extenders...),
 		scheduler.WithParallelism(cc.ComponentConfig.Parallelism),
 		scheduler.WithBuildFrameworkCapturer(func(profile kubeschedulerconfig.KubeSchedulerProfile) {

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -108,7 +108,7 @@ const (
 )
 
 // PodsToActivateKey is a reserved state key for stashing pods.
-// If the stashed pods are present in unschedulableQ or backoffQ，they will be
+// If the stashed pods are present in unschedulablePods or backoffQ，they will be
 // activated (i.e., moved to activeQ) in two phases:
 // - end of a scheduling cycle if it succeeds (will be cleared from `PodsToActivate` if activated)
 // - end of a binding cycle if it succeeds

--- a/pkg/scheduler/internal/queue/events.go
+++ b/pkg/scheduler/internal/queue/events.go
@@ -27,7 +27,7 @@ const (
 	ScheduleAttemptFailure = "ScheduleAttemptFailure"
 	// BackoffComplete is the event when a pod finishes backoff.
 	BackoffComplete = "BackoffComplete"
-	// ForceActivate is the event when a pod is moved from unschedulableQ/backoffQ
+	// ForceActivate is the event when a pod is moved from unschedulablePods/backoffQ
 	// to activeQ. Usually it's triggered by plugin implementations.
 	ForceActivate = "ForceActivate"
 )

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -15,11 +15,14 @@ limitations under the License.
 */
 
 // This file contains structures that implement scheduling queue types.
-// Scheduling queues hold pods waiting to be scheduled. This file implements a/
-// priority queue which has two sub queues. One sub-queue holds pods that are
-// being considered for scheduling. This is called activeQ. Another queue holds
-// pods that are already tried and are determined to be unschedulable. The latter
-// is called unschedulableQ.
+// Scheduling queues hold pods waiting to be scheduled. This file implements a
+// priority queue which has two sub queues and a additional data structure,
+// namely: activeQ, backoffQ and unschedulablePods.
+// - activeQ holds pods that are being considered for scheduling.
+// - backoffQ holds pods that moved from unschedulablePods and will move to
+//   activeQ when their backoff periods complete.
+// - unschedulablePods holds pods that were already attempted for scheduling and
+//   are currently determined to be unschedulable.
 
 package queue
 
@@ -46,12 +49,12 @@ import (
 )
 
 const (
-	// DefaultPodMaxUnschedulableQDuration is the default value for the maximum
-	// time a pod can stay in unschedulableQ. If a pod stays in unschedulableQ
-	// for longer than this value, the pod will be moved from unschedulableQ to
+	// DefaultPodMaxInUnschedulablePodsDuration is the default value for the maximum
+	// time a pod can stay in unschedulablePods. If a pod stays in unschedulablePods
+	// for longer than this value, the pod will be moved from unschedulablePods to
 	// backoffQ or activeQ. If this value is empty, the default value (5min)
 	// will be used.
-	DefaultPodMaxUnschedulableQDuration time.Duration = 5 * time.Minute
+	DefaultPodMaxInUnschedulablePodsDuration time.Duration = 5 * time.Minute
 
 	queueClosed = "scheduling queue is closed"
 )
@@ -78,7 +81,7 @@ type PreEnqueueCheck func(pod *v1.Pod) bool
 type SchedulingQueue interface {
 	framework.PodNominator
 	Add(pod *v1.Pod) error
-	// Activate moves the given pods to activeQ iff they're in unschedulableQ or backoffQ.
+	// Activate moves the given pods to activeQ iff they're in unschedulablePods or backoffQ.
 	// The passed-in pods are originally compiled from plugins that want to activate Pods,
 	// by injecting the pods through a reserved CycleState struct (PodsToActivate).
 	Activate(pods map[string]*v1.Pod)
@@ -121,11 +124,13 @@ func NominatedNodeName(pod *v1.Pod) string {
 
 // PriorityQueue implements a scheduling queue.
 // The head of PriorityQueue is the highest priority pending pod. This structure
-// has three sub queues. One sub-queue holds pods that are being considered for
-// scheduling. This is called activeQ and is a Heap. Another queue holds
-// pods that are already tried and are determined to be unschedulable. The latter
-// is called unschedulableQ. The third queue holds pods that are moved from
-// unschedulable queues and will be moved to active queue when backoff are completed.
+// has two sub queues and a additional data structure, namely: activeQ,
+// backoffQ and unschedulablePods.
+// - activeQ holds pods that are being considered for scheduling.
+// - backoffQ holds pods that moved from unschedulablePods and will move to
+//   activeQ when their backoff periods complete.
+// - unschedulablePods holds pods that were already attempted for scheduling and
+//   are currently determined to be unschedulable.
 type PriorityQueue struct {
 	// PodNominator abstracts the operations to maintain nominated Pods.
 	framework.PodNominator
@@ -137,8 +142,8 @@ type PriorityQueue struct {
 	podInitialBackoffDuration time.Duration
 	// pod maximum backoff duration.
 	podMaxBackoffDuration time.Duration
-	// the maximum time a pod can stay in the unschedulableQ.
-	podMaxUnschedulableQDuration time.Duration
+	// the maximum time a pod can stay in the unschedulablePods.
+	podMaxInUnschedulablePodsDuration time.Duration
 
 	lock sync.RWMutex
 	cond sync.Cond
@@ -149,8 +154,8 @@ type PriorityQueue struct {
 	// podBackoffQ is a heap ordered by backoff expiry. Pods which have completed backoff
 	// are popped from this heap before the scheduler looks at activeQ
 	podBackoffQ *heap.Heap
-	// unschedulableQ holds pods that have been tried and determined unschedulable.
-	unschedulableQ *UnschedulablePodsMap
+	// unschedulablePods holds pods that have been tried and determined unschedulable.
+	unschedulablePods *UnschedulablePods
 	// schedulingCycle represents sequence number of scheduling cycle and is incremented
 	// when a pod is popped.
 	schedulingCycle int64
@@ -170,12 +175,12 @@ type PriorityQueue struct {
 }
 
 type priorityQueueOptions struct {
-	clock                        util.Clock
-	podInitialBackoffDuration    time.Duration
-	podMaxBackoffDuration        time.Duration
-	podMaxUnschedulableQDuration time.Duration
-	podNominator                 framework.PodNominator
-	clusterEventMap              map[framework.ClusterEvent]sets.String
+	clock                             util.Clock
+	podInitialBackoffDuration         time.Duration
+	podMaxBackoffDuration             time.Duration
+	podMaxInUnschedulablePodsDuration time.Duration
+	podNominator                      framework.PodNominator
+	clusterEventMap                   map[framework.ClusterEvent]sets.String
 }
 
 // Option configures a PriorityQueue
@@ -216,18 +221,18 @@ func WithClusterEventMap(m map[framework.ClusterEvent]sets.String) Option {
 	}
 }
 
-// WithPodMaxUnschedulableQDuration sets podMaxUnschedulableQDuration for PriorityQueue.
-func WithPodMaxUnschedulableQDuration(duration time.Duration) Option {
+// WithPodMaxInUnschedulablePodsDuration sets podMaxInUnschedulablePodsDuration for PriorityQueue.
+func WithPodMaxInUnschedulablePodsDuration(duration time.Duration) Option {
 	return func(o *priorityQueueOptions) {
-		o.podMaxUnschedulableQDuration = duration
+		o.podMaxInUnschedulablePodsDuration = duration
 	}
 }
 
 var defaultPriorityQueueOptions = priorityQueueOptions{
-	clock:                        util.RealClock{},
-	podInitialBackoffDuration:    DefaultPodInitialBackoffDuration,
-	podMaxBackoffDuration:        DefaultPodMaxBackoffDuration,
-	podMaxUnschedulableQDuration: DefaultPodMaxUnschedulableQDuration,
+	clock:                             util.RealClock{},
+	podInitialBackoffDuration:         DefaultPodInitialBackoffDuration,
+	podMaxBackoffDuration:             DefaultPodMaxBackoffDuration,
+	podMaxInUnschedulablePodsDuration: DefaultPodMaxInUnschedulablePodsDuration,
 }
 
 // Making sure that PriorityQueue implements SchedulingQueue.
@@ -265,16 +270,16 @@ func NewPriorityQueue(
 	}
 
 	pq := &PriorityQueue{
-		PodNominator:                 options.podNominator,
-		clock:                        options.clock,
-		stop:                         make(chan struct{}),
-		podInitialBackoffDuration:    options.podInitialBackoffDuration,
-		podMaxBackoffDuration:        options.podMaxBackoffDuration,
-		podMaxUnschedulableQDuration: options.podMaxUnschedulableQDuration,
-		activeQ:                      heap.NewWithRecorder(podInfoKeyFunc, comp, metrics.NewActivePodsRecorder()),
-		unschedulableQ:               newUnschedulablePodsMap(metrics.NewUnschedulablePodsRecorder()),
-		moveRequestCycle:             -1,
-		clusterEventMap:              options.clusterEventMap,
+		PodNominator:                      options.podNominator,
+		clock:                             options.clock,
+		stop:                              make(chan struct{}),
+		podInitialBackoffDuration:         options.podInitialBackoffDuration,
+		podMaxBackoffDuration:             options.podMaxBackoffDuration,
+		podMaxInUnschedulablePodsDuration: options.podMaxInUnschedulablePodsDuration,
+		activeQ:                           heap.NewWithRecorder(podInfoKeyFunc, comp, metrics.NewActivePodsRecorder()),
+		unschedulablePods:                 newUnschedulablePods(metrics.NewUnschedulablePodsRecorder()),
+		moveRequestCycle:                  -1,
+		clusterEventMap:                   options.clusterEventMap,
 	}
 	pq.cond.L = &pq.lock
 	pq.podBackoffQ = heap.NewWithRecorder(podInfoKeyFunc, pq.podsCompareBackoffCompleted, metrics.NewBackoffPodsRecorder())
@@ -286,7 +291,7 @@ func NewPriorityQueue(
 // Run starts the goroutine to pump from podBackoffQ to activeQ
 func (p *PriorityQueue) Run() {
 	go wait.Until(p.flushBackoffQCompleted, 1.0*time.Second, p.stop)
-	go wait.Until(p.flushUnschedulableQLeftover, 30*time.Second, p.stop)
+	go wait.Until(p.flushUnschedulablePodsLeftover, 30*time.Second, p.stop)
 }
 
 // Add adds a pod to the active queue. It should be called only when a new pod
@@ -299,9 +304,9 @@ func (p *PriorityQueue) Add(pod *v1.Pod) error {
 		klog.ErrorS(err, "Error adding pod to the active queue", "pod", klog.KObj(pod))
 		return err
 	}
-	if p.unschedulableQ.get(pod) != nil {
+	if p.unschedulablePods.get(pod) != nil {
 		klog.ErrorS(nil, "Error: pod is already in the unschedulable queue", "pod", klog.KObj(pod))
-		p.unschedulableQ.delete(pod)
+		p.unschedulablePods.delete(pod)
 	}
 	// Delete pod from backoffQ if it is backing off
 	if err := p.podBackoffQ.Delete(pInfo); err == nil {
@@ -314,7 +319,7 @@ func (p *PriorityQueue) Add(pod *v1.Pod) error {
 	return nil
 }
 
-// Activate moves the given pods to activeQ iff they're in unschedulableQ or backoffQ.
+// Activate moves the given pods to activeQ iff they're in unschedulablePods or backoffQ.
 func (p *PriorityQueue) Activate(pods map[string]*v1.Pod) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
@@ -338,11 +343,11 @@ func (p *PriorityQueue) activate(pod *v1.Pod) bool {
 		return false
 	}
 	var pInfo *framework.QueuedPodInfo
-	// Verify if the pod is present in unschedulableQ or backoffQ.
-	if pInfo = p.unschedulableQ.get(pod); pInfo == nil {
-		// If the pod doesn't belong to unschedulableQ or backoffQ, don't activate it.
+	// Verify if the pod is present in unschedulablePods or backoffQ.
+	if pInfo = p.unschedulablePods.get(pod); pInfo == nil {
+		// If the pod doesn't belong to unschedulablePods or backoffQ, don't activate it.
 		if obj, exists, _ := p.podBackoffQ.Get(newQueuedPodInfoForLookup(pod)); !exists {
-			klog.ErrorS(nil, "To-activate pod does not exist in unschedulableQ or backoffQ", "pod", klog.KObj(pod))
+			klog.ErrorS(nil, "To-activate pod does not exist in unschedulablePods or backoffQ", "pod", klog.KObj(pod))
 			return false
 		} else {
 			pInfo = obj.(*framework.QueuedPodInfo)
@@ -359,7 +364,7 @@ func (p *PriorityQueue) activate(pod *v1.Pod) bool {
 		klog.ErrorS(err, "Error adding pod to the scheduling queue", "pod", klog.KObj(pod))
 		return false
 	}
-	p.unschedulableQ.delete(pod)
+	p.unschedulablePods.delete(pod)
 	p.podBackoffQ.Delete(pInfo)
 	metrics.SchedulerQueueIncomingPods.WithLabelValues("active", ForceActivate).Inc()
 	p.PodNominator.AddNominatedPod(pInfo.PodInfo, nil)
@@ -382,13 +387,13 @@ func (p *PriorityQueue) SchedulingCycle() int64 {
 
 // AddUnschedulableIfNotPresent inserts a pod that cannot be scheduled into
 // the queue, unless it is already in the queue. Normally, PriorityQueue puts
-// unschedulable pods in `unschedulableQ`. But if there has been a recent move
+// unschedulable pods in `unschedulablePods`. But if there has been a recent move
 // request, then the pod is put in `podBackoffQ`.
 func (p *PriorityQueue) AddUnschedulableIfNotPresent(pInfo *framework.QueuedPodInfo, podSchedulingCycle int64) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	pod := pInfo.Pod
-	if p.unschedulableQ.get(pod) != nil {
+	if p.unschedulablePods.get(pod) != nil {
 		return fmt.Errorf("Pod %v is already present in unschedulable queue", klog.KObj(pod))
 	}
 
@@ -403,7 +408,7 @@ func (p *PriorityQueue) AddUnschedulableIfNotPresent(pInfo *framework.QueuedPodI
 	pInfo.Timestamp = p.clock.Now()
 
 	// If a move request has been received, move it to the BackoffQ, otherwise move
-	// it to unschedulableQ.
+	// it to unschedulablePods.
 	for plugin := range pInfo.UnschedulablePlugins {
 		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Inc()
 	}
@@ -413,7 +418,7 @@ func (p *PriorityQueue) AddUnschedulableIfNotPresent(pInfo *framework.QueuedPodI
 		}
 		metrics.SchedulerQueueIncomingPods.WithLabelValues("backoff", ScheduleAttemptFailure).Inc()
 	} else {
-		p.unschedulableQ.addOrUpdate(pInfo)
+		p.unschedulablePods.addOrUpdate(pInfo)
 		metrics.SchedulerQueueIncomingPods.WithLabelValues("unschedulable", ScheduleAttemptFailure).Inc()
 
 	}
@@ -452,17 +457,17 @@ func (p *PriorityQueue) flushBackoffQCompleted() {
 	}
 }
 
-// flushUnschedulableQLeftover moves pods which stay in unschedulableQ longer than podMaxUnschedulableQDuration
-// to backoffQ or activeQ.
-func (p *PriorityQueue) flushUnschedulableQLeftover() {
+// flushUnschedulablePodsLeftover moves pods which stay in unschedulablePods
+// longer than podMaxInUnschedulablePodsDuration to backoffQ or activeQ.
+func (p *PriorityQueue) flushUnschedulablePodsLeftover() {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	var podsToMove []*framework.QueuedPodInfo
 	currentTime := p.clock.Now()
-	for _, pInfo := range p.unschedulableQ.podInfoMap {
+	for _, pInfo := range p.unschedulablePods.podInfoMap {
 		lastScheduleTime := pInfo.Timestamp
-		if currentTime.Sub(lastScheduleTime) > p.podMaxUnschedulableQDuration {
+		if currentTime.Sub(lastScheduleTime) > p.podMaxInUnschedulablePodsDuration {
 			podsToMove = append(podsToMove, pInfo)
 		}
 	}
@@ -538,7 +543,7 @@ func (p *PriorityQueue) Update(oldPod, newPod *v1.Pod) error {
 	}
 
 	// If the pod is in the unschedulable queue, updating it may make it schedulable.
-	if usPodInfo := p.unschedulableQ.get(newPod); usPodInfo != nil {
+	if usPodInfo := p.unschedulablePods.get(newPod); usPodInfo != nil {
 		pInfo := updatePod(usPodInfo, newPod)
 		p.PodNominator.UpdateNominatedPod(oldPod, pInfo.PodInfo)
 		if isPodUpdated(oldPod, newPod) {
@@ -546,17 +551,17 @@ func (p *PriorityQueue) Update(oldPod, newPod *v1.Pod) error {
 				if err := p.podBackoffQ.Add(pInfo); err != nil {
 					return err
 				}
-				p.unschedulableQ.delete(usPodInfo.Pod)
+				p.unschedulablePods.delete(usPodInfo.Pod)
 			} else {
 				if err := p.activeQ.Add(pInfo); err != nil {
 					return err
 				}
-				p.unschedulableQ.delete(usPodInfo.Pod)
+				p.unschedulablePods.delete(usPodInfo.Pod)
 				p.cond.Broadcast()
 			}
 		} else {
 			// Pod update didn't make it schedulable, keep it in the unschedulable queue.
-			p.unschedulableQ.addOrUpdate(pInfo)
+			p.unschedulablePods.addOrUpdate(pInfo)
 		}
 
 		return nil
@@ -580,7 +585,7 @@ func (p *PriorityQueue) Delete(pod *v1.Pod) error {
 	if err := p.activeQ.Delete(newQueuedPodInfoForLookup(pod)); err != nil {
 		// The item was probably not found in the activeQ.
 		p.podBackoffQ.Delete(newQueuedPodInfoForLookup(pod))
-		p.unschedulableQ.delete(pod)
+		p.unschedulablePods.delete(pod)
 	}
 	return nil
 }
@@ -601,15 +606,15 @@ func (p *PriorityQueue) AssignedPodUpdated(pod *v1.Pod) {
 	p.lock.Unlock()
 }
 
-// MoveAllToActiveOrBackoffQueue moves all pods from unschedulableQ to activeQ or backoffQ.
+// MoveAllToActiveOrBackoffQueue moves all pods from unschedulablePods to activeQ or backoffQ.
 // This function adds all pods and then signals the condition variable to ensure that
 // if Pop() is waiting for an item, it receives the signal after all the pods are in the
 // queue and the head is the highest priority pod.
 func (p *PriorityQueue) MoveAllToActiveOrBackoffQueue(event framework.ClusterEvent, preCheck PreEnqueueCheck) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	unschedulablePods := make([]*framework.QueuedPodInfo, 0, len(p.unschedulableQ.podInfoMap))
-	for _, pInfo := range p.unschedulableQ.podInfoMap {
+	unschedulablePods := make([]*framework.QueuedPodInfo, 0, len(p.unschedulablePods.podInfoMap))
+	for _, pInfo := range p.unschedulablePods.podInfoMap {
 		if preCheck == nil || preCheck(pInfo.Pod) {
 			unschedulablePods = append(unschedulablePods, pInfo)
 		}
@@ -635,14 +640,14 @@ func (p *PriorityQueue) movePodsToActiveOrBackoffQueue(podInfoList []*framework.
 				klog.ErrorS(err, "Error adding pod to the backoff queue", "pod", klog.KObj(pod))
 			} else {
 				metrics.SchedulerQueueIncomingPods.WithLabelValues("backoff", event.Label).Inc()
-				p.unschedulableQ.delete(pod)
+				p.unschedulablePods.delete(pod)
 			}
 		} else {
 			if err := p.activeQ.Add(pInfo); err != nil {
 				klog.ErrorS(err, "Error adding pod to the scheduling queue", "pod", klog.KObj(pod))
 			} else {
 				metrics.SchedulerQueueIncomingPods.WithLabelValues("active", event.Label).Inc()
-				p.unschedulableQ.delete(pod)
+				p.unschedulablePods.delete(pod)
 			}
 		}
 	}
@@ -660,7 +665,7 @@ func (p *PriorityQueue) getUnschedulablePodsWithMatchingAffinityTerm(pod *v1.Pod
 	nsLabels = interpodaffinity.GetNamespaceLabelsSnapshot(pod.Namespace, p.nsLister)
 
 	var podsToMove []*framework.QueuedPodInfo
-	for _, pInfo := range p.unschedulableQ.podInfoMap {
+	for _, pInfo := range p.unschedulablePods.podInfoMap {
 		for _, term := range pInfo.RequiredAffinityTerms {
 			if term.Matches(pod, nsLabels) {
 				podsToMove = append(podsToMove, pInfo)
@@ -684,7 +689,7 @@ func (p *PriorityQueue) PendingPods() []*v1.Pod {
 	for _, pInfo := range p.podBackoffQ.List() {
 		result = append(result, pInfo.(*framework.QueuedPodInfo).Pod)
 	}
-	for _, pInfo := range p.unschedulableQ.podInfoMap {
+	for _, pInfo := range p.unschedulablePods.podInfoMap {
 		result = append(result, pInfo.Pod)
 	}
 	return result
@@ -775,9 +780,9 @@ func updatePod(oldPodInfo interface{}, newPod *v1.Pod) *framework.QueuedPodInfo 
 	return pInfo
 }
 
-// UnschedulablePodsMap holds pods that cannot be scheduled. This data structure
-// is used to implement unschedulableQ.
-type UnschedulablePodsMap struct {
+// UnschedulablePods holds pods that cannot be scheduled. This data structure
+// is used to implement unschedulablePods.
+type UnschedulablePods struct {
 	// podInfoMap is a map key by a pod's full-name and the value is a pointer to the QueuedPodInfo.
 	podInfoMap map[string]*framework.QueuedPodInfo
 	keyFunc    func(*v1.Pod) string
@@ -787,7 +792,7 @@ type UnschedulablePodsMap struct {
 }
 
 // Add adds a pod to the unschedulable podInfoMap.
-func (u *UnschedulablePodsMap) addOrUpdate(pInfo *framework.QueuedPodInfo) {
+func (u *UnschedulablePods) addOrUpdate(pInfo *framework.QueuedPodInfo) {
 	podID := u.keyFunc(pInfo.Pod)
 	if _, exists := u.podInfoMap[podID]; !exists && u.metricRecorder != nil {
 		u.metricRecorder.Inc()
@@ -796,7 +801,7 @@ func (u *UnschedulablePodsMap) addOrUpdate(pInfo *framework.QueuedPodInfo) {
 }
 
 // Delete deletes a pod from the unschedulable podInfoMap.
-func (u *UnschedulablePodsMap) delete(pod *v1.Pod) {
+func (u *UnschedulablePods) delete(pod *v1.Pod) {
 	podID := u.keyFunc(pod)
 	if _, exists := u.podInfoMap[podID]; exists && u.metricRecorder != nil {
 		u.metricRecorder.Dec()
@@ -806,7 +811,7 @@ func (u *UnschedulablePodsMap) delete(pod *v1.Pod) {
 
 // Get returns the QueuedPodInfo if a pod with the same key as the key of the given "pod"
 // is found in the map. It returns nil otherwise.
-func (u *UnschedulablePodsMap) get(pod *v1.Pod) *framework.QueuedPodInfo {
+func (u *UnschedulablePods) get(pod *v1.Pod) *framework.QueuedPodInfo {
 	podKey := u.keyFunc(pod)
 	if pInfo, exists := u.podInfoMap[podKey]; exists {
 		return pInfo
@@ -815,16 +820,16 @@ func (u *UnschedulablePodsMap) get(pod *v1.Pod) *framework.QueuedPodInfo {
 }
 
 // Clear removes all the entries from the unschedulable podInfoMap.
-func (u *UnschedulablePodsMap) clear() {
+func (u *UnschedulablePods) clear() {
 	u.podInfoMap = make(map[string]*framework.QueuedPodInfo)
 	if u.metricRecorder != nil {
 		u.metricRecorder.Clear()
 	}
 }
 
-// newUnschedulablePodsMap initializes a new object of UnschedulablePodsMap.
-func newUnschedulablePodsMap(metricRecorder metrics.MetricRecorder) *UnschedulablePodsMap {
-	return &UnschedulablePodsMap{
+// newUnschedulablePods initializes a new object of UnschedulablePods.
+func newUnschedulablePods(metricRecorder metrics.MetricRecorder) *UnschedulablePods {
+	return &UnschedulablePods{
 		podInfoMap:     make(map[string]*framework.QueuedPodInfo),
 		keyFunc:        util.GetPodFullName,
 		metricRecorder: metricRecorder,
@@ -840,7 +845,7 @@ type nominator struct {
 	podLister listersv1.PodLister
 	// nominatedPods is a map keyed by a node name and the value is a list of
 	// pods which are nominated to run on the node. These are pods which can be in
-	// the activeQ or unschedulableQ.
+	// the activeQ or unschedulablePods.
 	nominatedPods map[string][]*framework.PodInfo
 	// nominatedPodToNode is map keyed by a Pod UID to the node name where it is
 	// nominated.

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -122,7 +122,7 @@ var highPriorityPodInfo, highPriNominatedPodInfo, medPriorityPodInfo, unschedula
 	})
 
 func getUnschedulablePod(p *PriorityQueue, pod *v1.Pod) *v1.Pod {
-	pInfo := p.unschedulableQ.get(pod)
+	pInfo := p.unschedulablePods.get(pod)
 	if pInfo != nil {
 		return pInfo.Pod
 	}
@@ -220,7 +220,7 @@ func TestPriorityQueue_AddUnschedulableIfNotPresent(t *testing.T) {
 		t.Errorf("Expected nomindatePods to have one element: %v", q.PodNominator)
 	}
 	if getUnschedulablePod(q, unschedulablePodInfo.Pod) != unschedulablePodInfo.Pod {
-		t.Errorf("Pod %v was not found in the unschedulableQ.", unschedulablePodInfo.Pod.Name)
+		t.Errorf("Pod %v was not found in the unschedulablePods.", unschedulablePodInfo.Pod.Name)
 	}
 }
 
@@ -344,8 +344,8 @@ func TestPriorityQueue_Update(t *testing.T) {
 	}
 	// Updating a pod that is already in activeQ, should not change it.
 	q.Update(unschedulablePodInfo.Pod, unschedulablePodInfo.Pod)
-	if len(q.unschedulableQ.podInfoMap) != 0 {
-		t.Error("Expected unschedulableQ to be empty.")
+	if len(q.unschedulablePods.podInfoMap) != 0 {
+		t.Error("Expected unschedulablePods to be empty.")
 	}
 	if _, exists, _ := q.activeQ.Get(newQueuedPodInfoForLookup(unschedulablePodInfo.Pod)); !exists {
 		t.Errorf("Expected: %v to be added to activeQ.", unschedulablePodInfo.Pod.Name)
@@ -370,8 +370,8 @@ func TestPriorityQueue_Update(t *testing.T) {
 	// updating a pod which is in unschedulable queue, and it is still backing off,
 	// we will move it to backoff queue
 	q.AddUnschedulableIfNotPresent(q.newQueuedPodInfo(medPriorityPodInfo.Pod), q.SchedulingCycle())
-	if len(q.unschedulableQ.podInfoMap) != 1 {
-		t.Error("Expected unschedulableQ to be 1.")
+	if len(q.unschedulablePods.podInfoMap) != 1 {
+		t.Error("Expected unschedulablePods to be 1.")
 	}
 	updatedPod := medPriorityPodInfo.Pod.DeepCopy()
 	updatedPod.Annotations["foo"] = "test"
@@ -385,12 +385,12 @@ func TestPriorityQueue_Update(t *testing.T) {
 	// updating a pod which is in unschedulable queue, and it is not backing off,
 	// we will move it to active queue
 	q.AddUnschedulableIfNotPresent(q.newQueuedPodInfo(medPriorityPodInfo.Pod), q.SchedulingCycle())
-	if len(q.unschedulableQ.podInfoMap) != 1 {
-		t.Error("Expected unschedulableQ to be 1.")
+	if len(q.unschedulablePods.podInfoMap) != 1 {
+		t.Error("Expected unschedulablePods to be 1.")
 	}
 	updatedPod = medPriorityPodInfo.Pod.DeepCopy()
 	updatedPod.Annotations["foo"] = "test1"
-	// Move clock by podInitialBackoffDuration, so that pods in the unschedulableQ would pass the backing off,
+	// Move clock by podInitialBackoffDuration, so that pods in the unschedulablePods would pass the backing off,
 	// and the pods will be moved into activeQ.
 	c.Step(q.podInitialBackoffDuration)
 	q.Update(medPriorityPodInfo.Pod, updatedPod)
@@ -428,12 +428,12 @@ func TestPriorityQueue_Delete(t *testing.T) {
 
 func TestPriorityQueue_Activate(t *testing.T) {
 	tests := []struct {
-		name                     string
-		qPodInfoInUnschedulableQ []*framework.QueuedPodInfo
-		qPodInfoInPodBackoffQ    []*framework.QueuedPodInfo
-		qPodInfoInActiveQ        []*framework.QueuedPodInfo
-		qPodInfoToActivate       *framework.QueuedPodInfo
-		want                     []*framework.QueuedPodInfo
+		name                        string
+		qPodInfoInUnschedulablePods []*framework.QueuedPodInfo
+		qPodInfoInPodBackoffQ       []*framework.QueuedPodInfo
+		qPodInfoInActiveQ           []*framework.QueuedPodInfo
+		qPodInfoToActivate          *framework.QueuedPodInfo
+		want                        []*framework.QueuedPodInfo
 	}{
 		{
 			name:               "pod already in activeQ",
@@ -442,15 +442,15 @@ func TestPriorityQueue_Activate(t *testing.T) {
 			want:               []*framework.QueuedPodInfo{{PodInfo: highPriNominatedPodInfo}}, // 1 already actived
 		},
 		{
-			name:               "pod not in unschedulableQ/podBackoffQ",
+			name:               "pod not in unschedulablePods/podBackoffQ",
 			qPodInfoToActivate: &framework.QueuedPodInfo{PodInfo: highPriNominatedPodInfo},
 			want:               []*framework.QueuedPodInfo{},
 		},
 		{
-			name:                     "pod in unschedulableQ",
-			qPodInfoInUnschedulableQ: []*framework.QueuedPodInfo{{PodInfo: highPriNominatedPodInfo}},
-			qPodInfoToActivate:       &framework.QueuedPodInfo{PodInfo: highPriNominatedPodInfo},
-			want:                     []*framework.QueuedPodInfo{{PodInfo: highPriNominatedPodInfo}},
+			name:                        "pod in unschedulablePods",
+			qPodInfoInUnschedulablePods: []*framework.QueuedPodInfo{{PodInfo: highPriNominatedPodInfo}},
+			qPodInfoToActivate:          &framework.QueuedPodInfo{PodInfo: highPriNominatedPodInfo},
+			want:                        []*framework.QueuedPodInfo{{PodInfo: highPriNominatedPodInfo}},
 		},
 		{
 			name:                  "pod in backoffQ",
@@ -467,13 +467,13 @@ func TestPriorityQueue_Activate(t *testing.T) {
 			defer cancel()
 			q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), objs)
 
-			// Prepare activeQ/unschedulableQ/podBackoffQ according to the table
+			// Prepare activeQ/unschedulablePods/podBackoffQ according to the table
 			for _, qPodInfo := range tt.qPodInfoInActiveQ {
 				q.activeQ.Add(qPodInfo)
 			}
 
-			for _, qPodInfo := range tt.qPodInfoInUnschedulableQ {
-				q.unschedulableQ.addOrUpdate(qPodInfo)
+			for _, qPodInfo := range tt.qPodInfoInUnschedulablePods {
+				q.unschedulablePods.addOrUpdate(qPodInfo)
 			}
 
 			for _, qPodInfo := range tt.qPodInfoInPodBackoffQ {
@@ -550,8 +550,8 @@ func BenchmarkMoveAllToActiveOrBackoffQueue(b *testing.B) {
 	}
 
 	for _, tt := range tests {
-		for _, podsInUnschedulableQ := range []int{1000, 5000} {
-			b.Run(fmt.Sprintf("%v-%v", tt.name, podsInUnschedulableQ), func(b *testing.B) {
+		for _, podsInUnschedulablePods := range []int{1000, 5000} {
+			b.Run(fmt.Sprintf("%v-%v", tt.name, podsInUnschedulablePods), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 					c := testingclock.NewFakeClock(time.Now())
@@ -574,8 +574,8 @@ func BenchmarkMoveAllToActiveOrBackoffQueue(b *testing.B) {
 					defer cancel()
 					q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithClusterEventMap(m))
 
-					// Init pods in unschedulableQ.
-					for j := 0; j < podsInUnschedulableQ; j++ {
+					// Init pods in unschedulablePods.
+					for j := 0; j < podsInUnschedulablePods; j++ {
 						p := podTemplates[j%len(podTemplates)].DeepCopy()
 						p.Name, p.UID = fmt.Sprintf("%v-%v", p.Name, j), types.UID(fmt.Sprintf("%v-%v", p.UID, j))
 						var podInfo *framework.QueuedPodInfo
@@ -652,11 +652,11 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueue(t *testing.T) {
 	q.AddUnschedulableIfNotPresent(q.newQueuedPodInfo(highPriorityPodInfo.Pod, "fooPlugin"), q.SchedulingCycle())
 	q.AddUnschedulableIfNotPresent(q.newQueuedPodInfo(hpp1), q.SchedulingCycle())
 	for _, pod := range []*v1.Pod{unschedulablePodInfo.Pod, highPriorityPodInfo.Pod, hpp1, hpp2} {
-		if q.unschedulableQ.get(pod) == nil {
-			t.Errorf("Expected %v in the unschedulableQ", pod.Name)
+		if q.unschedulablePods.get(pod) == nil {
+			t.Errorf("Expected %v in the unschedulablePods", pod.Name)
 		}
 	}
-	// Move clock by podInitialBackoffDuration, so that pods in the unschedulableQ would pass the backing off,
+	// Move clock by podInitialBackoffDuration, so that pods in the unschedulablePods would pass the backing off,
 	// and the pods will be moved into activeQ.
 	c.Step(q.podInitialBackoffDuration)
 	q.MoveAllToActiveOrBackoffQueue(NodeAdd, nil)
@@ -670,7 +670,7 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueue(t *testing.T) {
 }
 
 // TestPriorityQueue_AssignedPodAdded tests AssignedPodAdded. It checks that
-// when a pod with pod affinity is in unschedulableQ and another pod with a
+// when a pod with pod affinity is in unschedulablePods and another pod with a
 // matching label is added, the unschedulable pod is moved to activeQ.
 func TestPriorityQueue_AssignedPodAdded(t *testing.T) {
 	affinityPod := unschedulablePodInfo.Pod.DeepCopy()
@@ -711,7 +711,7 @@ func TestPriorityQueue_AssignedPodAdded(t *testing.T) {
 	defer cancel()
 	q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithClusterEventMap(m))
 	q.Add(medPriorityPodInfo.Pod)
-	// Add a couple of pods to the unschedulableQ.
+	// Add a couple of pods to the unschedulablePods.
 	q.AddUnschedulableIfNotPresent(q.newQueuedPodInfo(unschedulablePodInfo.Pod, "fakePlugin"), q.SchedulingCycle())
 	q.AddUnschedulableIfNotPresent(q.newQueuedPodInfo(affinityPod, "fakePlugin"), q.SchedulingCycle())
 
@@ -721,14 +721,14 @@ func TestPriorityQueue_AssignedPodAdded(t *testing.T) {
 	// affinityPod. So, affinityPod should go to activeQ.
 	q.AssignedPodAdded(&labelPod)
 	if getUnschedulablePod(q, affinityPod) != nil {
-		t.Error("affinityPod is still in the unschedulableQ.")
+		t.Error("affinityPod is still in the unschedulablePods.")
 	}
 	if _, exists, _ := q.activeQ.Get(newQueuedPodInfoForLookup(affinityPod)); !exists {
 		t.Error("affinityPod is not moved to activeQ.")
 	}
-	// Check that the other pod is still in the unschedulableQ.
+	// Check that the other pod is still in the unschedulablePods.
 	if getUnschedulablePod(q, unschedulablePodInfo.Pod) == nil {
-		t.Error("unschedulablePodInfo is not in the unschedulableQ.")
+		t.Error("unschedulablePodInfo is not in the unschedulablePods.")
 	}
 }
 
@@ -1045,7 +1045,7 @@ func TestUnschedulablePodsMap(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			upm := newUnschedulablePodsMap(nil)
+			upm := newUnschedulablePods(nil)
 			for _, p := range test.podsToAdd {
 				upm.addOrUpdate(newQueuedPodInfoForLookup(p))
 			}
@@ -1319,9 +1319,9 @@ func TestHighPriorityBackoff(t *testing.T) {
 	}
 }
 
-// TestHighPriorityFlushUnschedulableQLeftover tests that pods will be moved to
-// activeQ after one minutes if it is in unschedulableQ
-func TestHighPriorityFlushUnschedulableQLeftover(t *testing.T) {
+// TestHighPriorityFlushUnschedulablePodsLeftover tests that pods will be moved to
+// activeQ after one minutes if it is in unschedulablePods.
+func TestHighPriorityFlushUnschedulablePodsLeftover(t *testing.T) {
 	c := testingclock.NewFakeClock(time.Now())
 	m := map[framework.ClusterEvent]sets.String{
 		NodeAdd: sets.NewString("fakePlugin"),
@@ -1374,8 +1374,8 @@ func TestHighPriorityFlushUnschedulableQLeftover(t *testing.T) {
 
 	q.AddUnschedulableIfNotPresent(q.newQueuedPodInfo(&highPod, "fakePlugin"), q.SchedulingCycle())
 	q.AddUnschedulableIfNotPresent(q.newQueuedPodInfo(&midPod, "fakePlugin"), q.SchedulingCycle())
-	c.Step(DefaultPodMaxUnschedulableQDuration + time.Second)
-	q.flushUnschedulableQLeftover()
+	c.Step(DefaultPodMaxInUnschedulablePodsDuration + time.Second)
+	q.flushUnschedulablePodsLeftover()
 
 	if p, err := q.Pop(); err != nil || p.Pod != &highPod {
 		t.Errorf("Expected: %v after Pop, but got: %v", highPriorityPodInfo.Pod.Name, p.Pod.Name)
@@ -1385,7 +1385,7 @@ func TestHighPriorityFlushUnschedulableQLeftover(t *testing.T) {
 	}
 }
 
-func TestPriorityQueue_initPodMaxUnschedulableQDuration(t *testing.T) {
+func TestPriorityQueue_initPodMaxInUnschedulablePodsDuration(t *testing.T) {
 	pod1 := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod-1",
@@ -1419,28 +1419,28 @@ func TestPriorityQueue_initPodMaxUnschedulableQDuration(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                         string
-		podMaxUnschedulableQDuration time.Duration
-		operations                   []operation
-		operands                     []*framework.QueuedPodInfo
-		expected                     []*framework.QueuedPodInfo
+		name                              string
+		podMaxInUnschedulablePodsDuration time.Duration
+		operations                        []operation
+		operands                          []*framework.QueuedPodInfo
+		expected                          []*framework.QueuedPodInfo
 	}{
 		{
-			name: "New priority queue by the default value of podMaxUnschedulableQDuration",
+			name: "New priority queue by the default value of podMaxInUnschedulablePodsDuration",
 			operations: []operation{
-				addPodUnschedulableQ,
-				addPodUnschedulableQ,
+				addPodUnschedulablePods,
+				addPodUnschedulablePods,
 				flushUnschedulerQ,
 			},
 			operands: []*framework.QueuedPodInfo{pInfo1, pInfo2, nil},
 			expected: []*framework.QueuedPodInfo{pInfo2, pInfo1},
 		},
 		{
-			name:                         "New priority queue by user-defined value of podMaxUnschedulableQDuration",
-			podMaxUnschedulableQDuration: 30 * time.Second,
+			name:                              "New priority queue by user-defined value of podMaxInUnschedulablePodsDuration",
+			podMaxInUnschedulablePodsDuration: 30 * time.Second,
 			operations: []operation{
-				addPodUnschedulableQ,
-				addPodUnschedulableQ,
+				addPodUnschedulablePods,
+				addPodUnschedulablePods,
 				flushUnschedulerQ,
 			},
 			operands: []*framework.QueuedPodInfo{pInfo1, pInfo2, nil},
@@ -1453,10 +1453,10 @@ func TestPriorityQueue_initPodMaxUnschedulableQDuration(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			var queue *PriorityQueue
-			if test.podMaxUnschedulableQDuration > 0 {
+			if test.podMaxInUnschedulablePodsDuration > 0 {
 				queue = NewTestQueue(ctx, newDefaultQueueSort(),
 					WithClock(testingclock.NewFakeClock(timestamp)),
-					WithPodMaxUnschedulableQDuration(test.podMaxUnschedulableQDuration))
+					WithPodMaxInUnschedulablePodsDuration(test.podMaxInUnschedulablePodsDuration))
 			} else {
 				queue = NewTestQueue(ctx, newDefaultQueueSort(),
 					WithClock(testingclock.NewFakeClock(timestamp)))
@@ -1494,7 +1494,7 @@ var (
 	add = func(queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		queue.Add(pInfo.Pod)
 	}
-	addUnschedulablePodBackToUnschedulableQ = func(queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
+	addUnschedulablePodBackToUnschedulablePods = func(queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		queue.AddUnschedulableIfNotPresent(pInfo, 0)
 	}
 	addUnschedulablePodBackToBackoffQ = func(queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
@@ -1506,7 +1506,7 @@ var (
 	updatePodActiveQ = func(queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		queue.activeQ.Update(pInfo)
 	}
-	addPodUnschedulableQ = func(queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
+	addPodUnschedulablePods = func(queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		// Update pod condition to unschedulable.
 		podutil.UpdatePodCondition(&pInfo.Pod.Status, &v1.PodCondition{
 			Type:    v1.PodScheduled,
@@ -1514,7 +1514,7 @@ var (
 			Reason:  v1.PodReasonUnschedulable,
 			Message: "fake scheduling failure",
 		})
-		queue.unschedulableQ.addOrUpdate(pInfo)
+		queue.unschedulablePods.addOrUpdate(pInfo)
 	}
 	addPodBackoffQ = func(queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		queue.podBackoffQ.Add(pInfo)
@@ -1530,8 +1530,8 @@ var (
 		queue.clock.(*testingclock.FakeClock).Step(2 * time.Second)
 	}
 	flushUnschedulerQ = func(queue *PriorityQueue, _ *framework.QueuedPodInfo) {
-		queue.clock.(*testingclock.FakeClock).Step(queue.podMaxUnschedulableQDuration)
-		queue.flushUnschedulableQLeftover()
+		queue.clock.(*testingclock.FakeClock).Step(queue.podMaxInUnschedulablePodsDuration)
+		queue.flushUnschedulablePodsLeftover()
 	}
 )
 
@@ -1594,10 +1594,10 @@ func TestPodTimestamp(t *testing.T) {
 			expected: []*framework.QueuedPodInfo{pInfo1, pInfo2},
 		},
 		{
-			name: "add two pod to unschedulableQ then move them to activeQ and sort them by the timestamp",
+			name: "add two pod to unschedulablePods then move them to activeQ and sort them by the timestamp",
 			operations: []operation{
-				addPodUnschedulableQ,
-				addPodUnschedulableQ,
+				addPodUnschedulablePods,
+				addPodUnschedulablePods,
 				moveClockForward,
 				moveAllToActiveOrBackoffQ,
 			},
@@ -1666,10 +1666,10 @@ func TestPendingPodsMetric(t *testing.T) {
 		wants       string
 	}{
 		{
-			name: "add pods to activeQ and unschedulableQ",
+			name: "add pods to activeQ and unschedulablePods",
 			operations: []operation{
 				addPodActiveQ,
-				addPodUnschedulableQ,
+				addPodUnschedulablePods,
 			},
 			operands: [][]*framework.QueuedPodInfo{
 				pInfos[:30],
@@ -1677,7 +1677,7 @@ func TestPendingPodsMetric(t *testing.T) {
 			},
 			metricsName: "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableQ.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 30
 scheduler_pending_pods{queue="backoff"} 0
@@ -1689,7 +1689,7 @@ scheduler_pending_pods{queue="unschedulable"} 20
 			operations: []operation{
 				addPodActiveQ,
 				addPodBackoffQ,
-				addPodUnschedulableQ,
+				addPodUnschedulablePods,
 			},
 			operands: [][]*framework.QueuedPodInfo{
 				pInfos[:15],
@@ -1698,7 +1698,7 @@ scheduler_pending_pods{queue="unschedulable"} 20
 			},
 			metricsName: "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableQ.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 15
 scheduler_pending_pods{queue="backoff"} 25
@@ -1706,9 +1706,9 @@ scheduler_pending_pods{queue="unschedulable"} 10
 `,
 		},
 		{
-			name: "add pods to unschedulableQ and then move all to activeQ",
+			name: "add pods to unschedulablePods and then move all to activeQ",
 			operations: []operation{
-				addPodUnschedulableQ,
+				addPodUnschedulablePods,
 				moveClockForward,
 				moveAllToActiveOrBackoffQ,
 			},
@@ -1719,7 +1719,7 @@ scheduler_pending_pods{queue="unschedulable"} 10
 			},
 			metricsName: "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableQ.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 50
 scheduler_pending_pods{queue="backoff"} 0
@@ -1727,11 +1727,11 @@ scheduler_pending_pods{queue="unschedulable"} 0
 `,
 		},
 		{
-			name: "make some pods subject to backoff, add pods to unschedulableQ, and then move all to activeQ",
+			name: "make some pods subject to backoff, add pods to unschedulablePods, and then move all to activeQ",
 			operations: []operation{
-				addPodUnschedulableQ,
+				addPodUnschedulablePods,
 				moveClockForward,
-				addPodUnschedulableQ,
+				addPodUnschedulablePods,
 				moveAllToActiveOrBackoffQ,
 			},
 			operands: [][]*framework.QueuedPodInfo{
@@ -1742,7 +1742,7 @@ scheduler_pending_pods{queue="unschedulable"} 0
 			},
 			metricsName: "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableQ.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 30
 scheduler_pending_pods{queue="backoff"} 20
@@ -1750,9 +1750,9 @@ scheduler_pending_pods{queue="unschedulable"} 0
 `,
 		},
 		{
-			name: "make some pods subject to backoff, add pods to unschedulableQ/activeQ, move all to activeQ, and finally flush backoffQ",
+			name: "make some pods subject to backoff, add pods to unschedulablePods/activeQ, move all to activeQ, and finally flush backoffQ",
 			operations: []operation{
-				addPodUnschedulableQ,
+				addPodUnschedulablePods,
 				addPodActiveQ,
 				moveAllToActiveOrBackoffQ,
 				flushBackoffQ,
@@ -1765,7 +1765,7 @@ scheduler_pending_pods{queue="unschedulable"} 0
 			},
 			metricsName: "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableQ.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 50
 scheduler_pending_pods{queue="backoff"} 0
@@ -1825,7 +1825,7 @@ func TestPerPodSchedulingMetrics(t *testing.T) {
 	checkPerPodSchedulingMetrics("Attempt once", t, pInfo, 1, timestamp)
 
 	// Case 2: A pod is created and scheduled after 2 attempts. The queue operations are
-	// Add -> Pop -> AddUnschedulableIfNotPresent -> flushUnschedulableQLeftover -> Pop.
+	// Add -> Pop -> AddUnschedulableIfNotPresent -> flushUnschedulablePodsLeftover -> Pop.
 	c = testingclock.NewFakeClock(timestamp)
 	queue = NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c))
 	queue.Add(pod)
@@ -1834,10 +1834,10 @@ func TestPerPodSchedulingMetrics(t *testing.T) {
 		t.Fatalf("Failed to pop a pod %v", err)
 	}
 	queue.AddUnschedulableIfNotPresent(pInfo, 1)
-	// Override clock to exceed the DefaultPodMaxUnschedulableQDuration so that unschedulable pods
+	// Override clock to exceed the DefaultPodMaxInUnschedulablePodsDuration so that unschedulable pods
 	// will be moved to activeQ
-	c.SetTime(timestamp.Add(DefaultPodMaxUnschedulableQDuration + 1))
-	queue.flushUnschedulableQLeftover()
+	c.SetTime(timestamp.Add(DefaultPodMaxInUnschedulablePodsDuration + 1))
+	queue.flushUnschedulablePodsLeftover()
 	pInfo, err = queue.Pop()
 	if err != nil {
 		t.Fatalf("Failed to pop a pod %v", err)
@@ -1845,7 +1845,7 @@ func TestPerPodSchedulingMetrics(t *testing.T) {
 	checkPerPodSchedulingMetrics("Attempt twice", t, pInfo, 2, timestamp)
 
 	// Case 3: Similar to case 2, but before the second pop, call update, the queue operations are
-	// Add -> Pop -> AddUnschedulableIfNotPresent -> flushUnschedulableQLeftover -> Update -> Pop.
+	// Add -> Pop -> AddUnschedulableIfNotPresent -> flushUnschedulablePodsLeftover -> Update -> Pop.
 	c = testingclock.NewFakeClock(timestamp)
 	queue = NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c))
 	queue.Add(pod)
@@ -1854,10 +1854,10 @@ func TestPerPodSchedulingMetrics(t *testing.T) {
 		t.Fatalf("Failed to pop a pod %v", err)
 	}
 	queue.AddUnschedulableIfNotPresent(pInfo, 1)
-	// Override clock to exceed the DefaultPodMaxUnschedulableQDuration so that unschedulable pods
+	// Override clock to exceed the DefaultPodMaxInUnschedulablePodsDuration so that unschedulable pods
 	// will be moved to activeQ
-	c.SetTime(timestamp.Add(DefaultPodMaxUnschedulableQDuration + 1))
-	queue.flushUnschedulableQLeftover()
+	c.SetTime(timestamp.Add(DefaultPodMaxInUnschedulablePodsDuration + 1))
+	queue.flushUnschedulablePodsLeftover()
 	newPod := pod.DeepCopy()
 	newPod.Generation = 1
 	queue.Update(pod, newPod)
@@ -1900,18 +1900,18 @@ func TestIncomingPodsMetrics(t *testing.T) {
 `,
 		},
 		{
-			name: "add pods to unschedulableQ",
+			name: "add pods to unschedulablePods",
 			operations: []operation{
-				addUnschedulablePodBackToUnschedulableQ,
+				addUnschedulablePodBackToUnschedulablePods,
 			},
 			want: `
              scheduler_queue_incoming_pods_total{event="ScheduleAttemptFailure",queue="unschedulable"} 3
 `,
 		},
 		{
-			name: "add pods to unschedulableQ and then move all to backoffQ",
+			name: "add pods to unschedulablePods and then move all to backoffQ",
 			operations: []operation{
-				addUnschedulablePodBackToUnschedulableQ,
+				addUnschedulablePodBackToUnschedulablePods,
 				moveAllToActiveOrBackoffQ,
 			},
 			want: ` scheduler_queue_incoming_pods_total{event="ScheduleAttemptFailure",queue="unschedulable"} 3
@@ -1919,9 +1919,9 @@ func TestIncomingPodsMetrics(t *testing.T) {
 `,
 		},
 		{
-			name: "add pods to unschedulableQ and then move all to activeQ",
+			name: "add pods to unschedulablePods and then move all to activeQ",
 			operations: []operation{
-				addUnschedulablePodBackToUnschedulableQ,
+				addUnschedulablePodBackToUnschedulablePods,
 				moveClockForward,
 				moveAllToActiveOrBackoffQ,
 			},

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -93,7 +93,7 @@ var (
 		&metrics.GaugeOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "pending_pods",
-			Help:           "Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableQ.",
+			Help:           "Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods.",
 			StabilityLevel: metrics.STABLE,
 		}, []string{"queue"})
 	SchedulerGoroutines = metrics.NewGaugeVec(

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -124,12 +124,12 @@ type Scheduler struct {
 }
 
 type schedulerOptions struct {
-	componentConfigVersion       string
-	kubeConfig                   *restclient.Config
-	percentageOfNodesToScore     int32
-	podInitialBackoffSeconds     int64
-	podMaxBackoffSeconds         int64
-	podMaxUnschedulableQDuration time.Duration
+	componentConfigVersion            string
+	kubeConfig                        *restclient.Config
+	percentageOfNodesToScore          int32
+	podInitialBackoffSeconds          int64
+	podMaxBackoffSeconds              int64
+	podMaxInUnschedulablePodsDuration time.Duration
 	// Contains out-of-tree plugins to be merged with the in-tree registry.
 	frameworkOutOfTreeRegistry frameworkruntime.Registry
 	profiles                   []schedulerapi.KubeSchedulerProfile
@@ -215,10 +215,10 @@ func WithPodMaxBackoffSeconds(podMaxBackoffSeconds int64) Option {
 	}
 }
 
-// WithPodMaxUnschedulableQDuration sets PodMaxUnschedulableQDuration for PriorityQueue.
-func WithPodMaxUnschedulableQDuration(duration time.Duration) Option {
+// WithPodMaxInUnschedulablePodsDuration sets podMaxInUnschedulablePodsDuration for PriorityQueue.
+func WithPodMaxInUnschedulablePodsDuration(duration time.Duration) Option {
 	return func(o *schedulerOptions) {
-		o.podMaxUnschedulableQDuration = duration
+		o.podMaxInUnschedulablePodsDuration = duration
 	}
 }
 
@@ -240,11 +240,11 @@ func WithBuildFrameworkCapturer(fc FrameworkCapturer) Option {
 }
 
 var defaultSchedulerOptions = schedulerOptions{
-	percentageOfNodesToScore:     schedulerapi.DefaultPercentageOfNodesToScore,
-	podInitialBackoffSeconds:     int64(internalqueue.DefaultPodInitialBackoffDuration.Seconds()),
-	podMaxBackoffSeconds:         int64(internalqueue.DefaultPodMaxBackoffDuration.Seconds()),
-	podMaxUnschedulableQDuration: internalqueue.DefaultPodMaxUnschedulableQDuration,
-	parallelism:                  int32(parallelize.DefaultParallelism),
+	percentageOfNodesToScore:          schedulerapi.DefaultPercentageOfNodesToScore,
+	podInitialBackoffSeconds:          int64(internalqueue.DefaultPodInitialBackoffDuration.Seconds()),
+	podMaxBackoffSeconds:              int64(internalqueue.DefaultPodMaxBackoffDuration.Seconds()),
+	podMaxInUnschedulablePodsDuration: internalqueue.DefaultPodMaxInUnschedulablePodsDuration,
+	parallelism:                       int32(parallelize.DefaultParallelism),
 	// Ideally we would statically set the default profile here, but we can't because
 	// creating the default profile may require testing feature gates, which may get
 	// set dynamically in tests. Therefore, we delay creating it until New is actually
@@ -355,7 +355,7 @@ func New(client clientset.Interface,
 		internalqueue.WithPodMaxBackoffDuration(time.Duration(options.podMaxBackoffSeconds)*time.Second),
 		internalqueue.WithPodNominator(nominator),
 		internalqueue.WithClusterEventMap(clusterEventMap),
-		internalqueue.WithPodMaxUnschedulableQDuration(options.podMaxUnschedulableQDuration),
+		internalqueue.WithPodMaxInUnschedulablePodsDuration(options.podMaxInUnschedulablePodsDuration),
 	)
 
 	schedulerCache := internalcache.New(durationToExpireAssumedPod, stopEverything)

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -32,7 +32,7 @@
   subsystem: scheduler
   help: Number of pending pods, by the queue type. 'active' means number of pods in
     activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number
-    of pods in unschedulableQ.
+    of pods in unschedulablePods.
   type: Gauge
   stabilityLevel: STABLE
   labels:

--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -107,12 +107,12 @@ func TestCoreResourceEnqueue(t *testing.T) {
 		testCtx.Scheduler.Error(podInfo, fitError)
 
 		// Scheduling cycle is incremented by one after NextPod() is called, so
-		// pass a number larger than i to move Pod to unschedulableQ.
+		// pass a number larger than i to move Pod to unschedulablePods.
 		testCtx.Scheduler.SchedulingQueue.AddUnschedulableIfNotPresent(podInfo, int64(i+10))
 	}
 
 	// Trigger a NodeTaintChange event.
-	// We expect this event to trigger moving the test Pod from unschedulableQ to activeQ.
+	// We expect this event to trigger moving the test Pod from unschedulablePods to activeQ.
 	node.Spec.Taints = nil
 	if _, err := cs.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("Failed to remove taints off the node: %v", err)
@@ -285,11 +285,11 @@ func TestCustomResourceEnqueue(t *testing.T) {
 	testCtx.Scheduler.Error(podInfo, fitError)
 
 	// Scheduling cycle is incremented from 0 to 1 after NextPod() is called, so
-	// pass a number larger than 1 to move Pod to unschedulableQ.
+	// pass a number larger than 1 to move Pod to unschedulablePods.
 	testCtx.Scheduler.SchedulingQueue.AddUnschedulableIfNotPresent(podInfo, 10)
 
 	// Trigger a Custom Resource event.
-	// We expect this event to trigger moving the test Pod from unschedulableQ to activeQ.
+	// We expect this event to trigger moving the test Pod from unschedulablePods to activeQ.
 	crdGVR := schema.GroupVersionResource{Group: fooCRD.Spec.Group, Version: fooCRD.Spec.Versions[0].Name, Resource: "foos"}
 	crClient := dynamicClient.Resource(crdGVR).Namespace(ns)
 	if _, err := crClient.Create(ctx, &unstructured.Unstructured{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Actually unschedulableQ in SchedulingQueue isn't a queue. It's just a struct to store unschedulable pods.  It is easily misunderstood.
Discussion https://github.com/kubernetes-sigs/kueue/pull/135#discussion_r832019966

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Rename unschedulableQ to unschedulablePods
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
