### PR TITLE
Revert "Enable ServerSideFieldValidation feature gate on by default in beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1021,7 +1021,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	genericfeatures.OpenAPIEnums:                        {Default: true, PreRelease: featuregate.Beta},
 	genericfeatures.CustomResourceValidationExpressions: {Default: false, PreRelease: featuregate.Alpha},
 	genericfeatures.OpenAPIV3:                           {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.ServerSideFieldValidation:           {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.ServerSideFieldValidation:           {Default: false, PreRelease: featuregate.Alpha},
 	// features that enable backwards compatibility but are scheduled to be removed
 	// ...
 	HPAScaleToZero: {Default: false, PreRelease: featuregate.Alpha},

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -175,7 +175,6 @@ const (
 	// owner: @kevindelgado
 	// kep: http://kep.k8s.io/2885
 	// alpha: v1.23
-	// beta: v1.24
 	//
 	// Enables server-side field validation.
 	ServerSideFieldValidation featuregate.Feature = "ServerSideFieldValidation"
@@ -207,5 +206,5 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	OpenAPIEnums:                        {Default: true, PreRelease: featuregate.Beta},
 	CustomResourceValidationExpressions: {Default: false, PreRelease: featuregate.Alpha},
 	OpenAPIV3:                           {Default: true, PreRelease: featuregate.Beta},
-	ServerSideFieldValidation:           {Default: true, PreRelease: featuregate.Beta},
+	ServerSideFieldValidation:           {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1048,7 +1048,7 @@ metadata:
 			}
 		})
 
-		ginkgo.It("should create/apply an invalid/valid CR with arbitrary-extra properties for CRD with partially-specified validation schema", func() {
+		ginkgo.It("should create/apply a valid CR with arbitrary-extra properties for CRD with partially-specified validation schema", func() {
 			ginkgo.By("prepare CRD with partially-specified validation schema")
 			crd, err := crd.CreateTestCRD(f, func(crd *apiextensionsv1.CustomResourceDefinition) {
 				props := &apiextensionsv1.JSONSchemaProps{}
@@ -1073,15 +1073,6 @@ metadata:
 			framework.ExpectNotEqual(schema, nil, "retrieving a schema for the crd")
 
 			meta := fmt.Sprintf(metaPattern, crd.Crd.Spec.Names.Kind, crd.Crd.Spec.Group, crd.Crd.Spec.Versions[0].Name, "test-cr")
-
-			// XPreserveUnknownFields is defined on the root of the schema so unknown fields within the spec
-			// are still considered invalid
-			invalidArbitraryCR := fmt.Sprintf(`{%s,"spec":{"bars":[{"name":"test-bar"}],"extraProperty":"arbitrary-value"}}`, meta)
-			err = createApplyCustomResource(invalidArbitraryCR, f.Namespace.Name, "test-cr", crd)
-			framework.ExpectError(err, "creating custom resource")
-			if !strings.Contains(err.Error(), `unknown field "spec.extraProperty"`) {
-				framework.Failf("incorrect error from createApplyCustomResource: %v", err)
-			}
 
 			// unknown fields on the root are considered valid
 			validArbitraryCR := fmt.Sprintf(`{%s,"spec":{"bars":[{"name":"test-bar"}]},"extraProperty":"arbitrary-value"}`, meta)


### PR DESCRIPTION
This reverts commit a3a24e1c7b379c26b407ed081a0a17fde2410180.

Rolls server-side field validation beta back for 1.24 due to https://github.com/kubernetes/kubernetes/issues/109215#issuecomment-1087037419

```release-note
The `ServerSideFieldValidation` feature has been reverted to alpha for 1.24.
```

/assign @apelisse @kevindelgado 
/sig api-machinery
/milestone v1.24