### PR TITLE
Added warning event when fetching ImagePullSecret fails

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -876,6 +876,7 @@ func (kl *Kubelet) makePodDataDirs(pod *v1.Pod) error {
 // secrets.
 func (kl *Kubelet) getPullSecretsForPod(pod *v1.Pod) []v1.Secret {
 	pullSecrets := []v1.Secret{}
+	failedSecretNames := []string{}
 
 	for _, secretRef := range pod.Spec.ImagePullSecrets {
 		if len(secretRef.Name) == 0 {
@@ -885,11 +886,17 @@ func (kl *Kubelet) getPullSecretsForPod(pod *v1.Pod) []v1.Secret {
 		}
 		secret, err := kl.secretManager.GetSecret(pod.Namespace, secretRef.Name)
 		if err != nil {
-			klog.InfoS("Unable to retrieve pull secret, the image pull may not succeed.", "pod", klog.KObj(pod), "secret", klog.KObj(secret), "err", err)
+			klog.InfoS("Unable to retrieve pull secret, the image pull may not succeed.", "pod", klog.KObj(pod), "secret", klog.KObj(secret), "secretName", secretRef.Name, "err", err)
+			failedSecretNames = append(failedSecretNames, secretRef.Name)
 			continue
 		}
 
 		pullSecrets = append(pullSecrets, *secret)
+	}
+
+	if len(failedSecretNames) > 0 {
+		kl.recorder.Eventf(pod, v1.EventTypeWarning, "FailedToRetrieveImagePullSecret", 
+		"Unable to retrieve image pull secrets %s, will attempt to pull the image without these secrets. The image pull may not succeed.", strings.Join(failedSecretNames, ", "))
 	}
 
 	return pullSecrets


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Added a warning message according to the discussion in this thread https://github.com/kubernetes/kubernetes/issues/104432

#### Which issue(s) this PR fixes:
1. Added warning message when fetching ImagePullSecrets fails
2. Added unit tests to getPullSecretsForPod 

#### Does this PR introduce a user-facing change?
NONE