### PR TITLE
Introduce KUBECACHEDIR environment variable to override default discovery cache dir

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -276,12 +276,18 @@ func (f *ConfigFlags) toDiscoveryClient() (discovery.CachedDiscoveryInterface, e
 	config.QPS = f.discoveryQPS
 
 	cacheDir := defaultCacheDir
+	if kcd := os.Getenv("KUBECACHEDIR"); kcd != "" {
+		cacheDir = kcd
+	}
 
 	// retrieve a user-provided value for the "cache-dir"
 	// override httpCacheDir and discoveryCacheDir if user-value is given.
-	if f.CacheDir != nil {
+	// user-provided value has higher precedence than default
+	// and KUBECACHEDIR environment variable.
+	if f.CacheDir != nil && *f.CacheDir != "" {
 		cacheDir = *f.CacheDir
 	}
+
 	httpCacheDir := filepath.Join(cacheDir, "http")
 	discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(cacheDir, "discovery"), config.Host)
 
@@ -420,7 +426,7 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 		Timeout:    utilpointer.String("0"),
 		KubeConfig: utilpointer.String(""),
 
-		CacheDir:         utilpointer.String(defaultCacheDir),
+		CacheDir:         utilpointer.String(""),
 		ClusterName:      utilpointer.String(""),
 		AuthInfoName:     utilpointer.String(""),
 		Context:          utilpointer.String(""),

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -284,7 +284,7 @@ func (f *ConfigFlags) toDiscoveryClient() (discovery.CachedDiscoveryInterface, e
 	// override httpCacheDir and discoveryCacheDir if user-value is given.
 	// user-provided value has higher precedence than default
 	// and KUBECACHEDIR environment variable.
-	if f.CacheDir != nil && *f.CacheDir != "" {
+	if f.CacheDir != nil && *f.CacheDir != "" && *f.CacheDir != defaultCacheDir {
 		cacheDir = *f.CacheDir
 	}
 
@@ -426,7 +426,7 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 		Timeout:    utilpointer.String("0"),
 		KubeConfig: utilpointer.String(""),
 
-		CacheDir:         utilpointer.String(""),
+		CacheDir:         utilpointer.String(defaultCacheDir),
 		ClusterName:      utilpointer.String(""),
 		AuthInfoName:     utilpointer.String(""),
 		Context:          utilpointer.String(""),

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -57,10 +57,6 @@ const (
 	flagCacheDir         = "cache-dir"
 )
 
-var (
-	defaultCacheDir = filepath.Join(homedir.HomeDir(), ".kube", "cache")
-)
-
 // RESTClientGetter is an interface that the ConfigFlags describe to provide an easier way to mock for commands
 // and eliminate the direct coupling to a struct type.  Users may wish to duplicate this type in their own packages
 // as per the golang type overlapping.
@@ -275,16 +271,13 @@ func (f *ConfigFlags) toDiscoveryClient() (discovery.CachedDiscoveryInterface, e
 	config.Burst = f.discoveryBurst
 	config.QPS = f.discoveryQPS
 
-	cacheDir := defaultCacheDir
-	if kcd := os.Getenv("KUBECACHEDIR"); kcd != "" {
-		cacheDir = kcd
-	}
+	cacheDir := getDefaultCacheDir()
 
 	// retrieve a user-provided value for the "cache-dir"
 	// override httpCacheDir and discoveryCacheDir if user-value is given.
 	// user-provided value has higher precedence than default
 	// and KUBECACHEDIR environment variable.
-	if f.CacheDir != nil && *f.CacheDir != "" && *f.CacheDir != defaultCacheDir {
+	if f.CacheDir != nil && *f.CacheDir != "" && *f.CacheDir != getDefaultCacheDir() {
 		cacheDir = *f.CacheDir
 	}
 
@@ -292,6 +285,17 @@ func (f *ConfigFlags) toDiscoveryClient() (discovery.CachedDiscoveryInterface, e
 	discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(cacheDir, "discovery"), config.Host)
 
 	return diskcached.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, time.Duration(6*time.Hour))
+}
+
+// getDefaultCacheDir returns default caching directory path.
+// it first looks at KUBECACHEDIR env var if it is set, otherwise
+// it returns standard kube cache dir.
+func getDefaultCacheDir() string {
+	if kcd := os.Getenv("KUBECACHEDIR"); kcd != "" {
+		return kcd
+	}
+
+	return filepath.Join(homedir.HomeDir(), ".kube", "cache")
 }
 
 // ToRESTMapper returns a mapper.
@@ -426,7 +430,7 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 		Timeout:    utilpointer.String("0"),
 		KubeConfig: utilpointer.String(""),
 
-		CacheDir:         utilpointer.String(defaultCacheDir),
+		CacheDir:         utilpointer.String(getDefaultCacheDir()),
 		ClusterName:      utilpointer.String(""),
 		AuthInfoName:     utilpointer.String(""),
 		Context:          utilpointer.String(""),


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR introduces new environment variable, namely `KUBECACHEDIR`. `KUBECACHEDIR`
is used to override default discovery cache directory for all commands(whose default value
is $HOME/.kube/cache).

`--cache-dir` flag per command has higher precedence than `KUBECACHEDIR` and default
directory path.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1184

#### Does this PR introduce a user-facing change?
```release-note
Introduce new KUBECACHEDIR environment variable to override default discovery cache directory which is $HOME/.kube/cache
```
