### PR TITLE
fix some nits from API changes

### DIFF
--- a/pkg/apis/apps/v1/defaults.go
+++ b/pkg/apis/apps/v1/defaults.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/utils/pointer"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -116,8 +117,7 @@ func SetDefaults_StatefulSet(obj *appsv1.StatefulSet) {
 		obj.Spec.UpdateStrategy.RollingUpdate != nil {
 
 		if obj.Spec.UpdateStrategy.RollingUpdate.Partition == nil {
-			obj.Spec.UpdateStrategy.RollingUpdate.Partition = new(int32)
-			*obj.Spec.UpdateStrategy.RollingUpdate.Partition = 0
+			obj.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32(0)
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.MaxUnavailableStatefulSet) {
 			if obj.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable == nil {

--- a/pkg/apis/apps/v1beta1/defaults.go
+++ b/pkg/apis/apps/v1beta1/defaults.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/utils/pointer"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -73,8 +74,7 @@ func SetDefaults_StatefulSet(obj *appsv1beta1.StatefulSet) {
 		obj.Spec.UpdateStrategy.RollingUpdate != nil {
 
 		if obj.Spec.UpdateStrategy.RollingUpdate.Partition == nil {
-			obj.Spec.UpdateStrategy.RollingUpdate.Partition = new(int32)
-			*obj.Spec.UpdateStrategy.RollingUpdate.Partition = 0
+			obj.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32(0)
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.MaxUnavailableStatefulSet) {
 			if obj.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable == nil {

--- a/pkg/apis/apps/v1beta2/defaults.go
+++ b/pkg/apis/apps/v1beta2/defaults.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/utils/pointer"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -73,8 +74,7 @@ func SetDefaults_StatefulSet(obj *appsv1beta2.StatefulSet) {
 		obj.Spec.UpdateStrategy.RollingUpdate != nil {
 
 		if obj.Spec.UpdateStrategy.RollingUpdate.Partition == nil {
-			obj.Spec.UpdateStrategy.RollingUpdate.Partition = new(int32)
-			*obj.Spec.UpdateStrategy.RollingUpdate.Partition = 0
+			obj.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32(0)
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.MaxUnavailableStatefulSet) {
 			if obj.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable == nil {


### PR DESCRIPTION
#### What type of PR is this?
```release-note
NONE
```

/kind cleanup


Optionally add one or more of the following kinds if applicable:
/kind api-change

#### Which issue(s) this PR fixes:
some nits from previous PR https://github.com/kubernetes/kubernetes/pull/82162/files