### PR TITLE
Set kubelet node.Status.Allocatable.ResourcePods to minus the number …

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -624,7 +624,7 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(*v1.Node) error {
 	setters = append(setters,
 		nodestatus.NodeAddress(kl.nodeIPs, kl.nodeIPValidator, kl.hostname, kl.hostnameOverridden, kl.externalCloudProvider, kl.cloud, nodeAddressesFunc),
 		nodestatus.MachineInfo(string(kl.nodeName), kl.maxPods, kl.podsPerCore, kl.GetCachedMachineInfo, kl.containerManager.GetCapacity,
-			kl.containerManager.GetDevicePluginResourceCapacity, kl.containerManager.GetNodeAllocatableReservation, kl.recordEvent),
+			kl.containerManager.GetDevicePluginResourceCapacity, kl.containerManager.GetNodeAllocatableReservation, kl.podManager.GetAllPodNum, kl.recordEvent),
 		nodestatus.VersionInfo(kl.cadvisor.VersionInfo, kl.containerRuntime.Type, kl.containerRuntime.Version),
 		nodestatus.DaemonEndpoints(kl.daemonEndpoints),
 		nodestatus.Images(kl.nodeStatusMaxImages, kl.imageManager.GetImageList),

--- a/pkg/kubelet/pod/pod_manager.go
+++ b/pkg/kubelet/pod/pod_manager.go
@@ -93,7 +93,8 @@ type Manager interface {
 	// IsMirrorPodOf returns true if mirrorPod is a correct representation of
 	// pod; false otherwise.
 	IsMirrorPodOf(mirrorPod, pod *v1.Pod) bool
-
+	// GetAllPodNum returns pod number of both regular and mirror pods.
+	GetAllPodNum() int
 	MirrorClient
 }
 
@@ -346,4 +347,10 @@ func (pm *basicManager) GetPodByMirrorPod(mirrorPod *v1.Pod) (*v1.Pod, bool) {
 	defer pm.lock.RUnlock()
 	pod, ok := pm.podByFullName[kubecontainer.GetPodFullName(mirrorPod)]
 	return pod, ok
+}
+
+func (pm *basicManager) GetAllPodNum() int {
+	pm.lock.RLock()
+	defer pm.lock.RUnlock()
+	return len(pm.podByUID) + len(pm.mirrorPodByUID)
 }

--- a/pkg/kubelet/pod/testing/mock_manager.go
+++ b/pkg/kubelet/pod/testing/mock_manager.go
@@ -289,3 +289,7 @@ func (mr *MockManagerMockRecorder) UpdatePod(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePod", reflect.TypeOf((*MockManager)(nil).UpdatePod), arg0)
 }
+
+func (m *MockManager) GetAllPodNum() int {
+	return 0
+}


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
When I set kubelet option max-pods to limit the pod number on my node, I found the node.status.allocatable.pods is the same as node.status.capacity.pods. The kube-scheduler's Filter plugin NodeResourcesFit cannot filter node correctly with node.status.allocatable.pods always be the fix value set by max-pods. So I think node.status.allocatable.pods must be reported by kubelet on time with the really number of pods the node want to accept.
Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:
Does this PR introduce a user-facing change? No