### PR TITLE
Added warning event when fetching ImagePullSecret fails

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -876,6 +876,7 @@ func (kl *Kubelet) makePodDataDirs(pod *v1.Pod) error {
 // secrets.
 func (kl *Kubelet) getPullSecretsForPod(pod *v1.Pod) []v1.Secret {
 	pullSecrets := []v1.Secret{}
+	failedSecretNames := []string{}
 
 	for _, secretRef := range pod.Spec.ImagePullSecrets {
 		if len(secretRef.Name) == 0 {
@@ -885,11 +886,17 @@ func (kl *Kubelet) getPullSecretsForPod(pod *v1.Pod) []v1.Secret {
 		}
 		secret, err := kl.secretManager.GetSecret(pod.Namespace, secretRef.Name)
 		if err != nil {
-			klog.InfoS("Unable to retrieve pull secret, the image pull may not succeed.", "pod", klog.KObj(pod), "secret", klog.KObj(secret), "err", err)
+			klog.InfoS("Unable to retrieve pull secret, the image pull may not succeed.", "pod", klog.KObj(pod), "secret", klog.KObj(secret), "secretName", secretRef.Name, "err", err)
+			failedSecretNames = append(failedSecretNames, secretRef.Name)
 			continue
 		}
 
 		pullSecrets = append(pullSecrets, *secret)
+	}
+
+	if len(failedSecretNames) > 0 {
+		kl.recorder.Eventf(pod, v1.EventTypeWarning, "FailedToRetrieveImagePullSecret", 
+		"Unable to retrieve image pull secrets %s, will attempt to pull the image without these secrets. The image pull may not succeed.", strings.Join(failedSecretNames, ", "))
 	}
 
 	return pullSecrets

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -3732,3 +3732,88 @@ func TestConvertToAPIContainerStatusesDataRace(t *testing.T) {
 		}()
 	}
 }
+
+func TestGetPullSecretsForPod(t *testing.T) {
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "test1",
+			Name:        "image-pull-secrets-test-pod",
+			Annotations: map[string]string{},
+		},
+		Spec: v1.PodSpec{
+			ImagePullSecrets: []v1.LocalObjectReference{
+				{Name: "secret1"},
+				{Name: "secret2"},
+				{Name: "secret3"},
+			},
+		},
+	}
+
+	pullSecrets := testKubelet.kubelet.getPullSecretsForPod(testPod)
+
+	assert.Equal(t, 3, len(pullSecrets))
+}
+
+func TestFromPullSecretsForPodWithEmptySecret(t *testing.T) {
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "test1",
+			Name:        "image-pull-secrets-test-pod",
+			Annotations: map[string]string{},
+		},
+		Spec: v1.PodSpec{
+			ImagePullSecrets: []v1.LocalObjectReference{
+			},
+		},
+	}
+
+	pullSecrets := testKubelet.kubelet.getPullSecretsForPod(testPod)
+	assert.Equal(t, 0, len(pullSecrets))
+}
+
+type errorSecretManager struct {}
+
+func (s *errorSecretManager) GetSecret(namespace, name string) (*v1.Secret, error) {
+	return nil, fmt.Errorf("unexpected object type: %v", name)
+}
+
+func (s *errorSecretManager) RegisterPod(pod *v1.Pod) {
+	// No-Ops
+}
+
+func (s *errorSecretManager) UnregisterPod(pod *v1.Pod) {
+	// No-Ops
+}
+
+func TestFromPullSecretsForPodWithSecretError(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(1024)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	testKubelet.kubelet.recorder = fakeRecorder
+	testKubelet.kubelet.secretManager = &errorSecretManager{}
+	defer testKubelet.Cleanup()
+
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "test1",
+			Name:        "image-pull-secrets-test-pod",
+			Annotations: map[string]string{},
+		},
+		Spec: v1.PodSpec{
+			ImagePullSecrets: []v1.LocalObjectReference{
+				{Name: "secret1"},
+				{Name: "secret2"},
+			},
+		},
+	}
+
+	pullSecrets := testKubelet.kubelet.getPullSecretsForPod(testPod)
+	warningStr := <- fakeRecorder.Events 
+	assert.Equal(t, `Warning FailedToRetrieveImagePullSecret Unable to retrieve image pull secrets secret1, secret2, will attempt to pull the image without these secrets. The image pull may not succeed.`, warningStr)
+	assert.Equal(t, 0, len(pullSecrets))
+}


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
Added a warning message according to the discussion in this thread https://github.com/kubernetes/kubernetes/issues/104432

Which issue(s) this PR fixes:
1. Added warning message when fetching ImagePullSecrets fails
2. Added unit tests to getPullSecretsForPod

Does this PR introduce a user-facing change?
NONE