### PR TITLE
Update rs.extensions to rs.apps

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
@@ -46,7 +46,7 @@ var (
 		kubectl create clusterrole pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
 
 		# Create a cluster role named "foo" with API Group specified
-		kubectl create clusterrole foo --verb=get,list,watch --resource=rs.extensions
+		kubectl create clusterrole foo --verb=get,list,watch --resource=rs.apps
 
 		# Create a cluster role named "foo" with SubResource specified
 		kubectl create clusterrole foo --verb=get,list,watch --resource=pods,pods/status

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -51,7 +51,7 @@ var (
 		kubectl create role pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
 
 		# Create a role named "foo" with API Group specified
-		kubectl create role foo --verb=get,list,watch --resource=rs.extensions
+		kubectl create role foo --verb=get,list,watch --resource=rs.apps
 
 		# Create a role named "foo" with SubResource specified
 		kubectl create role foo --verb=get,list,watch --resource=pods,pods/status`))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind documentation

#### What this PR does / why we need it:

This PR updated the` --resource=rs.extensions` to `--resource=rs.apps` in Example  for role and clusterrole create command.

#### Which issue(s) this PR fixes:

Fixes #108604

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
