### PR TITLE
[release-1.23] [go] Update Go to 1.17.9

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.23.0-go1.17.8-bullseye.0
+v1.23.0-go1.17.9-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -91,7 +91,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
 readonly __default_debian_iptables_version=bullseye-v1.1.0
-readonly __default_go_runner_version=v2.3.1-go1.17.8-bullseye.0
+readonly __default_go_runner_version=v2.3.1-go1.17.9-bullseye.0
 readonly __default_setcap_version=bullseye-v1.0.0
 
 # These are the base images for the Docker-wrapped binaries.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -87,7 +87,7 @@ dependencies:
 
   # Golang
   - name: "golang: upstream version"
-    version: 1.17.8
+    version: 1.17.9
     refPaths:
     - path: build/build-image/cross/VERSION
     - path: cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
@@ -116,7 +116,7 @@ dependencies:
       match: 'GOLANG_VERSION\?=\d+.\d+(alpha|beta|rc)?\.?(\d+)?'
 
   - name: "k8s.gcr.io/kube-cross: dependents"
-    version: v1.23.0-go1.17.8-bullseye.0
+    version: v1.23.0-go1.17.9-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -146,7 +146,7 @@ dependencies:
       match: configs\[DebianIptables\] = Config{list\.BuildImageRegistry, "debian-iptables", "[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"}
 
   - name: "k8s.gcr.io/go-runner: dependents"
-    version: v2.3.1-go1.17.8-bullseye.0
+    version: v2.3.1-go1.17.9-bullseye.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.8 AS builder
+FROM golang:1.17.9 AS builder
 COPY elasticsearch_logging_discovery.go go.mod go.sum /
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -ldflags "-w" -o /elasticsearch_logging_discovery /elasticsearch_logging_discovery.go
 

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,7 +7,7 @@ recursive-delete-patterns:
 - BUILD.bazel
 - "*/BUILD.bazel"
 - Gopkg.toml
-default-go-version: 1.17.8
+default-go-version: 1.17.9
 rules:
 - destination: code-generator
   branches:

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -16,7 +16,7 @@ REGISTRY ?= k8s.gcr.io/e2e-test-images
 GOARM ?= 7
 DOCKER_CERT_BASE_PATH ?=
 QEMUVERSION=v5.1.0-2
-GOLANG_VERSION=1.17.8
+GOLANG_VERSION=1.17.9
 export
 
 ifndef WHAT


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Update Go to 1.17.9

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2499

#### Does this PR introduce a user-facing change?
```release-note
Kubernetes is now built with Golang 1.17.9
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assign @xmudrii  @saschagrunert @palnabarun @puerco @justaugustus @dims 
cc @kubernetes/release-engineering 