### PR TITLE
Add printer benchmarks

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/bench_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/bench_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func newBenchmarkList() *unstructured.UnstructuredList {
+	list := &unstructured.UnstructuredList{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "PodList",
+		},
+		Items: []unstructured.Unstructured{},
+	}
+	for i := 0; i < 1000; i++ {
+		list.Items = append(list.Items, unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":      fmt.Sprintf("pod%d", i),
+					"namespace": "ns",
+					"labels": map[string]interface{}{
+						"first-label":  "12",
+						"second-label": "label-value",
+					},
+				},
+			},
+		})
+	}
+	return list
+}
+
+func newBenchmarkTable() *metav1.Table {
+	table := &metav1.Table{
+		ColumnDefinitions: []metav1.TableColumnDefinition{
+			{Name: "Name", Type: "string"},
+			{Name: "Ready", Type: "string"},
+			{Name: "Status", Type: "string"},
+			{Name: "Retries", Type: "integer"},
+			{Name: "Age", Type: "string"},
+		},
+		Rows: []metav1.TableRow{},
+	}
+	for _, pod := range newBenchmarkList().Items {
+		raw, _ := json.Marshal(pod)
+		table.Rows = append(table.Rows, metav1.TableRow{
+			Cells: []interface{}{pod.GetName(), "1/1", "Ready", int64(0), "20h"},
+			Object: runtime.RawExtension{
+				Raw:    raw,
+				Object: &pod,
+			},
+		})
+	}
+	return table
+}
+
+func BenchmarkDiscardingPrinter(b *testing.B) {
+	data := newBenchmarkList()
+	b.ResetTimer()
+	benchmarkPrinter(b, func() ResourcePrinter { return NewDiscardingPrinter() }, data)
+}
+
+func BenchmarkJSONPrinter(b *testing.B) {
+	data := newBenchmarkList()
+	b.ResetTimer()
+	benchmarkPrinter(b, func() ResourcePrinter { return &JSONPrinter{} }, data)
+}
+
+func BenchmarkJSONPathPrinter(b *testing.B) {
+	data := newBenchmarkList()
+	b.ResetTimer()
+	benchmarkPrinter(b, func() ResourcePrinter {
+		printer, _ := NewJSONPathPrinter("{range .items[*]}{.metadata.name}\n{end}")
+		return printer
+	}, data)
+}
+
+func BenchmarkYAMLPrinter(b *testing.B) {
+	data := newBenchmarkList()
+	b.ResetTimer()
+	benchmarkPrinter(b, func() ResourcePrinter { return &YAMLPrinter{} }, data)
+}
+
+func BenchmarkTablePrinter(b *testing.B) {
+	data := newBenchmarkTable()
+	b.ResetTimer()
+	benchmarkPrinter(b, func() ResourcePrinter { return NewTablePrinter(PrintOptions{}) }, data)
+}
+
+func BenchmarkGoTemplatePrinter(b *testing.B) {
+	data := newBenchmarkList()
+	b.ResetTimer()
+	benchmarkPrinter(b, func() ResourcePrinter {
+		printer, _ := NewGoTemplatePrinter([]byte("{{range .items}}{{.metadata.name}}{{\"\\n\"}}{{end}}"))
+		return printer
+	}, data)
+}
+
+func BenchmarkNamePrinter(b *testing.B) {
+	data := newBenchmarkList()
+	b.ResetTimer()
+	benchmarkPrinter(b, func() ResourcePrinter { return &NamePrinter{} }, data)
+}
+
+func BenchmarkOmitManagedFieldsPrinter(b *testing.B) {
+	data := newBenchmarkList()
+	b.ResetTimer()
+	benchmarkPrinter(b, func() ResourcePrinter { return &OmitManagedFieldsPrinter{Delegate: NewDiscardingPrinter()} }, data)
+}
+
+func BenchmarkTypeSetterPrinter(b *testing.B) {
+	data := newBenchmarkList()
+	b.ResetTimer()
+	benchmarkPrinter(b, func() ResourcePrinter { return NewTypeSetter(scheme.Scheme).ToPrinter(NewDiscardingPrinter()) }, data)
+}
+
+func benchmarkPrinter(b *testing.B, printerFunc func() ResourcePrinter, data runtime.Object) {
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			buf := &bytes.Buffer{}
+			if err := printerFunc().PrintObj(data, buf); err != nil {
+				b.Errorf("PrintObj failed: %v", err)
+			}
+		}
+	})
+}

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/interface.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/interface.go
@@ -33,7 +33,7 @@ func (fn ResourcePrinterFunc) PrintObj(obj runtime.Object, w io.Writer) error {
 
 // ResourcePrinter is an interface that knows how to print runtime objects.
 type ResourcePrinter interface {
-	// Print receives a runtime object, formats it and prints it to a writer.
+	// PrintObj receives a runtime object, formats it and prints it to a writer.
 	PrintObj(runtime.Object, io.Writer) error
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
@@ -449,7 +449,7 @@ func formatEventType(eventType string) string {
 	if formatted, ok := formattedEventType[eventType]; ok {
 		return formatted
 	}
-	return string(eventType)
+	return eventType
 }
 
 // printRows writes the provided rows to output.
@@ -499,7 +499,7 @@ func formatLabelHeaders(columnLabels []string) []string {
 	formHead := make([]string, len(columnLabels))
 	for i, l := range columnLabels {
 		p := strings.Split(l, "/")
-		formHead[i] = strings.ToUpper((p[len(p)-1]))
+		formHead[i] = strings.ToUpper(p[len(p)-1])
 	}
 	return formHead
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
It has been reported that [kubectl uses far more memory than expected](https://github.com/kubernetes/kubectl/issues/978) when generating YAML output.

This PR adds benchmark tests for each of the printers in cli-runtime so that the current performance and potential future improvements can be measured.

Below is the output of these new benchmarks.  As expected, it shows the YAML printer to be >6x slower than JSON printer, using much more memory, and performing many more allocs:
```
$ go test ./pkg/printers -bench=.
goos: linux
goarch: amd64
pkg: k8s.io/cli-runtime/pkg/printers
cpu: Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz
BenchmarkDiscardingPrinter-12                   64136649                18.00 ns/op           48 B/op          1 allocs/op
BenchmarkJSONPrinter-12                              720           1615934 ns/op         3761403 B/op      31052 allocs/op
BenchmarkJSONPathPrinter-12                         2689            414798 ns/op          738164 B/op      15106 allocs/op
BenchmarkYAMLPrinter-12                               94          11862945 ns/op        24425175 B/op     170207 allocs/op
BenchmarkTablePrinter-12                            2088            507256 ns/op          487057 B/op       5068 allocs/op
BenchmarkGoTemplatePrinter-12                        553           2003169 ns/op         3689067 B/op      62891 allocs/op
BenchmarkNamePrinter-12                             7862            159113 ns/op          132548 B/op       4014 allocs/op
BenchmarkOmitManagedFieldsPrinter-12                2900            366321 ns/op         1024627 B/op       7006 allocs/op
BenchmarkTypeSetterPrinter-12                   25549080                45.86 ns/op           80 B/op          2 allocs/op
PASS
ok      k8s.io/cli-runtime/pkg/printers 13.136s
```

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:
While working in the printers package, I also cleaned up a few minor code issues:
- Remove redundant parentheses.
- Remove unnecessary type conversion of string to string.
- Fix wrong function name in comment.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
