### PR TITLE
don't use seek to read the request body

### DIFF
--- a/staging/src/k8s.io/client-go/rest/with_retry.go
+++ b/staging/src/k8s.io/client-go/rest/with_retry.go
@@ -179,10 +179,8 @@ func (r *withRetry) prepareForNextRetry(ctx context.Context, request *Request) e
 
 	// Ensure the response body is fully read and closed before
 	// we reconnect, so that we reuse the same TCP connection.
-	if seeker, ok := request.body.(io.Seeker); ok && request.body != nil {
-		if _, err := seeker.Seek(0, 0); err != nil {
-			return fmt.Errorf("can't Seek() back to beginning of body for %T", request)
-		}
+	if request.body != nil {
+		io.Copy(ioutil.Discard, request.body)
 	}
 
 	klog.V(4).Infof("Got a Retry-After %s response for attempt %d to %v", r.retryAfter.Wait, r.retryAfter.Attempt, request.URL().String())


### PR DESCRIPTION

/kind bug
/kind flake

Fixes #108906

```release-note
NONE
```


```sh
$ go test -timeout 120s -run ^TestCheckRetryClosesBody$ k8s.io/client-go/rest -c -race
$ stress ./rest.test -test.run TestCheckRetryClosesBody
5s: 1298 runs so far, 0 failures
10s: 2605 runs so far, 0 failures
15s: 3907 runs so far, 0 failures
20s: 5221 runs so far, 0 failures
25s: 6507 runs so far, 0 failures
30s: 7787 runs so far, 0 failures
35s: 9058 runs so far, 0 failures
```