### PR TITLE
Automated cherry pick of #108455: Copy request in timeout handler

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
@@ -91,6 +91,10 @@ func (t *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// resultCh is used as both errCh and stopCh
 	resultCh := make(chan interface{})
 	tw := newTimeoutWriter(w)
+
+	// Make a copy of request and work on it in new goroutine
+	// to avoid race condition when accessing/modifying request (e.g. headers)
+	rCopy := r.Clone(r.Context())
 	go func() {
 		defer func() {
 			err := recover()
@@ -105,7 +109,7 @@ func (t *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			resultCh <- err
 		}()
-		t.handler.ServeHTTP(tw, r)
+		t.handler.ServeHTTP(tw, rCopy)
 	}()
 	select {
 	case err := <-resultCh:


### PR DESCRIPTION
Cherry pick of #108455 on release-1.22.

#108455: Copy request in timeout handler

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```