### PR TITLE
listWorkEstimator: assign 1 InitialSeats for delegated api calls.

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -130,6 +130,10 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 		return nil, err
 	}
 
+	if err := aggregatorConfig.GenericConfig.DelegatedRequestsTracker.Bind(aggregatorServer.GenericAPIServer.Handler.NonGoRestfulMux.IsHandledPath); err != nil {
+		return nil, err
+	}
+
 	// create controllers for auto-registration
 	apiRegistrationClient, err := apiregistrationclient.NewForConfig(aggregatorConfig.GenericConfig.LoopbackClientConfig)
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/delegated_requests_tracker.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/delegated_requests_tracker.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"fmt"
+	"sync"
+)
+
+type IsDelegatedFunc func(url string) bool
+
+// DelegatedRequestsTracker is a tracker for urls that are being delegated to external apiservers.
+type DelegatedRequestsTracker struct {
+	mu sync.RWMutex
+	f  IsDelegatedFunc
+}
+
+// Binds stores a callback used to determine if call is delegated.
+func (d *DelegatedRequestsTracker) Bind(f IsDelegatedFunc) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.f != nil {
+		return fmt.Errorf("DelegatedRequestsTracker.Bind called twice. Previous value: %v. Current value: %v", d.f, f)
+	}
+	d.f = f
+	return nil
+}
+
+// IsDelegated checks if a given url is delegated to an external apiserver.
+func (d *DelegatedRequestsTracker) IsDelegated(url string) bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if d.f == nil {
+		return false
+	}
+	return d.f(url)
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
@@ -76,9 +76,9 @@ type watchCountGetterFunc func(*apirequest.RequestInfo) int
 // NewWorkEstimator estimates the work that will be done by a given request,
 // if no WorkEstimatorFunc matches the given request then the default
 // work estimate of 1 seat is allocated to the request.
-func NewWorkEstimator(objectCountFn objectCountGetterFunc, watchCountFn watchCountGetterFunc) WorkEstimatorFunc {
+func NewWorkEstimator(objectCountFn objectCountGetterFunc, watchCountFn watchCountGetterFunc, isDelegatedFn IsDelegatedFunc) WorkEstimatorFunc {
 	estimator := &workEstimator{
-		listWorkEstimator:     newListWorkEstimator(objectCountFn),
+		listWorkEstimator:     newListWorkEstimator(objectCountFn, isDelegatedFn),
 		mutatingWorkEstimator: newMutatingWorkEstimator(watchCountFn),
 	}
 	return estimator.estimate


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/109106

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
The estimated cost of requests delegated to other apiservers by kube-aggregator has been reduced.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

This is just POC for a potential solution of https://github.com/kubernetes/kubernetes/issues/109106.
I just wanted to present a size and complexity of this solution as input to discussion whether it's acceptable solution.

If we decide to go this way, I would like to still do some manual testing before submitting this.

/hold

