### PR TITLE
Fix requeueing of cronjobs with every-style schedule

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -396,7 +396,7 @@ func (jm *ControllerV2) updateCronJob(old interface{}, curr interface{}) {
 			return
 		}
 		now := jm.now()
-		t := nextScheduledTimeDuration(sched, now)
+		t := nextScheduledTimeDuration(*newCJ, sched, now)
 
 		jm.enqueueControllerAfter(curr, *t)
 		return
@@ -529,7 +529,7 @@ func (jm *ControllerV2) syncCronJob(
 		// Otherwise, the queue is always suppose to trigger sync function at the time of
 		// the scheduled time, that will give atleast 1 unmet time schedule
 		klog.V(4).InfoS("No unmet start times", "cronjob", klog.KRef(cronJob.GetNamespace(), cronJob.GetName()))
-		t := nextScheduledTimeDuration(sched, now)
+		t := nextScheduledTimeDuration(*cronJob, sched, now)
 		return cronJob, t, updateStatus, nil
 	}
 
@@ -548,7 +548,7 @@ func (jm *ControllerV2) syncCronJob(
 		// Status.LastScheduleTime, Status.LastMissedTime), and then so we won't generate
 		// and event the next time we process it, and also so the user looking at the status
 		// can see easily that there was a missed execution.
-		t := nextScheduledTimeDuration(sched, now)
+		t := nextScheduledTimeDuration(*cronJob, sched, now)
 		return cronJob, t, updateStatus, nil
 	}
 	if isJobInActiveList(&batchv1.Job{
@@ -557,7 +557,7 @@ func (jm *ControllerV2) syncCronJob(
 			Namespace: cronJob.Namespace,
 		}}, cronJob.Status.Active) || cronJob.Status.LastScheduleTime.Equal(&metav1.Time{Time: *scheduledTime}) {
 		klog.V(4).InfoS("Not starting job because the scheduled time is already processed", "cronjob", klog.KRef(cronJob.GetNamespace(), cronJob.GetName()), "schedule", scheduledTime)
-		t := nextScheduledTimeDuration(sched, now)
+		t := nextScheduledTimeDuration(*cronJob, sched, now)
 		return cronJob, t, updateStatus, nil
 	}
 	if cronJob.Spec.ConcurrencyPolicy == batchv1.ForbidConcurrent && len(cronJob.Status.Active) > 0 {
@@ -572,7 +572,7 @@ func (jm *ControllerV2) syncCronJob(
 		// But that would mean that you could not inspect prior successes or failures of Forbid jobs.
 		klog.V(4).InfoS("Not starting job because prior execution is still running and concurrency policy is Forbid", "cronjob", klog.KRef(cronJob.GetNamespace(), cronJob.GetName()))
 		jm.recorder.Eventf(cronJob, corev1.EventTypeNormal, "JobAlreadyActive", "Not starting job because prior execution is running and concurrency policy is Forbid")
-		t := nextScheduledTimeDuration(sched, now)
+		t := nextScheduledTimeDuration(*cronJob, sched, now)
 		return cronJob, t, updateStatus, nil
 	}
 	if cronJob.Spec.ConcurrencyPolicy == batchv1.ReplaceConcurrent {
@@ -633,7 +633,7 @@ func (jm *ControllerV2) syncCronJob(
 	cronJob.Status.LastScheduleTime = &metav1.Time{Time: *scheduledTime}
 	updateStatus = true
 
-	t := nextScheduledTimeDuration(sched, now)
+	t := nextScheduledTimeDuration(*cronJob, sched, now)
 	return cronJob, t, updateStatus, nil
 }
 
@@ -642,12 +642,26 @@ func getJobName(cj *batchv1.CronJob, scheduledTime time.Time) string {
 }
 
 // nextScheduledTimeDuration returns the time duration to requeue based on
-// the schedule and current time. It adds a 100ms padding to the next requeue to account
+// the schedule and last schedule time. It adds a 100ms padding to the next requeue to account
 // for Network Time Protocol(NTP) time skews. If the time drifts are adjusted which in most
 // realistic cases would be around 100s, scheduled cron will still be executed without missing
 // the schedule.
-func nextScheduledTimeDuration(sched cron.Schedule, now time.Time) *time.Duration {
-	t := sched.Next(now).Add(nextScheduleDelta).Sub(now)
+func nextScheduledTimeDuration(cj batchv1.CronJob, sched cron.Schedule, now time.Time) *time.Duration {
+	earliestTime := cj.ObjectMeta.CreationTimestamp.Time
+	if cj.Status.LastScheduleTime != nil {
+		earliestTime = cj.Status.LastScheduleTime.Time
+	}
+	mostRecentTime, _, err := getMostRecentScheduleTime(earliestTime, now, sched)
+	if err != nil {
+		// we still have to requeue at some point, so aim for the next scheduling slot from now
+		mostRecentTime = &now
+	} else if mostRecentTime == nil {
+		// no missed schedules since earliestTime
+		mostRecentTime = &earliestTime
+	}
+
+	t := sched.Next(*mostRecentTime).Add(nextScheduleDelta).Sub(now)
+
 	return &t
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:
In CronJob ControllerV2, cronjobs need to be requeued when it's time for the next schedule. This requeueing interval is currently calculated based off the time `now`. This works fine for classic cron schedule, b/c the "next" schedule is aligned with the specific day/hour/minute from the schedule, but breaks for @every X schedule, because the "next" schedule in this case becomes simply `now + X`, and is incorrect if a) kube-controller-manager was restarted and syncing all cronjobs; b) there was an update to cronjob schedule. Instead, for @every-style schedules, it becomes important to always base the calculation of the next time relative to the last scheduled time (or cronjob creation if it wasn't scheduled before).
Note that since before controllerv2, requeueing wasn't a thing, and therefore this bug didn't exist.

#### Which issue(s) this PR fixes:
Fixes #104012

#### Special notes for your reviewer:
Verified the fix with a local cluster (`./hack/local-up-cluster.sh`). Figured an e2e test for such a specific case would be an overkill. Either way, lmk if I'm over- or under-testing this. 
There's also one unit test that has a comment on why it will fail. The reason for its failure is outside of the scope of this PR, and not introduced by this PR - lmk if it should be deleted of kept to indicate that a future fix in necessary.

#### Does this PR introduce a user-facing change?
```release-note
Fixes scheduling of cronjobs with @every X schedules.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

