### PR TITLE
pkg/storage/etcd3: use correct diff in tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"k8s.io/apimachinery/pkg/api/apitesting"
@@ -390,9 +389,7 @@ func testCheckResult(t *testing.T, expectEventType watch.EventType, w watch.Inte
 			t.Errorf("event type want=%v, get=%v", expectEventType, res.Type)
 			return
 		}
-		if diff := cmp.Diff(expectObj, res.Object); diff != "" {
-			t.Errorf("incorrect obj: %s", diff)
-		}
+		expectNoDiff(t, "incorrect obj", expectObj, res.Object)
 	case <-time.After(wait.ForeverTestTimeout):
 		t.Errorf("time out after waiting %v on ResultChan", wait.ForeverTestTimeout)
 	}


### PR DESCRIPTION
Follows up on #108211 to implement fixes suggested in #108187

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind cleanup

```release-note
NONE
```

```docs

```

/sig api-machinery
/assign @liggitt @smarterclayton @sttts @deads2k 