### PR TITLE
kubectl: Remove multiple Visit calls on the visitor source when computing resources to scale

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
@@ -235,7 +235,7 @@ func (o *ScaleOptions) RunScale() error {
 	}
 
 	counter := 0
-	err = r.Visit(func(info *resource.Info, err error) error {
+	for _, info := range infos {
 		if err != nil {
 			return err
 		}
@@ -263,8 +263,9 @@ func (o *ScaleOptions) RunScale() error {
 			}
 		}
 
-		return o.PrintObj(info.Object, o.Out)
-	})
+		err = o.PrintObj(info.Object, o.Out)
+
+	}
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
@@ -209,13 +209,10 @@ func (o *ScaleOptions) RunScale() error {
 		return err
 	}
 
-	infos := []*resource.Info{}
-	r.Visit(func(info *resource.Info, err error) error {
-		if err == nil {
-			infos = append(infos, info)
-		}
-		return nil
-	})
+	infos, err := r.Infos()
+	if err != nil {
+		return err
+	}
 
 	if len(o.ResourceVersion) != 0 && len(infos) > 1 {
 		return fmt.Errorf("cannot use --resource-version with multiple resources")
@@ -236,9 +233,6 @@ func (o *ScaleOptions) RunScale() error {
 
 	counter := 0
 	for _, info := range infos {
-		if err != nil {
-			return err
-		}
 		counter++
 
 		mapping := info.ResourceMapping()
@@ -263,7 +257,7 @@ func (o *ScaleOptions) RunScale() error {
 			}
 		}
 
-		err = o.PrintObj(info.Object, o.Out)
+		return o.PrintObj(info.Object, o.Out)
 
 	}
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`RunScale()` contains two `Visit(fn VisitorFunc)` calls. When the input for the `scale` command is from pipe, the second call does not result in any `info` which results in error
Adding the fix to store the output from the first call into a `infos` variable and reusing it the second time
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1183

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
