### PR TITLE
move e2e framework.ProviderInterface to framework/providers sub-package

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -233,8 +233,6 @@ func (f *Framework) BeforeEach() {
 		restMapper.Reset()
 		resolver := scaleclient.NewDiscoveryScaleKindResolver(cachedDiscoClient)
 		f.ScalesGetter = scaleclient.New(restClient, restMapper, dynamic.LegacyAPIPathResolverFunc, resolver)
-
-		TestContext.CloudConfig.Provider.FrameworkBeforeEach(f)
 	}
 
 	if !f.SkipNamespaceCreation {
@@ -466,8 +464,6 @@ func (f *Framework) AfterEach() {
 			f.TestSummaries = append(f.TestSummaries, (*e2emetrics.ComponentCollection)(&received))
 		}
 	}
-
-	TestContext.CloudConfig.Provider.FrameworkAfterEach(f)
 
 	// Report any flakes that were observed in the e2e test and reset.
 	if f.flakeReport != nil && f.flakeReport.GetFlakeCount() > 0 {

--- a/test/e2e/framework/providers/aws/aws.go
+++ b/test/e2e/framework/providers/aws/aws.go
@@ -28,15 +28,16 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/providers"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
 	awscloud "k8s.io/legacy-cloud-providers/aws"
 )
 
 func init() {
-	framework.RegisterProvider("aws", newProvider)
+	providers.RegisterProvider("aws", newProvider)
 }
 
-func newProvider() (framework.ProviderInterface, error) {
+func newProvider() (providers.ProviderInterface, error) {
 	if framework.TestContext.CloudConfig.Zone == "" {
 		framework.Logf("Warning: gce-zone not specified! Some tests that use the AWS SDK may select the wrong region and fail.")
 	}
@@ -45,7 +46,7 @@ func newProvider() (framework.ProviderInterface, error) {
 
 // Provider is a structure to handle AWS clouds for e2e testing
 type Provider struct {
-	framework.NullProvider
+	providers.NullProvider
 }
 
 // ResizeGroup resizes an instance group

--- a/test/e2e/framework/providers/azure/azure.go
+++ b/test/e2e/framework/providers/azure/azure.go
@@ -26,15 +26,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/providers"
 	"k8s.io/legacy-cloud-providers/azure"
 	"k8s.io/legacy-cloud-providers/azure/clients/fileclient"
 )
 
 func init() {
-	framework.RegisterProvider("azure", newProvider)
+	providers.RegisterProvider("azure", newProvider)
 }
 
-func newProvider() (framework.ProviderInterface, error) {
+func newProvider() (providers.ProviderInterface, error) {
 	if framework.TestContext.CloudConfig.ConfigFile == "" {
 		return nil, fmt.Errorf("config-file must be specified for Azure")
 	}
@@ -53,7 +54,7 @@ func newProvider() (framework.ProviderInterface, error) {
 
 //Provider is a structure to handle Azure clouds for e2e testing
 type Provider struct {
-	framework.NullProvider
+	providers.NullProvider
 
 	azureCloud *azure.Cloud
 }

--- a/test/e2e/framework/providers/gce/gce.go
+++ b/test/e2e/framework/providers/gce/gce.go
@@ -34,17 +34,18 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/providers"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	gcecloud "k8s.io/legacy-cloud-providers/gce"
 )
 
 func init() {
-	framework.RegisterProvider("gce", factory)
-	framework.RegisterProvider("gke", factory)
+	providers.RegisterProvider("gce", factory)
+	providers.RegisterProvider("gke", factory)
 }
 
-func factory() (framework.ProviderInterface, error) {
+func factory() (providers.ProviderInterface, error) {
 	framework.Logf("Fetching cloud provider for %q\r", framework.TestContext.Provider)
 	zone := framework.TestContext.CloudConfig.Zone
 	region := framework.TestContext.CloudConfig.Region
@@ -115,7 +116,7 @@ func factory() (framework.ProviderInterface, error) {
 }
 
 // NewProvider returns a cloud provider interface for GCE
-func NewProvider(gceCloud *gcecloud.Cloud) framework.ProviderInterface {
+func NewProvider(gceCloud *gcecloud.Cloud) providers.ProviderInterface {
 	return &Provider{
 		gceCloud: gceCloud,
 	}
@@ -123,7 +124,7 @@ func NewProvider(gceCloud *gcecloud.Cloud) framework.ProviderInterface {
 
 // Provider is a structure to handle GCE clouds for e2e testing
 type Provider struct {
-	framework.NullProvider
+	providers.NullProvider
 	gceCloud *gcecloud.Cloud
 }
 

--- a/test/e2e/framework/providers/kubemark/kubemark.go
+++ b/test/e2e/framework/providers/kubemark/kubemark.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/pkg/kubemark"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/providers"
 )
 
 var (
@@ -32,17 +33,17 @@ var (
 )
 
 func init() {
-	framework.RegisterProvider("kubemark", newProvider)
+	providers.RegisterProvider("kubemark", newProvider)
 }
 
-func newProvider() (framework.ProviderInterface, error) {
+func newProvider() (providers.ProviderInterface, error) {
 	// Actual initialization happens when the e2e framework gets constructed.
 	return &Provider{}, nil
 }
 
 // Provider is a structure to handle Kubemark cluster for e2e testing
 type Provider struct {
-	framework.NullProvider
+	providers.NullProvider
 	controller   *kubemark.KubemarkController
 	closeChannel chan struct{}
 }

--- a/test/e2e/framework/providers/openstack/openstack.go
+++ b/test/e2e/framework/providers/openstack/openstack.go
@@ -17,18 +17,18 @@ limitations under the License.
 package openstack
 
 import (
-	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/providers"
 )
 
 func init() {
-	framework.RegisterProvider("openstack", newProvider)
+	providers.RegisterProvider("openstack", newProvider)
 }
 
-func newProvider() (framework.ProviderInterface, error) {
+func newProvider() (providers.ProviderInterface, error) {
 	return &Provider{}, nil
 }
 
 // Provider is a structure to handle OpenStack clouds for e2e testing
 type Provider struct {
-	framework.NullProvider
+	providers.NullProvider
 }

--- a/test/e2e/framework/providers/provider.go
+++ b/test/e2e/framework/providers/provider.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package providers
 
 import (
 	"fmt"
@@ -86,9 +86,6 @@ func SetupProviderConfig(providerName string) (ProviderInterface, error) {
 // ProviderInterface contains the implementation for certain
 // provider-specific functionality.
 type ProviderInterface interface {
-	FrameworkBeforeEach(f *Framework)
-	FrameworkAfterEach(f *Framework)
-
 	ResizeGroup(group string, size int32) error
 	GetGroupNodes(group string) ([]string, error)
 	GroupSize(group string) (int, error)
@@ -113,12 +110,6 @@ type ProviderInterface interface {
 // NullProvider is the default implementation of the ProviderInterface
 // which doesn't do anything.
 type NullProvider struct{}
-
-// FrameworkBeforeEach is a base implementation which does BeforeEach.
-func (n NullProvider) FrameworkBeforeEach(f *Framework) {}
-
-// FrameworkAfterEach is a base implementation which does AfterEach.
-func (n NullProvider) FrameworkAfterEach(f *Framework) {}
 
 // ResizeGroup is a base implementation which resizes group.
 func (n NullProvider) ResizeGroup(string, int32) error {

--- a/test/e2e/framework/providers/vsphere/vsphere.go
+++ b/test/e2e/framework/providers/vsphere/vsphere.go
@@ -17,13 +17,13 @@ limitations under the License.
 package vsphere
 
 import (
-	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/providers"
 )
 
 func init() {
-	framework.RegisterProvider("vsphere", newProvider)
+	providers.RegisterProvider("vsphere", newProvider)
 }
 
-func newProvider() (framework.ProviderInterface, error) {
-	return &framework.NullProvider{}, nil
+func newProvider() (providers.ProviderInterface, error) {
+	return &providers.NullProvider{}, nil
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/klog/v2"
 
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	e2eproviders "k8s.io/kubernetes/test/e2e/framework/providers"
 )
 
 const (
@@ -255,7 +256,7 @@ type CloudConfig struct {
 	NodeTag           string
 	MasterTag         string
 
-	Provider ProviderInterface
+	Provider e2eproviders.ProviderInterface
 }
 
 // TestContext should be used by all tests to access common context data.
@@ -488,12 +489,12 @@ func AfterReadingAllFlags(t *TestContextType) {
 	}
 
 	var err error
-	TestContext.CloudConfig.Provider, err = SetupProviderConfig(TestContext.Provider)
+	TestContext.CloudConfig.Provider, err = e2eproviders.SetupProviderConfig(TestContext.Provider)
 	if err != nil {
 		if os.IsNotExist(errors.Unwrap(err)) {
 			// Provide a more helpful error message when the provider is unknown.
 			var providers []string
-			for _, name := range GetProviders() {
+			for _, name := range e2eproviders.GetProviders() {
 				// The empty string is accepted, but looks odd in the output below unless we quote it.
 				if name == "" {
 					name = `""`


### PR DESCRIPTION
Part of the refactoring process of #109391

A note about the removal of `FrameworkBeforeEach(f *Framework)` and `FrameworkAfterEach(f *Framework)` from `ProviderInterface`:

These two methods reference `framework.Framework` directly, which is what we are trying to avoid, and currently none of these two methods are used or implemented, so it's safe to delete them.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #109391

#### Special notes for your reviewer:

This is the first separate PR that has to be done for the refactoring process of #109391. Successor PRs as a separate unit needs this change to avoid change spreading.

/cc @SataQiu @oomichi @aojea 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
