### PR TITLE
Add shell completion for new --subresource flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -475,6 +475,9 @@ func AddLabelSelectorFlagVar(cmd *cobra.Command, p *string) {
 
 func AddSubresourceFlags(cmd *cobra.Command, subresource *string, usage string, allowedSubresources ...string) {
 	cmd.Flags().StringVar(subresource, "subresource", "", fmt.Sprintf("%s Must be one of %v. This flag is alpha and may change in the future.", usage, allowedSubresources))
+	CheckErr(cmd.RegisterFlagCompletionFunc("subresource", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return allowedSubresources, cobra.ShellCompDirectiveNoFileComp
+	}))
 }
 
 type ValidateOptions struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig cli

#### What this PR does / why we need it:

Adds shell completion for the new `--subresource` flag.

#99556 added the `--subresource` flag which accepts a specific set of values, mostly `status` and `scale`.
The help message of the flag is clear on what values can be accepted.
I feel that having the shell completion provide those choices can help the user even further.
Currently, if users try to complete the values of the `--subresource` flag, they will get files being suggested.

Currently:
```
$ kubectl get --subresource s<TAB>
SECURITY_CONTACTS  SUPPORT.md         staging/
```
With PR:
```
$ /tmp/kubectl get --subresource s<TAB>
scale   status
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Shell completion is now provided for the "--subresource" flag.
```

/cc @nikhita 