### PR TITLE
Fix typo in v1.15 CHANGELOG

### DIFF
--- a/CHANGELOG/CHANGELOG-1.15.md
+++ b/CHANGELOG/CHANGELOG-1.15.md
@@ -1605,7 +1605,7 @@ filename | sha512 hash
 * vSphere: allow SAML token delegation (required for Zones support) ([#78876](https://github.com/kubernetes/kubernetes/pull/78876), [@dougm](https://github.com/dougm))
 * Update Cluster Autoscaler to 1.15.0; changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.15.0 ([#78866](https://github.com/kubernetes/kubernetes/pull/78866), [@losipiuk](https://github.com/losipiuk))
 * Revert the CoreDNS version to 1.3.1 ([#78691](https://github.com/kubernetes/kubernetes/pull/78691), [@rajansandeep](https://github.com/rajansandeep))
-* CRDs get support for x-kuberntes-int-or-string to allow faithful representation of IntOrString types in CustomResources. ([#78815](https://github.com/kubernetes/kubernetes/pull/78815), [@sttts](https://github.com/sttts))
+* CRDs get support for x-kubernetes-int-or-string to allow faithful representation of IntOrString types in CustomResources. ([#78815](https://github.com/kubernetes/kubernetes/pull/78815), [@sttts](https://github.com/sttts))
 * fix: retry detach azure disk issue ([#78700](https://github.com/kubernetes/kubernetes/pull/78700), [@andyzhangx](https://github.com/andyzhangx))
     * try to only update vm if detach a non-existing disk when got <200, error> after detach disk operation
 * Fix issue with kubelet waiting on invalid devicepath on AWS ([#78595](https://github.com/kubernetes/kubernetes/pull/78595), [@gnufied](https://github.com/gnufied))


### PR DESCRIPTION
Signed-off-by: xin.li <xin.li@daocloud.io>

Modify 'kuberntes' to 'kubernetes'

/kind cleanup

Does this PR introduce a user-facing change?
```
NONE
```