### PR TITLE
kube-proxy: fix healthz return unexpect code 200

### DIFF
--- a/pkg/proxy/healthcheck/proxier_health.go
+++ b/pkg/proxy/healthcheck/proxier_health.go
@@ -44,6 +44,7 @@ type ProxierHealthUpdater interface {
 }
 
 var _ ProxierHealthUpdater = &proxierHealthServer{}
+var zeroTime = time.Time{}
 
 // proxierHealthServer returns 200 "OK" by default. It verifies that the delay between
 // QueuedUpdate() calls and Updated() calls never exceeds healthTimeout.
@@ -57,8 +58,8 @@ type proxierHealthServer struct {
 	recorder      events.EventRecorder
 	nodeRef       *v1.ObjectReference
 
-	lastUpdated atomic.Value
-	lastQueued  atomic.Value
+	lastUpdated         atomic.Value
+	oldestPendingQueued atomic.Value
 }
 
 // NewProxierHealthServer returns a proxier health http server.
@@ -80,12 +81,14 @@ func newProxierHealthServer(listener listener, httpServerFactory httpServerFacto
 
 // Updated updates the lastUpdated timestamp.
 func (hs *proxierHealthServer) Updated() {
+	hs.oldestPendingQueued.Store(zeroTime)
 	hs.lastUpdated.Store(hs.clock.Now())
 }
 
 // QueuedUpdate updates the lastQueued timestamp.
 func (hs *proxierHealthServer) QueuedUpdate() {
-	hs.lastQueued.Store(hs.clock.Now())
+	// Set oldestPendingQueued only if it's currently zero
+	hs.oldestPendingQueued.CompareAndSwap(zeroTime, hs.clock.Now())
 }
 
 // Run starts the healthz HTTP server and blocks until it exits.
@@ -117,9 +120,9 @@ type healthzHandler struct {
 }
 
 func (h healthzHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
-	var lastQueued, lastUpdated time.Time
-	if val := h.hs.lastQueued.Load(); val != nil {
-		lastQueued = val.(time.Time)
+	var oldestPendingQueued, lastUpdated time.Time
+	if val := h.hs.oldestPendingQueued.Load(); val != nil {
+		oldestPendingQueued = val.(time.Time)
 	}
 	if val := h.hs.lastUpdated.Load(); val != nil {
 		lastUpdated = val.(time.Time)
@@ -128,15 +131,11 @@ func (h healthzHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 
 	healthy := false
 	switch {
-	case lastUpdated.IsZero():
+	case oldestPendingQueued.IsZero():
 		// The proxy is healthy while it's starting up
-		// TODO: this makes it useless as a readinessProbe. Consider changing
-		// to only become healthy after the proxy is fully synced.
+		// or the proxy is fully synced.
 		healthy = true
-	case lastUpdated.After(lastQueued):
-		// We've processed all updates
-		healthy = true
-	case currentTime.Sub(lastQueued) < h.hs.healthTimeout:
+	case currentTime.Sub(oldestPendingQueued) < h.hs.healthTimeout:
 		// There's an unprocessed update queued, but it's not late yet
 		healthy = true
 	}
@@ -147,14 +146,12 @@ func (h healthzHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusServiceUnavailable)
 	} else {
 		resp.WriteHeader(http.StatusOK)
-
 		// In older releases, the returned "lastUpdated" time indicated the last
 		// time the proxier sync loop ran, even if nothing had changed. To
 		// preserve compatibility, we use the same semantics: the returned
 		// lastUpdated value is "recent" if the server is healthy. The kube-proxy
 		// metrics provide more detailed information.
 		lastUpdated = currentTime
-
 	}
 	fmt.Fprintf(resp, `{"lastUpdated": %q,"currentTime": %q}`, lastUpdated, currentTime)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
fix when kube-proxy restore failed, but `/healthz` still return success
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/105742

#### Special notes for your reviewer:
I kept the `lastUpdated`, and I think `/healthz` should also return the time of `lastUpdated` and `currentTime`.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
