### PR TITLE
Fix crash in E2E Job lifecycle test when the job doesn't have annotations

### DIFF
--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -577,6 +577,9 @@ var _ = SIGDescribe("Job", func() {
 			patchedJob, err = jobClient.Get(context.TODO(), jobName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Unable to get job %s", jobName)
 			patchedJob.Spec.Suspend = pointer.BoolPtr(false)
+			if patchedJob.Annotations == nil {
+				patchedJob.Annotations = map[string]string{}
+			}
 			patchedJob.Annotations["updated"] = "true"
 			updatedJob, err = e2ejob.UpdateJob(f.ClientSet, ns, patchedJob)
 			return err


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

This test was initially created via PR #108642.
The test passed the 2 week flake free requiement, and was promoted to conformance with PR #109266
On submitting the Promotion PR it failed on the `pull-kubernetes-conformance-kind-ga-only-parallel` test due to an [assumption that annotations are alway set](https://github.com/kubernetes/kubernetes/pull/109266#issuecomment-1087917683). 
This PR correct the issue. The results was run against `/pull-kubernetes-conformance-kind-ga-only-parallel` locally in a Kind cluster and the test pass as expected.

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- patchBatchV1NamespacedJob
- replaceBatchV1NamespacedJob
- deleteBatchV1CollectionNamespacedJob
- listBatchV1JobForAllNamespaces

**Which issue(s) this PR fixes:**
Fixes #108641

**Testgrid Link:**


**Special notes for your reviewer:**
Adds +4 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance
