### PR TITLE
Fixed update sts status error while create sts pod failed

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -105,15 +105,18 @@ func (ssc *defaultStatefulSetControl) performUpdate(
 	}
 
 	// perform the main update function and get the status
-	currentStatus, err = ssc.updateStatefulSet(ctx, set, currentRevision, updateRevision, collisionCount, pods)
-	if err != nil {
-		return currentRevision, updateRevision, currentStatus, err
-	}
+	currentStatus, updateStatefulSetsErr = ssc.updateStatefulSet(ctx, set, currentRevision, updateRevision, collisionCount, pods)
 	// update the set's status
-	err = ssc.updateStatefulSetStatus(ctx, set, currentStatus)
-	if err != nil {
-		return currentRevision, updateRevision, currentStatus, err
+	updateStatefulSetStatusErr = ssc.updateStatefulSetStatus(ctx, set, currentStatus)
+	
+	if updateStatefulSetsErr != nil {
+		return currentRevision, updateRevision, currentStatus, updateStatefulSetsErr
 	}
+	
+	if updateStatefulSetStatusErr != nil {
+		return currentRevision, updateRevision, currentStatus, updateStatefulSetStatusErr
+	}
+	
 	klog.V(4).InfoS("StatefulSet pod status", "statefulSet", klog.KObj(set),
 		"replicas", currentStatus.Replicas,
 		"readyReplicas", currentStatus.ReadyReplicas,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In some specific scenario described in https://github.com/kubernetes/kubernetes/issues/108837 , the readyReplicas of StatefuleSetStatus is not correctly updated.
forcely update the sts status no matter create current  pod succeed or not

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #108837

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
