### PR TITLE
Bump CSI Proxy to v1.1.1-gke.0

### DIFF
--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -164,6 +164,6 @@ export WINDOWS_INFRA_CONTAINER="k8s.gcr.io/pause:3.7"
 # Storage Path for csi-proxy. csi-proxy only needs to be installed for Windows.
 export CSI_PROXY_STORAGE_PATH="https://storage.googleapis.com/gke-release/csi-proxy"
 # Version for csi-proxy
-export CSI_PROXY_VERSION="${CSI_PROXY_VERSION:-v1.0.1-gke.0}"
+export CSI_PROXY_VERSION="${CSI_PROXY_VERSION:-v1.1.1-gke.0}"
 # csi-proxy additional flags, there are additional flags that cannot be unset in k8s-node-setup.psm1
 export CSI_PROXY_FLAGS="${CSI_PROXY_FLAGS:-}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Bumps CSI Proxy to v1.1.1-gke.0 in the e2e tests, available at:

```
gsutil ls gs://gke-release/csi-proxy/v1.1.1-gke.0/
gs://gke-release/csi-proxy/v1.1.1-gke.0/csi-proxy.exe
gs://gke-release/csi-proxy/v1.1.1-gke.0/csi-proxy.exe.sig
gs://gke-release/csi-proxy/v1.1.1-gke.0/notices.tar.gz
gs://gke-release/csi-proxy/v1.1.1-gke.0/notices.tar.gz.sig
```

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @ibabou 