### PR TITLE
scheduler volumebinding: leverage PreFilterResult

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/fake_binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/fake_binder.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package volumebinding
 
-import v1 "k8s.io/api/core/v1"
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
 
 // FakeVolumeBinderConfig holds configurations for fake volume binder.
 type FakeVolumeBinderConfig struct {
@@ -42,13 +45,20 @@ type FakeVolumeBinder struct {
 	BindCalled   bool
 }
 
+var _ SchedulerVolumeBinder = &FakeVolumeBinder{}
+
 // GetPodVolumes implements SchedulerVolumeBinder.GetPodVolumes.
 func (b *FakeVolumeBinder) GetPodVolumes(pod *v1.Pod) (boundClaims, unboundClaimsDelayBinding, unboundClaimsImmediate []*v1.PersistentVolumeClaim, err error) {
 	return nil, nil, nil, nil
 }
 
+// GetEligibleNodes implements SchedulerVolumeBinder.GetEligibleNodes.
+func (b *FakeVolumeBinder) GetEligibleNodes(boundClaims []*v1.PersistentVolumeClaim) (sets.String, error) {
+	return nil, nil
+}
+
 // FindPodVolumes implements SchedulerVolumeBinder.FindPodVolumes.
-func (b *FakeVolumeBinder) FindPodVolumes(pod *v1.Pod, _, _ []*v1.PersistentVolumeClaim, node *v1.Node) (podVolumes *PodVolumes, reasons ConflictReasons, err error) {
+func (b *FakeVolumeBinder) FindPodVolumes(pod *v1.Pod, _, _ []*v1.PersistentVolumeClaim, node *v1.Node, skipNodeAffinityCheck bool) (podVolumes *PodVolumes, reasons ConflictReasons, err error) {
 	return nil, b.config.FindReasons, b.config.FindErr
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This change will leverage the new PreFilterResult
to allow the NodeAffinity check for bound claims
to be done during PreFilter to reduce down the list
of eligible nodes in subsequent scheduling stages.

Today, the NodeAffinity check is done during Filter
which means all nodes will be considered even though
there may be a large number of nodes that are not eligible
due to not matching the pod bound PV(s)' node affinity
requirement. This change will shift the node affinity
check to PreFilter in order to ensure during Filter
we are only considering the reduced list of nodes. This
can provide a more clear message to users when nodes are
not available for scheduling since the list is not reduced
to only eligible nodes.

If error is encountered during node affinity check or if
the set of nodes returned is empty, then we will still
proceed to consider all nodes for the rest of scheduling stages.
If node affinity check returns a reduced list, then we set
a boolean flag in the cycle state to indicate to the Filter
stage that node affinity check can be skipped to avoid
duplicating work.

Signed-off-by: Yibo Zhuang <yibzhuang@gmail.com>


### Testing example:
- 100 nodes cluster
- all 100 nodes tainted with different key, value
- pod has a bound PVC to PV with node affinity only matching 5/100 nodes

__without__ `PreFilter` change, scheduling output

```
  Type     Reason            Age   From               Message
  ----     ------            ----  ----               -------
  Warning  FailedScheduling  3s    default-scheduler  0/100 nodes are available: 1 node(s) had untolerated taint {key-fake-0: value-fake-0}, 1 node(s) had untolerated taint {key-fake-10: value-fake-10}, 1 node(s) had untolerated taint {key-fake-11: value-fake-11}, 1 node(s) had untolerated taint {key-fake-12: value-fake-12}, 1 node(s) had untolerated taint {key-fake-13: value-fake-13}, 1 node(s) had untolerated taint {key-fake-14: value-fake-14}, 1 node(s) had untolerated taint {key-fake-15: value-fake-15}, 1 node(s) had untolerated taint {key-fake-16: value-fake-16}, 1 node(s) had untolerated taint {key-fake-17: value-fake-17}, 1 node(s) had untolerated taint {key-fake-18: value-fake-18}, 1 node(s) had untolerated taint {key-fake-19: value-fake-19}, 1 node(s) had untolerated taint {key-fake-1: value-fake-1}, 1 node(s) had untolerated taint {key-fake-20: value-fake-20}, 1 node(s) had untolerated taint {key-fake-21: value-fake-21}, 1 node(s) had untolerated taint {key-fake-22: value-fake-22}, 1 node(s) had untolerated taint {key-fake-23: value-fake-23}, 1 nod ...
```

__with__ `PreFilter` change, scheduling output

```
  Type     Reason            Age   From               Message
  ----     ------            ----  ----               -------
  Warning  FailedScheduling  3s    default-scheduler  0/100 nodes are available: 1 node(s) had untolerated taint {key-fake-0: value-fake-0}, 1 node(s) had untolerated taint {key-fake-10: value-fake-10}, 1 node(s) had untolerated taint {key-fake-11: value-fake-11}, 1 node(s) had untolerated taint {key-fake-12: value-fake-12}, 1 node(s) had untolerated taint {key-fake-1: value-fake-1}. preemption: 0/100 nodes are available: 5 Preemption is not helpful for scheduling, 95 No preemption victims found for incoming pod.
```

#### Which issue(s) this PR fixes:

Fixes #109475 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
scheduler volumebinding: leverage PreFilterResult to reduce down to only eligible nodes for pod with bound claims
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
