### PR TITLE
Deprecate apiserver_dropped_requests_total metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -133,14 +133,12 @@ var (
 		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component"},
 	)
 	// droppedRequests is a number of requests dropped with 'Try again later' response"
-	//
-	// TODO(wojtek-t): This metric can be inferred both from requestTerminationsTotal as well as
-	// from requestCounter. We should deprecate and remove it.
 	droppedRequests = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
-			Name:           "apiserver_dropped_requests_total",
-			Help:           "Number of requests dropped with 'Try again later' response",
-			StabilityLevel: compbasemetrics.ALPHA,
+			Name:              "apiserver_dropped_requests_total",
+			Help:              "Number of requests dropped with 'Try again later' response. Use apiserver_request_total and/or apiserver_request_terminations_total metrics instead.",
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.24.0",
 		},
 		[]string{"request_kind"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -244,7 +244,7 @@ func TestRecordDroppedRequests(t *testing.T) {
 			},
 			isMutating: false,
 			want: `
-			            # HELP apiserver_dropped_requests_total [ALPHA] Number of requests dropped with 'Try again later' response
+			            # HELP apiserver_dropped_requests_total [ALPHA] Number of requests dropped with 'Try again later' response. Use apiserver_request_total and/or apiserver_request_terminations_total metrics instead.
 			            # TYPE apiserver_dropped_requests_total counter
 			            apiserver_dropped_requests_total{request_kind="readOnly"} 1
 			            # HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.
@@ -268,7 +268,7 @@ func TestRecordDroppedRequests(t *testing.T) {
 			},
 			isMutating: true,
 			want: `
-			            # HELP apiserver_dropped_requests_total [ALPHA] Number of requests dropped with 'Try again later' response
+			            # HELP apiserver_dropped_requests_total [ALPHA] Number of requests dropped with 'Try again later' response. Use apiserver_request_total and/or apiserver_request_terminations_total metrics instead.
 			            # TYPE apiserver_dropped_requests_total counter
 			            apiserver_dropped_requests_total{request_kind="mutating"} 1
 			            # HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.
@@ -294,7 +294,7 @@ func TestRecordDroppedRequests(t *testing.T) {
 			},
 			isMutating: true,
 			want: `
-			            # HELP apiserver_dropped_requests_total [ALPHA] Number of requests dropped with 'Try again later' response
+			            # HELP apiserver_dropped_requests_total [ALPHA] Number of requests dropped with 'Try again later' response. Use apiserver_request_total and/or apiserver_request_terminations_total metrics instead.
 			            # TYPE apiserver_dropped_requests_total counter
 			            apiserver_dropped_requests_total{request_kind="mutating"} 1
 			            # HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.


### PR DESCRIPTION
```release-note
Deprecate apiserver_dropped_requests_total metric. The same data can be read from apiserver_request_terminations_total metric.
```

/kind cleanup
/priority important-soon


/assign @logicalhan @dgrisonnet 