### PR TITLE
Move path error to const and squash tests

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -45,7 +45,8 @@ import (
 var FileExtensions = []string{".json", ".yaml", ".yml"}
 var InputExtensions = append(FileExtensions, "stdin")
 
-const defaultHttpGetAttempts int = 3
+const defaultHttpGetAttempts = 3
+const pathNotExistError = "the path %q does not exist"
 
 // Builder provides convenience functions for taking arguments and parameters
 // from the command line and converting them to a list of resources to iterate
@@ -416,7 +417,7 @@ func (b *Builder) Path(recursive bool, paths ...string) *Builder {
 	for _, p := range paths {
 		_, err := os.Stat(p)
 		if os.IsNotExist(err) {
-			b.errs = append(b.errs, fmt.Errorf("the path %q does not exist", p))
+			b.errs = append(b.errs, fmt.Errorf(pathNotExistError, p))
 			continue
 		}
 		if err != nil {
@@ -1213,7 +1214,7 @@ func expandIfFilePattern(pattern string) ([]string, error) {
 	if _, err := os.Stat(pattern); os.IsNotExist(err) {
 		matches, err := filepath.Glob(pattern)
 		if err == nil && len(matches) == 0 {
-			return nil, fmt.Errorf("the path %q does not exist", pattern)
+			return nil, fmt.Errorf(pathNotExistError, pattern)
 		}
 		if err == filepath.ErrBadPattern {
 			return nil, fmt.Errorf("pattern %q is not valid: %v", pattern, err)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli
/priority backlog

#### What this PR does / why we need it:
This is followup to https://github.com/kubernetes/kubernetes/pull/109488 as requested by @KnVerey to:
1. move the path error messages to a const
2. squash similar tests into single table-driven test case

While moving the tests I ensured that we maintain the same coverage as before this PR. 

#### Special notes for your reviewer:
/assign @KnVerey 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
