### PR TITLE
Fix volume reconstruction for CSI ephemeral volumes

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -454,14 +454,6 @@ func (rc *reconciler) reconstructVolume(volume podVolume) (*reconstructedVolume,
 	if err != nil {
 		return nil, err
 	}
-	attachablePlugin, err := rc.volumePluginMgr.FindAttachablePluginByName(volume.pluginName)
-	if err != nil {
-		return nil, err
-	}
-	deviceMountablePlugin, err := rc.volumePluginMgr.FindDeviceMountablePluginByName(volume.pluginName)
-	if err != nil {
-		return nil, err
-	}
 
 	// Create pod object
 	pod := &v1.Pod{
@@ -486,6 +478,20 @@ func (rc *reconciler) reconstructVolume(volume podVolume) (*reconstructedVolume,
 		volume.volumeSpecName,
 		volume.volumePath,
 		volume.pluginName)
+	if err != nil {
+		return nil, err
+	}
+
+	// We have to find the plugins by volume spec (NOT by plugin name) here
+	// in order to correctly reconstruct ephemeral volume types.
+	// Searching by spec checks whether the volume is actually attachable
+	// (i.e. has a PV) whereas searching by plugin name can only tell whether
+	// the plugin supports attachable volumes.
+	attachablePlugin, err := rc.volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+	if err != nil {
+		return nil, err
+	}
+	deviceMountablePlugin, err := rc.volumePluginMgr.FindDeviceMountablePluginBySpec(volumeSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -1039,7 +1039,7 @@ func (oe *operationExecutor) ReconstructVolumeOperation(
 	// Filesystem Volume case
 	if volumeMode == v1.PersistentVolumeFilesystem {
 		// Create volumeSpec from mount path
-		klog.V(5).Infof("Starting operationExecutor.ReconstructVolumepodName")
+		klog.V(5).Infof("Starting operationExecutor.ReconstructVolume for file volume on pod %q", podName)
 		volumeSpec, err := plugin.ConstructVolumeSpec(volumeSpecName, volumePath)
 		if err != nil {
 			return nil, err
@@ -1049,7 +1049,7 @@ func (oe *operationExecutor) ReconstructVolumeOperation(
 
 	// Block Volume case
 	// Create volumeSpec from mount path
-	klog.V(5).Infof("Starting operationExecutor.ReconstructVolume")
+	klog.V(5).Infof("Starting operationExecutor.ReconstructVolume for block volume on pod %q", podName)
 
 	// volumePath contains volumeName on the path. In the case of block volume, {volumeName} is symbolic link
 	// corresponding to raw block device.
@@ -1085,7 +1085,7 @@ func (oe *operationExecutor) CheckVolumeExistenceOperation(
 			if mounter == nil {
 				return false, fmt.Errorf("mounter was not set for a filesystem volume")
 			}
-			if isNotMount, mountCheckErr = mounter.IsLikelyNotMountPoint(mountPath); mountCheckErr != nil {
+			if isNotMount, mountCheckErr = mount.IsNotMountPoint(mounter, mountPath); mountCheckErr != nil {
 				return false, fmt.Errorf("could not check whether the volume %q (spec.Name: %q) pod %q (UID: %q) is mounted with: %v",
 					uniqueVolumeName,
 					volumeName,

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -40,7 +40,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -244,14 +243,6 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*storageframewo
 		ProvisionerContainerName: "csi-provisioner",
 		SnapshotterContainerName: "csi-snapshotter",
 		NodeName:                 node.Name,
-	}
-
-	// Disable volume lifecycle checks due to issue #103651 for the one
-	// test that it breaks.
-	// TODO: enable this check once issue is resolved for csi-host-path driver
-	// (https://github.com/kubernetes/kubernetes/pull/104858).
-	if regexp.MustCompile("should unmount if pod is.*deleted while kubelet is down").MatchString(ginkgo.CurrentGinkgoTestDescription().FullTestText) {
-		o.DriverContainerArguments = append(o.DriverContainerArguments, "--check-volume-lifecycle=false")
 	}
 
 	cleanup, err := utils.CreateFromManifests(config.Framework, driverNamespace, func(item interface{}) error {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This solves a [couple of issues](https://github.com/kubernetes/kubernetes/issues/79980#issuecomment-1078528540) with volume reconstruction for CSI ephemeral volumes.

#### Which issue(s) this PR fixes:

Fixes #79980

#### Special notes for your reviewer:

/cc @gnufied @jsafrane @pohly @jingxu97

CSI inline volume with these changes:

```
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl apply -f examples/csi-app-inline.yaml      pod/my-csi-app-inline created
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl get pod/my-csi-app-inline
NAME                READY   STATUS    RESTARTS   AGE
my-csi-app-inline   1/1     Running   0          16s
root@ubuntu2110:/workspace/csi-driver-host-path# mount | grep my-csi-volume
/dev/mapper/ubuntu--vg-ubuntu--lv on /var/lib/kubelet/pods/55703bf4-9ee4-4fd5-8f4c-1e20f82391e4/volumes/kubernetes.io~csi/my-csi-volume/mount type ext4 (rw,relatime)

root@ubuntu2110:/workspace/csi-driver-host-path# /root/stopkubelet.sh
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl delete --force pod/my-csi-app-inline
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
pod "my-csi-app-inline" force deleted

root@ubuntu2110:/workspace/csi-driver-host-path# /root/startkubelet.sh
root@ubuntu2110:/workspace/kubernetes# mount | grep my-csi-volume
root@ubuntu2110:/workspace/kubernetes# mount | grep 55703bf4-9ee4-4fd5-8f4c-1e20f82391e4
root@ubuntu2110:/workspace/csi-driver-host-path# grep 55703bf4-9ee4-4fd5-8f4c-1e20f82391e4 /tmp/kubelet.log
...
I0324 20:45:21.709899 2213546 operation_generator.go:864] UnmountVolume.TearDown succeeded for volume "kubernetes.io/csi/55703bf4-9ee4-4fd5-8f4c-1e20f82391e4-my-csi-volume" (OuterVolumeSpecName: "my-csi-volume") pod "55703bf4-9ee4-4fd5-8f4c-1e20f82391e4" (UID: "55703bf4-9ee4-4fd5-8f4c-1e20f82391e4"). InnerVolumeSpecName "my-csi-volume". PluginName "kubernetes.io/csi", VolumeGidValue ""
I0324 20:45:21.798304 2213546 reconciler.go:300] "Volume detached for volume \"my-csi-volume\" (UniqueName: \"kubernetes.io/csi/55703bf4-9ee4-4fd5-8f4c-1e20f82391e4-my-csi-volume\") on node \"127.0.0.1\" DevicePath \"\""
I0324 20:45:23.682333 2213546 kubelet_volumes.go:160] "Cleaned up orphaned pod volumes dir" podUID=55703bf4-9ee4-4fd5-8f4c-1e20f82391e4 path="/var/lib/kubelet/pods/55703bf4-9ee4-4fd5-8f4c-1e20f82391e4/volumes"
I0324 20:45:23.682673 2213546 kubelet_volumes.go:236] "Orphaned pod found, removing" podUID=55703bf4-9ee4-4fd5-8f4c-1e20f82391e4
```

PV spec with these changes:

```
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl apply -f examples/csi-storageclass.yaml
storageclass.storage.k8s.io/csi-hostpath-sc created
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl apply -f examples/csi-pvc.yaml     persistentvolumeclaim/csi-pvc created
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl apply -f examples/csi-app.yaml
pod/my-csi-app created
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl get pod/my-csi-app
NAME         READY   STATUS    RESTARTS   AGE
my-csi-app   1/1     Running   0          68s
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl get pod/my-csi-app -o yaml | grep uid
  uid: bf5d71e6-da6a-448a-bab2-f35b2a938d45
root@ubuntu2110:/workspace/csi-driver-host-path# mount | grep pvc-                          /dev/mapper/ubuntu--vg-ubuntu--lv on /var/lib/kubelet/pods/bf5d71e6-da6a-448a-bab2-f35b2a938d45/volumes/kubernetes.io~csi/pvc-1787a6c7-ccd3-44a1-b6ad-474da06c5e2b/mount type ext4 (rw,relatime)

root@ubuntu2110:/workspace/csi-driver-host-path# /root/stopkubelet.sh
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl get nodes
NAME        STATUS     ROLES    AGE   VERSION
127.0.0.1   NotReady   <none>   24h   v1.24.0-alpha.3.562+9eb3043a08b339-dirty
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl delete --force pod/my-csi-app
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
pod "my-csi-app" force deleted

root@ubuntu2110:/workspace/csi-driver-host-path# /root/startkubelet.sh
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl get nodes
NAME        STATUS   ROLES    AGE   VERSION
127.0.0.1   Ready    <none>   24h   v1.24.0-alpha.3.562+9eb3043a08b339-dirty
root@ubuntu2110:/workspace/csi-driver-host-path# mount | grep pvc-
root@ubuntu2110:/workspace/csi-driver-host-path# grep pvc-1787a6c7-ccd3-44a1-b6ad-474da06c5e2b /tmp/kubelet.log
...
I0324 23:09:04.774114 2453285 csi_mounter.go:388] kubernetes.io/csi: Unmounter.TearDownAt successfully unmounted dir [/var/lib/kubelet/pods/bf5d71e6-da6a-448a-bab2-f35b2a938d45/volumes/kubernetes.io~csi/pvc-1787a6c7-ccd3-44a1-b6ad-474da06c5e2b/mount]
I0324 23:09:04.774132 2453285 operation_generator.go:864] UnmountVolume.TearDown succeeded for volume "kubernetes.io/csi/hostpath.csi.k8s.io^7ede2757-abc4-11ec-80df-b6e25f7c1fda" (OuterVolumeSpecName: "pvc-1787a6c7-ccd3-44a1-b6ad-474da06c5e2b") pod "bf5d71e6-da6a-448a-bab2-f35b2a938d45" (UID: "bf5d71e6-da6a-448a-bab2-f35b2a938d45"). InnerVolumeSpecName "pvc-1787a6c7-ccd3-44a1-b6ad-474da06c5e2b". PluginName "kubernetes.io/csi", VolumeGidValue ""
```

subpath volumes with these changes:

```
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl get nodes
NAME        STATUS   ROLES    AGE   VERSION
127.0.0.1   Ready    <none>   25h   v1.24.0-alpha.3.562+9eb3043a08b339-dirty
root@ubuntu2110:/workspace/csi-driver-host-path# cat examples/csi-app-subpath.yaml
kind: Pod
apiVersion: v1
metadata:
  name: my-csi-app
spec:
  containers:
    - name: my-frontend
      image: busybox
      volumeMounts:
      - mountPath: "/data/subpath1"
        name: my-csi-volume
        subPath: subpath1
      - mountPath: "/data/subpath2"
        name: my-csi-volume
        subPath: subpath2
      command: [ "sleep", "1000000" ]
  volumes:
    - name: my-csi-volume
      persistentVolumeClaim:
        claimName: csi-pvc # defined in csi-pvc.yaml
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl apply -f examples/csi-app-subpath.yaml
pod/my-csi-app created
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl get pod/my-csi-app
NAME         READY   STATUS    RESTARTS   AGE
my-csi-app   1/1     Running   0          11s
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl get pod/my-csi-app -o yaml | grep uid 
  uid: 17bef72d-c2f7-4e9d-8988-dd8c725c54c8
root@ubuntu2110:/workspace/csi-driver-host-path# mount | grep subpath                       /dev/mapper/ubuntu--vg-ubuntu--lv on /var/lib/kubelet/pods/17bef72d-c2f7-4e9d-8988-dd8c725c54c8/volume-subpaths/pvc-1787a6c7-ccd3-44a1-b6ad-474da06c5e2b/my-frontend/0 type ext4 (rw,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /var/lib/kubelet/pods/17bef72d-c2f7-4e9d-8988-dd8c725c54c8/volume-subpaths/pvc-1787a6c7-ccd3-44a1-b6ad-474da06c5e2b/my-frontend/1 type ext4 (rw,relatime)

root@ubuntu2110:/workspace/csi-driver-host-path# /root/stopkubelet.sh
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl get nodes
NAME        STATUS     ROLES    AGE   VERSION
127.0.0.1   NotReady   <none>   25h   v1.24.0-alpha.3.562+9eb3043a08b339-dirty
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl delete --force pod/my-csi-app
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
pod "my-csi-app" force deleted

root@ubuntu2110:/workspace/csi-driver-host-path# /root/startkubelet.sh
root@ubuntu2110:/workspace/csi-driver-host-path# kubectl get nodes
NAME        STATUS   ROLES    AGE   VERSION
127.0.0.1   Ready    <none>   25h   v1.24.0-alpha.3.562+9eb3043a08b339-dirty

root@ubuntu2110:/workspace/csi-driver-host-path# mount | grep subpath
root@ubuntu2110:/workspace/csi-driver-host-path# mount | grep pvc-
root@ubuntu2110:/workspace/csi-driver-host-path# grep pvc-1787a6c7-ccd3-44a1-b6ad-474da06c5e2b /tmp/kubelet.log | grep 'TearDown succeeded'
I0324 23:41:31.759945 2511547 operation_generator.go:864] UnmountVolume.TearDown succeeded for volume "kubernetes.io/csi/hostpath.csi.k8s.io^7ede2757-abc4-11ec-80df-b6e25f7c1fda" (OuterVolumeSpecName: "pvc-1787a6c7-ccd3-44a1-b6ad-474da06c5e2b") pod "17bef72d-c2f7-4e9d-8988-dd8c725c54c8" (UID: "17bef72d-c2f7-4e9d-8988-dd8c725c54c8"). InnerVolumeSpecName "pvc-1787a6c7-ccd3-44a1-b6ad-474da06c5e2b". PluginName "kubernetes.io/csi", VolumeGidValue ""
```

#### Does this PR introduce a user-facing change?

```release-note
Fix for volume reconstruction of CSI ephemeral volumes
```