### PR TITLE
Add --write-config-to flag to kubelet

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -141,6 +141,8 @@ type KubeletFlags struct {
 	// SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads on the node.
 	// To use this flag, the corresponding SeccompDefault feature gate must be enabled.
 	SeccompDefault bool
+	// WriteConfigTo is the path where the parsed configuration will be written.
+	WriteConfigTo string
 }
 
 // NewKubeletFlags will create a new KubeletFlags with default values
@@ -354,6 +356,7 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 	fs.MarkDeprecated("cloud-config", "will be removed in 1.25 or later, in favor of removing cloud provider code from Kubelet.")
 	fs.BoolVar(&f.ExperimentalNodeAllocatableIgnoreEvictionThreshold, "experimental-allocatable-ignore-eviction", f.ExperimentalNodeAllocatableIgnoreEvictionThreshold, "When set to 'true', Hard Eviction Thresholds will be ignored while calculating Node Allocatable. See https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/ for more details. [default=false]")
 	fs.MarkDeprecated("experimental-allocatable-ignore-eviction", "will be removed in 1.25 or later.")
+	fs.StringVar(&f.WriteConfigTo, "write-config-to", f.WriteConfigTo, "If set, write the configuration values to this file and exit.")
 }
 
 // AddKubeletConfigFlags adds flags for a specific kubeletconfig.KubeletConfiguration to the specified FlagSet
@@ -376,6 +379,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 			"v":                   true,
 			"vmodule":             true,
 			"log-flush-frequency": true,
+			"write-config-to":     true,
 		}
 		fs.VisitAll(func(f *pflag.Flag) {
 			if notDeprecated[f.Name] {

--- a/cmd/kubelet/app/server_test.go
+++ b/cmd/kubelet/app/server_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"os"
 	"testing"
 )
 
@@ -59,5 +60,24 @@ func TestValueOfAllocatableResources(t *testing.T) {
 				t.Errorf("%s: unexpected error: %v, %v", test.name, err1, err2)
 			}
 		}
+	}
+}
+
+func TestWriteConfigTo(t *testing.T) {
+	if err := os.MkdirAll("testdata", 0755); err != nil {
+		t.Fatalf("failed to create temporary testdata directory: %v", err)
+	}
+	defer os.Remove("testdata/kubelet.conf")
+	cmd := NewKubeletCommand()
+	if err := cmd.RunE(cmd, []string{"--write-config-to", "testdata/kubelet.conf", "--port", "13131", "--container-runtime-endpoint", "/var/run/containerd.sock"}); err != nil {
+		t.Fatalf("failed to run kubelet: %v", err)
+	}
+
+	kubeletConfig, err := loadConfigFile("testdata/kubelet.conf")
+	if err != nil {
+		t.Fatalf("failed to load kubelet.conf: %v", err)
+	}
+	if kubeletConfig.Port != 13131 {
+		t.Fatalf("expected port to be %q, but it was %q instead", 13131, kubeletConfig.Port)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Add --write-config-to flag to kubelet. Kubelet configuration with flags is deprecated and users are told to use a configuration file instead. However, there is no straightforward 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108118 

#### Special notes for your reviewer:

Config file is created with mode 0666, to stay consistent with [kube-proxy](https://github.com/kubernetes/kubernetes/pull/45908/files#diff-962b78049692dfaf72923ea0eabea310b600f2e29011c837bdb49056e797ab34R242) and [kube-scheduler](https://github.com/kubernetes/kubernetes/pull/62515/files#diff-7a5cd3adb38f371f579372a2c901e73675f590515b35c4a8344217a91eff11fdR352)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add --write-config-to flag to kubelet to allow users to write the configuration settings to a file.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
