### PR TITLE
Fix inconsistent requirement for kind in strict json decoding

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -340,6 +340,7 @@ func (s unstructuredJSONScheme) Decode(data []byte, _ *schema.GroupVersionKind, 
 	if len(gvk.Kind) == 0 {
 		return nil, &gvk, runtime.NewMissingKindErr(string(data))
 	}
+	// TODO(109023): require apiVersion here as well
 
 	return obj, &gvk, nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -166,7 +166,20 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 			strictErrs, err := s.unmarshal(into, data, originalData)
 			if err != nil {
 				return nil, actual, err
-			} else if len(strictErrs) > 0 {
+			}
+
+			// when decoding directly into a provided unstructured object,
+			// extract the actual gvk decoded from the provided data,
+			// and ensure it is non-empty.
+			if isUnstructured {
+				*actual = into.GetObjectKind().GroupVersionKind()
+				if len(actual.Kind) == 0 {
+					return nil, actual, runtime.NewMissingKindErr(string(originalData))
+				}
+				// TODO(109023): require apiVersion here as well once unstructuredJSONScheme#Decode does
+			}
+
+			if len(strictErrs) > 0 {
 				return into, actual, runtime.NewStrictDecodingError(strictErrs)
 			}
 			return into, actual, nil
@@ -261,9 +274,9 @@ func (s *Serializer) unmarshal(into runtime.Object, data, originalData []byte) (
 	var strictJSONErrs []error
 	if u, isUnstructured := into.(runtime.Unstructured); isUnstructured {
 		// Unstructured is a custom unmarshaler that gets delegated
-		// to, so inorder to detect strict JSON errors we need
+		// to, so in order to detect strict JSON errors we need
 		// to unmarshal directly into the object.
-		m := u.UnstructuredContent()
+		m := map[string]interface{}{}
 		strictJSONErrs, err = kjson.UnmarshalStrict(data, &m)
 		u.SetUnstructuredContent(m)
 	} else {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
@@ -638,10 +638,10 @@ func TestDecode(t *testing.T) {
 		},
 		// Duplicate fields should return an error from the strict JSON deserializer for unstructured.
 		{
-			data:        []byte(`{"value":1,"value":1}`),
+			data:        []byte(`{"kind":"Custom","value":1,"value":1}`),
 			into:        &unstructured.Unstructured{},
 			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
-			expectedGVK: &schema.GroupVersionKind{},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Custom"},
 			errFn: func(err error) bool {
 				return strings.Contains(err.Error(), `duplicate field "value"`)
 			},
@@ -649,11 +649,12 @@ func TestDecode(t *testing.T) {
 		},
 		// Duplicate fields should return an error from the strict YAML deserializer for unstructured.
 		{
-			data: []byte("value: 1\n" +
+			data: []byte("kind: Custom\n" +
+				"value: 1\n" +
 				"value: 1\n"),
 			into:        &unstructured.Unstructured{},
 			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
-			expectedGVK: &schema.GroupVersionKind{},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Custom"},
 			errFn: func(err error) bool {
 				return strings.Contains(err.Error(), `"value" already set in map`)
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When using non-strict unstructured json decoding, kind and apiVersion are required.

When using strict unstructured json decoding, missing kind and apiVersion were tolerated. This adds tests and makes strict decoding consistent.

```release-note
Custom resource requests with fieldValidation=Strict consistently require apiVersion and kind, matching non-strict requests
```

/cc @apelisse @kevindelgado 
/sig api-machinery