### PR TITLE
[e2e][azure] Make internalStaticIP flexible

### DIFF
--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -377,6 +377,42 @@ func GetRandomReadySchedulableNode(c clientset.Interface) (*v1.Node, error) {
 	return &nodes.Items[rand.Intn(len(nodes.Items))], nil
 }
 
+// GetSubnetPrefix gets first 2 number of an IP in the node subnet. [IPv4]
+// It assumes that the subnet mask is /16.
+func GetSubnetPrefix(c clientset.Interface) ([]string, error) {
+	node, err := GetReadySchedulableWorkerNode(c)
+	if err != nil {
+		return nil, fmt.Errorf("error getting a ready schedulable worker Node, err: %v", err)
+	}
+	internalIP, err := GetInternalIP(node)
+	if err != nil {
+		return nil, fmt.Errorf("error getting Node internal IP, err: %v", err)
+	}
+	splitted := strings.Split(internalIP, ".")
+	if len(splitted) == 4 {
+		return splitted[:2], nil
+	}
+	return nil, fmt.Errorf("invalid IP address format: %s", internalIP)
+}
+
+// GetReadySchedulableWorkerNode gets a single worker node which is available for
+// running pods on. If there are no such available nodes it will return an error.
+func GetReadySchedulableWorkerNode(c clientset.Interface) (*v1.Node, error) {
+	nodes, err := GetReadySchedulableNodes(c)
+	if err != nil {
+		return nil, err
+	}
+	for i := range nodes.Items {
+		node := nodes.Items[i]
+		_, isMaster := node.Labels["node-role.kubernetes.io/master"]
+		_, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]
+		if !isMaster && !isControlPlane {
+			return &node, nil
+		}
+	}
+	return nil, fmt.Errorf("there are currently no ready, schedulable worker nodes in the cluster")
+}
+
 // GetReadyNodesIncludingTainted returns all ready nodes, even those which are tainted.
 // There are cases when we care about tainted nodes
 // E.g. in tests related to nodes with gpu we care about nodes despite

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -57,9 +57,13 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 
 	var cs clientset.Interface
 	serviceLBNames := []string{}
+	var subnetPrefix []string
+	var err error
 
 	ginkgo.BeforeEach(func() {
 		cs = f.ClientSet
+		subnetPrefix, err = e2enode.GetSubnetPrefix(cs)
+		framework.ExpectNoError(err)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -590,7 +594,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		isInternalEndpoint := func(lbIngress *v1.LoadBalancerIngress) bool {
 			ingressEndpoint := e2eservice.GetIngressPoint(lbIngress)
 			// Needs update for providers using hostname as endpoint.
-			return strings.HasPrefix(ingressEndpoint, "10.")
+			return strings.HasPrefix(ingressEndpoint, subnetPrefix[0]+".")
 		}
 
 		ginkgo.By("creating a service with type LoadBalancer and cloud specific Internal-LB annotation enabled")
@@ -669,7 +673,9 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		// will be removed when GCP supports similar functionality.
 		if framework.ProviderIs("azure") {
 			ginkgo.By("switching back to interal type LoadBalancer, with static IP specified.")
-			internalStaticIP := "10.240.11.11"
+			// For a cluster created with CAPZ, node-subnet may not be "10.240.0.0/16", e.g. "10.1.0.0/16".
+			internalStaticIP := fmt.Sprintf("%s.%s.11.11", subnetPrefix[0], subnetPrefix[1])
+
 			svc, err = jig.UpdateService(func(svc *v1.Service) {
 				svc.Spec.LoadBalancerIP = internalStaticIP
 				enableILB(svc)
@@ -987,6 +993,8 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 
 	var cs clientset.Interface
 	serviceLBNames := []string{}
+	var subnetPrefix []string
+	var err error
 
 	ginkgo.BeforeEach(func() {
 		// requires cloud load-balancer support - this feature currently supported only on GCE/GKE
@@ -994,6 +1002,8 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 
 		cs = f.ClientSet
 		loadBalancerCreateTimeout = e2eservice.GetServiceLoadBalancerCreationTimeout(cs)
+		subnetPrefix, err = e2enode.GetSubnetPrefix(cs)
+		framework.ExpectNoError(err)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -1052,7 +1062,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 		framework.Logf("ClientIP detected by target pod using VIP:SvcPort is %s", clientIP)
 
 		ginkgo.By("checking if Source IP is preserved")
-		if strings.HasPrefix(clientIP, "10.") {
+		if strings.HasPrefix(clientIP, subnetPrefix[0]+".") {
 			framework.Failf("Source IP was NOT preserved")
 		}
 	})
@@ -1334,7 +1344,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 			if err != nil {
 				return false, nil
 			}
-			if strings.HasPrefix(clientIP, "10.") {
+			if strings.HasPrefix(clientIP, subnetPrefix[0]+".") {
 				return true, nil
 			}
 			return false, nil
@@ -1363,7 +1373,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 				return false, nil
 			}
 			ginkgo.By(fmt.Sprintf("Endpoint %v:%v%v returned client ip %v", ingressIP, svcTCPPort, path, clientIP))
-			if !strings.HasPrefix(clientIP, "10.") {
+			if !strings.HasPrefix(clientIP, subnetPrefix[0]+".") {
 				return true, nil
 			}
 			return false, nil


### PR DESCRIPTION
Now, internalStaticIP is hard-coded to "10.240.11.11". Such IP works
for aks-engine cluster but not for CAPZ ones (node-subnet 10.1.0.0/16)

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind failing-test
#### What this PR does / why we need it:
Now, internalStaticIP is hard-coded to "10.240.11.11". Such IP works
for aks-engine cluster but not for CAPZ ones (node-subnet 10.1.0.0/16)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
