### PR TITLE
Automated cherry pick of #109103: cpu manager policy set to none, no one remove container id

### DIFF
--- a/pkg/kubelet/cm/containermap/container_map.go
+++ b/pkg/kubelet/cm/containermap/container_map.go
@@ -69,3 +69,10 @@ func (cm ContainerMap) GetContainerRef(containerID string) (string, string, erro
 	}
 	return cm[containerID].podUID, cm[containerID].containerName, nil
 }
+
+// Visit invoke visitor function to walks all of the entries in the container map
+func (cm ContainerMap) Visit(visitor func(podUID, containerName, containerID string)) {
+	for k, v := range cm {
+		visitor(v.podUID, v.containerName, k)
+	}
+}

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -356,6 +356,16 @@ func (m *manager) removeStaleState() {
 			}
 		}
 	}
+
+	m.containerMap.Visit(func(podUID, containerName, containerID string) {
+		if _, ok := activeContainers[podUID][containerName]; !ok {
+			klog.ErrorS(nil, "RemoveStaleState: removing container", "podUID", podUID, "containerName", containerName)
+			err := m.policyRemoveContainerByRef(podUID, containerName)
+			if err != nil {
+				klog.ErrorS(err, "RemoveStaleState: failed to remove container", "podUID", podUID, "containerName", containerName)
+			}
+		}
+	})
 }
 
 func (m *manager) reconcileState() (success []reconciledContainer, failure []reconciledContainer) {

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -304,6 +304,13 @@ func (m *manager) removeStaleState() {
 			}
 		}
 	}
+
+	m.containerMap.Visit(func(podUID, containerName, containerID string) {
+		if _, ok := activeContainers[podUID][containerName]; !ok {
+			klog.InfoS("RemoveStaleState removing state", "podUID", podUID, "containerName", containerName)
+			m.policyRemoveContainerByRef(podUID, containerName)
+		}
+	})
 }
 
 func (m *manager) policyRemoveContainerByRef(podUID string, containerName string) error {


### PR DESCRIPTION
Cherry pick of #109103 on release-1.21.

#109103: cpu manager policy set to none, no one remove container id

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```