### PR TITLE
WIP - POC - Read and close response body before seeking to retry

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -1371,8 +1371,6 @@ func (b *testBackoffManager) Sleep(d time.Duration) {
 }
 
 func TestCheckRetryClosesBody(t *testing.T) {
-	// unblock CI until http://issue.k8s.io/108906 is resolved in 1.24
-	t.Skip("http://issue.k8s.io/108906")
 	count := 0
 	ch := make(chan struct{})
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -3003,9 +3001,9 @@ type retryInterceptor struct {
 	invokeOrderGot []string
 }
 
-func (ri *retryInterceptor) IsNextRetry(ctx context.Context, restReq *Request, httpReq *http.Request, resp *http.Response, err error, f IsRetryableErrorFunc) bool {
+func (ri *retryInterceptor) IsNextRetry(ctx context.Context, restReq *Request, httpReq *http.Request, resp *http.Response, closer *responseCloser, err error, f IsRetryableErrorFunc) bool {
 	ri.invokeOrderGot = append(ri.invokeOrderGot, "WithRetry.IsNextRetry")
-	return ri.WithRetry.IsNextRetry(ctx, restReq, httpReq, resp, err, f)
+	return ri.WithRetry.IsNextRetry(ctx, restReq, httpReq, resp, closer, err, f)
 }
 
 func (ri *retryInterceptor) Before(ctx context.Context, request *Request) error {

--- a/staging/src/k8s.io/client-go/rest/with_retry_test.go
+++ b/staging/src/k8s.io/client-go/rest/with_retry_test.go
@@ -215,11 +215,12 @@ func TestIsNextRetry(t *testing.T) {
 				},
 			}
 			r := &withRetry{maxRetries: test.maxRetries}
+			closer := &responseCloser{resp: test.response}
 
 			retryGot := make([]bool, 0)
 			retryAfterGot := make([]*RetryAfter, 0)
 			for i := 0; i < test.attempts; i++ {
-				retry := r.IsNextRetry(context.TODO(), restReq, test.request, test.response, test.err, test.retryableErrFunc)
+				retry := r.IsNextRetry(context.TODO(), restReq, test.request, test.response, closer, test.err, test.retryableErrFunc)
 				retryGot = append(retryGot, retry)
 				retryAfterGot = append(retryAfterGot, r.retryAfter)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### Which issue(s) this PR fixes:

xref #108906

Fixes a bug in our client retry logic that was not draining/closing the body prior to trying to reset the request body for a retry. According to go upstream, this is required to avoid races.

WIP because one place we call IsNextRetry currently depends on being able to read from the response body *after* trying the Seek(0,0) call. Not sure what to do about that.

```release-note
NONE
```

/assign @smarterclayton 