### PR TITLE
Fix APIServer nil panic when calling the `GetResourceKind`

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -159,6 +159,10 @@ func getStorageVersionKind(storageVersioner runtime.GroupVersioner, storage rest
 // object. If the storage object is a subresource and has an override supplied for it, it returns
 // the group version kind supplied in the override.
 func GetResourceKind(groupVersion schema.GroupVersion, storage rest.Storage, typer runtime.ObjectTyper) (schema.GroupVersionKind, error) {
+	if storage == nil {
+		return schema.GroupVersionKind{}, fmt.Errorf("rest storage in %v is nil", groupVersion.String())
+	}
+
 	// Let the storage tell us exactly what GVK it has
 	if gvkProvider, ok := storage.(rest.GroupVersionKindProvider); ok {
 		return gvkProvider.GroupVersionKind(groupVersion), nil


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When the APIServer call the `GetResourceKind` at the startup, it will panic if the GVK scheme not found.
This PR is to check whether the REST Storage is nil, to prevent the nil pointer dereference.

#### Which issue(s) this PR fixes:
Fixes #109336

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```