### PR TITLE
ServerSideFieldValidation: Fix bug treating metadata fields as unknown fields

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -1332,7 +1332,7 @@ func (v *unstructuredSchemaCoercer) apply(u *unstructured.Unstructured) (unknown
 			if v.returnUnknownFieldPaths {
 				pruneOpts.ReturnPruned = true
 			}
-			unknownFieldPaths = structuralpruning.PruneWithOptions(u.Object, v.structuralSchemas[gv.Version], false, pruneOpts)
+			unknownFieldPaths = structuralpruning.PruneWithOptions(u.Object, v.structuralSchemas[gv.Version], true, pruneOpts)
 			structuraldefaulting.PruneNonNullableNullsWithoutDefaults(u.Object, v.structuralSchemas[gv.Version])
 		}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm_test.go
@@ -383,6 +383,8 @@ func TestPrune(t *testing.T) {
   "kind": "Foo",
   "metadata": {
     "name": "instance",
+    "namespace": "myns",
+    "labels":{"foo":"bar"},
     "unspecified": "bar"
   },
   "unspecified":"bar",
@@ -392,6 +394,8 @@ func TestPrune(t *testing.T) {
     "unspecified": "bar",
     "metadata": {
       "name": "instance",
+      "namespace": "myns",
+      "labels":{"foo":"bar"},
       "unspecified": "bar"
     },
     "spec": {
@@ -404,6 +408,8 @@ func TestPrune(t *testing.T) {
     "unspecified": "bar",
     "metadata": {
       "name": "instance",
+      "namespace": "myns",
+      "labels":{"foo":"bar"},
       "unspecified": "bar"
     },
     "spec": {
@@ -416,6 +422,8 @@ func TestPrune(t *testing.T) {
     "unspecified": "bar",
     "metadata": {
       "name": "instance",
+      "namespace": "myns",
+      "labels":{"foo":"bar"},
       "unspecified": "bar"
     },
     "spec": {
@@ -426,6 +434,8 @@ func TestPrune(t *testing.T) {
         "unspecified": "bar",
         "metadata": {
           "name": "instance",
+          "namespace": "myns",
+          "labels":{"foo":"bar"},
           "unspecified": "bar"
         },
         "spec": {
@@ -438,12 +448,18 @@ func TestPrune(t *testing.T) {
 `, isResourceRoot: true, schema: &structuralschema.Structural{
 			Generic: structuralschema.Generic{Type: "object"},
 			Properties: map[string]structuralschema.Structural{
+				"metadata": {
+					Generic: structuralschema.Generic{Type: "object"},
+				},
 				"pruned": {
 					Generic: structuralschema.Generic{Type: "object"},
 					Extensions: structuralschema.Extensions{
 						XEmbeddedResource: true,
 					},
 					Properties: map[string]structuralschema.Structural{
+						"metadata": {
+							Generic: structuralschema.Generic{Type: "object"},
+						},
 						"spec": {
 							Generic: structuralschema.Generic{Type: "object"},
 						},
@@ -471,6 +487,9 @@ func TestPrune(t *testing.T) {
 										XEmbeddedResource: true,
 									},
 									Properties: map[string]structuralschema.Structural{
+										"metadata": {
+											Generic: structuralschema.Generic{Type: "object"},
+										},
 										"spec": {
 											Generic: structuralschema.Generic{Type: "object"},
 										},
@@ -487,6 +506,8 @@ func TestPrune(t *testing.T) {
   "kind": "Foo",
   "metadata": {
     "name": "instance",
+    "namespace": "myns",
+    "labels": {"foo": "bar"},
     "unspecified": "bar"
   },
   "pruned": {
@@ -494,6 +515,8 @@ func TestPrune(t *testing.T) {
     "kind": "Foo",
     "metadata": {
       "name": "instance",
+      "namespace": "myns",
+      "labels": {"foo": "bar"},
       "unspecified": "bar"
     },
     "spec": {
@@ -505,6 +528,8 @@ func TestPrune(t *testing.T) {
     "unspecified": "bar",
     "metadata": {
       "name": "instance",
+      "namespace": "myns",
+      "labels": {"foo": "bar"},
       "unspecified": "bar"
     },
     "spec": {
@@ -516,6 +541,8 @@ func TestPrune(t *testing.T) {
     "kind": "Foo",
     "metadata": {
       "name": "instance",
+      "namespace": "myns",
+      "labels": {"foo": "bar"},
       "unspecified": "bar"
     },
     "spec": {
@@ -524,6 +551,8 @@ func TestPrune(t *testing.T) {
         "kind": "Foo",
         "metadata": {
           "name": "instance",
+          "namespace": "myns",
+          "labels": {"foo": "bar"},
           "unspecified": "bar"
         },
         "spec": {

--- a/test/cmd/crd.sh
+++ b/test/cmd/crd.sh
@@ -45,8 +45,22 @@ run_crd_tests() {
         "storage": true,
         "schema": {
           "openAPIV3Schema": {
-            "x-kubernetes-preserve-unknown-fields": true,
-            "type": "object"
+            "type": "object",
+            "properties": {
+              "metadata": {"type": "object"},
+              "nestedField": {
+                "type": "object",
+                "properties": {
+                  "someSubfield": {"type": "string"},
+                  "otherSubfield": {"type": "string"},
+                  "newSubfield": {"type": "string"}
+                }
+              },
+              "otherField": {"type": "string"},
+              "someField": {"type": "string"},
+              "newField": {"type": "string"},
+              "patched": {"type": "string"}
+            }
           }
         }
       }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area test

#### What this PR does / why we need it:

Fixes bug treating metadata fields as unknown fields in a custom resource whose CRD declared a metadata property

#### Which issue(s) this PR fixes:

fixes #109215

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes strict server-side field validation treating metadata fields as unknown fields
```

/assign @kevindelgado @apelisse 