### PR TITLE
Don't truncate resource usage

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -295,7 +295,7 @@ func printAllResourceUsages(out io.Writer, metrics *ResourceMetricsInfo) {
 		fmt.Fprint(out, "\t")
 		if available, found := metrics.Available[res]; found {
 			fraction := float64(quantity.MilliValue()) / float64(available.MilliValue()) * 100
-			fmt.Fprintf(out, "%d%%\t", int64(fraction))
+			fmt.Fprintf(out, "%.2f%%\t", fraction)
 		}
 	}
 }


### PR DESCRIPTION
Convert the resource usage to `int64` will usually truncate
the fracion part, this is misleading if the actual value is
less than 1.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
One of the node in my cluster have 20 processors, and the CPU usage returned back from `kubectl top node` is always 0, this makes me feel that something is abnormal on that node.

Before change, 
```
kubectl top node node1
NAME   CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%
node1  72m          0%     29721Mi         57%
```

After the change, 
```
kubectl top node node1
NAME   CPU(cores)   CPU%        MEMORY(bytes)   MEMORY%
node1   77m         0.385000%   29709Mi         57.677418%

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
