### PR TITLE
WIP - fix x509sha1 go1.18 errors

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -51,10 +51,5 @@ make generated_files
 go install ./cmd/...
 ./hack/install-etcd.sh
 
-# TODO(MadhavJivrajani): Temporary fix due to Go 1.18 changes.
-# Please see https://tip.golang.org/doc/go1.18#sha1
-GODEBUG=x509sha1=1
-export GODEBUG
-
 make test-cmd
 make test-integration


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Figure out which tests are failing the go 1.18 sha1 signature

```release-note
NONE
```