### PR TITLE
Promote Read, Replace, Patch BatchV1NamespacedJobStatus test - +3 endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -763,6 +763,15 @@
     pod. Modify the labels of one of the Job's Pods. The Job MUST release the Pod.
   release: v1.16
   file: test/e2e/apps/job.go
+- testname: Jobs, apply changes to status
+  codename: '[sig-apps] Job should apply changes to a job status [Conformance]'
+  description: Attempt to create a running Job which MUST succeed. Attempt to patch
+    the Job status to include a new start time which MUST succeed. An annotation for
+    the job that was patched MUST be found. Attempt to replace the job status with
+    a new start time which MUST succeed. Attempt to read its status sub-resource which
+    MUST succeed
+  release: v1.24
+  file: test/e2e/apps/job.go
 - testname: Ensure Pods of an Indexed Job get a unique index.
   codename: '[sig-apps] Job should create pods for an Indexed job with completion
     indexes and specified hostname [Conformance]'

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -440,7 +440,16 @@ var _ = SIGDescribe("Job", func() {
 		framework.ExpectEqual(successes, largeCompletions, "expected %d successful job pods, but got  %d", largeCompletions, successes)
 	})
 
-	ginkgo.It("should apply changes to a job status", func() {
+	/*
+		Release: v1.24
+		Testname: Jobs, apply changes to status
+		Description: Attempt to create a running Job which MUST succeed.
+		Attempt to patch the Job status to include a new start time which
+		MUST succeed. An annotation for the job that was patched MUST be found.
+		Attempt to replace the job status with a new start time which MUST
+		succeed. Attempt to read its status sub-resource which MUST succeed
+	*/
+	framework.ConformanceIt("should apply changes to a job status", func() {
 
 		ns := f.Namespace.Name
 		jClient := f.ClientSet.BatchV1().Jobs(ns)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceBatchV1NamespacedJobStatus
- readBatchV1NamespacedJobStatus
- patchBatchV1NamespacedJobStatus 

**Which issue(s) this PR fixes:**
Fixes #108113

**Testgrid Link:**
[testgrid-link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should%20apply%20changes%20to%20a%20job%20status&graph-metrics=test-duration-minutes)

**Special notes for your reviewer:**
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance
