### PR TITLE
feat: make jsonpath wait logics consistent with condition

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -227,7 +227,7 @@ func conditionFuncFor(condition string, errOut io.Writer) (ConditionFunc, error)
 
 // newJSONPathParser will create a new JSONPath parser based on the jsonPathExpression
 func newJSONPathParser(jsonPathExpression string) (*jsonpath.JSONPath, error) {
-	j := jsonpath.New("wait")
+	j := jsonpath.New("wait").AllowMissingKeys(true)
 	if jsonPathExpression == "" {
 		return nil, errors.New("jsonpath expression cannot be empty")
 	}
@@ -589,6 +589,9 @@ func (j JSONPathWait) checkCondition(obj *unstructured.Unstructured) (bool, erro
 	if err != nil {
 		return false, err
 	}
+	if len(parseResults) == 0 || len(parseResults[0]) == 0 {
+		return false, nil
+	}
 	if err := verifyParsedJSONPath(parseResults); err != nil {
 		return false, err
 	}
@@ -602,9 +605,6 @@ func (j JSONPathWait) checkCondition(obj *unstructured.Unstructured) (bool, erro
 // verifyParsedJSONPath verifies the JSON received from the API server is valid.
 // It will only accept a single JSON
 func verifyParsedJSONPath(results [][]reflect.Value) error {
-	if len(results) == 0 {
-		return errors.New("given jsonpath expression does not match any value")
-	}
 	if len(results) > 1 {
 		return errors.New("given jsonpath expression matches more than one list")
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -1173,7 +1173,7 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 			jsonPathExp:  "{.foo.bar}",
 			jsonPathCond: "baz",
 
-			expectedErr: "foo is not found",
+			expectedErr: "timed out waiting for the condition on theresource/foo-b6699dcfb-rnv7t",
 		},
 		{
 			name: "compare boolean JSONPath entry",

--- a/test/cmd/wait.sh
+++ b/test/cmd/wait.sh
@@ -35,6 +35,17 @@ run_wait_tests() {
     # Post-Condition: deployments exists
     kube::test::get_object_assert "deployments" "{{range .items}}{{.metadata.name}},{{end}}" 'test-1,test-2,'
 
+    # wait with jsonpath will timout for busybox deployment
+    set +o errexit
+
+    # Command: Wait with jsonpath support fields not exist in the first place
+    output_message=$(kubectl wait --for=jsonpath=.status.readyReplicas=1 deploy/test-1)
+    
+    # Post-Condition: Wait failed
+    kube::test::if_has_string "${output_message}" 'timed out'
+
+    set -o errexit
+
     # Delete all deployments async to kubectl wait
     ( sleep 2 && kubectl delete deployment --all ) &
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Keep the behavior of jsonpath and condition consistent.

#### Which issue(s) this PR fixes:

Fixes kubernetes/kubectl#1236

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubectl wait command with jsonpath flag will wait for target path appear until timeout.
```

