### PR TITLE
Add PodWrapper functions for scheduler testing

### DIFF
--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -201,6 +201,21 @@ func (p *PodWrapper) Priority(val int32) *PodWrapper {
 	return p
 }
 
+// Annotation adds a pair of (key, value) to a pod's Annotations.
+func (p *PodWrapper) Annotation(key, value string) *PodWrapper {
+	if p.Annotations == nil {
+		p.Annotations = make(map[string]string)
+	}
+	p.Annotations[key] = value
+	return p
+}
+
+// CreationTimestamp sets the inner pod's CreationTimestamp.
+func (p *PodWrapper) CreationTimestamp(t metav1.Time) *PodWrapper {
+	p.ObjectMeta.CreationTimestamp = t
+	return p
+}
+
 // Terminating sets the inner pod's deletionTimestamp to current timestamp.
 func (p *PodWrapper) Terminating() *PodWrapper {
 	now := metav1.Now()
@@ -263,6 +278,12 @@ func (p *PodWrapper) StartTime(t metav1.Time) *PodWrapper {
 // NominatedNodeName sets `n` as the .Status.NominatedNodeName of the inner pod.
 func (p *PodWrapper) NominatedNodeName(n string) *PodWrapper {
 	p.Status.NominatedNodeName = n
+	return p
+}
+
+// Condition adds a `condition(Type, Status, Reason)` to .Status.Conditions.
+func (p *PodWrapper) Condition(t v1.PodConditionType, s v1.ConditionStatus, r string) *PodWrapper {
+	p.Status.Conditions = append(p.Status.Conditions, v1.PodCondition{Type: t, Status: s, Reason: r})
 	return p
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

1. Add additional `PodWrapper` functions to facilitate scheduler testing. 
    1.1 `Annotation(key, value string)` adds a pair of (key, value) to pod.Annotations.
    1.2 `CreationTimestamp(t metav1.Time)` sets a pod's creationTimestamp.
    1.3 `Condition(type v1.PodConditionType, status v1.ConditionStatus, reason string)` adds  a condition to pod.Status.Conditions.
2. Replace ad-hoc pod building with `PodWrapper.MakePod` in `pkg/scheduler/internal/queue/scheduler_queue_test.go`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:

We should use `PodWrapper.MakePod` in other tests. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE

```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
