### PR TITLE
madvdontneed

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -53,7 +53,7 @@ go install ./cmd/...
 
 # TODO(MadhavJivrajani): Temporary fix due to Go 1.18 changes.
 # Please see https://tip.golang.org/doc/go1.18#sha1
-GODEBUG=x509sha1=1
+GODEBUG=x509sha1=1,madvdontneed=1
 export GODEBUG
 
 make test-cmd


### PR DESCRIPTION
/kind flake
```release-note
NONE
```

we had to add a GODEBUG variable to deal with the sha1 problems, let's discard that it doesn't make anything weird with the madvd setting , i.e., that it resets the default  to MADV_FREE  that was a problem for etcd in the past when set to free

https://etcd.io/blog/2021/announcing-etcd-3.5/#monitoring