### PR TITLE
storage e2e: set fstype for CSI ephemeral inline volumes

### DIFF
--- a/test/e2e/storage/framework/volume_resource.go
+++ b/test/e2e/storage/framework/volume_resource.go
@@ -121,6 +121,9 @@ func CreateVolumeResource(driver TestDriver, config *PerTestConfig, pattern Test
 					VolumeAttributes: attributes,
 				},
 			}
+			if pattern.FsType != "" {
+				r.VolSource.CSI.FSType = &pattern.FsType
+			}
 		}
 	default:
 		framework.Failf("VolumeResource doesn't support: %s", pattern.VolType)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This doesn't affect in-tree testing, but some out-of-tree usage of the
pre-defined test patterns with non-default fstype.

#### Which issue(s) this PR fixes:
Fixes #107286

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
