### PR TITLE
Start drafting timing histogram

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -22,6 +22,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	thprom "k8s.io/component-base/metrics/prometheusextension"
 
 	"k8s.io/klog/v2"
 )
@@ -203,6 +204,7 @@ func (c *selfCollector) Collect(ch chan<- prometheus.Metric) {
 // no-op vecs for convenience
 var noopCounterVec = &prometheus.CounterVec{}
 var noopHistogramVec = &prometheus.HistogramVec{}
+var noopTimingHistogramVec = &thprom.TimingHistogramVec{}
 var noopGaugeVec = &prometheus.GaugeVec{}
 var noopObserverVec = &noopObserverVector{}
 

--- a/staging/src/k8s.io/component-base/metrics/opts.go
+++ b/staging/src/k8s.io/component-base/metrics/opts.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/sets"
+	thprom "k8s.io/component-base/metrics/prometheusextension"
 )
 
 var (
@@ -186,6 +187,54 @@ func (o *HistogramOpts) toPromHistogramOpts() prometheus.HistogramOpts {
 		Help:        o.Help,
 		ConstLabels: o.ConstLabels,
 		Buckets:     o.Buckets,
+	}
+}
+
+// TimingHistogramOpts bundles the options for creating a Histogram metric. It is
+// mandatory to set Name to a non-empty string. All other fields are optional
+// and can safely be left at their zero value, although it is strongly
+// encouraged to set a Help string.
+type TimingHistogramOpts struct {
+	Namespace            string
+	Subsystem            string
+	Name                 string
+	Help                 string
+	ConstLabels          map[string]string
+	Buckets              []float64
+	InitialValue         float64
+	DeprecatedVersion    string
+	deprecateOnce        sync.Once
+	annotateOnce         sync.Once
+	StabilityLevel       StabilityLevel
+	LabelValueAllowLists *MetricLabelAllowList
+}
+
+// Modify help description on the metric description.
+func (o *TimingHistogramOpts) markDeprecated() {
+	o.deprecateOnce.Do(func() {
+		o.Help = fmt.Sprintf("(Deprecated since %v) %v", o.DeprecatedVersion, o.Help)
+	})
+}
+
+// annotateStabilityLevel annotates help description on the metric description with the stability level
+// of the metric
+func (o *TimingHistogramOpts) annotateStabilityLevel() {
+	o.annotateOnce.Do(func() {
+		o.Help = fmt.Sprintf("[%v] %v", o.StabilityLevel, o.Help)
+	})
+}
+
+// convenience function to allow easy transformation to the prometheus
+// counterpart. This will do more once we have a proper label abstraction
+func (o *TimingHistogramOpts) toPromTimingHistogramOpts() thprom.TimingHistogramOpts {
+	return thprom.TimingHistogramOpts{
+		Namespace:    o.Namespace,
+		Subsystem:    o.Subsystem,
+		Name:         o.Name,
+		Help:         o.Help,
+		ConstLabels:  o.ConstLabels,
+		Buckets:      o.Buckets,
+		InitialValue: o.InitialValue,
 	}
 }
 

