### PR TITLE
Automated cherry pick of #108429: Allow KUBE_TEST_REPO_LIST to be a remote url as well

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -408,9 +408,9 @@ function install-kube-manifests {
   tar xzf "${KUBE_HOME}/${manifests_tar}" -C "${dst_dir}" --overwrite
   local -r kube_addon_registry="${KUBE_ADDON_REGISTRY:-k8s.gcr.io}"
   if [[ "${kube_addon_registry}" != "k8s.gcr.io" ]]; then
-    find "${dst_dir}" \(-name '*.yaml' -or -name '*.yaml.in'\) -print0 | \
+    find "${dst_dir}" \( -name '*.yaml' -or -name '*.yaml.in' \) -print0 | \
       xargs -0 sed -ri "s@(image:\s.*)k8s.gcr.io@\1${kube_addon_registry}@"
-    find "${dst_dir}" \(-name '*.manifest' -or -name '*.json'\) -print0 | \
+    find "${dst_dir}" \( -name '*.manifest' -or -name '*.json' \) -print0 | \
       xargs -0 sed -ri "s@(image\":\s+\")k8s.gcr.io@\1${kube_addon_registry}@"
   fi
   cp "${dst_dir}/kubernetes/gci-trusty/gci-configure-helper.sh" "${KUBE_BIN}/configure-helper.sh"

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -17,10 +17,13 @@ limitations under the License.
 package image
 
 import (
+	"bufio"
+	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"net/http"
 	"os"
 	"regexp"
 	"strings"
@@ -73,9 +76,20 @@ func initReg() RegistryList {
 		return registry
 	}
 
-	fileContent, err := ioutil.ReadFile(repoList)
-	if err != nil {
-		panic(fmt.Errorf("Error reading '%v' file contents: %v", repoList, err))
+	var fileContent []byte
+	var err error
+	if strings.HasPrefix(repoList, "https://") || strings.HasPrefix(repoList, "http://") {
+		var b bytes.Buffer
+		err = readFromURL(repoList, bufio.NewWriter(&b))
+		if err != nil {
+			panic(fmt.Errorf("error reading '%v' url contents: %v", repoList, err))
+		}
+		fileContent = b.Bytes()
+	} else {
+		fileContent, err = os.ReadFile(repoList)
+		if err != nil {
+			panic(fmt.Errorf("error reading '%v' file contents: %v", repoList, err))
+		}
 	}
 
 	err = yaml.Unmarshal(fileContent, &registry)
@@ -83,6 +97,27 @@ func initReg() RegistryList {
 		panic(fmt.Errorf("Error unmarshalling '%v' YAML file: %v", repoList, err))
 	}
 	return registry
+}
+
+// Essentially curl url | writer
+func readFromURL(url string, writer io.Writer) error {
+	httpTransport := new(http.Transport)
+	httpTransport.Proxy = http.ProxyFromEnvironment
+
+	c := &http.Client{Transport: httpTransport}
+	r, err := c.Get(url)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+	if r.StatusCode >= 400 {
+		return fmt.Errorf("%v returned %d", url, r.StatusCode)
+	}
+	_, err = io.Copy(writer, r.Body)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 var (


### PR DESCRIPTION
Cherry pick of #108429 on release-1.23.

#108429: Allow KUBE_TEST_REPO_LIST to be a remote url as well

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Allow KUBE_TEST_REPO_LIST to be a remote url
```