### PR TITLE
[ALTERNATIVE] Expose the version of Kustomize that Kubectl embeds

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -328,12 +328,16 @@ kube::test::if_has_string() {
   local match=$2
 
   if grep -q "${match}" <<< "${message}"; then
+    echo -n "${green}"
     echo "Successful"
+    echo -n "${reset}"
     echo "message:${message}"
     echo "has:${match}"
     return 0
   else
+    echo -n "${bold}${red}"
     echo "FAIL!"
+    echo -n "${reset}"
     echo "message:${message}"
     echo "has not:${match}"
     caller
@@ -346,13 +350,17 @@ kube::test::if_has_not_string() {
   local match=$2
 
   if grep -q "${match}" <<< "${message}"; then
+    echo -n "${bold}${red}"
     echo "FAIL!"
+    echo -n "${reset}"
     echo "message:${message}"
     echo "has:${match}"
     caller
     return 1
   else
+    echo -n "${green}"
     echo "Successful"
+    echo -n "${reset}"
     echo "message:${message}"
     echo "has not:${match}"
     return 0
@@ -362,11 +370,16 @@ kube::test::if_has_not_string() {
 kube::test::if_empty_string() {
   local match=$1
   if [ -n "${match}" ]; then
+    echo -n "${bold}${red}"
+    echo "FAIL!"
     echo "${match} is not empty"
+    echo -n "${reset}"
     caller
     return 1
   else
+    echo -n "${green}"
     echo "Successful"
+    echo -n "${reset}"
     return 0
   fi
 }

--- a/hack/update-kustomize.sh
+++ b/hack/update-kustomize.sh
@@ -59,6 +59,14 @@ echo -e "\n${color_blue}Committing changes${color_norm}"
 git add .
 git commit -a -m "Update kubectl kustomize to kyaml/$LATEST_KYAML, cmd/config/$LATEST_CONFIG, api/$LATEST_API, kustomize/$LATEST_KUSTOMIZE"
 
+echo -e "\n${color_blue:?}Verifying kubectl kustomize version${color_norm:?}"
+make WHAT=cmd/kubectl
+
+if [[ $(_output/bin/kubectl version --client -o json | jq -r '.clientVersion.kustomizeVersion') != "$LATEST_KUSTOMIZE" ]]; then
+  echo -e "${color_red:?}Unexpected kubectl kustomize version${color_norm:?}"
+  exit 1
+fi
+
 echo -e "\n${color_green:?}Update successful${color_norm:?}"
 echo "Note: If any of the integration points changed, you may need to update them manually."
 echo "See https://github.com/kubernetes-sigs/kustomize/tree/master/releasing#update-kustomize-in-kubectl for more information"

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -42,6 +42,7 @@ require (
 	k8s.io/metrics v0.0.0
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2
+	sigs.k8s.io/kustomize/api v0.10.1
 	sigs.k8s.io/kustomize/kustomize/v4 v4.4.1
 	sigs.k8s.io/kustomize/kyaml v0.13.0
 	sigs.k8s.io/yaml v1.2.0

--- a/test/cmd/version.sh
+++ b/test/cmd/version.sh
@@ -66,6 +66,21 @@ run_kubectl_version_tests() {
   kube::test::version::yaml_object_to_file "" "${TEMP}/client_server_yaml_version_test"
   kube::test::version::diff_assert "${TEMP}/client_server_json_version_test" "eq" "${TEMP}/client_server_yaml_version_test" "--output json/yaml has identical information"
 
+  kube::log::status "Testing kubectl version: contains semantic version of embedded kustomize"
+  output_message=$(kubectl version)
+  kube::test::if_has_not_string "${output_message}" "KustomizeVersion:\"unknown\"" "kustomize version should not be unknown"
+  kube::test::if_has_string "${output_message}" "KustomizeVersion\:\"v[[:digit:]][[:digit:]]*\.[[:digit:]][[:digit:]]*\.[[:digit:]][[:digit:]]*\"" "kubectl kustomize version should have a reasonable value"
+
+  kube::log::status "Testing kubectl version: other output formats include kustomize version as appropriate"
+  output_message=$(kubectl version --client)
+  kube::test::if_has_string "${output_message}" "KustomizeVersion" "kustomize version should be printed when --client is specified"
+  output_message=$(kubectl version --short)
+  kube::test::if_has_not_string "${output_message}" "KustomizeVersion" "kustomize version should NOT be printed when --short is specified"
+  output_message=$(kubectl version -o yaml)
+  kube::test::if_has_string "${output_message}" "kustomizeVersion" "kustomize version should be printed when -o yaml is used"
+  output_message=$(kubectl version -o json)
+  kube::test::if_has_string "${output_message}" "kustomizeVersion" "kustomize version should be printed when -o json is used"
+
   set +o nounset
   set +o errexit
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/kustomize/issues/1424. **This is the top feature request on Kustomize by upvotes** and has also been requested directly on the kubectl and oc repos.

#### Special notes for your reviewer:

This PR is yet another alternative to https://github.com/kubernetes/kubernetes/pull/108817. It embeds the new info **inside the client section** of `kubectl version`. Conceptually this approach feels more intuitive to me, since kustomize is part of the client. But it has some implementation issues (commented inline) that could be major blockers.

#### Output

<details>

<summary>Expand to show output samples</summary>

```bash
༶ _output/bin/kubectl version
Client Version: version.Info{Major:"1", Minor:"24+", GitVersion:"v1.24.0-alpha.4.81+b17a9030362f16", GitCommit:"b17a9030362f16edcf5e6f109750736707ff089a", GitTreeState:"clean", BuildDate:"2022-03-23T23:39:15Z", GoVersion:"go1.17.6", Compiler:"gc", Platform:"darwin/arm64", KustomizeVersion:"v4.4.1"}
Server Version: # not relevant / unchanged

༶ _output/bin/kubectl version --client
Client Version: version.Info{Major:"1", Minor:"24+", GitVersion:"v1.24.0-alpha.4.81+b17a9030362f16", GitCommit:"b17a9030362f16edcf5e6f109750736707ff089a", GitTreeState:"clean", BuildDate:"2022-03-23T23:39:15Z", GoVersion:"go1.17.6", Compiler:"gc", Platform:"darwin/arm64", KustomizeVersion:"v4.4.1"}

༶ _output/bin/kubectl version --client -o yaml
clientVersion:
  buildDate: "2022-03-23T23:39:15Z"
  compiler: gc
  gitCommit: b17a9030362f16edcf5e6f109750736707ff089a
  gitTreeState: clean
  gitVersion: v1.24.0-alpha.4.81+b17a9030362f16
  goVersion: go1.17.6
  kustomizeVersion: v4.4.1
  major: "1"
  minor: 24+
  platform: darwin/arm64

༶ _output/bin/kubectl version --client -o json
{
  "clientVersion": {
    "major": "1",
    "minor": "24+",
    "gitVersion": "v1.24.0-alpha.4.81+b17a9030362f16",
    "gitCommit": "b17a9030362f16edcf5e6f109750736707ff089a",
    "gitTreeState": "clean",
    "buildDate": "2022-03-23T23:39:15Z",
    "goVersion": "go1.17.6",
    "compiler": "gc",
    "platform": "darwin/arm64",
    "kustomizeVersion": "v4.4.1"
  }
}

༶ _output/bin/kubectl version --short # NOTE: nothing about Kustomize here!
Client Version: v1.24.0-alpha.4.81+b17a9030362f16
Server Version: v1.22.4
```
</details>

#### Does this PR introduce a user-facing change?

```release-note
`kubectl version` now includes information on the embedded version of Kustomize
```
