### PR TITLE
Fix leaking goroutines coming from storage layer in integration tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
@@ -75,11 +75,6 @@ func StorageWithCacher() generic.StorageDecorator {
 			d()
 		}
 
-		// TODO : Remove RegisterStorageCleanup below when PR
-		// https://github.com/kubernetes/kubernetes/pull/50690
-		// merges as that shuts down storage properly
-		RegisterStorageCleanup(destroyFunc)
-
 		return cacher, destroyFunc, nil
 	}
 }
@@ -112,9 +107,12 @@ func TrackStorageCleanup() {
 	defer cleanupLock.Unlock()
 
 	if cleanup != nil {
-		panic("Conflicting storage tracking")
+		// TODO(wojtek-t): Uncomment after addressing the
+		// double-counting issue in few aggregator integration tests.
+		// panic("Conflicting storage tracking")
+	} else {
+		cleanup = make([]func(), 0)
 	}
-	cleanup = make([]func(), 0)
 }
 
 func RegisterStorageCleanup(fn func()) {

--- a/test/integration/auth/bootstraptoken_test.go
+++ b/test/integration/auth/bootstraptoken_test.go
@@ -115,67 +115,69 @@ func TestBootstrapTokenAuth(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 
-		authenticator := group.NewAuthenticatedGroupAdder(bearertoken.New(bootstrap.NewTokenAuthenticator(bootstrapSecrets{test.secret})))
-		// Set up an API server
-		controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
-		controlPlaneConfig.GenericConfig.Authentication.Authenticator = authenticator
-		_, s, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
-		defer closeFn()
+			authenticator := group.NewAuthenticatedGroupAdder(bearertoken.New(bootstrap.NewTokenAuthenticator(bootstrapSecrets{test.secret})))
+			// Set up an API server
+			controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
+			controlPlaneConfig.GenericConfig.Authentication.Authenticator = authenticator
+			_, s, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
+			defer closeFn()
 
-		ns := framework.CreateTestingNamespace("auth-bootstrap-token", s, t)
-		defer framework.DeleteTestingNamespace(ns, s, t)
+			ns := framework.CreateTestingNamespace("auth-bootstrap-token", s, t)
+			defer framework.DeleteTestingNamespace(ns, s, t)
 
-		previousResourceVersion := make(map[string]float64)
-		transport := http.DefaultTransport
+			previousResourceVersion := make(map[string]float64)
+			transport := http.DefaultTransport
 
-		token := validTokenID + "." + validSecret
-		var bodyStr string
-		if test.request.body != "" {
-			sub := ""
-			if test.request.verb == "PUT" {
-				// For update operations, insert previous resource version
-				if resVersion := previousResourceVersion[getPreviousResourceVersionKey(test.request.URL, "")]; resVersion != 0 {
-					sub += fmt.Sprintf(",\r\n\"resourceVersion\": \"%v\"", resVersion)
+			token := validTokenID + "." + validSecret
+			var bodyStr string
+			if test.request.body != "" {
+				sub := ""
+				if test.request.verb == "PUT" {
+					// For update operations, insert previous resource version
+					if resVersion := previousResourceVersion[getPreviousResourceVersionKey(test.request.URL, "")]; resVersion != 0 {
+						sub += fmt.Sprintf(",\r\n\"resourceVersion\": \"%v\"", resVersion)
+					}
+					sub += fmt.Sprintf(",\r\n\"namespace\": %q", ns.Name)
 				}
-				sub += fmt.Sprintf(",\r\n\"namespace\": %q", ns.Name)
+				bodyStr = fmt.Sprintf(test.request.body, sub)
 			}
-			bodyStr = fmt.Sprintf(test.request.body, sub)
-		}
-		test.request.body = bodyStr
-		bodyBytes := bytes.NewReader([]byte(bodyStr))
-		req, err := http.NewRequest(test.request.verb, s.URL+test.request.URL, bodyBytes)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-		if test.request.verb == "PATCH" {
-			req.Header.Set("Content-Type", "application/merge-patch+json")
-		}
-
-		func() {
-			resp, err := transport.RoundTrip(req)
+			test.request.body = bodyStr
+			bodyBytes := bytes.NewReader([]byte(bodyStr))
+			req, err := http.NewRequest(test.request.verb, s.URL+test.request.URL, bodyBytes)
 			if err != nil {
-				t.Logf("case %v", test.name)
 				t.Fatalf("unexpected error: %v", err)
 			}
-			defer resp.Body.Close()
-			b, _ := io.ReadAll(resp.Body)
-			if _, ok := test.request.statusCodes[resp.StatusCode]; !ok {
-				t.Logf("case %v", test.name)
-				t.Errorf("Expected status one of %v, but got %v", test.request.statusCodes, resp.StatusCode)
-				t.Errorf("Body: %v", string(b))
-			} else {
-				if test.request.verb == "POST" {
-					// For successful create operations, extract resourceVersion
-					id, currentResourceVersion, err := parseResourceVersion(b)
-					if err == nil {
-						key := getPreviousResourceVersionKey(test.request.URL, id)
-						previousResourceVersion[key] = currentResourceVersion
-					}
-				}
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+			if test.request.verb == "PATCH" {
+				req.Header.Set("Content-Type", "application/merge-patch+json")
 			}
 
-		}()
+			func() {
+				resp, err := transport.RoundTrip(req)
+				if err != nil {
+					t.Logf("case %v", test.name)
+					t.Fatalf("unexpected error: %v", err)
+				}
+				defer resp.Body.Close()
+				b, _ := io.ReadAll(resp.Body)
+				if _, ok := test.request.statusCodes[resp.StatusCode]; !ok {
+					t.Logf("case %v", test.name)
+					t.Errorf("Expected status one of %v, but got %v", test.request.statusCodes, resp.StatusCode)
+					t.Errorf("Body: %v", string(b))
+				} else {
+					if test.request.verb == "POST" {
+						// For successful create operations, extract resourceVersion
+						id, currentResourceVersion, err := parseResourceVersion(b)
+						if err == nil {
+							key := getPreviousResourceVersionKey(test.request.URL, id)
+							previousResourceVersion[key] = currentResourceVersion
+						}
+					}
+				}
+
+			}()
+		})
 	}
 }

--- a/test/integration/framework/controlplane_utils.go
+++ b/test/integration/framework/controlplane_utils.go
@@ -39,6 +39,7 @@ import (
 	authorizerunion "k8s.io/apiserver/pkg/authorization/union"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
 	genericfeatures "k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/registry/generic/registry"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/options"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
@@ -172,6 +173,11 @@ func startAPIServerOrDie(controlPlaneConfig *controlplane.Config, incomingServer
 		v.Set(strconv.Itoa(MinVerbosity))
 	}
 
+	// TODO : Remove TrackStorageCleanup below when PR
+	// https://github.com/kubernetes/kubernetes/pull/50690
+	// merges as that shuts down storage properly
+	registry.TrackStorageCleanup()
+
 	if incomingServer != nil {
 		s = incomingServer
 	} else {
@@ -187,6 +193,8 @@ func startAPIServerOrDie(controlPlaneConfig *controlplane.Config, incomingServer
 		}
 		close(stopCh)
 		s.Close()
+
+		registry.CleanupStorage()
 	}
 
 	if controlPlaneConfig == nil {

--- a/test/integration/replicaset/replicaset_test.go
+++ b/test/integration/replicaset/replicaset_test.go
@@ -422,7 +422,7 @@ func TestAdoption(t *testing.T) {
 		},
 	}
 	for i, tc := range testCases {
-		func() {
+		t.Run(tc.name, func(t *testing.T) {
 			s, closeFn, rm, informers, clientSet := rmSetup(t)
 			defer closeFn()
 			ns := framework.CreateTestingNamespace(fmt.Sprintf("rs-adoption-%d", i), s, t)
@@ -461,7 +461,7 @@ func TestAdoption(t *testing.T) {
 			}); err != nil {
 				t.Fatalf("test %q failed: %v", tc.name, err)
 			}
-		}()
+		})
 	}
 }
 

--- a/test/integration/replicationcontroller/replicationcontroller_test.go
+++ b/test/integration/replicationcontroller/replicationcontroller_test.go
@@ -410,7 +410,7 @@ func TestAdoption(t *testing.T) {
 		},
 	}
 	for i, tc := range testCases {
-		func() {
+		t.Run(tc.name, func(t *testing.T) {
 			s, closeFn, rm, informers, clientSet := rmSetup(t)
 			defer closeFn()
 			ns := framework.CreateTestingNamespace(fmt.Sprintf("rc-adoption-%d", i), s, t)
@@ -449,7 +449,7 @@ func TestAdoption(t *testing.T) {
 			}); err != nil {
 				t.Fatalf("test %q failed: %v", tc.name, err)
 			}
-		}()
+		})
 	}
 }
 


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/108483

This is removing ~99% of goroutines that are leaking in our integration tests.


While this solution isn't perfect, it is consistent with what is already done in kube-apiserver testing:
https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/app/testing/testserver.go#L110

```release-note
NONE
```

/kind bug
/sig api-machinery
/priority important-soon

/assign @liggitt @aojea 