### PR TITLE
pkg/credentialprovider/plugin: refactor for better testability with mulitple apiVersions

### DIFF
--- a/pkg/credentialprovider/plugin/plugin_test.go
+++ b/pkg/credentialprovider/plugin/plugin_test.go
@@ -56,7 +56,7 @@ func Test_Provide(t *testing.T) {
 		dockerconfig   credentialprovider.DockerConfig
 	}{
 		{
-			name: "exact image match, with Registry cache key",
+			name: "[v1beta1] exact image match, with Registry cache key",
 			pluginProvider: &pluginProvider{
 				apiVersion:     credentialproviderv1beta1.SchemeGroupVersion.String(),
 				clock:          tclock,
@@ -76,7 +76,27 @@ func Test_Provide(t *testing.T) {
 			},
 		},
 		{
-			name: "exact image match, with Image cache key",
+			name: "[v1alpha1] exact image match, with Registry cache key",
+			pluginProvider: &pluginProvider{
+				apiVersion:     credentialproviderv1alpha1.SchemeGroupVersion.String(),
+				clock:          tclock,
+				lastCachePurge: tclock.Now(),
+				matchImages:    []string{"test.registry.io"},
+				cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
+				plugin: &fakeExecPlugin{
+					data: []byte(`{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","cacheKeyType":"Registry","cacheDuration":"1m","auth":{"test.registry.io":{"username":"user","password":"password"}}}`),
+				},
+			},
+			image: "test.registry.io/foo/bar",
+			dockerconfig: credentialprovider.DockerConfig{
+				"test.registry.io": credentialprovider.DockerConfigEntry{
+					Username: "user",
+					Password: "password",
+				},
+			},
+		},
+		{
+			name: "[v1beta1] exact image match, with Image cache key",
 			pluginProvider: &pluginProvider{
 				apiVersion:     credentialproviderv1beta1.SchemeGroupVersion.String(),
 				clock:          tclock,
@@ -96,7 +116,27 @@ func Test_Provide(t *testing.T) {
 			},
 		},
 		{
-			name: "exact image match, with Global cache key",
+			name: "[v1alpha1] exact image match, with Image cache key",
+			pluginProvider: &pluginProvider{
+				apiVersion:     credentialproviderv1alpha1.SchemeGroupVersion.String(),
+				clock:          tclock,
+				lastCachePurge: tclock.Now(),
+				matchImages:    []string{"test.registry.io/foo/bar"},
+				cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
+				plugin: &fakeExecPlugin{
+					data: []byte(`{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","cacheKeyType":"Image","cacheDuration":"1m","auth":{"test.registry.io/foo/bar":{"username":"user","password":"password"}}}`),
+				},
+			},
+			image: "test.registry.io/foo/bar",
+			dockerconfig: credentialprovider.DockerConfig{
+				"test.registry.io/foo/bar": credentialprovider.DockerConfigEntry{
+					Username: "user",
+					Password: "password",
+				},
+			},
+		},
+		{
+			name: "[v1beta1] exact image match, with Global cache key",
 			pluginProvider: &pluginProvider{
 				apiVersion:     credentialproviderv1beta1.SchemeGroupVersion.String(),
 				clock:          tclock,
@@ -116,7 +156,27 @@ func Test_Provide(t *testing.T) {
 			},
 		},
 		{
-			name: "wild card image match, with Registry cache key",
+			name: "[v1alpha1] exact image match, with Global cache key",
+			pluginProvider: &pluginProvider{
+				apiVersion:     credentialproviderv1alpha1.SchemeGroupVersion.String(),
+				clock:          tclock,
+				lastCachePurge: tclock.Now(),
+				matchImages:    []string{"test.registry.io"},
+				cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
+				plugin: &fakeExecPlugin{
+					data: []byte(`{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","cacheKeyType":"Global","cacheDuration":"1m","auth":{"test.registry.io":{"username":"user","password":"password"}}}`),
+				},
+			},
+			image: "test.registry.io",
+			dockerconfig: credentialprovider.DockerConfig{
+				"test.registry.io": credentialprovider.DockerConfigEntry{
+					Username: "user",
+					Password: "password",
+				},
+			},
+		},
+		{
+			name: "[v1beta1] wild card image match, with Registry cache key",
 			pluginProvider: &pluginProvider{
 				apiVersion:     credentialproviderv1beta1.SchemeGroupVersion.String(),
 				clock:          tclock,
@@ -136,7 +196,27 @@ func Test_Provide(t *testing.T) {
 			},
 		},
 		{
-			name: "wild card image match, with Image cache key",
+			name: "[v1alpha1] wild card image match, with Registry cache key",
+			pluginProvider: &pluginProvider{
+				apiVersion:     credentialproviderv1alpha1.SchemeGroupVersion.String(),
+				clock:          tclock,
+				lastCachePurge: tclock.Now(),
+				matchImages:    []string{"*.registry.io:8080"},
+				cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
+				plugin: &fakeExecPlugin{
+					data: []byte(`{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","cacheKeyType":"Registry","cacheDuration":"1m","auth":{"*.registry.io:8080":{"username":"user","password":"password"}}}`),
+				},
+			},
+			image: "test.registry.io:8080/foo",
+			dockerconfig: credentialprovider.DockerConfig{
+				"*.registry.io:8080": credentialprovider.DockerConfigEntry{
+					Username: "user",
+					Password: "password",
+				},
+			},
+		},
+		{
+			name: "[v1beta1] wild card image match, with Image cache key",
 			pluginProvider: &pluginProvider{
 				apiVersion:     credentialproviderv1beta1.SchemeGroupVersion.String(),
 				clock:          tclock,
@@ -156,7 +236,27 @@ func Test_Provide(t *testing.T) {
 			},
 		},
 		{
-			name: "wild card image match, with Global cache key",
+			name: "[v1alpha1] wild card image match, with Image cache key",
+			pluginProvider: &pluginProvider{
+				apiVersion:     credentialproviderv1alpha1.SchemeGroupVersion.String(),
+				clock:          tclock,
+				lastCachePurge: tclock.Now(),
+				matchImages:    []string{"*.*.registry.io"},
+				cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
+				plugin: &fakeExecPlugin{
+					data: []byte(`{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","cacheKeyType":"Registry","cacheDuration":"1m","auth":{"*.*.registry.io":{"username":"user","password":"password"}}}`),
+				},
+			},
+			image: "foo.bar.registry.io/foo/bar",
+			dockerconfig: credentialprovider.DockerConfig{
+				"*.*.registry.io": credentialprovider.DockerConfigEntry{
+					Username: "user",
+					Password: "password",
+				},
+			},
+		},
+		{
+			name: "[v1beta1] wild card image match, with Global cache key",
 			pluginProvider: &pluginProvider{
 				apiVersion:     credentialproviderv1beta1.SchemeGroupVersion.String(),
 				clock:          tclock,
@@ -165,6 +265,26 @@ func Test_Provide(t *testing.T) {
 				cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
 				plugin: &fakeExecPlugin{
 					data: []byte(`{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1beta1","cacheKeyType":"Global","cacheDuration":"1m","auth":{"*.registry.io":{"username":"user","password":"password"}}}`),
+				},
+			},
+			image: "test.registry.io",
+			dockerconfig: credentialprovider.DockerConfig{
+				"*.registry.io": credentialprovider.DockerConfigEntry{
+					Username: "user",
+					Password: "password",
+				},
+			},
+		},
+		{
+			name: "[v1alpha1] wild card image match, with Global cache key",
+			pluginProvider: &pluginProvider{
+				apiVersion:     credentialproviderv1alpha1.SchemeGroupVersion.String(),
+				clock:          tclock,
+				lastCachePurge: tclock.Now(),
+				matchImages:    []string{"*.registry.io"},
+				cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
+				plugin: &fakeExecPlugin{
+					data: []byte(`{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","cacheKeyType":"Global","cacheDuration":"1m","auth":{"*.registry.io":{"username":"user","password":"password"}}}`),
 				},
 			},
 			image: "test.registry.io",

--- a/pkg/credentialprovider/plugin/plugin_test.go
+++ b/pkg/credentialprovider/plugin/plugin_test.go
@@ -295,6 +295,21 @@ func Test_Provide(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "kubelet configured with v1beta1 but plugin returns v1alpha1",
+			pluginProvider: &pluginProvider{
+				apiVersion:     credentialproviderv1beta1.SchemeGroupVersion.String(),
+				clock:          tclock,
+				lastCachePurge: tclock.Now(),
+				matchImages:    []string{"*.registry.io"},
+				cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
+				plugin: &fakeExecPlugin{
+					data: []byte(`{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","cacheKeyType":"Global","cacheDuration":"1m","auth":{"*.registry.io":{"username":"user","password":"password"}}}`),
+				},
+			},
+			image:        "test.registry.io",
+			dockerconfig: credentialprovider.DockerConfig{},
+		},
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/108847 introduced the v1beta1 APIs for the kubelet credential provider feature. Although the v1beta1 APIs are preferred going forward and there are no changes between v1alpha1 and v1beta1, we should still have tests validating v1alpha1 as long as it's supported. This PR refactors the credential provider plugin so we can unit test against multiple apiVersions and test behavior when the apiVersions are mismatched. These unit tests should also help fill in v1alpha1 coverage we're losing with https://github.com/kubernetes/kubernetes/pull/109006, since the node e2e tests would only be running with v1beta1 APIs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
