### PR TITLE
Reduce CEL runtime cost limits by 1/2 based on latency goals

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
@@ -44,11 +44,11 @@ const (
 
 	// PerCallLimit specify the actual cost limit per CEL validation call
 	// current PerCallLimit gives roughly 0.1 second for each expression validation call
-	PerCallLimit = 2000000
+	PerCallLimit = 1000000
 
 	// RuntimeCELCostBudget is the overall cost budget for runtime CEL validation cost per CustomResource
 	// current RuntimeCELCostBudget gives roughly 1 seconds for CR validation
-	RuntimeCELCostBudget = 20000000
+	RuntimeCELCostBudget = 10000000
 
 	// checkFrequency configures the number of iterations within a comprehension to evaluate
 	// before checking whether the function evaluation has been interrupted


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Based on local testing, the current runtime limits (which are set to 20% of the estimated limits) are a bit too lenient in some of the cases I've tested.  I was able to reach nearly 2s of CPU before hitting the runtime limit (Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz) using a CEL rule that did a simple compare (`self < 100`) on a very large list of numbers and are seeing close to 100ns per operation (higher than our earlier estimations of 50ns per operation, maybe due to the overhead of tracking runtime cost). I'm hopeful we can optimize and get the per cost back in future releases, but for now, I'd like to set the limit a bit lower.

This brings the the runtime limit to 10% of the estimated limit and close to our stated goal of 1s for the runtime limit per CRD.

#### Which issue(s) this PR fixes:

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
