### PR TITLE
Add NetworkPolicyStatus to ineligible_endpoints.yaml

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -424,3 +424,12 @@
 - endpoint: logFileListHandler
   reason: optional feature
   link: https://github.com/kubernetes/kubernetes/issues/108675
+- endpoint: readNetworkingV1NamespacedNetworkPolicyStatus
+  reason: endpoints is currently feature gated and and will only receive e2e & conformance test in 1.25
+  link: https://github.com/kubernetes/kubernetes/pull/107963
+- endpoint: patchNetworkingV1NamespacedNetworkPolicyStatus
+  reason: endpoints is currently feature gated and and will only receive e2e & conformance test in 1.25
+  link: https://github.com/kubernetes/kubernetes/pull/107963
+- endpoint: replaceNetworkingV1NamespacedNetworkPolicyStatus
+  reason: endpoints is currently feature gated and and will only receive e2e & conformance test in 1.25
+  link: https://github.com/kubernetes/kubernetes/pull/107963


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Add NetworkPolicyStatus endpoints to ineligible_endpoint.yaml as the endpoints are currently future gated and will only recieve e2e & confromance tests in 1.25. This would prevent the endpoints for incorrectly showing up as new conformance technical debt.
- readNetworkingV1NamespacedNetworkPolicyStatus
- patchNetworkingV1NamespacedNetworkPolicyStatus
- replaceNetworkingV1NamespacedNetworkPolicyStatus` 


Implementation on Network Policy Status #107963

**Special notes for your reviewer:**
As of 1.22 APISnoop [Ineligible endpoints](https://apisnoop.cncf.io/conformance-progress/ineligible-endpoints) are pulled from the community owned `inelegible_endpoint.yaml` file



**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig architecture
/area conformance
