### PR TITLE
add verify-licenses.sh hack script (#108942)

### DIFF
--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -31,6 +31,12 @@ kube::golang::verify_go_version
 kube::util::ensure-temp-dir
 
 
+# Creating a new repository tree 
+# Deleting vendor directory to make go-licenses fetch license URLs from go-packages source repository
+git worktree add -f "${KUBE_TEMP}"/tmp_test_licenses/kubernetes HEAD >/dev/null 2>&1 || true
+cd "${KUBE_TEMP}"/tmp_test_licenses/kubernetes && rm -rf vendor
+
+
 # Ensure that we find the binaries we build before anything else.
 export GOBIN="${KUBE_OUTPUT_BINPATH}"
 PATH="${GOBIN}:${PATH}"
@@ -50,7 +56,7 @@ git remote add licenses https://github.com/kubernetes/kubernetes >/dev/null 2>&1
 
 
 # Install go-licenses
-echo -e "[INFO] Installing go-licenses..."
+echo -e '[INFO] Installing go-licenses...'
 pushd "${KUBE_TEMP}" >/dev/null
     git clone https://github.com/google/go-licenses.git >/dev/null 2>&1
     cd go-licenses
@@ -60,14 +66,14 @@ popd >/dev/null
 
 # Fetching CNCF Approved List Of Licenses
 # Refer: https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md
-curl -s 'https://spdx.org/licenses/licenses.json' > "${KUBE_TEMP}"/licenses.json
+curl -s 'https://spdx.org/licenses/licenses.json' -o "${KUBE_TEMP}"/licenses.json
 
 
 number_of_licenses=$(jq '.licenses | length' "${KUBE_TEMP}"/licenses.json)
 loop_index_length=$(( number_of_licenses - 1 ))
 
 
-echo -e "[INFO] Fetching current list of CNCF approved licenses..."
+echo -e '[INFO] Fetching current list of CNCF approved licenses...'
 for index in $(seq 0 $loop_index_length);
 do
 	licenseID=$(jq ".licenses[$index] .licenseId" "${KUBE_TEMP}"/licenses.json)
@@ -78,26 +84,30 @@ do
 done
 
 
-# Scanning go-packages Under The Project & Verifying Against The CNCF Approved List Of Licenses
-echo -e "[INFO] Starting license scan on go-packages..."
+# Scanning go-packages under the project & verifying against the CNCF approved list of licenses
+echo -e '[INFO] Starting license scan on go-packages...'
 go-licenses csv --git_remote "licenses" ./... >> "${KUBE_TEMP}"/licenses.csv 2>/dev/null
 
 
-echo -e "PACKAGE_NAME  LICENSE_NAME  LICENSE_URL\n" >> "${KUBE_TEMP}"/approved_licenses.dump
+echo -e 'PACKAGE_NAME  LICENSE_NAME  LICENSE_URL\n' >> "${KUBE_TEMP}"/approved_licenses.dump
 while IFS=, read -r GO_PACKAGE LICENSE_URL LICENSE_NAME
 do
 	if [[ " ${allowed_licenses[*]} " == *"${LICENSE_NAME}"* ]];
 	then
-		if [[ "${LICENSE_URL}" == "Unknown" ]];
+		if [[ "${LICENSE_URL}" == 'Unknown' ]];
 		then
 			if  [[ "${GO_PACKAGE}" != k8s.io/* ]];
 			then
 				echo -e "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"/approved_licenses_with_missing_urls.dump
 				packages_url_missing+=("${GO_PACKAGE}")
 			else
-				LICENSE_URL="https://github.com/kubernetes/kubernetes/blob/master/LICENSE"
+				LICENSE_URL='https://github.com/kubernetes/kubernetes/blob/master/LICENSE'
 				echo -e "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"/approved_licenses.dump
 			fi
+		elif curl -Is "${LICENSE_URL}" | head -1 | grep -q 404;
+		then
+			packages_url_missing+=("${GO_PACKAGE}")
+			echo -e "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"/approved_licenses_with_missing_urls.dump
 		else
 			echo -e "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"/approved_licenses.dump
 		fi
@@ -114,16 +124,18 @@ git remote remove licenses
 
 
 if [[ ${#packages_url_missing[@]} -gt 0 ]]; then
-	kube::log::error "[ERROR] The following go-packages in the project have missing or unknown license URL.\n\n"
+	echo -e '\n[ERROR] The following go-packages in the project have unknown or unreachable license URL:'
 	awk '{ printf "%-100s :  %-20s : %s\n", $1, $2, $3 }' "${KUBE_TEMP}"/approved_licenses_with_missing_urls.dump
 	exit_code=1
 fi
 
 
 if [[ ${#packages_flagged[@]} -gt 0 ]]; then
-	kube::log::error "[ERROR] The following go-packages in the project are using non-CNCF approved licenses. Please check the CNCF allowed list of licenses for more details here: https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md\n\n"
+	kube::log::error "[ERROR] The following go-packages in the project are using non-CNCF approved licenses. Please refer to the CNCF's approved licence list for further information: https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md"
 	awk '{ printf "%-100s :  %-20s : %s\n", $1, $2, $3 }' "${KUBE_TEMP}"/notapproved_licenses.dump
 	exit_code=1
+elif [[ "${exit_code}" -eq 1 ]]; then
+	kube::log::status "[ERROR] Project is using go-packages with unknown or unreachable license URLs. Please refer to the CNCF's approved licence list for further information: https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md "
 else
 	kube::log::status "[SUCCESS] Scan complete! All go-packages under the project are using current CNCF approved licenses!"
 fi

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: `hack/verify-licenses.sh`.
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+source "${KUBE_ROOT}/hack/lib/util.sh"
+
+
+kube::golang::verify_go_version
+kube::util::ensure-temp-dir
+
+
+# Ensure that we find the binaries we build before anything else.
+export GOBIN="${KUBE_OUTPUT_BINPATH}"
+PATH="${GOBIN}:${PATH}"
+
+
+# Explicitly opt into go modules, even though we're inside a GOPATH directory
+export GO111MODULE=on
+
+
+allowed_licenses=()
+packages_flagged=()
+packages_url_missing=()
+exit_code=0
+
+
+git remote add licenses https://github.com/kubernetes/kubernetes >/dev/null 2>&1 || true
+
+
+# Install go-licenses
+echo -e "[INFO] Installing go-licenses..."
+pushd "${KUBE_TEMP}" >/dev/null
+    git clone https://github.com/google/go-licenses.git >/dev/null 2>&1
+    cd go-licenses
+    go build -o "${GOPATH}/bin"
+popd >/dev/null
+
+
+# Fetching CNCF Approved List Of Licenses
+# Refer: https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md
+curl -s 'https://spdx.org/licenses/licenses.json' > "${KUBE_TEMP}"/licenses.json
+
+
+number_of_licenses=$(jq '.licenses | length' "${KUBE_TEMP}"/licenses.json)
+loop_index_length=$(( number_of_licenses - 1 ))
+
+
+echo -e "[INFO] Fetching current list of CNCF approved licenses..."
+for index in $(seq 0 $loop_index_length);
+do
+	licenseID=$(jq ".licenses[$index] .licenseId" "${KUBE_TEMP}"/licenses.json)
+	if [[ $(jq ".licenses[$index] .isDeprecatedLicenseId" "${KUBE_TEMP}"/licenses.json) == false ]]
+	then
+		allowed_licenses+=("${licenseID}")
+        fi	
+done
+
+
+# Scanning go-packages Under The Project & Verifying Against The CNCF Approved List Of Licenses
+echo -e "[INFO] Starting license scan on go-packages..."
+go-licenses csv --git_remote "licenses" ./... >> "${KUBE_TEMP}"/licenses.csv 2>/dev/null
+
+
+echo -e "PACKAGE_NAME  LICENSE_NAME  LICENSE_URL\n" >> "${KUBE_TEMP}"/approved_licenses.dump
+while IFS=, read -r GO_PACKAGE LICENSE_URL LICENSE_NAME
+do
+	if [[ " ${allowed_licenses[*]} " == *"${LICENSE_NAME}"* ]];
+	then
+		if [[ "${LICENSE_URL}" == "Unknown" ]];
+		then
+			if  [[ "${GO_PACKAGE}" != k8s.io/* ]];
+			then
+				echo -e "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"/approved_licenses_with_missing_urls.dump
+				packages_url_missing+=("${GO_PACKAGE}")
+			else
+				LICENSE_URL="https://github.com/kubernetes/kubernetes/blob/master/LICENSE"
+				echo -e "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"/approved_licenses.dump
+			fi
+		else
+			echo -e "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"/approved_licenses.dump
+		fi
+	else
+		echo -e "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"notapproved_licenses.dump
+		packages_flagged+=("${GO_PACKAGE}")
+	fi
+done < "${KUBE_TEMP}"/licenses.csv
+awk '{ printf "%-100s : %-20s : %s\n", $1, $2, $3 }' "${KUBE_TEMP}"/approved_licenses.dump
+
+
+# cleanup
+git remote remove licenses
+
+
+if [[ ${#packages_url_missing[@]} -gt 0 ]]; then
+	kube::log::error "[ERROR] The following go-packages in the project have missing or unknown license URL.\n\n"
+	awk '{ printf "%-100s :  %-20s : %s\n", $1, $2, $3 }' "${KUBE_TEMP}"/approved_licenses_with_missing_urls.dump
+	exit_code=1
+fi
+
+
+if [[ ${#packages_flagged[@]} -gt 0 ]]; then
+	kube::log::error "[ERROR] The following go-packages in the project are using non-CNCF approved licenses. Please check the CNCF allowed list of licenses for more details here: https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md\n\n"
+	awk '{ printf "%-100s :  %-20s : %s\n", $1, $2, $3 }' "${KUBE_TEMP}"/notapproved_licenses.dump
+	exit_code=1
+else
+	kube::log::status "[SUCCESS] Scan complete! All go-packages under the project are using current CNCF approved licenses!"
+fi
+
+exit ${exit_code}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The PR adds a new hack script `hack/verify-licenses.sh` to the project, to partly address the asks from the Issue https://github.com/kubernetes/kubernetes/issues/108942#issue-1178724883: 

> We need to monitor all kubernetes repos for (At least start with k/k)
> 
>  - the licenses of dependencies listed in go.mod are valid ( https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md )
> - ensure the project continues to use a license that is valid for us over time
> - ensure that the dependency is still active/available for us to use.

![Screenshot 2022-04-05 at 10 21 34 AM](https://user-images.githubusercontent.com/30499743/161681200-d93929b4-ec51-460f-87b7-c47b3f48e3b4.png)
![Screenshot 2022-04-05 at 10 22 11 AM](https://user-images.githubusercontent.com/30499743/161681254-d2e84ea5-c63f-443e-8a78-bf140d3de346.png)
![Screenshot 2022-04-05 at 9 17 20 AM](https://user-images.githubusercontent.com/30499743/161674977-b3095f89-278f-4e35-badc-c8c2e2502363.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of the fix for https://github.com/kubernetes/kubernetes/issues/108942gi

#### Special notes for your reviewer:

The script assumes that the clone of the project has the following format of git remote origin:

```
❯ git remote -v
origin	https://github.com/kubernetes/kubernetes.git
```

In case if the format is `git@github.com:kubernetes/kubernetes.git`, the `go-licenses` library complains while fetching the URL to the dependency go-packages license from the project:

```
E0405 09:01:18.242103   88027 csv.go:84] Error discovering URL for "/Users/work/kubernetes/vendor/sigs.k8s.io/kustomize/kyaml/internal/forked/github.com/qri-io/starlib/util/LICENSE":
- the Git remote "origin" does not have a valid URL
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
