### PR TITLE
Use module mode when building/installing

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -106,7 +106,7 @@ ginkgo:
 	echo "$$GINKGO_HELP_INFO"
 else
 ginkgo:
-	hack/make-rules/build.sh vendor/github.com/onsi/ginkgo/ginkgo
+	hack/make-rules/build.sh github.com/onsi/ginkgo/ginkgo
 endif
 
 define VERIFY_HELP_INFO

--- a/build/root/Makefile.generated_files
+++ b/build/root/Makefile.generated_files
@@ -219,7 +219,7 @@ $(PRERELEASE_LIFECYCLE_FILES): $(PRERELEASE_LIFECYCLE_GEN)
 # it, and make is happy.
 $(PRERELEASE_LIFECYCLE_GEN): $(GODEPS_k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/prerelease-lifecycle-gen)
 	KUBE_BUILD_PLATFORMS="" \
-	    hack/make-rules/build.sh vendor/k8s.io/code-generator/cmd/prerelease-lifecycle-gen
+	    hack/make-rules/build.sh k8s.io/code-generator/cmd/prerelease-lifecycle-gen
 	touch $@
 
 
@@ -314,7 +314,7 @@ $(DEEPCOPY_FILES): $(DEEPCOPY_GEN)
 # it, and make is happy.
 $(DEEPCOPY_GEN): $(GODEPS_k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/deepcopy-gen)
 	KUBE_BUILD_PLATFORMS="" \
-	    hack/make-rules/build.sh vendor/k8s.io/code-generator/cmd/deepcopy-gen
+	    hack/make-rules/build.sh k8s.io/code-generator/cmd/deepcopy-gen
 	touch $@
 
 
@@ -415,7 +415,7 @@ $(DEFAULTER_FILES): $(DEFAULTER_GEN)
 # it, and make is happy.
 $(DEFAULTER_GEN): $(GODEPS_k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/defaulter-gen)
 	KUBE_BUILD_PLATFORMS="" \
-	    hack/make-rules/build.sh vendor/k8s.io/code-generator/cmd/defaulter-gen
+	    hack/make-rules/build.sh k8s.io/code-generator/cmd/defaulter-gen
 	touch $@
 
 
@@ -529,7 +529,7 @@ $(CONVERSION_FILES): $(CONVERSION_GEN)
 # and make is happy.
 $(CONVERSION_GEN): $(GODEPS_k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/conversion-gen)
 	KUBE_BUILD_PLATFORMS="" \
-	    hack/make-rules/build.sh vendor/k8s.io/code-generator/cmd/conversion-gen
+	    hack/make-rules/build.sh k8s.io/code-generator/cmd/conversion-gen
 	touch $@
 
 
