### PR TITLE
Automated cherry pick of #109137 upstream release 1.23 

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go
@@ -284,18 +284,15 @@ func (c *threadSafeMap) updateIndices(oldObj interface{}, newObj interface{}, ke
 			c.indices[name] = index
 		}
 
+		if len(indexValues) == 1 && len(oldIndexValues) == 1 && indexValues[0] == oldIndexValues[0] {
+			// We optimize for the most common case where indexFunc returns a single value which has not been changed
+			continue
+		}
+
 		for _, value := range oldIndexValues {
-			// We optimize for the most common case where index returns a single value.
-			if len(indexValues) == 1 && value == indexValues[0] {
-				continue
-			}
 			c.deleteKeyFromIndex(key, value, index)
 		}
 		for _, value := range indexValues {
-			// We optimize for the most common case where index returns a single value.
-			if len(oldIndexValues) == 1 && value == oldIndexValues[0] {
-				continue
-			}
 			c.addKeyToIndex(key, value, index)
 		}
 	}


### PR DESCRIPTION
Cherry pick of #109137 on release-1.23:
#109137 : Fix indexer bug that resulted in incorrect index updates if number of index values for a given object was changing during update

/kind bug
/sig api-machinery
/priority important-soon

Fix https://github.com/kubernetes/kubernetes/issues/109115

```release-note
Fix a 1.23 regression indexer bug that resulted in incorrect index updates if number of index values for a given object was changing during update
```
