### PR TITLE
Promote Batchv1JobLifecycleTest +4 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -785,6 +785,16 @@
     and delete the job. Job MUST be deleted successfully.
   release: v1.15
   file: test/e2e/apps/job.go
+- testname: Jobs, manage lifecycle
+  codename: '[sig-apps] Job should manage the lifecycle of a job [Conformance]'
+  description: Attempt to create a suspended Job which MUST succeed. Attempt to patch
+    the Job to include a new label which MUST succeed. The label MUST be found. Attempt
+    to replace the Job to include a new annotation which MUST succeed. The annotation
+    MUST be found. Attempt to list all namespaces with a label selector which MUST
+    succeed. One list MUST be found. It MUST succeed at deleting a collection of jobs
+    via a label selector.
+  release: v1.25
+  file: test/e2e/apps/job.go
 - testname: Jobs, completion after task failure
   codename: '[sig-apps] Job should run a job to completion when tasks sometimes fail
     and are locally restarted [Conformance]'

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -518,6 +518,8 @@ var _ = SIGDescribe("Job", func() {
 	})
 
 	/*
+		Release: v1.25
+		Testname: Jobs, manage lifecycle
 		Description: Attempt to create a suspended Job which MUST succeed.
 		Attempt to patch the Job to include a new label which MUST succeed.
 		The label MUST be found. Attempt to replace the Job to include a
@@ -526,7 +528,7 @@ var _ = SIGDescribe("Job", func() {
 		succeed. One list MUST be found. It MUST succeed at deleting a
 		collection of jobs via a label selector.
 	*/
-	ginkgo.It("should manage the lifecycle of a job", func() {
+	framework.ConformanceIt("should manage the lifecycle of a job", func() {
 		jobName := "e2e-" + utilrand.String(5)
 		label := map[string]string{"e2e-job-label": jobName}
 		labelSelector := labels.SelectorFromSet(label).String()


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- patchBatchV1NamespacedJob
- replaceBatchV1NamespacedJob
- deleteBatchV1CollectionNamespacedJob
- listBatchV1JobForAllNamespaces

**Which issue(s) this PR fixes:**
Fixes #108641

**Testgrid Link:** Batchv1JobLifecycleTest
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should%20manage%20the%20lifecycle%20of%20a%20job&graph-metrics=test-duration-minutes)


**Special notes for your reviewer:**
Adds +4 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance