### PR TITLE
kubectl: allow edit to accept VISUAL

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_edit_last_applied.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_edit_last_applied.go
@@ -32,7 +32,7 @@ var (
 		Edit the latest last-applied-configuration annotations of resources from the default editor.
 
 		The edit-last-applied command allows you to directly edit any API resource you can retrieve via the
-		command-line tools. It will open the editor defined by your KUBE_EDITOR, or EDITOR
+		command-line tools. It will open the editor defined by your KUBE_EDITOR, VISUAL, or EDITOR
 		environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
 		You can edit multiple objects, although changes are applied one at a time. The command
 		accepts file names as well as command-line arguments, although the files you point to must

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
@@ -32,7 +32,7 @@ var (
 		Edit a resource from the default editor.
 
 		The edit command allows you to directly edit any API resource you can retrieve via the
-		command-line tools. It will open the editor defined by your KUBE_EDITOR, or EDITOR
+		command-line tools. It will open the editor defined by your KUBE_EDITOR, VISUAL, or EDITOR
 		environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
 		You can edit multiple objects, although changes are applied one at a time. The command
 		accepts file names as well as command-line arguments, although the files you point to must

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -923,6 +923,7 @@ func hashOnLineBreak(s string) string {
 func editorEnvs() []string {
 	return []string{
 		"KUBE_EDITOR",
+		"VISUAL",
 		"EDITOR",
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The `VISUAL` environment variable is used by some programs to specify a graphical editor that needs to remain open while the edit operation is in progress. For example, a user might set `EDITOR` to `code` and `VISUAL` to `code -w`. Since `VISUAL` is supported by `git`, many users are likely to already have this configured in their environment, so this change would allow them to more easily reuse their settings between apps.

This is something that I've run into a few times; I have `VISUAL` and `EDITOR` set in my environment but not `KUBE_EDITOR`.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`kubectl edit` now respects the `VISUAL` environment variable to select an editor.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
