### PR TITLE
Bump default burst limit for discovery client to 300

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -437,9 +437,9 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 
 		usePersistentConfig: usePersistentConfig,
 		// The more groups you have, the more discovery requests you need to make.
-		// given 25 groups (our groups + a few custom resources) with one-ish version each, discovery needs to make 50 requests
-		// double it just so we don't end up here again for a while.  This config is only used for discovery.
-		discoveryBurst: 100,
+		// with a burst of 300, we will not be rate-limiting for most clusters but
+		// the safeguard will still be here. This config is only used for discovery.
+		discoveryBurst: 300,
 	}
 }
 

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -52,6 +52,9 @@ const (
 	// defaultTimeout is the maximum amount of time per request when no timeout has been set on a RESTClient.
 	// Defaults to 32s in order to have a distinguishable length of time, relative to other timeouts that exist.
 	defaultTimeout = 32 * time.Second
+
+	// defaultBurst is the default burst to be used with the discovery client's token bucket rate limiter
+	defaultBurst = 300
 )
 
 // DiscoveryInterface holds the methods that discover server-supported API groups,
@@ -456,12 +459,14 @@ func setDiscoveryDefaults(config *restclient.Config) error {
 	if config.Timeout == 0 {
 		config.Timeout = defaultTimeout
 	}
-	if config.Burst == 0 && config.QPS < 100 {
+	// if a burst limit is not already configured and
+	// an avg. rate of `defaultBurst` qps is not already configured
+	if config.Burst == 0 && config.QPS < defaultBurst {
 		// discovery is expected to be bursty, increase the default burst
 		// to accommodate looking up resource info for many API groups.
 		// matches burst set by ConfigFlags#ToDiscoveryClient().
 		// see https://issue.k8s.io/86149
-		config.Burst = 100
+		config.Burst = defaultBurst
 	}
 	codec := runtime.NoopEncoder{Decoder: scheme.Codecs.UniversalDecoder()}
 	config.NegotiatedSerializer = serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{Serializer: codec})

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -459,9 +459,8 @@ func setDiscoveryDefaults(config *restclient.Config) error {
 	if config.Timeout == 0 {
 		config.Timeout = defaultTimeout
 	}
-	// if a burst limit is not already configured and
-	// an avg. rate of `defaultBurst` qps is not already configured
-	if config.Burst == 0 && config.QPS < defaultBurst {
+	// if a burst limit is not already configured
+	if config.Burst == 0 {
 		// discovery is expected to be bursty, increase the default burst
 		// to accommodate looking up resource info for many API groups.
 		// matches burst set by ConfigFlags#ToDiscoveryClient().


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
/kind cleanup
/sig cli

The burst limit of the token bucket rate limiter of the discovery client for kubectl has been previously bumped to 300 [here](https://github.com/kubernetes/kubernetes/pull/105520). Similar to that, this PR proposes to bump the burst limit of the default discovery client to 300. With a large (over 100) number of GroupVersions in the cluster, we are now in a better situation with kubectl as it now uses `tbrl(b=300, r=50.0 qps)` but other clients, such as Helm still experience throttling during the discovery phase. 

As mentioned in this [comment](https://github.com/kubernetes/kubernetes/pull/105520#discussion_r723535829), it's not a good strategy to bump tbrl parameters as CRD use cases evolve but this PR proposes the limit currently in use by kubectl as the default, and in my opinion, this will allow a consistent experience among API server clients like kubectl, Helm and others. Currently in cases where kubectl is not throttled, other clients (which are using the default discovery client tbrl parameters) are being throttled.

Having proposed a bump for the default burst limit, I'd like to also ask why we do not remove the rate limiter from the discovery client as we have [APF](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/) now. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
<!-- Fixes # -->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Default burst limit for the discovery client is now 300.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
