### PR TITLE
pkg/storage/etcd3: refactor "too large" resourceVersions

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"reflect"
 	"strconv"
@@ -256,7 +257,7 @@ func TestGet(t *testing.T) {
 		name:             "too high resource version",
 		key:              key,
 		expectRVTooLarge: true,
-		rv:               fmt.Sprintf("%d", lastUpdatedCurrentRV+1),
+		rv:               strconv.FormatInt(math.MaxInt64, 10),
 	}, { // test get on non-existing item with ignoreNotFound=false
 		name:              "get non-existing",
 		key:               "/non-existing",
@@ -611,7 +612,7 @@ func TestGetListNonRecursive(t *testing.T) {
 		key:              key,
 		pred:             storage.Everything,
 		expectedOut:      []*example.Pod{storedObj},
-		rv:               fmt.Sprintf("%d", currentRV+1),
+		rv:               strconv.FormatInt(math.MaxInt64, 10),
 		expectRVTooLarge: true,
 	}, {
 		name:        "non-existing key",
@@ -1235,7 +1236,7 @@ func TestList(t *testing.T) {
 		{
 			name:             "rejects resource version set too high",
 			prefix:           "/",
-			rv:               fmt.Sprintf("%d", continueRV+1),
+			rv:               strconv.FormatInt(math.MaxInt64, 10),
 			expectRVTooLarge: true,
 		},
 		{


### PR DESCRIPTION
When tests attempt to validate behavior in the case that a client asks
for a resource version that is "too large" for the underlying storage,
the previous implementation would simply add 1 to the latest revision
seen. This is only appropriate for storage backends that
  a) provide a continuous monotonic logical clock
  b) have no other events occurring while the test runs

For instance, when using a singe etcd backend as a shared fixture for
these tests, adding 1 to a previously-seen revision is not suffcient to
ensure that the resulting revision is "too large". By instead using the
largest possible integer value, we can be certain of this.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind cleanup

```release-note
NONE
```

```docs

```

/sig api-machinery
/assign @liggitt @smarterclayton @sttts @deads2k 