### PR TITLE
Create a KUBE-IPTABLES-HINT chain

### DIFF
--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -22,22 +22,6 @@ import (
 	"k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
-	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
-)
-
-const (
-	// KubeMarkMasqChain is the mark-for-masquerade chain
-	// TODO: clean up this logic in kube-proxy
-	KubeMarkMasqChain utiliptables.Chain = "KUBE-MARK-MASQ"
-
-	// KubeMarkDropChain is the mark-for-drop chain
-	KubeMarkDropChain utiliptables.Chain = "KUBE-MARK-DROP"
-
-	// KubePostroutingChain is kubernetes postrouting rules
-	KubePostroutingChain utiliptables.Chain = "KUBE-POSTROUTING"
-
-	// KubeFirewallChain is kubernetes firewall rules
-	KubeFirewallChain utiliptables.Chain = "KUBE-FIREWALL"
 )
 
 // providerRequiresNetworkingConfiguration returns whether the cloud provider

--- a/pkg/kubelet/kubelet_network_linux.go
+++ b/pkg/kubelet/kubelet_network_linux.go
@@ -30,6 +30,21 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
+const (
+	// KubeMarkMasqChain is the mark-for-masquerade chain
+	// TODO: clean up this logic in kube-proxy
+	KubeMarkMasqChain utiliptables.Chain = "KUBE-MARK-MASQ"
+
+	// KubeMarkDropChain is the mark-for-drop chain
+	KubeMarkDropChain utiliptables.Chain = "KUBE-MARK-DROP"
+
+	// KubePostroutingChain is kubernetes postrouting rules
+	KubePostroutingChain utiliptables.Chain = "KUBE-POSTROUTING"
+
+	// KubeFirewallChain is kubernetes firewall rules
+	KubeFirewallChain utiliptables.Chain = "KUBE-FIREWALL"
+)
+
 func (kl *Kubelet) initNetworkUtil() {
 	exec := utilexec.New()
 	// TODO: @khenidak review when there is no IPv6 iptables exec  what should happen here (note: no error returned from this func)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
(Trying to get this in before 1.24 code freeze so that the new-and-improved approach is available in 1.24 and we can start documenting it and preparing to deprecate the old approach.)

Components that run in a container but modify the host network namespace iptables rules (such as kube-proxy in many clusters) need to know whether to use iptables-legacy or iptables-nft. Currently there are [heuristics](https://github.com/kubernetes-sigs/iptables-wrappers) but it would be nicer if kubelet helped them figure this out more explicitly.

This is a "pre-alpha" piece of [KEP-3178](https://github.com/kubernetes/enhancements/issues/3178). As discussed in the hopefully-about-to-be-merged [KEP PR](https://github.com/kubernetes/enhancements/pull/3179), we should create an approved way to detect what iptables mode the system (including kubelet) is using, so that we can start the process of deprecating the un-approved ways. (The rest of the plan in KEP-3178 isn't expected to start until next release, but if we merge this part now then that gives us another few months to advertise the plan to third-party components.)

#### Which issue(s) this PR fixes:
none

#### Special notes for your reviewer:
There may be further improvements later, such as adding an actual rule to the chain to document it:

    -A KUBE-IPTABLES-HINT -m comment --comment "The existence of this chain indicates that the system is using iptables-legacy rather than iptables-nft"

and making sure that the chain _doesn't_ exist in the wrong iptables mode. But this at least gets the baseline there.

The use of the `mangle` table rather than `filter` or `nat` is because just checking for the existence of a chain in the `filter` or `nat` tables can be slow on systems with lots of kube-proxy rules.

#### Does this PR introduce a user-facing change?
```release-note
Kubelet now creates an iptables chain named `KUBE-IPTABLES-HINT` in
the `mangle` table. Containerized components that need to modify iptables
rules in the host network namespace can use the existence of this chain
to more-reliably determine whether the system is using iptables-legacy or
iptables-nft.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: (in progress) https://github.com/kubernetes/enhancements/pull/3179
```

/sig network
/assign @thockin 
/priority important-soon