### PR TITLE
publishing/rules: remove .gitattributes before publishing

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,6 +7,7 @@ recursive-delete-patterns:
 - BUILD.bazel
 - "*/BUILD.bazel"
 - Gopkg.toml
+- "*/.gitattributes"
 default-go-version: 1.18
 rules:
 - destination: code-generator


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

If a staging repo has .gitattributes files containing the `export-subst`
attribute ([example](https://github.com/kubernetes/kubernetes/blob/b6c06a95d7ff262a876b95a1035eaf478a7cb961/staging/src/k8s.io/client-go/pkg/version/.gitattributes)), then git expands the specified placeholders
when git archive is used.

When a published repo is downloaded from GitHub, GitHub does a
"git archive" under the hood. This means that the placeholders get
replaced by their relevant values. This type of "git archive"
application sometimes leads to undesired values. See the example below.

- In client-go, [line 59 in `pkg/version/base.go`](https://github.com/kubernetes/kubernetes/blob/b6c06a95d7ff262a876b95a1035eaf478a7cb961/staging/src/k8s.io/client-go/pkg/version/base.go#L59)
is expanded on a git archive. This line is needed as a fallback to
inject k8s version info for client-go when this info is not provided
via ldflags during builds.

- However, when k/client-go is vendored, the line gets expanded to _the
commit of the project vendoring client-go_ -- which is not helpful at
all! This also means that the vendored client-go will now contain
different (expanded) commit shas for different projects.

- To ensure reproducibility of source, this commit helps remove
the .gitattributes files before publishing the staging repos.
Additionally, when client-go is used as a library, we don't care about
the line being expanded to inject version info so it is also safe to
remove these files.

#### Which issue(s) this PR fixes:

Ref:
- https://github.com/containerd/containerd/issues/6387#issuecomment-1010019352 (issue found in containerd, cri-o and podman)
- https://github.com/kubernetes/kubernetes/issues/99376#issuecomment-1009881488

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

---

/assign @dims 
/hold
for review
