### PR TITLE
Fix copylock vet errors in component-base metrics

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -827,7 +827,7 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, nod
 		}
 
 		legacyregistry.RawMustRegister(metrics.NewGaugeFunc(
-			metrics.GaugeOpts{
+			&metrics.GaugeOpts{
 				Subsystem: kubeletmetrics.KubeletSubsystem,
 				Name:      "certificate_manager_client_ttl_seconds",
 				Help: "Gauge of the TTL (time-to-live) of the Kubelet's client certificate. " +

--- a/pkg/kubelet/certificate/kubelet.go
+++ b/pkg/kubelet/certificate/kubelet.go
@@ -130,7 +130,7 @@ func NewKubeletServerCertificateManager(kubeClient clientset.Interface, kubeCfg 
 		return nil, fmt.Errorf("failed to initialize server certificate manager: %v", err)
 	}
 	legacyregistry.RawMustRegister(compbasemetrics.NewGaugeFunc(
-		compbasemetrics.GaugeOpts{
+		&compbasemetrics.GaugeOpts{
 			Subsystem: metrics.KubeletSubsystem,
 			Name:      "certificate_manager_server_ttl_seconds",
 			Help: "Gauge of the shortest TTL (time-to-live) of " +

--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -212,13 +212,13 @@ func (v *CounterVec) Reset() {
 func (v *CounterVec) WithContext(ctx context.Context) *CounterVecWithContext {
 	return &CounterVecWithContext{
 		ctx:        ctx,
-		CounterVec: *v,
+		CounterVec: v,
 	}
 }
 
 // CounterVecWithContext is the wrapper of CounterVec with context.
 type CounterVecWithContext struct {
-	CounterVec
+	*CounterVec
 	ctx context.Context
 }
 

--- a/staging/src/k8s.io/component-base/metrics/gauge.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge.go
@@ -189,8 +189,8 @@ func (v *GaugeVec) Reset() {
 	v.GaugeVec.Reset()
 }
 
-func newGaugeFunc(opts GaugeOpts, function func() float64, v semver.Version) GaugeFunc {
-	g := NewGauge(&opts)
+func newGaugeFunc(opts *GaugeOpts, function func() float64, v semver.Version) GaugeFunc {
+	g := NewGauge(opts)
 
 	if !g.Create(&v) {
 		return nil
@@ -205,7 +205,7 @@ func newGaugeFunc(opts GaugeOpts, function func() float64, v semver.Version) Gau
 // concurrently. If that results in concurrent calls to Write, like in the case
 // where a GaugeFunc is directly registered with Prometheus, the provided
 // function must be concurrency-safe.
-func NewGaugeFunc(opts GaugeOpts, function func() float64) GaugeFunc {
+func NewGaugeFunc(opts *GaugeOpts, function func() float64) GaugeFunc {
 	v := parseVersion(version.Get())
 
 	return newGaugeFunc(opts, function, v)
@@ -215,13 +215,13 @@ func NewGaugeFunc(opts GaugeOpts, function func() float64) GaugeFunc {
 func (v *GaugeVec) WithContext(ctx context.Context) *GaugeVecWithContext {
 	return &GaugeVecWithContext{
 		ctx:      ctx,
-		GaugeVec: *v,
+		GaugeVec: v,
 	}
 }
 
 // GaugeVecWithContext is the wrapper of GaugeVec with context.
 type GaugeVecWithContext struct {
-	GaugeVec
+	*GaugeVec
 	ctx context.Context
 }
 

--- a/staging/src/k8s.io/component-base/metrics/gauge_test.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge_test.go
@@ -31,14 +31,14 @@ func TestGauge(t *testing.T) {
 	v115 := semver.MustParse("1.15.0")
 	var tests = []struct {
 		desc string
-		GaugeOpts
+		*GaugeOpts
 		registryVersion     *semver.Version
 		expectedMetricCount int
 		expectedHelp        string
 	}{
 		{
 			desc: "Test non deprecated",
-			GaugeOpts: GaugeOpts{
+			GaugeOpts: &GaugeOpts{
 				Namespace: "namespace",
 				Name:      "metric_test_name",
 				Subsystem: "subsystem",
@@ -50,7 +50,7 @@ func TestGauge(t *testing.T) {
 		},
 		{
 			desc: "Test deprecated",
-			GaugeOpts: GaugeOpts{
+			GaugeOpts: &GaugeOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
@@ -63,7 +63,7 @@ func TestGauge(t *testing.T) {
 		},
 		{
 			desc: "Test hidden",
-			GaugeOpts: GaugeOpts{
+			GaugeOpts: &GaugeOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
@@ -83,7 +83,7 @@ func TestGauge(t *testing.T) {
 				Minor:      "15",
 				GitVersion: "v1.15.0-alpha-1.12345",
 			})
-			c := NewGauge(&test.GaugeOpts)
+			c := NewGauge(test.GaugeOpts)
 			registry.MustRegister(c)
 
 			ms, err := registry.Gather()
@@ -115,7 +115,7 @@ func TestGaugeVec(t *testing.T) {
 	v115 := semver.MustParse("1.15.0")
 	var tests = []struct {
 		desc string
-		GaugeOpts
+		*GaugeOpts
 		labels              []string
 		registryVersion     *semver.Version
 		expectedMetricCount int
@@ -123,7 +123,7 @@ func TestGaugeVec(t *testing.T) {
 	}{
 		{
 			desc: "Test non deprecated",
-			GaugeOpts: GaugeOpts{
+			GaugeOpts: &GaugeOpts{
 				Namespace: "namespace",
 				Name:      "metric_test_name",
 				Subsystem: "subsystem",
@@ -136,7 +136,7 @@ func TestGaugeVec(t *testing.T) {
 		},
 		{
 			desc: "Test deprecated",
-			GaugeOpts: GaugeOpts{
+			GaugeOpts: &GaugeOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
@@ -150,7 +150,7 @@ func TestGaugeVec(t *testing.T) {
 		},
 		{
 			desc: "Test hidden",
-			GaugeOpts: GaugeOpts{
+			GaugeOpts: &GaugeOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
@@ -171,7 +171,7 @@ func TestGaugeVec(t *testing.T) {
 				Minor:      "15",
 				GitVersion: "v1.15.0-alpha-1.12345",
 			})
-			c := NewGaugeVec(&test.GaugeOpts, test.labels)
+			c := NewGaugeVec(test.GaugeOpts, test.labels)
 			registry.MustRegister(c)
 			c.WithLabelValues("1", "2").Set(1.0)
 			ms, err := registry.Gather()
@@ -207,12 +207,12 @@ func TestGaugeFunc(t *testing.T) {
 
 	var tests = []struct {
 		desc string
-		GaugeOpts
+		*GaugeOpts
 		expectedMetrics string
 	}{
 		{
 			desc: "Test non deprecated",
-			GaugeOpts: GaugeOpts{
+			GaugeOpts: &GaugeOpts{
 				Namespace: "namespace",
 				Subsystem: "subsystem",
 				Name:      "metric_non_deprecated",
@@ -226,7 +226,7 @@ namespace_subsystem_metric_non_deprecated 1
 		},
 		{
 			desc: "Test deprecated",
-			GaugeOpts: GaugeOpts{
+			GaugeOpts: &GaugeOpts{
 				Namespace:         "namespace",
 				Subsystem:         "subsystem",
 				Name:              "metric_deprecated",
@@ -241,7 +241,7 @@ namespace_subsystem_metric_deprecated 1
 		},
 		{
 			desc: "Test hidden",
-			GaugeOpts: GaugeOpts{
+			GaugeOpts: &GaugeOpts{
 				Namespace:         "namespace",
 				Subsystem:         "subsystem",
 				Name:              "metric_hidden",

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -199,13 +199,13 @@ func (v *HistogramVec) Reset() {
 func (v *HistogramVec) WithContext(ctx context.Context) *HistogramVecWithContext {
 	return &HistogramVecWithContext{
 		ctx:          ctx,
-		HistogramVec: *v,
+		HistogramVec: v,
 	}
 }
 
 // HistogramVecWithContext is the wrapper of HistogramVec with context.
 type HistogramVecWithContext struct {
-	HistogramVec
+	*HistogramVec
 	ctx context.Context
 }
 

--- a/staging/src/k8s.io/component-base/metrics/histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram_test.go
@@ -30,14 +30,14 @@ func TestHistogram(t *testing.T) {
 	v115 := semver.MustParse("1.15.0")
 	var tests = []struct {
 		desc string
-		HistogramOpts
+		*HistogramOpts
 		registryVersion     *semver.Version
 		expectedMetricCount int
 		expectedHelp        string
 	}{
 		{
 			desc: "Test non deprecated",
-			HistogramOpts: HistogramOpts{
+			HistogramOpts: &HistogramOpts{
 				Namespace: "namespace",
 				Name:      "metric_test_name",
 				Subsystem: "subsystem",
@@ -50,7 +50,7 @@ func TestHistogram(t *testing.T) {
 		},
 		{
 			desc: "Test deprecated",
-			HistogramOpts: HistogramOpts{
+			HistogramOpts: &HistogramOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
@@ -64,7 +64,7 @@ func TestHistogram(t *testing.T) {
 		},
 		{
 			desc: "Test hidden",
-			HistogramOpts: HistogramOpts{
+			HistogramOpts: &HistogramOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
@@ -85,7 +85,7 @@ func TestHistogram(t *testing.T) {
 				Minor:      "15",
 				GitVersion: "v1.15.0-alpha-1.12345",
 			})
-			c := NewHistogram(&test.HistogramOpts)
+			c := NewHistogram(test.HistogramOpts)
 			registry.MustRegister(c)
 
 			ms, err := registry.Gather()
@@ -118,7 +118,7 @@ func TestHistogramVec(t *testing.T) {
 	v115 := semver.MustParse("1.15.0")
 	var tests = []struct {
 		desc string
-		HistogramOpts
+		*HistogramOpts
 		labels              []string
 		registryVersion     *semver.Version
 		expectedMetricCount int
@@ -126,7 +126,7 @@ func TestHistogramVec(t *testing.T) {
 	}{
 		{
 			desc: "Test non deprecated",
-			HistogramOpts: HistogramOpts{
+			HistogramOpts: &HistogramOpts{
 				Namespace: "namespace",
 				Name:      "metric_test_name",
 				Subsystem: "subsystem",
@@ -140,7 +140,7 @@ func TestHistogramVec(t *testing.T) {
 		},
 		{
 			desc: "Test deprecated",
-			HistogramOpts: HistogramOpts{
+			HistogramOpts: &HistogramOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
@@ -155,7 +155,7 @@ func TestHistogramVec(t *testing.T) {
 		},
 		{
 			desc: "Test hidden",
-			HistogramOpts: HistogramOpts{
+			HistogramOpts: &HistogramOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
@@ -177,7 +177,7 @@ func TestHistogramVec(t *testing.T) {
 				Minor:      "15",
 				GitVersion: "v1.15.0-alpha-1.12345",
 			})
-			c := NewHistogramVec(&test.HistogramOpts, test.labels)
+			c := NewHistogramVec(test.HistogramOpts, test.labels)
 			registry.MustRegister(c)
 			c.WithLabelValues("1", "2").Observe(1.0)
 			ms, err := registry.Gather()

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -169,8 +169,8 @@ func (r *lazyMetric) ClearState() {
 	r.isDeprecated = false
 	r.isHidden = false
 	r.isCreated = false
-	r.markDeprecationOnce = *(new(sync.Once))
-	r.createOnce = *(new(sync.Once))
+	r.markDeprecationOnce = sync.Once{}
+	r.createOnce = sync.Once{}
 }
 
 // FQName returns the fully-qualified metric name of the collector.

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -83,7 +83,7 @@ var (
 	execPluginCertTTLAdapter = &expiryToTTLAdapter{}
 
 	execPluginCertTTL = k8smetrics.NewGaugeFunc(
-		k8smetrics.GaugeOpts{
+		&k8smetrics.GaugeOpts{
 			Name: "rest_client_exec_plugin_ttl_seconds",
 			Help: "Gauge of the shortest TTL (time-to-live) of the client " +
 				"certificate(s) managed by the auth exec plugin. The value " +

--- a/staging/src/k8s.io/component-base/metrics/summary.go
+++ b/staging/src/k8s.io/component-base/metrics/summary.go
@@ -193,13 +193,13 @@ func (v *SummaryVec) Reset() {
 func (v *SummaryVec) WithContext(ctx context.Context) *SummaryVecWithContext {
 	return &SummaryVecWithContext{
 		ctx:        ctx,
-		SummaryVec: *v,
+		SummaryVec: v,
 	}
 }
 
 // SummaryVecWithContext is the wrapper of SummaryVec with context.
 type SummaryVecWithContext struct {
-	SummaryVec
+	*SummaryVec
 	ctx context.Context
 }
 

--- a/staging/src/k8s.io/component-base/metrics/summary_test.go
+++ b/staging/src/k8s.io/component-base/metrics/summary_test.go
@@ -29,14 +29,14 @@ func TestSummary(t *testing.T) {
 	v115 := semver.MustParse("1.15.0")
 	var tests = []struct {
 		desc string
-		SummaryOpts
+		*SummaryOpts
 		registryVersion     *semver.Version
 		expectedMetricCount int
 		expectedHelp        string
 	}{
 		{
 			desc: "Test non deprecated",
-			SummaryOpts: SummaryOpts{
+			SummaryOpts: &SummaryOpts{
 				Namespace:      "namespace",
 				Name:           "metric_test_name",
 				Subsystem:      "subsystem",
@@ -49,7 +49,7 @@ func TestSummary(t *testing.T) {
 		},
 		{
 			desc: "Test deprecated",
-			SummaryOpts: SummaryOpts{
+			SummaryOpts: &SummaryOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
@@ -63,7 +63,7 @@ func TestSummary(t *testing.T) {
 		},
 		{
 			desc: "Test hidden",
-			SummaryOpts: SummaryOpts{
+			SummaryOpts: &SummaryOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
@@ -83,7 +83,7 @@ func TestSummary(t *testing.T) {
 				Minor:      "15",
 				GitVersion: "v1.15.0-alpha-1.12345",
 			})
-			c := NewSummary(&test.SummaryOpts)
+			c := NewSummary(test.SummaryOpts)
 			registry.MustRegister(c)
 
 			ms, err := registry.Gather()
@@ -116,7 +116,7 @@ func TestSummaryVec(t *testing.T) {
 	v115 := semver.MustParse("1.15.0")
 	var tests = []struct {
 		desc string
-		SummaryOpts
+		*SummaryOpts
 		labels              []string
 		registryVersion     *semver.Version
 		expectedMetricCount int
@@ -124,7 +124,7 @@ func TestSummaryVec(t *testing.T) {
 	}{
 		{
 			desc: "Test non deprecated",
-			SummaryOpts: SummaryOpts{
+			SummaryOpts: &SummaryOpts{
 				Namespace: "namespace",
 				Name:      "metric_test_name",
 				Subsystem: "subsystem",
@@ -137,7 +137,7 @@ func TestSummaryVec(t *testing.T) {
 		},
 		{
 			desc: "Test deprecated",
-			SummaryOpts: SummaryOpts{
+			SummaryOpts: &SummaryOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
@@ -151,7 +151,7 @@ func TestSummaryVec(t *testing.T) {
 		},
 		{
 			desc: "Test hidden",
-			SummaryOpts: SummaryOpts{
+			SummaryOpts: &SummaryOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
@@ -172,7 +172,7 @@ func TestSummaryVec(t *testing.T) {
 				Minor:      "15",
 				GitVersion: "v1.15.0-alpha-1.12345",
 			})
-			c := NewSummaryVec(&test.SummaryOpts, test.labels)
+			c := NewSummaryVec(test.SummaryOpts, test.labels)
 			registry.MustRegister(c)
 			c.WithLabelValues("1", "2").Observe(1.0)
 			ms, err := registry.Gather()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/priority important-soon
/milestone 1.24

#### What this PR does / why we need it:

Fixes copylock vet errors discovered in https://github.com/kubernetes/kubernetes/issues/109197.

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/kubernetes/issues/109197

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @liggitt @logicalhan 