### PR TITLE
prevent the unit test name too long in report

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/celcoststability_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/celcoststability_test.go
@@ -1087,28 +1087,27 @@ func TestCelCostStability(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			for validRule, expectedCost := range tt.expectCost {
-				t.Run(validRule, func(t *testing.T) {
-					validRule := validRule
-					expectedCost := expectedCost
-					t.Run(validRule, func(t *testing.T) {
-						t.Parallel()
-						s := withRule(*tt.schema, validRule)
-						celValidator := NewValidator(&s, PerCallLimit)
-						if celValidator == nil {
-							t.Fatal("expected non nil validator")
-						}
-						ctx := context.TODO()
-						errs, remainingBudegt := celValidator.Validate(ctx, field.NewPath("root"), &s, tt.obj, nil, RuntimeCELCostBudget)
-						for _, err := range errs {
-							t.Errorf("unexpected error: %v", err)
-						}
-						rtCost := RuntimeCELCostBudget - remainingBudegt
-						if rtCost != expectedCost {
-							t.Fatalf("runtime cost %d does not match expected runtime cost %d", rtCost, expectedCost)
-						}
-					})
+				testName := validRule
+				if len(testName) > 127 {
+					testName = testName[:127]
+				}
+				t.Run(testName, func(t *testing.T) {
+					t.Parallel()
+					s := withRule(*tt.schema, validRule)
+					celValidator := NewValidator(&s, PerCallLimit)
+					if celValidator == nil {
+						t.Fatal("expected non nil validator")
+					}
+					ctx := context.TODO()
+					errs, remainingBudegt := celValidator.Validate(ctx, field.NewPath("root"), &s, tt.obj, nil, RuntimeCELCostBudget)
+					for _, err := range errs {
+						t.Errorf("unexpected error: %v", err)
+					}
+					rtCost := RuntimeCELCostBudget - remainingBudegt
+					if rtCost != expectedCost {
+						t.Fatalf("runtime cost %d does not match expected runtime cost %d", rtCost, expectedCost)
+					}
 				})
-
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -1760,7 +1760,11 @@ func TestValidationExpressions(t *testing.T) {
 			ctx := context.TODO()
 			for j := range tt.valid {
 				validRule := tt.valid[j]
-				t.Run(validRule, func(t *testing.T) {
+				testName := validRule
+				if len(testName) > 127 {
+					testName = testName[:127]
+				}
+				t.Run(testName, func(t *testing.T) {
 					t.Parallel()
 					s := withRule(*tt.schema, validRule)
 					celValidator := validator(&s, tt.isRoot, PerCallLimit)
@@ -1781,7 +1785,11 @@ func TestValidationExpressions(t *testing.T) {
 				})
 			}
 			for rule, expectErrToContain := range tt.errors {
-				t.Run(rule, func(t *testing.T) {
+				testName := rule
+				if len(testName) > 127 {
+					testName = testName[:127]
+				}
+				t.Run(testName, func(t *testing.T) {
 					s := withRule(*tt.schema, rule)
 					celValidator := NewValidator(&s, PerCallLimit)
 					if celValidator == nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

![image](https://user-images.githubusercontent.com/2010320/161243233-5a6ce8fb-fe75-48b5-b56d-1318b73d952d.png)

![image](https://user-images.githubusercontent.com/2010320/161243887-9c8cc507-3f25-4080-8216-5b430bebed37.png)

The length of TestCelCostStability test name is 1488. 

#### Which issue(s) this PR fixes:

Fixes NA

#### Special notes for your reviewer:
I find it when I want to see the TestValidationExpressions running duration of #109225.

#### Does this PR introduce a user-facing change?
```release-note
None
```

With this PR
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/2010320/161369005-0542600c-56af-4408-960f-9072df5e1e1a.png">
