### PR TITLE
Implementation of a function that returns the wait state of the scheduler

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -193,16 +193,21 @@ func (s *Status) IsSuccess() bool {
 	return s.Code() == Success
 }
 
+// IsWait returns true if and only if "Status" is non-nil and its Code is "Wait".
+func (s *Status) IsWait() bool {
+	return s.Code() == Wait
+}
+
 // IsUnschedulable returns true if "Status" is Unschedulable (Unschedulable or UnschedulableAndUnresolvable).
 func (s *Status) IsUnschedulable() bool {
 	code := s.Code()
 	return code == Unschedulable || code == UnschedulableAndUnresolvable
 }
 
-// AsError returns nil if the status is a success; otherwise returns an "error" object
+// AsError returns nil if the status is a success or a wait; otherwise returns an "error" object
 // with a concatenated message on reasons of the Status.
 func (s *Status) AsError() error {
-	if s.IsSuccess() {
+	if s.IsSuccess() || s.IsWait() {
 		return nil
 	}
 	if s.err != nil {

--- a/pkg/scheduler/framework/interface_test.go
+++ b/pkg/scheduler/framework/interface_test.go
@@ -34,6 +34,7 @@ func TestStatus(t *testing.T) {
 		expectedCode      Code
 		expectedMessage   string
 		expectedIsSuccess bool
+		expectedIsWait    bool
 		expectedAsError   error
 	}{
 		{
@@ -42,6 +43,16 @@ func TestStatus(t *testing.T) {
 			expectedCode:      Success,
 			expectedMessage:   "",
 			expectedIsSuccess: true,
+			expectedIsWait:    false,
+			expectedAsError:   nil,
+		},
+		{
+			name:              "wait status",
+			status:            NewStatus(Wait, ""),
+			expectedCode:      Wait,
+			expectedMessage:   "",
+			expectedIsSuccess: false,
+			expectedIsWait:    true,
 			expectedAsError:   nil,
 		},
 		{
@@ -50,6 +61,7 @@ func TestStatus(t *testing.T) {
 			expectedCode:      Error,
 			expectedMessage:   "unknown error",
 			expectedIsSuccess: false,
+			expectedIsWait:    false,
 			expectedAsError:   errors.New("unknown error"),
 		},
 		{
@@ -74,6 +86,10 @@ func TestStatus(t *testing.T) {
 
 			if test.status.IsSuccess() != test.expectedIsSuccess {
 				t.Errorf("expect status.IsSuccess() returns %v, but %v", test.expectedIsSuccess, test.status.IsSuccess())
+			}
+
+			if test.status.IsWait() != test.expectedIsWait {
+				t.Errorf("status.IsWait() returns %v, but want %v", test.status.IsWait(), test.expectedIsWait)
 			}
 
 			if test.status.AsError() == test.expectedAsError {

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -1158,7 +1158,7 @@ func (f *frameworkImpl) RunPermitPlugins(ctx context.Context, state *framework.C
 				status.SetFailedPlugin(pl.Name())
 				return status
 			}
-			if status.Code() == framework.Wait {
+			if status.IsWait() {
 				// Not allowed to be greater than maxTimeout.
 				if timeout > maxTimeout {
 					timeout = maxTimeout

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -164,7 +164,7 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 
 	// Run "permit" plugins.
 	runPermitStatus := fwk.RunPermitPlugins(schedulingCycleCtx, state, assumedPod, scheduleResult.SuggestedHost)
-	if runPermitStatus.Code() != framework.Wait && !runPermitStatus.IsSuccess() {
+	if !runPermitStatus.IsWait() && !runPermitStatus.IsSuccess() {
 		var reason string
 		if runPermitStatus.IsUnschedulable() {
 			metrics.PodUnschedulable(fwk.ProfileName(), metrics.SinceInSeconds(start))


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
I thought it would be useful to have this function when I am building my own Kubernetes scheduler, so I sent a PR.
Just as Success has an IsSuccess function, it would be nice to have an IsWait for Wait.
I am new to Kubernetes, so maybe this is a pointless change.
But I sent this PR in the hope that there is even a small chance of keeping the code clean. If it's useless, feel free to delete it!
Any reviews would be greatly appreciated!

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
