### PR TITLE
Split options and flags in kubectl config sub-commands

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -91,4 +92,18 @@ func helpErrorf(cmd *cobra.Command, format string, args ...interface{}) error {
 	cmd.Help()
 	msg := fmt.Sprintf(format, args...)
 	return fmt.Errorf("%s", msg)
+}
+
+func loadConfig(configAccess clientcmd.ConfigAccess) (*clientcmdapi.Config, string, error) {
+	config, err := configAccess.GetStartingConfig()
+	if err != nil {
+		return nil, "", err
+	}
+
+	configFile := configAccess.GetDefaultFilename()
+	if configAccess.IsExplicitFile() {
+		configFile = configAccess.GetExplicitFile()
+	}
+
+	return config, configFile, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"fmt"
 	"path"
 	"strconv"
 
@@ -55,22 +54,21 @@ func NewCmdConfig(pathOptions *clientcmd.PathOptions, streams genericclioptions.
 	// file paths are common to all sub commands
 	cmd.PersistentFlags().StringVar(&pathOptions.LoadingRules.ExplicitPath, pathOptions.ExplicitFileFlag, pathOptions.LoadingRules.ExplicitPath, "use a particular kubeconfig file")
 
-	// TODO(juanvallejo): update all subcommands to work with genericclioptions.IOStreams
 	cmd.AddCommand(NewCmdConfigView(streams, pathOptions))
-	cmd.AddCommand(NewCmdConfigSetCluster(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigSetCredentials(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigSetContext(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigSet(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigUnset(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigCurrentContext(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigUseContext(streams.Out, pathOptions))
+	cmd.AddCommand(NewCmdConfigSetCluster(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigSetCredentials(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigSetContext(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigSet(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigUnset(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigCurrentContext(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigUseContext(streams, pathOptions))
 	cmd.AddCommand(NewCmdConfigGetContexts(streams, pathOptions))
-	cmd.AddCommand(NewCmdConfigGetClusters(streams.Out, pathOptions))
+	cmd.AddCommand(NewCmdConfigGetClusters(streams, pathOptions))
 	cmd.AddCommand(NewCmdConfigGetUsers(streams, pathOptions))
-	cmd.AddCommand(NewCmdConfigDeleteCluster(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigDeleteContext(streams.Out, streams.ErrOut, pathOptions))
+	cmd.AddCommand(NewCmdConfigDeleteCluster(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigDeleteContext(streams, pathOptions))
 	cmd.AddCommand(NewCmdConfigDeleteUser(streams, pathOptions))
-	cmd.AddCommand(NewCmdConfigRenameContext(streams.Out, pathOptions))
+	cmd.AddCommand(NewCmdConfigRenameContext(streams, pathOptions))
 
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
@@ -88,12 +88,6 @@ func toBool(propertyValue string) (bool, error) {
 	return boolValue, nil
 }
 
-func helpErrorf(cmd *cobra.Command, format string, args ...interface{}) error {
-	cmd.Help()
-	msg := fmt.Sprintf(format, args...)
-	return fmt.Errorf("%s", msg)
-}
-
 func loadConfig(configAccess clientcmd.ConfigAccess) (*clientcmdapi.Config, string, error) {
 	config, err := configAccess.GetStartingConfig()
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context_test.go
@@ -17,81 +17,117 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
-	"fmt"
-	"os"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 type deleteContextTest struct {
-	config           clientcmdapi.Config
-	contextToDelete  string
-	expectedContexts []string
-	expectedOut      string
+	name           string
+	startingConfig *clientcmdapi.Config
+	args           []string
+	expectedConfig *clientcmdapi.Config
+	expectedOut    string
+	completeError  string
+	runError       string
 }
 
 func TestDeleteContext(t *testing.T) {
-	conf := clientcmdapi.Config{
-		Contexts: map[string]*clientcmdapi.Context{
-			"minikube":  {Cluster: "minikube"},
-			"otherkube": {Cluster: "otherkube"},
+	t.Parallel()
+	startConf := clientcmdapi.NewConfig()
+	startConf.CurrentContext = "otherkube"
+	startConf.Contexts = map[string]*clientcmdapi.Context{
+		"minikube":  {Cluster: "minikube"},
+		"otherkube": {Cluster: "otherkube"},
+	}
+
+	resultConfDeleteMinikube := clientcmdapi.NewConfig()
+	resultConfDeleteMinikube.CurrentContext = "otherkube"
+	resultConfDeleteMinikube.Contexts = map[string]*clientcmdapi.Context{
+		"otherkube": {Cluster: "otherkube"},
+	}
+
+	resultConfDeleteOtherkube := clientcmdapi.NewConfig()
+	resultConfDeleteOtherkube.CurrentContext = "otherkube"
+	resultConfDeleteOtherkube.Contexts = map[string]*clientcmdapi.Context{
+		"minikube": {Cluster: "minikube"},
+	}
+
+	for _, test := range []deleteContextTest{
+		{
+			name:           "DeleteContext",
+			startingConfig: startConf,
+			args:           []string{"minikube"},
+			expectedConfig: resultConfDeleteMinikube,
+			expectedOut:    "deleted context \"minikube\" from",
+		}, {
+			name:           "ErrorMultipleArgs",
+			startingConfig: startConf,
+			args:           []string{"minikube", "test"},
+			expectedConfig: startConf,
+			completeError:  "unexpected args: [minikube test]",
+		}, {
+			name:           "ErrorNonexistentContext",
+			startingConfig: startConf,
+			args:           []string{"test"},
+			expectedConfig: startConf,
+			runError:       "context \"test\" does not exist in config file",
+		}, {
+			name:           "WarningRemovedCurrentContext",
+			startingConfig: startConf,
+			args:           []string{"otherkube"},
+			expectedConfig: resultConfDeleteOtherkube,
+			expectedOut: `warning: this removed your active context, use "kubectl config use-context" to select a different one
+deleted context "otherkube" from`,
 		},
-	}
-	test := deleteContextTest{
-		config:           conf,
-		contextToDelete:  "minikube",
-		expectedContexts: []string{"otherkube"},
-		expectedOut:      "deleted context minikube from %s\n",
-	}
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			fakeKubeFile, err := generateTestKubeConfig(*test.startingConfig)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-	test.run(t)
-}
+			defer removeTempFile(t, fakeKubeFile.Name())
 
-func (test deleteContextTest) run(t *testing.T) {
-	fakeKubeFile, err := os.CreateTemp(os.TempDir(), "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	defer os.Remove(fakeKubeFile.Name())
-	err = clientcmd.WriteToFile(test.config, fakeKubeFile.Name())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+			pathOptions := clientcmd.NewDefaultPathOptions()
+			pathOptions.GlobalFile = fakeKubeFile.Name()
+			pathOptions.EnvVar = ""
 
-	pathOptions := clientcmd.NewDefaultPathOptions()
-	pathOptions.GlobalFile = fakeKubeFile.Name()
-	pathOptions.EnvVar = ""
+			streams, _, buffOut, _ := genericclioptions.NewTestIOStreams()
 
-	buf := bytes.NewBuffer([]byte{})
-	errBuf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdConfigDeleteContext(buf, errBuf, pathOptions)
-	cmd.SetArgs([]string{test.contextToDelete})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("unexpected error executing command: %v", err)
-	}
+			options := NewDeleteContextOptions(streams, pathOptions)
 
-	expectedOutWithFile := fmt.Sprintf(test.expectedOut, fakeKubeFile.Name())
-	if expectedOutWithFile != buf.String() {
-		t.Errorf("expected output %s, but got %s", expectedOutWithFile, buf.String())
-		return
-	}
+			err = options.Complete(test.args)
+			if len(test.completeError) != 0 && err != nil {
+				checkOutputResults(t, err.Error(), test.completeError)
+				checkOutputConfig(t, options.ConfigAccess, test.expectedConfig, cmp.Options{})
+				return
+			} else if len(test.completeError) != 0 && err == nil {
+				t.Fatalf("expected error %q running command but non received", test.completeError)
+			} else if err != nil {
+				t.Fatalf("unexpected error running to options: %v", err)
+			}
 
-	// Verify context was removed from kubeconfig file
-	config, err := clientcmd.LoadFromFile(fakeKubeFile.Name())
-	if err != nil {
-		t.Fatalf("unexpected error loading kubeconfig file: %v", err)
-	}
+			err = options.RunDeleteContext()
+			if len(test.runError) != 0 && err != nil {
+				checkOutputResults(t, err.Error(), test.completeError)
+				checkOutputConfig(t, options.ConfigAccess, test.expectedConfig, cmp.Options{})
+				return
+			} else if len(test.runError) != 0 && err == nil {
+				t.Fatalf("expected error %q running command but non received", test.completeError)
+			} else if err != nil {
+				t.Fatalf("unexpected error running to options: %v", err)
+			}
 
-	contexts := make([]string, 0, len(config.Contexts))
-	for k := range config.Contexts {
-		contexts = append(contexts, k)
-	}
-
-	if !reflect.DeepEqual(test.expectedContexts, contexts) {
-		t.Errorf("expected contexts %v, but found %v in kubeconfig", test.expectedContexts, contexts)
+			if len(test.expectedOut) != 0 {
+				checkOutputResults(t, buffOut.String(), test.expectedOut)
+				checkOutputConfig(t, options.ConfigAccess, test.expectedConfig, cmp.Options{})
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_clusters_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_clusters_test.go
@@ -32,7 +32,6 @@ type getClustersTest struct {
 	args           []string
 	expectedConfig *clientcmdapi.Config
 	expectedOut    string
-	runError       string
 }
 
 func TestGetClusters(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts_test.go
@@ -34,7 +34,6 @@ type getContextsRunTest struct {
 	options        *GetContextsOptions
 	expectedConfig *clientcmdapi.Config
 	expectedOut    string
-	toOptionsError string
 	runError       string
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_users_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_users_test.go
@@ -28,10 +28,7 @@ import (
 type testGetUser struct {
 	name           string
 	startingConfig *clientcmdapi.Config
-	args           []string
 	expectedOut    string
-	completeError  string
-	runError       string
 }
 
 func TestGetUsersRun(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_cluster.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_cluster.go
@@ -17,13 +17,13 @@ limitations under the License.
 package config
 
 import (
-	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -31,17 +31,6 @@ import (
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
-
-type setClusterOptions struct {
-	configAccess          clientcmd.ConfigAccess
-	name                  string
-	server                cliflag.StringFlag
-	tlsServerName         cliflag.StringFlag
-	insecureSkipTLSVerify cliflag.Tristate
-	certificateAuthority  cliflag.StringFlag
-	embedCAData           cliflag.Tristate
-	proxyURL              cliflag.StringFlag
-}
 
 var (
 	setClusterLong = templates.LongDesc(i18n.T(`
@@ -66,9 +55,34 @@ var (
 		kubectl config set-cluster e2e --proxy-url=https://1.2.3.4`)
 )
 
+type SetClusterFlags struct {
+	certificateAuthority  cliflag.StringFlag
+	embedCAData           bool
+	insecureSkipTLSVerify bool
+	proxyURL              cliflag.StringFlag
+	server                cliflag.StringFlag
+	tlsServerName         cliflag.StringFlag
+
+	configAccess clientcmd.ConfigAccess
+	ioStreams    genericclioptions.IOStreams
+}
+
+type SetClusterOptions struct {
+	CertificateAuthority  cliflag.StringFlag
+	EmbedCAData           bool
+	InsecureSkipTLSVerify bool
+	Name                  string
+	ProxyURL              cliflag.StringFlag
+	Server                cliflag.StringFlag
+	TlsServerName         cliflag.StringFlag
+
+	ConfigAccess clientcmd.ConfigAccess
+	IOStreams    genericclioptions.IOStreams
+}
+
 // NewCmdConfigSetCluster returns a Command instance for 'config set-cluster' sub command
-func NewCmdConfigSetCluster(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
-	options := &setClusterOptions{configAccess: configAccess}
+func NewCmdConfigSetCluster(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
+	flags := NewSetClusterFlags(streams, configAccess)
 
 	cmd := &cobra.Command{
 		Use:                   fmt.Sprintf("set-cluster NAME [--%v=server] [--%v=path/to/certificate/authority] [--%v=true] [--%v=example.com]", clientcmd.FlagAPIServer, clientcmd.FlagCAFile, clientcmd.FlagInsecure, clientcmd.FlagTLSServerName),
@@ -77,122 +91,142 @@ func NewCmdConfigSetCluster(out io.Writer, configAccess clientcmd.ConfigAccess) 
 		Long:                  setClusterLong,
 		Example:               setClusterExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(options.complete(cmd))
-			cmdutil.CheckErr(options.run())
-			fmt.Fprintf(out, "Cluster %q set.\n", options.name)
+			options, err := flags.ToOptions(args)
+			cmdutil.CheckErr(err)
+			cmdutil.CheckErr(options.RunSetCluster())
 		},
 	}
 
-	options.insecureSkipTLSVerify.Default(false)
-
-	cmd.Flags().Var(&options.server, clientcmd.FlagAPIServer, clientcmd.FlagAPIServer+" for the cluster entry in kubeconfig")
-	cmd.Flags().Var(&options.tlsServerName, clientcmd.FlagTLSServerName, clientcmd.FlagTLSServerName+" for the cluster entry in kubeconfig")
-	f := cmd.Flags().VarPF(&options.insecureSkipTLSVerify, clientcmd.FlagInsecure, "", clientcmd.FlagInsecure+" for the cluster entry in kubeconfig")
-	f.NoOptDefVal = "true"
-	cmd.Flags().Var(&options.certificateAuthority, clientcmd.FlagCAFile, "Path to "+clientcmd.FlagCAFile+" file for the cluster entry in kubeconfig")
-	cmd.MarkFlagFilename(clientcmd.FlagCAFile)
-	f = cmd.Flags().VarPF(&options.embedCAData, clientcmd.FlagEmbedCerts, "", clientcmd.FlagEmbedCerts+" for the cluster entry in kubeconfig")
-	f.NoOptDefVal = "true"
-	cmd.Flags().Var(&options.proxyURL, clientcmd.FlagProxyURL, clientcmd.FlagProxyURL+" for the cluster entry in kubeconfig")
+	if err := flags.AddFlags(cmd); err != nil {
+		cmdutil.CheckErr(err)
+	}
 
 	return cmd
 }
 
-func (o setClusterOptions) run() error {
-	err := o.validate()
+func NewSetClusterFlags(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *SetClusterFlags {
+	return &SetClusterFlags{
+		configAccess:          configAccess,
+		ioStreams:             streams,
+		server:                cliflag.StringFlag{},
+		tlsServerName:         cliflag.StringFlag{},
+		insecureSkipTLSVerify: false,
+		certificateAuthority:  cliflag.StringFlag{},
+		embedCAData:           false,
+		proxyURL:              cliflag.StringFlag{},
+	}
+}
+
+func (flags *SetClusterFlags) ToOptions(args []string) (*SetClusterOptions, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("unexpected args: %v", args)
+	}
+	if flags.insecureSkipTLSVerify && flags.certificateAuthority.Provided() {
+		return nil, fmt.Errorf("you cannot specify a certificate authority and insecure mode at the same time")
+	}
+	if flags.embedCAData {
+		if !flags.certificateAuthority.Provided() {
+			return nil, fmt.Errorf("you must specify a --%s to embed", clientcmd.FlagCAFile)
+		}
+		if _, err := os.Stat(flags.certificateAuthority.Value()); err != nil {
+			return nil, fmt.Errorf("could not stat %s file %s: %v", clientcmd.FlagCAFile, flags.certificateAuthority.Value(), err)
+		}
+	}
+
+	options := &SetClusterOptions{
+		ConfigAccess:          flags.configAccess,
+		IOStreams:             flags.ioStreams,
+		Name:                  args[0],
+		Server:                flags.server,
+		TlsServerName:         flags.tlsServerName,
+		InsecureSkipTLSVerify: flags.insecureSkipTLSVerify,
+		CertificateAuthority:  flags.certificateAuthority,
+		EmbedCAData:           flags.embedCAData,
+		ProxyURL:              flags.proxyURL,
+	}
+
+	return options, nil
+}
+
+// AddFlags registers flags for a cli
+func (flags *SetClusterFlags) AddFlags(cmd *cobra.Command) error {
+	cmd.Flags().Var(&flags.server, clientcmd.FlagAPIServer, clientcmd.FlagAPIServer+" for the cluster entry in kubeconfig")
+	cmd.Flags().Var(&flags.tlsServerName, clientcmd.FlagTLSServerName, clientcmd.FlagTLSServerName+" for the cluster entry in kubeconfig")
+	cmd.Flags().BoolVar(&flags.insecureSkipTLSVerify, clientcmd.FlagInsecure, false, clientcmd.FlagInsecure+" for the cluster entry in kubeconfig")
+	cmd.Flags().Var(&flags.certificateAuthority, clientcmd.FlagCAFile, "Path to "+clientcmd.FlagCAFile+" file for the cluster entry in kubeconfig")
+	if err := cmd.MarkFlagFilename(clientcmd.FlagCAFile); err != nil {
+		return err
+	}
+	cmd.Flags().BoolVar(&flags.embedCAData, clientcmd.FlagEmbedCerts, false, clientcmd.FlagEmbedCerts+" for the cluster entry in kubeconfig")
+	cmd.Flags().Var(&flags.proxyURL, clientcmd.FlagProxyURL, clientcmd.FlagProxyURL+" for the cluster entry in kubeconfig")
+	return nil
+}
+
+func (o *SetClusterOptions) RunSetCluster() error {
+	config, _, err := loadConfig(o.ConfigAccess)
 	if err != nil {
 		return err
 	}
 
-	config, err := o.configAccess.GetStartingConfig()
-	if err != nil {
-		return err
-	}
-
-	startingStanza, exists := config.Clusters[o.name]
+	startingStanza, exists := config.Clusters[o.Name]
 	if !exists {
 		startingStanza = clientcmdapi.NewCluster()
 	}
 	cluster := o.modifyCluster(*startingStanza)
-	config.Clusters[o.name] = &cluster
+	config.Clusters[o.Name] = &cluster
 
-	if err := clientcmd.ModifyConfig(o.configAccess, *config, true); err != nil {
+	if err := clientcmd.ModifyConfig(o.ConfigAccess, *config, true); err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(o.IOStreams.Out, "Cluster %q set.\n", o.Name)
+	if err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (o *setClusterOptions) modifyCluster(existingCluster clientcmdapi.Cluster) clientcmdapi.Cluster {
+func (o *SetClusterOptions) modifyCluster(existingCluster clientcmdapi.Cluster) clientcmdapi.Cluster {
 	modifiedCluster := existingCluster
 
-	if o.server.Provided() {
-		modifiedCluster.Server = o.server.Value()
+	if o.Server.Provided() {
+		modifiedCluster.Server = o.Server.Value()
 		// specifying a --server on the command line, overrides the TLSServerName that was specified in the kubeconfig file.
 		// if both are specified, then the next if block will write the new TLSServerName.
 		modifiedCluster.TLSServerName = ""
 	}
-	if o.tlsServerName.Provided() {
-		modifiedCluster.TLSServerName = o.tlsServerName.Value()
+	if o.TlsServerName.Provided() {
+		modifiedCluster.TLSServerName = o.TlsServerName.Value()
 	}
-	if o.insecureSkipTLSVerify.Provided() {
-		modifiedCluster.InsecureSkipTLSVerify = o.insecureSkipTLSVerify.Value()
+	if o.InsecureSkipTLSVerify {
+		modifiedCluster.InsecureSkipTLSVerify = o.InsecureSkipTLSVerify
 		// Specifying insecure mode clears any certificate authority
 		if modifiedCluster.InsecureSkipTLSVerify {
 			modifiedCluster.CertificateAuthority = ""
 			modifiedCluster.CertificateAuthorityData = nil
 		}
 	}
-	if o.certificateAuthority.Provided() {
-		caPath := o.certificateAuthority.Value()
-		if o.embedCAData.Value() {
-			modifiedCluster.CertificateAuthorityData, _ = os.ReadFile(caPath)
+	if o.CertificateAuthority.Provided() {
+		caPath := o.CertificateAuthority
+		if o.EmbedCAData {
+			modifiedCluster.CertificateAuthorityData, _ = os.ReadFile(caPath.Value())
 			modifiedCluster.InsecureSkipTLSVerify = false
 			modifiedCluster.CertificateAuthority = ""
 		} else {
-			caPath, _ = filepath.Abs(caPath)
-			modifiedCluster.CertificateAuthority = caPath
+			caPathAbs, _ := filepath.Abs(caPath.Value())
+			modifiedCluster.CertificateAuthority = caPathAbs
 			// Specifying a certificate authority file clears certificate authority data and insecure mode
-			if caPath != "" {
+			if caPath.Provided() {
 				modifiedCluster.InsecureSkipTLSVerify = false
 				modifiedCluster.CertificateAuthorityData = nil
 			}
 		}
 	}
 
-	if o.proxyURL.Provided() {
-		modifiedCluster.ProxyURL = o.proxyURL.Value()
+	if o.ProxyURL.Provided() {
+		modifiedCluster.ProxyURL = o.ProxyURL.Value()
 	}
 
 	return modifiedCluster
-}
-
-func (o *setClusterOptions) complete(cmd *cobra.Command) error {
-	args := cmd.Flags().Args()
-	if len(args) != 1 {
-		return helpErrorf(cmd, "Unexpected args: %v", args)
-	}
-
-	o.name = args[0]
-	return nil
-}
-
-func (o setClusterOptions) validate() error {
-	if len(o.name) == 0 {
-		return errors.New("you must specify a non-empty cluster name")
-	}
-	if o.insecureSkipTLSVerify.Value() && o.certificateAuthority.Value() != "" {
-		return errors.New("you cannot specify a certificate authority and insecure mode at the same time")
-	}
-	if o.embedCAData.Value() {
-		caPath := o.certificateAuthority.Value()
-		if caPath == "" {
-			return fmt.Errorf("you must specify a --%s to embed", clientcmd.FlagCAFile)
-		}
-		if _, err := os.Stat(caPath); err != nil {
-			return fmt.Errorf("could not stat %s file %s: %v", clientcmd.FlagCAFile, caPath, err)
-		}
-	}
-
-	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -33,7 +33,6 @@ type setRunTest struct {
 	options        *SetOptions
 	expectedConfig *clientcmdapi.Config
 	expectedOut    string
-	toOptionsError string
 	runError       string
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -17,71 +17,226 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
-	"os"
+	"reflect"
 	"testing"
 
-	"reflect"
+	"github.com/google/go-cmp/cmp"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-type setConfigTest struct {
-	description    string
-	config         clientcmdapi.Config
-	args           []string
-	expected       string
-	expectedConfig clientcmdapi.Config
+type setRunTest struct {
+	name           string
+	startingConfig *clientcmdapi.Config
+	options        *SetOptions
+	expectedConfig *clientcmdapi.Config
+	expectedOut    string
+	toOptionsError string
+	runError       string
 }
 
-func TestSetConfigCurrentContext(t *testing.T) {
-	conf := clientcmdapi.Config{
-		Kind:           "Config",
-		APIVersion:     "v1",
-		CurrentContext: "minikube",
-	}
-	expectedConfig := *clientcmdapi.NewConfig()
-	expectedConfig.CurrentContext = "my-cluster"
-	test := setConfigTest{
-		description:    "Testing for kubectl config set current-context",
-		config:         conf,
-		args:           []string{"current-context", "my-cluster"},
-		expected:       `Property "current-context" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
+type setToOptionsTest struct {
+	name            string
+	args            []string
+	flags           *SetFlags
+	expectedOptions *SetOptions
+	expectedError   string
 }
 
-func (test setConfigTest) run(t *testing.T) {
-	fakeKubeFile, err := os.CreateTemp(os.TempDir(), "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestRunSet(t *testing.T) {
+	t.Parallel()
+
+	startingConfigEmpty := clientcmdapi.NewConfig()
+
+	expectedConfigCurrentContext := clientcmdapi.NewConfig()
+	expectedConfigCurrentContext.CurrentContext = "my-cluster"
+
+	expectedConfigCluster := clientcmdapi.NewConfig()
+	myCluster := clientcmdapi.NewCluster()
+	myCluster.Server = "https://1.2.3.4"
+	expectedConfigCluster.Clusters = map[string]*clientcmdapi.Cluster{
+		"my-cluster": myCluster,
 	}
-	defer os.Remove(fakeKubeFile.Name())
-	err = clientcmd.WriteToFile(test.config, fakeKubeFile.Name())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+
+	expectedConfigContext := clientcmdapi.NewConfig()
+	myContext := clientcmdapi.NewContext()
+	myContext.Cluster = "my-cluster"
+	expectedConfigContext.Contexts = map[string]*clientcmdapi.Context{
+		"my-context": myContext,
 	}
-	pathOptions := clientcmd.NewDefaultPathOptions()
-	pathOptions.GlobalFile = fakeKubeFile.Name()
-	pathOptions.EnvVar = ""
-	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdConfigSet(buf, pathOptions)
-	cmd.SetArgs(test.args)
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("unexpected error executing command: %v", err)
+
+	expectedConfigUser := clientcmdapi.NewConfig()
+	myAuthInfo := clientcmdapi.NewAuthInfo()
+	myAuthInfo.ClientKey = "./fake-client-key"
+	myAuthInfo.ImpersonateUserExtra = nil // Required because set nils out this value if it doesn't get set
+	expectedConfigUser.AuthInfos = map[string]*clientcmdapi.AuthInfo{
+		"cluster-admin": myAuthInfo,
 	}
-	config, err := clientcmd.LoadFromFile(fakeKubeFile.Name())
-	if err != nil {
-		t.Fatalf("unexpected error loading kubeconfig file: %v", err)
+
+	expectedConfigUserRawBytes := clientcmdapi.NewConfig()
+	myAuthInfoRawBytes := clientcmdapi.NewAuthInfo()
+	myAuthInfoRawBytes.ClientKeyData = []byte("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	myAuthInfoRawBytes.ImpersonateUserExtra = nil // Required because set nils out this value if it doesn't get set
+	expectedConfigUserRawBytes.AuthInfos = map[string]*clientcmdapi.AuthInfo{
+		"cluster-admin": myAuthInfoRawBytes,
 	}
-	if len(test.expected) != 0 {
-		if buf.String() != test.expected {
-			t.Errorf("Failed in:%q\n expected %v\n but got %v", test.description, test.expected, buf.String())
-		}
+
+	for _, test := range []setRunTest{
+		{
+			name:           "CurrentContext",
+			startingConfig: startingConfigEmpty,
+			options: &SetOptions{
+				PropertyName:  "current-context",
+				PropertyValue: "my-cluster",
+				SetRawBytes:   false,
+			},
+			expectedConfig: expectedConfigCurrentContext,
+			expectedOut:    "Property \"current-context\" set.\n",
+		}, {
+			name:           "ClusterServer",
+			startingConfig: startingConfigEmpty,
+			options: &SetOptions{
+				PropertyName:  "clusters.my-cluster.server",
+				PropertyValue: "https://1.2.3.4",
+				SetRawBytes:   false,
+			},
+			expectedConfig: expectedConfigCluster,
+			expectedOut:    "Property \"clusters.my-cluster.server\" set.\n",
+		}, {
+			name:           "ContextCluster",
+			startingConfig: startingConfigEmpty,
+			options: &SetOptions{
+				PropertyName:  "contexts.my-context.cluster",
+				PropertyValue: "my-cluster",
+				SetRawBytes:   false,
+			},
+			expectedConfig: expectedConfigContext,
+			expectedOut:    "Property \"contexts.my-context.cluster\" set.\n",
+		}, {
+			name:           "UserClientKey",
+			startingConfig: startingConfigEmpty,
+			options: &SetOptions{
+				PropertyName:  "users.cluster-admin.client-key",
+				PropertyValue: "./fake-client-key",
+				SetRawBytes:   false,
+			},
+			expectedConfig: expectedConfigUser,
+			expectedOut:    "Property \"users.cluster-admin.client-key\" set.\n",
+		}, {
+			name:           "UserClientKeyData",
+			startingConfig: startingConfigEmpty,
+			options: &SetOptions{
+				PropertyName:  "users.cluster-admin.client-key-data",
+				PropertyValue: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+				SetRawBytes:   true,
+			},
+			expectedConfig: expectedConfigUserRawBytes,
+			expectedOut:    "Property \"users.cluster-admin.client-key-data\" set.\n",
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			fakeKubeFile, err := generateTestKubeConfig(*test.startingConfig)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			defer removeTempFile(t, fakeKubeFile.Name())
+
+			pathOptions := clientcmd.NewDefaultPathOptions()
+			pathOptions.GlobalFile = fakeKubeFile.Name()
+			pathOptions.EnvVar = ""
+
+			streams, _, buffOut, _ := genericclioptions.NewTestIOStreams()
+
+			test.options.IOStreams = streams
+			test.options.ConfigAccess = pathOptions
+
+			err = test.options.RunSet()
+			if len(test.runError) != 0 && err != nil {
+				checkOutputResults(t, err.Error(), test.runError)
+				checkOutputConfig(t, test.options.ConfigAccess, test.expectedConfig, cmp.Options{})
+				return
+			} else if len(test.runError) != 0 && err == nil {
+				t.Fatalf("expected error %q running command but non received", test.runError)
+			} else if err != nil {
+				t.Fatalf("unexpected error running to options: %v", err)
+			}
+
+			if len(test.expectedOut) != 0 {
+				checkOutputResults(t, buffOut.String(), test.expectedOut)
+				checkOutputConfig(t, test.options.ConfigAccess, test.expectedConfig, cmp.Options{})
+			}
+		})
 	}
-	if !reflect.DeepEqual(*config, test.expectedConfig) {
-		t.Errorf("Failed in: %q\n expected %v\n but got %v", test.description, *config, test.expectedConfig)
+}
+
+func TestSetToOptions(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []setToOptionsTest{
+		{
+			name:  "DefaultFlagsTwoArgs",
+			args:  []string{"current-context", "my-cluster"},
+			flags: &SetFlags{},
+			expectedOptions: &SetOptions{
+				PropertyName:  "current-context",
+				PropertyValue: "my-cluster",
+				SetRawBytes:   false,
+			},
+		}, {
+			name:          "ErrorDefaultFlagsZeroArgs",
+			args:          []string{},
+			flags:         &SetFlags{},
+			expectedError: "unexpected args:",
+		}, {
+			name:          "ErrorDefaultFlagsOneArg",
+			args:          []string{"current-context"},
+			flags:         &SetFlags{},
+			expectedError: "unexpected args: [current-context]",
+		}, {
+			name:          "ErrorDefaultFlagsThreeArg",
+			args:          []string{"current-context", "my-cluster", "fake-test"},
+			flags:         &SetFlags{},
+			expectedError: "unexpected args: [current-context my-cluster fake-test]",
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			fakeKubeFile, err := generateTestKubeConfig(*clientcmdapi.NewConfig())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			defer removeTempFile(t, fakeKubeFile.Name())
+
+			pathOptions := clientcmd.NewDefaultPathOptions()
+			pathOptions.GlobalFile = fakeKubeFile.Name()
+			pathOptions.EnvVar = ""
+
+			streams, _, _, _ := genericclioptions.NewTestIOStreams()
+
+			test.flags.configAccess = pathOptions
+			test.flags.ioStreams = streams
+
+			options, err := test.flags.ToOptions(test.args)
+			if len(test.expectedError) != 0 && err != nil {
+				checkOutputResults(t, err.Error(), test.expectedError)
+				return
+			} else if len(test.expectedError) != 0 && err == nil {
+				t.Fatalf("expected error %q running command but non received", test.expectedError)
+			} else if err != nil {
+				t.Fatalf("unexpected error running to options: %v", err)
+			}
+
+			// finish options for proper comparison
+			test.expectedOptions.IOStreams = streams
+			test.expectedOptions.ConfigAccess = pathOptions
+			if !reflect.DeepEqual(test.expectedOptions, options) {
+				t.Errorf("expected options did not match actual options (-want, +got):\n%v", cmp.Diff(test.expectedOptions, options))
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/test_utils.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/test_utils.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// Write out a fake kube config for testing and return the file object
+func generateTestKubeConfig(config clientcmdapi.Config) (*os.File, error) {
+	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
+	if err != nil {
+		return nil, err
+	}
+	err = clientcmd.WriteToFile(config, fakeKubeFile.Name())
+	if err != nil {
+		return nil, err
+	}
+	return fakeKubeFile, nil
+}
+
+// Set locations of origin for the provided fake kubefile name so that deep equals works as expected
+func completeConfig(conf *clientcmdapi.Config, locOfOrigin string) *clientcmdapi.Config {
+	for _, contexts := range conf.Contexts {
+		contexts.LocationOfOrigin = locOfOrigin
+		contexts.Extensions = make(map[string]runtime.Object)
+	}
+	for _, cluster := range conf.Clusters {
+		cluster.LocationOfOrigin = locOfOrigin
+		cluster.Extensions = make(map[string]runtime.Object)
+	}
+	for _, authInfo := range conf.AuthInfos {
+		authInfo.LocationOfOrigin = locOfOrigin
+		authInfo.Extensions = make(map[string]runtime.Object)
+	}
+
+	return conf
+}
+
+// Check if the provided string has a substring and log out a consistently formatted testing error if not
+func checkOutputResults(t *testing.T, output, expectedOutput string) {
+	if !strings.Contains(output, expectedOutput) {
+		t.Fatalf("did not get expected output:\nwant: %v\ngot:  %v", expectedOutput, output)
+	}
+}
+
+// Check if the provided config is the same as the expected configuration, using the provided comparison options
+func checkOutputConfig(t *testing.T, configAccess clientcmd.ConfigAccess, wantConfig *clientcmdapi.Config, cmpOptions cmp.Option) {
+	gotConfig, configFileName, err := loadConfig(configAccess)
+	if err != nil {
+		t.Fatalf("unexpected error loading temp config from file")
+	}
+	expectedConfig := completeConfig(wantConfig, configFileName)
+	if cmp.Diff(expectedConfig, gotConfig, cmpOptions) != "" {
+		t.Fatalf("expected config did not match actual config (-want, +got):\n%v", cmp.Diff(expectedConfig, gotConfig, cmpOptions))
+	}
+}
+
+// Wrapper function to remove a temp file, to be used for defer lines
+func removeTempFile(t *testing.T, name string) {
+	err := os.Remove(name)
+	if err != nil {
+		t.Fatalf("unexpected error removing fake kube config file: %v", err)
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/view.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/view.go
@@ -193,14 +193,3 @@ func (o *ViewOptions) RunView() error {
 
 	return o.PrintObject(convertedObj, o.IOStreams.Out)
 }
-
-// getStartingConfig returns the Config object built from the sources specified by the options, the filename read (only if it was a single file), and an error if something goes wrong
-func (o *ViewOptions) getStartingConfig() (*clientcmdapi.Config, error) {
-	switch {
-	case !o.Merge:
-		return clientcmd.LoadFromFile(o.ConfigAccess.GetExplicitFile())
-
-	default:
-		return o.ConfigAccess.GetStartingConfig()
-	}
-}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/view_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/view_test.go
@@ -35,7 +35,6 @@ type viewRunTest struct {
 	startingConfig *clientcmdapi.Config
 	options        *ViewOptions
 	expectedOut    string
-	toOptionsError string
 	runError       string
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Part of ongoing effort to split options and flags out in kubectl commands.

#### Special notes for your reviewer:

The way I have put this together we have three main categories of functions:

Commands that takes flags
- New\<subcommand\>Flags - This function creates a new initialized set of flags passing in the config file access and io streams objects at a minimum. All other flags are granted default values here.
- AddFlags - This function adds the flags to the `cobra.Command` object.
- ToOptions - This function takes the arguments provided by the user, the flags provided by the user, the default values of the flags, and composes all of this into a set of subcommand options that are returned which will then be later used by the run command.

Commands that do not take flags
- New\<subcommand\>Options - This function creates a new initialized set of options, passing the config file access and io streams objects at a minimum.
- Complete - This function takes the arguments provided by the user that would normally be added to the options object in the ToOptions function and adds them to the options object.

Utility functions
- Validate - Sometimes it is necessary to apply complicated logic to verify that an options object is both complete and valid based on user inputs. This function can accomplish this step if necessary.

#### Does this PR introduce a user-facing change?
No

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
See following issue for more details.

https://github.com/kubernetes/kubectl/issues/1046
