### PR TITLE
properly return if a cloudprovider requires networking configuration

### DIFF
--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -31,7 +31,7 @@ func (kl *Kubelet) providerRequiresNetworkingConfiguration() bool {
 	// is used or whether we are using overlay networking. We should return
 	// true for cloud providers if they implement Routes() interface and
 	// we are not using overlay networking.
-	if kl.cloud == nil || kl.cloud.ProviderName() != "gce" {
+	if kl.cloud == nil {
 		return false
 	}
 	_, supported := kl.cloud.Routes()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Kubelet has [logic](https://github.com/kubernetes/kubernetes/blob/39c76ba2edeadb84a115cc3fbd9204a2177f1c28/pkg/kubelet/kubelet_node_status.go#L337-L345) to set the `NodeNetworkUnavailable` condition to true when initialization the node object. However, because of the short-circuit check on `cloudprovider == gce`, the code always returns false for all non-gce providers. 

This means that nodes get created with `NodeNetworkUnavailable == False`. This leads to a race condition where the scheduler can schedule pods on those nodes before routes get created in case the cloudprovider request fails or is taking too long.

There seems to have been several back and forth on this behaviour so hoping to arrive at a consistent reproducible behaviour here to avoid races.

1) It seems that in the past the Kube scheduler (prior to the new framework migration) used to consider this condition for scheduling purposes and would avoid scheduling (#26415)

2) Right now, I don't see any scheduler references to that condition - is it now the responsibility of another controller to taint the nodes in response to the the condition being set? Does the scheduler no longer consider this condition for scheduling purposes?


There also seems be another codepath in `node_controller` that sets this condition, specifically for GCE. Is [that](https://github.com/kubernetes/kubernetes/blob/efdb80dcc61846a802aa233be1374628c5fd84ed/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go#L425-L437) even needed if kubelet is always initializing the condition to true for GCE?


I am convinced this PR still does the sane thing: initialize the node with the `NodeNetworkUnavailable` condition set to true, because the route controller will clean this condition once routes are created. 

It's now a matter of whether this change would address the race or not so I'll defer it to people with more expertise.

I assume the intended behaviour was always as follows:

```
Kubelet creates a node, and sets the NodeNetworkUnavailable condition to true.
RouteController in cloud controller will set it to false when the routes are created
Scheduler would only consider scheduling to nodes that have NodeNetworkUnavailable ==false
``` 

This should keep the GCE behaviour the same because `gce.Routes()` still returns true.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Ensure kubelet initializes nodes with NodeNetworkUnavailable == true if the cloudprovider requires networking configuration
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
