### PR TITLE
WIP: use nice and ionice for etcd clients

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -31,9 +31,9 @@ export KUBE_PANIC_WATCH_DECODE_ERROR
 
 KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=${KUBE_INTEGRATION_TEST_MAX_CONCURRENCY:-"-1"}
 if [[ ${KUBE_INTEGRATION_TEST_MAX_CONCURRENCY} -gt 0 ]]; then
-  GOMAXPROCS=${KUBE_INTEGRATION_TEST_MAX_CONCURRENCY}
-  export GOMAXPROCS
-  kube::log::status "Setting parallelism to ${GOMAXPROCS}"
+  # GOMAXPROCS=${KUBE_INTEGRATION_TEST_MAX_CONCURRENCY}
+  # export GOMAXPROCS
+  kube::log::status "*Not* setting parallelism to ${KUBE_INTEGRATION_TEST_MAX_CONCURRENCY}"
 fi
 
 # Give integration tests longer to run by default.

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -75,7 +75,9 @@ runTests() {
   kube::etcd::start_scraping
   kube::log::status "Running integration test cases"
 
-  make -C "${KUBE_ROOT}" test \
+  # Lower CPU priority by one compared to etcd and IO priority to
+  # "best-effort" with lowest priority.
+  nice -1 ionice -c 2 -n 7 make -C "${KUBE_ROOT}" test \
       WHAT="${WHAT:-$(kube::test::find_integration_test_dirs | paste -sd' ' -)}" \
       GOFLAGS="${GOFLAGS:-}" \
       KUBE_TEST_ARGS="--alsologtostderr=true ${SHORT:--short=true} --vmodule=${KUBE_TEST_VMODULE} ${KUBE_TEST_ARGS:-}" \


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Keeping etcd responsive while tests run is crucial. We cannot raise its priority, but we can lower the priority of the other processes created during integration testing.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
