### PR TITLE
Fix cluster-info jws-token didn't update

### DIFF
--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -254,7 +254,6 @@ func newVolume(name, capacity, boundToClaimUID, boundToClaimName string, phase v
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			ResourceVersion: "1",
-			Finalizers:      []string{storagehelpers.PVDeletionInTreeProtectionFinalizer},
 		},
 		Spec: v1.PersistentVolumeSpec{
 			Capacity: v1.ResourceList{
@@ -296,6 +295,72 @@ func newVolume(name, capacity, boundToClaimUID, boundToClaimName string, phase v
 	}
 
 	return &volume
+}
+
+// newExternalProvisionedVolume returns a new volume with given attributes
+func newExternalProvisionedVolume(name, capacity, boundToClaimUID, boundToClaimName string, phase v1.PersistentVolumePhase, reclaimPolicy v1.PersistentVolumeReclaimPolicy, class string, driverName string, finalizers []string, annotations ...string) *v1.PersistentVolume {
+	fs := v1.PersistentVolumeFilesystem
+	volume := v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			ResourceVersion: "1",
+			Finalizers:      finalizers,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse(capacity),
+			},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       driverName,
+					VolumeHandle: "527b55dc-c7db-4574-9226-2e33318b06a3",
+					ReadOnly:     false,
+					FSType:       "ext4",
+					VolumeAttributes: map[string]string{
+						"Test-Key": "Test-Value",
+					},
+				},
+			},
+			AccessModes:                   []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce, v1.ReadOnlyMany},
+			PersistentVolumeReclaimPolicy: reclaimPolicy,
+			StorageClassName:              class,
+			VolumeMode:                    &fs,
+		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: phase,
+		},
+	}
+
+	if boundToClaimName != "" {
+		volume.Spec.ClaimRef = &v1.ObjectReference{
+			Kind:       "PersistentVolumeClaim",
+			APIVersion: "v1",
+			UID:        types.UID(boundToClaimUID),
+			Namespace:  testNamespace,
+			Name:       boundToClaimName,
+		}
+	}
+
+	if len(annotations) > 0 {
+		volume.Annotations = make(map[string]string)
+		for _, a := range annotations {
+			switch a {
+			case storagehelpers.AnnDynamicallyProvisioned:
+				volume.Annotations[a] = driverName
+			default:
+				volume.Annotations[a] = "yes"
+			}
+		}
+	}
+
+	return &volume
+}
+
+// newVolume returns a new volume with given attributes
+func newVolumeWithFinalizers(name, capacity, boundToClaimUID, boundToClaimName string, phase v1.PersistentVolumePhase, reclaimPolicy v1.PersistentVolumeReclaimPolicy, class string, finalizers []string, annotations ...string) *v1.PersistentVolume {
+	retVolume := newVolume(name, capacity, boundToClaimUID, boundToClaimName, phase, reclaimPolicy, class, annotations...)
+	retVolume.SetFinalizers(finalizers)
+	return retVolume
 }
 
 // withLabels applies the given labels to the first volume in the array and

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -815,7 +815,6 @@ const (
 	// owner: @deepakkinni @xing-yang
 	// kep: http://kep.k8s.io/2680
 	// alpha: v1.23
-	// beta: v1.24
 	//
 	// Honor Persistent Volume Reclaim Policy when it is "Delete" irrespective of PV-PVC
 	// deletion ordering.
@@ -1000,7 +999,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	JobMutableNodeSchedulingDirectives:             {Default: true, PreRelease: featuregate.Beta},
 	IdentifyPodOS:                                  {Default: true, PreRelease: featuregate.Beta},
 	PodAndContainerStatsFromCRI:                    {Default: false, PreRelease: featuregate.Alpha},
-	HonorPVReclaimPolicy:                           {Default: true, PreRelease: featuregate.Beta},
+	HonorPVReclaimPolicy:                           {Default: false, PreRelease: featuregate.Alpha},
 	RecoverVolumeExpansionFailure:                  {Default: false, PreRelease: featuregate.Alpha},
 	GRPCContainerProbe:                             {Default: true, PreRelease: featuregate.Beta},
 	LegacyServiceAccountTokenNoAutoGeneration:      {Default: true, PreRelease: featuregate.Beta},


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:
the cluster-info's jws-token didn't update until we update configmap again or restart controller-manager.

Fixes #109233