### PR TITLE
Cleanup rest storage resources on shutdown

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -159,7 +159,7 @@ func Run(completeOptions completedServerRunOptions, stopCh <-chan struct{}) erro
 
 	klog.InfoS("Golang settings", "GOGC", os.Getenv("GOGC"), "GOMAXPROCS", os.Getenv("GOMAXPROCS"), "GOTRACEBACK", os.Getenv("GOTRACEBACK"))
 
-	server, err := CreateServerChain(completeOptions, stopCh)
+	server, err := CreateServerChain(completeOptions)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func Run(completeOptions completedServerRunOptions, stopCh <-chan struct{}) erro
 }
 
 // CreateServerChain creates the apiservers connected via delegation.
-func CreateServerChain(completedOptions completedServerRunOptions, stopCh <-chan struct{}) (*aggregatorapiserver.APIAggregator, error) {
+func CreateServerChain(completedOptions completedServerRunOptions) (*aggregatorapiserver.APIAggregator, error) {
 	kubeAPIServerConfig, serviceResolver, pluginInitializer, err := CreateKubeAPIServerConfig(completedOptions)
 	if err != nil {
 		return nil, err

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -213,7 +213,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 
 	t.Logf("runtime-config=%v", completedOptions.APIEnablement.RuntimeConfig)
 	t.Logf("Starting kube-apiserver on port %d...", s.SecureServing.BindPort)
-	server, err := app.CreateServerChain(completedOptions, stopCh)
+	server, err := app.CreateServerChain(completedOptions)
 	if err != nil {
 		return result, fmt.Errorf("failed to create server chain: %v", err)
 	}

--- a/pkg/registry/apiserverinternal/storageversion/storage/storage.go
+++ b/pkg/registry/apiserverinternal/storageversion/storage/storage.go
@@ -73,6 +73,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &apiserverinternal.StorageVersion{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/apps/daemonset/storage/storage.go
+++ b/pkg/registry/apps/daemonset/storage/storage.go
@@ -88,6 +88,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &apps.DaemonSet{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/apps/deployment/storage/storage.go
+++ b/pkg/registry/apps/deployment/storage/storage.go
@@ -140,6 +140,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &apps.Deployment{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)
@@ -183,6 +189,12 @@ var _ = rest.StorageMetadata(&RollbackREST{})
 // New creates a rollback
 func (r *RollbackREST) New() runtime.Object {
 	return &apps.DeploymentRollback{}
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *RollbackREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
 }
 
 var _ = rest.NamedCreater(&RollbackREST{})
@@ -281,6 +293,12 @@ func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.Gr
 // New creates a new Scale object
 func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *ScaleREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
 }
 
 // Get retrieves object from Scale storage.

--- a/pkg/registry/apps/replicaset/storage/storage.go
+++ b/pkg/registry/apps/replicaset/storage/storage.go
@@ -136,6 +136,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &apps.ReplicaSet{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)
@@ -183,6 +189,12 @@ func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.Gr
 // New creates a new Scale object
 func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *ScaleREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
 }
 
 // Get retrieves object from Scale storage.

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -124,6 +124,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &apps.StatefulSet{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)
@@ -177,6 +183,12 @@ func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.Gr
 // New creates a new Scale object
 func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *ScaleREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
 }
 
 // Get retrieves object from Scale storage.

--- a/pkg/registry/authentication/tokenreview/storage.go
+++ b/pkg/registry/authentication/tokenreview/storage.go
@@ -54,6 +54,12 @@ func (r *REST) New() runtime.Object {
 	return &authentication.TokenReview{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *REST) Destroy() {
+	// Given no underlying store, we don't destroy anything
+	// here explicitly.
+}
+
 func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	tokenReview, ok := obj.(*authentication.TokenReview)
 	if !ok {

--- a/pkg/registry/authorization/localsubjectaccessreview/rest.go
+++ b/pkg/registry/authorization/localsubjectaccessreview/rest.go
@@ -47,6 +47,12 @@ func (r *REST) New() runtime.Object {
 	return &authorizationapi.LocalSubjectAccessReview{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *REST) Destroy() {
+	// Given no underlying store, we don't destroy anything
+	// here explicitly.
+}
+
 func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	localSubjectAccessReview, ok := obj.(*authorizationapi.LocalSubjectAccessReview)
 	if !ok {

--- a/pkg/registry/authorization/selfsubjectaccessreview/rest.go
+++ b/pkg/registry/authorization/selfsubjectaccessreview/rest.go
@@ -47,6 +47,12 @@ func (r *REST) New() runtime.Object {
 	return &authorizationapi.SelfSubjectAccessReview{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *REST) Destroy() {
+	// Given no underlying store, we don't destroy anything
+	// here explicitly.
+}
+
 func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	selfSAR, ok := obj.(*authorizationapi.SelfSubjectAccessReview)
 	if !ok {

--- a/pkg/registry/authorization/selfsubjectrulesreview/rest.go
+++ b/pkg/registry/authorization/selfsubjectrulesreview/rest.go
@@ -49,6 +49,12 @@ func (r *REST) New() runtime.Object {
 	return &authorizationapi.SelfSubjectRulesReview{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *REST) Destroy() {
+	// Given no underlying store, we don't destroy anything
+	// here explicitly.
+}
+
 // Create attempts to get self subject rules in specific namespace.
 func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	selfSRR, ok := obj.(*authorizationapi.SelfSubjectRulesReview)

--- a/pkg/registry/authorization/subjectaccessreview/rest.go
+++ b/pkg/registry/authorization/subjectaccessreview/rest.go
@@ -46,6 +46,12 @@ func (r *REST) New() runtime.Object {
 	return &authorizationapi.SubjectAccessReview{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *REST) Destroy() {
+	// Given no underlying store, we don't destroy anything
+	// here explicitly.
+}
+
 func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	subjectAccessReview, ok := obj.(*authorizationapi.SubjectAccessReview)
 	if !ok {

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
@@ -88,6 +88,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &autoscaling.HorizontalPodAutoscaler{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/batch/cronjob/storage/storage.go
+++ b/pkg/registry/batch/cronjob/storage/storage.go
@@ -86,6 +86,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &batch.CronJob{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/batch/job/storage/storage.go
+++ b/pkg/registry/batch/job/storage/storage.go
@@ -129,6 +129,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &batch.Job{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/certificates/certificates/storage/storage.go
+++ b/pkg/registry/certificates/certificates/storage/storage.go
@@ -89,6 +89,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &certificates.CertificateSigningRequest{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)
@@ -120,6 +126,12 @@ type ApprovalREST struct {
 // New creates a new CertificateSigningRequest object.
 func (r *ApprovalREST) New() runtime.Object {
 	return &certificates.CertificateSigningRequest{}
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *ApprovalREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
 }
 
 // Get retrieves the object from the storage. It is required to support Patch.

--- a/pkg/registry/core/componentstatus/rest.go
+++ b/pkg/registry/core/componentstatus/rest.go
@@ -58,6 +58,12 @@ func (rs *REST) New() runtime.Object {
 	return &api.ComponentStatus{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *REST) Destroy() {
+	// Given no underlying store, we don't destroy anything
+	// here explicitly.
+}
+
 func (rs *REST) NewList() runtime.Object {
 	return &api.ComponentStatusList{}
 }

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -98,6 +98,11 @@ func (r *REST) New() runtime.Object {
 	return r.store.New()
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *REST) Destroy() {
+	r.store.Destroy()
+}
+
 func (r *REST) NewList() runtime.Object {
 	return r.store.NewList()
 }
@@ -300,6 +305,12 @@ func (r *StatusREST) New() runtime.Object {
 	return r.store.New()
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)
@@ -323,6 +334,12 @@ func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, 
 
 func (r *FinalizeREST) New() runtime.Object {
 	return r.store.New()
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *FinalizeREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
 }
 
 // Update alters the status finalizers subset of an object.

--- a/pkg/registry/core/node/rest/proxy.go
+++ b/pkg/registry/core/node/rest/proxy.go
@@ -50,6 +50,12 @@ func (r *ProxyREST) New() runtime.Object {
 	return &api.NodeProxyOptions{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *ProxyREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // ConnectMethods returns the list of HTTP methods that can be proxied
 func (r *ProxyREST) ConnectMethods() []string {
 	return proxyMethods

--- a/pkg/registry/core/node/storage/storage.go
+++ b/pkg/registry/core/node/storage/storage.go
@@ -66,6 +66,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.Node{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/core/persistentvolume/storage/storage.go
+++ b/pkg/registry/core/persistentvolume/storage/storage.go
@@ -83,6 +83,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.PersistentVolume{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage.go
@@ -127,6 +127,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.PersistentVolumeClaim{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/core/pod/rest/log.go
+++ b/pkg/registry/core/pod/rest/log.go
@@ -51,6 +51,12 @@ func (r *LogREST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *LogREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // ProducesMIMETypes returns a list of the MIME types the specified HTTP verb (GET, POST, DELETE,
 // PATCH) can respond with.
 func (r *LogREST) ProducesMIMETypes(verb string) []string {

--- a/pkg/registry/core/pod/rest/subresources.go
+++ b/pkg/registry/core/pod/rest/subresources.go
@@ -49,6 +49,12 @@ func (r *ProxyREST) New() runtime.Object {
 	return &api.PodProxyOptions{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *ProxyREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // ConnectMethods returns the list of HTTP methods that can be proxied
 func (r *ProxyREST) ConnectMethods() []string {
 	return proxyMethods
@@ -91,6 +97,12 @@ func (r *AttachREST) New() runtime.Object {
 	return &api.PodAttachOptions{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *AttachREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Connect returns a handler for the pod exec proxy
 func (r *AttachREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	attachOpts, ok := opts.(*api.PodAttachOptions)
@@ -128,6 +140,12 @@ func (r *ExecREST) New() runtime.Object {
 	return &api.PodExecOptions{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *ExecREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Connect returns a handler for the pod exec proxy
 func (r *ExecREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	execOpts, ok := opts.(*api.PodExecOptions)
@@ -163,6 +181,12 @@ var _ = rest.Connecter(&PortForwardREST{})
 // New returns an empty podPortForwardOptions object
 func (r *PortForwardREST) New() runtime.Object {
 	return &api.PodPortForwardOptions{}
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *PortForwardREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
 }
 
 // NewConnectOptions returns the versioned object that represents the

--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -95,6 +95,12 @@ func (r *EvictionREST) New() runtime.Object {
 	return &policy.Eviction{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *EvictionREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Propagate dry-run takes the dry-run option from the request and pushes it into the eviction object.
 // It returns an error if they have non-matching dry-run options.
 func propagateDryRun(eviction *policy.Eviction, options *metav1.CreateOptions) (*metav1.DeleteOptions, error) {

--- a/pkg/registry/core/pod/storage/eviction_test.go
+++ b/pkg/registry/core/pod/storage/eviction_test.go
@@ -689,3 +689,6 @@ func (ms *mockStore) NewList() runtime.Object {
 func (ms *mockStore) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	return nil, nil
 }
+
+func (ms *mockStore) Destroy() {
+}

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -157,6 +157,12 @@ func (r *BindingREST) New() runtime.Object {
 	return &api.Binding{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *BindingREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 var _ = rest.NamedCreater(&BindingREST{})
 
 // Create ensures a pod is bound to a specific host.
@@ -263,6 +269,12 @@ func (r *LegacyBindingREST) New() runtime.Object {
 	return r.bindingRest.New()
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *LegacyBindingREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Create ensures a pod is bound to a specific host.
 func (r *LegacyBindingREST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (out runtime.Object, err error) {
 	metadata, err := meta.Accessor(obj)
@@ -280,6 +292,12 @@ type StatusREST struct {
 // New creates a new pod resource
 func (r *StatusREST) New() runtime.Object {
 	return &api.Pod{}
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
 }
 
 // Get retrieves the object from the storage. It is required to support Patch.
@@ -322,6 +340,12 @@ func (r *EphemeralContainersREST) Get(ctx context.Context, name string, options 
 // New creates a new pod resource
 func (r *EphemeralContainersREST) New() runtime.Object {
 	return &api.Pod{}
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *EphemeralContainersREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
 }
 
 // Update alters the EphemeralContainers field in PodSpec

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -131,6 +131,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.ReplicationController{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)
@@ -172,6 +178,12 @@ func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.Gr
 // New creates a new Scale object
 func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *ScaleREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
 }
 
 func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {

--- a/pkg/registry/core/resourcequota/storage/storage.go
+++ b/pkg/registry/core/resourcequota/storage/storage.go
@@ -82,6 +82,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.ResourceQuota{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/core/service/proxy.go
+++ b/pkg/registry/core/service/proxy.go
@@ -46,6 +46,12 @@ func (r *ProxyREST) New() runtime.Object {
 	return &api.ServiceProxyOptions{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *ProxyREST) Destroy() {
+	// Given no underlying store, we don't destroy anything
+	// here explicitly.
+}
+
 // ConnectMethods returns the list of HTTP methods that can be proxied
 func (r *ProxyREST) ConnectMethods() []string {
 	return proxyMethods

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -166,6 +166,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.Service{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/core/serviceaccount/storage/token.go
+++ b/pkg/registry/core/serviceaccount/storage/token.go
@@ -43,6 +43,12 @@ func (r *TokenREST) New() runtime.Object {
 	return &authenticationapi.TokenRequest{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *TokenREST) Destroy() {
+	// Given no underlying store, we don't destroy anything
+	// here explicitly.
+}
+
 type TokenREST struct {
 	svcaccts             getter
 	pods                 getter

--- a/pkg/registry/flowcontrol/flowschema/storage/storage.go
+++ b/pkg/registry/flowcontrol/flowschema/storage/storage.go
@@ -81,6 +81,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &flowcontrol.FlowSchema{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/storage/storage.go
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/storage/storage.go
@@ -81,6 +81,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &flowcontrol.PriorityLevelConfiguration{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/networking/ingress/storage/storage.go
+++ b/pkg/registry/networking/ingress/storage/storage.go
@@ -80,6 +80,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &networking.Ingress{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/networking/networkpolicy/storage/storage.go
+++ b/pkg/registry/networking/networkpolicy/storage/storage.go
@@ -82,6 +82,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &networkingapi.NetworkPolicy{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/policy/poddisruptionbudget/storage/storage.go
+++ b/pkg/registry/policy/poddisruptionbudget/storage/storage.go
@@ -77,6 +77,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &policyapi.PodDisruptionBudget{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/rbac/clusterrole/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrole/policybased/storage.go
@@ -48,7 +48,7 @@ func NewStorage(s rest.StandardStorage, authorizer authorizer.Authorizer, ruleRe
 
 // Destroy cleans up resources on shutdown.
 func (r *Storage) Destroy() {
-	// FIXME: Do we have to anything to destroy here?
+	r.StandardStorage.Destroy()
 }
 
 func (r *Storage) NamespaceScoped() bool {

--- a/pkg/registry/rbac/clusterrole/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrole/policybased/storage.go
@@ -46,6 +46,11 @@ func NewStorage(s rest.StandardStorage, authorizer authorizer.Authorizer, ruleRe
 	return &Storage{s, authorizer, ruleResolver}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *Storage) Destroy() {
+	// FIXME: Do we have to anything to destroy here?
+}
+
 func (r *Storage) NamespaceScoped() bool {
 	return false
 }

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -47,6 +47,11 @@ func NewStorage(s rest.StandardStorage, authorizer authorizer.Authorizer, ruleRe
 	return &Storage{s, authorizer, ruleResolver}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *Storage) Destroy() {
+	// FIXME: Do we have to anything to destroy here?
+}
+
 func (r *Storage) NamespaceScoped() bool {
 	return false
 }

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -49,7 +49,7 @@ func NewStorage(s rest.StandardStorage, authorizer authorizer.Authorizer, ruleRe
 
 // Destroy cleans up resources on shutdown.
 func (r *Storage) Destroy() {
-	// FIXME: Do we have to anything to destroy here?
+	r.StandardStorage.Destroy()
 }
 
 func (r *Storage) NamespaceScoped() bool {

--- a/pkg/registry/rbac/role/policybased/storage.go
+++ b/pkg/registry/rbac/role/policybased/storage.go
@@ -47,7 +47,7 @@ func NewStorage(s rest.StandardStorage, authorizer authorizer.Authorizer, ruleRe
 
 // Destroy cleans up resources on shutdown.
 func (r *Storage) Destroy() {
-	// FIXME: Do we have to anything to destroy here?
+	r.StandardStorage.Destroy()
 }
 
 func (r *Storage) NamespaceScoped() bool {

--- a/pkg/registry/rbac/role/policybased/storage.go
+++ b/pkg/registry/rbac/role/policybased/storage.go
@@ -45,6 +45,11 @@ func NewStorage(s rest.StandardStorage, authorizer authorizer.Authorizer, ruleRe
 	return &Storage{s, authorizer, ruleResolver}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *Storage) Destroy() {
+	// FIXME: Do we have to anything to destroy here?
+}
+
 func (r *Storage) NamespaceScoped() bool {
 	return true
 }

--- a/pkg/registry/rbac/rolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/rolebinding/policybased/storage.go
@@ -48,6 +48,11 @@ func NewStorage(s rest.StandardStorage, authorizer authorizer.Authorizer, ruleRe
 	return &Storage{s, authorizer, ruleResolver}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *Storage) Destroy() {
+	// FIXME: Do we have to anything to destroy here?
+}
+
 func (r *Storage) NamespaceScoped() bool {
 	return true
 }

--- a/pkg/registry/rbac/rolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/rolebinding/policybased/storage.go
@@ -50,7 +50,7 @@ func NewStorage(s rest.StandardStorage, authorizer authorizer.Authorizer, ruleRe
 
 // Destroy cleans up resources on shutdown.
 func (r *Storage) Destroy() {
-	// FIXME: Do we have to anything to destroy here?
+	r.StandardStorage.Destroy()
 }
 
 func (r *Storage) NamespaceScoped() bool {

--- a/pkg/registry/storage/volumeattachment/storage/storage.go
+++ b/pkg/registry/storage/volumeattachment/storage/storage.go
@@ -85,6 +85,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &storageapi.VolumeAttachment{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -195,6 +195,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &apiextensions.CustomResourceDefinition{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -462,6 +462,9 @@ func (storage *SimpleRESTStorage) NewList() runtime.Object {
 	return &genericapitesting.SimpleList{}
 }
 
+func (storage *SimpleRESTStorage) Destroy() {
+}
+
 func (storage *SimpleRESTStorage) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	storage.checkContext(ctx)
 	storage.created = obj.(*genericapitesting.Simple)
@@ -545,6 +548,9 @@ var _ = rest.Connecter(&ConnecterRESTStorage{})
 
 func (s *ConnecterRESTStorage) New() runtime.Object {
 	return &genericapitesting.Simple{}
+}
+
+func (s *ConnecterRESTStorage) Destroy() {
 }
 
 func (s *ConnecterRESTStorage) Connect(ctx context.Context, id string, options runtime.Object, responder rest.Responder) (http.Handler, error) {
@@ -666,6 +672,9 @@ type SimpleTypedStorage struct {
 
 func (storage *SimpleTypedStorage) New() runtime.Object {
 	return storage.baseType
+}
+
+func (storage *SimpleTypedStorage) Destroy() {
 }
 
 func (storage *SimpleTypedStorage) Get(ctx context.Context, id string, options *metav1.GetOptions) (runtime.Object, error) {
@@ -808,6 +817,9 @@ func (UnimplementedRESTStorage) NamespaceScoped() bool {
 
 func (UnimplementedRESTStorage) New() runtime.Object {
 	return &genericapitesting.Simple{}
+}
+
+func (UnimplementedRESTStorage) Destroy() {
 }
 
 // TestUnimplementedRESTStorage ensures that if a rest.Storage does not implement a given
@@ -4320,6 +4332,9 @@ var _ = rest.GroupVersionKindProvider(&SimpleXGSubresourceRESTStorage{})
 
 func (storage *SimpleXGSubresourceRESTStorage) New() runtime.Object {
 	return &genericapitesting.SimpleXGSubresource{}
+}
+
+func (storage *SimpleXGSubresourceRESTStorage) Destroy() {
 }
 
 func (storage *SimpleXGSubresourceRESTStorage) Get(ctx context.Context, id string, options *metav1.GetOptions) (runtime.Object, error) {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
@@ -70,9 +70,12 @@ func StorageWithCacher() generic.StorageDecorator {
 		if err != nil {
 			return nil, func() {}, err
 		}
+		var once sync.Once
 		destroyFunc := func() {
-			cacher.Stop()
-			d()
+			once.Do(func() {
+				cacher.Stop()
+				d()
+			})
 		}
 
 		// TODO : Remove RegisterStorageCleanup below when PR

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -283,6 +283,11 @@ type StandardStorage interface {
 	GracefulDeleter
 	CollectionDeleter
 	Watcher
+
+	// Destroy cleans up its resources on shutdown.
+	// Destroy has to be implemented in thread-safe way and be prepared
+	// for being called more than once.
+	Destroy()
 }
 
 // Redirector know how to return a remote resource's location.

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -56,6 +56,11 @@ type Storage interface {
 	// New returns an empty object that can be used with Create and Update after request data has been put into it.
 	// This object must be a pointer type for use with Codec.DecodeInto([]byte, runtime.Object)
 	New() runtime.Object
+
+	// Destroy cleans up its resources on shutdown.
+	// Destroy has to be implemented in thread-safe way and be prepared
+	// for being called more than once.
+	Destroy()
 }
 
 // Scoper indicates what scope the resource is at. It must be specified.

--- a/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds_test.go
@@ -110,6 +110,9 @@ func (r removedInStorage) New() runtime.Object {
 	return removedInObj{major: r.major, minor: r.minor}
 }
 
+func (r removedInStorage) Destroy() {
+}
+
 type neverRemovedObj struct {
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -92,9 +92,7 @@ type APIGroupInfo struct {
 func (a *APIGroupInfo) destroyStorage() {
 	for _, stores := range a.VersionedResourcesStorageMap {
 		for _, store := range stores {
-			// TODO(wojtek-t): Uncomment once all storage support it.
-			klog.Errorf("Destroying storage: %v", store)
-			// store.Destroy()
+			store.Destroy()
 		}
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -544,6 +544,9 @@ func (p *testGetterStorage) New() runtime.Object {
 	}
 }
 
+func (p *testGetterStorage) Destroy() {
+}
+
 func (p *testGetterStorage) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return nil, nil
 }
@@ -563,6 +566,9 @@ func (p *testNoVerbsStorage) New() runtime.Object {
 			APIVersion: p.Version,
 		},
 	}
+}
+
+func (p *testNoVerbsStorage) Destroy() {
 }
 
 func fakeVersion() version.Info {

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
@@ -147,6 +147,12 @@ func (r *StatusREST) New() runtime.Object {
 	return &apiregistration.APIService{}
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/registry.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/registry.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
-	"k8s.io/apiserver/pkg/registry/rest"
 )
 
 // REST implements a RESTStorage for API services against etcd
@@ -31,7 +30,7 @@ type REST struct {
 // RESTInPeace is just a simple function that panics on error.
 // Otherwise returns the given storage object. It is meant to be
 // a wrapper for wardle registries.
-func RESTInPeace(storage rest.StandardStorage, err error) rest.StandardStorage {
+func RESTInPeace(storage *REST, err error) *REST {
 	if err != nil {
 		err = fmt.Errorf("unable to create REST storage for a resource due to %v, will die", err)
 		panic(err)

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -136,7 +136,7 @@ func StartRealAPIServerOrDie(t *testing.T, configFuncs ...func(*options.ServerRu
 
 	stopCh := make(chan struct{})
 
-	kubeAPIServer, err := app.CreateServerChain(completedOptions, stopCh)
+	kubeAPIServer, err := app.CreateServerChain(completedOptions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/framework/controlplane_utils.go
+++ b/test/integration/framework/controlplane_utils.go
@@ -186,6 +186,7 @@ func startAPIServerOrDie(controlPlaneConfig *controlplane.Config, incomingServer
 			m.GenericAPIServer.RunPreShutdownHooks()
 		}
 		close(stopCh)
+		m.GenericAPIServer.Destroy()
 		s.Close()
 	}
 


### PR DESCRIPTION
This effectively resurrects https://github.com/kubernetes/kubernetes/pull/50690 though in a bit cleaner way.

Ref #108483

```release-note
NONE
```

/sig api-machinery
/priority important-longterm
/kind cleanup