### PR TITLE
Switch to pause 3.7 for Kubernetes 1.24

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -150,7 +150,7 @@ dependencies:
       match: TAG\s*\?=
 
   - name: "k8s.gcr.io/pause: dependents"
-    version: 3.6
+    version: 3.7
     refPaths:
     - path: cluster/gce/config-common.sh
       match: k8s.gcr.io\/pause:\d+\.\d+

--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -160,7 +160,7 @@ export WINDOWS_KUBEPROXY_KUBECONFIG_FILE="${WINDOWS_K8S_DIR}\kubeproxy.kubeconfi
 # Path for kube-proxy kubeconfig file on Windows nodes.
 export WINDOWS_NODEPROBLEMDETECTOR_KUBECONFIG_FILE="${WINDOWS_K8S_DIR}\node-problem-detector.kubeconfig"
 # Pause container image for Windows container.
-export WINDOWS_INFRA_CONTAINER="k8s.gcr.io/pause:3.6"
+export WINDOWS_INFRA_CONTAINER="k8s.gcr.io/pause:3.7"
 # Storage Path for csi-proxy. csi-proxy only needs to be installed for Windows.
 export CSI_PROXY_STORAGE_PATH="https://storage.googleapis.com/gke-release/csi-proxy"
 # Version for csi-proxy

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -3087,7 +3087,7 @@ oom_score = -999
 [plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   max_container_log_line_size = ${CONTAINERD_MAX_CONTAINER_LOG_LINE:-262144}
-  sandbox_image = "${CONTAINERD_INFRA_CONTAINER:-"k8s.gcr.io/pause:3.6"}"
+  sandbox_image = "${CONTAINERD_INFRA_CONTAINER:-"k8s.gcr.io/pause:3.7"}"
 [plugins."io.containerd.grpc.v1.cri".cni]
   bin_dir = "${KUBE_HOME}/bin"
   conf_dir = "/etc/cni/net.d"

--- a/cluster/gce/windows/smoke-test.sh
+++ b/cluster/gce/windows/smoke-test.sh
@@ -358,7 +358,7 @@ spec:
     spec:
       containers:
       - name: pause-win
-        image: k8s.gcr.io/pause:3.6
+        image: k8s.gcr.io/pause:3.7
       nodeSelector:
         kubernetes.io/os: windows
       tolerations:

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -425,7 +425,7 @@ const (
 	ModeNode string = "Node"
 
 	// PauseVersion indicates the default pause image version for kubeadm
-	PauseVersion = "3.6"
+	PauseVersion = "3.7"
 
 	// CgroupDriverSystemd holds the systemd driver type
 	CgroupDriverSystemd = "systemd"

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -122,11 +122,11 @@ func TestBuildKubeletArgMap(t *testing.T) {
 				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
 					CRISocket: "unix:///var/run/dockershim.sock",
 				},
-				pauseImage: "k8s.gcr.io/pause:3.6",
+				pauseImage: "k8s.gcr.io/pause:3.7",
 			},
 			expected: map[string]string{
 				"network-plugin":            "cni",
-				"pod-infra-container-image": "k8s.gcr.io/pause:3.6",
+				"pod-infra-container-image": "k8s.gcr.io/pause:3.7",
 			},
 		},
 		{

--- a/cmd/kubeadm/app/util/template_test.go
+++ b/cmd/kubeadm/app/util/template_test.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	validTmpl    = "image: {{ .ImageRepository }}/pause:3.6"
-	validTmplOut = "image: k8s.gcr.io/pause:3.6"
-	doNothing    = "image: k8s.gcr.io/pause:3.6"
+	validTmpl    = "image: {{ .ImageRepository }}/pause:3.7"
+	validTmplOut = "image: k8s.gcr.io/pause:3.7"
+	doNothing    = "image: k8s.gcr.io/pause:3.7"
 	invalidTmpl1 = "{{ .baz }/d}"
 	invalidTmpl2 = "{{ !foobar }}"
 )

--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -24,7 +24,7 @@ import (
 const (
 	// When these values are updated, also update test/utils/image/manifest.go
 	defaultPodSandboxImageName    = "k8s.gcr.io/pause"
-	defaultPodSandboxImageVersion = "3.6"
+	defaultPodSandboxImageVersion = "3.7"
 )
 
 var (

--- a/hack/testdata/filter/pod-apply-selector.yaml
+++ b/hack/testdata/filter/pod-apply-selector.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7

--- a/hack/testdata/filter/pod-dont-apply.yaml
+++ b/hack/testdata/filter/pod-dont-apply.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7

--- a/hack/testdata/multi-resource-1.yaml
+++ b/hack/testdata/multi-resource-1.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7
 ---
 apiVersion: v1
 kind: Namespace

--- a/hack/testdata/multi-resource-3.yaml
+++ b/hack/testdata/multi-resource-3.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7
 ---
 apiVersion: v1
 kind: Pod
@@ -17,7 +17,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7
 ---
 apiVersion: v1
 kind: Pod
@@ -26,5 +26,5 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7
 

--- a/hack/testdata/multi-resource-json-modify.json
+++ b/hack/testdata/multi-resource-json-modify.json
@@ -43,7 +43,7 @@
        "spec":{
          "containers":[{
            "name": "mock-container",
-           "image": "k8s.gcr.io/pause:3.6",
+           "image": "k8s.gcr.io/pause:3.7",
            "ports":[{
              "containerPort":9949,
              "protocol":"TCP"

--- a/hack/testdata/multi-resource-json.json
+++ b/hack/testdata/multi-resource-json.json
@@ -41,7 +41,7 @@
        "spec":{
          "containers":[{
            "name": "mock-container",
-           "image": "k8s.gcr.io/pause:3.6",
+           "image": "k8s.gcr.io/pause:3.7",
            "ports":[{
              "containerPort":9949,
              "protocol":"TCP"

--- a/hack/testdata/multi-resource-list-modify.json
+++ b/hack/testdata/multi-resource-list-modify.json
@@ -47,7 +47,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "k8s.gcr.io/pause:3.6",
+                    "image": "k8s.gcr.io/pause:3.7",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"

--- a/hack/testdata/multi-resource-list.json
+++ b/hack/testdata/multi-resource-list.json
@@ -45,7 +45,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "k8s.gcr.io/pause:3.6",
+                    "image": "k8s.gcr.io/pause:3.7",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"

--- a/hack/testdata/multi-resource-rclist-modify.json
+++ b/hack/testdata/multi-resource-rclist-modify.json
@@ -26,7 +26,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "k8s.gcr.io/pause:3.6",
+                    "image": "k8s.gcr.io/pause:3.7",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"
@@ -60,7 +60,7 @@
             "spec":{
               "containers":[{
                 "name": "mock-container",
-                "image": "k8s.gcr.io/pause:3.6",
+                "image": "k8s.gcr.io/pause:3.7",
                 "ports":[{
                   "containerPort":9949,
                   "protocol":"TCP"

--- a/hack/testdata/multi-resource-rclist.json
+++ b/hack/testdata/multi-resource-rclist.json
@@ -26,7 +26,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "k8s.gcr.io/pause:3.6",
+                    "image": "k8s.gcr.io/pause:3.7",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"
@@ -60,7 +60,7 @@
             "spec":{
               "containers":[{
                 "name": "mock-container",
-                "image": "k8s.gcr.io/pause:3.6",
+                "image": "k8s.gcr.io/pause:3.7",
                 "ports":[{
                   "containerPort":9949,
                   "protocol":"TCP"

--- a/hack/testdata/multi-resource-yaml-modify.yaml
+++ b/hack/testdata/multi-resource-yaml-modify.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.6
+        image: k8s.gcr.io/pause:3.7
         ports:
         - containerPort: 9949
           protocol: TCP

--- a/hack/testdata/multi-resource-yaml.yaml
+++ b/hack/testdata/multi-resource-yaml.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.6
+        image: k8s.gcr.io/pause:3.7
         ports:
         - containerPort: 9949
           protocol: TCP

--- a/hack/testdata/pod-apply.yaml
+++ b/hack/testdata/pod-apply.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7

--- a/hack/testdata/pod-with-precision.json
+++ b/hack/testdata/pod-with-precision.json
@@ -9,7 +9,7 @@
     "containers": [
       {
         "name": "kubernetes-pause",
-        "image": "k8s.gcr.io/pause:3.6"
+        "image": "k8s.gcr.io/pause:3.7"
       }
     ],
     "restartPolicy": "Never",

--- a/hack/testdata/pod.yaml
+++ b/hack/testdata/pod.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7

--- a/hack/testdata/prune/a.yaml
+++ b/hack/testdata/prune/a.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7

--- a/hack/testdata/prune/b.yaml
+++ b/hack/testdata/prune/b.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7

--- a/hack/testdata/sorted-pods/sorted-pod1.yaml
+++ b/hack/testdata/sorted-pods/sorted-pod1.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause2
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7
     resources: 
       requests:
         memory: "64Mi"

--- a/hack/testdata/sorted-pods/sorted-pod2.yaml
+++ b/hack/testdata/sorted-pods/sorted-pod2.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause1
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7
     resources: 
       requests:
         memory: "1G"

--- a/hack/testdata/sorted-pods/sorted-pod3.yaml
+++ b/hack/testdata/sorted-pods/sorted-pod3.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause3
-    image: k8s.gcr.io/pause:3.6
+    image: k8s.gcr.io/pause:3.7

--- a/staging/src/k8s.io/kubectl/testdata/set/multi-resource-yaml.yaml
+++ b/staging/src/k8s.io/kubectl/testdata/set/multi-resource-yaml.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.6
+        image: k8s.gcr.io/pause:3.7
 ---
 apiVersion: v1
 kind: ReplicationController
@@ -30,4 +30,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.6
+        image: k8s.gcr.io/pause:3.7

--- a/staging/src/k8s.io/kubectl/testdata/set/namespaced-resource.yaml
+++ b/staging/src/k8s.io/kubectl/testdata/set/namespaced-resource.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.6
+        image: k8s.gcr.io/pause:3.7

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -537,9 +537,9 @@ run_pod_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'changed-with-yaml:'
   ## Patch pod from JSON can change image
   # Command
-  kubectl patch "${kube_flags[@]}" -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "k8s.gcr.io/pause:3.6"}]}}'
+  kubectl patch "${kube_flags[@]}" -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "k8s.gcr.io/pause:3.7"}]}}'
   # Post-condition: valid-pod POD has expected image
-  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'k8s.gcr.io/pause:3.6:'
+  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'k8s.gcr.io/pause:3.7:'
 
   # pod has field for kubectl patch field manager
   output_message=$(kubectl get pod valid-pod -o=jsonpath='{.metadata.managedFields[*].manager}' "${kube_flags[@]:?}" 2>&1)

--- a/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
+++ b/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
@@ -81,6 +81,6 @@ spec:
         - name: root-mount
           mountPath: /root
       containers:
-      - image: "k8s.gcr.io/pause:3.6"
+      - image: "k8s.gcr.io/pause:3.7"
         name: pause
 

--- a/test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.6
+        image: k8s.gcr.io/pause:3.7
 ---
 apiVersion: v1
 kind: ReplicationController
@@ -30,4 +30,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.6
+        image: k8s.gcr.io/pause:3.7

--- a/test/fixtures/pkg/kubectl/cmd/set/namespaced-resource.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/set/namespaced-resource.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.6
+        image: k8s.gcr.io/pause:3.7

--- a/test/integration/benchmark-controller.json
+++ b/test/integration/benchmark-controller.json
@@ -17,7 +17,7 @@
        "spec": {
            "containers": [{
              "name": "test-container",
-             "image": "k8s.gcr.io/pause:3.6"
+             "image": "k8s.gcr.io/pause:3.7"
            }]
        }
     }

--- a/test/integration/scheduler_perf/config/churn/pod-default.yaml
+++ b/test/integration/scheduler_perf/config/churn/pod-default.yaml
@@ -4,5 +4,5 @@ metadata:
   generateName: pod-churn-
 spec:
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause

--- a/test/integration/scheduler_perf/config/pod-affinity-ns-selector.yaml
+++ b/test/integration/scheduler_perf/config/pod-affinity-ns-selector.yaml
@@ -16,7 +16,7 @@ spec:
           matchLabels:
             team: devops
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-anti-affinity-ns-selector.yaml
+++ b/test/integration/scheduler_perf/config/pod-anti-affinity-ns-selector.yaml
@@ -16,7 +16,7 @@ spec:
           matchLabels:
             team: devops
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-default.yaml
+++ b/test/integration/scheduler_perf/config/pod-default.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: pod-
 spec:
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-high-priority-large-cpu.yaml
+++ b/test/integration/scheduler_perf/config/pod-high-priority-large-cpu.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   priority: 10
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-high-priority.yaml
+++ b/test/integration/scheduler_perf/config/pod-high-priority.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   priority: 10
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-large-cpu.yaml
+++ b/test/integration/scheduler_perf/config/pod-large-cpu.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: pod-
 spec:
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-low-priority.yaml
+++ b/test/integration/scheduler_perf/config/pod-low-priority.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-preferred-affinity-ns-selector.yaml
+++ b/test/integration/scheduler_perf/config/pod-preferred-affinity-ns-selector.yaml
@@ -18,7 +18,7 @@ spec:
                 team: devops
           weight: 1
   containers:
-    - image: k8s.gcr.io/pause:3.6
+    - image: k8s.gcr.io/pause:3.7
       name: pause
       ports:
         - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-preferred-anti-affinity-ns-selector.yaml
+++ b/test/integration/scheduler_perf/config/pod-preferred-anti-affinity-ns-selector.yaml
@@ -18,7 +18,7 @@ spec:
               team: devops
         weight: 1
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-node-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-node-affinity.yaml
@@ -14,7 +14,7 @@ spec:
             - zone1
             - zone2
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-pod-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-pod-affinity.yaml
@@ -14,7 +14,7 @@ spec:
         topologyKey: topology.kubernetes.io/zone
         namespaces: ["sched-1", "sched-0"]
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-pod-anti-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-pod-anti-affinity.yaml
@@ -14,7 +14,7 @@ spec:
         topologyKey: kubernetes.io/hostname
         namespaces: ["sched-1", "sched-0"]
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-preferred-pod-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-preferred-pod-affinity.yaml
@@ -16,7 +16,7 @@ spec:
             namespaces: ["sched-1", "sched-0"]
           weight: 1
   containers:
-    - image: k8s.gcr.io/pause:3.6
+    - image: k8s.gcr.io/pause:3.7
       name: pause
       ports:
         - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-preferred-pod-anti-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-preferred-pod-anti-affinity.yaml
@@ -16,7 +16,7 @@ spec:
             namespaces: ["sched-1", "sched-0"]
           weight: 1
   containers:
-    - image: k8s.gcr.io/pause:3.6
+    - image: k8s.gcr.io/pause:3.7
       name: pause
       ports:
         - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-preferred-topology-spreading.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-preferred-topology-spreading.yaml
@@ -13,7 +13,7 @@ spec:
         matchLabels:
           color: blue
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-secret-volume.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-secret-volume.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: secret-volume-
 spec:
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-topology-spreading.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-topology-spreading.yaml
@@ -13,7 +13,7 @@ spec:
         matchLabels:
           color: blue
   containers:
-  - image: k8s.gcr.io/pause:3.6
+  - image: k8s.gcr.io/pause:3.7
     name: pause
     ports:
     - containerPort: 80

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -260,7 +260,7 @@ func initImageConfigs(list RegistryList) (map[int]Config, map[int]Config) {
 	configs[Nonewprivs] = Config{list.PromoterE2eRegistry, "nonewprivs", "1.3"}
 	configs[NonRoot] = Config{list.PromoterE2eRegistry, "nonroot", "1.2"}
 	// Pause - when these values are updated, also update cmd/kubelet/app/options/container_runtime.go
-	configs[Pause] = Config{list.GcRegistry, "pause", "3.6"}
+	configs[Pause] = Config{list.GcRegistry, "pause", "3.7"}
 	configs[Perl] = Config{list.PromoterE2eRegistry, "perl", "5.26"}
 	configs[PrometheusDummyExporter] = Config{list.GcRegistry, "prometheus-dummy-exporter", "v0.1.0"}
 	configs[PrometheusToSd] = Config{list.GcRegistry, "prometheus-to-sd", "v0.5.0"}

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -1319,7 +1319,7 @@ func MakePodSpec() v1.PodSpec {
 	return v1.PodSpec{
 		Containers: []v1.Container{{
 			Name:  "pause",
-			Image: "k8s.gcr.io/pause:3.6",
+			Image: "k8s.gcr.io/pause:3.7",
 			Ports: []v1.ContainerPort{{ContainerPort: 80}},
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
@@ -1741,7 +1741,7 @@ type DaemonConfig struct {
 
 func (config *DaemonConfig) Run() error {
 	if config.Image == "" {
-		config.Image = "k8s.gcr.io/pause:3.6"
+		config.Image = "k8s.gcr.io/pause:3.7"
 	}
 	nameLabel := map[string]string{
 		"name": config.Name + "-daemon",


### PR DESCRIPTION
We merged a change https://github.com/kubernetes/kubernetes/pull/107056 to drop some unsupported Windows SAC images from pause. So let's make sure we test this new version and ship it with 1.24

Looks like someone forgot to switch the image from 3.6->3.7 afrer the #107056 landed

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
