### PR TITLE
Fix case where validation errors might not use the stringer type

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -77,12 +77,6 @@ func (v *Error) ErrorBody() string {
 					value = reflectValue.Elem().Interface()
 				}
 			}
-		} else {
-			valuePtr := reflect.New(valueType)
-			if valuePtr.Type().Implements(stringerType) {
-				valuePtr.Elem().Set(reflect.ValueOf(value))
-				value = valuePtr.Interface()
-			}
 		}
 		switch t := value.(type) {
 		case int64, int32, float64, float32, bool:

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -77,6 +77,12 @@ func (v *Error) ErrorBody() string {
 					value = reflectValue.Elem().Interface()
 				}
 			}
+		} else {
+			valuePtr := reflect.New(valueType)
+			if valuePtr.Type().Implements(stringerType) {
+				valuePtr.Elem().Set(reflect.ValueOf(value))
+				value = valuePtr.Interface()
+			}
 		}
 		switch t := value.(type) {
 		case int64, int32, float64, float32, bool:

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -46,6 +46,8 @@ type omitValueType struct{}
 
 var omitValue = omitValueType{}
 
+var stringerType = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+
 // ErrorBody returns the error message without the field name.  This is useful
 // for building nice-looking higher-level error reporting.
 func (v *Error) ErrorBody() string {
@@ -70,7 +72,10 @@ func (v *Error) ErrorBody() string {
 			if reflectValue := reflect.ValueOf(value); reflectValue.IsNil() {
 				value = "null"
 			} else {
-				value = reflectValue.Elem().Interface()
+				// Do not use the pointer value if the pointer implements fmt.Stringer
+				if !reflectValue.Type().Implements(stringerType) {
+					value = reflectValue.Elem().Interface()
+				}
 			}
 		}
 		switch t := value.(type) {

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors_test.go
@@ -181,14 +181,54 @@ func (s stringer) String() string {
 	return "stringer"
 }
 
+type stringerPtr struct {
+}
+
+func (s *stringerPtr) String() string {
+	return "stringer"
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
 func TestErrorBody(t *testing.T) {
 	var nilStringer *stringer = nil
+	var nilStringerPtr *stringerPtr = nil
+	var nilInt *int
+	type dummy struct{}
+	var nilDummy *dummy
+
 	testCases := []struct {
 		name     string
 		err      *Error
 		expected string
 	}{
 		{
+			name:     "int",
+			err:      Invalid(NewPath("bla"), 2, "details"),
+			expected: "Invalid value: 2: details",
+		}, {
+			name:     "intPtr",
+			err:      Invalid(NewPath("bla"), intPtr(2), "details"),
+			expected: "Invalid value: 2: details",
+		}, {
+			name:     "nil intPtr",
+			err:      Invalid(NewPath("bla"), nilInt, "details"),
+			expected: `Invalid value: "null": details`,
+		}, {
+			name:     "dummy",
+			err:      Invalid(NewPath("bla"), dummy{}, "details"),
+			expected: "Invalid value: field.dummy{}: details",
+		}, {
+			name:     "dummyPtr",
+			err:      Invalid(NewPath("bla"), &dummy{}, "details"),
+			expected: "Invalid value: field.dummy{}: details",
+		}, {
+			name:     "nil dummyPtr",
+			err:      Invalid(NewPath("bla"), nilDummy, "details"),
+			expected: `Invalid value: "null": details`,
+		}, {
 			name:     "stringer",
 			err:      Invalid(NewPath("bla"), stringer{}, "details"),
 			expected: "Invalid value: stringer: details",
@@ -199,7 +239,19 @@ func TestErrorBody(t *testing.T) {
 		}, {
 			name:     "nil stringer",
 			err:      Invalid(NewPath("bla"), nilStringer, "details"),
-			expected: "Invalid value: \"null\": details",
+			expected: `Invalid value: "null": details`,
+		}, {
+			name:     "stringerPtr",
+			err:      Invalid(NewPath("bla"), stringerPtr{}, "details"),
+			expected: "Invalid value: stringer: details",
+		}, {
+			name:     "stringerPtr pointer",
+			err:      Invalid(NewPath("bla"), &stringerPtr{}, "details"),
+			expected: "Invalid value: stringer: details",
+		}, {
+			name:     "nil stringerPtr",
+			err:      Invalid(NewPath("bla"), nilStringerPtr, "details"),
+			expected: `Invalid value: "null": details`,
 		},
 	}
 	for _, testCase := range testCases {

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors_test.go
@@ -243,7 +243,7 @@ func TestErrorBody(t *testing.T) {
 		}, {
 			name:     "stringerPtr",
 			err:      Invalid(NewPath("bla"), stringerPtr{}, "details"),
-			expected: "Invalid value: stringer: details",
+			expected: "Invalid value: field.stringerPtr{}: details",
 		}, {
 			name:     "stringerPtr pointer",
 			err:      Invalid(NewPath("bla"), &stringerPtr{}, "details"),

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors_test.go
@@ -173,3 +173,42 @@ func TestNotSupported(t *testing.T) {
 		t.Errorf("Expected: %s\n, but got: %s\n", expected, notSupported.ErrorBody())
 	}
 }
+
+type stringer struct {
+}
+
+func (s stringer) String() string {
+	return "stringer"
+}
+
+func TestErrorBody(t *testing.T) {
+	var nilStringer *stringer = nil
+	testCases := []struct {
+		name     string
+		err      *Error
+		expected string
+	}{
+		{
+			name:     "stringer",
+			err:      Invalid(NewPath("bla"), stringer{}, "details"),
+			expected: "Invalid value: stringer: details",
+		}, {
+			name:     "stringer pointer",
+			err:      Invalid(NewPath("bla"), &stringer{}, "details"),
+			expected: "Invalid value: stringer: details",
+		}, {
+			name:     "nil stringer",
+			err:      Invalid(NewPath("bla"), nilStringer, "details"),
+			expected: "Invalid value: \"null\": details",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := testCase.err.ErrorBody()
+			expected := testCase.expected
+			if actual != expected {
+				t.Errorf("Expected: %s\n, but got: %s\n", expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

The `Error` struct in the `validation/field` package has a `ErrorBody()` method. It tries to handle printing useful error messages. When the inner `value` is a `Stringer()`, it tries to print that. Though, it will not work is the value is a pointer to a `Stringer`. 

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

#### Relase Notes

```release-note
NONE
```
