### PR TITLE
Fix translation of Azure availability zones

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
@@ -45,6 +45,7 @@ var (
 	managedDiskPathRE   = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(?:.*)/providers/Microsoft.Compute/disks/(.+)`)
 	unmanagedDiskPathRE = regexp.MustCompile(`http(?:.*)://(?:.*)/vhds/(.+)`)
 	managed             = string(v1.AzureManagedDisk)
+	unzonedCSIRegionRE  = regexp.MustCompile(`^[0-9]+$`)
 )
 
 var _ InTreePlugin = &azureDiskCSITranslator{}
@@ -86,6 +87,7 @@ func (t *azureDiskCSITranslator) TranslateInTreeStorageClassToCSI(sc *storage.St
 		}
 		sc.AllowedTopologies = newTopologies
 	}
+	sc.AllowedTopologies = t.replaceFailureDomainsToCSI(sc.AllowedTopologies)
 
 	sc.Parameters = params
 
@@ -272,4 +274,35 @@ func getDiskName(diskURI string) (string, error) {
 		return "", fmt.Errorf("could not get disk name from %s, correct format: %s", diskURI, diskPathRE)
 	}
 	return matches[1], nil
+}
+
+// Replace topology values for failure domains ("<number>") to "",
+// as it's the value that the CSI driver expects.
+func (t *azureDiskCSITranslator) replaceFailureDomainsToCSI(terms []v1.TopologySelectorTerm) []v1.TopologySelectorTerm {
+	if terms == nil {
+		return nil
+	}
+
+	newTopologies := []v1.TopologySelectorTerm{}
+	for _, term := range terms {
+		newTerm := term.DeepCopy()
+		for i := range newTerm.MatchLabelExpressions {
+			exp := &newTerm.MatchLabelExpressions[i]
+			if exp.Key == AzureDiskTopologyKey {
+				for j := range exp.Values {
+					if unzonedCSIRegionRE.Match([]byte(exp.Values[j])) {
+						// Topologies "0", "1" etc are used when in-tree topology is translated to CSI in Azure
+						// regions that don't have availability zones. E.g.:
+						//    topology.kubernetes.io/region: westus
+						//    topology.kubernetes.io/zone: "0"
+						// The CSI driver uses zone "" instead of "0" in this case.
+						//    topology.disk.csi.azure.com/zone": ""
+						exp.Values[j] = ""
+					}
+				}
+			}
+		}
+		newTopologies = append(newTopologies, *newTerm)
+	}
+	return newTopologies
 }

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk_test.go
@@ -97,7 +97,7 @@ func TestGetDiskName(t *testing.T) {
 	}
 }
 
-func TestTranslateAzureDiskInTreeStorageClassToCSI(t *testing.T) {
+func TestTranslateAzureDiskInTreeInlineVolumeToCSI(t *testing.T) {
 	sharedBlobDiskKind := v1.AzureDedicatedBlobDisk
 	translator := NewAzureDiskCSITranslator()
 
@@ -494,6 +494,21 @@ func TestTranslateInTreeStorageClassToCSI(t *testing.T) {
 			name:    "zone and topology",
 			options: NewStorageClass(map[string]string{"zone": "foo"}, generateToplogySelectors(AzureDiskTopologyKey, []string{"foo"})),
 			expErr:  true,
+		},
+		{
+			name:       "topology in regions without zones",
+			options:    NewStorageClass(map[string]string{}, generateToplogySelectors(v1.LabelTopologyZone, []string{"0"})),
+			expOptions: NewStorageClass(map[string]string{}, generateToplogySelectors(AzureDiskTopologyKey, []string{""})),
+		},
+		{
+			name:       "longer topology in regions without zones",
+			options:    NewStorageClass(map[string]string{}, generateToplogySelectors(v1.LabelTopologyZone, []string{"1234"})),
+			expOptions: NewStorageClass(map[string]string{}, generateToplogySelectors(AzureDiskTopologyKey, []string{""})),
+		},
+		{
+			name:       "topology in regions with zones",
+			options:    NewStorageClass(map[string]string{}, generateToplogySelectors(v1.LabelTopologyZone, []string{"centralus-1"})),
+			expOptions: NewStorageClass(map[string]string{}, generateToplogySelectors(AzureDiskTopologyKey, []string{"centralus-1"})),
 		},
 	}
 


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Some Azure regions do not have any availability zones. Nodes in such zones have these labels, where "0" is a fault domain, not an availability zone.

```
  "topology.kubernetes.io/region": "westus"
  "topology.kubernetes.io/zone": "0"
```

Azure Disk CSI driver uses zone "" in this case:
```
  "topology.disk.csi.azure.com/zone": ""
```

Fix the CSI translation to translate the fault domain `"0"` to `""`. Any value that is just a number and not `"<region>-<number>"` (`"centralus-1"`) needs to be translated to `""` in similar fashion.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108980

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed CSI migration of Azure Disk in-tree StorageClasses with topology requirements in Azure regions that do not have availability zones.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
