### PR TITLE
GCE: skip updating external load balancer if service is managed by ingress-gce

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external_test.go
@@ -617,6 +617,13 @@ func TestEnsureExternalLoadBalancerRBSAnnotation(t *testing.T) {
 			} else {
 				assert.NoError(t, err, "Should not return an error "+desc)
 			}
+
+			err = gce.updateExternalLoadBalancer(vals.ClusterName, svc, nodes)
+			if tc.expectError != nil {
+				assert.EqualError(t, err, (*tc.expectError).Error())
+			} else {
+				assert.NoError(t, err, "Should not return an error "+desc)
+			}
 		})
 	}
 }
@@ -649,6 +656,13 @@ func TestEnsureExternalLoadBalancerRBSFinalizer(t *testing.T) {
 			svc := fakeLoadbalancerService("")
 			svc.Finalizers = tc.finalizers
 			_, err = gce.ensureExternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, nil, nodes)
+			if tc.expectError != nil {
+				assert.EqualError(t, err, (*tc.expectError).Error())
+			} else {
+				assert.NoError(t, err, "Should not return an error "+desc)
+			}
+
+			err = gce.updateExternalLoadBalancer(vals.ClusterName, svc, nodes)
 			if tc.expectError != nil {
 				assert.EqualError(t, err, (*tc.expectError).Error())
 			} else {


### PR DESCRIPTION
GCE: skip updating external load balancer if service is managed by ingress-gce
External load balancer services managed by ingress-gce should be annotated and use special finalizer.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
GCE: skip updating external load balancer if service is managed by ingress-gce
Otherwise service controller prints an error tat target pool was not found.
With this PR we avoid misleading error log line and API call to GCE.


#### Which issue(s) this PR fixes:
None, we noticed the issue internally 


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

