### PR TITLE
reset metrics per test

### DIFF
--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -1376,7 +1376,7 @@ func assertIPTablesRulesNotEqual(t *testing.T, line int, expected, result string
 func TestOverallIPTablesRulesWithMultipleServices(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)
-	metrics.RegisterMetrics()
+	setupMetrics()
 	tcpProtocol := v1.ProtocolTCP
 
 	makeServiceMap(fp,
@@ -4260,7 +4260,7 @@ func TestProxierMetricsIptablesTotalRules(t *testing.T) {
 	fp := NewFakeProxier(ipt)
 	tcpProtocol := v1.ProtocolTCP
 
-	metrics.RegisterMetrics()
+	setupMetrics()
 
 	svcIP := "172.30.0.41"
 	svcPort := 80
@@ -6060,7 +6060,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 	internalTrafficPolicyLocal := v1.ServiceInternalTrafficPolicyLocal
 	externalTrafficPolicyLocal := v1.ServiceExternalTrafficPolicyTypeLocal
 
-	metrics.RegisterMetrics()
+	setupMetrics()
 	testCases := []struct {
 		name                                                string
 		internalTrafficPolicy                               *v1.ServiceInternalTrafficPolicyType
@@ -6203,4 +6203,11 @@ func TestNoEndpointsMetric(t *testing.T) {
 			}
 		})
 	}
+}
+
+func setupMetrics() {
+	metrics.RegisterMetrics()
+	metrics.IptablesRestoreFailuresTotal.Reset()
+	metrics.IptablesRulesTotal.Reset()
+	metrics.SyncProxyRulesNoLocalEndpointsTotal.Reset()
 }

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -5810,7 +5810,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 
 	internalTrafficPolicyLocal := v1.ServiceInternalTrafficPolicyLocal
 	externalTrafficPolicyLocal := v1.ServiceExternalTrafficPolicyTypeLocal
-	metrics.RegisterMetrics()
+	setupMetrics()
 
 	testCases := []struct {
 		name                                                string
@@ -5959,4 +5959,9 @@ func TestNoEndpointsMetric(t *testing.T) {
 			t.Errorf("sync_proxy_rules_no_endpoints_total metric mismatch(external): got=%d, expected %d", int(syncProxyRulesNoLocalEndpointsTotalExternal), tc.expectedSyncProxyRulesNoLocalEndpointsTotalExternal)
 		}
 	}
+}
+
+func setupMetrics() {
+	metrics.RegisterMetrics()
+	metrics.SyncProxyRulesNoLocalEndpointsTotal.Reset()
 }


### PR DESCRIPTION


```release-note
NONE

```
metrics are global, we have discussed this several times and seems that the approach it has been implemented to deal with it was to reset the metrics on start