--- a/staging/src/k8s.io/component-base/metrics/prometheusextension/timing_histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheusextension/timing_histogram.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheusextension
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"k8s.io/utils/clock"
+)
+
+// WritableVariable is a `float64`-valued variable that can be written to.
+type WritableVariable interface {
+	// Set the variable to the given value.
+	Set(float64)
+
+	// Add the given change to the variable
+	Add(float64)
+}
+
+// A TimingHistogram tracks how long a `float64` variable spends in
+// ranges defined by buckets.  Time is counted in nanoseconds.  The
+// histogram's sum is the integral over time (in nanoseconds, from
+// creation of the histogram) of the variable's value.
+type TimingHistogram interface {
+	prometheus.Metric
+	prometheus.Collector
+	WritableVariable
+}
+
+// TimingHistogramOpts is the parameters of the TimingHistogram constructor
+type TimingHistogramOpts struct {
+	Namespace   string
+	Subsystem   string
+	Name        string
+	Help        string
+	ConstLabels prometheus.Labels
+
+	// Buckets defines the buckets into which observations are
+	// accumulated. Each element in the slice is the upper
+	// inclusive bound of a bucket. The values must be sorted in
+	// strictly increasing order. There is no need to add a
+	// highest bucket with +Inf bound. The default value is
+	// prometheus.DefBuckets.
+	Buckets []float64
+
+	// The initial value of the variable.
+	InitialValue float64
+}
+
+// NewTimingHistogram creates a new TimingHistogram
+func NewTimingHistogram(opts TimingHistogramOpts) (TimingHistogram, error) {
+	return NewTestableTimingHistogram(clock.RealClock{}, opts)
+}
+
+// NewTestableTimingHistogram creates a TimingHistogram that uses a mockable clock
+func NewTestableTimingHistogram(clock clock.PassiveClock, opts TimingHistogramOpts) (TimingHistogram, error) {
+	desc := prometheus.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, opts.Subsystem, opts.Name),
+		opts.Help,
+		nil,
+		opts.ConstLabels,
+	)
+	return newTimingHistogram(clock, desc, opts)
+}
+
+func newTimingHistogram(clock clock.PassiveClock, desc *prometheus.Desc, opts TimingHistogramOpts, variableLabelValues ...string) (TimingHistogram, error) {
+	if len(opts.Buckets) == 0 {
+		opts.Buckets = prometheus.DefBuckets
+	}
+
+	for i, upperBound := range opts.Buckets {
+		if i < len(opts.Buckets)-1 {
+			if upperBound >= opts.Buckets[i+1] {
+				return nil, fmt.Errorf(
+					"histogram buckets must be in increasing order: %f >= %f",
+					upperBound, opts.Buckets[i+1],
+				)
+			}
+		} else {
+			if math.IsInf(upperBound, +1) {
+				// The +Inf bucket is implicit. Remove it here.
+				opts.Buckets = opts.Buckets[:i]
+			}
+		}
+	}
+	upperBounds := make([]float64, len(opts.Buckets))
+	copy(upperBounds, opts.Buckets)
+
+	return &timingHistogram{
+		desc:                desc,
+		variableLabelValues: variableLabelValues,
+		clock:               clock,
+		upperBounds:         upperBounds,
+		buckets:             make([]time.Duration, len(upperBounds)+1),
+		lastSetTime:         clock.Now(),
+		value:               opts.InitialValue,
+		hotCount:            initialHotCount,
+	}, nil
+}
+
+// initialHotCount is the negative of the number of terms
+// that are summed into sumHot before it makes another term
+// of sumCold.
+const initialHotCount = -1000000
+
+type timingHistogram struct {
+	desc                *prometheus.Desc
+	variableLabelValues []string
+	clock               clock.PassiveClock
+	upperBounds         []float64 // exclusive of +Inf
+
+	lock sync.Mutex // applies to all the following
+
+	// buckets is longer by one than upperBounds.
+	// For 0 <= idx < len(upperBounds), buckets[idx] holds the
+	// accumulated time.Duration that value has been <=
+	// upperBounds[idx] but not <= upperBounds[idx-1].
+	// buckets[len(upperBounds)] holds the accumulated
+	// time.Duration when value fit in no other bucket.
+	buckets []time.Duration
+
+	// identifies when value was last set
+	lastSetTime time.Time
+	value       float64
+
+	// sumHot + sumCold is the integral of value over time (in
+	// nanoseconds).  Rather than risk loss of precision in one
+	// float64, we do this sum hierarchically.  Many successive
+	// increments are added into sumHot, and once in a great while
+	// that is added into sumCold and reset to zero.
+	sumHot  float64
+	sumCold float64
+
+	// hotCount is used to decide when to dump sumHot into sumCold.
+	// hotCount counts upward from initialHotCount to zero.
+	hotCount int
+}
+
+var _ TimingHistogram = &timingHistogram{}
+
+func (sh *timingHistogram) Set(newValue float64) {
+	sh.update(func(float64) float64 { return newValue })
+}
+
+func (sh *timingHistogram) Add(delta float64) {
+	sh.update(func(oldValue float64) float64 { return oldValue + delta })
+}
+
+func (sh *timingHistogram) update(updateFn func(float64) float64) {
+	sh.lock.Lock()
+	defer sh.lock.Unlock()
+	sh.updateLocked(updateFn)
+}
+
+func (sh *timingHistogram) updateLocked(updateFn func(float64) float64) {
+	now := sh.clock.Now()
+	delta := now.Sub(sh.lastSetTime)
+	if delta > 0 {
+		idx := sort.SearchFloat64s(sh.upperBounds, sh.value)
+		sh.buckets[idx] += delta
+		sh.lastSetTime = now
+		sh.sumHot += float64(delta) * sh.value
+		sh.hotCount++
+		if sh.hotCount >= 0 {
+			sh.sumCold += sh.sumHot
+			sh.sumHot = 0
+			sh.hotCount = initialHotCount
+		}
+	}
+	sh.value = updateFn(sh.value)
+}
+
+func (sh *timingHistogram) Desc() *prometheus.Desc {
+	return sh.desc
+}
+
+func (sh *timingHistogram) Write(dest *dto.Metric) error {
+	sh.lock.Lock()
+	defer sh.lock.Unlock()
+	sh.updateLocked(func(x float64) float64 { return x })
+	nBounds := len(sh.upperBounds)
+	buckets := make(map[float64]uint64, nBounds)
+	var cumCount uint64
+	for idx, upperBound := range sh.upperBounds {
+		cumCount += uint64(sh.buckets[idx])
+		buckets[upperBound] = cumCount
+	}
+	cumCount += uint64(sh.buckets[nBounds])
+	metric, err := prometheus.NewConstHistogram(sh.desc, cumCount, sh.sumHot+sh.sumCold, buckets, sh.variableLabelValues...)
+	if err != nil {
+		return err
+	}
+	return metric.Write(dest)
+}
+
+func (sh *timingHistogram) Describe(ch chan<- *prometheus.Desc) {
+	ch <- sh.desc
+}
+
+func (sh *timingHistogram) Collect(ch chan<- prometheus.Metric) {
+	sh.Add(0)
+	ch <- sh
+}

