### PR TITLE
Start deprecating long/golang version information

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -86,6 +86,7 @@ func NewCmdVersion(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 	}
 	cmd.Flags().BoolVar(&o.ClientOnly, "client", o.ClientOnly, "If true, shows client version only (no server required).")
 	cmd.Flags().BoolVar(&o.Short, "short", o.Short, "If true, print just the version number.")
+	cmd.Flags().MarkDeprecated("short", "and will be removed in the future. The --short output will become the default.")
 	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "One of 'yaml' or 'json'.")
 	return cmd
 }
@@ -143,6 +144,7 @@ func (o *Options) Run() error {
 				fmt.Fprintf(o.Out, "Server Version: %s\n", versionInfo.ServerVersion.GitVersion)
 			}
 		} else {
+			fmt.Fprintf(o.ErrOut, "WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.\n")
 			fmt.Fprintf(o.Out, "Client Version: %#v\n", *versionInfo.ClientVersion)
 			fmt.Fprintf(o.Out, "Kustomize Version: %s\n", versionInfo.KustomizeVersion)
 			if versionInfo.ServerVersion != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation
/sig cli

#### What this PR does / why we need it:
This PR starts the deprecation of the long/golang-based version information in `kubectl version`. Eventually we'll switch to the output from `kubectl version --short`. For machine-parsing output users should use json or yaml output.

#### Special notes for your reviewer:
/assign @KnVerey 

#### Does this PR introduce a user-facing change?
```release-note
Deprecate kubectl version long output, will be replaced with kubectl version --short. Users requiring full output should use --output=yaml|json instead.
```

