### PR TITLE
fix failing test TestDefaultsYAML on mac

### DIFF
--- a/pkg/kubelet/apis/config/v1beta1/defaults_others.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults_others.go
@@ -1,5 +1,5 @@
-//go:build !linux
-// +build !linux
+//go:build !linux && !darwin
+// +build !linux,!darwin
 
 /*
 Copyright 2018 The Kubernetes Authors.

--- a/pkg/kubelet/apis/config/v1beta1/defaults_unix.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults_unix.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux || darwin
+// +build linux darwin
 
 /*
 Copyright 2018 The Kubernetes Authors.


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
```bash
$ go test k8s.io/kubernetes/pkg/kubelet/apis/config/scheme -run TestDefaultsYAML
--- FAIL: TestDefaultsYAML (0.01s)
    --- FAIL: TestDefaultsYAML/KubeletConfiguration_default_v1beta1 (0.00s)
        helpers.go:90: Output does not match expected, diff (- want, + got):
              (
                """
                ... // 36 identical lines
                  memory.available: 100Mi
                  nodefs.available: 10%
            -     nodefs.inodesFree: 5%
                evictionPressureTransitionPeriod: 5m0s
                failSwapOn: true
                ... // 49 identical lines
                """
              )

        helpers.go:105: if the diff is expected because of a new type or a new field, re-run with UPDATE_COMPONENTCONFIG_FIXTURE_DATA=true to update the compatibility data or generate missing files
FAIL
FAIL    k8s.io/kubernetes/pkg/kubelet/apis/config/scheme        0.023s
FAIL
```
There is a fix pr https://github.com/kubernetes/kubernetes/pull/104376 but closed. 
Fix this problem inspired by @liggitt's suggestion https://github.com/kubernetes/kubernetes/pull/104376#issuecomment-899532470
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #73853

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
