### PR TITLE
deprecate vsphere releases less than 7.0u2 for in-tree vsphere volumes 

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -306,7 +306,7 @@ const (
 	InTreePluginAzureFileUnregister featuregate.Feature = "InTreePluginAzureFileUnregister"
 
 	// owner: @divyenpatel
-	// beta: v1.19 (requires: vSphere vCenter/ESXi Version: 7.0u1, HW Version: VM version 15)
+	// beta: v1.19 (requires: vSphere vCenter/ESXi Version: 7.0u2, HW Version: VM version 15)
 	//
 	// Enables the vSphere in-tree driver to vSphere CSI Driver migration feature.
 	CSIMigrationvSphere featuregate.Feature = "CSIMigrationvSphere"

--- a/staging/src/k8s.io/legacy-cloud-providers/go.mod
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.16.1-0.20210702024009-ea6160c1d0e3
 	github.com/aws/aws-sdk-go v1.38.49
-	github.com/blang/semver/v4 v4.0.0
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/golang/mock v1.5.0

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/constants.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/constants.go
@@ -53,7 +53,7 @@ const (
 	ClusterComputeResourceType = "ClusterComputeResource"
 	HostSystemType             = "HostSystem"
 	NameProperty               = "name"
-	MinvCenterVersion          = "6.7.0"
+	MinvCenterVersion          = "7.0.2"
 )
 
 // Test Constants

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
-	"github.com/blang/semver/v4"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -202,32 +202,82 @@ func VerifyVolumePathsForVMDevices(vmDevices object.VirtualDeviceList, volPaths 
 }
 
 // isvCenterDeprecated takes vCenter version and vCenter API version as input and return true if vCenter is deprecated
-func isvCenterDeprecated(vCenterVersion string, vCenerAPIVersion string) (bool, error) {
-	minvcversion, err := semver.New(MinvCenterVersion)
-	vcdeprecated := false
+func isvCenterDeprecated(vCenterVersion string, vCenterAPIVersion string) (bool, error) {
+	var vcversion, vcapiversion, minvcversion vcVersion
+	var err error
+	err = vcversion.parse(vCenterVersion)
 	if err != nil {
-		return false, fmt.Errorf("failed to get parse vCenter version: %s. err: %+v", MinvCenterVersion, err)
-	} else {
-		vcversion, err := semver.New(vCenterVersion)
+		return false, fmt.Errorf("failed to parse vCenter version: %s. err: %+v", vCenterVersion, err)
+	}
+	err = vcapiversion.parse(vCenterAPIVersion)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse vCenter API version: %s. err: %+v", vCenterAPIVersion, err)
+	}
+	err = minvcversion.parse(MinvCenterVersion)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse minimum vCenter version: %s. err: %+v", MinvCenterVersion, err)
+	}
+	if vcversion.isLessThan(minvcversion) && vcapiversion.isLessThan(minvcversion) {
+		return true, nil
+	}
+	return false, nil
+}
+
+// vcVersion represents a VC version
+type vcVersion struct {
+	Major    int64
+	Minor    int64
+	Revision int64
+	Build    int64
+}
+
+// parse helps parse version string to VCVersion
+// returns error when parse fail
+func (v *vcVersion) parse(version string) error {
+	for index, value := range strings.Split(version, ".") {
+		var err error
+		if index == 0 {
+			v.Major, err = strconv.ParseInt(value, 10, 64)
+		} else if index == 1 {
+			v.Minor, err = strconv.ParseInt(value, 10, 64)
+		} else if index == 2 {
+			v.Revision, err = strconv.ParseInt(value, 10, 64)
+		} else if index == 3 {
+			v.Build, err = strconv.ParseInt(value, 10, 64)
+		}
 		if err != nil {
-			return false, fmt.Errorf("failed to parse vCenter version: %s. err: %+v", vCenterVersion, err)
-		} else {
-			result := vcversion.Compare(*minvcversion)
-			if result == -1 {
-				// vcversion is less than minvcversion
-				vcdeprecated = true
-			} else if result == 0 {
-				// vcversion is equal to minvcversion
-				// check patch version
-				vcapiversion, err := semver.ParseTolerant(vCenerAPIVersion)
-				if err != nil {
-					return false, fmt.Errorf("failed to parse vCenter api version: %s. err: %+v", vCenerAPIVersion, err)
-				}
-				if vcapiversion.Patch < 3 {
-					vcdeprecated = true
-				}
-			}
+			return fmt.Errorf("failed to parse version: %q, err: %v", version, err)
 		}
 	}
-	return vcdeprecated, nil
+	return nil
+}
+
+// isLessThan compares VCVersion v to o and returns
+// true if v is less than o
+func (v *vcVersion) isLessThan(o vcVersion) bool {
+	if v.Major != o.Major {
+		if v.Major > o.Major {
+			return false
+		}
+		return true
+	}
+	if v.Minor != o.Minor {
+		if v.Minor > o.Minor {
+			return false
+		}
+		return true
+	}
+	if v.Revision != o.Revision {
+		if v.Revision > o.Revision {
+			return false
+		}
+		return true
+	}
+	if v.Build != o.Build {
+		if v.Build > o.Build {
+			return false
+		}
+		return true
+	}
+	return false
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils_test.go
@@ -70,72 +70,36 @@ func TestUtils(t *testing.T) {
 	}
 }
 