@@ -656,5 +656,5 @@ gen_openapi: $(OPENAPI_GEN) $(KUBE_OPENAPI_OUTFILE) $(AGGREGATOR_OPENAPI_OUTFILE
 # it, and make is happy.
 $(OPENAPI_GEN): $(GODEPS_k8s.io/kubernetes/vendor/k8s.io/kube-openapi/cmd/openapi-gen)
 	KUBE_BUILD_PLATFORMS="" \
-	    hack/make-rules/build.sh vendor/k8s.io/kube-openapi/cmd/openapi-gen
+	    hack/make-rules/build.sh k8s.io/kube-openapi/cmd/openapi-gen
 	touch $@

--- a/hack/dev-push-conformance.sh
+++ b/hack/dev-push-conformance.sh
@@ -42,7 +42,7 @@ IMAGE="${REGISTRY}/conformance-amd64:${VERSION}"
 
 kube::build::verify_prereqs
 kube::build::build_image
-kube::build::run_build_command make WHAT="vendor/github.com/onsi/ginkgo/ginkgo test/e2e/e2e.test cmd/kubectl test/conformance/image/go-runner"
+kube::build::run_build_command make WHAT="github.com/onsi/ginkgo/ginkgo test/e2e/e2e.test cmd/kubectl test/conformance/image/go-runner"
 kube::build::copy_output
 
 make -C "${KUBE_ROOT}/test/conformance/image" build

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -111,7 +111,7 @@ readonly KUBE_SERVER_IMAGE_BINARIES=("${KUBE_SERVER_IMAGE_TARGETS[@]##*/}")
 kube::golang::conformance_image_targets() {
   # NOTE: this contains cmd targets for kube::release::build_conformance_image
   local targets=(
-    vendor/github.com/onsi/ginkgo/ginkgo
+    github.com/onsi/ginkgo/ginkgo
     test/e2e/e2e.test
     test/conformance/image/go-runner
     cmd/kubectl
@@ -274,7 +274,7 @@ kube::golang::test_targets() {
     cmd/genyaml
     cmd/genswaggertypedocs
     cmd/linkcheck
-    vendor/github.com/onsi/ginkgo/ginkgo
+    github.com/onsi/ginkgo/ginkgo
     test/e2e/e2e.test
     test/conformance/image/go-runner
   )
@@ -301,7 +301,7 @@ readonly KUBE_TEST_PORTABLE=(
 kube::golang::server_test_targets() {
   local targets=(
     cmd/kubemark
-    vendor/github.com/onsi/ginkgo/ginkgo
+    github.com/onsi/ginkgo/ginkgo
   )
 
   if [[ "${OSTYPE:-}" == "linux"* ]]; then

--- a/hack/lib/protoc.sh
+++ b/hack/lib/protoc.sh
@@ -27,7 +27,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 # $1: Full path to the directory where the api.proto file is
 function kube::protoc::generate_proto() {
   kube::golang::setup_env
-  go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
+  GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
   kube::protoc::check_protoc
 

--- a/hack/lib/swagger.sh
+++ b/hack/lib/swagger.sh
@@ -53,7 +53,7 @@ EOF
 
   if ! which genswaggertypedocs >/dev/null; then
     # build if needed
-    go install k8s.io/kubernetes/cmd/genswaggertypedocs
+    GO111MODULE=on GOPROXY=off go install k8s.io/kubernetes/cmd/genswaggertypedocs
   fi
 
   genswaggertypedocs -s \

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -26,11 +26,11 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-go install k8s.io/kubernetes/pkg/generated/openapi/cmd/models-schema
-go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/client-gen
-go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/lister-gen
-go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/informer-gen
-go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/applyconfiguration-gen
+GO111MODULE=on GOPROXY=off go install k8s.io/kubernetes/pkg/generated/openapi/cmd/models-schema
+GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/client-gen
+GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/lister-gen
+GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/informer-gen
+GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/applyconfiguration-gen
 
 modelsschema=$(kube::util::find-binary "models-schema")
 clientgen=$(kube::util::find-binary "client-gen")

--- a/hack/update-generated-kms-dockerized.sh
+++ b/hack/update-generated-kms-dockerized.sh
@@ -24,7 +24,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
+GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
 if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3."* ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"

--- a/hack/update-generated-protobuf-dockerized.sh
+++ b/hack/update-generated-protobuf-dockerized.sh
@@ -28,8 +28,8 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/go-to-protobuf
-go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
+GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/go-to-protobuf
+GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
 if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3."* ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"

--- a/hack/update-generated-runtime-dockerized.sh
+++ b/hack/update-generated-runtime-dockerized.sh
@@ -29,7 +29,7 @@ runtime_versions=("v1alpha2" "v1")
 
 kube::golang::setup_env
 
-go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
+GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
 if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3."* ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"

--- a/hack/update-generated-swagger-docs.sh
+++ b/hack/update-generated-swagger-docs.sh
@@ -36,7 +36,7 @@ for group_version in "${GROUP_VERSIONS[@]}"; do
   rm -f "$(kube::util::group-version-to-pkg-path "${group_version}")/types_swagger_doc_generated.go"
 done
 # ensure we have the latest genswaggertypedocs built
-go install k8s.io/kubernetes/cmd/genswaggertypedocs
+GO111MODULE=on GOPROXY=off go install k8s.io/kubernetes/cmd/genswaggertypedocs
 for group_version in "${GROUP_VERSIONS[@]}"; do
   kube::swagger::gen_types_swagger_doc "${group_version}" "$(kube::util::group-version-to-pkg-path "${group_version}")"
 done

--- a/hack/verify-import-boss.sh
+++ b/hack/verify-import-boss.sh
@@ -28,7 +28,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/import-boss
+GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/import-boss
 
 packages=(
   "k8s.io/kubernetes/pkg/..."

--- a/test/conformance/gen-specsummaries.sh
+++ b/test/conformance/gen-specsummaries.sh
@@ -26,7 +26,7 @@ cd "${KUBE_ROOT}"
 # NOTE: we do *not* use `make WHAT=...` because we do *not* want to be running
 # make generated_files when diffing things (see: hack/verify-conformance-yaml.sh)
 # other update/verify already handle the generated files
-hack/make-rules/build.sh vendor/github.com/onsi/ginkgo/ginkgo test/e2e/e2e.test
+hack/make-rules/build.sh github.com/onsi/ginkgo/ginkgo test/e2e/e2e.test
 
 # dump spec
 ./_output/bin/ginkgo --dryRun=true --focus='[Conformance]' ./_output/bin/e2e.test -- --spec-dump "${KUBE_ROOT}/_output/specsummaries.json" > /dev/null

--- a/test/e2e_node/builder/build.go
+++ b/test/e2e_node/builder/build.go
@@ -33,7 +33,7 @@ var k8sBinDir = flag.String("k8s-bin-dir", "", "Directory containing k8s kubelet
 var buildTargets = []string{
 	"cmd/kubelet",
 	"test/e2e_node/e2e_node.test",
-	"vendor/github.com/onsi/ginkgo/ginkgo",
+	"github.com/onsi/ginkgo/ginkgo",
 	"cluster/gce/gci/mounter",
 	"test/e2e_node/plugins/gcp-credential-provider",
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Targeted change to build with module mode enabled to be able to use buildinfo added in go1.18

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/kubernetes/issues/82531

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Kubernetes binaries are now built in module mode instead of GOPATH mode
```