--- a/staging/src/k8s.io/component-base/metrics/prometheusextension/timing_histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheusextension/timing_histogram_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheusextension
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+
+	testclock "k8s.io/utils/clock/testing"
+)
+
+func TestTimingHistogramNonMonotonicBuckets(t *testing.T) {
+	testCases := map[string][]float64{
+		"not strictly monotonic":  {1, 2, 2, 3},
+		"not monotonic at all":    {1, 2, 4, 3, 5},
+		"have +Inf in the middle": {1, 2, math.Inf(+1), 3},
+	}
+	for name, buckets := range testCases {
+		_, err := NewTimingHistogram(TimingHistogramOpts{
+			Name:    "test_histogram",
+			Help:    "helpless",
+			Buckets: buckets,
+		})
+		if err == nil {
+			t.Errorf("Buckets %v are %s but NewHTimingistogram did not complain.", buckets, name)
+		}
+	}
+}
+
+var testBuckets = []float64{0, 0.5, 1}
+var value0 float64 = 0.25
+
+func exerciseTimingHistogram(th TimingHistogram, t0 time.Time, clk *testclock.FakePassiveClock) func(t *testing.T) {
+	return func(t *testing.T) {
+		v0 := value0
+		t1 := t0.Add(time.Nanosecond)
+		var v1 float64 = 0.75
+		clk.SetTime(t1)
+		th.Set(v1)
+		t2 := t1.Add(time.Microsecond)
+		var d2 float64 = 0.5
+		v2 := v1 + d2
+		clk.SetTime(t2)
+		th.Add(d2)
+		t3 := t2
+		for i := 0; i < 1000000; i++ {
+			t3 = t3.Add(time.Nanosecond)
+			clk.SetTime(t3)
+			th.Set(v2)
+		}
+		var d3 float64 = -0.6
+		v3 := v2 + d3
+		th.Add(d3)
+		t4 := t3.Add(time.Second)
+		clk.SetTime(t4)
+
+		metric := &dto.Metric{}
+		err := th.Write(metric)
+		if err != nil {
+			t.Error(err)
+		}
+		wroteHist := metric.Histogram
+		if want, got := uint64(t4.Sub(t0)), wroteHist.GetSampleCount(); want != got {
+			t.Errorf("Wanted %v but got %v", want, got)
+		}
+		if want, got := float64(t1.Sub(t0))*v0+float64(t2.Sub(t1))*v1+float64(t3.Sub(t2))*v2+float64(t4.Sub(t3))*v3, wroteHist.GetSampleSum(); want != got {
+			t.Errorf("Wanted %v but got %v", want, got)
+		}
+		wroteBuckets := wroteHist.GetBucket()
+		if len(wroteBuckets) != len(testBuckets) {
+			t.Errorf("Got buckets %#+v", wroteBuckets)
+		}
+		expectedCounts := []time.Duration{0, t1.Sub(t0), t2.Sub(t0) + t4.Sub(t3)}
+		for idx, ub := range testBuckets {
+			if want, got := wroteBuckets[idx].GetCumulativeCount(), uint64(expectedCounts[idx]); want != got {
+				t.Errorf("In bucket %d, wanted %v but got %v", idx, want, got)
+			}
+			if want, got := ub, wroteBuckets[idx].GetUpperBound(); want != got {
+				t.Errorf("In bucket %d, wanted %v but got %v", idx, want, got)
+			}
+		}
+	}
+}
+
+func TestTimeIntegration(t *testing.T) {
+	t0 := time.Now()
+	clk := testclock.NewFakePassiveClock(t0)
+	th, err := NewTestableTimingHistogram(clk, TimingHistogramOpts{
+		Name:         "TestTimeIntegration",
+		Help:         "helpless",
+		Buckets:      testBuckets,
+		InitialValue: value0,
+	})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	t.Run("non-vec", exerciseTimingHistogram(th, t0, clk))
+}
+
+func TestVecTimeIntegration(t *testing.T) {
+	t0 := time.Now()
+	clk := testclock.NewFakePassiveClock(t0)
+	thv := NewTestableTimingHistogramVec(clk, TimingHistogramOpts{
+		Name:         "TestTimeIntegration",
+		Help:         "helpless",
+		Buckets:      testBuckets,
+		InitialValue: value0,
+	},
+		[]string{"l1", "l2"})
+	th1, err := thv.GetMetricWithLabelValues("v1", "v2")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	t.Run("th1", exerciseTimingHistogram(th1.(TimingHistogram), t0, clk))
+	clk.SetTime(t0)
+	th2, err := thv.GetMetricWithLabelValues("u1", "u2")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if th1 == th2 {
+		t.Errorf("GetMetricWithLabelValues returned same metric for different labels")
+	}
+	t.Run("th2", exerciseTimingHistogram(th2.(TimingHistogram), t0, clk))
+}

