### PR TITLE
Fix duplicate code block of `ListAll` function

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/listers.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listers.go
@@ -53,24 +53,8 @@ func ListAll(store Store, selector labels.Selector, appendFn AppendFunc) error {
 
 // ListAllByNamespace used to list items belongs to namespace from Indexer.
 func ListAllByNamespace(indexer Indexer, namespace string, selector labels.Selector, appendFn AppendFunc) error {
-	selectAll := selector.Empty()
 	if namespace == metav1.NamespaceAll {
-		for _, m := range indexer.List() {
-			if selectAll {
-				// Avoid computing labels of the objects to speed up common flows
-				// of listing all objects.
-				appendFn(m)
-				continue
-			}
-			metadata, err := meta.Accessor(m)
-			if err != nil {
-				return err
-			}
-			if selector.Matches(labels.Set(metadata.GetLabels())) {
-				appendFn(m)
-			}
-		}
-		return nil
+		return ListAll(indexer, selector, appendFn)
 	}
 
 	items, err := indexer.Index(NamespaceIndex, &metav1.ObjectMeta{Namespace: namespace})
@@ -89,6 +73,8 @@ func ListAllByNamespace(indexer Indexer, namespace string, selector labels.Selec
 		}
 		return nil
 	}
+
+	selectAll := selector.Empty()
 	for _, m := range items {
 		if selectAll {
 			// Avoid computing labels of the objects to speed up common flows


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
In the `ListAllByNamespace` function, when the namespace is all, the `ListAll` code block is duplicate, so this PR is to make it clean.

#### Special notes for your reviewer:
The `Indexer` extends `Store` interface, so it is safe to pass indexer as store param.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```