### PR TITLE
Automated cherry pick of #109188 upstream release 1.23 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
@@ -125,7 +125,7 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "events",
 			},
 			countErr:             ObjectCountNotFoundErr,
-			initialSeatsExpected: maximumSeats,
+			initialSeatsExpected: minimumSeats,
 		},
 		{
 			name:       "request verb is list, continuation is set",
@@ -214,7 +214,7 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "events",
 			},
 			countErr:             ObjectCountNotFoundErr,
-			initialSeatsExpected: maximumSeats,
+			initialSeatsExpected: minimumSeats,
 		},
 		{
 			name:       "request verb is list, object count is stale",
@@ -239,7 +239,7 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "events",
 			},
 			countErr:             ObjectCountNotFoundErr,
-			initialSeatsExpected: maximumSeats,
+			initialSeatsExpected: minimumSeats,
 		},
 		{
 			name:       "request verb is list, count getter throws unknown error",


### PR DESCRIPTION
Cherry pick of https://github.com/kubernetes/kubernetes/pull/109188 on release-1.23:
https://github.com/kubernetes/kubernetes/pull/109188 : Fix the overestimated cost of deletaged API requests in P&F

```release-note
Fix a 1.23 regression overestimating the cost of delegated API requests in kube-apiserver API priority&fairness
```

/kind bug
/sig api-machinery
/priority important-soon