### PR TITLE
Promote Batchv1JobLifecycleTest & BatchV1NamespacedJobStatus test +7 endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -763,6 +763,15 @@
     pod. Modify the labels of one of the Job's Pods. The Job MUST release the Pod.
   release: v1.16
   file: test/e2e/apps/job.go
+- testname: Jobs, apply changes to status
+  codename: '[sig-apps] Job should apply changes to a job status [Conformance]'
+  description: Attempt to create a running Job which MUST succeed. Attempt to patch
+    the Job status to include a new start time which MUST succeed. An annotation for
+    the job that was patched MUST be found. Attempt to replace the job status with
+    a new start time which MUST succeed. Attempt to read its status sub-resource which
+    MUST succeed.
+  release: v1.24
+  file: test/e2e/apps/job.go
 - testname: Ensure Pods of an Indexed Job get a unique index.
   codename: '[sig-apps] Job should create pods for an Indexed job with completion
     indexes and specified hostname [Conformance]'
@@ -775,6 +784,16 @@
   description: Create a job. Ensure the active pods reflect paralellism in the namespace
     and delete the job. Job MUST be deleted successfully.
   release: v1.15
+  file: test/e2e/apps/job.go
+- testname: Jobs, manage lifecycle
+  codename: '[sig-apps] Job should manage the lifecycle of a job [Conformance]'
+  description: Attempt to create a suspended Job which MUST succeed. Attempt to patch
+    the Job to include a new label which MUST succeed. The label MUST be found. Attempt
+    to replace the Job to include a new annotation which MUST succeed. The annotation
+    MUST be found. Attempt to list all namespaces with a label selector which MUST
+    succeed. One list MUST be found. It MUST succeed at deleting a collection of jobs
+    via a label selector.
+  release: v1.24
   file: test/e2e/apps/job.go
 - testname: Jobs, completion after task failure
   codename: '[sig-apps] Job should run a job to completion when tasks sometimes fail

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -440,7 +440,16 @@ var _ = SIGDescribe("Job", func() {
 		framework.ExpectEqual(successes, largeCompletions, "expected %d successful job pods, but got  %d", largeCompletions, successes)
 	})
 
-	ginkgo.It("should apply changes to a job status", func() {
+	/*
+		Release: v1.24
+		Testname: Jobs, apply changes to status
+		Description: Attempt to create a running Job which MUST succeed.
+		Attempt to patch the Job status to include a new start time which
+		MUST succeed. An annotation for the job that was patched MUST be found.
+		Attempt to replace the job status with a new start time which MUST
+		succeed. Attempt to read its status sub-resource which MUST succeed.
+	*/
+	framework.ConformanceIt("should apply changes to a job status", func() {
 
 		ns := f.Namespace.Name
 		jClient := f.ClientSet.BatchV1().Jobs(ns)
@@ -497,6 +506,8 @@ var _ = SIGDescribe("Job", func() {
 	})
 
 	/*
+		Release: v1.24
+		Testname: Jobs, manage lifecycle
 		Description: Attempt to create a suspended Job which MUST succeed.
 		Attempt to patch the Job to include a new label which MUST succeed.
 		The label MUST be found. Attempt to replace the Job to include a
@@ -505,7 +516,7 @@ var _ = SIGDescribe("Job", func() {
 		succeed. One list MUST be found. It MUST succeed at deleting a
 		collection of jobs via a label selector.
 	*/
-	ginkgo.It("should manage the lifecycle of a job", func() {
+	framework.ConformanceIt("should manage the lifecycle of a job", func() {
 		jobName := "e2e-" + utilrand.String(5)
 		label := map[string]string{"e2e-job-label": jobName}
 		labelSelector := labels.SelectorFromSet(label).String()


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- patchBatchV1NamespacedJob
- replaceBatchV1NamespacedJob
- deleteBatchV1CollectionNamespacedJob
- listBatchV1JobForAllNamespaces
- replaceBatchV1NamespacedJobStatus
- readBatchV1NamespacedJobStatus
- patchBatchV1NamespacedJobStatus 

**Which issue(s) this PR fixes:**
Fixes #108113
Fixes #108641

**Testgrid Link:** Batchv1JobLifecycleTest
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should%20manage%20the%20lifecycle%20of%20a%20job&graph-metrics=test-duration-minutes)

**Testgrid Link:** BatchV1NamespacedJobStatus
[testgrid-link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should%20apply%20changes%20to%20a%20job%20status&graph-metrics=test-duration-minutes)

**Special notes for your reviewer:**
Adds +7 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance
