### PR TITLE
kubelet: migrate container-runtime endpoint flag into config

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -591,6 +591,8 @@ API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,V
 API rule violation: names_match,k8s.io/kube-proxy/config/v1alpha1,KubeProxyConfiguration,IPTables
 API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,IPTablesDropBit
 API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,IPTablesMasqueradeBit
+API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,RemoteImageEndpoint
+API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,RemoteRuntimeEndpoint
 API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,ResolverConfig
 API rule violation: names_match,k8s.io/metrics/pkg/apis/custom_metrics/v1beta1,MetricValue,WindowSeconds
 API rule violation: names_match,k8s.io/metrics/pkg/apis/external_metrics/v1beta1,ExternalMetricValue,WindowSeconds

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -96,10 +96,6 @@ type KubeletFlags struct {
 	// Source: https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities
 	WindowsPriorityClass string
 
-	// remoteRuntimeEndpoint is the endpoint of remote runtime service
-	RemoteRuntimeEndpoint string
-	// remoteImageEndpoint is the endpoint of remote image service
-	RemoteImageEndpoint string
 	// experimentalMounterPath is the path of mounter binary. Leave empty to use the default mount path
 	ExperimentalMounterPath string
 	// This flag, if set, will avoid including `EvictionHard` limits while computing Node Allocatable.
@@ -299,9 +295,6 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 
 	fs.StringVar(&f.RootDirectory, "root-dir", f.RootDirectory, "Directory path for managing kubelet files (volume mounts,etc).")
 
-	fs.StringVar(&f.RemoteRuntimeEndpoint, "container-runtime-endpoint", f.RemoteRuntimeEndpoint, "The endpoint of remote runtime service. Unix Domain Sockets are supported on Linux, while npipe and tcp endpoints are supported on Windows. Examples:'unix:///path/to/runtime.sock', 'npipe:////./pipe/runtime'")
-	fs.StringVar(&f.RemoteImageEndpoint, "image-service-endpoint", f.RemoteImageEndpoint, "The endpoint of remote image service. If not specified, it will be the same with --container-runtime-endpoint by default. Unix Domain Socket are supported on Linux, while npipe and tcp endpoints are supported on Windows. Examples:'unix:///path/to/runtime.sock', 'npipe:////./pipe/runtime'")
-
 	// EXPERIMENTAL FLAGS
 	bindableNodeLabels := cliflag.ConfigurationMap(f.NodeLabels)
 	fs.Var(&bindableNodeLabels, "node-labels", fmt.Sprintf("<Warning: Alpha feature> Labels to add when registering the node in the cluster.  Labels must be key=value pairs separated by ','. Labels in the 'kubernetes.io' namespace must begin with an allowed prefix (%s) or be in the specifically allowed set (%s)", strings.Join(kubeletapis.KubeletLabelNamespaces(), ", "), strings.Join(kubeletapis.KubeletLabels(), ", ")))
@@ -374,6 +367,9 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 	fs.Var(&utilflag.IPVar{Val: &c.Address}, "address", "The IP address for the Kubelet to serve on (set to '0.0.0.0' or '::' for listening in all interfaces and IP families)")
 	fs.Int32Var(&c.Port, "port", c.Port, "The port for the Kubelet to serve on.")
 	fs.Int32Var(&c.ReadOnlyPort, "read-only-port", c.ReadOnlyPort, "The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable)")
+	// Container Runtime
+	fs.StringVar(&c.RemoteRuntimeEndpoint, "container-runtime-endpoint", c.RemoteRuntimeEndpoint, "The endpoint of remote runtime service. Unix Domain Sockets are supported on Linux, while npipe and tcp endpoints are supported on Windows. Examples:'unix:///path/to/runtime.sock', 'npipe:////./pipe/runtime'")
+	fs.StringVar(&c.RemoteImageEndpoint, "image-service-endpoint", c.RemoteImageEndpoint, "The endpoint of remote image service. If not specified, it will be the same with --container-runtime-endpoint by default. Unix Domain Socket are supported on Linux, while npipe and tcp endpoints are supported on Windows. Examples:'unix:///path/to/runtime.sock', 'npipe:////./pipe/runtime'")
 
 	// Authentication
 	fs.BoolVar(&c.Authentication.Anonymous.Enabled, "anonymous-auth", c.Authentication.Anonymous.Enabled, ""+

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -53452,6 +53452,22 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 							Format:      "",
 						},
 					},