--- a/staging/src/k8s.io/component-base/metrics/prometheusextension/timing_histogram_vec.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheusextension/timing_histogram_vec.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheusextension
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"k8s.io/utils/clock"
+)
+
+type TimingHistogramVec struct {
+	*prometheus.MetricVec
+}
+
+func NewTimingHistogramVec(opts TimingHistogramOpts, variableLabelNames []string) *TimingHistogramVec {
+	return NewTestableTimingHistogramVec(clock.RealClock{}, opts, variableLabelNames)
+}
+
+func NewTestableTimingHistogramVec(clk clock.PassiveClock, opts TimingHistogramOpts, variableLabelNames []string) *TimingHistogramVec {
+	desc := prometheus.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, opts.Subsystem, opts.Name),
+		opts.Help,
+		variableLabelNames,
+		opts.ConstLabels,
+	)
+	return &TimingHistogramVec{
+		MetricVec: prometheus.NewMetricVec(desc, func(variableLabelValues ...string) prometheus.Metric {
+			hist, err := newTimingHistogram(clk, desc, opts, variableLabelValues...)
+			if err != nil {
+				panic(err)
+			}
+			return hist
+		}),
+	}
+}
+
+func (v *TimingHistogramVec) GetMetricWithLabelValues(lvs ...string) (WritableVariable, error) {
+	metric, err := v.MetricVec.GetMetricWithLabelValues(lvs...)
+	if metric != nil {
+		return metric.(WritableVariable), err
+	}
+	return nil, err
+}
+
+func (v *TimingHistogramVec) GetMetricWith(labels prometheus.Labels) (WritableVariable, error) {
+	metric, err := v.MetricVec.GetMetricWith(labels)
+	if metric != nil {
+		return metric.(WritableVariable), err
+	}
+	return nil, err
+}
+
+func (v *TimingHistogramVec) WithLabelValues(lvs ...string) WritableVariable {
+	h, err := v.GetMetricWithLabelValues(lvs...)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}
+
+func (v *TimingHistogramVec) With(labels prometheus.Labels) WritableVariable {
+	h, err := v.GetMetricWith(labels)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}

