### PR TITLE
Integration Webhook tests: TLS handshakes EOF errors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
@@ -421,8 +421,8 @@ func TestTLSConfig(t *testing.T) {
 
 	lastSHA1SigCounter := 0
 	for _, tt := range tests {
-		// Use a closure so defer statements trigger between loop iterations.
-		func() {
+		t.Run(tt.test, func(t *testing.T) {
+			// Use a closure so defer statements trigger between loop iterations.
 			// Create and start a simple HTTPS server
 			server, err := newTestServer(tt.serverCert, tt.serverKey, tt.serverCA, nil)
 			if err != nil {
@@ -513,7 +513,7 @@ func TestTLSConfig(t *testing.T) {
 
 				lastSHA1SigCounter++
 			}
-		}()
+		})
 	}
 }
 

--- a/test/integration/apiserver/admissionwebhook/admission_test.go
+++ b/test/integration/apiserver/admissionwebhook/admission_test.go
@@ -1355,6 +1355,9 @@ func newV1beta1WebhookHandler(t *testing.T, holder *holder, phase string, conver
 		if err := json.NewEncoder(w).Encode(review); err != nil {
 			t.Errorf("Marshal of response failed with error: %v", err)
 		}
+		// TODO: temporary hold the request to avoid TCP collisions on the client
+		// xref: https://github.com/kubernetes/kubernetes/issues/109022#issuecomment-1083362211
+		time.Sleep(500 * time.Millisecond)
 	})
 }
 
@@ -1449,6 +1452,9 @@ func newV1WebhookHandler(t *testing.T, holder *holder, phase string, converted b
 		if err := json.NewEncoder(w).Encode(review); err != nil {
 			t.Errorf("Marshal of response failed with error: %v", err)
 		}
+		// TODO: temporary hold the request to avoid TCP collisions on the client
+		// xref: https://github.com/kubernetes/kubernetes/issues/109022#issuecomment-1083362211
+		time.Sleep(500 * time.Millisecond)
 	})
 }
 

--- a/test/integration/apiserver/admissionwebhook/admission_test.go
+++ b/test/integration/apiserver/admissionwebhook/admission_test.go
@@ -1281,7 +1281,8 @@ func newV1beta1WebhookHandler(t *testing.T, holder *holder, phase string, conver
 		}
 
 		if review.GetObjectKind().GroupVersionKind() != gvk("admission.k8s.io", "v1beta1", "AdmissionReview") {
-			t.Errorf("Invalid admission review kind: %#v", review.GetObjectKind().GroupVersionKind())
+			err := fmt.Errorf("Invalid admission review kind: %#v", review.GetObjectKind().GroupVersionKind())
+			t.Error(err)
 			http.Error(w, err.Error(), 400)
 			return
 		}


### PR DESCRIPTION

/kind bug
/kind flake
/kind regression

```release-note
NONE
```

Avoid TLS handshake errors on webhook tests


xref: https://github.com/kubernetes/kubernetes/issues/109022#issuecomment-1083362211
