### PR TITLE
[WIP] move taint to default kubelet config generating from mark-control-plane

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubelet.go
@@ -66,10 +66,8 @@ func runKubeletStart(c workflow.RunData) error {
 		kubeletphase.TryStopKubelet()
 	}
 
-	// Write env file with flags for the kubelet to use. We do not need to write the --register-with-taints for the control-plane,
-	// as we handle that ourselves in the mark-control-plane phase
-	// TODO: Maybe we want to do that some time in the future, in order to remove some logic from the mark-control-plane phase?
-	if err := kubeletphase.WriteKubeletDynamicEnvFile(&data.Cfg().ClusterConfiguration, &data.Cfg().NodeRegistration, false, data.KubeletDir()); err != nil {
+	// Write env file with flags for the kubelet to use.
+	if err := kubeletphase.WriteKubeletDynamicEnvFile(&data.Cfg().ClusterConfiguration, &data.Cfg().NodeRegistration, true, data.KubeletDir()); err != nil {
 		return errors.Wrap(err, "error writing a dynamic environment file for the kubelet")
 	}
 

--- a/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
@@ -27,10 +27,10 @@ import (
 
 var (
 	markControlPlaneExample = cmdutil.Examples(`
-		# Applies control-plane label and taint to the current node, functionally equivalent to what executed by kubeadm init.
+		# Applies control-plane label to the current node, functionally equivalent to what executed by kubeadm init.
 		kubeadm init phase mark-control-plane --config config.yaml
 
-		# Applies control-plane label and taint to a specific node
+		# Applies control-plane label to a specific node
 		kubeadm init phase mark-control-plane --node-name myNode
 		`)
 )
@@ -62,5 +62,5 @@ func runMarkControlPlane(c workflow.RunData) error {
 	}
 
 	nodeRegistration := data.Cfg().NodeRegistration
-	return markcontrolplanephase.MarkControlPlane(client, nodeRegistration.Name, nodeRegistration.Taints)
+	return markcontrolplanephase.MarkControlPlane(client, nodeRegistration.Name)
 }

--- a/cmd/kubeadm/app/cmd/phases/init/uploadconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/uploadconfig.go
@@ -121,6 +121,8 @@ func runUploadKubeletConfig(c workflow.RunData) error {
 		return err
 	}
 
+	// todo Paco
+	// upload should use the configuration without tainted fields
 	klog.V(1).Infoln("[upload-config] Uploading the kubelet component config to a ConfigMap")
 	if err = kubeletphase.CreateConfigMap(&cfg.ClusterConfiguration, client); err != nil {
 		return errors.Wrap(err, "error creating kubelet configuration ConfigMap")

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -190,8 +190,8 @@ func runMarkControlPlanePhase(c workflow.RunData) error {
 	}
 
 	if !data.DryRun() {
-		if err := markcontrolplanephase.MarkControlPlane(client, cfg.NodeRegistration.Name, cfg.NodeRegistration.Taints); err != nil {
-			return errors.Wrap(err, "error applying control-plane label and taints")
+		if err := markcontrolplanephase.MarkControlPlane(client, cfg.NodeRegistration.Name); err != nil {
+			return errors.Wrap(err, "error applying control-plane label")
 		}
 	} else {
 		fmt.Printf("[control-plane-join] Would mark node %s as a control-plane\n", cfg.NodeRegistration.Name)

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	phases "k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/upgrade/node"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
+	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 )
@@ -128,14 +129,7 @@ func newNodeData(cmd *cobra.Command, args []string, options *nodeOptions) (*node
 		return nil, errors.Wrapf(err, "couldn't create a Kubernetes client from file %q", options.kubeConfigPath)
 	}
 
-	// isControlPlane checks if a node is a control-plane node by looking up
-	// the kube-apiserver manifest file
-	isControlPlaneNode := true
-	filepath := constants.GetStaticPodFilepath(constants.KubeAPIServer, constants.GetStaticPodDirectory())
-	if _, err := os.Stat(filepath); os.IsNotExist(err) {
-		isControlPlaneNode = false
-	}
-
+	isControlPlaneNode := cmdutil.IsControlPlaneNode()
 	// Fetches the cluster configuration
 	// NB in case of control-plane node, we are reading all the info for the node; in case of NOT control-plane node
 	//    (worker node), we are not reading local API address and the CRI socket from the node object

--- a/cmd/kubeadm/app/cmd/util/cmdutil.go
+++ b/cmd/kubeadm/app/cmd/util/cmdutil.go
@@ -17,6 +17,8 @@ limitations under the License.
 package util
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -26,6 +28,7 @@ import (
 
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
@@ -99,4 +102,14 @@ func DefaultInitConfiguration() *kubeadmapiv1.InitConfiguration {
 		},
 	}
 	return initCfg
+}
+
+// isControlPlaneNode checks if a node is a control-plane node by looking up
+// the kube-apiserver manifest file
+func IsControlPlaneNode() bool {
+	filepath := constants.GetStaticPodFilepath(constants.KubeAPIServer, constants.GetStaticPodDirectory())
+	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+		return false
+	}
+	return true
 }

--- a/cmd/kubeadm/app/componentconfigs/kubelet_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_test.go
@@ -60,12 +60,12 @@ func TestKubeletDefault(t *testing.T) {
 	tests := []struct {
 		name       string
 		clusterCfg kubeadmapi.ClusterConfiguration
-		expected   kubeletConfig
+		expected   KubeletConfig
 	}{
 		{
 			name:       "No specific defaulting works",
 			clusterCfg: kubeadmapi.ClusterConfiguration{},
-			expected: kubeletConfig{
+			expected: KubeletConfig{
 				config: kubeletconfig.KubeletConfiguration{
 					FeatureGates:  map[string]bool{},
 					StaticPodPath: kubeadmapiv1.DefaultManifestsDir,
@@ -99,7 +99,7 @@ func TestKubeletDefault(t *testing.T) {
 					ServiceSubnet: "192.168.0.0/16",
 				},
 			},
-			expected: kubeletConfig{
+			expected: KubeletConfig{
 				config: kubeletconfig.KubeletConfiguration{
 					FeatureGates:  map[string]bool{},
 					StaticPodPath: kubeadmapiv1.DefaultManifestsDir,
@@ -133,7 +133,7 @@ func TestKubeletDefault(t *testing.T) {
 					ServiceSubnet: "192.168.0.0/16",
 				},
 			},
-			expected: kubeletConfig{
+			expected: KubeletConfig{
 				config: kubeletconfig.KubeletConfiguration{
 					FeatureGates:  map[string]bool{},
 					StaticPodPath: kubeadmapiv1.DefaultManifestsDir,
@@ -167,7 +167,7 @@ func TestKubeletDefault(t *testing.T) {
 					DNSDomain: "example.com",
 				},
 			},
-			expected: kubeletConfig{
+			expected: KubeletConfig{
 				config: kubeletconfig.KubeletConfiguration{
 					FeatureGates:  map[string]bool{},
 					StaticPodPath: kubeadmapiv1.DefaultManifestsDir,
@@ -200,7 +200,7 @@ func TestKubeletDefault(t *testing.T) {
 			clusterCfg: kubeadmapi.ClusterConfiguration{
 				CertificatesDir: "/path/to/certs",
 			},
-			expected: kubeletConfig{
+			expected: KubeletConfig{
 				config: kubeletconfig.KubeletConfiguration{
 					FeatureGates:  map[string]bool{},
 					StaticPodPath: kubeadmapiv1.DefaultManifestsDir,
@@ -235,7 +235,7 @@ func TestKubeletDefault(t *testing.T) {
 			expected := test.expected
 			expected.configBase.GroupVersion = kubeletconfig.SchemeGroupVersion
 
-			got := &kubeletConfig{
+			got := &KubeletConfig{
 				configBase: configBase{
 					GroupVersion: kubeletconfig.SchemeGroupVersion,
 				},
@@ -267,7 +267,7 @@ func runKubeletFromTest(t *testing.T, perform func(gvk schema.GroupVersionKind, 
 	if cfg == nil {
 		t.Fatal("no config loaded where it should have been")
 	}
-	if kubeletCfg, ok := cfg.(*kubeletConfig); !ok {
+	if kubeletCfg, ok := cfg.(*KubeletConfig); !ok {
 		t.Fatalf("found different object type than expected: %s", reflect.TypeOf(cfg))
 	} else if kubeletCfg.config.ClusterDomain != clusterDomain {
 		t.Fatalf("unexpected control value (clusterDomain):\n\tgot: %q\n\texpected: %q", kubeletCfg.config.ClusterDomain, clusterDomain)

--- a/cmd/kubeadm/app/componentconfigs/kubelet_unix.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_unix.go
@@ -20,6 +20,6 @@ limitations under the License.
 package componentconfigs
 
 // Mutate allows applying pre-defined modifications to the config before it's marshaled.
-func (kc *kubeletConfig) Mutate() error {
+func (kc *KubeletConfig) Mutate() error {
 	return nil
 }

--- a/cmd/kubeadm/app/componentconfigs/kubelet_windows.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_windows.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Mutate modifies absolute path fields in the KubeletConfiguration to be Windows compatible absolute paths.
-func (kc *kubeletConfig) Mutate() error {
+func (kc *KubeletConfig) Mutate() error {
 	// When "kubeadm join" downloads the KubeletConfiguration from the cluster on Windows
 	// nodes, it would contain absolute paths that may lack drive letters, since the config
 	// could have been generated on a Linux control-plane node. On Windows the

--- a/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane.go
+++ b/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane.go
@@ -32,44 +32,18 @@ var labelsToAdd = []string{
 	constants.LabelExcludeFromExternalLB,
 }
 
-// MarkControlPlane taints the control-plane and sets the control-plane label
-func MarkControlPlane(client clientset.Interface, controlPlaneName string, taints []v1.Taint) error {
+// MarkControlPlane sets the control-plane label
+func MarkControlPlane(client clientset.Interface, controlPlaneName string) error {
 	fmt.Printf("[mark-control-plane] Marking the node %s as control-plane by adding the labels: %v\n",
 		controlPlaneName, labelsToAdd)
 
-	if len(taints) > 0 {
-		taintStrs := []string{}
-		for _, taint := range taints {
-			taintStrs = append(taintStrs, taint.ToString())
-		}
-		fmt.Printf("[mark-control-plane] Marking the node %s as control-plane by adding the taints %v\n", controlPlaneName, taintStrs)
-	}
-
 	return apiclient.PatchNode(client, controlPlaneName, func(n *v1.Node) {
-		markControlPlaneNode(n, taints)
+		markControlPlaneNode(n)
 	})
 }
 
-func taintExists(taint v1.Taint, taints []v1.Taint) bool {
-	for _, t := range taints {
-		if t == taint {
-			return true
-		}
-	}
-
-	return false
-}
-
-func markControlPlaneNode(n *v1.Node, taints []v1.Taint) {
+func markControlPlaneNode(n *v1.Node) {
 	for _, label := range labelsToAdd {
 		n.ObjectMeta.Labels[label] = ""
 	}
-
-	for _, nt := range n.Spec.Taints {
-		if !taintExists(nt, taints) {
-			taints = append(taints, nt)
-		}
-	}
-
-	n.Spec.Taints = taints
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubeadm/issues/1621

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: move Control Planes taint to kubelet config instead of mark-control-plane phase
```