--- a/staging/src/k8s.io/component-base/metrics/timing_histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/timing_histogram.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+
+	"github.com/blang/semver"
+	thprom "k8s.io/component-base/metrics/prometheusextension"
+)
+
+// TimingHistogram is our internal representation for our wrapping struct around prometheus
+// TimingHistograms. It implements both kubeCollector and WritableVariable
+type TimingHistogram struct {
+	WritableVariable
+	*TimingHistogramOpts
+	lazyMetric
+	selfCollector
+}
+
+// NewTimingHistogram returns an object which is TimingHistogram-like. However, nothing
+// will be measured until the histogram is registered somewhere.
+func NewTimingHistogram(opts *TimingHistogramOpts) *TimingHistogram {
+	opts.StabilityLevel.setDefaults()
+
+	h := &TimingHistogram{
+		TimingHistogramOpts: opts,
+		lazyMetric:          lazyMetric{},
+	}
+	h.setPrometheusHistogram(noopMetric{})
+	h.lazyInit(h, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
+	return h
+}
+
+// setPrometheusHistogram sets the underlying KubeGauge object, i.e. the thing that does the measurement.
+func (h *TimingHistogram) setPrometheusHistogram(histogram thprom.TimingHistogram) {
+	h.WritableVariable = histogram
+	h.initSelfCollection(histogram)
+}
+
+// DeprecatedVersion returns a pointer to the Version or nil
+func (h *TimingHistogram) DeprecatedVersion() *semver.Version {
+	return parseSemver(h.TimingHistogramOpts.DeprecatedVersion)
+}
+
+// initializeMetric invokes the actual prometheus.Histogram object instantiation
+// and stores a reference to it
+func (h *TimingHistogram) initializeMetric() {
+	h.TimingHistogramOpts.annotateStabilityLevel()
+	// this actually creates the underlying prometheus metric.
+	under, err := thprom.NewTimingHistogram(h.TimingHistogramOpts.toPromTimingHistogramOpts())
+	if err != nil {
+		panic(err)
+	}
+	h.setPrometheusHistogram(under)
+}
+
+// initializeDeprecatedMetric invokes the actual prometheus.Histogram object instantiation
+// but modifies the Help description prior to object instantiation.
+func (h *TimingHistogram) initializeDeprecatedMetric() {
+	h.TimingHistogramOpts.markDeprecated()
+	h.initializeMetric()
+}
+
+// WithContext allows the normal Histogram metric to pass in context. The context is no-op now.
+func (h *TimingHistogram) WithContext(ctx context.Context) WritableVariable {
+	return h.WritableVariable
+}
+
+// TimingHistogramVec is the internal representation of our wrapping struct around prometheus
+// TimingHistogramVecs.
+type TimingHistogramVec struct {
+	*thprom.TimingHistogramVec
+	*TimingHistogramOpts
+	lazyMetric
+	originalLabels []string
+}
+
+// NewTimingHistogramVec returns an object which satisfies kubeCollector and wraps the
+// thprom.TimingHistogramVec object. However, the object returned will not measure
+// anything unless the collector is first registered, since the metric is lazily instantiated.
+func NewTimingHistogramVec(opts *TimingHistogramOpts, labels []string) *TimingHistogramVec {
+	opts.StabilityLevel.setDefaults()
+
+	fqName := BuildFQName(opts.Namespace, opts.Subsystem, opts.Name)
+	allowListLock.RLock()
+	if allowList, ok := labelValueAllowLists[fqName]; ok {
+		opts.LabelValueAllowLists = allowList
+	}
+	allowListLock.RUnlock()
+
+	v := &TimingHistogramVec{
+		TimingHistogramVec:  noopTimingHistogramVec,
+		TimingHistogramOpts: opts,
+		originalLabels:      labels,
+		lazyMetric:          lazyMetric{},
+	}
+	v.lazyInit(v, fqName)
+	return v
+}
+
+// DeprecatedVersion returns a pointer to the Version or nil
+func (v *TimingHistogramVec) DeprecatedVersion() *semver.Version {
+	return parseSemver(v.TimingHistogramOpts.DeprecatedVersion)
+}
+
+func (v *TimingHistogramVec) initializeMetric() {
+	v.TimingHistogramOpts.annotateStabilityLevel()
+	v.TimingHistogramVec = thprom.NewTimingHistogramVec(v.TimingHistogramOpts.toPromTimingHistogramOpts(), v.originalLabels)
+}
+
+func (v *TimingHistogramVec) initializeDeprecatedMetric() {
+	v.TimingHistogramOpts.markDeprecated()
+	v.initializeMetric()
+}
+
+// Default Prometheus behavior actually results in the creation of a new metric
+// if a metric with the unique label values is not found in the underlying stored metricMap.
+// This means  that if this function is called but the underlying metric is not registered
+// (which means it will never be exposed externally nor consumed), the metric will exist in memory
+// for perpetuity (i.e. throughout application lifecycle).
+//
+// For reference: https://github.com/prometheus/client_golang/blob/v0.9.2/prometheus/histogram.go#L460-L470
+
+// WithLabelValues returns the WritableVariable for the given slice of label
+// values (same order as the VariableLabels in Desc). If that combination of
+// label values is accessed for the first time, a new WritableVariable is created IFF the HistogramVec
+// has been registered to a metrics registry.
+func (v *TimingHistogramVec) WithLabelValues(lvs ...string) WritableVariable {
+	if !v.IsCreated() {
+		return noop
+	}
+	if v.LabelValueAllowLists != nil {
+		v.LabelValueAllowLists.ConstrainToAllowedList(v.originalLabels, lvs)
+	}
+	return v.TimingHistogramVec.WithLabelValues(lvs...)
+}
+
+// With returns the ObserverMetric for the given Labels map (the label names
+// must match those of the VariableLabels in Desc). If that label map is
+// accessed for the first time, a new ObserverMetric is created IFF the HistogramVec has
+// been registered to a metrics registry.
+func (v *TimingHistogramVec) With(labels map[string]string) WritableVariable {
+	if !v.IsCreated() {
+		return noop
+	}
+	if v.LabelValueAllowLists != nil {
+		v.LabelValueAllowLists.ConstrainLabelMap(labels)
+	}
+	return v.TimingHistogramVec.With(labels)
+}
+
+// Delete deletes the metric where the variable labels are the same as those
+// passed in as labels. It returns true if a metric was deleted.
+//
+// It is not an error if the number and names of the Labels are inconsistent
+// with those of the VariableLabels in Desc. However, such inconsistent Labels
+// can never match an actual metric, so the method will always return false in
+// that case.
+func (v *TimingHistogramVec) Delete(labels map[string]string) bool {
+	if !v.IsCreated() {
+		return false // since we haven't created the metric, we haven't deleted a metric with the passed in values
+	}
+	return v.TimingHistogramVec.Delete(labels)
+}
+
+// Reset deletes all metrics in this vector.
+func (v *TimingHistogramVec) Reset() {
+	if !v.IsCreated() {
+		return
+	}
+
+	v.TimingHistogramVec.Reset()
+}
+
+// WithContext returns wrapped HistogramVec with context
+func (v *TimingHistogramVec) WithContext(ctx context.Context) *TimingHistogramVecWithContext {
+	return &TimingHistogramVecWithContext{
+		ctx:                ctx,
+		TimingHistogramVec: *v,
+	}
+}
+
+// HistogramVecWithContext is the wrapper of HistogramVec with context.
+type TimingHistogramVecWithContext struct {
+	TimingHistogramVec
+	ctx context.Context
+}
+
+// WithLabelValues is the wrapper of HistogramVec.WithLabelValues.
+func (vc *TimingHistogramVecWithContext) WithLabelValues(lvs ...string) WritableVariable {
+	return vc.TimingHistogramVec.WithLabelValues(lvs...)
+}
+
+// With is the wrapper of HistogramVec.With.
+func (vc *TimingHistogramVecWithContext) With(labels map[string]string) WritableVariable {
+	return vc.TimingHistogramVec.With(labels)
+}

--- a/staging/src/k8s.io/component-base/metrics/wrappers.go
+++ b/staging/src/k8s.io/component-base/metrics/wrappers.go
@@ -70,6 +70,15 @@ type ObserverMetric interface {
 	Observe(float64)
 }
 
+// WritableVariable is a `float64`-valued variable that can be written to.
+type WritableVariable interface {
+	// Set the variable to the given value.
+	Set(float64)
+
+	// Add the given change to the variable
+	Add(float64)
+}
+
 // PromRegistry is an interface which implements a subset of prometheus.Registerer and
 // prometheus.Gatherer interfaces
 type PromRegistry interface {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1955,6 +1955,7 @@ k8s.io/component-base/metrics/prometheus/ratelimiter
 k8s.io/component-base/metrics/prometheus/restclient
 k8s.io/component-base/metrics/prometheus/version
 k8s.io/component-base/metrics/prometheus/workqueue
+k8s.io/component-base/metrics/prometheusextension
 k8s.io/component-base/metrics/testutil
 k8s.io/component-base/term
 k8s.io/component-base/traces


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR introduces a new variant of Prometheus histograms, intended to eventually replace the existing sample-and-watermark histograms in k/apiserver/pkg/util/flowcontrol with something less complex to consume and less costly at runtime to update.  This new variant keeps track of the time that the relevant variable spends in each of the ranges defined by the bucket boundaries.

This variant of histograms is hoped to eventually migrate into prometheus.  Until then, it resides in k/component-base/metrics/prometheusextension .

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:
This is part of addressing #108272 .

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
TBD
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
