### PR TITLE
Deprecate net.Dialer by a dial function for SpdyRoundTripper

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -63,7 +63,7 @@ type SpdyRoundTripper struct {
 	// DialContext specifies the dial function for creating unencrypted TCP connections.
 	DialContext func(ctx context.Context, network, address string) (net.Conn, error)
 
-	// Deprecated: Use Dial instead, we can do little to control the action how the connection created by *net.Dialer
+	// Deprecated: Use DialContext instead, we can do little to control the detail how the connection created by *net.Dialer
 	Dialer *net.Dialer
 
 	// proxier knows which proxy to use given a request, defaults to http.ProxyFromEnvironment

--- a/staging/src/k8s.io/client-go/transport/spdy/spdy.go
+++ b/staging/src/k8s.io/client-go/transport/spdy/spdy.go
@@ -51,7 +51,7 @@ func RoundTripperFor(config *restclient.Config) (http.RoundTripper, Upgrader, er
 		PingPeriod:               time.Second * 5,
 	})
 	if config.Dial != nil {
-		upgradeRoundTripper.Dial = config.Dial
+		upgradeRoundTripper.DialContext = config.Dial
 	}
 	wrapper, err := restclient.HTTPWrappersForConfig(config, upgradeRoundTripper)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/transport/spdy/spdy.go
+++ b/staging/src/k8s.io/client-go/transport/spdy/spdy.go
@@ -50,6 +50,9 @@ func RoundTripperFor(config *restclient.Config) (http.RoundTripper, Upgrader, er
 		Proxier:                  proxy,
 		PingPeriod:               time.Second * 5,
 	})
+	if config.Dial != nil {
+		upgradeRoundTripper.Dial = config.Dial
+	}
 	wrapper, err := restclient.HTTPWrappersForConfig(config, upgradeRoundTripper)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
`func RoundTripperFor(config *restclient.Config)` in staging/src/k8s.io/client-go/transport/spdy/spdy.go read a *restclient.Config parameter which contains a `Dial` function, but it does not use it to make a *spdy.SpdyRoundTripper object. The mainly reason of that is the struct spdy.SpdyRoundTripper contains a *net.Dialer, it is hard(or impossible) to make a *net.Dialer from a Dial function. This makes we cannot control how spdy.SpdyRoundTripper dials a connetion.

So I'd like to change from net.Dialer to a dial function for SpdyRoundTripper. And I think, dial function is more general than net.Dialer.

#### Which issue(s) this PR fixes:

Fixes #none

#### Special notes for your reviewer:
It is similar to Dial in http.Transport.
#### Does this PR introduce a user-facing change?
```release-note
NONE
```

