### PR TITLE
Migrate `verify-flags-underscore.py` to Python 3 and improve readability

### DIFF
--- a/hack/verify-flags-underscore.py
+++ b/hack/verify-flags-underscore.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-# Copyright 2015 The Kubernetes Authors.
+# Copyright 2022 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,110 +14,117 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import argparse
 import os
 import re
 import sys
 
-parser = argparse.ArgumentParser()
-parser.add_argument("filenames", help="list of files to check, all files if unspecified", nargs='*')
-args = parser.parse_args()
 
 # Cargo culted from http://stackoverflow.com/questions/898669/how-can-i-detect-if-a-file-is-binary-non-text-in-python
 def is_binary(pathname):
     """Return true if the given filename is binary.
+
     @raise EnvironmentError: if the file does not exist or cannot be accessed.
     @attention: found @ http://bytes.com/topic/python/answers/21222-determine-file-type-binary-text on 6/08/2010
     @author: Trent Mick <TrentM@ActiveState.com>
-    @author: Jorge Orpinel <jorge@orpinel.com>"""
+    @author: Jorge Orpinel <jorge@orpinel.com>
+    """
     try:
-        with open(pathname, 'r') as f:
-            CHUNKSIZE = 1024
+        with open(pathname, 'r') as file:
+            CHUNK_SIZE = 1024
             while True:
-                chunk = f.read(CHUNKSIZE)
+                chunk = file.read(CHUNK_SIZE)
                 if '\0' in chunk: # found null byte
                     return True
-                if len(chunk) < CHUNKSIZE:
+                if len(chunk) < CHUNK_SIZE:
                     break # done
-    except:
+    except Exception:
         return True
 
     return False
 
-def get_all_files(rootdir):
+def get_all_files(rootdir: str):
     all_files = []
     for root, dirs, files in os.walk(rootdir):
         # don't visit certain dirs
-        if 'vendor' in dirs:
-            dirs.remove('vendor')
-        if 'staging' in dirs:
-            dirs.remove('staging')
-        if '_output' in dirs:
-            dirs.remove('_output')
-        if '_gopath' in dirs:
-            dirs.remove('_gopath')
-        if 'third_party' in dirs:
-            dirs.remove('third_party')
-        if '.git' in dirs:
-            dirs.remove('.git')
-        if '.make' in dirs:
-            dirs.remove('.make')
-        if 'BUILD' in files:
-           files.remove('BUILD')
+        ignored_dirs = [
+            'vendor', 'staging', '_output',
+            '_gopath', 'third_party', '.git',
+            '.make',
+        ]
+        for ignored_dir in ignored_dirs:
+            if ignored_dir in dirs:
+                dirs.remove(ignored_dir)
+
+        # don't visit certain files
+        ignored_files = ['BUILD']
+        for ignored_file in ignored_files:
+            if ignored_file in files:
+                files.remove(ignored_file)
 
         for name in files:
             pathname = os.path.join(root, name)
             if not is_binary(pathname):
                 all_files.append(pathname)
+
     return all_files
 
-# Collects all the flags used in golang files and verifies the flags do
-# not contain underscore. If any flag needs to be excluded from this check,
-# need to add that flag in hack/verify-flags/excluded-flags.txt.
-def check_underscore_in_flags(rootdir, files):
+def check_underscore_in_flags(rootdir: str, files: list[str]):
+    """Collects all the flags used in golang files and verifies the flags do not contain underscore.
+
+    If any flag needs to be excluded from this check, need to add that flag in hack/verify-flags/excluded-flags.txt.
+    """
+
     # preload the 'known' flags which don't follow the - standard
-    pathname = os.path.join(rootdir, "hack/verify-flags/excluded-flags.txt")
-    f = open(pathname, 'r')
-    excluded_flags = set(f.read().splitlines())
-    f.close()
+    excluded_flags_path = os.path.join(rootdir, "hack/verify-flags/excluded-flags.txt")
+    excluded_flags_file = open(excluded_flags_path, 'r')
+    excluded_flags = set(excluded_flags_file.read().splitlines())
+    excluded_flags_file.close()
 
-    regexs = [ re.compile('Var[P]?\([^,]*, "([^"]*)"'),
-               re.compile('.String[P]?\("([^"]*)",[^,]+,[^)]+\)'),
-               re.compile('.Int[P]?\("([^"]*)",[^,]+,[^)]+\)'),
-               re.compile('.Bool[P]?\("([^"]*)",[^,]+,[^)]+\)'),
-               re.compile('.Duration[P]?\("([^"]*)",[^,]+,[^)]+\)'),
-               re.compile('.StringSlice[P]?\("([^"]*)",[^,]+,[^)]+\)') ]
+    regexes = [
+        re.compile('Var[P]?\([^,]*, "([^"]*)"'),
+        re.compile('.String[P]?\("([^"]*)",[^,]+,[^)]+\)'),
+        re.compile('.Int[P]?\("([^"]*)",[^,]+,[^)]+\)'),
+        re.compile('.Bool[P]?\("([^"]*)",[^,]+,[^)]+\)'),
+        re.compile('.Duration[P]?\("([^"]*)",[^,]+,[^)]+\)'),
+        re.compile('.StringSlice[P]?\("([^"]*)",[^,]+,[^)]+\)'),
+    ]
 
-    new_excluded_flags = set()
+    unexpected_excluded_flags = set()
     # walk all the files looking for any flags being declared
     for pathname in files:
         if not pathname.endswith(".go"):
             continue
-        f = open(pathname, 'r')
-        data = f.read()
-        f.close()
+        file = open(pathname, 'r')
+        content = file.read()
+        file.close()
+
         matches = []
-        for regex in regexs:
-            matches = matches + regex.findall(data)
+        for regex in regexes:
+            matches.extend(regex.findall(content))
         for flag in matches:
             if any(x in flag for x in excluded_flags):
                 continue
             if "_" in flag:
-                new_excluded_flags.add(flag)
-    if len(new_excluded_flags) != 0:
-        print("Found a flag declared with an _ but which is not explicitly listed as a valid flag name in hack/verify-flags/excluded-flags.txt")
+                unexpected_excluded_flags.add(flag)
+
+    if len(unexpected_excluded_flags) != 0:
+        print("Found a flag declared with an _ but which is not explicitly listed as a valid flag name in 'hack/verify-flags/excluded-flags.txt'")
         print("Are you certain this flag should not have been declared with an - instead?")
-        l = list(new_excluded_flags)
-        l.sort()
-        print("%s" % "\n".join(l))
+        excluded_flag_list = sorted(list(unexpected_excluded_flags))
+        print("\n".join(excluded_flag_list))
         sys.exit(1)
 
 def main():
-    rootdir = os.path.dirname(__file__) + "/../"
-    rootdir = os.path.abspath(rootdir)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "filenames",
+        help="list of files to check, all files if unspecified",
+        nargs='*',
+    )
+    args = parser.parse_args()
 
+    rootdir = os.path.abspath(os.path.dirname(__file__) + "/../")
     if len(args.filenames) > 0:
         files = args.filenames
     else:
@@ -126,4 +133,4 @@ def main():
     check_underscore_in_flags(rootdir, files)
 
 if __name__ == "__main__":
-  sys.exit(main())
+    main()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

- Migrate `verify-flags-underscore.py` to Python 3 (e.g. remove the `__future__` module)
- Improve the code readability by changing variable names and adding comments
- Add type hints to function arguments

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

