### PR TITLE
Fix replica calculation at start of HPA scaling policy period

### DIFF
--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -3029,7 +3029,7 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 func TestCalculateScaleUpLimitWithScalingRules(t *testing.T) {
 	policy := autoscalingv2.MinChangePolicySelect
 
-	calculated := calculateScaleUpLimitWithScalingRules(1, []timestampedScaleEvent{}, &autoscalingv2.HPAScalingRules{
+	calculated := calculateScaleUpLimitWithScalingRules(1, []timestampedScaleEvent{}, []timestampedScaleEvent{}, &autoscalingv2.HPAScalingRules{
 		StabilizationWindowSeconds: utilpointer.Int32Ptr(300),
 		SelectPolicy:               &policy,
 		Policies: []autoscalingv2.HPAScalingPolicy{
@@ -3051,7 +3051,7 @@ func TestCalculateScaleUpLimitWithScalingRules(t *testing.T) {
 func TestCalculateScaleDownLimitWithBehaviors(t *testing.T) {
 	policy := autoscalingv2.MinChangePolicySelect
 
-	calculated := calculateScaleDownLimitWithBehaviors(5, []timestampedScaleEvent{}, &autoscalingv2.HPAScalingRules{
+	calculated := calculateScaleDownLimitWithBehaviors(5, []timestampedScaleEvent{}, []timestampedScaleEvent{}, &autoscalingv2.HPAScalingRules{
 		StabilizationWindowSeconds: utilpointer.Int32Ptr(300),
 		SelectPolicy:               &policy,
 		Policies: []autoscalingv2.HPAScalingPolicy{
@@ -3480,6 +3480,18 @@ func TestScalingWithRules(t *testing.T) {
 			expectedReplicas:             255, // (100 - 15) + 200%
 			expectedCondition:            "ScaleUpLimit",
 		},
+		{
+			name:                         "scaleUp with percent policy and previous scale up and down events",
+			scaleUpEvents:                generateEventsUniformDistribution([]int{4}, 120),
+			scaleDownEvents:              generateEventsUniformDistribution([]int{2}, 120),
+			specMinReplicas:              1,
+			specMaxReplicas:              1000,
+			scaleUpRules:                 generateScalingRules(0, 0, 300, 300, 0),
+			currentReplicas:              6,
+			prenormalizedDesiredReplicas: 24,
+			expectedReplicas:             16,
+			expectedCondition:            "ScaleUpLimit",
+		},
 		// ScaleDown with PeriodSeconds usage
 		{
 			name:                         "scaleDown with default policy and previous events",
@@ -3544,6 +3556,18 @@ func TestScalingWithRules(t *testing.T) {
 			currentReplicas:              100,
 			prenormalizedDesiredReplicas: 0,
 			expectedReplicas:             56, // (100 + 12) - 50%
+			expectedCondition:            "ScaleDownLimit",
+		},
+		{
+			name:                         "scaleDown with percent policy and previous scale up and down events",
+			scaleUpEvents:                generateEventsUniformDistribution([]int{2}, 120),
+			scaleDownEvents:              generateEventsUniformDistribution([]int{4}, 120),
+			specMinReplicas:              1,
+			specMaxReplicas:              1000,
+			scaleDownRules:               generateScalingRules(0, 0, 50, 180, 0),
+			currentReplicas:              10,
+			prenormalizedDesiredReplicas: 1,
+			expectedReplicas:             6,
 			expectedCondition:            "ScaleDownLimit",
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When calculating the scale-up/scale-down limit of a `HPAScalingPolicy`, the number of replicas
at the start of the scaling policy period is calculated incorrectly in some cases.
This leads to unexpected behavior, where the HPA does not scale correctly in case there have been both scale-up and scale-down events within the `periodSeconds` window of the policy. See #108354 for more detailed information.

This PR intends to solve the unexpected behavior by including both scale-up and scale-down events which happened in the `periodSeconds` window in order to calculate the correct number of replicas at the start of the scaling policy window.

I read through [KEP 853 - Configurable scale up/down velocity for HPA](https://github.com/kubernetes/enhancements/tree/master/keps/sig-autoscaling/853-configurable-hpa-scale-velocity) and think  that the change is in accordance with the KEP. 

#### Which issue(s) this PR fixes:

Fixes #108354

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/kind sig/autoscaling
/cc @josephburnett @mwielgus
