### PR TITLE
Scheduler-perf: reduce allocation of temporary resourceToValueMap objects on hotspot paths(use resourceToValueMapPool)

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -95,11 +95,11 @@ func NewBalancedAllocation(baArgs runtime.Object, h framework.Handle, fts featur
 	}, nil
 }
 
-func balancedResourceScorer(requested, allocable resourceToValueMap) int64 {
+func balancedResourceScorer(requested, allocatable resourceToValueMap) int64 {
 	var resourceToFractions []float64
 	var totalFraction float64
 	for name, value := range requested {
-		fraction := float64(value) / float64(allocable[name])
+		fraction := float64(value) / float64(allocatable[name])
 		if fraction > 1 {
 			fraction = 1
 		}

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -34,7 +34,7 @@ import (
 // of capacity, and prioritizes the host based on how close the two metrics are to each other.
 type BalancedAllocation struct {
 	handle framework.Handle
-	resourceAllocationScorer
+	*resourceAllocationScorer
 }
 
 var _ = framework.ScorePlugin(&BalancedAllocation{})
@@ -86,12 +86,8 @@ func NewBalancedAllocation(baArgs runtime.Object, h framework.Handle, fts featur
 
 	return &BalancedAllocation{
 		handle: h,
-		resourceAllocationScorer: resourceAllocationScorer{
-			Name:                BalancedAllocationName,
-			scorer:              balancedResourceScorer,
-			useRequested:        true,
-			resourceToWeightMap: resToWeightMap,
-		},
+		resourceAllocationScorer: newResourceAllocationScorer(BalancedAllocationName, balancedResourceScorer,
+			resToWeightMap, true),
 	}, nil
 }
 

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
@@ -316,7 +316,7 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 		// Node1 scores on 0-MaxNodeScore scale
 		// CPU Fraction: 3000 / 3500 = 85.71%
 		// Memory Fraction: 5000 / 40000 = 12.5%
-		// GPU Fraction: 4 / 8 = 0.5%
+		// GPU Fraction: 4 / 8 = 50%
 		// Node1 std: sqrt(((0.8571 - 0.503) *  (0.8571 - 0.503) + (0.503 - 0.125) * (0.503 - 0.125) + (0.503 - 0.5) * (0.503 - 0.5)) / 3) = 0.3002
 		// Node1 Score: (1 - 0.3002)*MaxNodeScore = 70
 		// Node2 scores on 0-MaxNodeScore scale

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -19,8 +19,6 @@ package noderesources
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -30,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
+	"strings"
 )
 
 var _ framework.PreFilterPlugin = &Fit{}

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -19,6 +19,8 @@ package noderesources
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -28,7 +30,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
-	"strings"
 )
 
 var _ framework.PreFilterPlugin = &Fit{}
@@ -49,27 +50,19 @@ const (
 var nodeResourceStrategyTypeMap = map[config.ScoringStrategyType]scorer{
 	config.LeastAllocated: func(args *config.NodeResourcesFitArgs) *resourceAllocationScorer {
 		resToWeightMap := resourcesToWeightMap(args.ScoringStrategy.Resources)
-		return &resourceAllocationScorer{
-			Name:                string(config.LeastAllocated),
-			scorer:              leastResourceScorer(resToWeightMap),
-			resourceToWeightMap: resToWeightMap,
-		}
+		return newResourceAllocationScorer(string(config.LeastAllocated),
+			leastResourceScorer(resToWeightMap), resToWeightMap, false)
 	},
 	config.MostAllocated: func(args *config.NodeResourcesFitArgs) *resourceAllocationScorer {
 		resToWeightMap := resourcesToWeightMap(args.ScoringStrategy.Resources)
-		return &resourceAllocationScorer{
-			Name:                string(config.MostAllocated),
-			scorer:              mostResourceScorer(resToWeightMap),
-			resourceToWeightMap: resToWeightMap,
-		}
+		return newResourceAllocationScorer(string(config.MostAllocated),
+			mostResourceScorer(resToWeightMap), resToWeightMap, false)
 	},
 	config.RequestedToCapacityRatio: func(args *config.NodeResourcesFitArgs) *resourceAllocationScorer {
 		resToWeightMap := resourcesToWeightMap(args.ScoringStrategy.Resources)
-		return &resourceAllocationScorer{
-			Name:                string(config.RequestedToCapacityRatio),
-			scorer:              requestedToCapacityRatioScorer(resToWeightMap, args.ScoringStrategy.RequestedToCapacityRatio.Shape),
-			resourceToWeightMap: resToWeightMap,
-		}
+		return newResourceAllocationScorer(string(config.RequestedToCapacityRatio),
+			requestedToCapacityRatioScorer(resToWeightMap, args.ScoringStrategy.RequestedToCapacityRatio.Shape),
+			resToWeightMap, false)
 	},
 }
 

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
@@ -27,11 +27,11 @@ import (
 // Details:
 // (cpu((capacity-requested)*MaxNodeScore*cpuWeight/capacity) + memory((capacity-requested)*MaxNodeScore*memoryWeight/capacity) + ...)/weightSum
 func leastResourceScorer(resToWeightMap resourceToWeightMap) func(resourceToValueMap, resourceToValueMap) int64 {
-	return func(requested, allocable resourceToValueMap) int64 {
+	return func(requested, allocatable resourceToValueMap) int64 {
 		var nodeScore, weightSum int64
 		for resource := range requested {
 			weight := resToWeightMap[resource]
-			resourceScore := leastRequestedScore(requested[resource], allocable[resource])
+			resourceScore := leastRequestedScore(requested[resource], allocatable[resource])
 			nodeScore += resourceScore * weight
 			weightSum += weight
 		}

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
@@ -26,12 +26,12 @@ import (
 //
 // Details:
 // (cpu(MaxNodeScore * sum(requested) / capacity) + memory(MaxNodeScore * sum(requested) / capacity)) / weightSum
-func mostResourceScorer(resToWeightMap resourceToWeightMap) func(requested, allocable resourceToValueMap) int64 {
-	return func(requested, allocable resourceToValueMap) int64 {
+func mostResourceScorer(resToWeightMap resourceToWeightMap) func(requested, allocatable resourceToValueMap) int64 {
+	return func(requested, allocatable resourceToValueMap) int64 {
 		var nodeScore, weightSum int64
 		for resource := range requested {
 			weight := resToWeightMap[resource]
-			resourceScore := mostRequestedScore(requested[resource], allocable[resource])
+			resourceScore := mostRequestedScore(requested[resource], allocatable[resource])
 			nodeScore += resourceScore * weight
 			weightSum += weight
 		}

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
@@ -39,11 +39,11 @@ func buildRequestedToCapacityRatioScorerFunction(scoringFunctionShape helper.Fun
 
 		return rawScoringFunction(requested * maxUtilization / capacity)
 	}
-	return func(requested, allocable resourceToValueMap) int64 {
+	return func(requested, allocatable resourceToValueMap) int64 {
 		var nodeScore, weightSum int64
 		for resource := range requested {
 			weight := resourceToWeightMap[resource]
-			resourceScore := resourceScoringFunction(requested[resource], allocable[resource])
+			resourceScore := resourceScoringFunction(requested[resource], allocatable[resource])
 			if resourceScore > 0 {
 				nodeScore += resourceScore * weight
 				weightSum += weight


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
After perf scheduler by the following command:

```bash
make test-integration WHAT=./test/integration/scheduler_perf KUBE_TIMEOUT="-timeout=3600s" ETCD_LOGLEVEL=warn KUBE_TEST_VMODULE="''" KUBE_TEST_ARGS="-alsologtostderr=false -logtostderr=false -run=^$$ -benchtime=1ns -bench=BenchmarkPerfScheduling/MixedSchedulingBasePod/5000Nodes -memprofile ~/profiles/mem-profile.out-`date +%Y-%m-%d-%H:%M` -cpuprofile ~/profiles/cpu-profile.out-`date +%Y-%m-%d-%H:%M`"
```

I found`scheduler/framework/plugins/noderesources.(*resourceAllocationScorer).score` consumes a lot of memory
https://github.com/kubernetes/kubernetes/blob/7380fc735aca591325ae1fabf8dab194b40367de/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go#L47-L76
I researched why this method allocates so much memory, and came to the conclusion: 
the temporary variable `resourceToValueMap` is newly allocated in large quantities on the hotspot path, so I try to cache it with sync.pool.


**Before optimization:**
```
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/test/integration/scheduler_perf
cpu: AMD Ryzen 5 5600H with Radeon Graphics
BenchmarkPerfScheduling/MixedSchedulingBasePod/5000Nodes-6         	       1	67890966449 ns/op
PASS
ok  	k8s.io/kubernetes/test/integration/scheduler_perf	79.390s
```

```
      File: scheduler_perf.test
Type: alloc_space
Time: Apr 9, 2022 at 8:41am (UTC)
Showing nodes accounting for 28924.93MB, 100% of 28924.93MB total
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                         2177.43MB 50.16% |   k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources.(*Fit).Score /root/nova/dev/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources/fit.go:334
                                         2163.93MB 49.84% |   k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources.(*BalancedAllocation).Score /root/nova/dev/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go:62
 4341.36MB 15.01% 15.01%  4341.36MB 15.01%                | k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources.(*resourceAllocationScorer).score /root/nova/dev/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go:64
----------------------------------------------------------+-------------
```

**Optimized:**
```
      File: scheduler_perf.test
Type: alloc_space
Time: Apr 9, 2022 at 8:36am (UTC)
Showing nodes accounting for 23928MB, 100% of 23928MB total
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                         1016.19MB 50.12% |   k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources.(*BalancedAllocation).Score /root/nova/dev/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go:62
                                         1011.19MB 49.88% |   k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources.(*Fit).Score /root/nova/dev/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources/fit.go:326
 2027.37MB  8.47%  8.47%  2027.37MB  8.47%                | k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources.(*resourceAllocationScorer).score /root/nova/dev/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go:101
----------------------------------------------------------+-------------
```

```bash
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/test/integration/scheduler_perf
cpu: AMD Ryzen 5 5600H with Radeon Graphics
BenchmarkPerfScheduling/MixedSchedulingBasePod/5000Nodes-6         	       1	67006806701 ns/op
PASS
ok  	k8s.io/kubernetes/test/integration/scheduler_perf	75.106s
```
**Summarize:**
|        | cpuprofile        | memprofile | gc time consuming(from flamegraph) |
| ------ | ----------------- | ---------- | -------------- |
| before | 67890966449 ns/op | 4341.36MB  | 21.56s(13.21%) |
| after  | 67006806701 ns/op | 2027.37MB  | 15.89s(10.6%)  |

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
The pr also fixed a few typos by the way
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
