### PR TITLE
Print pointer values correctly in column printer

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn.go
@@ -252,7 +252,11 @@ func (s *CustomColumnsPrinter) printOneObject(obj runtime.Object, parsers []*jso
 		}
 		for arrIx := range values {
 			for valIx := range values[arrIx] {
-				valueStrings = append(valueStrings, printers.EscapeTerminal(fmt.Sprint(values[arrIx][valIx].Interface())))
+				value := values[arrIx][valIx].Interface()
+				if values[arrIx][valIx].Kind() == reflect.Ptr && !values[arrIx][valIx].IsNil() {
+					value = values[arrIx][valIx].Elem().Interface()
+				}
+				valueStrings = append(valueStrings, printers.EscapeTerminal(fmt.Sprintf("%v", value)))
 			}
 		}
 		columns[ix] = strings.Join(valueStrings, ",")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn_test.go
@@ -329,6 +329,49 @@ foo    baz           <none>
 ^[ \r
 `,
 		},
+		{
+			columns: []Column{
+				{
+					Header:    "NAME",
+					FieldSpec: "{.metadata.name}",
+				},
+				{
+					Header:    "API_VERSION",
+					FieldSpec: "{.apiVersion}",
+				},
+				{
+					Header:    "TERMINATION_GRACE_PERIOD_SECONDS",
+					FieldSpec: "{.spec.terminationGracePeriodSeconds}",
+				},
+			},
+			obj: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, TypeMeta: metav1.TypeMeta{APIVersion: "baz"}, Spec: corev1.PodSpec{TerminationGracePeriodSeconds: func() *int64 {
+				result := int64(42)
+				return &result
+			}()}},
+			expectedOutput: `NAME   API_VERSION   TERMINATION_GRACE_PERIOD_SECONDS
+foo    baz           42
+`,
+		},
+		{
+			columns: []Column{
+				{
+					Header:    "NAME",
+					FieldSpec: "{.metadata.name}",
+				},
+				{
+					Header:    "API_VERSION",
+					FieldSpec: "{.apiVersion}",
+				},
+				{
+					Header:    "TERMINATION_GRACE_PERIOD_SECONDS",
+					FieldSpec: "{.spec.terminationGracePeriodSeconds}",
+				},
+			},
+			obj: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, TypeMeta: metav1.TypeMeta{APIVersion: "baz"}},
+			expectedOutput: `NAME   API_VERSION   TERMINATION_GRACE_PERIOD_SECONDS
+foo    baz           <nil>
+`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Closes #1176

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes a bug in kubectl where kubectl would print the pointer address of a pointer field in a K8s object instead of dereferencing the pointer and printing the value.

#### Which issue(s) this PR fixes:
Fixes #1176
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

I don't know how to link the kubectl issue here. Here's the issue: https://github.com/kubernetes/kubectl/issues/1176

#### Does this PR introduce a user-facing change?

Yes

```release-note
When server-side flattening and printing isn't used, the CustomColumnsPrinter printed the address of object fields that are pointer types instead of the actual, dereferenced value. The value of a nil pointer will be printed as `<nil>`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

