### PR TITLE
Automated cherry pick of #109288: Cleanup KUBE-NODE-PORT chain in filter table.

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -143,6 +143,7 @@ var iptablesCleanupChains = []struct {
 	{utiliptables.TableNAT, KubeNodePortChain},
 	{utiliptables.TableNAT, KubeLoadBalancerChain},
 	{utiliptables.TableFilter, KubeForwardChain},
+	{utiliptables.TableFilter, KubeNodePortChain},
 }
 
 // ipsetInfo is all ipset we needed in ipvs proxier


### PR DESCRIPTION
Cherry pick of #109288 on release-1.23.

#109288: Cleanup KUBE-NODE-PORT chain in filter table.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
An issue causing `kube-proxy --cleanup` to fail in IPVS mode is now fixed.
```

