### PR TITLE
Replace nil spec in ASW with the volumeSpec found in DSW

### DIFF
--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -142,6 +142,9 @@ type ActualStateOfWorld interface {
 
 	// GetNodesToUpdateStatusFor returns the map of nodeNames to nodeToUpdateStatusFor
 	GetNodesToUpdateStatusFor() map[types.NodeName]nodeToUpdateStatusFor
+
+	// SetVolumeSpec set volumeSpec for specified attachedVolume
+	SetVolumeSpec(volumeName v1.UniqueVolumeName, volumeSpec *volume.Spec)
 }
 
 // AttachedVolume represents a volume that is attached to a node.
@@ -726,4 +729,16 @@ func getAttachedVolume(
 		},
 		MountedByNode:       nodeAttachedTo.mountedByNode,
 		DetachRequestedTime: nodeAttachedTo.detachRequestedTime}
+}
+
+func (asw *actualStateOfWorld) SetVolumeSpec(
+	volumeName v1.UniqueVolumeName, volumeSpec *volume.Spec) {
+	asw.Lock()
+	defer asw.Unlock()
+
+	volumeObj, volumeExists := asw.attachedVolumes[volumeName]
+	if volumeExists {
+		volumeObj.spec = volumeSpec
+		asw.attachedVolumes[volumeName] = volumeObj
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
For attachable csi volume，when attach/detach controller  starts,  restores node/volume for ASW from node.Status.VolumesAttached. If the volume is not used by a pod, volumeSpec in ASW will be nil. In this case the volume should be detached. 
But if detach fails and VA is deleted and volume is used again by pod, volumeSpec is always nil, which will cause VerifyVolumesAreAttached to fail, as below.
  `E0216 08:38:20.647821       1 operation_executor.go:711] VerifyVolumesAreAttached: nil spec for volume kubernetes.io/csi/opdisk.csi.openpalette.org^131ab496-40a5-47a0-8011-4554779c5688`

This pr fix the promblem by updating nil spec in ASW with the volumeSpec found in DSW.

#### Which issue(s) this PR fixes:
Fixes #108869

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: