### PR TITLE
Add metrics for OpenAPI v3 generation

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapiv3/controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapiv3/controller.go
@@ -178,6 +178,7 @@ func (c *Controller) deleteCRD(name string) {
 			if len(crdListForGV) == 0 {
 				delete(c.specsByGVandName, gv)
 			}
+			regenerationCounter.With(map[string]string{"group": gv.Group, "version": gv.Version, "crd": name, "reason": "remove"})
 			c.updateGroupVersion(gv)
 		}
 	}
@@ -210,7 +211,9 @@ func (c *Controller) updateCRDSpec(crd *apiextensionsv1.CustomResourceDefinition
 	}
 
 	_, ok := c.specsByGVandName[gv]
+	reason := "update"
 	if !ok {
+		reason = "add"
 		c.specsByGVandName[gv] = map[string]*spec3.OpenAPI{}
 	}
 
@@ -222,7 +225,7 @@ func (c *Controller) updateCRDSpec(crd *apiextensionsv1.CustomResourceDefinition
 		}
 	}
 	c.specsByGVandName[gv][name] = v3
-
+	regenerationCounter.With(map[string]string{"crd": name, "group": gv.Group, "version": gv.Version, "reason": reason})
 	return c.updateGroupVersion(gv)
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapiv3/metrics.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapiv3/metrics.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapiv3
+
+import (
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	regenerationCounter = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Name:           "apiextensions_openapi_v3_regeneration_count",
+			Help:           "Counter of OpenAPI v3 spec regeneration count broken down by group, version, causing CRD and reason.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"group", "version", "crd", "reason"},
+	)
+)
+
+func init() {
+	legacyregistry.MustRegister(regenerationCounter)
+}


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

Add metrics for OpenAPI v3 spec generation for CRDs. Mostly duplicated from the v2 controller. https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/metrics.go

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
apiextensions_openapi_v3_regeneration_count metric (alpha) will be emitted for OpenAPI V3.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
