### PR TITLE
Improve restMapper unsafeguess

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -144,6 +144,13 @@ func UnsafeGuessKindToResource(kind schema.GroupVersionKind) ( /*plural*/ schema
 		return kind.GroupVersion().WithResource(strings.TrimSuffix(singularName, "y") + "ies"), singular
 	}
 
+	if len(singularName) > 1 {
+		switch singularName[len(singularName)-2:] {
+		case "ch", "sh":
+			return kind.GroupVersion().WithResource(singularName + "es"), singular
+		}
+	}
+
 	return kind.GroupVersion().WithResource(singularName + "s"), singular
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper_test.go
@@ -452,6 +452,10 @@ func TestKindToResource(t *testing.T) {
 		{Kind: "miss", Plural: "misses", Singular: "miss"},
 		// Add "s" otherwise
 		{Kind: "lowercase", Plural: "lowercases", Singular: "lowercase"},
+		// Add "es" when ending with "ch"
+		{Kind: "Bench", Plural: "benches", Singular: "bench"},
+		// Add "es" when ending with "sh"
+		{Kind: "Mesh", Plural: "meshes", Singular: "mesh"},
 	}
 	for i, testCase := range testCases {
 		version := schema.GroupVersion{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind flake
-->

#### What this PR does / why we need it:
If currently I have a singular resource named `mesh`, it will assume the gvr to be `meshs`, however it should be end with `-es`. This PR can covers with singular end with `ch` and `sh`, to provide a better guess experience.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
