### PR TITLE
Optimization tips for `kubectl version should fail when given extra arguments`

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -57,8 +57,6 @@ type Options struct {
 	Short      bool
 	Output     string
 
-	args []string
-
 	discoveryClient discovery.CachedDiscoveryInterface
 
 	genericclioptions.IOStreams
@@ -93,8 +91,11 @@ func NewCmdVersion(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 	return cmd
 }
 
-// Complete completes all the required options
+// Complete adapts from the command line args and factory to the data required
 func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmdutil.UsageErrorf(cmd, "unexpected arguments: %v", args)
+	}
 	var err error
 	if o.ClientOnly {
 		return nil
@@ -106,16 +107,11 @@ func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string)
 		return err
 	}
 
-	o.args = args
 	return nil
 }
 
 // Validate validates the provided options
 func (o *Options) Validate() error {
-	if len(o.args) != 0 {
-		return errors.New(fmt.Sprintf("extra arguments: %v", o.args))
-	}
-
 	if o.Output != "" && o.Output != "yaml" && o.Output != "json" {
 		return errors.New(`--output must be 'yaml' or 'json'`)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
@@ -37,11 +37,8 @@ func TestNewCmdVersionClientVersion(t *testing.T) {
 	if err := o.Validate(); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if err := o.Complete(tf, &cobra.Command{}, []string{"extraParameter0"}); err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	if err := o.Validate(); !strings.Contains(err.Error(), "extra arguments") {
-		t.Errorf("Unexpected error: should fail to validate the args length greater than 0")
+	if err := o.Complete(tf, &cobra.Command{}, []string{"extraParameter0"}); err == nil {
+		t.Errorf("Expected error: unexpected arguments: [extraParameter0], but got err: nil")
 	}
 	if err := o.Run(); err != nil {
 		t.Errorf("Cannot execute version command: %v", err)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig cli
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`kubectl version` tips are not friendly when given extra arguments.
 Validation args should be done in `Complete` similarly to `kubectl api-versions`:
https://github.com/kubernetes/kubernetes/blob/b36c927d957e585ce54d415be4d7e4621e189d85/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiversions.go#L71-L74
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