+					"RemoteRuntimeEndpoint": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RemoteRuntimeEndpoint is the endpoint of remote runtime service Default:\n       Linux:   \"unix:///run/containerd/containerd.sock\"\n       Windows: \"tcp://localhost:3735\"",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"RemoteImageEndpoint": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RemoteImageEndpoint is the endpoint to pull images from in order to handle If not specified, it will be the same with --container-runtime-endpoint by default Default: \"\"",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -18,9 +18,10 @@ package fuzzer
 
 import (
 	"math/rand"
+	"runtime"
 	"time"
 
-	"github.com/google/gofuzz"
+	fuzz "github.com/google/gofuzz"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
@@ -110,6 +111,12 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			}
 			obj.EnableSystemLogHandler = true
 			obj.MemoryThrottlingFactor = utilpointer.Float64Ptr(rand.Float64())
+			if runtime.GOOS == "linux" {
+				obj.RemoteRuntimeEndpoint = "unix:///run/containerd/containerd.sock"
+			} else if runtime.GOOS == "windows" {
+				obj.RemoteRuntimeEndpoint = "tcp://localhost:3735"
+			}
+			obj.RemoteImageEndpoint = obj.RemoteRuntimeEndpoint
 		},
 	}
 }

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -445,6 +445,18 @@ type KubeletConfiguration struct {
 	// registerNode enables automatic registration with the apiserver.
 	// +optional
 	RegisterNode bool
+
+	// RemoteRuntimeEndpoint is the endpoint of remote runtime service
+	// Default:
+	//        Linux:   "unix:///run/containerd/containerd.sock"
+	//        Windows: "tcp://localhost:3735"
+	// +optional
+	RemoteRuntimeEndpoint string
+	// RemoteImageEndpoint is the endpoint to pull images from in order to handle
+	// If not specified, it will be the same with --container-runtime-endpoint by default
+	// Default: ""
+	// +optional
+	RemoteImageEndpoint string
 }
 
 // KubeletAuthorizationMode denotes the authorization mode for the kubelet

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"runtime"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -263,5 +264,15 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 	}
 	if obj.RegisterNode == nil {
 		obj.RegisterNode = utilpointer.BoolPtr(true)
+	}
+	if obj.RemoteRuntimeEndpoint == "" {
+		if runtime.GOOS == "linux" {
+			obj.RemoteRuntimeEndpoint = "unix:///run/containerd/containerd.sock"
+		} else if runtime.GOOS == "windows" {
+			obj.RemoteRuntimeEndpoint = "tcp://localhost:3735"
+		}
+	}
+	if obj.RemoteImageEndpoint == "" {
+		obj.RemoteImageEndpoint = obj.RemoteRuntimeEndpoint
 	}
 }

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -509,6 +509,8 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	if err := v1.Convert_Pointer_bool_To_bool(&in.RegisterNode, &out.RegisterNode, s); err != nil {
 		return err
 	}
+	out.RemoteRuntimeEndpoint = in.RemoteRuntimeEndpoint
+	out.RemoteImageEndpoint = in.RemoteImageEndpoint
 	return nil
 }
 
@@ -685,6 +687,8 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	if err := v1.Convert_bool_To_Pointer_bool(&in.RegisterNode, &out.RegisterNode, s); err != nil {
 		return err
 	}
+	out.RemoteRuntimeEndpoint = in.RemoteRuntimeEndpoint
+	out.RemoteImageEndpoint = in.RemoteImageEndpoint
 	return nil
 }
 

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -780,6 +780,17 @@ type KubeletConfiguration struct {
 	// Default: true
 	// +optional
 	RegisterNode *bool `json:"registerNode,omitempty"`
+	// RemoteRuntimeEndpoint is the endpoint of remote runtime service
+	// Default:
+	//        Linux:   "unix:///run/containerd/containerd.sock"
+	//        Windows: "tcp://localhost:3735"
+	// +optional
+	RemoteRuntimeEndpoint string
+	// RemoteImageEndpoint is the endpoint to pull images from in order to handle
+	// If not specified, it will be the same with --container-runtime-endpoint by default
+	// Default: ""
+	// +optional
+	RemoteImageEndpoint string
 }
 
 type KubeletAuthorizationMode string


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
https://github.com/kubernetes/kubeadm/issues/1924 needs this.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubernetes/kubernetes/issues/61663
https://github.com/kubernetes/kubernetes/issues/61674

#### Special notes for your reviewer:
like #66208
-  "image-service-endpoint", c.RemoteImageEndpoint: RemoteRuntimeEndpoint string  `json:"remoteRuntimeEndpoint,omitempty"`
- "container-runtime-endpoint", c.RemoteRuntimeEndpoint: RemoteImageEndpoint string  `json:"remoteImageEndpoint,omitempty"`

The naming is tricky here. Should I use  ImageServiceEndpoint and ContainerServiceEndpoint instead?

#### Does this PR introduce a user-facing change?
```release-note
kubelet: migrate `--container-runtime-endpoint` and `--image-runtime-endpoint`  flags into kubelet config
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
@mtaufen
