### PR TITLE
golang: Update to 1.18.1 from 1.18

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.24.0-go1.18-bullseye.0
+v1.24.0-go1.18.1-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -91,7 +91,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
 readonly __default_debian_iptables_version=bullseye-v1.1.0
-readonly __default_go_runner_version=v2.3.1-go1.18-bullseye.0
+readonly __default_go_runner_version=v2.3.1-go1.18.1-bullseye.0
 readonly __default_setcap_version=bullseye-v1.0.0
 
 # These are the base images for the Docker-wrapped binaries.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -80,7 +80,7 @@ dependencies:
 
   # Golang
   - name: "golang: upstream version"
-    version: 1.18
+    version: 1.18.1
     refPaths:
     - path: build/build-image/cross/VERSION
     - path: staging/publishing/rules.yaml
@@ -94,10 +94,10 @@ dependencies:
   # This entry is a stub of the major version to allow dependency checks to
   # pass when building Kubernetes using a pre-release of Golang.
   - name: "golang: 1.<major>"
-    version: 1.18
+    version: 1.18.1
     refPaths:
     - path: build/build-image/cross/VERSION
-    # TODO(dims): Uncomment once images are updated to go1.18
+    # TODO(dims): Uncomment once images are updated to go1.18.1
     #- path: hack/lib/golang.sh
     #  match: minimum_go_version=go([0-9]+\.[0-9]+)
 
@@ -108,7 +108,7 @@ dependencies:
       match: 'GOLANG_VERSION\?=\d+.\d+(alpha|beta|rc)?\.?(\d+)?'
 
   - name: "k8s.gcr.io/kube-cross: dependents"
-    version: v1.24.0-go1.18-bullseye.0
+    version: v1.24.0-go1.18.1-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -138,7 +138,7 @@ dependencies:
       match: configs\[DebianIptables\] = Config{list\.BuildImageRegistry, "debian-iptables", "[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"}
 
   - name: "k8s.gcr.io/go-runner: dependents"
-    version: v2.3.1-go1.18-bullseye.0
+    version: v2.3.1-go1.18.1-bullseye.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -8,7 +8,7 @@ recursive-delete-patterns:
 - "*/BUILD.bazel"
 - Gopkg.toml
 - "*/.gitattributes"
-default-go-version: 1.18
+default-go-version: 1.18.1
 rules:
 - destination: code-generator
   branches:

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -16,7 +16,7 @@ REGISTRY ?= k8s.gcr.io/e2e-test-images
 GOARM ?= 7
 DOCKER_CERT_BASE_PATH ?=
 QEMUVERSION=v5.1.0-2
-GOLANG_VERSION=1.18
+GOLANG_VERSION=1.18.1
 export
 
 ifndef WHAT


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
waiting for https://github.com/kubernetes/release/pull/2498 and promoting of images

#### Which issue(s) this PR fixes:

xref #108910

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Kubernetes 1.24 bumped version of golang it is compiled with to go1.18.1
```

