### PR TITLE
fix flake for TestUpdatePodWithTerminatedPod

### DIFF
--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -414,13 +414,15 @@ func TestUpdatePodWithTerminatedPod(t *testing.T) {
 		RunningPod: runningPod,
 	})
 
+	drainAllWorkers(podWorkers)
+
 	if podWorkers.IsPodKnownTerminated(pod.UID) == true {
 		t.Errorf("podWorker state should not be terminated")
 	}
 	if podWorkers.IsPodKnownTerminated(terminatedPod.UID) == false {
 		t.Errorf("podWorker state should be terminated")
 	}
-	if podWorkers.IsPodKnownTerminated(runningPod.ID) == true {
+	if podWorkers.IsPodKnownTerminated(runningPod.ID) == false {
 		t.Errorf("podWorker state should not be marked terminated for a running pod")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
This PR fixes a flake with TestUpdatePodWithTerminatedPod. The unit test does not call drainAllWorkers to synchronize the state of the pod worker. The test also erroneously reversed the logic of what the state of the runningpod should be in.

#### Which issue(s) this PR fixes:
Fixes #105589 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
