### PR TITLE
Track field validation in metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -204,6 +204,62 @@ func TestCleanScope(t *testing.T) {
 	}
 }
 
+func TestCleanFieldValidation(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		url                     *url.URL
+		expectedFieldValidation string
+	}{
+		{
+			name:                    "empty field validation",
+			url:                     &url.URL{},
+			expectedFieldValidation: "",
+		},
+		{
+			name: "ignore field validation",
+			url: &url.URL{
+				RawQuery: "fieldValidation=Ignore",
+			},
+			expectedFieldValidation: "Ignore",
+		},
+		{
+			name: "warn field validation",
+			url: &url.URL{
+				RawQuery: "fieldValidation=Warn",
+			},
+			expectedFieldValidation: "Warn",
+		},
+		{
+			name: "strict field validation",
+			url: &url.URL{
+				RawQuery: "fieldValidation=Strict",
+			},
+			expectedFieldValidation: "Strict",
+		},
+		{
+			name: "invalid field validation",
+			url: &url.URL{
+				RawQuery: "fieldValidation=foo",
+			},
+			expectedFieldValidation: "invalid",
+		},
+		{
+			name: "multiple field validation",
+			url: &url.URL{
+				RawQuery: "fieldValidation=Strict&fieldValidation=Ignore",
+			},
+			expectedFieldValidation: "invalid",
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			if fieldValidation := cleanFieldValidation(test.url); fieldValidation != test.expectedFieldValidation {
+				t.Errorf("failed to clean field validation, expected: %s, got: %s", test.expectedFieldValidation, fieldValidation)
+			}
+		})
+	}
+}
+
 func TestResponseWriterDecorator(t *testing.T) {
 	decorator := &ResponseWriterDelegator{
 		ResponseWriter: &responsewriter.FakeResponseWriter{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/sig api-machinery

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
New "field_validation_request_duration_seconds" metric, measures how long requests take, indicating the value of the fieldValidation query parameter and whether or not server-side field validation is enabled on the apiserver

Server-Side Field Validation is graduating to beta in 1.24 and we would like to track it's usage similar to how we've tracked the usage of server-side dry run (i.e. https://github.com/kubernetes/kubernetes/pull/74997)
<!--
#### Which issue(s) this PR fixes:

*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*

Fixes #
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
New "field_validation_request_duration_seconds" metric, measures how long requests take, indicating the value of the fieldValidation query parameter and whether or not server-side field validation is enabled on the apiserver
```
<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->
