### PR TITLE
Automated cherry pick of #109245: Fix: abort nominating a pod that was already scheduled to a

### DIFF
--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -132,7 +132,7 @@ func (c *Configurator) create() (*Scheduler, error) {
 	}
 
 	// The nominator will be passed all the way to framework instantiation.
-	nominator := internalqueue.NewPodNominator()
+	nominator := internalqueue.NewSafePodNominator(c.informerFactory.Core().V1().Pods().Lister())
 	// It's a "cluster event" -> "plugin names" map.
 	clusterEventMap := make(map[framework.ClusterEvent]sets.String)
 	profiles, err := profile.NewMap(c.profiles, c.registry, c.recorderFactory,

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,19 +50,21 @@ const queueMetricMetadata = `
 		# TYPE scheduler_queue_incoming_pods_total counter
 	`
 
-var lowPriority, midPriority, highPriority = int32(0), int32(100), int32(1000)
-var mediumPriority = (lowPriority + highPriority) / 2
-var highPriorityPodInfo, highPriNominatedPodInfo, medPriorityPodInfo, unschedulablePodInfo = framework.NewPodInfo(&v1.Pod{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "hpp",
-		Namespace: "ns1",
-		UID:       "hppns1",
-	},
-	Spec: v1.PodSpec{
-		Priority: &highPriority,
-	},
-}),
-	framework.NewPodInfo(&v1.Pod{
+var (
+	lowPriority, midPriority, highPriority = int32(0), int32(100), int32(1000)
+	mediumPriority                         = (lowPriority + highPriority) / 2
+
+	highPriorityPodInfo = framework.NewPodInfo(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hpp",
+			Namespace: "ns1",
+			UID:       "hppns1",
+		},
+		Spec: v1.PodSpec{
+			Priority: &highPriority,
+		},
+	})
+	highPriNominatedPodInfo = framework.NewPodInfo(&v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "hpp",
 			Namespace: "ns1",
@@ -73,8 +76,8 @@ var highPriorityPodInfo, highPriNominatedPodInfo, medPriorityPodInfo, unschedula
 		Status: v1.PodStatus{
 			NominatedNodeName: "node1",
 		},
-	}),
-	framework.NewPodInfo(&v1.Pod{
+	})
+	medPriorityPodInfo = framework.NewPodInfo(&v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mpp",
 			Namespace: "ns2",
@@ -89,8 +92,8 @@ var highPriorityPodInfo, highPriNominatedPodInfo, medPriorityPodInfo, unschedula
 		Status: v1.PodStatus{
 			NominatedNodeName: "node1",
 		},
-	}),
-	framework.NewPodInfo(&v1.Pod{
+	})
+	unschedulablePodInfo = framework.NewPodInfo(&v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "up",
 			Namespace: "ns1",
@@ -113,6 +116,24 @@ var highPriorityPodInfo, highPriNominatedPodInfo, medPriorityPodInfo, unschedula
 			NominatedNodeName: "node1",
 		},
 	})
+	deletedPodInfo = framework.NewPodInfo(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dp",
+			Namespace: "ns1",
+			UID:       "dpns1",
+		},
+	})
+	scheduledPodInfo = framework.NewPodInfo(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sp",
+			Namespace: "ns1",
+			UID:       "spns1",
+		},
+		Spec: v1.PodSpec{
+			NodeName: "foo",
+		},
+	})
+)
 
 func getUnschedulablePod(p *PriorityQueue, pod *v1.Pod) *v1.Pod {
 	pInfo := p.unschedulableQ.get(pod)
@@ -704,7 +725,8 @@ func TestPriorityQueue_PendingPods(t *testing.T) {
 }
 
 func TestPriorityQueue_UpdateNominatedPodForNode(t *testing.T) {
-	q := NewTestQueue(context.Background(), newDefaultQueueSort())
+	objs := []runtime.Object{medPriorityPodInfo.Pod, unschedulablePodInfo.Pod, highPriorityPodInfo.Pod, scheduledPodInfo.Pod}
+	q := NewTestQueueWithObjects(context.Background(), newDefaultQueueSort(), objs)
 	if err := q.Add(medPriorityPodInfo.Pod); err != nil {
 		t.Errorf("add failed: %v", err)
 	}
@@ -752,6 +774,21 @@ func TestPriorityQueue_UpdateNominatedPodForNode(t *testing.T) {
 	}
 	if diff := cmp.Diff(q.PodNominator, expectedNominatedPods, cmp.AllowUnexported(nominatedPodMap{}), cmpopts.IgnoreFields(nominatedPodMap{}, "RWMutex")); diff != "" {
 		t.Errorf("Unexpected diff after updating pods (-want, +got):\n%s", diff)
+	}
+
+	// Attempt to nominate a pod that was deleted from the informer cache.
+	// Nothing should change.
+	q.AddNominatedPod(deletedPodInfo, "node1")
+	if diff := cmp.Diff(q.PodNominator, expectedNominatedPods, cmp.AllowUnexported(nominatedPodMap{}), cmpopts.IgnoreFields(nominatedPodMap{}, "RWMutex")); diff != "" {
+		t.Errorf("Unexpected diff after nominating a deleted pod (-want, +got):\n%s", diff)
+	}
+	// Attempt to nominate a pod that was already scheduled in the informer cache.
+	// Nothing should change.
+	scheduledPodCopy := scheduledPodInfo.Pod.DeepCopy()
+	scheduledPodInfo.Pod.Spec.NodeName = ""
+	q.AddNominatedPod(framework.NewPodInfo(scheduledPodCopy), "node1")
+	if diff := cmp.Diff(q.PodNominator, expectedNominatedPods, cmp.AllowUnexported(nominatedPodMap{}), cmpopts.IgnoreFields(nominatedPodMap{}, "RWMutex")); diff != "" {
+		t.Errorf("Unexpected diff after nominating a scheduled pod (-want, +got):\n%s", diff)
 	}
 
 	// Delete a nominated pod that doesn't have nominatedNodeName in the pod


### PR DESCRIPTION
Cherry pick of #109245 on release-1.21.

#109245: Fix: abort nominating a pod that was already scheduled to a

Also completed cherry-pick #102667 that missed a line from #102498

Ref #109236

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in 1.21 so kube-scheduler will not nominate a Pod that was already scheduled to a node
```
