### PR TITLE
fix the retry logic in ssh in test framework

### DIFF
--- a/test/e2e/framework/ssh/ssh.go
+++ b/test/e2e/framework/ssh/ssh.go
@@ -244,7 +244,7 @@ func runSSHCommand(cmd, user, host string, signer ssh.Signer) (string, string, i
 		err = wait.Poll(5*time.Second, 20*time.Second, func() (bool, error) {
 			fmt.Printf("error dialing %s@%s: '%v', retrying\n", user, host, err)
 			if client, err = ssh.Dial("tcp", host, config); err != nil {
-				return false, err
+				return false, nil // retrying, error will be logged above
 			}
 			return true, nil
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/sig node
/area test

#### What this PR does / why we need it:

I cannot repro flake locally, but this is very straightforward fix of the retry logic in ssh. As may be observed in logs, there is only one retry [occurring](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce/1511340765639348224):

```
error dialing prow@34.105.88.48:22: 'ssh: handshake failed: read tcp 10.33.156.38:42130->34.105.88.48:22: read: connection reset by peer', retrying
Apr  5 14:17:44.130: FAIL: Unexpected error:
    <*errors.errorString | 0xc001314b10>: {
        s: "error getting SSH client to prow@34.105.88.48:22: 'ssh: handshake failed: read tcp 10.33.156.38:42184->34.105.88.48:22: read: connection reset by peer'",
    }
    error getting SSH client to prow@34.105.88.48:22: 'ssh: handshake failed: read tcp 10.33.156.38:42184->34.105.88.48:22: read: connection reset by peer'
occurred

Full Stack Trace
k8s.io/kubernetes/test/e2e/node.getMemoryStat(0x648e800?, {0xc0030a4b40, 0xf})
	test/e2e/node/node_problem_detector.go:270 +0x14b
k8s.io/kubernetes/test/e2e/node.glob..func8.2()
	test/e2e/node/node_problem_detector.go:167 +0x1338
k8s.io/kubernetes/test/e2e.RunE2ETests(0x248f2f7?)
	test/e2e/e2e.go:130 +0x686
k8s.io/kubernetes/test/e2e.TestE2E(0x2405d19?)
	test/e2e/e2e_test.go:136 +0x19
testing.tRunner(0xc0006a36c0, 0x71bc778)
	/usr/local/go/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1486 +0x35f
[AfterEach] [sig-node] NodeProblemDetector
  test/e2e/framework/framework.go:188
```


https://github.com/SergeyKanzhelev/kubernetes/blob/ee80dd19db93443880e75d10ecb1ee60b8a8204d/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go#L432-L442

#### Which issue(s) this PR fixes:

Related to #109281

```release-note
NONE
```

`wait.Poll` tries a condition func until it returns true, an error, or the timeout is reached.