### PR TITLE
test/e2e_node: update kubelet credential provider tests to use new v1beta1 APIs

### DIFF
--- a/test/e2e_node/plugins/gcp-credential-provider/main.go
+++ b/test/e2e_node/plugins/gcp-credential-provider/main.go
@@ -27,7 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
-	credentialproviderv1alpha1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1alpha1"
+	credentialproviderv1beta1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1beta1"
 )
 
 const metadataTokenEndpoint = "http://metadata.google.internal./computeMetadata/v1/instance/service-accounts/default/token"
@@ -51,7 +51,7 @@ func getCredentials(tokenEndpoint string, r io.Reader, w io.Writer) error {
 		return err
 	}
 
-	var authRequest credentialproviderv1alpha1.CredentialProviderRequest
+	var authRequest credentialproviderv1beta1.CredentialProviderRequest
 	err = json.Unmarshal(data, &authRequest)
 	if err != nil {
 		return err
@@ -62,12 +62,12 @@ func getCredentials(tokenEndpoint string, r io.Reader, w io.Writer) error {
 		return err
 	}
 
-	response := &credentialproviderv1alpha1.CredentialProviderResponse{
+	response := &credentialproviderv1beta1.CredentialProviderResponse{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "CredentialProviderResponse",
-			APIVersion: "credentialprovider.kubelet.k8s.io/v1alpha1",
+			APIVersion: "credentialprovider.kubelet.k8s.io/v1beta1",
 		},
-		CacheKeyType: credentialproviderv1alpha1.RegistryPluginCacheKeyType,
+		CacheKeyType: credentialproviderv1beta1.RegistryPluginCacheKeyType,
 		Auth:         auth,
 	}
 

--- a/test/e2e_node/plugins/gcp-credential-provider/main_test.go
+++ b/test/e2e_node/plugins/gcp-credential-provider/main_test.go
@@ -36,7 +36,7 @@ func Test_getCredentials(t *testing.T) {
 	server := httptest.NewServer(&fakeTokenServer{token: "abc123"})
 	defer server.Close()
 
-	in := bytes.NewBuffer([]byte(`{"kind":"CredentialProviderRequest","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","image":"gcr.io/foobar"}`))
+	in := bytes.NewBuffer([]byte(`{"kind":"CredentialProviderRequest","apiVersion":"credentialprovider.kubelet.k8s.io/v1beta1","image":"gcr.io/foobar"}`))
 	out := bytes.NewBuffer(nil)
 
 	err := getCredentials(server.URL, in, out)
@@ -44,7 +44,7 @@ func Test_getCredentials(t *testing.T) {
 		t.Fatalf("unexpected error running getCredentials: %v", err)
 	}
 
-	expected := `{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","cacheKeyType":"Registry","auth":{"*.gcr.io":{"username":"_token","password":"abc123"},"*.pkg.dev":{"username":"_token","password":"abc123"},"container.cloud.google.com":{"username":"_token","password":"abc123"},"gcr.io":{"username":"_token","password":"abc123"}}}
+	expected := `{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1beta1","cacheKeyType":"Registry","auth":{"*.gcr.io":{"username":"_token","password":"abc123"},"*.pkg.dev":{"username":"_token","password":"abc123"},"container.cloud.google.com":{"username":"_token","password":"abc123"},"gcr.io":{"username":"_token","password":"abc123"}}}
 `
 
 	if out.String() != expected {

--- a/test/e2e_node/plugins/gcp-credential-provider/provider.go
+++ b/test/e2e_node/plugins/gcp-credential-provider/provider.go
@@ -25,7 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	credentialproviderv1alpha1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1alpha1"
+	credentialproviderv1beta1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1beta1"
 )
 
 const (
@@ -59,8 +59,8 @@ type provider struct {
 	tokenEndpoint string
 }
 
-func (p *provider) Provide(image string) (map[string]credentialproviderv1alpha1.AuthConfig, error) {
-	cfg := map[string]credentialproviderv1alpha1.AuthConfig{}
+func (p *provider) Provide(image string) (map[string]credentialproviderv1beta1.AuthConfig, error) {
+	cfg := map[string]credentialproviderv1beta1.AuthConfig{}
 
 	tokenJSONBlob, err := readURL(p.tokenEndpoint, p.client)
 	if err != nil {
@@ -72,7 +72,7 @@ func (p *provider) Provide(image string) (map[string]credentialproviderv1alpha1.
 		return cfg, err
 	}
 
-	authConfig := credentialproviderv1alpha1.AuthConfig{
+	authConfig := credentialproviderv1beta1.AuthConfig{
 		Username: "_token",
 		Password: parsedBlob.AccessToken,
 	}

--- a/test/e2e_node/remote/utils.go
+++ b/test/e2e_node/remote/utils.go
@@ -49,10 +49,10 @@ const cniConfig = `{
 `
 
 const credentialProviderConfig = `kind: CredentialProviderConfig
-apiVersion: kubelet.config.k8s.io/v1alpha1
+apiVersion: kubelet.config.k8s.io/v1beta1
 providers:
   - name: gcp-credential-provider
-    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
     matchImages:
     - "gcr.io"
     - "*.gcr.io"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update the kubelet credential provider node e2e tests to use the new v1beta1 APIs that was recently added in https://github.com/kubernetes/kubernetes/pull/108847. 

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
