### PR TITLE
use etcd v3.4.18

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.5.1}
+ETCD_VERSION=${ETCD_VERSION:-3.4.18}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 # This is intentionally not called ETCD_LOG_LEVEL:


### PR DESCRIPTION
/kind failing-test
/kind flake
```release-note
NONE
```

From https://github.com/etcd-io/etcd/releases

> This release is no longer recommended for production. Please use v3.4 minor until v3.5.3 is released. Read more in https://github.com/etcd-io/etcd/tree/main/CHANGELOG.

