### PR TITLE
Automated cherry pick of #105676: Fix name for Pods of NonIndexed Jobs

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -627,18 +627,7 @@ func (f *FakePodControl) PatchPod(namespace, name string, data []byte) error {
 }
 
 func (f *FakePodControl) CreatePods(namespace string, spec *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
-	f.Lock()
-	defer f.Unlock()
-	f.CreateCallCount++
-	if f.CreateLimit != 0 && f.CreateCallCount > f.CreateLimit {
-		return fmt.Errorf("not creating pod, limit %d already reached (create call %d)", f.CreateLimit, f.CreateCallCount)
-	}
-	f.Templates = append(f.Templates, *spec)
-	f.ControllerRefs = append(f.ControllerRefs, *controllerRef)
-	if f.Err != nil {
-		return f.Err
-	}
-	return nil
+	return f.CreatePodsWithGenerateName(namespace, spec, object, controllerRef, "")
 }
 
 func (f *FakePodControl) CreatePodsWithGenerateName(namespace string, spec *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference, generateNamePrefix string) error {
@@ -648,6 +637,7 @@ func (f *FakePodControl) CreatePodsWithGenerateName(namespace string, spec *v1.P
 	if f.CreateLimit != 0 && f.CreateCallCount > f.CreateLimit {
 		return fmt.Errorf("not creating pod, limit %d already reached (create call %d)", f.CreateLimit, f.CreateCallCount)
 	}
+	spec.GenerateName = generateNamePrefix
 	f.Templates = append(f.Templates, *spec)
 	f.ControllerRefs = append(f.ControllerRefs, *controllerRef)
 	if f.Err != nil {

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1283,13 +1283,14 @@ func (jm *Controller) manageJob(job *batch.Job, activePods []*v1.Pod, succeeded 
 				}
 				go func() {
 					template := podTemplate
+					generateName := ""
 					if completionIndex != unknownCompletionIndex {
 						template = podTemplate.DeepCopy()
 						addCompletionIndexAnnotation(template, completionIndex)
 						template.Spec.Hostname = fmt.Sprintf("%s-%d", job.Name, completionIndex)
+						generateName = podGenerateNameWithIndex(job.Name, completionIndex)
 					}
 					defer wait.Done()
-					generateName := podGenerateNameWithIndex(job.Name, completionIndex)
 					err := jm.podControl.CreatePodsWithGenerateName(job.Namespace, template, job, metav1.NewControllerRef(job, controllerKind), generateName)
 					if err != nil {
 						if apierrors.HasStatusCause(err, v1.NamespaceTerminatingCause) {

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -778,6 +778,16 @@ func TestControllerSyncJob(t *testing.T) {
 				}
 				if tc.completionMode == batch.IndexedCompletion {
 					checkIndexedJobPods(t, &fakePodControl, tc.expectedCreatedIndexes, job.Name)
+				} else {
+					for _, p := range fakePodControl.Templates {
+						// Fake pod control doesn't add generate name from the owner reference.
+						if p.GenerateName != "" {
+							t.Errorf("Got pod generate name %s, want %s", p.GenerateName, "")
+						}
+						if p.Spec.Hostname != "" {
+							t.Errorf("Got pod hostname %q, want none", p.Spec.Hostname)
+						}
+					}
 				}
 				if int32(len(fakePodControl.DeletePodName)) != tc.expectedDeletions {
 					t.Errorf("Unexpected number of deletes.  Expected %d, saw %d\n", tc.expectedDeletions, len(fakePodControl.DeletePodName))
@@ -868,8 +878,12 @@ func checkIndexedJobPods(t *testing.T, control *controller.FakePodControl, wantI
 			gotIndexes.Insert(ix)
 		}
 		expectedName := fmt.Sprintf("%s-%d", jobName, ix)
-		if diff := cmp.Equal(expectedName, p.Spec.Hostname); !diff {
+		if expectedName != p.Spec.Hostname {
 			t.Errorf("Got pod hostname %s, want %s", p.Spec.Hostname, expectedName)
+		}
+		expectedName += "-"
+		if expectedName != p.GenerateName {
+			t.Errorf("Got pod generate name %s, want %s", p.GenerateName, expectedName)
 		}
 	}
 	if diff := cmp.Diff(wantIndexes.List(), gotIndexes.List()); diff != "" {


### PR DESCRIPTION
Cherry pick of #105676 on release-1.22.

#105676: Fix name for Pods of NonIndexed Jobs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix 1.22 regression so pod name of NonIndexed jobs does not include rogue -1 substring
```