### PR TITLE
TestPreShutdownHooks: change timeout to 1s (maybe remove the timeout later)

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_graceful_termination_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_graceful_termination_test.go
@@ -443,7 +443,7 @@ func TestPreShutdownHooks(t *testing.T) {
 		var r result
 		client := newClient(true)
 		for i := 0; i < 5; i++ {
-			r = doer.Do(client, func(httptrace.GotConnInfo) {}, fmt.Sprintf("/echo?message=attempt-%d", i), 100*time.Millisecond)
+			r = doer.Do(client, func(httptrace.GotConnInfo) {}, fmt.Sprintf("/echo?message=attempt-%d", i), 1*time.Second)
 			if r.err != nil {
 				break
 			}


### PR DESCRIPTION
Fixes #109136 #109133
a try

https://prow.k8s.io/?pull=109134&job=pull-kubernetes-unit
- The first failed for another flake
- All 3 times passed with 200ms timeout