### PR TITLE
replace deprecated setoutput

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
@@ -427,7 +427,7 @@ func TestAnnotateErrors(t *testing.T) {
 
 			iostreams, _, bufOut, bufErr := genericclioptions.NewTestIOStreams()
 			cmd := NewCmdAnnotate("kubectl", tf, iostreams)
-			cmd.SetOutput(bufOut)
+			cmd.SetOut(bufOut)
 
 			for k, v := range testCase.flags {
 				cmd.Flags().Set(k, v)
@@ -490,7 +490,7 @@ func TestAnnotateObject(t *testing.T) {
 
 	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
-	cmd.SetOutput(bufOut)
+	cmd.SetOut(bufOut)
 	options := NewAnnotateOptions(iostreams)
 	args := []string{"pods/foo", "a=b", "c-"}
 	if err := options.Complete(tf, cmd, args); err != nil {
@@ -556,7 +556,7 @@ func TestAnnotateResourceVersion(t *testing.T) {
 
 	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
-	cmd.SetOutput(bufOut)
+	cmd.SetOut(bufOut)
 	options := NewAnnotateOptions(iostreams)
 	options.resourceVersion = "10"
 	args := []string{"pods/foo", "a=b"}
@@ -610,7 +610,7 @@ func TestAnnotateObjectFromFile(t *testing.T) {
 
 	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
-	cmd.SetOutput(bufOut)
+	cmd.SetOut(bufOut)
 	options := NewAnnotateOptions(iostreams)
 	options.Filenames = []string{"../../../testdata/controller.yaml"}
 	args := []string{"a=b", "c-"}
@@ -696,7 +696,7 @@ func TestAnnotateMultipleObjects(t *testing.T) {
 
 	iostreams, _, _, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
-	cmd.SetOutput(iostreams.Out)
+	cmd.SetOut(iostreams.Out)
 	options := NewAnnotateOptions(iostreams)
 	options.all = true
 	args := []string{"pods", "a=b", "c-"}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
@@ -428,6 +428,7 @@ func TestAnnotateErrors(t *testing.T) {
 			iostreams, _, bufOut, bufErr := genericclioptions.NewTestIOStreams()
 			cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 			cmd.SetOut(bufOut)
+			cmd.SetErr(bufOut)
 
 			for k, v := range testCase.flags {
 				cmd.Flags().Set(k, v)
@@ -491,6 +492,7 @@ func TestAnnotateObject(t *testing.T) {
 	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 	cmd.SetOut(bufOut)
+	cmd.SetErr(bufOut)
 	options := NewAnnotateOptions(iostreams)
 	args := []string{"pods/foo", "a=b", "c-"}
 	if err := options.Complete(tf, cmd, args); err != nil {
@@ -557,6 +559,7 @@ func TestAnnotateResourceVersion(t *testing.T) {
 	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 	cmd.SetOut(bufOut)
+	cmd.SetErr(bufOut)
 	options := NewAnnotateOptions(iostreams)
 	options.resourceVersion = "10"
 	args := []string{"pods/foo", "a=b"}
@@ -611,6 +614,7 @@ func TestAnnotateObjectFromFile(t *testing.T) {
 	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 	cmd.SetOut(bufOut)
+	cmd.SetErr(bufOut)
 	options := NewAnnotateOptions(iostreams)
 	options.Filenames = []string{"../../../testdata/controller.yaml"}
 	args := []string{"a=b", "c-"}
@@ -697,6 +701,7 @@ func TestAnnotateMultipleObjects(t *testing.T) {
 	iostreams, _, _, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 	cmd.SetOut(iostreams.Out)
+	cmd.SetErr(iostreams.Out)
 	options := NewAnnotateOptions(iostreams)
 	options.all = true
 	args := []string{"pods", "a=b", "c-"}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
@@ -250,7 +250,7 @@ func TestDescribeHelpMessage(t *testing.T) {
 
 	cmd := NewCmdDescribe("kubectl", tf, streams)
 	cmd.SetArgs([]string{"-h"})
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	_, err := cmd.ExecuteC()
 
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
@@ -251,6 +251,7 @@ func TestDescribeHelpMessage(t *testing.T) {
 	cmd := NewCmdDescribe("kubectl", tf, streams)
 	cmd.SetArgs([]string{"-h"})
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	_, err := cmd.ExecuteC()
 
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose_test.go
@@ -660,7 +660,7 @@ func TestRunExposeService(t *testing.T) {
 
 			ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
 			cmd := NewCmdExposeService(tf, ioStreams)
-			cmd.SetOutput(buf)
+			cmd.SetOut(buf)
 			for flag, value := range test.flags {
 				cmd.Flags().Set(flag, value)
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose_test.go
@@ -661,6 +661,7 @@ func TestRunExposeService(t *testing.T) {
 			ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
 			cmd := NewCmdExposeService(tf, ioStreams)
 			cmd.SetOut(buf)
+			cmd.SetErr(buf)
 			for flag, value := range test.flags {
 				cmd.Flags().Set(flag, value)
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -111,7 +111,7 @@ func TestGetUnknownSchemaObject(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"type", "foo"})
 
 	expected := []runtime.Object{cmdtesting.NewInternalType("", "", "foo")}
@@ -178,7 +178,7 @@ func TestGetObjectsWithOpenAPIOutputFormatPresent(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set(useOpenAPIPrintColumnFlagLabel, "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
@@ -231,7 +231,7 @@ func TestGetObjects(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"pods", "foo"})
 
 	expected := `NAME   AGE
@@ -256,7 +256,7 @@ func TestGetObjectSubresourceStatus(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("subresource", "status")
 	cmd.Run(cmd, []string{"replicationcontrollers", "rc1"})
 
@@ -283,7 +283,7 @@ func TestGetObjectSubresourceScale(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("subresource", "scale")
 	cmd.Run(cmd, []string{"replicationcontrollers", "rc1"})
 
@@ -310,7 +310,7 @@ func TestGetTableObjects(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"pods", "foo"})
 
 	expected := `NAME   READY   STATUS   RESTARTS   AGE
@@ -335,7 +335,7 @@ func TestGetV1TableObjects(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"pods", "foo"})
 
 	expected := `NAME   READY   STATUS   RESTARTS   AGE
@@ -360,7 +360,7 @@ func TestGetObjectsShowKind(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("show-kind", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
@@ -386,7 +386,7 @@ func TestGetTableObjectsShowKind(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("show-kind", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
@@ -439,7 +439,7 @@ func TestGetMultipleResourceTypesShowKinds(t *testing.T) {
 
 	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"all"})
 
 	expected := `NAME      AGE
@@ -500,7 +500,7 @@ func TestGetMultipleTableResourceTypesShowKinds(t *testing.T) {
 
 	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"all"})
 
 	expected := `NAME      READY   STATUS   RESTARTS   AGE
@@ -561,7 +561,7 @@ func TestNoBlankLinesForGetMultipleTableResource(t *testing.T) {
 
 	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	expected := `NAME      READY   STATUS   RESTARTS   AGE
 pod/foo   0/0              0          <unknown>
@@ -630,7 +630,7 @@ func TestNoBlankLinesForGetAll(t *testing.T) {
 
 	streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"all"})
 
 	expected := ``
@@ -656,7 +656,7 @@ func TestNotFoundMessageForGetNonNamespacedResources(t *testing.T) {
 
 	streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"persistentvolumes"})
 
 	expected := ``
@@ -684,7 +684,7 @@ func TestGetObjectsShowLabels(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("show-labels", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
@@ -710,7 +710,7 @@ func TestGetTableObjectsShowLabels(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("show-labels", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
@@ -745,7 +745,7 @@ func TestGetEmptyTable(t *testing.T) {
 
 	streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"pods"})
 
 	expected := ``
@@ -795,7 +795,7 @@ func TestGetObjectIgnoreNotFound(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("ignore-not-found", "true")
 	cmd.Flags().Set("output", "yaml")
 	cmd.Run(cmd, []string{"pods", "nonexistentpod"})
@@ -910,7 +910,7 @@ func TestGetSortedObjects(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	// sorting with metadata.name
 	cmd.Flags().Set("sort-by", ".metadata.name")
@@ -949,7 +949,7 @@ func TestGetSortedObjectsUnstructuredTable(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	// sorting with metadata.name
 	cmd.Flags().Set("sort-by", ".metadata.name")
@@ -1181,7 +1181,7 @@ func TestGetObjectsIdentifiedByFile(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("filename", "../../../testdata/controller.yaml")
 	cmd.Run(cmd, []string{})
 
@@ -1207,7 +1207,7 @@ func TestGetTableObjectsIdentifiedByFile(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("filename", "../../../testdata/controller.yaml")
 	cmd.Run(cmd, []string{})
 
@@ -1233,7 +1233,7 @@ func TestGetListObjects(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"pods"})
 
 	expected := `NAME   AGE
@@ -1259,7 +1259,7 @@ func TestGetListTableObjects(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"pods"})
 
 	expected := `NAME   READY   STATUS   RESTARTS   AGE
@@ -1285,7 +1285,7 @@ func TestGetListComponentStatus(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"componentstatuses"})
 
 	expected := `NAME            STATUS      MESSAGE   ERROR
@@ -1334,7 +1334,7 @@ func TestGetMixedGenericObjects(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("output", "json")
 	cmd.Run(cmd, []string{"pods"})
 
@@ -1383,7 +1383,7 @@ func TestGetMultipleTypeObjects(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"pods,services"})
 
 	expected := `NAME      AGE
@@ -1422,7 +1422,7 @@ func TestGetMultipleTypeTableObjects(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Run(cmd, []string{"pods,services"})
 
 	expected := `NAME      READY   STATUS   RESTARTS   AGE
@@ -1462,7 +1462,7 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("output", "json")
 	cmd.Run(cmd, []string{"pods,services"})
@@ -1564,7 +1564,7 @@ func TestGetMultipleTypeObjectsWithLabelSelector(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
@@ -1608,7 +1608,7 @@ func TestGetMultipleTypeTableObjectsWithLabelSelector(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
@@ -1652,7 +1652,7 @@ func TestGetMultipleTypeObjectsWithFieldSelector(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("field-selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
@@ -1696,7 +1696,7 @@ func TestGetMultipleTypeTableObjectsWithFieldSelector(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("field-selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
@@ -1742,7 +1742,7 @@ func TestGetMultipleTypeObjectsWithDirectReference(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Run(cmd, []string{"services/bar", "node/foo"})
 
@@ -1786,7 +1786,7 @@ func TestGetMultipleTypeTableObjectsWithDirectReference(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Run(cmd, []string{"services/bar", "node/foo"})
 
@@ -1941,7 +1941,7 @@ func TestWatchLabelSelector(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Flags().Set("selector", "a=b")
@@ -1992,7 +1992,7 @@ func TestWatchTableLabelSelector(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Flags().Set("selector", "a=b")
@@ -2043,7 +2043,7 @@ func TestWatchFieldSelector(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Flags().Set("field-selector", "a=b")
@@ -2094,7 +2094,7 @@ func TestWatchTableFieldSelector(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Flags().Set("field-selector", "a=b")
@@ -2139,7 +2139,7 @@ func TestWatchResource(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
@@ -2183,7 +2183,7 @@ func TestWatchStatus(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
@@ -2229,7 +2229,7 @@ func TestWatchTableResource(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
@@ -2335,7 +2335,7 @@ func TestWatchResourceTable(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Run(cmd, []string{"pods"})
@@ -2547,7 +2547,7 @@ pod/foo
 
 			streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 			cmd := NewCmdGet("kubectl", tf, streams)
-			cmd.SetOutput(buf)
+			cmd.SetOut(buf)
 
 			cmd.Flags().Set("watch", "true")
 			cmd.Flags().Set("all-namespaces", "true")
@@ -2593,7 +2593,7 @@ func TestWatchResourceIdentifiedByFile(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Flags().Set("filename", "../../../testdata/controller.yaml")
@@ -2637,7 +2637,7 @@ func TestWatchOnlyResource(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch-only", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
@@ -2679,7 +2679,7 @@ func TestWatchOnlyTableResource(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch-only", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
@@ -2724,7 +2724,7 @@ func TestWatchOnlyList(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch-only", "true")
 	cmd.Run(cmd, []string{"pods"})
@@ -2769,7 +2769,7 @@ func TestWatchOnlyTableList(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 
 	cmd.Flags().Set("watch-only", "true")
 	cmd.Run(cmd, []string{"pods"})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -112,6 +112,7 @@ func TestGetUnknownSchemaObject(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"type", "foo"})
 
 	expected := []runtime.Object{cmdtesting.NewInternalType("", "", "foo")}
@@ -179,6 +180,7 @@ func TestGetObjectsWithOpenAPIOutputFormatPresent(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set(useOpenAPIPrintColumnFlagLabel, "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
@@ -232,6 +234,7 @@ func TestGetObjects(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"pods", "foo"})
 
 	expected := `NAME   AGE
@@ -257,6 +260,7 @@ func TestGetObjectSubresourceStatus(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("subresource", "status")
 	cmd.Run(cmd, []string{"replicationcontrollers", "rc1"})
 
@@ -284,6 +288,7 @@ func TestGetObjectSubresourceScale(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("subresource", "scale")
 	cmd.Run(cmd, []string{"replicationcontrollers", "rc1"})
 
@@ -311,6 +316,7 @@ func TestGetTableObjects(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"pods", "foo"})
 
 	expected := `NAME   READY   STATUS   RESTARTS   AGE
@@ -336,6 +342,7 @@ func TestGetV1TableObjects(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"pods", "foo"})
 
 	expected := `NAME   READY   STATUS   RESTARTS   AGE
@@ -361,6 +368,7 @@ func TestGetObjectsShowKind(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("show-kind", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
@@ -387,6 +395,7 @@ func TestGetTableObjectsShowKind(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("show-kind", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
@@ -440,6 +449,7 @@ func TestGetMultipleResourceTypesShowKinds(t *testing.T) {
 	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"all"})
 
 	expected := `NAME      AGE
@@ -501,6 +511,7 @@ func TestGetMultipleTableResourceTypesShowKinds(t *testing.T) {
 	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"all"})
 
 	expected := `NAME      READY   STATUS   RESTARTS   AGE
@@ -562,6 +573,7 @@ func TestNoBlankLinesForGetMultipleTableResource(t *testing.T) {
 	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	expected := `NAME      READY   STATUS   RESTARTS   AGE
 pod/foo   0/0              0          <unknown>
@@ -631,6 +643,7 @@ func TestNoBlankLinesForGetAll(t *testing.T) {
 	streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"all"})
 
 	expected := ``
@@ -657,6 +670,7 @@ func TestNotFoundMessageForGetNonNamespacedResources(t *testing.T) {
 	streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"persistentvolumes"})
 
 	expected := ``
@@ -685,6 +699,7 @@ func TestGetObjectsShowLabels(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("show-labels", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
@@ -711,6 +726,7 @@ func TestGetTableObjectsShowLabels(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("show-labels", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
@@ -746,6 +762,7 @@ func TestGetEmptyTable(t *testing.T) {
 	streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"pods"})
 
 	expected := ``
@@ -796,6 +813,7 @@ func TestGetObjectIgnoreNotFound(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("ignore-not-found", "true")
 	cmd.Flags().Set("output", "yaml")
 	cmd.Run(cmd, []string{"pods", "nonexistentpod"})
@@ -911,6 +929,7 @@ func TestGetSortedObjects(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	// sorting with metadata.name
 	cmd.Flags().Set("sort-by", ".metadata.name")
@@ -950,6 +969,7 @@ func TestGetSortedObjectsUnstructuredTable(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	// sorting with metadata.name
 	cmd.Flags().Set("sort-by", ".metadata.name")
@@ -1182,6 +1202,7 @@ func TestGetObjectsIdentifiedByFile(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("filename", "../../../testdata/controller.yaml")
 	cmd.Run(cmd, []string{})
 
@@ -1208,6 +1229,7 @@ func TestGetTableObjectsIdentifiedByFile(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("filename", "../../../testdata/controller.yaml")
 	cmd.Run(cmd, []string{})
 
@@ -1234,6 +1256,7 @@ func TestGetListObjects(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"pods"})
 
 	expected := `NAME   AGE
@@ -1260,6 +1283,7 @@ func TestGetListTableObjects(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"pods"})
 
 	expected := `NAME   READY   STATUS   RESTARTS   AGE
@@ -1286,6 +1310,7 @@ func TestGetListComponentStatus(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"componentstatuses"})
 
 	expected := `NAME            STATUS      MESSAGE   ERROR
@@ -1335,6 +1360,7 @@ func TestGetMixedGenericObjects(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("output", "json")
 	cmd.Run(cmd, []string{"pods"})
 
@@ -1384,6 +1410,7 @@ func TestGetMultipleTypeObjects(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"pods,services"})
 
 	expected := `NAME      AGE
@@ -1423,6 +1450,7 @@ func TestGetMultipleTypeTableObjects(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"pods,services"})
 
 	expected := `NAME      READY   STATUS   RESTARTS   AGE
@@ -1463,6 +1491,7 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("output", "json")
 	cmd.Run(cmd, []string{"pods,services"})
@@ -1565,6 +1594,7 @@ func TestGetMultipleTypeObjectsWithLabelSelector(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
@@ -1609,6 +1639,7 @@ func TestGetMultipleTypeTableObjectsWithLabelSelector(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
@@ -1653,6 +1684,7 @@ func TestGetMultipleTypeObjectsWithFieldSelector(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("field-selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
@@ -1697,6 +1729,7 @@ func TestGetMultipleTypeTableObjectsWithFieldSelector(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("field-selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
@@ -1743,6 +1776,7 @@ func TestGetMultipleTypeObjectsWithDirectReference(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Run(cmd, []string{"services/bar", "node/foo"})
 
@@ -1787,6 +1821,7 @@ func TestGetMultipleTypeTableObjectsWithDirectReference(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Run(cmd, []string{"services/bar", "node/foo"})
 
@@ -1942,6 +1977,7 @@ func TestWatchLabelSelector(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Flags().Set("selector", "a=b")
@@ -1993,6 +2029,7 @@ func TestWatchTableLabelSelector(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Flags().Set("selector", "a=b")
@@ -2044,6 +2081,7 @@ func TestWatchFieldSelector(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Flags().Set("field-selector", "a=b")
@@ -2095,6 +2133,7 @@ func TestWatchTableFieldSelector(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Flags().Set("field-selector", "a=b")
@@ -2140,6 +2179,7 @@ func TestWatchResource(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
@@ -2184,6 +2224,7 @@ func TestWatchStatus(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
@@ -2230,6 +2271,7 @@ func TestWatchTableResource(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
@@ -2336,6 +2378,7 @@ func TestWatchResourceTable(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Run(cmd, []string{"pods"})
@@ -2548,6 +2591,7 @@ pod/foo
 			streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 			cmd := NewCmdGet("kubectl", tf, streams)
 			cmd.SetOut(buf)
+			cmd.SetErr(buf)
 
 			cmd.Flags().Set("watch", "true")
 			cmd.Flags().Set("all-namespaces", "true")
@@ -2594,6 +2638,7 @@ func TestWatchResourceIdentifiedByFile(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch", "true")
 	cmd.Flags().Set("filename", "../../../testdata/controller.yaml")
@@ -2638,6 +2683,7 @@ func TestWatchOnlyResource(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch-only", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
@@ -2680,6 +2726,7 @@ func TestWatchOnlyTableResource(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch-only", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
@@ -2725,6 +2772,7 @@ func TestWatchOnlyList(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch-only", "true")
 	cmd.Run(cmd, []string{"pods"})
@@ -2770,6 +2818,7 @@ func TestWatchOnlyTableList(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 
 	cmd.Flags().Set("watch-only", "true")
 	cmd.Run(cmd, []string{"pods"})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
@@ -333,7 +333,7 @@ func TestLabelErrors(t *testing.T) {
 			ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
 			buf := bytes.NewBuffer([]byte{})
 			cmd := NewCmdLabel(tf, ioStreams)
-			cmd.SetOutput(buf)
+			cmd.SetOut(buf)
 
 			for k, v := range testCase.flags {
 				cmd.Flags().Set(k, v)
@@ -552,7 +552,7 @@ func TestLabelResourceVersion(t *testing.T) {
 
 	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdLabel(tf, iostreams)
-	cmd.SetOutput(bufOut)
+	cmd.SetOut(bufOut)
 	options := NewLabelOptions(iostreams)
 	options.resourceVersion = "10"
 	args := []string{"pods/foo", "a=b"}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
@@ -334,6 +334,7 @@ func TestLabelErrors(t *testing.T) {
 			buf := bytes.NewBuffer([]byte{})
 			cmd := NewCmdLabel(tf, ioStreams)
 			cmd.SetOut(buf)
+			cmd.SetErr(buf)
 
 			for k, v := range testCase.flags {
 				cmd.Flags().Set(k, v)
@@ -553,6 +554,7 @@ func TestLabelResourceVersion(t *testing.T) {
 	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdLabel(tf, iostreams)
 	cmd.SetOut(bufOut)
+	cmd.SetErr(bufOut)
 	options := NewLabelOptions(iostreams)
 	options.resourceVersion = "10"
 	args := []string{"pods/foo", "a=b"}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/options/options.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/options/options.go
@@ -48,7 +48,8 @@ func NewCmdOptions(out io.Writer) *cobra.Command {
 	// function call will fall back to stderr.
 	//
 	// See https://github.com/kubernetes/kubernetes/pull/46394 for details.
-	cmd.SetOutput(out)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
 
 	templates.UseOptionsTemplates(cmd)
 	return cmd

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
@@ -60,7 +60,7 @@ func TestImageLocal(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdImage(tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 
@@ -172,7 +172,7 @@ func TestSetMultiResourcesImageLocal(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdImage(tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
@@ -61,6 +61,7 @@ func TestImageLocal(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdImage(tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 
@@ -173,6 +174,7 @@ func TestSetMultiResourcesImageLocal(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdImage(tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources_test.go
@@ -59,7 +59,7 @@ func TestResourcesLocal(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdResources(tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 
@@ -107,7 +107,7 @@ func TestSetMultiResourcesLimitsLocal(t *testing.T) {
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdResources(tf, streams)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources_test.go
@@ -60,6 +60,7 @@ func TestResourcesLocal(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdResources(tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 
@@ -108,6 +109,7 @@ func TestSetMultiResourcesLimitsLocal(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdResources(tf, streams)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -745,7 +745,8 @@ func IsSiblingCommandExists(cmd *cobra.Command, targetCmdName string) bool {
 // arguments (sub-commands) are provided, or a usage error otherwise.
 func DefaultSubCommandRun(out io.Writer) func(c *cobra.Command, args []string) {
 	return func(c *cobra.Command, args []string) {
-		c.SetOutput(out)
+		c.SetOut(out)
+		c.SetErr(out)
 		RequireNoArguments(c, args)
 		c.Help()
 		CheckErr(ErrExit)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind deprecation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Replace deprecated `SetOutput` in kubectl options cmds and tests to `SetOut and/or SetErr`, consistent to all current logics.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