-func TestIsvCenter70update1Deprecated(t *testing.T) {
-	vcdeprecated, err := isvCenterDeprecated("7.0.1", "7.0.1.1")
-	if err != nil {
-		t.Fatal(err)
+func TestIsvCenterDeprecated(t *testing.T) {
+	type testsData struct {
+		vcVersion    string
+		vcAPIVersion string
+		isDeprecated bool
 	}
-	if vcdeprecated {
-		t.Fatal("vSphere 7.0 update1 should not be deprecated")
+	testdataArray := []testsData{
+		{"8.0.0", "8.0.0.0", false},
+		{"7.0.3", "7.0.3.0", false},
+		{"7.0.2", "7.0.2.0", false},
+		{"7.0.1", "7.0.1.1", true},
+		{"7.0.0", "7.0.0.0", true},
+		{"6.7.0", "6.7.3", true},
+		{"6.7.0", "6.7", true},
+		{"6.7.0", "6.7.2", true},
+		{"6.7.0", "6.7.1", true},
+		{"6.5.0", "6.5", true},
 	}
-}
 
-func TestIsvCenter70Deprecated(t *testing.T) {
-	vcdeprecated, err := isvCenterDeprecated("7.0.0", "7.0.0.0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if vcdeprecated {
-		t.Fatal("vSphere 7.0 should not be deprecated")
-	}
-}
-
-func TestIsvCenter67u3Deprecated(t *testing.T) {
-	vcdeprecated, err := isvCenterDeprecated("6.7.0", "6.7.3")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if vcdeprecated {
-		t.Fatal("vSphere 67u3 should not be deprecated")
-	}
-}
-
-func TestIsvCenter67Deprecated(t *testing.T) {
-	vcdeprecated, err := isvCenterDeprecated("6.7.0", "6.7")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !vcdeprecated {
-		t.Fatal("vSphere 6.7 should be deprecated")
-	}
-}
-
-func TestIsvCenter67u2Deprecated(t *testing.T) {
-	vcdeprecated, err := isvCenterDeprecated("6.7.0", "6.7.2")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !vcdeprecated {
-		t.Fatal("vSphere 6.7 update 2 should be deprecated")
-	}
-}
-
-func TestIsvCenter67u1Deprecated(t *testing.T) {
-	vcdeprecated, err := isvCenterDeprecated("6.7.0", "6.7.1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !vcdeprecated {
-		t.Fatal("vSphere 6.7 update 1 should be deprecated")
-	}
-}
-
-func TestIsvCenter65Deprecated(t *testing.T) {
-	vcdeprecated, err := isvCenterDeprecated("6.5.0", "6.5")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !vcdeprecated {
-		t.Fatal("vSphere 6.5 should be deprecated")
+	for _, test := range testdataArray {
+		deprecated, err := isvCenterDeprecated(test.vcVersion, test.vcAPIVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if deprecated != test.isDeprecated {
+			t.Fatalf("deprecation test failed for vc version: %q and vc API version: %q",
+				test.vcVersion, test.vcAPIVersion)
+		} else {
+			t.Logf("deprecation test for vc version: %q and vc API version: %q passed. Is Deprecated : %v",
+				test.vcAPIVersion, test.vcAPIVersion, deprecated)
+		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind deprecation

#### What this PR does / why we need it:
This PR is deprecating vSp[here](https://lifecycle.vmware.com/#/) releases less than 7.0u2 for in-tree vSp[here](https://blogs.vmware.com/vsphere/2020/06/announcing-extension-of-vsphere-6-7-general-support-period.html) volumes.

General Support for vSphere 6.7 will end on October 15, 2022 as documented here and here. vSphere 6.7 Update 3 is deprecated in Kubernetes v1.24. Customers are recommended to upgrade vSphere (both ESXi and vCenter) to 7.0u2 or above. vSphere CSI Driver 2.2.3 and higher supports CSI Migration.


#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

Unit Tests executed
```
% go test -v -run TestIsvCenterDeprecated
=== RUN   TestIsvCenterDeprecated
    utils_test.go:101: deprecation test for vc version: "8.0.0.0" and vc API version: "8.0.0.0" passed. Is Deprecated : false
    utils_test.go:101: deprecation test for vc version: "7.0.3.0" and vc API version: "7.0.3.0" passed. Is Deprecated : false
    utils_test.go:101: deprecation test for vc version: "7.0.2.0" and vc API version: "7.0.2.0" passed. Is Deprecated : false
    utils_test.go:101: deprecation test for vc version: "7.0.1.1" and vc API version: "7.0.1.1" passed. Is Deprecated : true
    utils_test.go:101: deprecation test for vc version: "7.0.0.0" and vc API version: "7.0.0.0" passed. Is Deprecated : true
    utils_test.go:101: deprecation test for vc version: "6.7.3" and vc API version: "6.7.3" passed. Is Deprecated : true
    utils_test.go:101: deprecation test for vc version: "6.7" and vc API version: "6.7" passed. Is Deprecated : true
    utils_test.go:101: deprecation test for vc version: "6.7.2" and vc API version: "6.7.2" passed. Is Deprecated : true
    utils_test.go:101: deprecation test for vc version: "6.7.1" and vc API version: "6.7.1" passed. Is Deprecated : true
    utils_test.go:101: deprecation test for vc version: "6.5" and vc API version: "6.5" passed. Is Deprecated : true
--- PASS: TestIsvCenterDeprecated (0.00s)
PASS
ok      k8s.io/legacy-cloud-providers/vsphere/vclib     0.264s
```

#### Does this PR introduce a user-facing change?

```release-note
ACTION REQUIRED: 

vSphere releases less than 7.0u2 are deprecated as of v1.24. Please consider upgrading vSphere to 7.0u2 or above. vSphere CSI Driver requires minimum vSphere 7.0u2.

General Support for vSphere 6.7 will end on October 15, 2022. vSphere 6.7 Update 3 is deprecated in Kubernetes v1.24.  Customers are recommended to upgrade vSphere (both ESXi and vCenter) to 7.0u2 or above.  vSphere CSI Driver 2.2.3 and higher supports CSI Migration.

Support for these deprecations will be available till October 15, 2022.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

cc: @xing-yang 