### PR TITLE
Automated cherry pick of #108107: kubelet apiserver: be gentle closing connections on

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -606,14 +606,14 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 		klog.InfoS("Standalone mode, no API client")
 
 	case kubeDeps.KubeClient == nil, kubeDeps.EventClient == nil, kubeDeps.HeartbeatClient == nil:
-		clientConfig, closeAllConns, err := buildKubeletClientConfig(ctx, s, nodeName)
+		clientConfig, onHeartbeatFailure, err := buildKubeletClientConfig(ctx, s, nodeName)
 		if err != nil {
 			return err
 		}
-		if closeAllConns == nil {
-			return errors.New("closeAllConns must be a valid function other than nil")
+		if onHeartbeatFailure == nil {
+			return errors.New("onHeartbeatFailure must be a valid function other than nil")
 		}
-		kubeDeps.OnHeartbeatFailure = closeAllConns
+		kubeDeps.OnHeartbeatFailure = onHeartbeatFailure
 
 		kubeDeps.KubeClient, err = clientset.NewForConfig(clientConfig)
 		if err != nil {
@@ -914,6 +914,7 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, nod
 		if err != nil {
 			return nil, nil, err
 		}
+		var onHeartbeatFailure func()
 		// Kubelet needs to be able to recover from stale http connections.
 		// HTTP2 has a mechanism to detect broken connections by sending periodical pings.
 		// HTTP1 only can have one persistent connection, and it will close all Idle connections
@@ -922,14 +923,15 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, nod
 		// setting the environment variable DISABLE_HTTP2.
 		if s := os.Getenv("DISABLE_HTTP2"); len(s) > 0 {
 			klog.InfoS("HTTP2 has been explicitly disabled, Kubelet will forcefully close active connections on heartbeat failures")
+			onHeartbeatFailure = closeAllConns
 		} else {
-			closeAllConns = func() { utilnet.CloseIdleConnectionsFor(transportConfig.Transport) }
+			onHeartbeatFailure = func() { utilnet.CloseIdleConnectionsFor(transportConfig.Transport) }
 		}
 
 		klog.V(2).InfoS("Starting client certificate rotation")
 		clientCertificateManager.Start()
 
-		return transportConfig, closeAllConns, nil
+		return transportConfig, onHeartbeatFailure, nil
 	}
 
 	if len(s.BootstrapKubeconfig) > 0 {
@@ -953,19 +955,19 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, nod
 	// once the Kubelet heartbeat fails. However, since there are many edge cases that we can't
 	// control, users can still opt-in to the previous behavior for closing the connections by
 	// setting the environment variable DISABLE_HTTP2.
-	var closeAllConns func()
+	var onHeartbeatFailure func()
 	if s := os.Getenv("DISABLE_HTTP2"); len(s) > 0 {
 		klog.InfoS("HTTP2 has been explicitly disabled, updating Kubelet client Dialer to forcefully close active connections on heartbeat failures")
-		closeAllConns, err = updateDialer(clientConfig)
+		onHeartbeatFailure, err = updateDialer(clientConfig)
 		if err != nil {
 			return nil, nil, err
 		}
 	} else {
-		closeAllConns = func() {
+		onHeartbeatFailure = func() {
 			utilnet.CloseIdleConnectionsFor(clientConfig.Transport)
 		}
 	}
-	return clientConfig, closeAllConns, nil
+	return clientConfig, onHeartbeatFailure, nil
 }
 
 // updateDialer instruments a restconfig with a dial. the returned function allows forcefully closing all active connections.


### PR DESCRIPTION
Cherry pick of #108107 on release-1.23.

#108107: kubelet apiserver: be gentle closing connections on

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```