### PR TITLE
kubelet: Add GracefulNodeShutdownPodPolicy  config option to graceful node shutdown

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -53440,6 +53440,13 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 							},
 						},
 					},
+					"gracefulNodeShutdownPodPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GracefulNodeShutdownPodPolicy defines the policy for how pods are handled during graceful shutdown. GracefulNodeShutdownPodPolicy will only take affect if kubelet graceful node shutdown is enabled (i.e. `ShutdownGracePeriod` is set or `ShutdownGracePeriodByPodPriority` is set.) The policy types available are `SetTerminal` or `LeaveRunning`. `SetTerminal` will result in pods being set to terminal phase during shutdown. `SetTerminal` is the default policy if graceful node shutdown is enabled. If a node becomes ready again after graceful node shutdown (e.g. a reboot), it will result in pods not being started on the same node since the pods will be placed into the `Failed` terminal phase on the API server. `LeaveRunning` policy, in contrast, will result in pods not being placed in terminal phase, and as result they will resume to run if the node becomes ready again (for example after a reboot). This was the default behavior in kubernetes prior to when graceful node shutdown was introduced. Default: SetTerminal",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"reservedMemory": {
 						SchemaProps: spec.SchemaProps{
 							Description: "reservedMemory specifies a comma-separated list of memory reservations for NUMA nodes. The parameter makes sense only in the context of the memory manager feature. The memory manager will not allocate reserved memory for container workloads. For example, if you have a NUMA0 with 10Gi of memory and the reservedMemory was specified to reserve 1Gi of memory at NUMA0, the memory manager will assume that only 9Gi is available for allocation. You can specify a different amount of NUMA node and memory types. You can omit this parameter at all, but you should be aware that the amount of reserved memory from all NUMA nodes should be equal to the amount of memory specified by the [node allocatable](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable). If at least one node allocatable parameter has a non-zero value, you will need to specify at least one NUMA node. Also, avoid specifying:\n\n1. Duplicates, the same NUMA node, and memory type, but with a different value. 2. zero limits for any memory type. 3. NUMAs nodes IDs that do not exist under the machine. 4. memory types except for memory and hugepages-<size>\n\nDefault: nil",

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -280,5 +280,6 @@ var (
 		"ShutdownGracePeriod.Duration",
 		"ShutdownGracePeriodCriticalPods.Duration",
 		"MemoryThrottlingFactor",
+		"GracefulNodeShutdownPodPolicy",
 	)
 )

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
@@ -40,6 +40,7 @@ evictionHard:
 evictionPressureTransitionPeriod: 5m0s
 failSwapOn: true
 fileCheckFrequency: 20s
+gracefulNodeShutdownPodPolicy: SetTerminal
 hairpinMode: promiscuous-bridge
 healthzBindAddress: 127.0.0.1
 healthzPort: 10248

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -75,6 +75,22 @@ const (
 	PodTopologyManagerScope = "pod"
 )
 
+type GracefulNodeShutdownPodPolicyType string
+
+const (
+	// GracefulNodeShutdownPodPolicySetTerminal is Graceful Node Shutdown policy type,
+	// which will ensure that during graceful node shutdown, pods will be terminated by kubelet and
+	// placed into terminal Failed phase on API server,
+	// and as a result, will not start again if nodes becomes ready again.
+	GracefulNodeShutdownPodPolicySetTerminal = "SetTerminal"
+
+	// GracefulNodeShutdownPodPolicyLeaveRunning is Graceful Node Shutdown policy type,
+	// which will ensure that during graceful node shutdown,
+	// pods will be terminated by kubelet, but left running on API server,
+	// and a result, will start again if the node becomes ready again.
+	GracefulNodeShutdownPodPolicyLeaveRunning = "LeaveRunning"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // KubeletConfiguration contains the configuration for the Kubelet
@@ -407,6 +423,19 @@ type KubeletConfiguration struct {
 	// class value that lies in the range of that value and the next higher entry in the
 	// list when the node is shutting down.
 	ShutdownGracePeriodByPodPriority []ShutdownGracePeriodByPodPriority
+	// GracefulNodeShutdownPodPolicy defines the policy for how pods are handled during graceful shutdown.
+	// GracefulNodeShutdownPodPolicy will only take affect if kubelet graceful node shutdown is enabled (i.e. `ShutdownGracePeriod` is set or `ShutdownGracePeriodByPodPriority` is set.)
+	// The policy types available are `SetTerminal` or `LeaveRunning`.
+	// `SetTerminal` will result in pods being set to terminal phase during shutdown. `SetTerminal` is the default policy if graceful node shutdown is enabled.
+	// If a node becomes ready again after graceful node shutdown (e.g. a reboot), it will result in pods not being started on the same node
+	// since the pods will be placed into the `Failed` terminal phase on the API server.
+	// `LeaveRunning` policy, in contrast, will result in pods not being placed in terminal phase,
+	// and as result they will resume to run if the node becomes ready again (for example after a reboot).
+	// This was the default behavior in kubernetes prior to when graceful node shutdown was introduced.
+	// Default: SetTerminal
+	// +featureGate=GracefulNodeShutdown
+	// +optional
+	GracefulNodeShutdownPodPolicy GracefulNodeShutdownPodPolicyType
 	// ReservedMemory specifies a comma-separated list of memory reservations for NUMA nodes.
 	// The parameter makes sense only in the context of the memory manager feature. The memory manager will not allocate reserved memory for container workloads.
 	// For example, if you have a NUMA0 with 10Gi of memory and the ReservedMemory was specified to reserve 1Gi of memory at NUMA0,

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -264,4 +264,9 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 	if obj.RegisterNode == nil {
 		obj.RegisterNode = utilpointer.BoolPtr(true)
 	}
+	if obj.ShutdownGracePeriod != zeroDuration || len(obj.ShutdownGracePeriodByPodPriority) != 0 {
+		if obj.GracefulNodeShutdownPodPolicy == "" {
+			obj.GracefulNodeShutdownPodPolicy = kubeletconfigv1beta1.GracefulNodeShutdownPodPolicySetTerminal
+		}
+	}
 }

--- a/pkg/kubelet/apis/config/v1beta1/defaults_test.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults_test.go
@@ -239,6 +239,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				EnableSystemLogHandler:          utilpointer.Bool(false),
 				ShutdownGracePeriod:             zeroDuration,
 				ShutdownGracePeriodCriticalPods: zeroDuration,
+				GracefulNodeShutdownPodPolicy:   v1beta1.GracefulNodeShutdownPodPolicyLeaveRunning,
 				ReservedMemory:                  []v1beta1.MemoryReservation{},
 				EnableProfilingHandler:          utilpointer.Bool(false),
 				EnableDebugFlagsHandler:         utilpointer.Bool(false),
@@ -333,13 +334,14 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 					Format:         "text",
 					FlushFrequency: 5 * time.Second,
 				},
-				EnableSystemLogHandler:  utilpointer.Bool(false),
-				ReservedMemory:          []v1beta1.MemoryReservation{},
-				EnableProfilingHandler:  utilpointer.Bool(false),
-				EnableDebugFlagsHandler: utilpointer.Bool(false),
-				SeccompDefault:          utilpointer.Bool(false),
-				MemoryThrottlingFactor:  utilpointer.Float64(0),
-				RegisterNode:            utilpointer.BoolPtr(false),
+				EnableSystemLogHandler:        utilpointer.Bool(false),
+				ReservedMemory:                []v1beta1.MemoryReservation{},
+				EnableProfilingHandler:        utilpointer.Bool(false),
+				EnableDebugFlagsHandler:       utilpointer.Bool(false),
+				SeccompDefault:                utilpointer.Bool(false),
+				MemoryThrottlingFactor:        utilpointer.Float64(0),
+				RegisterNode:                  utilpointer.BoolPtr(false),
+				GracefulNodeShutdownPodPolicy: v1beta1.GracefulNodeShutdownPodPolicyLeaveRunning,
 			},
 		},
 		{
@@ -475,6 +477,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				EnableSystemLogHandler:          utilpointer.Bool(true),
 				ShutdownGracePeriod:             metav1.Duration{Duration: 60 * time.Second},
 				ShutdownGracePeriodCriticalPods: metav1.Duration{Duration: 60 * time.Second},
+				GracefulNodeShutdownPodPolicy:   v1beta1.GracefulNodeShutdownPodPolicySetTerminal,
 				ReservedMemory: []v1beta1.MemoryReservation{
 					{
 						NumaNode: 1,
@@ -618,6 +621,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				EnableSystemLogHandler:          utilpointer.Bool(true),
 				ShutdownGracePeriod:             metav1.Duration{Duration: 60 * time.Second},
 				ShutdownGracePeriodCriticalPods: metav1.Duration{Duration: 60 * time.Second},
+				GracefulNodeShutdownPodPolicy:   v1beta1.GracefulNodeShutdownPodPolicySetTerminal,
 				ReservedMemory: []v1beta1.MemoryReservation{
 					{
 						NumaNode: 1,

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -494,6 +494,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	out.ShutdownGracePeriod = in.ShutdownGracePeriod
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.ShutdownGracePeriodByPodPriority = *(*[]config.ShutdownGracePeriodByPodPriority)(unsafe.Pointer(&in.ShutdownGracePeriodByPodPriority))
+	out.GracefulNodeShutdownPodPolicy = config.GracefulNodeShutdownPodPolicyType(in.GracefulNodeShutdownPodPolicy)
 	out.ReservedMemory = *(*[]config.MemoryReservation)(unsafe.Pointer(&in.ReservedMemory))
 	if err := v1.Convert_Pointer_bool_To_bool(&in.EnableProfilingHandler, &out.EnableProfilingHandler, s); err != nil {
 		return err
@@ -670,6 +671,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	out.ShutdownGracePeriod = in.ShutdownGracePeriod
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.ShutdownGracePeriodByPodPriority = *(*[]v1beta1.ShutdownGracePeriodByPodPriority)(unsafe.Pointer(&in.ShutdownGracePeriodByPodPriority))
+	out.GracefulNodeShutdownPodPolicy = v1beta1.GracefulNodeShutdownPodPolicyType(in.GracefulNodeShutdownPodPolicy)
 	out.ReservedMemory = *(*[]v1beta1.MemoryReservation)(unsafe.Pointer(&in.ReservedMemory))
 	if err := v1.Convert_bool_To_Pointer_bool(&in.EnableProfilingHandler, &out.EnableProfilingHandler, s); err != nil {
 		return err

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -165,6 +165,13 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration) error 
 		if kc.ShutdownGracePeriodCriticalPods.Duration < 0 || (kc.ShutdownGracePeriodCriticalPods.Duration > 0 && kc.ShutdownGracePeriodCriticalPods.Duration < time.Second) {
 			allErrors = append(allErrors, fmt.Errorf("invalid configuration: shutdownGracePeriodCriticalPods %v must be either zero or otherwise >= 1 sec", kc.ShutdownGracePeriodCriticalPods))
 		}
+		switch kc.GracefulNodeShutdownPodPolicy {
+		case kubeletconfig.GracefulNodeShutdownPodPolicySetTerminal:
+		case kubeletconfig.GracefulNodeShutdownPodPolicyLeaveRunning:
+		default:
+			allErrors = append(allErrors, fmt.Errorf("invalid configuration: GracefulNodeShutdownPodPolicy %q must be one of: %q, or %q", kc.GracefulNodeShutdownPodPolicy, kubeletconfig.GracefulNodeShutdownPodPolicySetTerminal, kubeletconfig.GracefulNodeShutdownPodPolicyLeaveRunning))
+		}
+
 	}
 	if (kc.ShutdownGracePeriod.Duration > 0 || kc.ShutdownGracePeriodCriticalPods.Duration > 0) && !localFeatureGate.Enabled(features.GracefulNodeShutdown) {
 		allErrors = append(allErrors, fmt.Errorf("invalid configuration: specifying shutdownGracePeriod or shutdownGracePeriodCriticalPods requires feature gate GracefulNodeShutdown"))

--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -62,6 +62,7 @@ var (
 		TopologyManagerPolicy:           kubeletconfig.SingleNumaNodeTopologyManagerPolicy,
 		ShutdownGracePeriod:             metav1.Duration{Duration: 30 * time.Second},
 		ShutdownGracePeriodCriticalPods: metav1.Duration{Duration: 10 * time.Second},
+		GracefulNodeShutdownPodPolicy:   kubeletconfig.GracefulNodeShutdownPodPolicySetTerminal,
 		MemoryThrottlingFactor:          utilpointer.Float64Ptr(0.8),
 		FeatureGates: map[string]bool{
 			"CustomCPUCFSQuotaPeriod": true,
@@ -380,6 +381,17 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 				return conf
 			},
 			errMsg: "invalid configuration: specifying shutdownGracePeriod or shutdownGracePeriodCriticalPods requires feature gate GracefulNodeShutdown",
+		},
+		{
+			name: "GracefulNodeShutdownPodPolicy is invalid value",
+			configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+				conf.FeatureGates = map[string]bool{"GracefulNodeShutdown": true}
+				conf.ShutdownGracePeriod = metav1.Duration{Duration: 10 * time.Second}
+				conf.ShutdownGracePeriodCriticalPods = metav1.Duration{Duration: 5 * time.Second}
+				conf.GracefulNodeShutdownPodPolicy = "invalid-behavior"
+				return conf
+			},
+			errMsg: "invalid configuration: GracefulNodeShutdownPodPolicy \"invalid-behavior\" must be one of: \"SetTerminal\", or \"LeaveRunning\"",
 		},
 		{
 			name: "invalid MemorySwap.SwapBehavior",

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -830,6 +830,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		ShutdownGracePeriodCriticalPods:  kubeCfg.ShutdownGracePeriodCriticalPods.Duration,
 		ShutdownGracePeriodByPodPriority: kubeCfg.ShutdownGracePeriodByPodPriority,
 		StateDirectory:                   rootDirectory,
+		GracefulNodeShutdownPodPolicy:    kubeCfg.GracefulNodeShutdownPodPolicy,
 	})
 	klet.shutdownManager = shutdownManager
 	klet.admitHandlers.AddPodAdmitHandler(shutdownAdmitHandler)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/flowcontrol"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	cadvisortest "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/config"
@@ -329,6 +330,7 @@ func newTestKubeletWithImageList(
 		SyncNodeStatusFunc:              func() {},
 		ShutdownGracePeriodRequested:    0,
 		ShutdownGracePeriodCriticalPods: 0,
+		GracefulNodeShutdownPodPolicy:   kubeletconfig.GracefulNodeShutdownPodPolicySetTerminal,
 	})
 	kubelet.shutdownManager = shutdownManager
 	kubelet.admitHandlers.AddPodAdmitHandler(shutdownAdmitHandler)

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
@@ -47,6 +47,7 @@ type Config struct {
 	ShutdownGracePeriodCriticalPods  time.Duration
 	ShutdownGracePeriodByPodPriority []kubeletconfig.ShutdownGracePeriodByPodPriority
 	StateDirectory                   string
+	GracefulNodeShutdownPodPolicy    kubeletconfig.GracefulNodeShutdownPodPolicyType
 	Clock                            clock.Clock
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Graceful node shutdown currently places pods into terminal phase upon shutdown. As discussed in https://github.com/kubernetes/kubernetes/issues/104531#issuecomment-982763592 and https://github.com/kubernetes/kubernetes/issues/104531#issuecomment-982766908 some users/distributions would benefit from the ability to toggle this behavior and instead to not put pods into terminal phase on shutdown. 

For example, if it's expected that after shutdown the node will reboot, it may be desirable to not place the pods into terminal phase, so that way after reboot the pods will start running again after the node comes back up.

This PR adds a new kubelet configuration option to toggle this behavior `GracefulNodeShutdownPodPolicy`. The default setting of `GracefulNodeShutdownPodPolicy` is enabled `SetTerminal` (which matches current behavior since 1.20) when graceful node shutdown was introduced. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108991

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a new kubelet configuration option `GracefulNodeShutdownPodPolicy` to toggle setting pods to terminal phase during graceful node shutdown.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
