### PR TITLE
Tolerate additional error messages in TLS unit tests

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial_test.go
@@ -26,7 +26,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
-	"strings"
+	"regexp"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -56,7 +56,7 @@ func TestDialURL(t *testing.T) {
 		},
 		"secure, no roots": {
 			TLSConfig:   &tls.Config{InsecureSkipVerify: false},
-			ExpectError: "unknown authority",
+			ExpectError: "unknown authority|not trusted",
 		},
 		"secure with roots": {
 			TLSConfig: &tls.Config{InsecureSkipVerify: false, RootCAs: roots},
@@ -76,7 +76,7 @@ func TestDialURL(t *testing.T) {
 		"secure, no roots, custom dial": {
 			TLSConfig:   &tls.Config{InsecureSkipVerify: false},
 			Dial:        d.DialContext,
-			ExpectError: "unknown authority",
+			ExpectError: "unknown authority|not trusted",
 		},
 		"secure with roots, custom dial": {
 			TLSConfig: &tls.Config{InsecureSkipVerify: false, RootCAs: roots},
@@ -154,7 +154,7 @@ func TestDialURL(t *testing.T) {
 				if tc.ExpectError == "" {
 					t.Errorf("%s: expected no error, got %q", k, err.Error())
 				}
-				if !strings.Contains(err.Error(), tc.ExpectError) {
+				if tc.ExpectError != "" && !regexp.MustCompile(tc.ExpectError).MatchString(err.Error()) {
 					t.Errorf("%s: expected error containing %q, got %q", k, tc.ExpectError, err.Error())
 				}
 				return

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
@@ -50,7 +50,7 @@ const (
 	errBadCertificate    = "Get .*: remote error: tls: bad certificate"
 	errNoConfiguration   = "invalid configuration: no configuration has been provided"
 	errMissingCertPath   = "invalid configuration: unable to read %s %s for %s due to open %s: .*"
-	errSignedByUnknownCA = "Get .*: x509: certificate signed by unknown authority"
+	errSignedByUnknownCA = "Get .*: x509: .*(unknown authority|not standards compliant|not trusted)"
 )
 
 var (


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/108956

#### Special notes for your reviewer:

Go 1.18 changes how certificate validation is done when using system roots, which results in different error strings being returned. Expand the accepted error strings to include the results of certificate validation on darwin systems.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @dims