### PR TITLE
Prevent space-prefixed tokens

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
@@ -46,9 +46,9 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.R
 
 	token := parts[1]
 
-	// Empty bearer tokens aren't valid
+	// Passing empty bearer tokens or prefixing them with a space is illegal.
 	if len(token) == 0 {
-		return nil, false, nil
+		return nil, false, invalidToken
 	}
 
 	resp, ok, err := a.auth.AuthenticateToken(req.Context(), token)

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken_test.go
@@ -184,6 +184,13 @@ func TestBearerToken(t *testing.T) {
 			ExpectedErr:                  true,
 			ExpectedAuthorizationHeaders: []string{"Bearer 123"},
 		},
+		"invalid bearer token with a space": {
+			AuthorizationHeaders:         []string{"Bearer  token"},
+			ExpectedUserName:             "",
+			ExpectedOK:                   false,
+			ExpectedErr:                  true,
+			ExpectedAuthorizationHeaders: []string{"Bearer  token"},
+		},
 		"error bearer token": {
 			AuthorizationHeaders: []string{"Bearer 123"},
 			TokenAuth: authenticator.TokenFunc(func(ctx context.Context, t string) (*authenticator.Response, bool, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This Pull Request prevents users from sending a space-prefixed bearer tokens, e.g.:

```
$ curl -k https://IP -H "Authorization: Bearer  asdf"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #106142

#### Special notes for your reviewer:

The space-prefixed Authorization headers violate [RFC 6750, Section 2.1](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Bearer tokens prefixed with a space are not allowed due to RFC 6750, Section 2.1 violation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
