### PR TITLE
conformance-test: use kubelet healthz port.

### DIFF
--- a/pkg/cluster/ports/ports.go
+++ b/pkg/cluster/ports/ports.go
@@ -31,6 +31,9 @@ const (
 	// until heapster can transition to using the SSL endpoint.
 	// TODO(roberthbailey): Remove this once we have a better solution for heapster.
 	KubeletReadOnlyPort = 10255
+	// KubeletHealthzPort exposes a healthz endpoint from the kubelet.
+	// May be overridden by a flag at startup.
+	KubeletHealthzPort = 10248
 	// ProxyHealthzPort is the default port for the proxy healthz server.
 	// May be overridden by a flag at startup.
 	ProxyHealthzPort = 10256

--- a/test/e2e_node/conformance/run_test.sh
+++ b/test/e2e_node/conformance/run_test.sh
@@ -126,10 +126,10 @@ start_kubelet() {
   fi
 }
 
-# wait_kubelet retries for 10 times for kubelet to be ready by checking http://127.0.0.1:10255/healthz.
+# wait_kubelet retries for 10 times for kubelet to be ready by checking http://127.0.0.1:10248/healthz.
 wait_kubelet() {
   echo "Health checking kubelet..."
-  healthCheckURL=http://127.0.0.1:10255/healthz
+  healthCheckURL=http://127.0.0.1:10248/healthz
   local maxRetry=10
   local cur=1
   while [ $cur -le $maxRetry ]; do

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -88,13 +88,12 @@ func RunKubelet() {
 }
 
 const (
-	// Ports of different e2e services.
-	kubeletReadOnlyPort = "10255"
 	// KubeletRootDirectory specifies the directory where the kubelet runtime information is stored.
 	KubeletRootDirectory = "/var/lib/kubelet"
-	// Health check url of kubelet
-	kubeletHealthCheckURL = "http://127.0.0.1:" + kubeletReadOnlyPort + "/healthz"
 )
+
+// Health check url of kubelet
+var kubeletHealthCheckURL = fmt.Sprintf("http://127.0.0.1:%d/healthz", ports.KubeletHealthzPort)
 
 func baseKubeConfiguration(cfgPath string) (*kubeletconfig.KubeletConfiguration, error) {
 	cfgPath, err := filepath.Abs(cfgPath)

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -41,6 +41,7 @@ import (
 	kubeletpodresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 	kubeletpodresourcesv1alpha1 "k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
 	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	"k8s.io/kubernetes/pkg/cluster/ports"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/apis/podresources"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -70,12 +71,12 @@ const (
 	defaultPodResourcesPath    = "/var/lib/kubelet/pod-resources"
 	defaultPodResourcesTimeout = 10 * time.Second
 	defaultPodResourcesMaxSize = 1024 * 1024 * 16 // 16 Mb
-	kubeletReadOnlyPort        = "10255"
-	kubeletHealthCheckURL      = "http://127.0.0.1:" + kubeletReadOnlyPort + "/healthz"
 	// state files
 	cpuManagerStateFile    = "/var/lib/kubelet/cpu_manager_state"
 	memoryManagerStateFile = "/var/lib/kubelet/memory_manager_state"
 )
+
+var kubeletHealthCheckURL = fmt.Sprintf("http://127.0.0.1:%d/healthz", ports.KubeletHealthzPort)
 
 func getNodeSummary() (*stats.Summary, error) {
 	kubeletConfig, err := getCurrentKubeletConfig()
@@ -259,7 +260,7 @@ func logKubeletLatencyMetrics(metricNames ...string) {
 	for _, key := range metricNames {
 		metricSet.Insert(kubeletmetrics.KubeletSubsystem + "_" + key)
 	}
-	metric, err := e2emetrics.GrabKubeletMetricsWithoutProxy(framework.TestContext.NodeName+":10255", "/metrics")
+	metric, err := e2emetrics.GrabKubeletMetricsWithoutProxy(fmt.Sprintf("%s:%d", framework.TestContext.NodeName, ports.KubeletReadOnlyPort), "/metrics")
 	if err != nil {
 		framework.Logf("Error getting kubelet metrics: %v", err)
 	} else {


### PR DESCRIPTION
The readonly port could be disabled.

Since we are only using the /healthz endpoint,
we can use the healthz port.

/kind cleanup

#### What this PR does / why we need it:

Removes an unnecessary usage of the kubelet readonly port, replacing it with healthz port instead. 

```release-note
NONE

```
