### PR TITLE
e2e: Deprecated timeout constants migration

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -905,7 +905,7 @@ func testRolloverDeployment(f *framework.Framework) {
 
 	// Wait for replica set to become ready before adopting it.
 	framework.Logf("Waiting for pods owned by replica set %q to become ready", rsName)
-	err = e2ereplicaset.WaitForReadyReplicaSet(c, ns, rsName)
+	err = e2ereplicaset.WaitForReadyReplicaSet(c, ns, rsName, f.Timeouts.PodStart)
 	framework.ExpectNoError(err)
 
 	// Create a deployment to delete webserver pods and instead bring up redis-slave pods.
@@ -1228,7 +1228,7 @@ func testProportionalScalingDeployment(f *framework.Framework) {
 	// First rollout's replicaset should have Deployment's (replicas - maxUnavailable) = 10 - 2 = 8 available replicas.
 	minAvailableReplicas := replicas - int32(maxUnavailable)
 	framework.Logf("Waiting for the first rollout's replicaset to have .status.availableReplicas = %d", minAvailableReplicas)
-	err = e2ereplicaset.WaitForReplicaSetTargetAvailableReplicas(c, firstRS, minAvailableReplicas)
+	err = e2ereplicaset.WaitForReplicaSetTargetAvailableReplicas(c, firstRS, minAvailableReplicas, f.Timeouts.PodStart)
 	framework.ExpectNoError(err)
 
 	// First rollout's replicaset should have .spec.replicas = 8 too.

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -313,7 +313,7 @@ var _ = SIGDescribe("Probing container", func() {
 			"reason":                   events.ContainerProbeWarning,
 		}.AsSelector().String()
 		framework.ExpectNoError(e2eevents.WaitTimeoutForEvent(
-			f.ClientSet, f.Namespace.Name, expectedEvent, "Probe terminated redirects, Response body: <a href=\"http://0.0.0.0/\">Found</a>.", framework.PodEventTimeout))
+			f.ClientSet, f.Namespace.Name, expectedEvent, "Probe terminated redirects, Response body: <a href=\"http://0.0.0.0/\">Found</a>.", f.Timeouts.PodEvent))
 	})
 
 	/*

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -67,7 +67,7 @@ var _ = SIGDescribe("Probing container", func() {
 	framework.ConformanceIt("with readiness probe should not be ready before initial delay and never restart [NodeConformance]", func() {
 		containerName := "test-webserver"
 		p := podClient.Create(testWebServerPodSpec(probe.withInitialDelay().build(), nil, containerName, 80))
-		e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, p.Name, f.Namespace.Name, framework.PodStartTimeout)
+		e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, p.Name, f.Namespace.Name, f.Timeouts.PodStart)
 
 		p, err := podClient.Get(context.TODO(), p.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
@@ -429,13 +429,13 @@ var _ = SIGDescribe("Probing container", func() {
 		p, err := podClient.Get(context.TODO(), p.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
-		err = e2epod.WaitForPodContainerStarted(f.ClientSet, f.Namespace.Name, p.Name, 0, framework.PodStartTimeout)
+		err = e2epod.WaitForPodContainerStarted(f.ClientSet, f.Namespace.Name, p.Name, 0, f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
 		startedTime := time.Now()
 
 		// We assume the pod became ready when the container became ready. This
 		// is true for a single container pod.
-		err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, p.Name, f.Namespace.Name, framework.PodStartTimeout)
+		err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, p.Name, f.Namespace.Name, f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
 		readyTime := time.Now()
 

--- a/test/e2e/common/node/expansion.go
+++ b/test/e2e/common/node/expansion.go
@@ -264,7 +264,7 @@ var _ = SIGDescribe("Variable Expansion", func() {
 		var podClient *framework.PodClient = f.PodClient()
 		pod = podClient.Create(pod)
 
-		err := e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
+		err := e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodStartShort)
 		framework.ExpectError(err, "while waiting for pod to be running")
 
 		ginkgo.By("updating the pod")
@@ -276,7 +276,7 @@ var _ = SIGDescribe("Variable Expansion", func() {
 		})
 
 		ginkgo.By("waiting for pod running")
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodStartShort)
 		framework.ExpectNoError(err, "while waiting for pod to be running")
 
 		ginkgo.By("deleting the pod gracefully")
@@ -337,7 +337,7 @@ var _ = SIGDescribe("Variable Expansion", func() {
 		pod = podClient.Create(pod)
 
 		ginkgo.By("waiting for pod running")
-		err := e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
+		err := e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodStartShort)
 		framework.ExpectNoError(err, "while waiting for pod to be running")
 
 		ginkgo.By("creating a file in subpath")
@@ -360,7 +360,7 @@ var _ = SIGDescribe("Variable Expansion", func() {
 		})
 
 		ginkgo.By("waiting for annotated pod running")
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodStartShort)
 		framework.ExpectNoError(err, "while waiting for annotated pod to be running")
 
 		ginkgo.By("deleting the pod gracefully")
@@ -377,7 +377,7 @@ func testPodFailSubpath(f *framework.Framework, pod *v1.Pod) {
 		e2epod.DeletePodWithWait(f.ClientSet, pod)
 	}()
 
-	err := e2epod.WaitForPodContainerToFail(f.ClientSet, pod.Namespace, pod.Name, 0, "CreateContainerConfigError", framework.PodStartShortTimeout)
+	err := e2epod.WaitForPodContainerToFail(f.ClientSet, pod.Namespace, pod.Name, 0, "CreateContainerConfigError", f.Timeouts.PodStartShort)
 	framework.ExpectNoError(err, "while waiting for the pod container to fail")
 }
 

--- a/test/e2e/common/node/init_container.go
+++ b/test/e2e/common/node/init_container.go
@@ -219,7 +219,7 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 			},
 		}
 		var events []watch.Event
-		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), framework.PodStartTimeout)
+		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), f.Timeouts.PodStart)
 		defer cancel()
 		event, err := watchtools.Until(ctx, startedPod.ResourceVersion, w,
 			recordEvents(events, conditions.PodCompleted),
@@ -298,7 +298,7 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 			},
 		}
 		var events []watch.Event
-		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), framework.PodStartTimeout)
+		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), f.Timeouts.PodStart)
 		defer cancel()
 		event, err := watchtools.Until(ctx, startedPod.ResourceVersion, w, recordEvents(events, conditions.PodRunning))
 		framework.ExpectNoError(err)
@@ -377,7 +377,7 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 		}
 
 		var events []watch.Event
-		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), framework.PodStartTimeout)
+		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), f.Timeouts.PodStart)
 		defer cancel()
 		event, err := watchtools.Until(
 			ctx,
@@ -502,7 +502,7 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 		}
 
 		var events []watch.Event
-		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), framework.PodStartTimeout)
+		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), f.Timeouts.PodStart)
 		defer cancel()
 		event, err := watchtools.Until(
 			ctx, startedPod.ResourceVersion, w,

--- a/test/e2e/common/node/kubelet.go
+++ b/test/e2e/common/node/kubelet.go
@@ -123,7 +123,7 @@ var _ = SIGDescribe("Kubelet", func() {
 					return fmt.Errorf("expected non-zero exitCode and non-empty terminated state reason. Got exitCode: %+v and terminated state reason: %+v", contTerminatedState.ExitCode, contTerminatedState.Reason)
 				}
 				return nil
-			}, framework.PodStartTimeout, time.Second*4).Should(gomega.BeNil())
+			}, f.Timeouts.PodStart, time.Second*4).Should(gomega.BeNil())
 		})
 
 		/*

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -291,7 +291,7 @@ var _ = SIGDescribe("Pods", func() {
 				if event.Type != watch.Added {
 					framework.Failf("Failed to observe pod creation: %v", event)
 				}
-			case <-time.After(framework.PodStartTimeout):
+			case <-time.After(f.Timeouts.PodStart):
 				framework.Failf("Timeout while waiting for pod creation")
 			}
 		case <-time.After(10 * time.Second):

--- a/test/e2e/common/node/runtimeclass.go
+++ b/test/e2e/common/node/runtimeclass.go
@@ -70,7 +70,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 			"reason":                   events.FailedCreatePodSandBox,
 		}.AsSelector().String()
 		// Events are unreliable, don't depend on the event. It's used only to speed up the test.
-		err := e2eevents.WaitTimeoutForEvent(f.ClientSet, f.Namespace.Name, eventSelector, handler, framework.PodEventTimeout)
+		err := e2eevents.WaitTimeoutForEvent(f.ClientSet, f.Namespace.Name, eventSelector, handler, f.Timeouts.PodEvent)
 		if err != nil {
 			framework.Logf("Warning: did not get event about FailedCreatePodSandBox. Err: %v", err)
 		}

--- a/test/e2e/common/node/security_context.go
+++ b/test/e2e/common/node/security_context.go
@@ -78,7 +78,7 @@ var _ = SIGDescribe("Security Context", func() {
 				userid,
 			))
 
-			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+			podClient.WaitForSuccess(podName, f.Timeouts.PodStart)
 		}
 
 		/*
@@ -135,7 +135,7 @@ var _ = SIGDescribe("Security Context", func() {
 			pod := makeNonRootPod(name, rootImage, pointer.Int64Ptr(nonRootTestUserID))
 			podClient.Create(pod)
 
-			podClient.WaitForSuccess(name, framework.PodStartTimeout)
+			podClient.WaitForSuccess(name, f.Timeouts.PodStart)
 			framework.ExpectNoError(podClient.MatchContainerOutput(name, name, "1000"))
 		})
 		ginkgo.It("should not run with an explicit root user ID [LinuxOnly]", func() {
@@ -155,7 +155,7 @@ var _ = SIGDescribe("Security Context", func() {
 			pod := makeNonRootPod(name, nonRootImage, nil)
 			podClient.Create(pod)
 
-			podClient.WaitForSuccess(name, framework.PodStartTimeout)
+			podClient.WaitForSuccess(name, f.Timeouts.PodStart)
 			framework.ExpectNoError(podClient.MatchContainerOutput(name, name, "1234"))
 		})
 		ginkgo.It("should not run without a specified user ID", func() {
@@ -200,9 +200,9 @@ var _ = SIGDescribe("Security Context", func() {
 			))
 
 			if readOnlyRootFilesystem {
-				waitForFailure(f, podName, framework.PodStartTimeout)
+				waitForFailure(f, podName, f.Timeouts.PodStart)
 			} else {
-				podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+				podClient.WaitForSuccess(podName, f.Timeouts.PodStart)
 			}
 
 			return podName
@@ -259,7 +259,7 @@ var _ = SIGDescribe("Security Context", func() {
 				[]string{"sh", "-c", "ip link add dummy0 type dummy || true"},
 				privileged,
 			))
-			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+			podClient.WaitForSuccess(podName, f.Timeouts.PodStart)
 			return podName
 		}
 		/*
@@ -321,7 +321,7 @@ var _ = SIGDescribe("Security Context", func() {
 				allowPrivilegeEscalation,
 				uid,
 			))
-			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+			podClient.WaitForSuccess(podName, f.Timeouts.PodStart)
 			return podClient.MatchContainerOutput(podName, podName, output)
 		}
 

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -860,7 +860,7 @@ func (config *NetworkingTestConfig) createNetProxyPods(podName string, selector 
 	// wait that all of them are up
 	runningPods := make([]*v1.Pod, 0, len(nodes))
 	for _, p := range createdPods {
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(config.f.ClientSet, p.Name, config.f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(config.f.ClientSet, p.Name, config.f.Namespace.Name, config.f.Timeouts.PodStart))
 		rp, err := config.getPodClient().Get(context.TODO(), p.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		runningPods = append(runningPods, rp)

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -104,7 +104,7 @@ func (c *PodClient) Create(pod *v1.Pod) *v1.Pod {
 func (c *PodClient) CreateSync(pod *v1.Pod) *v1.Pod {
 	namespace := c.f.Namespace.Name
 	p := c.Create(pod)
-	ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(c.f.ClientSet, p.Name, namespace, PodStartTimeout))
+	ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(c.f.ClientSet, p.Name, namespace, c.f.Timeouts.PodStart))
 	// Get the newest pod after it becomes running and ready, some status may change after pod created, such as pod ip.
 	p, err := c.Get(context.TODO(), p.Name, metav1.GetOptions{})
 	ExpectNoError(err)
@@ -260,7 +260,7 @@ func (c *PodClient) WaitForFinish(name string, timeout time.Duration) {
 // WaitForErrorEventOrSuccess waits for pod to succeed or an error event for that pod.
 func (c *PodClient) WaitForErrorEventOrSuccess(pod *v1.Pod) (*v1.Event, error) {
 	var ev *v1.Event
-	err := wait.Poll(Poll, PodStartTimeout, func() (bool, error) {
+	err := wait.Poll(Poll, c.f.Timeouts.PodStart, func() (bool, error) {
 		evnts, err := c.f.ClientSet.CoreV1().Events(pod.Namespace).Search(scheme.Scheme, pod)
 		if err != nil {
 			return false, fmt.Errorf("error in listing events: %s", err)

--- a/test/e2e/framework/replicaset/wait.go
+++ b/test/e2e/framework/replicaset/wait.go
@@ -29,8 +29,8 @@ import (
 )
 
 // WaitForReadyReplicaSet waits until the replicaset has all of its replicas ready.
-func WaitForReadyReplicaSet(c clientset.Interface, ns, name string) error {
-	err := wait.Poll(framework.Poll, framework.PodStartTimeout, func() (bool, error) {
+func WaitForReadyReplicaSet(c clientset.Interface, ns, name string, podStartTimeout time.Duration) error {
+	err := wait.Poll(framework.Poll, podStartTimeout, func() (bool, error) {
 		rs, err := c.AppsV1().ReplicaSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -44,8 +44,8 @@ func WaitForReadyReplicaSet(c clientset.Interface, ns, name string) error {
 }
 
 // WaitForReplicaSetTargetAvailableReplicas waits for .status.availableReplicas of a RS to equal targetReplicaNum
-func WaitForReplicaSetTargetAvailableReplicas(c clientset.Interface, replicaSet *appsv1.ReplicaSet, targetReplicaNum int32) error {
-	return WaitForReplicaSetTargetAvailableReplicasWithTimeout(c, replicaSet, targetReplicaNum, framework.PodStartTimeout)
+func WaitForReplicaSetTargetAvailableReplicas(c clientset.Interface, replicaSet *appsv1.ReplicaSet, targetReplicaNum int32, podStartTimeout time.Duration) error {
+	return WaitForReplicaSetTargetAvailableReplicasWithTimeout(c, replicaSet, targetReplicaNum, podStartTimeout)
 }
 
 // WaitForReplicaSetTargetAvailableReplicasWithTimeout waits for .status.availableReplicas of a RS to equal targetReplicaNum

--- a/test/e2e/framework/timeouts.go
+++ b/test/e2e/framework/timeouts.go
@@ -38,6 +38,7 @@ const (
 	snapshotCreateTimeout            = 5 * time.Minute
 	snapshotDeleteTimeout            = 5 * time.Minute
 	snapshotControllerMetricsTimeout = 5 * time.Minute
+	serviceStartTimeout              = 3 * time.Minute
 )
 
 // TimeoutContext contains timeout settings for several actions.
@@ -97,6 +98,9 @@ type TimeoutContext struct {
 
 	// SnapshotControllerMetrics is how long to wait for snapshot controller metrics.
 	SnapshotControllerMetrics time.Duration
+
+	// ServiceStartTimeout is how long to wait for a service endpoint to be resolvable.
+	ServiceStart time.Duration
 }
 
 // NewTimeoutContextWithDefaults returns a TimeoutContext with default values.
@@ -120,5 +124,6 @@ func NewTimeoutContextWithDefaults() *TimeoutContext {
 		SnapshotCreate:            snapshotCreateTimeout,
 		SnapshotDelete:            snapshotDeleteTimeout,
 		SnapshotControllerMetrics: snapshotControllerMetricsTimeout,
+		ServiceStart:              serviceStartTimeout,
 	}
 }

--- a/test/e2e/framework/timeouts.go
+++ b/test/e2e/framework/timeouts.go
@@ -24,6 +24,7 @@ const (
 	podStartShortTimeout             = 2 * time.Minute
 	podStartSlowTimeout              = 15 * time.Minute
 	podDeleteTimeout                 = 5 * time.Minute
+	podListTimeout                   = time.Minute
 	claimProvisionTimeout            = 5 * time.Minute
 	claimProvisionShortTimeout       = 1 * time.Minute
 	dataSourceProvisionTimeout       = 5 * time.Minute
@@ -53,6 +54,9 @@ type TimeoutContext struct {
 
 	// PodDelete is how long to wait for the pod to be deleted.
 	PodDelete time.Duration
+
+	// PodList is how long to wait for the pod to be listable.
+	PodList time.Duration
 
 	// ClaimProvision is how long claims have to become dynamically provisioned.
 	ClaimProvision time.Duration
@@ -98,6 +102,7 @@ func NewTimeoutContextWithDefaults() *TimeoutContext {
 		PodStartShort:             podStartShortTimeout,
 		PodStartSlow:              podStartSlowTimeout,
 		PodDelete:                 podDeleteTimeout,
+		PodList:                   podListTimeout,
 		ClaimProvision:            claimProvisionTimeout,
 		ClaimProvisionShort:       claimProvisionShortTimeout,
 		DataSourceProvision:       dataSourceProvisionTimeout,

--- a/test/e2e/framework/timeouts.go
+++ b/test/e2e/framework/timeouts.go
@@ -25,6 +25,7 @@ const (
 	podStartSlowTimeout              = 15 * time.Minute
 	podDeleteTimeout                 = 5 * time.Minute
 	podListTimeout                   = time.Minute
+	podEventTimeout                  = 2 * time.Minute
 	claimProvisionTimeout            = 5 * time.Minute
 	claimProvisionShortTimeout       = 1 * time.Minute
 	dataSourceProvisionTimeout       = 5 * time.Minute
@@ -57,6 +58,9 @@ type TimeoutContext struct {
 
 	// PodList is how long to wait for the pod to be listable.
 	PodList time.Duration
+
+	// PodEventTimeout is how much we wait for a pod event to occur.
+	PodEvent time.Duration
 
 	// ClaimProvision is how long claims have to become dynamically provisioned.
 	ClaimProvision time.Duration
@@ -103,6 +107,7 @@ func NewTimeoutContextWithDefaults() *TimeoutContext {
 		PodStartSlow:              podStartSlowTimeout,
 		PodDelete:                 podDeleteTimeout,
 		PodList:                   podListTimeout,
+		PodEvent:                  podEventTimeout,
 		ClaimProvision:            claimProvisionTimeout,
 		ClaimProvisionShort:       claimProvisionShortTimeout,
 		DataSourceProvision:       dataSourceProvisionTimeout,

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -86,11 +86,6 @@ const (
 
 // DEPRECATED constants. Use the timeouts in framework.Framework instead.
 const (
-	// PodStartShortTimeout is same as `PodStartTimeout` to wait for the pod to be started, but shorter.
-	// Use it case by case when we are sure pod start will not be delayed.
-	// minutes by slow docker pulls or something else.
-	PodStartShortTimeout = 2 * time.Minute
-
 	// PodDeleteTimeout is how long to wait for a pod to be deleted.
 	PodDeleteTimeout = 5 * time.Minute
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -86,9 +86,6 @@ const (
 
 // DEPRECATED constants. Use the timeouts in framework.Framework instead.
 const (
-	// PodStartTimeout is how long to wait for the pod to be started.
-	PodStartTimeout = 5 * time.Minute
-
 	// PodStartShortTimeout is same as `PodStartTimeout` to wait for the pod to be started, but shorter.
 	// Use it case by case when we are sure pod start will not be delayed.
 	// minutes by slow docker pulls or something else.

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -111,9 +111,6 @@ const (
 	// PodReadyBeforeTimeout is how long pods have to be "ready" when a test begins.
 	PodReadyBeforeTimeout = 5 * time.Minute
 
-	// ClaimProvisionTimeout is how long claims have to become dynamically provisioned.
-	ClaimProvisionTimeout = 5 * time.Minute
-
 	// RestartNodeReadyAgainTimeout is how long a node is allowed to become "Ready" after it is restarted before
 	// the test is considered failed.
 	RestartNodeReadyAgainTimeout = 5 * time.Minute

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -86,9 +86,6 @@ const (
 
 // DEPRECATED constants. Use the timeouts in framework.Framework instead.
 const (
-	// PodListTimeout is how long to wait for the pod to be listable.
-	PodListTimeout = time.Minute
-
 	// PodStartTimeout is how long to wait for the pod to be started.
 	PodStartTimeout = 5 * time.Minute
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -86,9 +86,6 @@ const (
 
 // DEPRECATED constants. Use the timeouts in framework.Framework instead.
 const (
-	// PodDeleteTimeout is how long to wait for a pod to be deleted.
-	PodDeleteTimeout = 5 * time.Minute
-
 	// PodGetTimeout is how long to wait for a pod to be got.
 	PodGetTimeout = 2 * time.Minute
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -89,9 +89,6 @@ const (
 	// PodGetTimeout is how long to wait for a pod to be got.
 	PodGetTimeout = 2 * time.Minute
 
-	// ServiceStartTimeout is how long to wait for a service endpoint to be resolvable.
-	ServiceStartTimeout = 3 * time.Minute
-
 	// Poll is how often to Poll pods, nodes and claims.
 	Poll = 2 * time.Second
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -111,10 +111,6 @@ const (
 	// PodReadyBeforeTimeout is how long pods have to be "ready" when a test begins.
 	PodReadyBeforeTimeout = 5 * time.Minute
 
-	// ClaimProvisionShortTimeout is same as `ClaimProvisionTimeout` to wait for claim to be dynamically provisioned, but shorter.
-	// Use it case by case when we are sure this timeout is enough.
-	ClaimProvisionShortTimeout = 1 * time.Minute
-
 	// ClaimProvisionTimeout is how long claims have to become dynamically provisioned.
 	ClaimProvisionTimeout = 5 * time.Minute
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -89,9 +89,6 @@ const (
 	// PodGetTimeout is how long to wait for a pod to be got.
 	PodGetTimeout = 2 * time.Minute
 
-	// PodEventTimeout is how much we wait for a pod event to occur.
-	PodEventTimeout = 2 * time.Minute
-
 	// ServiceStartTimeout is how long to wait for a service endpoint to be resolvable.
 	ServiceStartTimeout = 3 * time.Minute
 

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -109,9 +109,6 @@ var (
 	httpdImage    = imageutils.GetE2EImage(imageutils.Httpd)
 	busyboxImage  = imageutils.GetE2EImage(imageutils.BusyBox)
 	agnhostImage  = imageutils.GetE2EImage(imageutils.Agnhost)
-
-	// If this suite still flakes due to timeouts we should change this to framework.PodStartTimeout
-	podRunningTimeoutArg = fmt.Sprintf("--pod-running-timeout=%s", framework.PodStartShortTimeout.String())
 )
 
 var proxyRegexp = regexp.MustCompile("Starting to serve on 127.0.0.1:([0-9]+)")
@@ -228,6 +225,8 @@ var _ = SIGDescribe("Kubectl client", func() {
 	f := framework.NewDefaultFramework("kubectl")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 
+	// If this suite still flakes due to timeouts we should change this to framework.PodStartTimeout
+	var podRunningTimeoutArg = fmt.Sprintf("--pod-running-timeout=%s", f.Timeouts.PodStartShort.String())
 	// Reusable cluster state function.  This won't be adversely affected by lazy initialization of framework.
 	clusterState := func() *framework.ClusterVerification {
 		return f.NewClusterVerification(

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -826,7 +826,7 @@ metadata:
 				WithStdinReader(stdin).
 				ExecOrDie(ns)
 			ginkgo.By("checking the result")
-			forEachReplicationController(c, ns, "app", "agnhost", validateReplicationControllerConfiguration)
+			forEachReplicationController(c, ns, "app", "agnhost", f.Timeouts.PodList, validateReplicationControllerConfiguration)
 		})
 		ginkgo.It("should reuse port when apply to an existing SVC", func() {
 			serviceJSON := readTestFileOrDie(agnhostServiceFilename)
@@ -2053,10 +2053,10 @@ func modifyReplicationControllerConfiguration(contents string) io.Reader {
 	return bytes.NewReader(data)
 }
 
-func forEachReplicationController(c clientset.Interface, ns, selectorKey, selectorValue string, fn func(v1.ReplicationController)) {
+func forEachReplicationController(c clientset.Interface, ns, selectorKey, selectorValue string, podListTimeout time.Duration, fn func(v1.ReplicationController)) {
 	var rcs *v1.ReplicationControllerList
 	var err error
-	for t := time.Now(); time.Since(t) < framework.PodListTimeout; time.Sleep(framework.Poll) {
+	for t := time.Now(); time.Since(t) < podListTimeout; time.Sleep(framework.Poll) {
 		label := labels.SelectorFromSet(labels.Set(map[string]string{selectorKey: selectorValue}))
 		options := metav1.ListOptions{LabelSelector: label.String()}
 		rcs, err = c.CoreV1().ReplicationControllers(ns).List(context.TODO(), options)

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1318,13 +1318,13 @@ metadata:
 
 			ginkgo.By("exposing RC")
 			framework.RunKubectlOrDie(ns, "expose", "rc", "agnhost-primary", "--name=rm2", "--port=1234", fmt.Sprintf("--target-port=%d", agnhostPort))
-			e2enetwork.WaitForService(c, ns, "rm2", true, framework.Poll, framework.ServiceStartTimeout)
-			validateService("rm2", 1234, framework.ServiceStartTimeout)
+			e2enetwork.WaitForService(c, ns, "rm2", true, framework.Poll, f.Timeouts.ServiceStart)
+			validateService("rm2", 1234, f.Timeouts.ServiceStart)
 
 			ginkgo.By("exposing service")
 			framework.RunKubectlOrDie(ns, "expose", "service", "rm2", "--name=rm3", "--port=2345", fmt.Sprintf("--target-port=%d", agnhostPort))
-			e2enetwork.WaitForService(c, ns, "rm3", true, framework.Poll, framework.ServiceStartTimeout)
-			validateService("rm3", 2345, framework.ServiceStartTimeout)
+			e2enetwork.WaitForService(c, ns, "rm3", true, framework.Poll, f.Timeouts.ServiceStart)
+			validateService("rm3", 2345, f.Timeouts.ServiceStart)
 		})
 	})
 

--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -124,8 +124,8 @@ func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string, bi
 }
 
 // WaitForTerminatedContainer waits till a given container be terminated for a given pod.
-func WaitForTerminatedContainer(f *framework.Framework, pod *v1.Pod, containerName string) error {
-	return e2epod.WaitForPodCondition(f.ClientSet, f.Namespace.Name, pod.Name, "container terminated", framework.PodStartTimeout, func(pod *v1.Pod) (bool, error) {
+func WaitForTerminatedContainer(f *framework.Framework, pod *v1.Pod, containerName string, podStartTimeout time.Duration) error {
+	return e2epod.WaitForPodCondition(f.ClientSet, f.Namespace.Name, pod.Name, "container terminated", podStartTimeout, func(pod *v1.Pod) (bool, error) {
 		if len(testutils.TerminatedContainers(pod)[containerName]) > 0 {
 			return true, nil
 		}
@@ -213,7 +213,7 @@ func doTestConnectSendDisconnect(bindAddress string, f *framework.Framework) {
 	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
 		framework.Failf("Couldn't create pod: %v", err)
 	}
-	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
+	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, f.Timeouts.PodStart); err != nil {
 		framework.Failf("Pod did not start running: %v", err)
 	}
 
@@ -242,7 +242,7 @@ func doTestConnectSendDisconnect(bindAddress string, f *framework.Framework) {
 	}
 
 	ginkgo.By("Waiting for the target pod to stop running")
-	if err := WaitForTerminatedContainer(f, pod, "portforwardtester"); err != nil {
+	if err := WaitForTerminatedContainer(f, pod, "portforwardtester", f.Timeouts.PodStart); err != nil {
 		framework.Failf("Container did not terminate: %v", err)
 	}
 
@@ -261,7 +261,7 @@ func doTestMustConnectSendNothing(bindAddress string, f *framework.Framework) {
 	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
 		framework.Failf("Couldn't create pod: %v", err)
 	}
-	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
+	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, f.Timeouts.PodStart); err != nil {
 		framework.Failf("Pod did not start running: %v", err)
 	}
 
@@ -279,7 +279,7 @@ func doTestMustConnectSendNothing(bindAddress string, f *framework.Framework) {
 	conn.Close()
 
 	ginkgo.By("Waiting for the target pod to stop running")
-	if err := WaitForTerminatedContainer(f, pod, "portforwardtester"); err != nil {
+	if err := WaitForTerminatedContainer(f, pod, "portforwardtester", f.Timeouts.PodStart); err != nil {
 		framework.Failf("Container did not terminate: %v", err)
 	}
 
@@ -298,7 +298,7 @@ func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework)
 	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
 		framework.Failf("Couldn't create pod: %v", err)
 	}
-	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
+	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, f.Timeouts.PodStart); err != nil {
 		framework.Failf("Pod did not start running: %v", err)
 	}
 
@@ -345,7 +345,7 @@ func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework)
 	}
 
 	ginkgo.By("Waiting for the target pod to stop running")
-	if err := WaitForTerminatedContainer(f, pod, "portforwardtester"); err != nil {
+	if err := WaitForTerminatedContainer(f, pod, "portforwardtester", f.Timeouts.PodStart); err != nil {
 		framework.Failf("Container did not terminate: %v", err)
 	}
 
@@ -368,7 +368,7 @@ func doTestOverWebSockets(bindAddress string, f *framework.Framework) {
 	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
 		framework.Failf("Couldn't create pod: %v", err)
 	}
-	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
+	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, f.Timeouts.PodStart); err != nil {
 		framework.Failf("Pod did not start running: %v", err)
 	}
 

--- a/test/e2e/network/conntrack.go
+++ b/test/e2e/network/conntrack.go
@@ -165,7 +165,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		e2epod.SetNodeSelection(&serverPod1.Spec, nodeSelection)
 		fr.PodClient().CreateSync(serverPod1)
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podBackend1: {80}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podBackend1: {80}}, fr.Timeouts.ServiceStart)
 
 		// Note that the fact that Endpoints object already exists, does NOT mean
 		// that iptables (or whatever else is used) was already programmed.
@@ -192,7 +192,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		framework.Logf("Cleaning up %s pod", podBackend1)
 		fr.PodClient().DeleteSync(podBackend1, metav1.DeleteOptions{}, framework.DefaultPodDeletionTimeout)
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podBackend2: {80}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podBackend2: {80}}, fr.Timeouts.ServiceStart)
 
 		// Check that the second pod keeps receiving traffic
 		// UDP conntrack entries timeout is 30 sec by default
@@ -241,7 +241,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		e2epod.SetNodeSelection(&serverPod1.Spec, nodeSelection)
 		fr.PodClient().CreateSync(serverPod1)
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podBackend1: {80}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podBackend1: {80}}, fr.Timeouts.ServiceStart)
 
 		// Note that the fact that Endpoints object already exists, does NOT mean
 		// that iptables (or whatever else is used) was already programmed.
@@ -268,7 +268,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		framework.Logf("Cleaning up %s pod", podBackend1)
 		fr.PodClient().DeleteSync(podBackend1, metav1.DeleteOptions{}, framework.DefaultPodDeletionTimeout)
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podBackend2: {80}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podBackend2: {80}}, fr.Timeouts.ServiceStart)
 
 		// Check that the second pod keeps receiving traffic
 		// UDP conntrack entries timeout is 30 sec by default
@@ -337,7 +337,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		fr.PodClient().CreateSync(serverPod1)
 
 		// wait until the endpoints are ready
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podBackend1: {80}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podBackend1: {80}}, fr.Timeouts.ServiceStart)
 
 		// Note that the fact that Endpoints object already exists, does NOT mean
 		// that iptables (or whatever else is used) was already programmed.

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -427,7 +427,7 @@ var _ = common.SIGDescribe("DNS", func() {
 				framework.Failf("ginkgo.Failed to delete pod %s: %v", testAgnhostPod.Name, err)
 			}
 		}()
-		err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, testAgnhostPod.Name, f.Namespace.Name, framework.PodStartTimeout)
+		err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, testAgnhostPod.Name, f.Namespace.Name, f.Timeouts.PodStart)
 		framework.ExpectNoError(err, "failed to wait for pod %s to be running", testAgnhostPod.Name)
 
 		runCommand := func(arg string) string {

--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -159,7 +159,7 @@ var _ = common.SIGDescribe("ClusterDns [Feature:Example]", func() {
 
 		// wait for pods to print their result
 		for _, ns := range namespaces {
-			_, err := framework.LookForStringInLog(ns.Name, frontendName, frontendName, podOutput, framework.PodStartTimeout)
+			_, err := framework.LookForStringInLog(ns.Name, frontendName, frontendName, podOutput, f.Timeouts.PodStart)
 			framework.ExpectNoError(err, "pod %s failed to print result in logs", frontendName)
 		}
 	})

--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -105,7 +105,7 @@ var _ = common.SIGDescribe("ClusterDns [Feature:Example]", func() {
 		// wait for objects
 		for _, ns := range namespaces {
 			e2eresource.WaitForControlledPodsRunning(c, ns.Name, backendName, api.Kind("ReplicationController"))
-			e2enetwork.WaitForService(c, ns.Name, backendName, true, framework.Poll, framework.ServiceStartTimeout)
+			e2enetwork.WaitForService(c, ns.Name, backendName, true, framework.Poll, f.Timeouts.ServiceStart)
 		}
 		// it is not enough that pods are running because they may be set to running, but
 		// the application itself may have not been initialized. Just query the application.

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -160,7 +160,7 @@ var _ = common.SIGDescribe("Firewall rule", func() {
 			pod.Spec.HostNetwork = true
 			_, err := cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podName, f.Namespace.Name, framework.PodStartTimeout))
+			framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podName, f.Namespace.Name, f.Timeouts.PodStart))
 			framework.Logf("Netexec pod %q in namespace %q running", podName, ns)
 
 			defer func() {

--- a/test/e2e/network/hostport.go
+++ b/test/e2e/network/hostport.go
@@ -195,7 +195,7 @@ func createHostPortPodOnNode(f *framework.Framework, podName, ns, hostIP string,
 		framework.Failf("error creating pod %s, err:%v", podName, err)
 	}
 
-	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podName, ns, framework.PodStartTimeout); err != nil {
+	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podName, ns, f.Timeouts.PodStart); err != nil {
 		framework.Failf("wait for pod %s timeout, err:%v", podName, err)
 	}
 }

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -187,7 +187,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		fr.PodClient().CreateSync(serverPodSpec)
 
 		// The server should be listening before spawning the client pod
-		if readyErr := e2epod.WaitTimeoutForPodReadyInNamespace(fr.ClientSet, serverPodSpec.Name, fr.Namespace.Name, framework.PodStartTimeout); readyErr != nil {
+		if readyErr := e2epod.WaitTimeoutForPodReadyInNamespace(fr.ClientSet, serverPodSpec.Name, fr.Namespace.Name, fr.Timeouts.PodStart); readyErr != nil {
 			framework.Failf("error waiting for server pod %s to be ready: %v", serverPodSpec.Name, readyErr)
 		}
 		// Connect to the server and leak the connection

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -618,7 +618,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		//  a pod to test the service.
 		ginkgo.By("hitting the internal load balancer from pod")
 		framework.Logf("creating pod with host network")
-		hostExec := launchHostExecPod(f.ClientSet, f.Namespace.Name, "ilb-host-exec")
+		hostExec := launchHostExecPod(f.ClientSet, f.Namespace.Name, "ilb-host-exec", f.Timeouts.PodStart)
 
 		framework.Logf("Waiting up to %v for service %q's internal LB to respond to requests", createTimeout, serviceName)
 		tcpIngressIP := e2eservice.GetIngressPoint(lbIngress)

--- a/test/e2e/network/netpol/network_legacy.go
+++ b/test/e2e/network/netpol/network_legacy.go
@@ -776,15 +776,15 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 			framework.ExpectNoError(err, "Error creating Network Policy %v: %v", policy.ObjectMeta.Name, err)
 
 			testCanConnect(f, f.Namespace, "client-a", service, clientAAllowedPort)
-			e2epod.WaitForPodNotFoundInNamespace(f.ClientSet, "client-a", f.Namespace.Name, framework.PodDeleteTimeout)
+			e2epod.WaitForPodNotFoundInNamespace(f.ClientSet, "client-a", f.Namespace.Name, f.Timeouts.PodDelete)
 			framework.ExpectNoError(err, "Expected pod to be not found.")
 
 			testCannotConnect(f, f.Namespace, "client-b", service, clientAAllowedPort)
-			e2epod.WaitForPodNotFoundInNamespace(f.ClientSet, "client-b", f.Namespace.Name, framework.PodDeleteTimeout)
+			e2epod.WaitForPodNotFoundInNamespace(f.ClientSet, "client-b", f.Namespace.Name, f.Timeouts.PodDelete)
 			framework.ExpectNoError(err, "Expected pod to be not found.")
 
 			testCannotConnect(f, f.Namespace, "client-a", service, clientANotAllowedPort)
-			e2epod.WaitForPodNotFoundInNamespace(f.ClientSet, "client-a", f.Namespace.Name, framework.PodDeleteTimeout)
+			e2epod.WaitForPodNotFoundInNamespace(f.ClientSet, "client-a", f.Namespace.Name, f.Timeouts.PodDelete)
 			framework.ExpectNoError(err, "Expected pod to be not found.")
 
 			const (
@@ -823,7 +823,7 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 			defer cleanupNetworkPolicy(f, policy)
 
 			testCannotConnect(f, f.Namespace, "client-b", service, clientBNotAllowedPort)
-			e2epod.WaitForPodNotFoundInNamespace(f.ClientSet, "client-b", f.Namespace.Name, framework.PodDeleteTimeout)
+			e2epod.WaitForPodNotFoundInNamespace(f.ClientSet, "client-b", f.Namespace.Name, f.Timeouts.PodDelete)
 			framework.ExpectNoError(err, "Expected pod to be not found.")
 
 			testCannotConnect(f, f.Namespace, "client-a", service, clientBNotAllowedPort)

--- a/test/e2e/network/netpol/network_legacy.go
+++ b/test/e2e/network/netpol/network_legacy.go
@@ -79,7 +79,7 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 			podServer, service = createServerPodAndService(f, f.Namespace, "server", []protocolPort{{80, v1.ProtocolTCP}, {81, v1.ProtocolTCP}})
 
 			ginkgo.By("Waiting for pod ready", func() {
-				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServer.Name, f.Namespace.Name, framework.PodStartTimeout)
+				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServer.Name, f.Namespace.Name, f.Timeouts.PodStart)
 				framework.ExpectNoError(err)
 			})
 
@@ -128,7 +128,7 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 			podB, serviceB := createServerPodAndService(f, nsB, "pod-b", []protocolPort{{80, v1.ProtocolTCP}, {81, v1.ProtocolTCP}})
 
 			ginkgo.By("Waiting for pod ready", func() {
-				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podB.Name, nsB.Name, framework.PodStartTimeout)
+				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podB.Name, nsB.Name, f.Timeouts.PodStart)
 				framework.ExpectNoError(err)
 			})
 
@@ -978,7 +978,7 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 
 			// Wait for Server with Service in NS-B to be ready
 			framework.Logf("Waiting for servers to be ready.")
-			err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podB.Name, nsB.Name, framework.PodStartTimeout)
+			err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podB.Name, nsB.Name, f.Timeouts.PodStart)
 			framework.ExpectNoError(err, "Error occurred while waiting for pod status in namespace: Ready.")
 
 			ginkgo.By("Create a network policy for the server which denies both Ingress and Egress traffic.")
@@ -1059,14 +1059,14 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 
 			// Wait for Server with Service in NS-A to be ready
 			framework.Logf("Waiting for servers to be ready.")
-			err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServer.Name, podServer.Namespace, framework.PodStartTimeout)
+			err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServer.Name, podServer.Namespace, f.Timeouts.PodStart)
 			framework.ExpectNoError(err, "Error occurred while waiting for pod status in namespace: Ready.")
 
 			// Wait for Servers with Services in NS-B to be ready
-			err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, nsBpodServerA.Name, nsBpodServerA.Namespace, framework.PodStartTimeout)
+			err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, nsBpodServerA.Name, nsBpodServerA.Namespace, f.Timeouts.PodStart)
 			framework.ExpectNoError(err, "Error occurred while waiting for pod status in namespace: Ready.")
 
-			err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, nsBpodServerB.Name, nsBpodServerB.Namespace, framework.PodStartTimeout)
+			err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, nsBpodServerB.Name, nsBpodServerB.Namespace, f.Timeouts.PodStart)
 			framework.ExpectNoError(err, "Error occurred while waiting for pod status in namespace: Ready.")
 
 			ginkgo.By("Creating a network policy for the server which allows traffic only to a server in different namespace.")
@@ -1192,7 +1192,7 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 			defer cleanupServerPodAndService(f, podServerB, serviceB)
 
 			ginkgo.By("Waiting for pod ready", func() {
-				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServerB.Name, f.Namespace.Name, framework.PodStartTimeout)
+				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServerB.Name, f.Namespace.Name, f.Timeouts.PodStart)
 				framework.ExpectNoError(err, "Error occurred while waiting for pod type: Ready.")
 			})
 
@@ -1357,7 +1357,7 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 			// Creating pod-b and service-b
 			podServerB, serviceB = createServerPodAndService(f, f.Namespace, "pod-b", []protocolPort{{80, v1.ProtocolTCP}})
 			ginkgo.By("Waiting for pod-b to be ready", func() {
-				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServerB.Name, f.Namespace.Name, framework.PodStartTimeout)
+				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServerB.Name, f.Namespace.Name, f.Timeouts.PodStart)
 				framework.ExpectNoError(err, "Error occurred while waiting for pod type: Ready.")
 			})
 			defer cleanupServerPodAndService(f, podServerB, serviceB)
@@ -1593,7 +1593,7 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 			// Before applying policy, communication should be successful between pod-a and pod-b
 			podA, serviceA = createServerPodAndService(f, f.Namespace, "pod-a", []protocolPort{{80, v1.ProtocolTCP}})
 			ginkgo.By("Waiting for pod-a to be ready", func() {
-				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podA.Name, f.Namespace.Name, framework.PodStartTimeout)
+				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podA.Name, f.Namespace.Name, f.Timeouts.PodStart)
 				framework.ExpectNoError(err, "Error occurred while waiting for pod type: Ready.")
 			})
 			ginkgo.By("Creating client pod-b which should be able to contact the server pod-a.", func() {
@@ -1603,7 +1603,7 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 
 			podB, serviceB = createServerPodAndService(f, f.Namespace, "pod-b", []protocolPort{{80, v1.ProtocolTCP}})
 			ginkgo.By("Waiting for pod-b to be ready", func() {
-				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podB.Name, f.Namespace.Name, framework.PodStartTimeout)
+				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podB.Name, f.Namespace.Name, f.Timeouts.PodStart)
 				framework.ExpectNoError(err, "Error occurred while waiting for pod type: Ready.")
 			})
 			ginkgo.By("Creating client pod-a which should be able to contact the server pod-b.", func() {
@@ -1676,7 +1676,7 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 			// Creating server pod with label "pod-name": "pod-a" to deny traffic from client pod with label "pod-name": "pod-b"
 			podA, serviceA = createServerPodAndService(f, f.Namespace, "pod-a", []protocolPort{{80, v1.ProtocolTCP}})
 			ginkgo.By("Waiting for pod-a to be ready", func() {
-				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podA.Name, f.Namespace.Name, framework.PodStartTimeout)
+				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podA.Name, f.Namespace.Name, f.Timeouts.PodStart)
 				framework.ExpectNoError(err, "Error occurred while waiting for pod type: Ready.")
 			})
 
@@ -1746,7 +1746,7 @@ var _ = common.SIGDescribe("NetworkPolicy [Feature:SCTPConnectivity][LinuxOnly][
 			podServer, service = createServerPodAndService(f, f.Namespace, "server", []protocolPort{{80, v1.ProtocolSCTP}, {81, v1.ProtocolSCTP}})
 
 			ginkgo.By("Waiting for pod ready", func() {
-				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServer.Name, f.Namespace.Name, framework.PodStartTimeout)
+				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServer.Name, f.Namespace.Name, f.Timeouts.PodStart)
 				framework.ExpectNoError(err)
 			})
 
@@ -1959,7 +1959,7 @@ func checkNoConnectivity(f *framework.Framework, ns *v1.Namespace, podClient *v1
 }
 
 func checkNoConnectivityByExitCode(f *framework.Framework, ns *v1.Namespace, podClient *v1.Pod, service *v1.Service) {
-	err := e2epod.WaitForPodCondition(f.ClientSet, ns.Name, podClient.Name, "terminated", framework.PodStartTimeout, func(pod *v1.Pod) (bool, error) {
+	err := e2epod.WaitForPodCondition(f.ClientSet, ns.Name, podClient.Name, "terminated", f.Timeouts.PodStart, func(pod *v1.Pod) (bool, error) {
 		statuses := pod.Status.ContainerStatuses
 		if len(statuses) == 0 || statuses[0].State.Terminated == nil {
 			return false, nil

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -614,7 +614,7 @@ var _ = common.SIGDescribe("Networking", func() {
 		}
 
 		ginkgo.By("verifying that kube-proxy rules are eventually recreated")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(f.ClientSet, ns, podNames, svcIP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(f.ClientSet, ns, podNames, svcIP, servicePort, f.Timeouts.PodStart))
 
 		ginkgo.By("verifying that kubelet rules are eventually recreated")
 		err = utilwait.PollImmediate(framework.Poll, framework.RestartNodeReadyAgainTimeout, func() (bool, error) {

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -799,7 +799,7 @@ var _ = common.SIGDescribe("Services", func() {
 		svc, err := jig.CreateTCPServiceWithPort(nil, 80)
 		framework.ExpectNoError(err)
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{}, f.Timeouts.ServiceStart)
 
 		names := map[string]bool{}
 		defer func() {
@@ -814,7 +814,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		createPodOrFail(f, ns, name1, jig.Labels, []v1.ContainerPort{{ContainerPort: 80}}, "netexec", "--http-port", "80")
 		names[name1] = true
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name1: {80}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name1: {80}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Checking if the Service forwards traffic to pod1")
 		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
@@ -823,7 +823,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		createPodOrFail(f, ns, name2, jig.Labels, []v1.ContainerPort{{ContainerPort: 80}}, "netexec", "--http-port", "80")
 		names[name2] = true
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name1: {80}, name2: {80}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name1: {80}, name2: {80}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Checking if the Service forwards traffic to pod1 and pod2")
 		err = jig.CheckServiceReachability(svc, execPod)
@@ -831,7 +831,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		e2epod.DeletePodOrFail(cs, ns, name1)
 		delete(names, name1)
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name2: {80}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name2: {80}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Checking if the Service forwards traffic to pod2")
 		err = jig.CheckServiceReachability(svc, execPod)
@@ -839,7 +839,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		e2epod.DeletePodOrFail(cs, ns, name2)
 		delete(names, name2)
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{}, f.Timeouts.ServiceStart)
 	})
 
 	/*
@@ -880,7 +880,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		port1 := 100
 		port2 := 101
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{}, f.Timeouts.ServiceStart)
 
 		names := map[string]bool{}
 		defer func() {
@@ -908,11 +908,11 @@ var _ = common.SIGDescribe("Services", func() {
 
 		createPodOrFail(f, ns, podname1, jig.Labels, containerPorts1, "netexec", "--http-port", strconv.Itoa(port1))
 		names[podname1] = true
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podname1: {port1}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podname1: {port1}}, f.Timeouts.ServiceStart)
 
 		createPodOrFail(f, ns, podname2, jig.Labels, containerPorts2, "netexec", "--http-port", strconv.Itoa(port2))
 		names[podname2] = true
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podname1: {port1}, podname2: {port2}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podname1: {port1}, podname2: {port2}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Checking if the Service forwards traffic to pods")
 		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
@@ -921,11 +921,11 @@ var _ = common.SIGDescribe("Services", func() {
 
 		e2epod.DeletePodOrFail(cs, ns, podname1)
 		delete(names, podname1)
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podname2: {port2}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podname2: {port2}}, f.Timeouts.ServiceStart)
 
 		e2epod.DeletePodOrFail(cs, ns, podname2)
 		delete(names, podname2)
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{}, f.Timeouts.ServiceStart)
 	})
 
 	ginkgo.It("should preserve source pod IP for traffic thru service cluster IP [LinuxOnly]", func() {
@@ -980,7 +980,7 @@ var _ = common.SIGDescribe("Services", func() {
 			framework.ExpectNoError(err, "failed to delete pod: %s on node", serverPodName)
 		}()
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{serverPodName: {servicePort}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{serverPodName: {servicePort}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Creating pause pod deployment")
 		deployment := createPausePodDeployment(cs, "pause-pod", ns, nodeCounts)
@@ -1033,7 +1033,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, f.Timeouts.PodStart))
 
 		ginkgo.By("waiting for the service to expose an endpoint")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{serverPodName: {servicePort}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{serverPodName: {servicePort}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Checking if the pod can reach itself")
 		err = jig.CheckServiceReachability(svc, pod)
@@ -2088,7 +2088,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, f.Timeouts.PodStart))
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webservers")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
@@ -2166,7 +2166,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, f.Timeouts.PodStart))
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webservers")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
@@ -2250,7 +2250,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, f.Timeouts.PodStart))
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {endpointPort}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {endpointPort}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webserver")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
@@ -2356,7 +2356,7 @@ var _ = common.SIGDescribe("Services", func() {
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, f.Timeouts.PodStart))
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}}, f.Timeouts.ServiceStart)
 
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod0.Spec, e2epod.NodeSelection{Name: node0.Name})
@@ -2454,7 +2454,7 @@ var _ = common.SIGDescribe("Services", func() {
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, f.Timeouts.PodStart))
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webservers")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
@@ -2539,7 +2539,7 @@ var _ = common.SIGDescribe("Services", func() {
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, f.Timeouts.PodStart))
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webservers")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
@@ -2626,7 +2626,7 @@ var _ = common.SIGDescribe("Services", func() {
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, f.Timeouts.PodStart))
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webservers")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
@@ -2712,7 +2712,7 @@ var _ = common.SIGDescribe("Services", func() {
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, f.Timeouts.PodStart))
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webservers")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
@@ -3614,8 +3614,8 @@ func translatePodNameToUID(c clientset.Interface, ns string, expectedEndpoints p
 }
 
 // validateEndpointsPortsOrFail validates that the given service exists and is served by the given expectedEndpoints.
-func validateEndpointsPortsOrFail(c clientset.Interface, namespace, serviceName string, expectedEndpoints portsByPodName) {
-	ginkgo.By(fmt.Sprintf("waiting up to %v for service %s in namespace %s to expose endpoints %v", framework.ServiceStartTimeout, serviceName, namespace, expectedEndpoints))
+func validateEndpointsPortsOrFail(c clientset.Interface, namespace, serviceName string, expectedEndpoints portsByPodName, timeout time.Duration) {
+	ginkgo.By(fmt.Sprintf("waiting up to %v for service %s in namespace %s to expose endpoints %v", timeout, serviceName, namespace, expectedEndpoints))
 	expectedPortsByPodUID, err := translatePodNameToUID(c, namespace, expectedEndpoints)
 	framework.ExpectNoError(err, "failed to translate pod name to UID, ns:%s, expectedEndpoints:%v", namespace, expectedEndpoints)
 
@@ -3623,7 +3623,7 @@ func validateEndpointsPortsOrFail(c clientset.Interface, namespace, serviceName 
 		pollErr error
 		i       = 0
 	)
-	if pollErr = wait.PollImmediate(time.Second, framework.ServiceStartTimeout, func() (bool, error) {
+	if pollErr = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		i++
 
 		ep, err := c.CoreV1().Endpoints(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
@@ -3738,7 +3738,7 @@ var _ = common.SIGDescribe("SCTP [LinuxOnly]", func() {
 		framework.ExpectNoError(err, fmt.Sprintf("error while waiting for service:%s err: %v", serviceName, err))
 
 		ginkgo.By("validating endpoints do not exist yet")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("creating a pod for the service")
 		names := map[string]bool{}
@@ -3755,13 +3755,13 @@ var _ = common.SIGDescribe("SCTP [LinuxOnly]", func() {
 		}()
 
 		ginkgo.By("validating endpoints exists")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name1: {5060}})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name1: {5060}}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("deleting the pod")
 		e2epod.DeletePodOrFail(cs, ns, name1)
 		delete(names, name1)
 		ginkgo.By("validating endpoints do not exist anymore")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{}, f.Timeouts.ServiceStart)
 
 		ginkgo.By("validating sctp module is still not loaded")
 		sctpLoadedAtEnd := CheckSCTPModuleLoadedOnNodes(f, nodes)

--- a/test/e2e/network/topology_hints.go
+++ b/test/e2e/network/topology_hints.go
@@ -80,7 +80,7 @@ var _ = common.SIGDescribe("[Feature:Topology Hints]", func() {
 			},
 		})
 
-		err = wait.Poll(5*time.Second, framework.PodStartTimeout, func() (bool, error) {
+		err = wait.Poll(5*time.Second, f.Timeouts.PodStart, func() (bool, error) {
 			return e2edaemonset.CheckRunningOnAllNodes(f, ds)
 		})
 		framework.ExpectNoError(err, "timed out waiting for DaemonSets to be ready")

--- a/test/e2e/node/apparmor.go
+++ b/test/e2e/node/apparmor.go
@@ -43,11 +43,11 @@ var _ = SIGDescribe("AppArmor", func() {
 		})
 
 		ginkgo.It("should enforce an AppArmor profile", func() {
-			e2esecurity.CreateAppArmorTestPod(f.Namespace.Name, f.ClientSet, f.PodClient(), false, true)
+			e2esecurity.CreateAppArmorTestPod(f.Namespace.Name, f.ClientSet, f.PodClient(), false, true, f.Timeouts.PodStart)
 		})
 
 		ginkgo.It("can disable an AppArmor profile, using unconfined", func() {
-			e2esecurity.CreateAppArmorTestPod(f.Namespace.Name, f.ClientSet, f.PodClient(), true, true)
+			e2esecurity.CreateAppArmorTestPod(f.Namespace.Name, f.ClientSet, f.PodClient(), true, true, f.Timeouts.PodStart)
 		})
 	})
 })

--- a/test/e2e/node/examples.go
+++ b/test/e2e/node/examples.go
@@ -39,8 +39,6 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
-const ()
-
 var _ = SIGDescribe("[Feature:Example]", func() {
 	f := framework.NewDefaultFramework("examples")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline

--- a/test/e2e/node/examples.go
+++ b/test/e2e/node/examples.go
@@ -39,13 +39,13 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
-const (
-	serverStartTimeout = framework.PodStartTimeout + 3*time.Minute
-)
+const ()
 
 var _ = SIGDescribe("[Feature:Example]", func() {
 	f := framework.NewDefaultFramework("examples")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
+
+	var serverStartTimeout = f.Timeouts.PodStart + 3*time.Minute
 
 	var c clientset.Interface
 	var ns string

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -193,7 +193,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 				Requests: podRes,
 				Limits:   podRes,
 			},
-		}, framework.PodStartShortTimeout)
+		}, f.Timeouts.PodStartShort)
 
 		preemptedPod, err := cs.CoreV1().Pods(pods[0].Namespace).Get(context.TODO(), pods[0].Name, metav1.GetOptions{})
 		podPreempted := (err != nil && apierrors.IsNotFound(err)) ||
@@ -291,7 +291,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 				Requests: podRes,
 				Limits:   podRes,
 			},
-		}, framework.PodStartShortTimeout)
+		}, f.Timeouts.PodStartShort)
 
 		defer func() {
 			// Clean-up the critical pod

--- a/test/e2e/storage/flexvolume_mounted_volume_resize.go
+++ b/test/e2e/storage/flexvolume_mounted_volume_resize.go
@@ -151,7 +151,7 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Mounted flexvolume expand[Slow]
 		pvcClaims := []*v1.PersistentVolumeClaim{pvc}
 		var pvs []*v1.PersistentVolume
 
-		pvs, err = e2epv.WaitForPVClaimBoundPhase(c, pvcClaims, framework.ClaimProvisionTimeout)
+		pvs, err = e2epv.WaitForPVClaimBoundPhase(c, pvcClaims, f.Timeouts.ClaimProvision)
 		framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
 		framework.ExpectEqual(len(pvs), 1)
 

--- a/test/e2e/storage/flexvolume_online_resize.go
+++ b/test/e2e/storage/flexvolume_online_resize.go
@@ -150,7 +150,7 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Mounted flexvolume volume expan
 		pvcClaims := []*v1.PersistentVolumeClaim{pvc}
 		var pvs []*v1.PersistentVolume
 
-		pvs, err = e2epv.WaitForPVClaimBoundPhase(c, pvcClaims, framework.ClaimProvisionTimeout)
+		pvs, err = e2epv.WaitForPVClaimBoundPhase(c, pvcClaims, f.Timeouts.ClaimProvision)
 		framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
 		framework.ExpectEqual(len(pvs), 1)
 

--- a/test/e2e/storage/generic_persistent_volume-disruptive.go
+++ b/test/e2e/storage/generic_persistent_volume-disruptive.go
@@ -106,7 +106,7 @@ func createPodPVCFromSC(f *framework.Framework, c clientset.Interface, ns string
 	pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "Error creating pvc")
 	pvcClaims := []*v1.PersistentVolumeClaim{pvc}
-	pvs, err := e2epv.WaitForPVClaimBoundPhase(c, pvcClaims, framework.ClaimProvisionTimeout)
+	pvs, err := e2epv.WaitForPVClaimBoundPhase(c, pvcClaims, f.Timeouts.ClaimProvision)
 	framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
 	framework.ExpectEqual(len(pvs), 1)
 

--- a/test/e2e/storage/mounted_volume_resize.go
+++ b/test/e2e/storage/mounted_volume_resize.go
@@ -134,7 +134,7 @@ var _ = utils.SIGDescribe("Mounted volume expand [Feature:StorageProvider]", fun
 
 		// PVC should be bound at this point
 		ginkgo.By("Checking for bound PVC")
-		pvs, err := e2epv.WaitForPVClaimBoundPhase(c, pvcClaims, framework.ClaimProvisionTimeout)
+		pvs, err := e2epv.WaitForPVClaimBoundPhase(c, pvcClaims, f.Timeouts.ClaimProvision)
 		framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
 		framework.ExpectEqual(len(pvs), 1)
 

--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -196,7 +196,7 @@ var _ = utils.SIGDescribe("Pod Disks [Feature:StorageProvider]", func() {
 					ginkgo.By("deleting host0Pod") // delete this pod before creating next pod
 					framework.ExpectNoError(podClient.Delete(context.TODO(), host0Pod.Name, podDelOpt), "Failed to delete host0Pod")
 					framework.Logf("deleted host0Pod %q", host0Pod.Name)
-					e2epod.WaitForPodToDisappear(cs, host0Pod.Namespace, host0Pod.Name, labels.Everything(), framework.Poll, framework.PodDeleteTimeout)
+					e2epod.WaitForPodToDisappear(cs, host0Pod.Namespace, host0Pod.Name, labels.Everything(), framework.Poll, f.Timeouts.PodDelete)
 					framework.Logf("deleted host0Pod %q disappeared", host0Pod.Name)
 				}
 

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -660,7 +660,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			}()
 
 			// The claim should timeout phase:Pending
-			err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, claim.Name, 2*time.Second, framework.ClaimProvisionShortTimeout)
+			err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, claim.Name, 2*time.Second, f.Timeouts.ClaimProvisionShort)
 			framework.ExpectError(err)
 			framework.Logf(err.Error())
 			claim, err = c.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), claim.Name, metav1.GetOptions{})
@@ -699,7 +699,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			}()
 
 			// The claim should timeout phase:Pending
-			err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, claim.Name, 2*time.Second, framework.ClaimProvisionShortTimeout)
+			err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, claim.Name, 2*time.Second, f.Timeouts.ClaimProvisionShort)
 			framework.ExpectError(err)
 			framework.Logf(err.Error())
 			claim, err = c.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), claim.Name, metav1.GetOptions{})

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -776,7 +776,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			// Event delivery is not reliable and it's used only as a quick way how to check if volume with wrong KMS
 			// key was not provisioned. If the event is not delivered, we check that the volume is not Bound for whole
 			// ClaimProvisionTimeout in the very same loop.
-			err = wait.Poll(time.Second, framework.ClaimProvisionTimeout, func() (bool, error) {
+			err = wait.Poll(time.Second, f.Timeouts.ClaimProvision, func() (bool, error) {
 				events, err := c.CoreV1().Events(claim.Namespace).List(context.TODO(), metav1.ListOptions{})
 				if err != nil {
 					return false, fmt.Errorf("could not list PVC events in %s: %v", claim.Namespace, err)
@@ -799,7 +799,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				return false, nil
 			})
 			if err == wait.ErrWaitTimeout {
-				framework.Logf("The test missed event about failed provisioning, but checked that no volume was provisioned for %v", framework.ClaimProvisionTimeout)
+				framework.Logf("The test missed event about failed provisioning, but checked that no volume was provisioned for %v", f.Timeouts.ClaimProvision)
 				err = nil
 			}
 			framework.ExpectNoError(err, "Error waiting for PVC to fail provisioning: %v", err)

--- a/test/e2e/storage/vsphere/vsphere_statefulsets.go
+++ b/test/e2e/storage/vsphere/vsphere_statefulsets.go
@@ -137,7 +137,7 @@ var _ = utils.SIGDescribe("vsphere statefulset [Feature:vsphere]", func() {
 		// After scale up, verify all vsphere volumes are attached to node VMs.
 		ginkgo.By("Verify all volumes are attached to Nodes after Statefulsets is scaled up")
 		for _, sspod := range ssPodsAfterScaleUp.Items {
-			err := e2epod.WaitTimeoutForPodReadyInNamespace(client, sspod.Name, statefulset.Namespace, framework.PodStartTimeout)
+			err := e2epod.WaitTimeoutForPodReadyInNamespace(client, sspod.Name, statefulset.Namespace, f.Timeouts.PodStart)
 			framework.ExpectNoError(err)
 			pod, err := client.CoreV1().Pods(namespace).Get(context.TODO(), sspod.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)

--- a/test/e2e/upgrades/apps/daemonsets.go
+++ b/test/e2e/upgrades/apps/daemonsets.go
@@ -18,6 +18,7 @@ package apps
 
 import (
 	"context"
+
 	"github.com/onsi/ginkgo"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -58,7 +59,7 @@ func (t *DaemonSetUpgradeTest) Setup(f *framework.Framework) {
 	}
 
 	ginkgo.By("Waiting for DaemonSet pods to become ready")
-	err = wait.Poll(framework.Poll, framework.PodStartTimeout, func() (bool, error) {
+	err = wait.Poll(framework.Poll, f.Timeouts.PodStart, func() (bool, error) {
 		return e2edaemonset.CheckRunningOnAllNodes(f, t.daemonSet)
 	})
 	framework.ExpectNoError(err)

--- a/test/e2e/upgrades/apps/replicasets.go
+++ b/test/e2e/upgrades/apps/replicasets.go
@@ -19,6 +19,7 @@ package apps
 import (
 	"context"
 	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,7 +60,7 @@ func (r *ReplicaSetUpgradeTest) Setup(f *framework.Framework) {
 	framework.ExpectNoError(err)
 
 	ginkgo.By(fmt.Sprintf("Waiting for replicaset %s to have all of its replicas ready", rsName))
-	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(c, ns, rsName))
+	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(c, ns, rsName, f.Timeouts.PodStart))
 
 	r.UID = rs.UID
 }
@@ -83,7 +84,7 @@ func (r *ReplicaSetUpgradeTest) Test(f *framework.Framework, done <-chan struct{
 	}
 
 	ginkgo.By(fmt.Sprintf("Waiting for replicaset %s to have all of its replicas ready after upgrade", rsName))
-	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(c, ns, rsName))
+	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(c, ns, rsName, f.Timeouts.PodStart))
 
 	// Verify the upgraded RS is active by scaling up the RS to scaleNum and ensuring all pods are Ready
 	ginkgo.By(fmt.Sprintf("Scaling up replicaset %s to %d", rsName, scaleNum))
@@ -93,7 +94,7 @@ func (r *ReplicaSetUpgradeTest) Test(f *framework.Framework, done <-chan struct{
 	framework.ExpectNoError(err)
 
 	ginkgo.By(fmt.Sprintf("Waiting for replicaset %s to have all of its replicas ready after scaling", rsName))
-	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(c, ns, rsName))
+	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(c, ns, rsName, f.Timeouts.PodStart))
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/e2e/upgrades/node/apparmor.go
+++ b/test/e2e/upgrades/node/apparmor.go
@@ -18,6 +18,7 @@ package node
 
 import (
 	"context"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -61,7 +62,7 @@ func (t *AppArmorUpgradeTest) Setup(f *framework.Framework) {
 
 	// Create the initial test pod.
 	ginkgo.By("Creating a long-running AppArmor enabled pod.")
-	t.pod = e2esecurity.CreateAppArmorTestPod(f.Namespace.Name, f.ClientSet, f.PodClient(), false, false)
+	t.pod = e2esecurity.CreateAppArmorTestPod(f.Namespace.Name, f.ClientSet, f.PodClient(), false, false, f.Timeouts.PodStart)
 
 	// Verify initial state.
 	t.verifyNodesAppArmorEnabled(f)
@@ -97,7 +98,7 @@ func (t *AppArmorUpgradeTest) verifyPodStillUp(f *framework.Framework) {
 
 func (t *AppArmorUpgradeTest) verifyNewPodSucceeds(f *framework.Framework) {
 	ginkgo.By("Verifying an AppArmor profile is enforced for a new pod")
-	e2esecurity.CreateAppArmorTestPod(f.Namespace.Name, f.ClientSet, f.PodClient(), false, true)
+	e2esecurity.CreateAppArmorTestPod(f.Namespace.Name, f.ClientSet, f.PodClient(), false, true, f.Timeouts.PodStart)
 }
 
 func (t *AppArmorUpgradeTest) verifyNodesAppArmorEnabled(f *framework.Framework) {

--- a/test/e2e/upgrades/storage/volume_mode.go
+++ b/test/e2e/upgrades/storage/volume_mode.go
@@ -101,7 +101,7 @@ func (t *VolumeModeDowngradeTest) Setup(f *framework.Framework) {
 		PVCs:         []*v1.PersistentVolumeClaim{t.pvc},
 		SeLinuxLabel: e2epv.SELinuxLabel,
 	}
-	t.pod, err = e2epod.CreateSecPod(cs, &podConfig, framework.PodStartTimeout)
+	t.pod, err = e2epod.CreateSecPod(cs, &podConfig, f.Timeouts.PodStart)
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Checking if PV exists as expected volume mode")

--- a/test/e2e/upgrades/storage/volume_mode.go
+++ b/test/e2e/upgrades/storage/volume_mode.go
@@ -86,7 +86,7 @@ func (t *VolumeModeDowngradeTest) Setup(f *framework.Framework) {
 	t.pvc, err = e2epv.CreatePVC(cs, ns, t.pvc)
 	framework.ExpectNoError(err)
 
-	err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, cs, ns, t.pvc.Name, framework.Poll, framework.ClaimProvisionTimeout)
+	err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, cs, ns, t.pvc.Name, framework.Poll, f.Timeouts.ClaimProvision)
 	framework.ExpectNoError(err)
 
 	t.pvc, err = cs.CoreV1().PersistentVolumeClaims(t.pvc.Namespace).Get(context.TODO(), t.pvc.Name, metav1.GetOptions{})

--- a/test/e2e/windows/device_plugin.go
+++ b/test/e2e/windows/device_plugin.go
@@ -106,7 +106,7 @@ var _ = SIGDescribe("[Feature:GPUDevicePlugin] Device Plugin", func() {
 		windowsPod, err = cs.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), windowsPod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		ginkgo.By("Waiting for the pod Running")
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(cs, windowsPod.Name, f.Namespace.Name, testSlowMultiplier*framework.PodStartTimeout)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(cs, windowsPod.Name, f.Namespace.Name, testSlowMultiplier*f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("verifying device access in Windows testing Pod")

--- a/test/e2e/windows/security_context.go
+++ b/test/e2e/windows/security_context.go
@@ -96,7 +96,7 @@ var _ = SIGDescribe("[Feature:Windows] SecurityContext", func() {
 			}
 
 			return false
-		}, framework.PodStartTimeout, 1*time.Second).Should(gomega.BeTrue())
+		}, f.Timeouts.PodStart, 1*time.Second).Should(gomega.BeTrue())
 	})
 
 	ginkgo.It("should not be able to create pods with unknown usernames at Container level", func() {

--- a/test/e2e_node/apparmor_test.go
+++ b/test/e2e_node/apparmor_test.go
@@ -20,12 +20,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	admissionapi "k8s.io/pod-security-admission/api"
 	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
+
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	v1 "k8s.io/api/core/v1"
@@ -154,7 +155,7 @@ func runAppArmorTest(f *framework.Framework, shouldRun bool, profile string) v1.
 	if shouldRun {
 		// The pod needs to start before it stops, so wait for the longer start timeout.
 		framework.ExpectNoError(e2epod.WaitTimeoutForPodNoLongerRunningInNamespace(
-			f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout))
+			f.ClientSet, pod.Name, f.Namespace.Name, f.Timeouts.PodStart))
 	} else {
 		// Pod should remain in the pending state. Wait for the Reason to be set to "AppArmor".
 		fieldSelector := fields.OneTermEqualSelector("metadata.name", pod.Name).String()
@@ -181,7 +182,7 @@ func runAppArmorTest(f *framework.Framework, shouldRun bool, profile string) v1.
 
 			return false, nil
 		}
-		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), framework.PodStartTimeout)
+		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), f.Timeouts.PodStart)
 		defer cancel()
 		_, err := watchtools.UntilWithSync(ctx, w, &v1.Pod{}, preconditionFunc, func(e watch.Event) (bool, error) {
 			switch e.Type {

--- a/test/e2e_node/image_id_test.go
+++ b/test/e2e_node/image_id_test.go
@@ -18,7 +18,8 @@ package e2enode
 
 import (
 	"context"
-	"k8s.io/api/core/v1"
+
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -54,7 +55,7 @@ var _ = SIGDescribe("ImageID [NodeFeature: ImageID]", func() {
 		pod := f.PodClient().Create(podDesc)
 
 		framework.ExpectNoError(e2epod.WaitTimeoutForPodNoLongerRunningInNamespace(
-			f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout))
+			f.ClientSet, pod.Name, f.Namespace.Name, f.Timeouts.PodStart))
 		runningPod, err := f.PodClient().Get(context.TODO(), pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 

--- a/test/e2e_node/pod_hostnamefqdn_test.go
+++ b/test/e2e_node/pod_hostnamefqdn_test.go
@@ -198,7 +198,7 @@ func expectSandboxFailureEvent(f *framework.Framework, pod *v1.Pod, msg string) 
 		"reason":                   events.FailedCreatePodSandBox,
 	}.AsSelector().String()
 	framework.ExpectNoError(e2eevents.WaitTimeoutForEvent(
-		f.ClientSet, f.Namespace.Name, eventSelector, msg, framework.PodEventTimeout))
+		f.ClientSet, f.Namespace.Name, eventSelector, msg, f.Timeouts.PodEvent))
 }
 
 func checkPodIsPending(f *framework.Framework, podName, namespace string) error {

--- a/test/e2e_node/security_context_test.go
+++ b/test/e2e_node/security_context_test.go
@@ -129,7 +129,7 @@ var _ = SIGDescribe("Security Context", func() {
 				hostPID,
 			))
 
-			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+			podClient.WaitForSuccess(podName, f.Timeouts.PodStart)
 		}
 
 		nginxPid := ""
@@ -209,7 +209,7 @@ var _ = SIGDescribe("Security Context", func() {
 				hostNetwork,
 			))
 
-			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+			podClient.WaitForSuccess(podName, f.Timeouts.PodStart)
 		}
 
 		hostSharedMemoryID := ""
@@ -289,7 +289,7 @@ var _ = SIGDescribe("Security Context", func() {
 				hostNetwork,
 			))
 
-			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+			podClient.WaitForSuccess(podName, f.Timeouts.PodStart)
 		}
 
 		listeningPort := ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:



Remove some of e2e framework deprecated timeout constants, use their corresponding framework.TimeContext values instead.

Some timeout constants from the same file are not able to migrate for now, like `Poll` or `PodGetTimeout`, because they are referenced by Framework itself, so they are left out.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
