### PR TITLE
kubelet: fix panic triggered when playing with a wip CRI

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -496,7 +496,7 @@ func (m *kubeGenericRuntimeManager) podSandboxChanged(pod *v1.Pod, podStatus *ku
 	}
 
 	// Needs to create a new sandbox when the sandbox does not have an IP address.
-	if !kubecontainer.IsHostNetworkPod(pod) && sandboxStatus.Network.Ip == "" {
+	if !kubecontainer.IsHostNetworkPod(pod) && sandboxStatus.Network != nil && sandboxStatus.Network.Ip == "" {
 		klog.V(2).InfoS("Sandbox for pod has no IP address. Need to start a new one", "pod", klog.KObj(pod))
 		return true, sandboxStatus.Metadata.Attempt + 1, sandboxStatus.Id
 	}


### PR DESCRIPTION
I'm writing a custom container runtime and I encounter a kubelet panic:

```
I0325 22:39:20.613544    9913 kuberuntime_sandbox.go:296] "Pod Sandbox status doesn't have network information, cannot report IPs" pod="default/httpd-86d666c486-s58ls"
I0325 22:39:20.620552    9913 kubelet.go:2098] "SyncLoop (PLEG): event for pod" pod="default/httpd-86d666c486-s58ls" event=&{ID:7d04550d-2db8-4725-91d8-316f3fb95636 Type:ContainerStarted Data:7d04550d-2db8-4725-91d8-316f3fb95636}
E0325 22:39:20.622081    9913 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 344 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x438b5a0, 0x77750e0})
  /home/meister/go/src/github.com/kubernetes/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0xb4
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x0})
  /home/meister/go/src/github.com/kubernetes/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x8c
panic({0x438b5a0, 0x77750e0})
  /usr/local/go/src/runtime/panic.go:1038 +0x25b
k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).podSandboxChanged(0xc0008c29a0, 0xc000eb7000, 0xc000ed4980)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_manager.go:500 +0x2b5
k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).computePodActions(0xc0008c29a0, 0xc000eb7000, 0xc000ed4980)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_manager.go:529 +0x225
k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).SyncPod(0xc0008c29a0, 0xc000eb7000, 0xc000ed4980, {0x77e7ed8, 0x0, 0x0}, 0xc00009da40)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_manager.go:714 +0x89
k8s.io/kubernetes/pkg/kubelet.(*Kubelet).syncPod(0xc000a68000, {0x53b6a50, 0xc000e73880}, 0x0, 0xc000eb7000, 0x0, 0xc000ed4980)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/kubelet.go:1718 +0x23c4
k8s.io/kubernetes/pkg/kubelet.(*podWorkers).managePodLoop.func1(0xc000b3dee0, 0xc0004c3680, 0xc000eb7000, 0xc000b3dea8)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/pod_workers.go:935 +0x333
k8s.io/kubernetes/pkg/kubelet.(*podWorkers).managePodLoop(0xc0004c3680, 0xc000e8e960)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/pod_workers.go:940 +0x469
k8s.io/kubernetes/pkg/kubelet.(*podWorkers).UpdatePod.func1(0xc0004c3680, 0xc000e8e960)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/pod_workers.go:736 +0x72
created by k8s.io/kubernetes/pkg/kubelet.(*podWorkers).UpdatePod
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/pod_workers.go:734 +0x2005
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
  panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x3b99615]

goroutine 344 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x0})
  /home/meister/go/src/github.com/kubernetes/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0x109
panic({0x438b5a0, 0x77750e0})
  /usr/local/go/src/runtime/panic.go:1038 +0x25b
k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).podSandboxChanged(0xc0008c29a0, 0xc000eb7000, 0xc000ed4980)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_manager.go:500 +0x2b5
k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).computePodActions(0xc0008c29a0, 0xc000eb7000, 0xc000ed4980)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_manager.go:529 +0x225
k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).SyncPod(0xc0008c29a0, 0xc000eb7000, 0xc000ed4980, {0x77e7ed8, 0x0, 0x0}, 0xc00009da40)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_manager.go:714 +0x89
k8s.io/kubernetes/pkg/kubelet.(*Kubelet).syncPod(0xc000a68000, {0x53b6a50, 0xc000e73880}, 0x0, 0xc000eb7000, 0x0, 0xc000ed4980)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/kubelet.go:1718 +0x23c4
k8s.io/kubernetes/pkg/kubelet.(*podWorkers).managePodLoop.func1(0xc000b3dee0, 0xc0004c3680, 0xc000eb7000, 0xc000b3dea8)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/pod_workers.go:935 +0x333
k8s.io/kubernetes/pkg/kubelet.(*podWorkers).managePodLoop(0xc0004c3680, 0xc000e8e960)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/pod_workers.go:940 +0x469
k8s.io/kubernetes/pkg/kubelet.(*podWorkers).UpdatePod.func1(0xc0004c3680, 0xc000e8e960)
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/pod_workers.go:736 +0x72
created by k8s.io/kubernetes/pkg/kubelet.(*podWorkers).UpdatePod
  /home/meister/go/src/github.com/kubernetes/kubernetes/pkg/kubelet/pod_workers.go:734 +0x2005
```

/kind bug

```release-note
NONE
```