### PR TITLE
Fix job && cronJob template metadata name

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -628,7 +628,11 @@ func (jm *ControllerV2) syncCronJob(
 }
 
 func getJobName(cj *batchv1.CronJob, scheduledTime time.Time) string {
-	return fmt.Sprintf("%s-%d", cj.Name, getTimeHashInMinutes(scheduledTime))
+	jobName := cj.Name
+	if cj.Spec.JobTemplate.ObjectMeta.Name != "" {
+		jobName = cj.Spec.JobTemplate.ObjectMeta.Name
+	}
+	return fmt.Sprintf("%s-%d", jobName, getTimeHashInMinutes(scheduledTime))
 }
 
 // nextScheduledTimeDuration returns the time duration to requeue based on

--- a/pkg/controller/job/indexed_job_utils_test.go
+++ b/pkg/controller/job/indexed_job_utils_test.go
@@ -451,7 +451,7 @@ func TestPodGenerateNameWithIndex(t *testing.T) {
 			index:               1,
 			wantPodGenerateName: "indexed-job-1-",
 		},
-		"job name exceeds MaxGeneneratedNameLength": {
+		"job name exceeds MaxGeneratedNameLength": {
 			jobname:             "hhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhooooo",
 			index:               1,
 			wantPodGenerateName: "hhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhh-1-",

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	batch "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -1369,7 +1369,11 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, activePods 
 						template = podTemplate.DeepCopy()
 						addCompletionIndexAnnotation(template, completionIndex)
 						template.Spec.Hostname = fmt.Sprintf("%s-%d", job.Name, completionIndex)
-						generateName = podGenerateNameWithIndex(job.Name, completionIndex)
+						podName := job.Name
+						if template.ObjectMeta.Name != "" {
+							podName = template.ObjectMeta.Name
+						}
+						generateName = podGenerateNameWithIndex(podName, completionIndex)
 					}
 					defer wait.Done()
 					err := jm.podControl.CreatePodsWithGenerateName(ctx, job.Namespace, template, job, metav1.NewControllerRef(job, controllerKind), generateName)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When create job && cronJob with template metadata name specified, the metadata name of job-name or pod-name will not take effect.
This PR is to honor the template metadata name, and take it into effect.

#### Which issue(s) this PR fixes:
Fixes #108977

#### Special notes for your reviewer:
Also fixed a word typo.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```