### PR TITLE
Do not raise an error proposing to use '--overwrite' when annotating with the same value

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
@@ -404,16 +404,16 @@ func validateAnnotations(removeAnnotations []string, newAnnotations map[string]s
 // validateNoAnnotationOverwrites validates that when overwrite is false, to-be-updated annotations don't exist in the object annotation map (yet)
 func validateNoAnnotationOverwrites(accessor metav1.Object, annotations map[string]string) error {
 	var buf bytes.Buffer
-	for key := range annotations {
+	for key, value := range annotations {
 		// change-cause annotation can always be overwritten
 		if key == polymorphichelpers.ChangeCauseAnnotation {
 			continue
 		}
-		if value, found := accessor.GetAnnotations()[key]; found {
+		if currValue, found := accessor.GetAnnotations()[key]; found && currValue != value {
 			if buf.Len() > 0 {
 				buf.WriteString("; ")
 			}
-			buf.WriteString(fmt.Sprintf("'%s' already has a value (%s)", key, value))
+			buf.WriteString(fmt.Sprintf("'%s' already has a value (%s)", key, currValue))
 		}
 	}
 	if buf.Len() > 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
@@ -236,6 +236,19 @@ func TestUpdateAnnotations(t *testing.T) {
 				},
 			},
 			annotations: map[string]string{"a": "b"},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"a": "b"},
+				},
+			},
+		},
+		{
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"a": "b"},
+				},
+			},
+			annotations: map[string]string{"a": "c"},
 			expectErr:   true,
 		},
 		{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
@@ -227,7 +227,7 @@ func TestUpdateAnnotations(t *testing.T) {
 		annotations map[string]string
 		remove      []string
 		expected    runtime.Object
-		expectErr   bool
+		expectedErr string
 	}{
 		{
 			obj: &v1.Pod{
@@ -249,7 +249,7 @@ func TestUpdateAnnotations(t *testing.T) {
 				},
 			},
 			annotations: map[string]string{"a": "c"},
-			expectErr:   true,
+			expectedErr: "--overwrite is false but found the following declared annotation(s): 'a' already has a value (b)",
 		},
 		{
 			obj: &v1.Pod{
@@ -378,13 +378,16 @@ func TestUpdateAnnotations(t *testing.T) {
 			resourceVersion:   test.version,
 		}
 		err := options.updateAnnotations(test.obj)
-		if test.expectErr {
+		if test.expectedErr != "" {
 			if err == nil {
 				t.Errorf("unexpected non-error: %v", test)
 			}
+			if err.Error() != test.expectedErr {
+				t.Errorf("error expected: %v, got: %v", test.expectedErr, err.Error())
+			}
 			continue
 		}
-		if !test.expectErr && err != nil {
+		if test.expectedErr == "" && err != nil {
 			t.Errorf("unexpected error: %v %v", err, test)
 		}
 		if !reflect.DeepEqual(test.obj, test.expected) {


### PR DESCRIPTION
Equivalent of PR #105936 for annotations.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently, when trying to set a label with the same value as current one, `kubectl` advise to use the `--overwrite` option:

```shell-session
$ kubectl create namespace test
namespace/test created
$ kubectl annotate namespace test usage=test
namespace/test annotated
$ kubectl annotate namespace test usage=test
error: --overwrite is false but found the following declared annotation(s): 'usage' already has a value (test)
```

But then, overwriting for the same value is a bit weird.

This PR propose to detect this situation and do nothing:

```shell-session
$ kubectl annotate namespace test usage=test
namespace/test annotated
```

#### Which issue(s) this PR fixes:

No existing issue.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Do not raise an error when setting an annotation with the same value, just ignore it.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
