### PR TITLE
Fix: Kubelet cannot finish terminating a pod that uses a PVC with volumeMode: Block if the underlying block device is accidentally disconnected from the node

### DIFF
--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -1230,7 +1230,7 @@ func (fv *FakeVolumePathHandler) DetachFileDevice(path string) error {
 	return nil
 }
 
-func (fv *FakeVolumePathHandler) GetLoopDevice(path string) (string, error) {
+func (fv *FakeVolumePathHandler) GetLoopDevice(path string, detectDeletedDevice bool) (string, error) {
 	// nil is success, else error
 	return "/dev/loop1", nil
 }

--- a/pkg/volume/util/volumepathhandler/volume_path_handler.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler.go
@@ -58,7 +58,7 @@ type BlockVolumePathHandler interface {
 	// detach it from block device.
 	DetachFileDevice(path string) error
 	// GetLoopDevice returns the full path to the loop device associated with the given path.
-	GetLoopDevice(path string) (string, error)
+	GetLoopDevice(path string, detectDeletedDevice bool) (string, error)
 }
 
 // NewBlockVolumePathHandler returns a new instance of BlockVolumeHandler.

--- a/pkg/volume/util/volumepathhandler/volume_path_handler_linux_test.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler_linux_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumepathhandler
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	utiltesting "k8s.io/client-go/util/testing"
+)
+
+func TestDetachFileDevice(t *testing.T) {
+	blockVolumePathHandler := NewBlockVolumePathHandler()
+	retryInterval := 100 * time.Millisecond
+	retryCount := 5
+
+	tests := []struct {
+		description string
+		setupFunc   func(path string) (string, string, error)
+		assertFunc  func(blockDevicePath string) error
+	}{
+		{
+			description: "detach loopback device corresponding to an existing backing file",
+			setupFunc: func(path string) (string, string, error) {
+				filePath := filepath.Join(path, "file")
+				if err := createFile(filePath, 1024*1024); err != nil {
+					return "", "", err
+				}
+				blockDevicePath, err := makeLoopDevice(filePath)
+				if err != nil {
+					return "", "", err
+				}
+				return filePath, blockDevicePath, nil
+
+			},
+			assertFunc: func(blockDevicePath string) error {
+				return verifyBlockDeviceRemoval(blockDevicePath, retryInterval, retryCount)
+			},
+		},
+		{
+			description: "detach loopback device corresponding to non existing backing file",
+			setupFunc: func(path string) (string, string, error) {
+				filePath := filepath.Join(path, "file")
+				if err := createFile(filePath, 1024*1024); err != nil {
+					return "", "", err
+				}
+				blockDevicePath, err := makeLoopDevice(filePath)
+				if err != nil {
+					return "", "", err
+				}
+				// Simulate an unexpected detachment and reattachment of the backing file
+				e := os.Remove(filePath)
+				if e != nil {
+					return "", "", err
+				}
+				if err := createFile(filePath, 512*1024); err != nil {
+					return "", "", err
+				}
+				return filePath, blockDevicePath, nil
+
+			},
+			assertFunc: func(blockDevicePath string) error {
+				return verifyBlockDeviceRemoval(blockDevicePath, retryInterval, retryCount)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			tmpDir, err := utiltesting.MkTmpdir("volume_path_handler_linux")
+			if err != nil {
+				t.Fatalf("error creating temp dir: %v", err)
+			}
+			var blockDeviceToCleanUp []string
+
+			defer func() {
+				for _, blockDevicePath := range blockDeviceToCleanUp {
+					removeLoopDevice(blockDevicePath)
+				}
+				os.RemoveAll(tmpDir)
+			}()
+
+			filePath, blockDevicePath, err := test.setupFunc(tmpDir)
+			if err != nil {
+				t.Fatalf("for %s error running setup with: %v", test.description, err)
+			}
+			blockDeviceToCleanUp = append(blockDeviceToCleanUp, blockDevicePath)
+
+			err = blockVolumePathHandler.DetachFileDevice(filePath)
+			if err != nil {
+				t.Fatalf("for %s error detaching device with: %v", test.description, err)
+			}
+
+			err = test.assertFunc(blockDevicePath)
+			if err != nil {
+				t.Fatalf("for %s error verifying removing device: %v", test.description, err)
+			}
+		})
+	}
+}
+
+func createFile(filePath string, size int64) error {
+	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		return err
+	}
+	_, err = io.CopyN(file, rand.Reader, size)
+	if err != nil {
+		return err
+	}
+	file.Close()
+	return nil
+}
+
+func verifyBlockDeviceRemoval(blockDevicePath string, retryInterval time.Duration, retryCount int) error {
+	args := []string{blockDevicePath}
+	for i := 0; i < retryCount; i++ {
+		time.Sleep(retryInterval)
+		cmd := exec.Command(losetupPath, args...)
+		out, err := cmd.CombinedOutput()
+		if strings.Contains(string(out), "No such file or directory") {
+			return nil
+		}
+		fmt.Printf("couldn't verify the removed block device: %v: out: %v, err: %v \n", cmd.String(), string(out), err)
+		fmt.Printf("retrying in %v \n", retryInterval)
+	}
+	return fmt.Errorf("failed to verify that loopback device %v is removed", blockDevicePath)
+}

--- a/pkg/volume/util/volumepathhandler/volume_path_handler_unsupported.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler_unsupported.go
@@ -38,7 +38,7 @@ func (v VolumePathHandler) DetachFileDevice(path string) error {
 }
 
 // GetLoopDevice returns the full path to the loop device associated with the given path.
-func (v VolumePathHandler) GetLoopDevice(path string) (string, error) {
+func (v VolumePathHandler) GetLoopDevice(path string, detectDeletedDevice bool) (string, error) {
 	return "", fmt.Errorf("GetLoopDevice not supported for this build.")
 }
 


### PR DESCRIPTION
Signed-off-by: Phan Le <phan.le@suse.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Kubelet should be able to identify the deleted block device and finish terminating a pod when the corresponding block device is already removed from the node.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #109132 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
