### PR TITLE
1.25: feature gate cleanup

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -169,15 +169,6 @@ const (
 	// Enables SecretRef field in CSI NodeExpandVolume request.
 	CSINodeExpandSecret featuregate.Feature = "CSINodeExpandSecret"
 
-	// owner: @zshihang
-	// alpha: v1.20
-	// beta: v1.21
-	// ga: v1.22
-	//
-	// Enable kubelet to pass pod's service account token to NodePublishVolume
-	// call of CSI driver which is mounting volumes for that pod.
-	CSIServiceAccountToken featuregate.Feature = "CSIServiceAccountToken"
-
 	// owner: @pohly
 	// alpha: v1.19
 	// beta: v1.21
@@ -291,31 +282,6 @@ const (
 	// deprecated: 1.22
 	DynamicKubeletConfig featuregate.Feature = "DynamicKubeletConfig"
 
-	// owner: @robscott @freehan
-	// kep: http://kep.k8s.io/752
-	// alpha: v1.16
-	// beta: v1.18
-	// ga: v1.21
-	//
-	// Enable Endpoint Slices for more scalable Service endpoints.
-	EndpointSlice featuregate.Feature = "EndpointSlice"
-
-	// owner: @robscott
-	// kep: http://kep.k8s.io/752
-	// alpha: v1.20
-	//
-	// Enable NodeName field on Endpoint Slices.
-	EndpointSliceNodeName featuregate.Feature = "EndpointSliceNodeName"
-
-	// owner: @robscott @freehan
-	// kep: http://kep.k8s.io/752
-	// alpha: v1.18
-	// beta: v1.19
-	// ga: v1.22
-	//
-	// Enable Endpoint Slice consumption by kube-proxy for improved scalability.
-	EndpointSliceProxying featuregate.Feature = "EndpointSliceProxying"
-
 	// owner: @andrewsykim
 	// kep: http://kep.k8s.io/1672
 	// alpha: v1.20
@@ -381,14 +347,6 @@ const (
 	// Enables GRPC probe method for {Liveness,Readiness,Startup}Probe.
 	GRPCContainerProbe featuregate.Feature = "GRPCContainerProbe"
 
-	// owner: @pohly
-	// alpha: v1.19
-	// beta: v1.21
-	// GA: v1.23
-	//
-	// Enables generic ephemeral inline volume support for pods
-	GenericEphemeralVolume featuregate.Feature = "GenericEphemeralVolume"
-
 	// owner: @bobbypage
 	// alpha: v1.20
 	// beta:  v1.21
@@ -421,15 +379,6 @@ const (
 	// Honor Persistent Volume Reclaim Policy when it is "Delete" irrespective of PV-PVC
 	// deletion ordering.
 	HonorPVReclaimPolicy featuregate.Feature = "HonorPVReclaimPolicy"
-
-	// owner: @khenidak
-	// kep: http://kep.k8s.io/563
-	// alpha: v1.15
-	// beta: v1.21
-	// ga: v1.23
-	//
-	// Enables ipv6 dual stack
-	IPv6DualStack featuregate.Feature = "IPv6DualStack"
 
 	// owner: @ravig
 	// alpha: v1.23
@@ -493,15 +442,6 @@ const (
 	//
 	// Allows Job controller to manage Pod completions per completion index.
 	IndexedJob featuregate.Feature = "IndexedJob"
-
-	// owner: @hbagdi
-	// kep: http://kep.k8s.io/2365
-	// alpha: v1.21
-	// beta: v1.22
-	// GA: v1.23
-	//
-	// Enable Scope and Namespace fields on IngressClassParametersReference.
-	IngressClassNamespacedParams featuregate.Feature = "IngressClassNamespacedParams"
 
 	// owner: @ahg
 	// beta: v1.23
@@ -817,12 +757,6 @@ const (
 	// StatefulSetMinReadySeconds allows minReadySeconds to be respected by StatefulSet controller
 	StatefulSetMinReadySeconds featuregate.Feature = "StatefulSetMinReadySeconds"
 
-	// owner: @pospispa
-	// GA: v1.11
-	//
-	// Postpone deletion of a PV or a PVC when they are being used
-	StorageObjectInUseProtection featuregate.Feature = "StorageObjectInUseProtection"
-
 	// owner: @adtac
 	// alpha: v1.21
 	// beta: v1.22
@@ -830,13 +764,6 @@ const (
 	//
 	// Allows jobs to be created in the suspended state.
 	SuspendJob featuregate.Feature = "SuspendJob"
-
-	// owner: @janetkuo
-	// alpha: v1.12
-	// beta:  v1.21
-	//
-	// Allow TTL controller to clean up Pods and Jobs after they finish.
-	TTLAfterFinished featuregate.Feature = "TTLAfterFinished"
 
 	// owner: @robscott
 	// kep: http://kep.k8s.io/2433
@@ -857,14 +784,6 @@ const (
 	// alpha: v1.21
 	VolumeCapacityPriority featuregate.Feature = "VolumeCapacityPriority"
 
-	// owner: @saad-ali
-	// ga: 	  v1.10
-	//
-	// Allow mounting a subpath of a volume in a container
-	// NOTE: This feature gate has been deprecated and is no longer enforced.
-	// It will be completely removed in 1.25. Until then, it's still visible in `kubelet --help`
-	VolumeSubpath featuregate.Feature = "VolumeSubpath"
-
 	// owner: @ksubrmnn
 	// alpha: v1.14
 	//
@@ -877,15 +796,6 @@ const (
 	//
 	// Allows kube-proxy to run in Overlay mode for Windows
 	WinOverlay featuregate.Feature = "WinOverlay"
-
-	// owner: @robscott @kumarvin123
-	// kep: http://kep.k8s.io/752
-	// alpha: v1.19
-	// beta: v1.21
-	// ga: v1.22
-	//
-	// Enable Endpoint Slice consumption by kube-proxy in Windows for improved scalability.
-	WindowsEndpointSliceProxying featuregate.Feature = "WindowsEndpointSliceProxying"
 
 	// owner: @marosset
 	// alpha: v1.22
@@ -942,8 +852,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	CSINodeExpandSecret: {Default: false, PreRelease: featuregate.Alpha},
 
-	CSIServiceAccountToken: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
-
 	CSIStorageCapacity: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
 
 	CSIVolumeFSGroupPolicy: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
@@ -976,31 +884,23 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	DynamicKubeletConfig: {Default: false, PreRelease: featuregate.Deprecated}, // feature gate is deprecated in 1.22, kubelet logic is removed in 1.24, api server logic can be removed in 1.26
 
-	EndpointSlice: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-
-	EndpointSliceNodeName: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-
-	EndpointSliceProxying: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-
 	EndpointSliceTerminatingCondition: {Default: true, PreRelease: featuregate.Beta},
 
 	EphemeralContainers: {Default: true, PreRelease: featuregate.Beta},
 
 	ExecProbeTimeout: {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
 
-	ExpandCSIVolumes: {Default: true, PreRelease: featuregate.GA}, // remove in 1.25
+	ExpandCSIVolumes: {Default: true, PreRelease: featuregate.GA}, // remove in 1.26
 
-	ExpandInUsePersistentVolumes: {Default: true, PreRelease: featuregate.GA}, // remove in 1.25
+	ExpandInUsePersistentVolumes: {Default: true, PreRelease: featuregate.GA}, // remove in 1.26
 
-	ExpandPersistentVolumes: {Default: true, PreRelease: featuregate.GA}, // remove in 1.25
+	ExpandPersistentVolumes: {Default: true, PreRelease: featuregate.GA}, // remove in 1.26
 
 	ExpandedDNSConfig: {Default: false, PreRelease: featuregate.Alpha},
 
 	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: featuregate.Beta},
 
 	GRPCContainerProbe: {Default: true, PreRelease: featuregate.Beta},
-
-	GenericEphemeralVolume: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
 
 	GracefulNodeShutdown: {Default: true, PreRelease: featuregate.Beta},
 
@@ -1009,8 +909,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	HPAContainerMetrics: {Default: false, PreRelease: featuregate.Alpha},
 
 	HonorPVReclaimPolicy: {Default: false, PreRelease: featuregate.Alpha},
-
-	IPv6DualStack: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
 
 	IdentifyPodOS: {Default: true, PreRelease: featuregate.Beta},
 
@@ -1031,8 +929,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	InTreePluginvSphereUnregister: {Default: false, PreRelease: featuregate.Alpha},
 
 	IndexedJob: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-
-	IngressClassNamespacedParams: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
 
 	JobMutableNodeSchedulingDirectives: {Default: true, PreRelease: featuregate.Beta},
 
@@ -1074,7 +970,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	NodeSwap: {Default: false, PreRelease: featuregate.Alpha},
 
-	NonPreemptingPriority: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+	NonPreemptingPriority: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
 
 	PodAffinityNamespaceSelector: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
 
@@ -1088,7 +984,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	PodSecurity: {Default: true, PreRelease: featuregate.Beta},
 
-	PreferNominatedNode: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+	PreferNominatedNode: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
 
 	ProbeTerminationGracePeriod: {Default: false, PreRelease: featuregate.Beta}, // Default to false in beta 1.22, set to true in 1.24
 
@@ -1120,11 +1016,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	StatefulSetMinReadySeconds: {Default: true, PreRelease: featuregate.Beta},
 
-	StorageObjectInUseProtection: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-
 	SuspendJob: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-
-	TTLAfterFinished: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
 
 	TopologyAwareHints: {Default: true, PreRelease: featuregate.Beta},
 
@@ -1132,13 +1024,9 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	VolumeCapacityPriority: {Default: false, PreRelease: featuregate.Alpha},
 
-	VolumeSubpath: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-
 	WinDSR: {Default: false, PreRelease: featuregate.Alpha},
 
 	WinOverlay: {Default: true, PreRelease: featuregate.Beta},
-
-	WindowsEndpointSliceProxying: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
 
 	WindowsHostProcessContainers: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -30,434 +30,11 @@ const (
 	// // kep: http://kep.k8s.io/NNN
 	// // alpha: v1.X
 	// MyFeature featuregate.Feature = "MyFeature"
-
-	// owner: @tallclair
-	// beta: v1.4
-	AppArmor featuregate.Feature = "AppArmor"
-
-	// owner: @mtaufen
-	// alpha: v1.4
-	// beta: v1.11
-	// deprecated: 1.22
-	DynamicKubeletConfig featuregate.Feature = "DynamicKubeletConfig"
-
-	// owner: @pweil-
-	// alpha: v1.5
 	//
-	// Default userns=host for containers that are using other host namespaces, host mounts, the pod
-	// contains a privileged container, or specific non-namespaced capabilities (MKNOD, SYS_MODULE,
-	// SYS_TIME). This should only be enabled if user namespace remapping is enabled in the docker daemon.
-	ExperimentalHostUserNamespaceDefaultingGate featuregate.Feature = "ExperimentalHostUserNamespaceDefaulting"
-
-	// owner: @jiayingz
-	// beta: v1.10
-	//
-	// Enables support for Device Plugins
-	DevicePlugins featuregate.Feature = "DevicePlugins"
-
-	// owner: @dxist
-	// alpha: v1.16
-	//
-	// Enables support of HPA scaling to zero pods when an object or custom metric is configured.
-	HPAScaleToZero featuregate.Feature = "HPAScaleToZero"
-
-	// owner: @mikedanese
-	// alpha: v1.7
-	// beta: v1.12
-	//
-	// Gets a server certificate for the kubelet from the Certificate Signing
-	// Request API instead of generating one self signed and auto rotates the
-	// certificate as expiration approaches.
-	RotateKubeletServerCertificate featuregate.Feature = "RotateKubeletServerCertificate"
-
-	// owner: @jinxu
-	// beta: v1.10
-	//
-	// New local storage types to support local storage capacity isolation
-	LocalStorageCapacityIsolation featuregate.Feature = "LocalStorageCapacityIsolation"
-
-	// owner: @gnufied
-	// beta: v1.11
-	// GA: 1.24
-	// Ability to Expand persistent volumes
-	ExpandPersistentVolumes featuregate.Feature = "ExpandPersistentVolumes"
-
-	// owner: @mlmhl @gnufied
-	// beta: v1.15
-	// GA: 1.24
-	// Ability to expand persistent volumes' file system without unmounting volumes.
-	ExpandInUsePersistentVolumes featuregate.Feature = "ExpandInUsePersistentVolumes"
-
-	// owner: @gnufied
-	// alpha: v1.14
-	// beta: v1.16
-	// GA: 1.24
-	// Ability to expand CSI volumes
-	ExpandCSIVolumes featuregate.Feature = "ExpandCSIVolumes"
-
-	// owner: @verb
-	// alpha: v1.16
-	// beta: v1.23
-	//
-	// Allows running an ephemeral container in pod namespaces to troubleshoot a running pod.
-	EphemeralContainers featuregate.Feature = "EphemeralContainers"
-
-	// owner: @sjenning
-	// alpha: v1.11
-	//
-	// Allows resource reservations at the QoS level preventing pods at lower QoS levels from
-	// bursting into resources requested at higher QoS levels (memory only for now)
-	QOSReserved featuregate.Feature = "QOSReserved"
-
-	// owner: @ConnorDoyle
-	// alpha: v1.8
-	// beta: v1.10
-	//
-	// Alternative container-level CPU affinity policies.
-	CPUManager featuregate.Feature = "CPUManager"
-
-	// owner: @szuecs
-	// alpha: v1.12
-	//
-	// Enable nodes to change CPUCFSQuotaPeriod
-	CPUCFSQuotaPeriod featuregate.Feature = "CustomCPUCFSQuotaPeriod"
-
-	// owner: @lmdaly
-	// alpha: v1.16
-	// beta: v1.18
-	//
-	// Enable resource managers to make NUMA aligned decisions
-	TopologyManager featuregate.Feature = "TopologyManager"
-
-	// owner: @cynepco3hahue(alukiano) @cezaryzukowski @k-wiatrzyk
-	// alpha: v1.21
-	// beta: v1.22
-
-	// Allows setting memory affinity for a container based on NUMA topology
-	MemoryManager featuregate.Feature = "MemoryManager"
-
-	// owner: @pospispa
-	// GA: v1.11
-	//
-	// Postpone deletion of a PV or a PVC when they are being used
-	StorageObjectInUseProtection featuregate.Feature = "StorageObjectInUseProtection"
-
-	// owner: @saad-ali
-	// ga: 	  v1.10
-	//
-	// Allow mounting a subpath of a volume in a container
-	// NOTE: This feature gate has been deprecated and is no longer enforced.
-	// It will be completely removed in 1.25. Until then, it's still visible in `kubelet --help`
-	VolumeSubpath featuregate.Feature = "VolumeSubpath"
-
-	// owner: @pohly
-	// alpha: v1.14
-	// beta: v1.16
-	//
-	// Enables CSI Inline volumes support for pods
-	CSIInlineVolume featuregate.Feature = "CSIInlineVolume"
-
-	// owner: @pohly
-	// alpha: v1.19
-	// beta: v1.21
-	// GA: v1.24
-	//
-	// Enables tracking of available storage capacity that CSI drivers provide.
-	CSIStorageCapacity featuregate.Feature = "CSIStorageCapacity"
-
-	// owner: @alculquicondor
-	// alpha: v1.19
-	// beta: v1.20
-	// GA: v1.24
-	//
-	// Enables the use of PodTopologySpread scheduling plugin to do default
-	// spreading and disables legacy SelectorSpread plugin.
-	DefaultPodTopologySpread featuregate.Feature = "DefaultPodTopologySpread"
-
-	// owner: @pohly
-	// alpha: v1.19
-	// beta: v1.21
-	// GA: v1.23
-	//
-	// Enables generic ephemeral inline volume support for pods
-	GenericEphemeralVolume featuregate.Feature = "GenericEphemeralVolume"
-
-	// owner: @chendave
-	// alpha: v1.21
-	// beta: v1.22
-	// GA: v1.24
-	//
-	// PreferNominatedNode tells scheduler whether the nominated node will be checked first before looping
-	// all the rest of nodes in the cluster.
-	// Enabling this feature also implies the preemptor pod might not be dispatched to the best candidate in
-	// some corner case, e.g. another node releases enough resources after the nominated node has been set
-	// and hence is the best candidate instead.
-	PreferNominatedNode featuregate.Feature = "PreferNominatedNode"
-
-	// owner: @rikatz
-	// kep: http://kep.k8s.io/2079
-	// alpha: v1.21
-	// beta:  v1.22
-	//
-	// Enables the endPort field in NetworkPolicy to enable a Port Range behavior in Network Policies.
-	NetworkPolicyEndPort featuregate.Feature = "NetworkPolicyEndPort"
-
-	// owner: @jessfraz
-	// alpha: v1.12
-	//
-	// Enables control over ProcMountType for containers.
-	ProcMountType featuregate.Feature = "ProcMountType"
-
-	// owner: @janetkuo
-	// alpha: v1.12
-	// beta:  v1.21
-	//
-	// Allow TTL controller to clean up Pods and Jobs after they finish.
-	TTLAfterFinished featuregate.Feature = "TTLAfterFinished"
-
-	// owner: @alculquicondor
-	// alpha: v1.21
-	// beta: v1.22
-	// stable: v1.24
-	//
-	// Allows Job controller to manage Pod completions per completion index.
-	IndexedJob featuregate.Feature = "IndexedJob"
-
-	// owner: @alculquicondor
-	// alpha: v1.22
-	// beta: v1.23
-	//
-	// Track Job completion without relying on Pod remaining in the cluster
-	// indefinitely. Pod finalizers, in addition to a field in the Job status
-	// allow the Job controller to keep track of Pods that it didn't account for
-	// yet.
-	JobTrackingWithFinalizers featuregate.Feature = "JobTrackingWithFinalizers"
-
-	// owner: @alculquicondor
-	// alpha: v1.23
-	// beta: v1.24
-	//
-	// Track the number of pods with Ready condition in the Job status.
-	JobReadyPods featuregate.Feature = "JobReadyPods"
-
-	// owner: @dashpole
-	// alpha: v1.13
-	// beta: v1.15
-	//
-	// Enables the kubelet's pod resources grpc endpoint
-	KubeletPodResources featuregate.Feature = "KubeletPodResources"
-
-	// owner: @davidz627
-	// alpha: v1.14
-	// beta: v1.17
-	//
-	// Enables the in-tree storage to CSI Plugin migration feature.
-	CSIMigration featuregate.Feature = "CSIMigration"
-
-	// owner: @davidz627
-	// alpha: v1.14
-	// beta: v1.17
-	//
-	// Enables the GCE PD in-tree driver to GCE CSI Driver migration feature.
-	CSIMigrationGCE featuregate.Feature = "CSIMigrationGCE"
-
-	// owner: @Jiawei0227
-	// alpha: v1.21
-	//
-	// Disables the GCE PD in-tree driver.
-	InTreePluginGCEUnregister featuregate.Feature = "InTreePluginGCEUnregister"
-
-	// owner: @leakingtapan
-	// alpha: v1.14
-	// beta: v1.17
-	//
-	// Enables the AWS EBS in-tree driver to AWS EBS CSI Driver migration feature.
-	CSIMigrationAWS featuregate.Feature = "CSIMigrationAWS"
-
-	// owner: @leakingtapan
-	// alpha: v1.21
-	//
-	// Disables the AWS EBS in-tree driver.
-	InTreePluginAWSUnregister featuregate.Feature = "InTreePluginAWSUnregister"
-
-	// owner: @andyzhangx
-	// alpha: v1.15
-	// beta: v1.19
-	// GA: v1.24
-	//
-	// Enables the Azure Disk in-tree driver to Azure Disk Driver migration feature.
-	CSIMigrationAzureDisk featuregate.Feature = "CSIMigrationAzureDisk"
-
-	// owner: @andyzhangx
-	// alpha: v1.21
-	//
-	// Disables the Azure Disk in-tree driver.
-	InTreePluginAzureDiskUnregister featuregate.Feature = "InTreePluginAzureDiskUnregister"
-
-	// owner: @andyzhangx
-	// alpha: v1.15
-	// beta: v1.21
-	//
-	// Enables the Azure File in-tree driver to Azure File Driver migration feature.
-	CSIMigrationAzureFile featuregate.Feature = "CSIMigrationAzureFile"
-
-	// owner: @andyzhangx
-	// alpha: v1.21
-	//
-	// Disables the Azure File in-tree driver.
-	InTreePluginAzureFileUnregister featuregate.Feature = "InTreePluginAzureFileUnregister"
-
-	// owner: @divyenpatel
-	// beta: v1.19 (requires: vSphere vCenter/ESXi Version: 7.0u2, HW Version: VM version 15)
-	//
-	// Enables the vSphere in-tree driver to vSphere CSI Driver migration feature.
-	CSIMigrationvSphere featuregate.Feature = "CSIMigrationvSphere"
-
-	// owner: @divyenpatel
-	// alpha: v1.21
-	//
-	// Disables the vSphere in-tree driver.
-	InTreePluginvSphereUnregister featuregate.Feature = "InTreePluginvSphereUnregister"
-
-	// owner: @adisky
-	// alpha: v1.14
-	// beta: v1.18
-	//
-	// Enables the OpenStack Cinder in-tree driver to OpenStack Cinder CSI Driver migration feature.
-	CSIMigrationOpenStack featuregate.Feature = "CSIMigrationOpenStack"
-
-	// owner: @adisky
-	// alpha: v1.21
-	//
-	// Disables the OpenStack Cinder in-tree driver.
-	InTreePluginOpenStackUnregister featuregate.Feature = "InTreePluginOpenStackUnregister"
-
-	// owner: @trierra
-	// alpha: v1.23
-	//
-	// Enables the Portworx in-tree driver to Portworx migration feature.
-	CSIMigrationPortworx featuregate.Feature = "CSIMigrationPortworx"
-
-	// owner: @trierra
-	// alpha: v1.23
-	//
-	// Disables the Portworx in-tree driver.
-	InTreePluginPortworxUnregister featuregate.Feature = "InTreePluginPortworxUnregister"
-
-	// owner: @humblec
-	// alpha: v1.23
-	//
-	// Enables the RBD in-tree driver to RBD CSI Driver  migration feature.
-	CSIMigrationRBD featuregate.Feature = "CSIMigrationRBD"
-
-	// owner: @humblec
-	// alpha: v1.23
-	//
-	// Disables the RBD in-tree driver.
-	InTreePluginRBDUnregister featuregate.Feature = "InTreePluginRBDUnregister"
-
-	// owner: @huffmanca, @dobsonj
-	// alpha: v1.19
-	// beta: v1.20
-	// GA: v1.23
-	//
-	// Determines if a CSI Driver supports applying fsGroup.
-	CSIVolumeFSGroupPolicy featuregate.Feature = "CSIVolumeFSGroupPolicy"
-
-	// owner: @gnufied
-	// alpha: v1.18
-	// beta: v1.20
-	// GA: v1.23
-	// Allows user to configure volume permission change policy for fsGroups when mounting
-	// a volume in a Pod.
-	ConfigurableFSGroupPolicy featuregate.Feature = "ConfigurableFSGroupPolicy"
-
-	// owner: @gnufied, @verult
-	// alpha: v1.22
-	// beta: v1.23
-	// If supported by the CSI driver, delegates the role of applying FSGroup to
-	// the driver by passing FSGroup through the NodeStageVolume and
-	// NodePublishVolume calls.
-	DelegateFSGroupToCSIDriver featuregate.Feature = "DelegateFSGroupToCSIDriver"
-
-	// owner: @RobertKrawitz
-	// alpha: v1.15
-	//
-	// Allow use of filesystems for ephemeral storage monitoring.
-	// Only applies if LocalStorageCapacityIsolation is set.
-	LocalStorageCapacityIsolationFSQuotaMonitoring featuregate.Feature = "LocalStorageCapacityIsolationFSQuotaMonitoring"
-
-	// owner: @denkensk
-	// alpha: v1.15
-	// beta: v1.19
-	// ga: v1.24
-	//
-	// Enables NonPreempting option for priorityClass and pod.
-	NonPreemptingPriority featuregate.Feature = "NonPreemptingPriority"
-
-	// owner: @egernst
-	// alpha: v1.16
-	// beta: v1.18
-	// ga: v1.24
-	//
-	// Enables PodOverhead, for accounting pod overheads which are specific to a given RuntimeClass
-	PodOverhead featuregate.Feature = "PodOverhead"
-
-	// owner: @khenidak
-	// kep: http://kep.k8s.io/563
-	// alpha: v1.15
-	// beta: v1.21
-	// ga: v1.23
-	//
-	// Enables ipv6 dual stack
-	IPv6DualStack featuregate.Feature = "IPv6DualStack"
-
-	// owner: @robscott @freehan
-	// kep: http://kep.k8s.io/752
-	// alpha: v1.16
-	// beta: v1.18
-	// ga: v1.21
-	//
-	// Enable Endpoint Slices for more scalable Service endpoints.
-	EndpointSlice featuregate.Feature = "EndpointSlice"
-
-	// owner: @robscott @freehan
-	// kep: http://kep.k8s.io/752
-	// alpha: v1.18
-	// beta: v1.19
-	// ga: v1.22
-	//
-	// Enable Endpoint Slice consumption by kube-proxy for improved scalability.
-	EndpointSliceProxying featuregate.Feature = "EndpointSliceProxying"
-
-	// owner: @robscott @kumarvin123
-	// kep: http://kep.k8s.io/752
-	// alpha: v1.19
-	// beta: v1.21
-	// ga: v1.22
-	//
-	// Enable Endpoint Slice consumption by kube-proxy in Windows for improved scalability.
-	WindowsEndpointSliceProxying featuregate.Feature = "WindowsEndpointSliceProxying"
-
-	// owner: @mortent
-	// alpha: v1.3
-	// beta:  v1.5
-	//
-	// Enable all logic related to the PodDisruptionBudget API object in policy
-	PodDisruptionBudget featuregate.Feature = "PodDisruptionBudget"
-
-	// owner: @smarterclayton
-	// alpha: v1.21
-	// beta: v1.22
-	// DaemonSets allow workloads to maintain availability during update per node
-	DaemonSetUpdateSurge featuregate.Feature = "DaemonSetUpdateSurge"
-
-	// owner: @derekwaynecarr
-	// alpha: v1.20
-	// beta: v1.21 (off by default until 1.22)
-	//
-	// Enables usage of hugepages-<size> in downward API.
-	DownwardAPIHugePages featuregate.Feature = "DownwardAPIHugePages"
+	// Feature gates should be listed in alphabetical, case-sensitive
+	// (upper before any lower case character) order. This reduces the risk
+	// of code conflicts because changes are more likely to be scattered
+	// across the file.
 
 	// owner: @bswartz
 	// alpha: v1.18
@@ -466,308 +43,22 @@ const (
 	// Enables usage of any object for volume data source in PVCs
 	AnyVolumeDataSource featuregate.Feature = "AnyVolumeDataSource"
 
-	// owner: @ksubrmnn
-	// alpha: v1.14
-	// beta: v1.20
+	// owner: @tallclair
+	// beta: v1.4
+	AppArmor featuregate.Feature = "AppArmor"
+
+	// owner: @szuecs
+	// alpha: v1.12
 	//
-	// Allows kube-proxy to run in Overlay mode for Windows
-	WinOverlay featuregate.Feature = "WinOverlay"
+	// Enable nodes to change CPUCFSQuotaPeriod
+	CPUCFSQuotaPeriod featuregate.Feature = "CustomCPUCFSQuotaPeriod"
 
-	// owner: @ksubrmnn
-	// alpha: v1.14
+	// owner: @ConnorDoyle
+	// alpha: v1.8
+	// beta: v1.10
 	//
-	// Allows kube-proxy to create DSR loadbalancers for Windows
-	WinDSR featuregate.Feature = "WinDSR"
-
-	// owner: @RenaudWasTaken @dashpole
-	// alpha: v1.19
-	// beta: v1.20
-	//
-	// Disables Accelerator Metrics Collected by Kubelet
-	DisableAcceleratorUsageMetrics featuregate.Feature = "DisableAcceleratorUsageMetrics"
-
-	// owner: @arjunrn @mwielgus @josephburnett
-	// alpha: v1.20
-	//
-	// Add support for the HPA to scale based on metrics from individual containers
-	// in target pods
-	HPAContainerMetrics featuregate.Feature = "HPAContainerMetrics"
-
-	// owner: @andrewsykim
-	// kep: http://kep.k8s.io/1672
-	// alpha: v1.20
-	// beta: v1.22
-	//
-	// Enable Terminating condition in Endpoint Slices.
-	EndpointSliceTerminatingCondition featuregate.Feature = "EndpointSliceTerminatingCondition"
-
-	// owner: @andrewsykim
-	// kep: http://kep.k8s.io/1669
-	// alpha: v1.22
-	//
-	// Enable kube-proxy to handle terminating ednpoints when externalTrafficPolicy=Local
-	ProxyTerminatingEndpoints featuregate.Feature = "ProxyTerminatingEndpoints"
-
-	// owner: @robscott
-	// kep: http://kep.k8s.io/752
-	// alpha: v1.20
-	//
-	// Enable NodeName field on Endpoint Slices.
-	EndpointSliceNodeName featuregate.Feature = "EndpointSliceNodeName"
-
-	// owner: @derekwaynecarr
-	// alpha: v1.20
-	// beta: v1.22
-	//
-	// Enables kubelet support to size memory backed volumes
-	SizeMemoryBackedVolumes featuregate.Feature = "SizeMemoryBackedVolumes"
-
-	// owner: @andrewsykim @SergeyKanzhelev
-	// GA: v1.20
-	//
-	// Ensure kubelet respects exec probe timeouts. Feature gate exists in-case existing workloads
-	// may depend on old behavior where exec probe timeouts were ignored.
-	// Lock to default and remove after v1.22 based on user feedback that should be reflected in KEP #1972 update
-	ExecProbeTimeout featuregate.Feature = "ExecProbeTimeout"
-
-	// owner: @andrewsykim @adisky
-	// alpha: v1.20
-	// beta: v1.24
-	//
-	// Enable kubelet exec plugins for image pull credentials.
-	KubeletCredentialProviders featuregate.Feature = "KubeletCredentialProviders"
-
-	// owner: @andrewsykim
-	// alpha: v1.22
-	//
-	// Disable any functionality in kube-apiserver, kube-controller-manager and kubelet related to the `--cloud-provider` component flag.
-	DisableCloudProviders featuregate.Feature = "DisableCloudProviders"
-
-	// owner: @andrewsykim
-	// alpha: v1.23
-	//
-	// Disable in-tree functionality in kubelet to authenticate to cloud provider container registries for image pull credentials.
-	DisableKubeletCloudCredentialProviders featuregate.Feature = "DisableKubeletCloudCredentialProviders"
-
-	// owner: @zshihang
-	// alpha: v1.20
-	// beta: v1.21
-	// ga: v1.22
-	//
-	// Enable kubelet to pass pod's service account token to NodePublishVolume
-	// call of CSI driver which is mounting volumes for that pod.
-	CSIServiceAccountToken featuregate.Feature = "CSIServiceAccountToken"
-
-	// owner: @bobbypage
-	// alpha: v1.20
-	// beta:  v1.21
-	// Adds support for kubelet to detect node shutdown and gracefully terminate pods prior to the node being shutdown.
-	GracefulNodeShutdown featuregate.Feature = "GracefulNodeShutdown"
-
-	// owner: @wzshiming
-	// alpha: v1.23
-	// beta:  v1.24
-	// Make the kubelet use shutdown configuration based on pod priority values for graceful shutdown.
-	GracefulNodeShutdownBasedOnPodPriority featuregate.Feature = "GracefulNodeShutdownBasedOnPodPriority"
-
-	// owner: @andrewsykim @uablrek
-	// kep: http://kep.k8s.io/1864
-	// alpha: v1.20
-	// beta: v1.22
-	// ga: v1.24
-	//
-	// Allows control if NodePorts shall be created for services with "type: LoadBalancer" by defining the spec.AllocateLoadBalancerNodePorts field (bool)
-	ServiceLBNodePortControl featuregate.Feature = "ServiceLBNodePortControl"
-
-	// owner: @janosi @bridgetkromhout
-	// kep: http://kep.k8s.io/1435
-	// alpha: v1.20
-	// beta: v1.24
-	//
-	// Enables the usage of different protocols in the same Service with type=LoadBalancer
-	MixedProtocolLBService featuregate.Feature = "MixedProtocolLBService"
-
-	// owner: @cofyc
-	// alpha: v1.21
-	VolumeCapacityPriority featuregate.Feature = "VolumeCapacityPriority"
-
-	// owner: @mattcary
-	// alpha: v1.22
-	//
-	// Enables policies controlling deletion of PVCs created by a StatefulSet.
-	StatefulSetAutoDeletePVC featuregate.Feature = "StatefulSetAutoDeletePVC"
-
-	// owner: @ahg-g
-	// alpha: v1.21
-	// beta: v1.22
-	//
-	// Enables controlling pod ranking on replicaset scale-down.
-	PodDeletionCost featuregate.Feature = "PodDeletionCost"
-
-	// owner: @robscott
-	// kep: http://kep.k8s.io/2433
-	// alpha: v1.21
-	// beta: v1.23
-	//
-	// Enables topology aware hints for EndpointSlices
-	TopologyAwareHints featuregate.Feature = "TopologyAwareHints"
-
-	// owner: @ehashman
-	// alpha: v1.21
-	//
-	// Allows user to override pod-level terminationGracePeriod for probes
-	ProbeTerminationGracePeriod featuregate.Feature = "ProbeTerminationGracePeriod"
-
-	// owner: @ehashman
-	// alpha: v1.22
-	//
-	// Permits kubelet to run with swap enabled
-	NodeSwap featuregate.Feature = "NodeSwap"
-
-	// owner: @ahg-g
-	// alpha: v1.21
-	// beta: v1.22
-	// GA: v1.24
-	//
-	// Allow specifying NamespaceSelector in PodAffinityTerm.
-	PodAffinityNamespaceSelector featuregate.Feature = "PodAffinityNamespaceSelector"
-
-	// owner: @andrewsykim @XudongLiuHarold
-	// kep: http://kep.k8s.io/1959
-	// alpha: v1.21
-	// beta: v1.22
-	// GA: v1.24
-	//
-	// Enable support multiple Service "type: LoadBalancer" implementations in a cluster by specifying LoadBalancerClass
-	ServiceLoadBalancerClass featuregate.Feature = "ServiceLoadBalancerClass"
-
-	// owner: @damemi
-	// alpha: v1.21
-	// beta: v1.22
-	//
-	// Enables scaling down replicas via logarithmic comparison of creation/ready timestamps
-	LogarithmicScaleDown featuregate.Feature = "LogarithmicScaleDown"
-
-	// owner: @hbagdi
-	// kep: http://kep.k8s.io/2365
-	// alpha: v1.21
-	// beta: v1.22
-	// GA: v1.23
-	//
-	// Enable Scope and Namespace fields on IngressClassParametersReference.
-	IngressClassNamespacedParams featuregate.Feature = "IngressClassNamespacedParams"
-
-	// owner: @maplain @andrewsykim
-	// kep: http://kep.k8s.io/2086
-	// alpha: v1.21
-	// beta: v1.22
-	//
-	// Enables node-local routing for Service internal traffic
-	ServiceInternalTrafficPolicy featuregate.Feature = "ServiceInternalTrafficPolicy"
-
-	// owner: @adtac
-	// alpha: v1.21
-	// beta: v1.22
-	// GA: v1.24
-	//
-	// Allows jobs to be created in the suspended state.
-	SuspendJob featuregate.Feature = "SuspendJob"
-
-	// owner: @fromanirh
-	// alpha: v1.21
-	// beta: v1.23
-	// Enable POD resources API to return allocatable resources
-	KubeletPodResourcesGetAllocatable featuregate.Feature = "KubeletPodResourcesGetAllocatable"
-
-	// owner: @fengzixu
-	// alpha: v1.21
-	//
-	// Enables kubelet to detect CSI volume condition and send the event of the abnormal volume to the corresponding pod that is using it.
-	CSIVolumeHealth featuregate.Feature = "CSIVolumeHealth"
-
-	// owner: @marosset
-	// alpha: v1.22
-	// beta: v1.23
-	//
-	// Enables support for 'HostProcess' containers on Windows nodes.
-	WindowsHostProcessContainers featuregate.Feature = "WindowsHostProcessContainers"
-
-	// owner: @ravig
-	// kep: https://kep.k8s.io/2607
-	// alpha: v1.22
-	// beta: v1.23
-	// StatefulSetMinReadySeconds allows minReadySeconds to be respected by StatefulSet controller
-	StatefulSetMinReadySeconds featuregate.Feature = "StatefulSetMinReadySeconds"
-
-	// owner: @ravig
-	// alpha: v1.23
-	// beta: v1.24
-	// IdentifyPodOS allows user to specify OS on which they'd like the Pod run. The user should still set the nodeSelector
-	// with appropriate `kubernetes.io/os` label for scheduler to identify appropriate node for the pod to run.
-	IdentifyPodOS featuregate.Feature = "IdentifyPodOS"
-
-	// owner: @gjkim42
-	// kep: http://kep.k8s.io/2595
-	// alpha: v1.22
-	//
-	// Enables apiserver and kubelet to allow up to 32 DNSSearchPaths and up to 2048 DNSSearchListChars.
-	ExpandedDNSConfig featuregate.Feature = "ExpandedDNSConfig"
-
-	// owner: @saschagrunert
-	// alpha: v1.22
-	//
-	// Enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
-	SeccompDefault featuregate.Feature = "SeccompDefault"
-
-	// owner: @liggitt, @tallclair, sig-auth
-	// alpha: v1.22
-	// beta: v1.23
-	//
-	// Enables the PodSecurity admission plugin
-	PodSecurity featuregate.Feature = "PodSecurity"
-
-	// owner: @chrishenzie
-	// alpha: v1.22
-	//
-	// Enables usage of the ReadWriteOncePod PersistentVolume access mode.
-	ReadWriteOncePod featuregate.Feature = "ReadWriteOncePod"
-
-	// owner: @enj
-	// beta: v1.22
-	// ga: v1.24
-	//
-	// Allows clients to request a duration for certificates issued via the Kubernetes CSR API.
-	CSRDuration featuregate.Feature = "CSRDuration"
-
-	// owner: @AkihiroSuda
-	// alpha: v1.22
-	//
-	// Enables support for running kubelet in a user namespace.
-	// The user namespace has to be created before running kubelet.
-	// All the node components such as CRI need to be running in the same user namespace.
-	KubeletInUserNamespace featuregate.Feature = "KubeletInUserNamespace"
-
-	// owner: @xiaoxubeii
-	// kep: http://kep.k8s.io/2570
-	// alpha: v1.22
-	//
-	// Enables kubelet to support memory QoS with cgroups v2.
-	MemoryQoS featuregate.Feature = "MemoryQoS"
-
-	// owner: @fromanirh
-	// alpha: v1.22
-	// beta: v1.23
-	//
-	// Allow the usage of options to fine-tune the cpumanager policies.
-	CPUManagerPolicyOptions featuregate.Feature = "CPUManagerPolicyOptions"
-
-	// owner: @jiahuif
-	// alpha: v1.21
-	// beta:  v1.22
-	// GA:    v1.24
-	//
-	// Enables Leader Migration for kube-controller-manager and cloud-controller-manager
-	ControllerManagerLeaderMigration featuregate.Feature = "ControllerManagerLeaderMigration"
+	// Alternative container-level CPU affinity policies.
+	CPUManager featuregate.Feature = "CPUManager"
 
 	// owner: @fromanirh
 	// alpha: v1.23
@@ -796,36 +87,291 @@ const (
 	// for details about the removal of this feature gate.
 	CPUManagerPolicyBetaOptions featuregate.Feature = "CPUManagerPolicyBetaOptions"
 
-	// owner: @ahg
+	// owner: @fromanirh
+	// alpha: v1.22
 	// beta: v1.23
 	//
-	// Allow updating node scheduling directives in the pod template of jobs. Specifically,
-	// node affinity, selector and tolerations. This is allowed only for suspended jobs
-	// that have never been unsuspended before.
-	JobMutableNodeSchedulingDirectives featuregate.Feature = "JobMutableNodeSchedulingDirectives"
+	// Allow the usage of options to fine-tune the cpumanager policies.
+	CPUManagerPolicyOptions featuregate.Feature = "CPUManagerPolicyOptions"
 
-	// owner: @haircommander
-	// kep: http://kep.k8s.io/2364
+	// owner: @pohly
+	// alpha: v1.14
+	// beta: v1.16
+	//
+	// Enables CSI Inline volumes support for pods
+	CSIInlineVolume featuregate.Feature = "CSIInlineVolume"
+
+	// owner: @davidz627
+	// alpha: v1.14
+	// beta: v1.17
+	//
+	// Enables the in-tree storage to CSI Plugin migration feature.
+	CSIMigration featuregate.Feature = "CSIMigration"
+
+	// owner: @leakingtapan
+	// alpha: v1.14
+	// beta: v1.17
+	//
+	// Enables the AWS EBS in-tree driver to AWS EBS CSI Driver migration feature.
+	CSIMigrationAWS featuregate.Feature = "CSIMigrationAWS"
+
+	// owner: @andyzhangx
+	// alpha: v1.15
+	// beta: v1.19
+	// GA: v1.24
+	//
+	// Enables the Azure Disk in-tree driver to Azure Disk Driver migration feature.
+	CSIMigrationAzureDisk featuregate.Feature = "CSIMigrationAzureDisk"
+
+	// owner: @andyzhangx
+	// alpha: v1.15
+	// beta: v1.21
+	//
+	// Enables the Azure File in-tree driver to Azure File Driver migration feature.
+	CSIMigrationAzureFile featuregate.Feature = "CSIMigrationAzureFile"
+
+	// owner: @davidz627
+	// alpha: v1.14
+	// beta: v1.17
+	//
+	// Enables the GCE PD in-tree driver to GCE CSI Driver migration feature.
+	CSIMigrationGCE featuregate.Feature = "CSIMigrationGCE"
+
+	// owner: @adisky
+	// alpha: v1.14
+	// beta: v1.18
+	//
+	// Enables the OpenStack Cinder in-tree driver to OpenStack Cinder CSI Driver migration feature.
+	CSIMigrationOpenStack featuregate.Feature = "CSIMigrationOpenStack"
+
+	// owner: @trierra
 	// alpha: v1.23
 	//
-	// Configures the Kubelet to use the CRI to populate pod and container stats, instead of supplimenting with stats from cAdvisor.
-	// Requires the CRI implementation supports supplying the required stats.
-	PodAndContainerStatsFromCRI featuregate.Feature = "PodAndContainerStatsFromCRI"
+	// Enables the Portworx in-tree driver to Portworx migration feature.
+	CSIMigrationPortworx featuregate.Feature = "CSIMigrationPortworx"
 
-	// owner: @deepakkinni @xing-yang
-	// kep: http://kep.k8s.io/2680
+	// owner: @humblec
 	// alpha: v1.23
 	//
-	// Honor Persistent Volume Reclaim Policy when it is "Delete" irrespective of PV-PVC
-	// deletion ordering.
-	HonorPVReclaimPolicy featuregate.Feature = "HonorPVReclaimPolicy"
+	// Enables the RBD in-tree driver to RBD CSI Driver  migration feature.
+	CSIMigrationRBD featuregate.Feature = "CSIMigrationRBD"
+
+	// owner: @divyenpatel
+	// beta: v1.19 (requires: vSphere vCenter/ESXi Version: 7.0u2, HW Version: VM version 15)
+	//
+	// Enables the vSphere in-tree driver to vSphere CSI Driver migration feature.
+	CSIMigrationvSphere featuregate.Feature = "CSIMigrationvSphere"
+
+	// owner: @humblec, @zhucan
+	// kep: http://kep.k8s.io/3171
+	// alpha: v1.24
+	//
+	// Enables SecretRef field in CSI NodeExpandVolume request.
+	CSINodeExpandSecret featuregate.Feature = "CSINodeExpandSecret"
+
+	// owner: @zshihang
+	// alpha: v1.20
+	// beta: v1.21
+	// ga: v1.22
+	//
+	// Enable kubelet to pass pod's service account token to NodePublishVolume
+	// call of CSI driver which is mounting volumes for that pod.
+	CSIServiceAccountToken featuregate.Feature = "CSIServiceAccountToken"
+
+	// owner: @pohly
+	// alpha: v1.19
+	// beta: v1.21
+	// GA: v1.24
+	//
+	// Enables tracking of available storage capacity that CSI drivers provide.
+	CSIStorageCapacity featuregate.Feature = "CSIStorageCapacity"
+
+	// owner: @huffmanca, @dobsonj
+	// alpha: v1.19
+	// beta: v1.20
+	// GA: v1.23
+	//
+	// Determines if a CSI Driver supports applying fsGroup.
+	CSIVolumeFSGroupPolicy featuregate.Feature = "CSIVolumeFSGroupPolicy"
+
+	// owner: @fengzixu
+	// alpha: v1.21
+	//
+	// Enables kubelet to detect CSI volume condition and send the event of the abnormal volume to the corresponding pod that is using it.
+	CSIVolumeHealth featuregate.Feature = "CSIVolumeHealth"
+
+	// owner: @enj
+	// beta: v1.22
+	// ga: v1.24
+	//
+	// Allows clients to request a duration for certificates issued via the Kubernetes CSR API.
+	CSRDuration featuregate.Feature = "CSRDuration"
 
 	// owner: @gnufied
-	// kep: http://kep.k8s.io/1790
+	// alpha: v1.18
+	// beta: v1.20
+	// GA: v1.23
+	// Allows user to configure volume permission change policy for fsGroups when mounting
+	// a volume in a Pod.
+	ConfigurableFSGroupPolicy featuregate.Feature = "ConfigurableFSGroupPolicy"
+
+	// owner: @jiahuif
+	// alpha: v1.21
+	// beta:  v1.22
+	// GA:    v1.24
+	//
+	// Enables Leader Migration for kube-controller-manager and cloud-controller-manager
+	ControllerManagerLeaderMigration featuregate.Feature = "ControllerManagerLeaderMigration"
+
+	// owner: @deejross
+	// kep: http://kep.k8s.io/3140
+	// alpha: v1.24
+	//
+	// Enables support for time zones in CronJobs.
+	CronJobTimeZone featuregate.Feature = "CronJobTimeZone"
+
+	// owner: @smarterclayton
+	// alpha: v1.21
+	// beta: v1.22
+	// DaemonSets allow workloads to maintain availability during update per node
+	DaemonSetUpdateSurge featuregate.Feature = "DaemonSetUpdateSurge"
+
+	// owner: @alculquicondor
+	// alpha: v1.19
+	// beta: v1.20
+	// GA: v1.24
+	//
+	// Enables the use of PodTopologySpread scheduling plugin to do default
+	// spreading and disables legacy SelectorSpread plugin.
+	DefaultPodTopologySpread featuregate.Feature = "DefaultPodTopologySpread"
+
+	// owner: @gnufied, @verult
+	// alpha: v1.22
+	// beta: v1.23
+	// If supported by the CSI driver, delegates the role of applying FSGroup to
+	// the driver by passing FSGroup through the NodeStageVolume and
+	// NodePublishVolume calls.
+	DelegateFSGroupToCSIDriver featuregate.Feature = "DelegateFSGroupToCSIDriver"
+
+	// owner: @jiayingz
+	// beta: v1.10
+	//
+	// Enables support for Device Plugins
+	DevicePlugins featuregate.Feature = "DevicePlugins"
+
+	// owner: @RenaudWasTaken @dashpole
+	// alpha: v1.19
+	// beta: v1.20
+	//
+	// Disables Accelerator Metrics Collected by Kubelet
+	DisableAcceleratorUsageMetrics featuregate.Feature = "DisableAcceleratorUsageMetrics"
+
+	// owner: @andrewsykim
+	// alpha: v1.22
+	//
+	// Disable any functionality in kube-apiserver, kube-controller-manager and kubelet related to the `--cloud-provider` component flag.
+	DisableCloudProviders featuregate.Feature = "DisableCloudProviders"
+
+	// owner: @andrewsykim
 	// alpha: v1.23
 	//
-	// Allow users to recover from volume expansion failure
-	RecoverVolumeExpansionFailure featuregate.Feature = "RecoverVolumeExpansionFailure"
+	// Disable in-tree functionality in kubelet to authenticate to cloud provider container registries for image pull credentials.
+	DisableKubeletCloudCredentialProviders featuregate.Feature = "DisableKubeletCloudCredentialProviders"
+
+	// owner: @derekwaynecarr
+	// alpha: v1.20
+	// beta: v1.21 (off by default until 1.22)
+	//
+	// Enables usage of hugepages-<size> in downward API.
+	DownwardAPIHugePages featuregate.Feature = "DownwardAPIHugePages"
+
+	// owner: @mtaufen
+	// alpha: v1.4
+	// beta: v1.11
+	// deprecated: 1.22
+	DynamicKubeletConfig featuregate.Feature = "DynamicKubeletConfig"
+
+	// owner: @robscott @freehan
+	// kep: http://kep.k8s.io/752
+	// alpha: v1.16
+	// beta: v1.18
+	// ga: v1.21
+	//
+	// Enable Endpoint Slices for more scalable Service endpoints.
+	EndpointSlice featuregate.Feature = "EndpointSlice"
+
+	// owner: @robscott
+	// kep: http://kep.k8s.io/752
+	// alpha: v1.20
+	//
+	// Enable NodeName field on Endpoint Slices.
+	EndpointSliceNodeName featuregate.Feature = "EndpointSliceNodeName"
+
+	// owner: @robscott @freehan
+	// kep: http://kep.k8s.io/752
+	// alpha: v1.18
+	// beta: v1.19
+	// ga: v1.22
+	//
+	// Enable Endpoint Slice consumption by kube-proxy for improved scalability.
+	EndpointSliceProxying featuregate.Feature = "EndpointSliceProxying"
+
+	// owner: @andrewsykim
+	// kep: http://kep.k8s.io/1672
+	// alpha: v1.20
+	// beta: v1.22
+	//
+	// Enable Terminating condition in Endpoint Slices.
+	EndpointSliceTerminatingCondition featuregate.Feature = "EndpointSliceTerminatingCondition"
+
+	// owner: @verb
+	// alpha: v1.16
+	// beta: v1.23
+	//
+	// Allows running an ephemeral container in pod namespaces to troubleshoot a running pod.
+	EphemeralContainers featuregate.Feature = "EphemeralContainers"
+
+	// owner: @andrewsykim @SergeyKanzhelev
+	// GA: v1.20
+	//
+	// Ensure kubelet respects exec probe timeouts. Feature gate exists in-case existing workloads
+	// may depend on old behavior where exec probe timeouts were ignored.
+	// Lock to default and remove after v1.22 based on user feedback that should be reflected in KEP #1972 update
+	ExecProbeTimeout featuregate.Feature = "ExecProbeTimeout"
+
+	// owner: @gnufied
+	// alpha: v1.14
+	// beta: v1.16
+	// GA: 1.24
+	// Ability to expand CSI volumes
+	ExpandCSIVolumes featuregate.Feature = "ExpandCSIVolumes"
+
+	// owner: @mlmhl @gnufied
+	// beta: v1.15
+	// GA: 1.24
+	// Ability to expand persistent volumes' file system without unmounting volumes.
+	ExpandInUsePersistentVolumes featuregate.Feature = "ExpandInUsePersistentVolumes"
+
+	// owner: @gnufied
+	// beta: v1.11
+	// GA: 1.24
+	// Ability to Expand persistent volumes
+	ExpandPersistentVolumes featuregate.Feature = "ExpandPersistentVolumes"
+
+	// owner: @gjkim42
+	// kep: http://kep.k8s.io/2595
+	// alpha: v1.22
+	//
+	// Enables apiserver and kubelet to allow up to 32 DNSSearchPaths and up to 2048 DNSSearchListChars.
+	ExpandedDNSConfig featuregate.Feature = "ExpandedDNSConfig"
+
+	// owner: @pweil-
+	// alpha: v1.5
+	//
+	// Default userns=host for containers that are using other host namespaces, host mounts, the pod
+	// contains a privileged container, or specific non-namespaced capabilities (MKNOD, SYS_MODULE,
+	// SYS_TIME). This should only be enabled if user namespace remapping is enabled in the docker daemon.
+	ExperimentalHostUserNamespaceDefaultingGate featuregate.Feature = "ExperimentalHostUserNamespaceDefaulting"
 
 	// owner: @yuzhiquan, @bowei, @PxyUp, @SergeyKanzhelev
 	// kep: http://kep.k8s.io/2727
@@ -835,12 +381,226 @@ const (
 	// Enables GRPC probe method for {Liveness,Readiness,Startup}Probe.
 	GRPCContainerProbe featuregate.Feature = "GRPCContainerProbe"
 
+	// owner: @pohly
+	// alpha: v1.19
+	// beta: v1.21
+	// GA: v1.23
+	//
+	// Enables generic ephemeral inline volume support for pods
+	GenericEphemeralVolume featuregate.Feature = "GenericEphemeralVolume"
+
+	// owner: @bobbypage
+	// alpha: v1.20
+	// beta:  v1.21
+	// Adds support for kubelet to detect node shutdown and gracefully terminate pods prior to the node being shutdown.
+	GracefulNodeShutdown featuregate.Feature = "GracefulNodeShutdown"
+
+	// owner: @wzshiming
+	// alpha: v1.23
+	// beta:  v1.24
+	// Make the kubelet use shutdown configuration based on pod priority values for graceful shutdown.
+	GracefulNodeShutdownBasedOnPodPriority featuregate.Feature = "GracefulNodeShutdownBasedOnPodPriority"
+
+	// owner: @arjunrn @mwielgus @josephburnett
+	// alpha: v1.20
+	//
+	// Add support for the HPA to scale based on metrics from individual containers
+	// in target pods
+	HPAContainerMetrics featuregate.Feature = "HPAContainerMetrics"
+
+	// owner: @dxist
+	// alpha: v1.16
+	//
+	// Enables support of HPA scaling to zero pods when an object or custom metric is configured.
+	HPAScaleToZero featuregate.Feature = "HPAScaleToZero"
+
+	// owner: @deepakkinni @xing-yang
+	// kep: http://kep.k8s.io/2680
+	// alpha: v1.23
+	//
+	// Honor Persistent Volume Reclaim Policy when it is "Delete" irrespective of PV-PVC
+	// deletion ordering.
+	HonorPVReclaimPolicy featuregate.Feature = "HonorPVReclaimPolicy"
+
+	// owner: @khenidak
+	// kep: http://kep.k8s.io/563
+	// alpha: v1.15
+	// beta: v1.21
+	// ga: v1.23
+	//
+	// Enables ipv6 dual stack
+	IPv6DualStack featuregate.Feature = "IPv6DualStack"
+
+	// owner: @ravig
+	// alpha: v1.23
+	// beta: v1.24
+	// IdentifyPodOS allows user to specify OS on which they'd like the Pod run. The user should still set the nodeSelector
+	// with appropriate `kubernetes.io/os` label for scheduler to identify appropriate node for the pod to run.
+	IdentifyPodOS featuregate.Feature = "IdentifyPodOS"
+
+	// owner: @leakingtapan
+	// alpha: v1.21
+	//
+	// Disables the AWS EBS in-tree driver.
+	InTreePluginAWSUnregister featuregate.Feature = "InTreePluginAWSUnregister"
+
+	// owner: @andyzhangx
+	// alpha: v1.21
+	//
+	// Disables the Azure Disk in-tree driver.
+	InTreePluginAzureDiskUnregister featuregate.Feature = "InTreePluginAzureDiskUnregister"
+
+	// owner: @andyzhangx
+	// alpha: v1.21
+	//
+	// Disables the Azure File in-tree driver.
+	InTreePluginAzureFileUnregister featuregate.Feature = "InTreePluginAzureFileUnregister"
+
+	// owner: @Jiawei0227
+	// alpha: v1.21
+	//
+	// Disables the GCE PD in-tree driver.
+	InTreePluginGCEUnregister featuregate.Feature = "InTreePluginGCEUnregister"
+
+	// owner: @adisky
+	// alpha: v1.21
+	//
+	// Disables the OpenStack Cinder in-tree driver.
+	InTreePluginOpenStackUnregister featuregate.Feature = "InTreePluginOpenStackUnregister"
+
+	// owner: @trierra
+	// alpha: v1.23
+	//
+	// Disables the Portworx in-tree driver.
+	InTreePluginPortworxUnregister featuregate.Feature = "InTreePluginPortworxUnregister"
+
+	// owner: @humblec
+	// alpha: v1.23
+	//
+	// Disables the RBD in-tree driver.
+	InTreePluginRBDUnregister featuregate.Feature = "InTreePluginRBDUnregister"
+
+	// owner: @divyenpatel
+	// alpha: v1.21
+	//
+	// Disables the vSphere in-tree driver.
+	InTreePluginvSphereUnregister featuregate.Feature = "InTreePluginvSphereUnregister"
+
+	// owner: @alculquicondor
+	// alpha: v1.21
+	// beta: v1.22
+	// stable: v1.24
+	//
+	// Allows Job controller to manage Pod completions per completion index.
+	IndexedJob featuregate.Feature = "IndexedJob"
+
+	// owner: @hbagdi
+	// kep: http://kep.k8s.io/2365
+	// alpha: v1.21
+	// beta: v1.22
+	// GA: v1.23
+	//
+	// Enable Scope and Namespace fields on IngressClassParametersReference.
+	IngressClassNamespacedParams featuregate.Feature = "IngressClassNamespacedParams"
+
+	// owner: @ahg
+	// beta: v1.23
+	//
+	// Allow updating node scheduling directives in the pod template of jobs. Specifically,
+	// node affinity, selector and tolerations. This is allowed only for suspended jobs
+	// that have never been unsuspended before.
+	JobMutableNodeSchedulingDirectives featuregate.Feature = "JobMutableNodeSchedulingDirectives"
+
+	// owner: @alculquicondor
+	// alpha: v1.23
+	// beta: v1.24
+	//
+	// Track the number of pods with Ready condition in the Job status.
+	JobReadyPods featuregate.Feature = "JobReadyPods"
+
+	// owner: @alculquicondor
+	// alpha: v1.22
+	// beta: v1.23
+	//
+	// Track Job completion without relying on Pod remaining in the cluster
+	// indefinitely. Pod finalizers, in addition to a field in the Job status
+	// allow the Job controller to keep track of Pods that it didn't account for
+	// yet.
+	JobTrackingWithFinalizers featuregate.Feature = "JobTrackingWithFinalizers"
+
+	// owner: @andrewsykim @adisky
+	// alpha: v1.20
+	// beta: v1.24
+	//
+	// Enable kubelet exec plugins for image pull credentials.
+	KubeletCredentialProviders featuregate.Feature = "KubeletCredentialProviders"
+
+	// owner: @AkihiroSuda
+	// alpha: v1.22
+	//
+	// Enables support for running kubelet in a user namespace.
+	// The user namespace has to be created before running kubelet.
+	// All the node components such as CRI need to be running in the same user namespace.
+	KubeletInUserNamespace featuregate.Feature = "KubeletInUserNamespace"
+
+	// owner: @dashpole
+	// alpha: v1.13
+	// beta: v1.15
+	//
+	// Enables the kubelet's pod resources grpc endpoint
+	KubeletPodResources featuregate.Feature = "KubeletPodResources"
+
+	// owner: @fromanirh
+	// alpha: v1.21
+	// beta: v1.23
+	// Enable POD resources API to return allocatable resources
+	KubeletPodResourcesGetAllocatable featuregate.Feature = "KubeletPodResourcesGetAllocatable"
+
 	// owner: @zshihang
 	// kep: http://kep.k8s.io/2800
 	// beta: v1.24
 	//
 	// Stop auto-generation of secret-based service account tokens.
 	LegacyServiceAccountTokenNoAutoGeneration featuregate.Feature = "LegacyServiceAccountTokenNoAutoGeneration"
+
+	// owner: @jinxu
+	// beta: v1.10
+	//
+	// New local storage types to support local storage capacity isolation
+	LocalStorageCapacityIsolation featuregate.Feature = "LocalStorageCapacityIsolation"
+
+	// owner: @RobertKrawitz
+	// alpha: v1.15
+	//
+	// Allow use of filesystems for ephemeral storage monitoring.
+	// Only applies if LocalStorageCapacityIsolation is set.
+	LocalStorageCapacityIsolationFSQuotaMonitoring featuregate.Feature = "LocalStorageCapacityIsolationFSQuotaMonitoring"
+
+	// owner: @damemi
+	// alpha: v1.21
+	// beta: v1.22
+	//
+	// Enables scaling down replicas via logarithmic comparison of creation/ready timestamps
+	LogarithmicScaleDown featuregate.Feature = "LogarithmicScaleDown"
+
+	// owner: @krmayankk
+	// alpha: v1.24
+	//
+	// Enables maxUnavailable for StatefulSet
+	MaxUnavailableStatefulSet featuregate.Feature = "MaxUnavailableStatefulSet"
+
+	// owner: @cynepco3hahue(alukiano) @cezaryzukowski @k-wiatrzyk
+	// alpha: v1.21
+	// beta: v1.22
+	// Allows setting memory affinity for a container based on NUMA topology
+	MemoryManager featuregate.Feature = "MemoryManager"
+
+	// owner: @xiaoxubeii
+	// kep: http://kep.k8s.io/2570
+	// alpha: v1.22
+	//
+	// Enables kubelet to support memory QoS with cgroups v2.
+	MemoryQoS featuregate.Feature = "MemoryQoS"
 
 	// owner: @sanposhiho
 	// kep: http://kep.k8s.io/3022
@@ -849,25 +609,21 @@ const (
 	// Enable MinDomains in Pod Topology Spread.
 	MinDomainsInPodTopologySpread featuregate.Feature = "MinDomainsInPodTopologySpread"
 
-	// owner: @aojea
-	// kep: http://kep.k8s.io/3070
-	// alpha: v1.24
+	// owner: @janosi @bridgetkromhout
+	// kep: http://kep.k8s.io/1435
+	// alpha: v1.20
+	// beta: v1.24
 	//
-	// Subdivide the ClusterIP range for dynamic and static IP allocation.
-	ServiceIPStaticSubrange featuregate.Feature = "ServiceIPStaticSubrange"
+	// Enables the usage of different protocols in the same Service with type=LoadBalancer
+	MixedProtocolLBService featuregate.Feature = "MixedProtocolLBService"
 
-	// owner: @xing-yang @sonasingh46
-	// kep: http://kep.k8s.io/2268
-	// alpha: v1.24
+	// owner: @rikatz
+	// kep: http://kep.k8s.io/2079
+	// alpha: v1.21
+	// beta:  v1.22
 	//
-	// Allow pods to failover to a different node in case of non graceful node shutdown
-	NodeOutOfServiceVolumeDetach featuregate.Feature = "NodeOutOfServiceVolumeDetach"
-
-	// owner: @krmayankk
-	// alpha: v1.24
-	//
-	// Enables maxUnavailable for StatefulSet
-	MaxUnavailableStatefulSet featuregate.Feature = "MaxUnavailableStatefulSet"
+	// Enables the endPort field in NetworkPolicy to enable a Port Range behavior in Network Policies.
+	NetworkPolicyEndPort featuregate.Feature = "NetworkPolicyEndPort"
 
 	// owner: @rikatz
 	// kep: http://kep.k8s.io/2943
@@ -876,19 +632,267 @@ const (
 	// Enables NetworkPolicy status subresource
 	NetworkPolicyStatus featuregate.Feature = "NetworkPolicyStatus"
 
-	// owner: @deejross
-	// kep: http://kep.k8s.io/3140
+	// owner: @xing-yang @sonasingh46
+	// kep: http://kep.k8s.io/2268
 	// alpha: v1.24
 	//
-	// Enables support for time zones in CronJobs.
-	CronJobTimeZone featuregate.Feature = "CronJobTimeZone"
+	// Allow pods to failover to a different node in case of non graceful node shutdown
+	NodeOutOfServiceVolumeDetach featuregate.Feature = "NodeOutOfServiceVolumeDetach"
 
-	// owner: @humblec, @zhucan
-	// kep: http://kep.k8s.io/3171
+	// owner: @ehashman
+	// alpha: v1.22
+	//
+	// Permits kubelet to run with swap enabled
+	NodeSwap featuregate.Feature = "NodeSwap"
+
+	// owner: @denkensk
+	// alpha: v1.15
+	// beta: v1.19
+	// ga: v1.24
+	//
+	// Enables NonPreempting option for priorityClass and pod.
+	NonPreemptingPriority featuregate.Feature = "NonPreemptingPriority"
+
+	// owner: @ahg-g
+	// alpha: v1.21
+	// beta: v1.22
+	// GA: v1.24
+	//
+	// Allow specifying NamespaceSelector in PodAffinityTerm.
+	PodAffinityNamespaceSelector featuregate.Feature = "PodAffinityNamespaceSelector"
+
+	// owner: @haircommander
+	// kep: http://kep.k8s.io/2364
+	// alpha: v1.23
+	//
+	// Configures the Kubelet to use the CRI to populate pod and container stats, instead of supplimenting with stats from cAdvisor.
+	// Requires the CRI implementation supports supplying the required stats.
+	PodAndContainerStatsFromCRI featuregate.Feature = "PodAndContainerStatsFromCRI"
+
+	// owner: @ahg-g
+	// alpha: v1.21
+	// beta: v1.22
+	//
+	// Enables controlling pod ranking on replicaset scale-down.
+	PodDeletionCost featuregate.Feature = "PodDeletionCost"
+
+	// owner: @mortent
+	// alpha: v1.3
+	// beta:  v1.5
+	//
+	// Enable all logic related to the PodDisruptionBudget API object in policy
+	PodDisruptionBudget featuregate.Feature = "PodDisruptionBudget"
+
+	// owner: @egernst
+	// alpha: v1.16
+	// beta: v1.18
+	// ga: v1.24
+	//
+	// Enables PodOverhead, for accounting pod overheads which are specific to a given RuntimeClass
+	PodOverhead featuregate.Feature = "PodOverhead"
+
+	// owner: @liggitt, @tallclair, sig-auth
+	// alpha: v1.22
+	// beta: v1.23
+	//
+	// Enables the PodSecurity admission plugin
+	PodSecurity featuregate.Feature = "PodSecurity"
+
+	// owner: @chendave
+	// alpha: v1.21
+	// beta: v1.22
+	// GA: v1.24
+	//
+	// PreferNominatedNode tells scheduler whether the nominated node will be checked first before looping
+	// all the rest of nodes in the cluster.
+	// Enabling this feature also implies the preemptor pod might not be dispatched to the best candidate in
+	// some corner case, e.g. another node releases enough resources after the nominated node has been set
+	// and hence is the best candidate instead.
+	PreferNominatedNode featuregate.Feature = "PreferNominatedNode"
+
+	// owner: @ehashman
+	// alpha: v1.21
+	//
+	// Allows user to override pod-level terminationGracePeriod for probes
+	ProbeTerminationGracePeriod featuregate.Feature = "ProbeTerminationGracePeriod"
+
+	// owner: @jessfraz
+	// alpha: v1.12
+	//
+	// Enables control over ProcMountType for containers.
+	ProcMountType featuregate.Feature = "ProcMountType"
+
+	// owner: @andrewsykim
+	// kep: http://kep.k8s.io/1669
+	// alpha: v1.22
+	//
+	// Enable kube-proxy to handle terminating ednpoints when externalTrafficPolicy=Local
+	ProxyTerminatingEndpoints featuregate.Feature = "ProxyTerminatingEndpoints"
+
+	// owner: @sjenning
+	// alpha: v1.11
+	//
+	// Allows resource reservations at the QoS level preventing pods at lower QoS levels from
+	// bursting into resources requested at higher QoS levels (memory only for now)
+	QOSReserved featuregate.Feature = "QOSReserved"
+
+	// owner: @chrishenzie
+	// alpha: v1.22
+	//
+	// Enables usage of the ReadWriteOncePod PersistentVolume access mode.
+	ReadWriteOncePod featuregate.Feature = "ReadWriteOncePod"
+
+	// owner: @gnufied
+	// kep: http://kep.k8s.io/1790
+	// alpha: v1.23
+	//
+	// Allow users to recover from volume expansion failure
+	RecoverVolumeExpansionFailure featuregate.Feature = "RecoverVolumeExpansionFailure"
+
+	// owner: @mikedanese
+	// alpha: v1.7
+	// beta: v1.12
+	//
+	// Gets a server certificate for the kubelet from the Certificate Signing
+	// Request API instead of generating one self signed and auto rotates the
+	// certificate as expiration approaches.
+	RotateKubeletServerCertificate featuregate.Feature = "RotateKubeletServerCertificate"
+
+	// owner: @saschagrunert
+	// alpha: v1.22
+	//
+	// Enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
+	SeccompDefault featuregate.Feature = "SeccompDefault"
+
+	// owner: @maplain @andrewsykim
+	// kep: http://kep.k8s.io/2086
+	// alpha: v1.21
+	// beta: v1.22
+	//
+	// Enables node-local routing for Service internal traffic
+	ServiceInternalTrafficPolicy featuregate.Feature = "ServiceInternalTrafficPolicy"
+
+	// owner: @aojea
+	// kep: http://kep.k8s.io/3070
 	// alpha: v1.24
 	//
-	// Enables SecretRef field in CSI NodeExpandVolume request.
-	CSINodeExpandSecret featuregate.Feature = "CSINodeExpandSecret"
+	// Subdivide the ClusterIP range for dynamic and static IP allocation.
+	ServiceIPStaticSubrange featuregate.Feature = "ServiceIPStaticSubrange"
+
+	// owner: @andrewsykim @uablrek
+	// kep: http://kep.k8s.io/1864
+	// alpha: v1.20
+	// beta: v1.22
+	// ga: v1.24
+	//
+	// Allows control if NodePorts shall be created for services with "type: LoadBalancer" by defining the spec.AllocateLoadBalancerNodePorts field (bool)
+	ServiceLBNodePortControl featuregate.Feature = "ServiceLBNodePortControl"
+
+	// owner: @andrewsykim @XudongLiuHarold
+	// kep: http://kep.k8s.io/1959
+	// alpha: v1.21
+	// beta: v1.22
+	// GA: v1.24
+	//
+	// Enable support multiple Service "type: LoadBalancer" implementations in a cluster by specifying LoadBalancerClass
+	ServiceLoadBalancerClass featuregate.Feature = "ServiceLoadBalancerClass"
+
+	// owner: @derekwaynecarr
+	// alpha: v1.20
+	// beta: v1.22
+	//
+	// Enables kubelet support to size memory backed volumes
+	SizeMemoryBackedVolumes featuregate.Feature = "SizeMemoryBackedVolumes"
+
+	// owner: @mattcary
+	// alpha: v1.22
+	//
+	// Enables policies controlling deletion of PVCs created by a StatefulSet.
+	StatefulSetAutoDeletePVC featuregate.Feature = "StatefulSetAutoDeletePVC"
+
+	// owner: @ravig
+	// kep: https://kep.k8s.io/2607
+	// alpha: v1.22
+	// beta: v1.23
+	// StatefulSetMinReadySeconds allows minReadySeconds to be respected by StatefulSet controller
+	StatefulSetMinReadySeconds featuregate.Feature = "StatefulSetMinReadySeconds"
+
+	// owner: @pospispa
+	// GA: v1.11
+	//
+	// Postpone deletion of a PV or a PVC when they are being used
+	StorageObjectInUseProtection featuregate.Feature = "StorageObjectInUseProtection"
+
+	// owner: @adtac
+	// alpha: v1.21
+	// beta: v1.22
+	// GA: v1.24
+	//
+	// Allows jobs to be created in the suspended state.
+	SuspendJob featuregate.Feature = "SuspendJob"
+
+	// owner: @janetkuo
+	// alpha: v1.12
+	// beta:  v1.21
+	//
+	// Allow TTL controller to clean up Pods and Jobs after they finish.
+	TTLAfterFinished featuregate.Feature = "TTLAfterFinished"
+
+	// owner: @robscott
+	// kep: http://kep.k8s.io/2433
+	// alpha: v1.21
+	// beta: v1.23
+	//
+	// Enables topology aware hints for EndpointSlices
+	TopologyAwareHints featuregate.Feature = "TopologyAwareHints"
+
+	// owner: @lmdaly
+	// alpha: v1.16
+	// beta: v1.18
+	//
+	// Enable resource managers to make NUMA aligned decisions
+	TopologyManager featuregate.Feature = "TopologyManager"
+
+	// owner: @cofyc
+	// alpha: v1.21
+	VolumeCapacityPriority featuregate.Feature = "VolumeCapacityPriority"
+
+	// owner: @saad-ali
+	// ga: 	  v1.10
+	//
+	// Allow mounting a subpath of a volume in a container
+	// NOTE: This feature gate has been deprecated and is no longer enforced.
+	// It will be completely removed in 1.25. Until then, it's still visible in `kubelet --help`
+	VolumeSubpath featuregate.Feature = "VolumeSubpath"
+
+	// owner: @ksubrmnn
+	// alpha: v1.14
+	//
+	// Allows kube-proxy to create DSR loadbalancers for Windows
+	WinDSR featuregate.Feature = "WinDSR"
+
+	// owner: @ksubrmnn
+	// alpha: v1.14
+	// beta: v1.20
+	//
+	// Allows kube-proxy to run in Overlay mode for Windows
+	WinOverlay featuregate.Feature = "WinOverlay"
+
+	// owner: @robscott @kumarvin123
+	// kep: http://kep.k8s.io/752
+	// alpha: v1.19
+	// beta: v1.21
+	// ga: v1.22
+	//
+	// Enable Endpoint Slice consumption by kube-proxy in Windows for improved scalability.
+	WindowsEndpointSliceProxying featuregate.Feature = "WindowsEndpointSliceProxying"
+
+	// owner: @marosset
+	// alpha: v1.22
+	// beta: v1.23
+	//
+	// Enables support for 'HostProcess' containers on Windows nodes.
+	WindowsHostProcessContainers featuregate.Feature = "WindowsHostProcessContainers"
 )
 
 func init() {
@@ -898,138 +902,269 @@ func init() {
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout Kubernetes binaries.
+//
+// Entries are separated from each other with blank lines to avoid sweeping gofmt changes
+// when adding or removing one entry.
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	AppArmor:             {Default: true, PreRelease: featuregate.Beta},
+	AnyVolumeDataSource: {Default: true, PreRelease: featuregate.Beta}, // on by default in 1.24
+
+	AppArmor: {Default: true, PreRelease: featuregate.Beta},
+
+	CPUCFSQuotaPeriod: {Default: false, PreRelease: featuregate.Alpha},
+
+	CPUManager: {Default: true, PreRelease: featuregate.Beta},
+
+	CPUManagerPolicyAlphaOptions: {Default: false, PreRelease: featuregate.Alpha},
+
+	CPUManagerPolicyBetaOptions: {Default: true, PreRelease: featuregate.Beta},
+
+	CPUManagerPolicyOptions: {Default: true, PreRelease: featuregate.Beta},
+
+	CSIInlineVolume: {Default: true, PreRelease: featuregate.Beta},
+
+	CSIMigration: {Default: true, PreRelease: featuregate.Beta},
+
+	CSIMigrationAWS: {Default: true, PreRelease: featuregate.Beta},
+
+	CSIMigrationAzureDisk: {Default: true, PreRelease: featuregate.GA}, // On by default in 1.23 (requires Azure Disk CSI driver)
+
+	CSIMigrationAzureFile: {Default: true, PreRelease: featuregate.Beta}, // On by default in 1.24 (requires Azure File CSI driver)
+
+	CSIMigrationGCE: {Default: true, PreRelease: featuregate.Beta}, // On by default in 1.23 (requires GCE PD CSI Driver)
+
+	CSIMigrationOpenStack: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	CSIMigrationPortworx: {Default: false, PreRelease: featuregate.Alpha}, // Off by default (requires Portworx CSI driver)
+
+	CSIMigrationRBD: {Default: false, PreRelease: featuregate.Alpha}, // Off by default (requires RBD CSI driver)
+
+	CSIMigrationvSphere: {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires vSphere CSI driver)
+
+	CSINodeExpandSecret: {Default: false, PreRelease: featuregate.Alpha},
+
+	CSIServiceAccountToken: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
+
+	CSIStorageCapacity: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	CSIVolumeFSGroupPolicy: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	CSIVolumeHealth: {Default: false, PreRelease: featuregate.Alpha},
+
+	CSRDuration: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	ConfigurableFSGroupPolicy: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	ControllerManagerLeaderMigration: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	CronJobTimeZone: {Default: false, PreRelease: featuregate.Alpha},
+
+	DaemonSetUpdateSurge: {Default: true, PreRelease: featuregate.Beta}, // on by default in 1.22
+
+	DefaultPodTopologySpread: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	DelegateFSGroupToCSIDriver: {Default: true, PreRelease: featuregate.Beta},
+
+	DevicePlugins: {Default: true, PreRelease: featuregate.Beta},
+
+	DisableAcceleratorUsageMetrics: {Default: true, PreRelease: featuregate.Beta},
+
+	DisableCloudProviders: {Default: false, PreRelease: featuregate.Alpha},
+
+	DisableKubeletCloudCredentialProviders: {Default: false, PreRelease: featuregate.Alpha},
+
+	DownwardAPIHugePages: {Default: true, PreRelease: featuregate.Beta}, // on by default in 1.22
+
 	DynamicKubeletConfig: {Default: false, PreRelease: featuregate.Deprecated}, // feature gate is deprecated in 1.22, kubelet logic is removed in 1.24, api server logic can be removed in 1.26
+
+	EndpointSlice: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	EndpointSliceNodeName: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	EndpointSliceProxying: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	EndpointSliceTerminatingCondition: {Default: true, PreRelease: featuregate.Beta},
+
+	EphemeralContainers: {Default: true, PreRelease: featuregate.Beta},
+
+	ExecProbeTimeout: {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
+
+	ExpandCSIVolumes: {Default: true, PreRelease: featuregate.GA}, // remove in 1.25
+
+	ExpandInUsePersistentVolumes: {Default: true, PreRelease: featuregate.GA}, // remove in 1.25
+
+	ExpandPersistentVolumes: {Default: true, PreRelease: featuregate.GA}, // remove in 1.25
+
+	ExpandedDNSConfig: {Default: false, PreRelease: featuregate.Alpha},
+
 	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: featuregate.Beta},
-	DevicePlugins:                                  {Default: true, PreRelease: featuregate.Beta},
-	RotateKubeletServerCertificate:                 {Default: true, PreRelease: featuregate.Beta},
-	LocalStorageCapacityIsolation:                  {Default: true, PreRelease: featuregate.Beta},
-	EphemeralContainers:                            {Default: true, PreRelease: featuregate.Beta},
-	QOSReserved:                                    {Default: false, PreRelease: featuregate.Alpha},
-	ExpandPersistentVolumes:                        {Default: true, PreRelease: featuregate.GA}, // remove in 1.25
-	ExpandInUsePersistentVolumes:                   {Default: true, PreRelease: featuregate.GA}, // remove in 1.25
-	ExpandCSIVolumes:                               {Default: true, PreRelease: featuregate.GA}, // remove in 1.25
-	CPUManager:                                     {Default: true, PreRelease: featuregate.Beta},
-	MemoryManager:                                  {Default: true, PreRelease: featuregate.Beta},
-	CPUCFSQuotaPeriod:                              {Default: false, PreRelease: featuregate.Alpha},
-	TopologyManager:                                {Default: true, PreRelease: featuregate.Beta},
-	StorageObjectInUseProtection:                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	CSIMigration:                                   {Default: true, PreRelease: featuregate.Beta},
-	CSIMigrationGCE:                                {Default: true, PreRelease: featuregate.Beta}, // On by default in 1.23 (requires GCE PD CSI Driver)
-	InTreePluginGCEUnregister:                      {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationAWS:                                {Default: true, PreRelease: featuregate.Beta},
-	InTreePluginAWSUnregister:                      {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationAzureDisk:                          {Default: true, PreRelease: featuregate.GA}, // On by default in 1.23 (requires Azure Disk CSI driver)
-	InTreePluginAzureDiskUnregister:                {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationAzureFile:                          {Default: true, PreRelease: featuregate.Beta}, // On by default in 1.24 (requires Azure File CSI driver)
-	InTreePluginAzureFileUnregister:                {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationvSphere:                            {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires vSphere CSI driver)
-	InTreePluginvSphereUnregister:                  {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationOpenStack:                          {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-	InTreePluginOpenStackUnregister:                {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationRBD:                                {Default: false, PreRelease: featuregate.Alpha}, // Off by default (requires RBD CSI driver)
-	InTreePluginRBDUnregister:                      {Default: false, PreRelease: featuregate.Alpha},
-	ConfigurableFSGroupPolicy:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	CSIMigrationPortworx:                           {Default: false, PreRelease: featuregate.Alpha},                  // Off by default (requires Portworx CSI driver)
-	InTreePluginPortworxUnregister:                 {Default: false, PreRelease: featuregate.Alpha},
-	CSIInlineVolume:                                {Default: true, PreRelease: featuregate.Beta},
-	CSIStorageCapacity:                             {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-	CSIServiceAccountToken:                         {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
-	GenericEphemeralVolume:                         {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	CSIVolumeFSGroupPolicy:                         {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	VolumeSubpath:                                  {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	NetworkPolicyEndPort:                           {Default: true, PreRelease: featuregate.Beta},
-	ProcMountType:                                  {Default: false, PreRelease: featuregate.Alpha},
-	TTLAfterFinished:                               {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	IndexedJob:                                     {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-	JobTrackingWithFinalizers:                      {Default: false, PreRelease: featuregate.Beta},                   // Disabled due to #109485
-	JobReadyPods:                                   {Default: true, PreRelease: featuregate.Beta},
-	KubeletPodResources:                            {Default: true, PreRelease: featuregate.Beta},
+
+	GRPCContainerProbe: {Default: true, PreRelease: featuregate.Beta},
+
+	GenericEphemeralVolume: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	GracefulNodeShutdown: {Default: true, PreRelease: featuregate.Beta},
+
+	GracefulNodeShutdownBasedOnPodPriority: {Default: true, PreRelease: featuregate.Beta},
+
+	HPAContainerMetrics: {Default: false, PreRelease: featuregate.Alpha},
+
+	HonorPVReclaimPolicy: {Default: false, PreRelease: featuregate.Alpha},
+
+	IPv6DualStack: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	IdentifyPodOS: {Default: true, PreRelease: featuregate.Beta},
+
+	InTreePluginAWSUnregister: {Default: false, PreRelease: featuregate.Alpha},
+
+	InTreePluginAzureDiskUnregister: {Default: false, PreRelease: featuregate.Alpha},
+
+	InTreePluginAzureFileUnregister: {Default: false, PreRelease: featuregate.Alpha},
+
+	InTreePluginGCEUnregister: {Default: false, PreRelease: featuregate.Alpha},
+
+	InTreePluginOpenStackUnregister: {Default: false, PreRelease: featuregate.Alpha},
+
+	InTreePluginPortworxUnregister: {Default: false, PreRelease: featuregate.Alpha},
+
+	InTreePluginRBDUnregister: {Default: false, PreRelease: featuregate.Alpha},
+
+	InTreePluginvSphereUnregister: {Default: false, PreRelease: featuregate.Alpha},
+
+	IndexedJob: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	IngressClassNamespacedParams: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	JobMutableNodeSchedulingDirectives: {Default: true, PreRelease: featuregate.Beta},
+
+	JobReadyPods: {Default: true, PreRelease: featuregate.Beta},
+
+	JobTrackingWithFinalizers: {Default: false, PreRelease: featuregate.Beta}, // Disabled due to #109485
+
+	KubeletCredentialProviders: {Default: true, PreRelease: featuregate.Beta},
+
+	KubeletInUserNamespace: {Default: false, PreRelease: featuregate.Alpha},
+
+	KubeletPodResources: {Default: true, PreRelease: featuregate.Beta},
+
+	KubeletPodResourcesGetAllocatable: {Default: true, PreRelease: featuregate.Beta},
+
+	LegacyServiceAccountTokenNoAutoGeneration: {Default: true, PreRelease: featuregate.Beta},
+
+	LocalStorageCapacityIsolation: {Default: true, PreRelease: featuregate.Beta},
+
 	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Alpha},
-	NonPreemptingPriority:                          {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	PodOverhead:                                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-	IPv6DualStack:                                  {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	EndpointSlice:                                  {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	EndpointSliceProxying:                          {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	EndpointSliceTerminatingCondition:              {Default: true, PreRelease: featuregate.Beta},
-	ProxyTerminatingEndpoints:                      {Default: false, PreRelease: featuregate.Alpha},
-	EndpointSliceNodeName:                          {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	WindowsEndpointSliceProxying:                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	PodDisruptionBudget:                            {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	DaemonSetUpdateSurge:                           {Default: true, PreRelease: featuregate.Beta},                    // on by default in 1.22
-	DownwardAPIHugePages:                           {Default: true, PreRelease: featuregate.Beta},                    // on by default in 1.22
-	AnyVolumeDataSource:                            {Default: true, PreRelease: featuregate.Beta},                    // on by default in 1.24
-	DefaultPodTopologySpread:                       {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-	WinOverlay:                                     {Default: true, PreRelease: featuregate.Beta},
-	WinDSR:                                         {Default: false, PreRelease: featuregate.Alpha},
-	DisableAcceleratorUsageMetrics:                 {Default: true, PreRelease: featuregate.Beta},
-	HPAContainerMetrics:                            {Default: false, PreRelease: featuregate.Alpha},
-	SizeMemoryBackedVolumes:                        {Default: true, PreRelease: featuregate.Beta},
-	ExecProbeTimeout:                               {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
-	KubeletCredentialProviders:                     {Default: true, PreRelease: featuregate.Beta},
-	GracefulNodeShutdown:                           {Default: true, PreRelease: featuregate.Beta},
-	GracefulNodeShutdownBasedOnPodPriority:         {Default: true, PreRelease: featuregate.Beta},
-	ServiceLBNodePortControl:                       {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-	MixedProtocolLBService:                         {Default: true, PreRelease: featuregate.Beta},
-	VolumeCapacityPriority:                         {Default: false, PreRelease: featuregate.Alpha},
-	PreferNominatedNode:                            {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	ProbeTerminationGracePeriod:                    {Default: false, PreRelease: featuregate.Beta},                   // Default to false in beta 1.22, set to true in 1.24
-	NodeSwap:                                       {Default: false, PreRelease: featuregate.Alpha},
-	PodDeletionCost:                                {Default: true, PreRelease: featuregate.Beta},
-	StatefulSetAutoDeletePVC:                       {Default: false, PreRelease: featuregate.Alpha},
-	TopologyAwareHints:                             {Default: true, PreRelease: featuregate.Beta},
-	PodAffinityNamespaceSelector:                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-	ServiceLoadBalancerClass:                       {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-	IngressClassNamespacedParams:                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
-	ServiceInternalTrafficPolicy:                   {Default: true, PreRelease: featuregate.Beta},
-	LogarithmicScaleDown:                           {Default: true, PreRelease: featuregate.Beta},
-	SuspendJob:                                     {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-	KubeletPodResourcesGetAllocatable:              {Default: true, PreRelease: featuregate.Beta},
-	CSIVolumeHealth:                                {Default: false, PreRelease: featuregate.Alpha},
-	WindowsHostProcessContainers:                   {Default: true, PreRelease: featuregate.Beta},
-	DisableCloudProviders:                          {Default: false, PreRelease: featuregate.Alpha},
-	DisableKubeletCloudCredentialProviders:         {Default: false, PreRelease: featuregate.Alpha},
-	StatefulSetMinReadySeconds:                     {Default: true, PreRelease: featuregate.Beta},
-	ExpandedDNSConfig:                              {Default: false, PreRelease: featuregate.Alpha},
-	SeccompDefault:                                 {Default: false, PreRelease: featuregate.Alpha},
-	PodSecurity:                                    {Default: true, PreRelease: featuregate.Beta},
-	ReadWriteOncePod:                               {Default: false, PreRelease: featuregate.Alpha},
-	CSRDuration:                                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-	DelegateFSGroupToCSIDriver:                     {Default: true, PreRelease: featuregate.Beta},
-	CSINodeExpandSecret:                            {Default: false, PreRelease: featuregate.Alpha},
-	KubeletInUserNamespace:                         {Default: false, PreRelease: featuregate.Alpha},
-	MemoryQoS:                                      {Default: false, PreRelease: featuregate.Alpha},
-	CPUManagerPolicyOptions:                        {Default: true, PreRelease: featuregate.Beta},
-	ControllerManagerLeaderMigration:               {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
-	CPUManagerPolicyAlphaOptions:                   {Default: false, PreRelease: featuregate.Alpha},
-	CPUManagerPolicyBetaOptions:                    {Default: true, PreRelease: featuregate.Beta},
-	JobMutableNodeSchedulingDirectives:             {Default: true, PreRelease: featuregate.Beta},
-	IdentifyPodOS:                                  {Default: true, PreRelease: featuregate.Beta},
-	PodAndContainerStatsFromCRI:                    {Default: false, PreRelease: featuregate.Alpha},
-	HonorPVReclaimPolicy:                           {Default: false, PreRelease: featuregate.Alpha},
-	RecoverVolumeExpansionFailure:                  {Default: false, PreRelease: featuregate.Alpha},
-	GRPCContainerProbe:                             {Default: true, PreRelease: featuregate.Beta},
-	LegacyServiceAccountTokenNoAutoGeneration:      {Default: true, PreRelease: featuregate.Beta},
-	MinDomainsInPodTopologySpread:                  {Default: false, PreRelease: featuregate.Alpha},
-	ServiceIPStaticSubrange:                        {Default: false, PreRelease: featuregate.Alpha},
-	NodeOutOfServiceVolumeDetach:                   {Default: false, PreRelease: featuregate.Alpha},
-	MaxUnavailableStatefulSet:                      {Default: false, PreRelease: featuregate.Alpha},
-	NetworkPolicyStatus:                            {Default: false, PreRelease: featuregate.Alpha},
-	CronJobTimeZone:                                {Default: false, PreRelease: featuregate.Alpha},
+
+	LogarithmicScaleDown: {Default: true, PreRelease: featuregate.Beta},
+
+	MaxUnavailableStatefulSet: {Default: false, PreRelease: featuregate.Alpha},
+
+	MemoryManager: {Default: true, PreRelease: featuregate.Beta},
+
+	MemoryQoS: {Default: false, PreRelease: featuregate.Alpha},
+
+	MinDomainsInPodTopologySpread: {Default: false, PreRelease: featuregate.Alpha},
+
+	MixedProtocolLBService: {Default: true, PreRelease: featuregate.Beta},
+
+	NetworkPolicyEndPort: {Default: true, PreRelease: featuregate.Beta},
+
+	NetworkPolicyStatus: {Default: false, PreRelease: featuregate.Alpha},
+
+	NodeOutOfServiceVolumeDetach: {Default: false, PreRelease: featuregate.Alpha},
+
+	NodeSwap: {Default: false, PreRelease: featuregate.Alpha},
+
+	NonPreemptingPriority: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	PodAffinityNamespaceSelector: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	PodAndContainerStatsFromCRI: {Default: false, PreRelease: featuregate.Alpha},
+
+	PodDeletionCost: {Default: true, PreRelease: featuregate.Beta},
+
+	PodDisruptionBudget: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	PodOverhead: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	PodSecurity: {Default: true, PreRelease: featuregate.Beta},
+
+	PreferNominatedNode: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	ProbeTerminationGracePeriod: {Default: false, PreRelease: featuregate.Beta}, // Default to false in beta 1.22, set to true in 1.24
+
+	ProcMountType: {Default: false, PreRelease: featuregate.Alpha},
+
+	ProxyTerminatingEndpoints: {Default: false, PreRelease: featuregate.Alpha},
+
+	QOSReserved: {Default: false, PreRelease: featuregate.Alpha},
+
+	ReadWriteOncePod: {Default: false, PreRelease: featuregate.Alpha},
+
+	RecoverVolumeExpansionFailure: {Default: false, PreRelease: featuregate.Alpha},
+
+	RotateKubeletServerCertificate: {Default: true, PreRelease: featuregate.Beta},
+
+	SeccompDefault: {Default: false, PreRelease: featuregate.Alpha},
+
+	ServiceIPStaticSubrange: {Default: false, PreRelease: featuregate.Alpha},
+
+	ServiceInternalTrafficPolicy: {Default: true, PreRelease: featuregate.Beta},
+
+	ServiceLBNodePortControl: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	ServiceLoadBalancerClass: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	SizeMemoryBackedVolumes: {Default: true, PreRelease: featuregate.Beta},
+
+	StatefulSetAutoDeletePVC: {Default: false, PreRelease: featuregate.Alpha},
+
+	StatefulSetMinReadySeconds: {Default: true, PreRelease: featuregate.Beta},
+
+	StorageObjectInUseProtection: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	SuspendJob: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	TTLAfterFinished: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	TopologyAwareHints: {Default: true, PreRelease: featuregate.Beta},
+
+	TopologyManager: {Default: true, PreRelease: featuregate.Beta},
+
+	VolumeCapacityPriority: {Default: false, PreRelease: featuregate.Alpha},
+
+	VolumeSubpath: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	WinDSR: {Default: false, PreRelease: featuregate.Alpha},
+
+	WinOverlay: {Default: true, PreRelease: featuregate.Beta},
+
+	WindowsEndpointSliceProxying: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
+
+	WindowsHostProcessContainers: {Default: true, PreRelease: featuregate.Beta},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
-	genericfeatures.AdvancedAuditing:                    {Default: true, PreRelease: featuregate.GA},
-	genericfeatures.APIResponseCompression:              {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.APIListChunking:                     {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.DryRun:                              {Default: true, PreRelease: featuregate.GA},
-	genericfeatures.ServerSideApply:                     {Default: true, PreRelease: featuregate.GA},
-	genericfeatures.APIPriorityAndFairness:              {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.OpenAPIEnums:                        {Default: true, PreRelease: featuregate.Beta},
+
+	genericfeatures.APIListChunking: {Default: true, PreRelease: featuregate.Beta},
+
+	genericfeatures.APIPriorityAndFairness: {Default: true, PreRelease: featuregate.Beta},
+
+	genericfeatures.APIResponseCompression: {Default: true, PreRelease: featuregate.Beta},
+
+	genericfeatures.AdvancedAuditing: {Default: true, PreRelease: featuregate.GA},
+
 	genericfeatures.CustomResourceValidationExpressions: {Default: false, PreRelease: featuregate.Alpha},
-	genericfeatures.OpenAPIV3:                           {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.ServerSideFieldValidation:           {Default: false, PreRelease: featuregate.Alpha},
+
+	genericfeatures.DryRun: {Default: true, PreRelease: featuregate.GA},
+
+	genericfeatures.OpenAPIEnums: {Default: true, PreRelease: featuregate.Beta},
+
+	genericfeatures.OpenAPIV3: {Default: true, PreRelease: featuregate.Beta},
+
+	genericfeatures.ServerSideApply: {Default: true, PreRelease: featuregate.GA},
+
+	genericfeatures.ServerSideFieldValidation: {Default: false, PreRelease: featuregate.Alpha},
+
 	// features that enable backwards compatibility but are scheduled to be removed
 	// ...
 	HPAScaleToZero: {Default: false, PreRelease: featuregate.Alpha},

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -28,7 +28,48 @@ const (
 	//
 	// // owner: @username
 	// // alpha: v1.4
-	// MyFeature() bool
+	// MyFeature featuregate.Feature = "MyFeature"
+	//
+	// Feature gates should be listed in alphabetical, case-sensitive
+	// (upper before any lower case character) order. This reduces the risk
+	// of code conflicts because changes are more likely to be scattered
+	// across the file.
+
+	// owner: @smarterclayton
+	// alpha: v1.8
+	// beta: v1.9
+	//
+	// Allow API clients to retrieve resource lists in chunks rather than
+	// all at once.
+	APIListChunking featuregate.Feature = "APIListChunking"
+
+	// owner: @MikeSpreitzer @yue9944882
+	// alpha: v1.18
+	// beta: v1.20
+	//
+	// Enables managing request concurrency with prioritization and fairness at each server.
+	// The FeatureGate was introduced in release 1.15 but the feature
+	// was not really implemented before 1.18.
+	APIPriorityAndFairness featuregate.Feature = "APIPriorityAndFairness"
+
+	// owner: @ilackams
+	// alpha: v1.7
+	// beta: v1.16
+	//
+	// Enables compression of REST responses (GET and LIST only)
+	APIResponseCompression featuregate.Feature = "APIResponseCompression"
+
+	// owner: @roycaihw
+	// alpha: v1.20
+	//
+	// Assigns each kube-apiserver an ID in a cluster.
+	APIServerIdentity featuregate.Feature = "APIServerIdentity"
+
+	// owner: @dashpole
+	// alpha: v1.22
+	//
+	// Add support for distributed tracing in the API Server
+	APIServerTracing featuregate.Feature = "APIServerTracing"
 
 	// owner: @tallclair
 	// alpha: v1.7
@@ -40,20 +81,12 @@ const (
 	// audited.
 	AdvancedAuditing featuregate.Feature = "AdvancedAuditing"
 
-	// owner: @ilackams
-	// alpha: v1.7
-	// beta: v1.16
+	// owner: @cici37
+	// kep: http://kep.k8s.io/2876
+	// alpha: v1.23
 	//
-	// Enables compression of REST responses (GET and LIST only)
-	APIResponseCompression featuregate.Feature = "APIResponseCompression"
-
-	// owner: @smarterclayton
-	// alpha: v1.8
-	// beta: v1.9
-	//
-	// Allow API clients to retrieve resource lists in chunks rather than
-	// all at once.
-	APIListChunking featuregate.Feature = "APIListChunking"
+	// Enables expression validation for Custom Resource
+	CustomResourceValidationExpressions featuregate.Feature = "CustomResourceValidationExpressions"
 
 	// owner: @apelisse
 	// alpha: v1.12
@@ -65,6 +98,31 @@ const (
 	// committing.
 	DryRun featuregate.Feature = "DryRun"
 
+	// owner: @wojtek-t
+	// alpha: v1.20
+	// beta: v1.21
+	// GA: v1.24
+	//
+	// Allows for updating watchcache resource version with progress notify events.
+	EfficientWatchResumption featuregate.Feature = "EfficientWatchResumption"
+
+	// owner: @jiahuif
+	// kep: http://kep.k8s.io/2887
+	// alpha: v1.23
+	// beta: v1.24
+	//
+	// Enables populating "enum" field of OpenAPI schemas
+	// in the spec returned from kube-apiserver.
+	OpenAPIEnums featuregate.Feature = "OpenAPIEnums"
+
+	// owner: @jefftree
+	// kep: http://kep.k8s.io/2896
+	// alpha: v1.23
+	// beta: v1.24
+	//
+	// Enables kubernetes to publish OpenAPI v3
+	OpenAPIV3 featuregate.Feature = "OpenAPIV3"
+
 	// owner: @caesarxuchao
 	// alpha: v1.15
 	// beta: v1.16
@@ -72,45 +130,6 @@ const (
 	// Allow apiservers to show a count of remaining items in the response
 	// to a chunking list request.
 	RemainingItemCount featuregate.Feature = "RemainingItemCount"
-
-	// owner: @apelisse, @lavalamp
-	// alpha: v1.14
-	// beta: v1.16
-	// stable: v1.22
-	//
-	// Server-side apply. Merging happens on the server.
-	ServerSideApply featuregate.Feature = "ServerSideApply"
-
-	// owner: @caesarxuchao
-	// alpha: v1.14
-	// beta: v1.15
-	//
-	// Allow apiservers to expose the storage version hash in the discovery
-	// document.
-	StorageVersionHash featuregate.Feature = "StorageVersionHash"
-
-	// owner: @caesarxuchao @roycaihw
-	// alpha: v1.20
-	//
-	// Enable the storage version API.
-	StorageVersionAPI featuregate.Feature = "StorageVersionAPI"
-
-	// owner: @wojtek-t
-	// alpha: v1.15
-	// beta: v1.16
-	// GA: v1.17
-	//
-	// Enables support for watch bookmark events.
-	WatchBookmark featuregate.Feature = "WatchBookmark"
-
-	// owner: @MikeSpreitzer @yue9944882
-	// alpha: v1.18
-	// beta: v1.20
-	//
-	// Enables managing request concurrency with prioritization and fairness at each server.
-	// The FeatureGate was introduced in release 1.15 but the feature
-	// was not really implemented before 1.18.
-	APIPriorityAndFairness featuregate.Feature = "APIPriorityAndFairness"
 
 	// owner: @wojtek-t
 	// alpha: v1.16
@@ -128,49 +147,13 @@ const (
 	// Allows label and field based indexes in apiserver watch cache to accelerate list operations.
 	SelectorIndex featuregate.Feature = "SelectorIndex"
 
-	// owner: @wojtek-t
-	// alpha: v1.20
-	// beta: v1.21
-	// GA: v1.24
+	// owner: @apelisse, @lavalamp
+	// alpha: v1.14
+	// beta: v1.16
+	// stable: v1.22
 	//
-	// Allows for updating watchcache resource version with progress notify events.
-	EfficientWatchResumption featuregate.Feature = "EfficientWatchResumption"
-
-	// owner: @roycaihw
-	// alpha: v1.20
-	//
-	// Assigns each kube-apiserver an ID in a cluster.
-	APIServerIdentity featuregate.Feature = "APIServerIdentity"
-
-	// owner: @dashpole
-	// alpha: v1.22
-	//
-	// Add support for distributed tracing in the API Server
-	APIServerTracing featuregate.Feature = "APIServerTracing"
-
-	// owner: @jiahuif
-	// kep: http://kep.k8s.io/2887
-	// alpha: v1.23
-	// beta: v1.24
-	//
-	// Enables populating "enum" field of OpenAPI schemas
-	// in the spec returned from kube-apiserver.
-	OpenAPIEnums featuregate.Feature = "OpenAPIEnums"
-
-	// owner: @cici37
-	// kep: http://kep.k8s.io/2876
-	// alpha: v1.23
-	//
-	// Enables expression validation for Custom Resource
-	CustomResourceValidationExpressions featuregate.Feature = "CustomResourceValidationExpressions"
-
-	// owner: @jefftree
-	// kep: http://kep.k8s.io/2896
-	// alpha: v1.23
-	// beta: v1.24
-	//
-	// Enables kubernetes to publish OpenAPI v3
-	OpenAPIV3 featuregate.Feature = "OpenAPIV3"
+	// Server-side apply. Merging happens on the server.
+	ServerSideApply featuregate.Feature = "ServerSideApply"
 
 	// owner: @kevindelgado
 	// kep: http://kep.k8s.io/2885
@@ -178,6 +161,28 @@ const (
 	//
 	// Enables server-side field validation.
 	ServerSideFieldValidation featuregate.Feature = "ServerSideFieldValidation"
+
+	// owner: @caesarxuchao @roycaihw
+	// alpha: v1.20
+	//
+	// Enable the storage version API.
+	StorageVersionAPI featuregate.Feature = "StorageVersionAPI"
+
+	// owner: @caesarxuchao
+	// alpha: v1.14
+	// beta: v1.15
+	//
+	// Allow apiservers to expose the storage version hash in the discovery
+	// document.
+	StorageVersionHash featuregate.Feature = "StorageVersionHash"
+
+	// owner: @wojtek-t
+	// alpha: v1.15
+	// beta: v1.16
+	// GA: v1.17
+	//
+	// Enables support for watch bookmark events.
+	WatchBookmark featuregate.Feature = "WatchBookmark"
 )
 
 func init() {
@@ -188,23 +193,41 @@ func init() {
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout Kubernetes binaries.
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	AdvancedAuditing:                    {Default: true, PreRelease: featuregate.GA},
-	APIResponseCompression:              {Default: true, PreRelease: featuregate.Beta},
-	APIListChunking:                     {Default: true, PreRelease: featuregate.Beta},
-	DryRun:                              {Default: true, PreRelease: featuregate.GA},
-	RemainingItemCount:                  {Default: true, PreRelease: featuregate.Beta},
-	ServerSideApply:                     {Default: true, PreRelease: featuregate.GA},
-	StorageVersionHash:                  {Default: true, PreRelease: featuregate.Beta},
-	StorageVersionAPI:                   {Default: false, PreRelease: featuregate.Alpha},
-	WatchBookmark:                       {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	APIPriorityAndFairness:              {Default: true, PreRelease: featuregate.Beta},
-	RemoveSelfLink:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	SelectorIndex:                       {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	EfficientWatchResumption:            {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	APIServerIdentity:                   {Default: false, PreRelease: featuregate.Alpha},
-	APIServerTracing:                    {Default: false, PreRelease: featuregate.Alpha},
-	OpenAPIEnums:                        {Default: true, PreRelease: featuregate.Beta},
+	APIListChunking: {Default: true, PreRelease: featuregate.Beta},
+
+	APIPriorityAndFairness: {Default: true, PreRelease: featuregate.Beta},
+
+	APIResponseCompression: {Default: true, PreRelease: featuregate.Beta},
+
+	APIServerIdentity: {Default: false, PreRelease: featuregate.Alpha},
+
+	APIServerTracing: {Default: false, PreRelease: featuregate.Alpha},
+
+	AdvancedAuditing: {Default: true, PreRelease: featuregate.GA},
+
 	CustomResourceValidationExpressions: {Default: false, PreRelease: featuregate.Alpha},
-	OpenAPIV3:                           {Default: true, PreRelease: featuregate.Beta},
-	ServerSideFieldValidation:           {Default: false, PreRelease: featuregate.Alpha},
+
+	DryRun: {Default: true, PreRelease: featuregate.GA},
+
+	EfficientWatchResumption: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+
+	OpenAPIEnums: {Default: true, PreRelease: featuregate.Beta},
+
+	OpenAPIV3: {Default: true, PreRelease: featuregate.Beta},
+
+	RemainingItemCount: {Default: true, PreRelease: featuregate.Beta},
+
+	RemoveSelfLink: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+
+	SelectorIndex: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+
+	ServerSideApply: {Default: true, PreRelease: featuregate.GA},
+
+	ServerSideFieldValidation: {Default: false, PreRelease: featuregate.Alpha},
+
+	StorageVersionAPI: {Default: false, PreRelease: featuregate.Alpha},
+
+	StorageVersionHash: {Default: true, PreRelease: featuregate.Beta},
+
+	WatchBookmark: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 }

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -25,14 +25,12 @@ const (
 	//
 	// // owner: @username
 	// // alpha: v1.4
-	// MyFeature() bool
-
-	// owner: @khenidak
-	// alpha: v1.15
+	// MyFeature featuregate.Feature = "MyFeature"
 	//
-	// Enables ipv6 dual stack
-	// Original copy from k8s.io/kubernetes/pkg/features/kube_features.go
-	IPv6DualStack featuregate.Feature = "IPv6DualStack"
+	// Feature gates should be listed in alphabetical, case-sensitive
+	// (upper before any lower case character) order. This reduces the risk
+	// of code conflicts because changes are more likely to be scattered
+	// across the file.
 
 	// owner: @jiahuif
 	// alpha: v1.21
@@ -42,6 +40,13 @@ const (
 	// Enables Leader Migration for kube-controller-manager and cloud-controller-manager
 	// copied and sync'ed from k8s.io/kubernetes/pkg/features/kube_features.go
 	ControllerManagerLeaderMigration featuregate.Feature = "ControllerManagerLeaderMigration"
+
+	// owner: @khenidak
+	// alpha: v1.15
+	//
+	// Enables ipv6 dual stack
+	// Original copy from k8s.io/kubernetes/pkg/features/kube_features.go
+	IPv6DualStack featuregate.Feature = "IPv6DualStack"
 )
 
 func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.MutableFeatureGate) error {
@@ -51,6 +56,7 @@ func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.Mutable
 // cloudPublicFeatureGates consists of cloud-specific feature keys.
 // To add a new feature, define a key for it at k8s.io/api/pkg/features and add it here.
 var cloudPublicFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	IPv6DualStack:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ControllerManagerLeaderMigration: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	IPv6DualStack: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Sorting is meant to decrease the risk of code conflicts during the period before code freeze.

Removal of GA features is part of the usual maintenance and was due for several features in 1.25.

#### Special notes for your reviewer:

Discussed here: https://groups.google.com/g/kubernetes-sig-architecture/c/7J6_YYvdugc/m/rr1jde6JBgAJ

#### Does this PR introduce a user-facing change?
```release-note
Feature gates that graduated to GA in 1.23 or earlier and were unconditionally enabled have been removed: CSIServiceAccountToken, ConfigurableFSGroupPolicy, EndpointSlice, EndpointSliceNodeName, EndpointSliceProxying, GenericEphemeralVolume, IPv6DualStack, IngressClassNamespacedParams, StorageObjectInUseProtection, TTLAfterFinished, VolumeSubpath, WindowsEndpointSliceProxying
```