### PR TITLE
Update publishing-bot rules for Go 1.17.9

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -35,7 +35,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/code-generator
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
 
 - destination: apimachinery
   library: true
@@ -63,7 +63,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apimachinery
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
 
 - destination: api
   library: true
@@ -103,7 +103,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/api
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -170,7 +170,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/client-go
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -235,7 +235,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-base
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -298,7 +298,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-helpers
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -369,7 +369,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apiserver
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -457,7 +457,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -569,7 +569,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -670,7 +670,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/sample-controller
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -771,7 +771,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -850,7 +850,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/metrics
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -915,7 +915,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: api
       branch: release-1.23
@@ -986,7 +986,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1059,7 +1059,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1132,7 +1132,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubelet
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1205,7 +1205,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1286,7 +1286,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/controller-manager
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1385,7 +1385,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1496,7 +1496,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1561,7 +1561,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1614,7 +1614,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1647,7 +1647,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/mount-utils
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
 
 - destination: legacy-cloud-providers
   library: true
@@ -1755,7 +1755,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1804,7 +1804,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cri-api
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
 
 - destination: kubectl
   library: true
@@ -1900,7 +1900,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubectl
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1957,7 +1957,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/pod-security-admission
     name: release-1.23
-    go: 1.17.8
+    go: 1.17.9
     dependencies:
     - repository: api
       branch: release-1.23


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Update publishing-bot rules for Go 1.17.9

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2499

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assign @xmudrii  @saschagrunert @palnabarun @Verolop @dims @nikhita 
cc @kubernetes/release-engineering 