### PR TITLE
Remove pjh from cluster/gce/ OWNERS files

### DIFF
--- a/cluster/gce/OWNERS
+++ b/cluster/gce/OWNERS
@@ -7,7 +7,6 @@ reviewers:
   - yujuhong
   - mtaufen
   - ibabou
-  - pjh
   - sig-scalability-reviewers
 approvers:
   - bowei
@@ -16,7 +15,6 @@ approvers:
   - yujuhong
   - mtaufen
   - ibabou
-  - pjh
   - sig-scalability-approvers
 emeritus_approvers:
   - gmarek

--- a/cluster/gce/windows/OWNERS
+++ b/cluster/gce/windows/OWNERS
@@ -3,14 +3,14 @@
 reviewers:
   - ibabou
   - mtaufen
-  - pjh
   - yujuhong
   - yliaog
 approvers:
   - ibabou
   - mtaufen
-  - pjh
   - yujuhong
   - yliaog
+emeritus_approvers:
+  - pjh
 labels:
   - area/provider/gcp


### PR DESCRIPTION
I'm no longer working on Kubernetes / GKE on a regular basis.

I've moved myself to emeritus_approvers for the windows directory - this seems appropriate according to https://www.kubernetes.dev/docs/guide/owners/#emeritus.

/kind cleanup
```release-note
NONE
```