### PR TITLE
compact scheduling failure msg for taint/toleration mismatch

### DIFF
--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -76,8 +76,7 @@ func (pl *TaintToleration) Filter(ctx context.Context, state *framework.CycleSta
 		return nil
 	}
 
-	errReason := fmt.Sprintf("node(s) had taint {%s: %s}, that the pod didn't tolerate",
-		taint.Key, taint.Value)
+	errReason := fmt.Sprintf("node(s) had untolerated taint {%s: %s}", taint.Key, taint.Value)
 	return framework.NewStatus(framework.UnschedulableAndUnresolvable, errReason)
 }
 

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -271,7 +271,7 @@ func TestTaintTolerationFilter(t *testing.T) {
 			pod:  podWithTolerations("pod1", []v1.Toleration{}),
 			node: nodeWithTaints("nodeA", []v1.Taint{{Key: "dedicated", Value: "user1", Effect: "NoSchedule"}}),
 			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
-				"node(s) had taint {dedicated: user1}, that the pod didn't tolerate"),
+				"node(s) had untolerated taint {dedicated: user1}"),
 		},
 		{
 			name: "A pod which can be scheduled on a dedicated node assigned to user1 with effect NoSchedule",
@@ -283,7 +283,7 @@ func TestTaintTolerationFilter(t *testing.T) {
 			pod:  podWithTolerations("pod1", []v1.Toleration{{Key: "dedicated", Operator: "Equal", Value: "user2", Effect: "NoSchedule"}}),
 			node: nodeWithTaints("nodeA", []v1.Taint{{Key: "dedicated", Value: "user1", Effect: "NoSchedule"}}),
 			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
-				"node(s) had taint {dedicated: user1}, that the pod didn't tolerate"),
+				"node(s) had untolerated taint {dedicated: user1}"),
 		},
 		{
 			name: "A pod can be scheduled onto the node, with a toleration uses operator Exists that tolerates the taints on the node",
@@ -307,7 +307,7 @@ func TestTaintTolerationFilter(t *testing.T) {
 			pod:  podWithTolerations("pod1", []v1.Toleration{{Key: "foo", Operator: "Equal", Value: "bar", Effect: "PreferNoSchedule"}}),
 			node: nodeWithTaints("nodeA", []v1.Taint{{Key: "foo", Value: "bar", Effect: "NoSchedule"}}),
 			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
-				"node(s) had taint {foo: bar}, that the pod didn't tolerate"),
+				"node(s) had untolerated taint {foo: bar}"),
 		},
 		{
 			name: "The pod has a toleration that keys and values match the taint on the node, the effect of toleration is empty, " +


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind cleanup
/sig scheduling

#### What this PR does / why we need it:

Shorten the taint/toleration mismatch message:

Before:

```
node(s) had taint {foo: bar}, that the pod didn't tolerate
```

Now:

```
node(s) had untolerated taint {foo: bar}
```

#### Which issue(s) this PR fixes:

Part of #108931

#### Special notes for your reviewer:

- the first commit includes the minimum changes
- ~~the second commit is a good-to-have, which unifies the message used in both scheduler and kubelet~~ (will pursue in 1.25)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
