### PR TITLE
scheduler_perf: Remove test cases for Preemption which always fail

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -405,11 +405,14 @@
       initNodes: 500
       initPods: 2000
       measurePods: 500
-  - name: 5000Nodes
-    params:
-      initNodes: 5000
-      initPods: 20000
-      measurePods: 5000
+# This test case always seems to fail.
+# https://github.com/kubernetes/kubernetes/issues/108308
+# 
+#  - name: 5000Nodes
+#    params:
+#      initNodes: 5000
+#      initPods: 20000
+#      measurePods: 5000
 
 - name: PreemptionPVs
   workloadTemplate:
@@ -430,11 +433,14 @@
       initNodes: 500
       initPods: 2000
       measurePods: 500
-  - name: 5000Nodes
-    params:
-      initNodes: 5000
-      initPods: 20000
-      measurePods: 5000
+# This test case always seems to fail.
+# https://github.com/kubernetes/kubernetes/issues/108308
+# 
+#  - name: 5000Nodes
+#    params:
+#      initNodes: 5000
+#      initPods: 20000
+#      measurePods: 5000
 
 - name: Unschedulable
   workloadTemplate:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR removes test cases PreemptionBasic/5000Nodes and PreemptionPV/5000Nodes.

Currently, the test cases PreemptionBasic/5000Nodes and PreemptionPV/5000Nodes always fail. 
It seems that these test cases are impossible test cases with a realistic machine pawer. "A realistic machine" at least includes a PC "64GB RAM, 36 cores, albeit with hyperthreading" ref: https://github.com/kubernetes/kubernetes/pull/107771#issuecomment-1024366152. 

And because of it, the prow job for scheduler_perf (ci-benchmark-scheduler-perf-master) has also always failed.
ref: https://prow.k8s.io/?job=ci-benchmark-scheduler-perf-master
> ci-benchmark-scheduler-perf-master: {
  failing_days: 729
},
[ref](https://00f74ba44b5dfe11595010c1e02598e66f604fb22b-apidata.googleusercontent.com/download/storage/v1/b/k8s-metrics/o/failures-latest.json?jk=AFshE3UrhOa8Q4inLSRl5C2O1RCfdlSNvG7YxWQ7Zsm0DF7hU6dUMZQegRX6tfNMI-m_HXYjphIBgTyR1vxgm-ouYW958P0vv_MmMjzU7BaRx1glTjn4svJ4ef47fnw62UXOrsk7m_TbaG0n4O3p7-L0ZNQba6ckXIQ_1doe1Mw2AU3Om1isvrNlXJSI3OoluCYRTc_oj2yO35lN3vsqLdacQqGq1hgdw-SfP6GFai0xWqpM8Bt80TNqSwfRtTgPIU47lYat5axSWlTA9LcwO9mjtMy9ZD_fBUqQe7gezwjoSQ8k90rzeoZt2QnfVH4Ej3kwd_JHDK3SA_5mxjuAYDQib19hAd0eqbW68N673bqWXe7VYaYCHwD3vn9C14AacDsUKqRMzmjq0kppxhZdBBpopquL2g3xrO6hPTG_N3b1gWw8OoYQqNHwG24Km9vMNgkGsxUxQlYinWa7onL8iJYA9EIWqpp5Kl9OZzKXNRP1TYKxeW-qlynf9BV-lHeW3vqaRb1TqSC4xs-G5Jv4sL3GaCc1NGa4p0lL5-SFWFLnr34_0j4sPFIWKw17JDRyNu7o1SgBHFGrtHnhChXtdYTvg_YajpMjKsTtnjAqoYiVsFEwOyxXbra-2AZ-zz6fLqg4ZOO3sMDJbsI-p81tXBJqdjnDowWDjjv3uYcju6VqRA-fHubpKY6zty35GRWd1QLwMf6Y5Qr2MskZveN6jopgBkHIrFycWkEwYpvIUK0wqRZuiJ2dZzXQj6Mp97J81Sgq-D49uj22qO8PpRzvAcz94KKg9cEgAffCNOt6xv2aQG5dooYvg68LX1GRxX4TbxYf5gZBfjmNggLcfVqYEQ3xIM7ICfTlIuQ3Kb8n-Q7dUQalVgswsPKzioORP27PfjSXyoXN3axKylANwYhovbnTjL_VrT_lm-5DlNleoxH3_WanvKWj4PVT9LxXq7tsJXWE86OyBzh6evouLgCj2QoFwcK6P8JAUrBjvxDD-MsUlIRZ&isca=1)

We can also see the failing of these test cases from perf-dash. 
For PreemptionBasic/5000Nodes, only a few results were recorded, indicating that they were not always successful.:
https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkResults&benchmark=BenchmarkPerfScheduling%2FPreemptionBasic%2F5000Nodes-8&metricName=time
For PreemptionPV/5000Nodes, no result are recoreded. I guess we've never been able to successfully run PreemptionPV/5000Nodes on prow.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #108308

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```