### PR TITLE
Automated cherry pick of #106969: kubectl: fix hard-coded value in zsh completion

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
@@ -171,8 +171,7 @@ func runCompletionBash(out io.Writer, boilerPlate string, kubectl *cobra.Command
 }
 
 func runCompletionZsh(out io.Writer, boilerPlate string, kubectl *cobra.Command) error {
-	commandName := kubectl.Name()
-	zshHead := fmt.Sprintf("#compdef %[1]s\ncompdef _%[1]s %[1]s\n", commandName)
+	zshHead := fmt.Sprintf("#compdef %[1]s\ncompdef _%[1]s %[1]s\n", kubectl.Name())
 	out.Write([]byte(zshHead))
 
 	if len(boilerPlate) == 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
@@ -17,6 +17,7 @@ limitations under the License.
 package completion
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -170,7 +171,8 @@ func runCompletionBash(out io.Writer, boilerPlate string, kubectl *cobra.Command
 }
 
 func runCompletionZsh(out io.Writer, boilerPlate string, kubectl *cobra.Command) error {
-	zshHead := "#compdef kubectl\ncompdef _kubectl kubectl\n"
+	commandName := kubectl.Name()
+	zshHead := fmt.Sprintf("#compdef %[1]s\ncompdef _%[1]s %[1]s\n", commandName)
 	out.Write([]byte(zshHead))
 
 	if len(boilerPlate) == 0 {


### PR DESCRIPTION
Cherry pick of #106969 on release-1.23.

#106969: kubectl: fix hard-coded value in zsh completion

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix kubectl completion zsh to use any command name rather than hardcoded kubectl
```