### PR TITLE
[release-1.24] Update publishing-bot rules

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1,193 +1,202 @@
-recursive-delete-patterns:
-# TODO: remove bazel related files after we stop publishing branches with
-# bazel files
-# See: https://github.com/kubernetes/enhancements/issues/2420
-- BUILD
-- "*/BUILD"
-- BUILD.bazel
-- "*/BUILD.bazel"
-- Gopkg.toml
-- "*/.gitattributes"
-default-go-version: 1.18.1
 rules:
 - destination: code-generator
   branches:
-  - source:
+  - name: master
+    source:
       branch: master
       dir: staging/src/k8s.io/code-generator
-    name: master
-  - source:
+  - name: release-1.20
+    go: 1.15.15
+    source:
       branch: release-1.20
       dir: staging/src/k8s.io/code-generator
-    name: release-1.20
-    go: 1.15.15
-  - source:
+  - name: release-1.21
+    go: 1.16.15
+    source:
       branch: release-1.21
       dir: staging/src/k8s.io/code-generator
-    name: release-1.21
+  - name: release-1.22
     go: 1.16.15
-  - source:
+    source:
       branch: release-1.22
       dir: staging/src/k8s.io/code-generator
-    name: release-1.22
-    go: 1.16.15
-  - source:
+  - name: release-1.23
+    go: 1.17.9
+    source:
       branch: release-1.23
       dir: staging/src/k8s.io/code-generator
-    name: release-1.23
-    go: 1.17.9
-
+  - name: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/code-generator
 - destination: apimachinery
-  library: true
   branches:
-  - source:
+  - name: master
+    source:
       branch: master
       dir: staging/src/k8s.io/apimachinery
-    name: master
-  - source:
+  - name: release-1.20
+    go: 1.15.15
+    source:
       branch: release-1.20
       dir: staging/src/k8s.io/apimachinery
-    name: release-1.20
-    go: 1.15.15
-  - source:
+  - name: release-1.21
+    go: 1.16.15
+    source:
       branch: release-1.21
       dir: staging/src/k8s.io/apimachinery
-    name: release-1.21
+  - name: release-1.22
     go: 1.16.15
-  - source:
+    source:
       branch: release-1.22
       dir: staging/src/k8s.io/apimachinery
-    name: release-1.22
-    go: 1.16.15
-  - source:
+  - name: release-1.23
+    go: 1.17.9
+    source:
       branch: release-1.23
       dir: staging/src/k8s.io/apimachinery
-    name: release-1.23
-    go: 1.17.9
-
+  - name: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/apimachinery
+  library: true
 - destination: api
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/api
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/api
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
-      - repository: apimachinery
-        branch: release-1.20
-  - source:
-      branch: release-1.21
+    - repository: apimachinery
+      branch: release-1.20
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/api
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
-      - repository: apimachinery
-        branch: release-1.21
-  - source:
-      branch: release-1.22
+    - repository: apimachinery
+      branch: release-1.21
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/api
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/api
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/api
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/api
+  library: true
 - destination: client-go
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/client-go
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
     - repository: api
       branch: master
+    source:
+      branch: master
+      dir: staging/src/k8s.io/client-go
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod ./...
       go test -mod=mod ./...
-  - source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/client-go
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
-      - repository: apimachinery
-        branch: release-1.20
-      - repository: api
-        branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/client-go
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod ./...
       go test -mod=mod ./...
-  - source:
+  - name: release-1.21
+    go: 1.16.15
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    source:
       branch: release-1.21
       dir: staging/src/k8s.io/client-go
-    name: release-1.21
-    go: 1.16.15
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.21
-      - repository: api
-        branch: release-1.21
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod ./...
       go test -mod=mod ./...
-  - source:
+  - name: release-1.22
+    go: 1.16.15
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    source:
       branch: release-1.22
       dir: staging/src/k8s.io/client-go
-    name: release-1.22
-    go: 1.16.15
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.22
-      - repository: api
-        branch: release-1.22
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod ./...
       go test -mod=mod ./...
-  - source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/client-go
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
     - repository: api
       branch: release-1.23
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/client-go
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod ./...
       go test -mod=mod ./...
-
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/client-go
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod ./...
+      go test -mod=mod ./...
+  library: true
 - destination: component-base
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/component-base
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
@@ -195,10 +204,10 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/component-base
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
@@ -207,10 +216,10 @@ rules:
       branch: release-1.20
     - repository: client-go
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/component-base
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -219,10 +228,10 @@ rules:
       branch: release-1.21
     - repository: client-go
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/component-base
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -231,10 +240,10 @@ rules:
       branch: release-1.22
     - repository: client-go
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/component-base
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
@@ -243,14 +252,24 @@ rules:
       branch: release-1.23
     - repository: client-go
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/component-base
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/component-base
+  library: true
 - destination: component-helpers
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/component-helpers
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
@@ -258,10 +277,10 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/component-helpers
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
@@ -270,10 +289,10 @@ rules:
       branch: release-1.20
     - repository: client-go
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/component-helpers
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -282,10 +301,10 @@ rules:
       branch: release-1.21
     - repository: client-go
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/component-helpers
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -294,10 +313,10 @@ rules:
       branch: release-1.22
     - repository: client-go
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/component-helpers
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
@@ -306,14 +325,24 @@ rules:
       branch: release-1.23
     - repository: client-go
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/component-helpers
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/component-helpers
+  library: true
 - destination: apiserver
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/apiserver
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
@@ -323,10 +352,10 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/apiserver
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
@@ -337,10 +366,10 @@ rules:
       branch: release-1.20
     - repository: component-base
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/apiserver
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -351,10 +380,10 @@ rules:
       branch: release-1.21
     - repository: component-base
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/apiserver
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -365,10 +394,10 @@ rules:
       branch: release-1.22
     - repository: component-base
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/apiserver
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
@@ -379,13 +408,26 @@ rules:
       branch: release-1.23
     - repository: component-base
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/apiserver
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/apiserver
+  library: true
 - destination: kube-aggregator
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/kube-aggregator
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
@@ -399,10 +441,10 @@ rules:
       branch: master
     - repository: code-generator
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
@@ -417,10 +459,10 @@ rules:
       branch: release-1.20
     - repository: code-generator
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -435,10 +477,10 @@ rules:
       branch: release-1.21
     - repository: code-generator
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -453,10 +495,10 @@ rules:
       branch: release-1.22
     - repository: code-generator
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
@@ -471,13 +513,29 @@ rules:
       branch: release-1.23
     - repository: code-generator
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/kube-aggregator
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: apiserver
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    - repository: code-generator
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/kube-aggregator
 - destination: sample-apiserver
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/sample-apiserver
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
@@ -491,15 +549,15 @@ rules:
       branch: master
     - repository: component-base
       branch: master
+    source:
+      branch: master
+      dir: staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
@@ -514,15 +572,15 @@ rules:
       branch: release-1.20
     - repository: component-base
       branch: release-1.20
+    source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -537,15 +595,15 @@ rules:
       branch: release-1.21
     - repository: component-base
       branch: release-1.21
+    source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -560,15 +618,15 @@ rules:
       branch: release-1.22
     - repository: component-base
       branch: release-1.22
+    source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
@@ -583,18 +641,39 @@ rules:
       branch: release-1.23
     - repository: component-base
       branch: release-1.23
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: apiserver
+      branch: release-1.24
+    - repository: code-generator
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/sample-apiserver
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
 - destination: sample-controller
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/sample-controller
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
@@ -604,15 +683,15 @@ rules:
       branch: master
     - repository: code-generator
       branch: master
+    source:
+      branch: master
+      dir: staging/src/k8s.io/sample-controller
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
@@ -623,15 +702,15 @@ rules:
       branch: release-1.20
     - repository: code-generator
       branch: release-1.20
+    source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/sample-controller
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -642,15 +721,15 @@ rules:
       branch: release-1.21
     - repository: code-generator
       branch: release-1.21
+    source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/sample-controller
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -661,15 +740,15 @@ rules:
       branch: release-1.22
     - repository: code-generator
       branch: release-1.22
+    source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/sample-controller
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
@@ -680,18 +759,35 @@ rules:
       branch: release-1.23
     - repository: code-generator
       branch: release-1.23
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/sample-controller
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: code-generator
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/sample-controller
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
 - destination: apiextensions-apiserver
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
@@ -705,12 +801,12 @@ rules:
       branch: master
     - repository: component-base
       branch: master
+    source:
+      branch: master
+      dir: staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
-  - source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
@@ -725,12 +821,12 @@ rules:
       branch: release-1.20
     - repository: component-base
       branch: release-1.20
+    source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
-  - source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -745,12 +841,12 @@ rules:
       branch: release-1.21
     - repository: component-base
       branch: release-1.21
+    source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
-  - source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -765,12 +861,12 @@ rules:
       branch: release-1.22
     - repository: component-base
       branch: release-1.22
+    source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
-  - source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
@@ -785,16 +881,33 @@ rules:
       branch: release-1.23
     - repository: component-base
       branch: release-1.23
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
-
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: apiserver
+      branch: release-1.24
+    - repository: code-generator
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    required-packages:
+    - k8s.io/code-generator
 - destination: metrics
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/metrics
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
@@ -804,10 +917,10 @@ rules:
       branch: master
     - repository: code-generator
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/metrics
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
@@ -818,10 +931,10 @@ rules:
       branch: release-1.20
     - repository: code-generator
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/metrics
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -832,10 +945,10 @@ rules:
       branch: release-1.21
     - repository: code-generator
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/metrics
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -846,10 +959,10 @@ rules:
       branch: release-1.22
     - repository: code-generator
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/metrics
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
@@ -860,14 +973,26 @@ rules:
       branch: release-1.23
     - repository: code-generator
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/metrics
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: code-generator
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/metrics
+  library: true
 - destination: cli-runtime
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/cli-runtime
-    name: master
+  - name: master
     dependencies:
     - repository: api
       branch: master
@@ -875,10 +1000,10 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/cli-runtime
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: api
@@ -887,10 +1012,10 @@ rules:
       branch: release-1.20
     - repository: client-go
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/cli-runtime
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: api
@@ -899,10 +1024,10 @@ rules:
       branch: release-1.21
     - repository: client-go
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/cli-runtime
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: api
@@ -911,10 +1036,10 @@ rules:
       branch: release-1.22
     - repository: client-go
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/cli-runtime
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: api
@@ -923,14 +1048,24 @@ rules:
       branch: release-1.23
     - repository: client-go
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/cli-runtime
+  - name: release-1.24
+    dependencies:
+    - repository: api
+      branch: release-1.24
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/cli-runtime
+  library: true
 - destination: sample-cli-plugin
-  library: false
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/sample-cli-plugin
-    name: master
+  - name: master
     dependencies:
     - repository: api
       branch: master
@@ -940,10 +1075,10 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: api
@@ -954,10 +1089,10 @@ rules:
       branch: release-1.20
     - repository: client-go
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: api
@@ -968,10 +1103,10 @@ rules:
       branch: release-1.21
     - repository: client-go
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: api
@@ -982,10 +1117,10 @@ rules:
       branch: release-1.22
     - repository: client-go
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: api
@@ -996,14 +1131,25 @@ rules:
       branch: release-1.23
     - repository: client-go
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/sample-cli-plugin
+  - name: release-1.24
+    dependencies:
+    - repository: api
+      branch: release-1.24
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: cli-runtime
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/sample-cli-plugin
 - destination: kube-proxy
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/kube-proxy
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
@@ -1013,10 +1159,10 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/kube-proxy
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
@@ -1027,10 +1173,10 @@ rules:
       branch: release-1.20
     - repository: client-go
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/kube-proxy
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -1041,10 +1187,10 @@ rules:
       branch: release-1.21
     - repository: client-go
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/kube-proxy
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -1055,10 +1201,10 @@ rules:
       branch: release-1.22
     - repository: client-go
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/kube-proxy
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
@@ -1069,14 +1215,26 @@ rules:
       branch: release-1.23
     - repository: client-go
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/kube-proxy
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/kube-proxy
+  library: true
 - destination: kubelet
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/kubelet
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
@@ -1086,10 +1244,10 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/kubelet
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
@@ -1100,10 +1258,10 @@ rules:
       branch: release-1.20
     - repository: component-base
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/kubelet
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -1114,10 +1272,10 @@ rules:
       branch: release-1.21
     - repository: component-base
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/kubelet
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -1128,10 +1286,10 @@ rules:
       branch: release-1.22
     - repository: component-base
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/kubelet
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
@@ -1142,14 +1300,26 @@ rules:
       branch: release-1.23
     - repository: component-base
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/kubelet
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/kubelet
+  library: true
 - destination: kube-scheduler
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/kube-scheduler
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
@@ -1159,10 +1329,10 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
@@ -1173,10 +1343,10 @@ rules:
       branch: release-1.20
     - repository: client-go
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -1187,10 +1357,10 @@ rules:
       branch: release-1.21
     - repository: client-go
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -1201,10 +1371,10 @@ rules:
       branch: release-1.22
     - repository: client-go
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
@@ -1215,14 +1385,26 @@ rules:
       branch: release-1.23
     - repository: client-go
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/kube-scheduler
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/kube-scheduler
+  library: true
 - destination: controller-manager
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/controller-manager
-    name: master
+  - name: master
     dependencies:
     - repository: api
       branch: master
@@ -1234,10 +1416,10 @@ rules:
       branch: master
     - repository: apiserver
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/controller-manager
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: api
@@ -1250,10 +1432,10 @@ rules:
       branch: release-1.20
     - repository: apiserver
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/controller-manager
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: api
@@ -1266,10 +1448,10 @@ rules:
       branch: release-1.21
     - repository: apiserver
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/controller-manager
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: api
@@ -1282,10 +1464,10 @@ rules:
       branch: release-1.22
     - repository: apiserver
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/controller-manager
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: api
@@ -1298,14 +1480,28 @@ rules:
       branch: release-1.23
     - repository: apiserver
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/controller-manager
+  - name: release-1.24
+    dependencies:
+    - repository: api
+      branch: release-1.24
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    - repository: apiserver
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/controller-manager
+  library: true
 - destination: cloud-provider
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/cloud-provider
-    name: master
+  - name: master
     dependencies:
     - repository: api
       branch: master
@@ -1321,10 +1517,10 @@ rules:
       branch: master
     - repository: component-helpers
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/cloud-provider
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: api
@@ -1341,10 +1537,10 @@ rules:
       branch: release-1.20
     - repository: component-helpers
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/cloud-provider
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: api
@@ -1361,10 +1557,10 @@ rules:
       branch: release-1.21
     - repository: component-helpers
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/cloud-provider
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: api
@@ -1381,10 +1577,10 @@ rules:
       branch: release-1.22
     - repository: component-helpers
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/cloud-provider
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: api
@@ -1401,14 +1597,32 @@ rules:
       branch: release-1.23
     - repository: component-helpers
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/cloud-provider
+  - name: release-1.24
+    dependencies:
+    - repository: api
+      branch: release-1.24
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: apiserver
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    - repository: controller-manager
+      branch: release-1.24
+    - repository: component-helpers
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/cloud-provider
+  library: true
 - destination: kube-controller-manager
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/kube-controller-manager
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
@@ -1426,10 +1640,10 @@ rules:
       branch: master
     - repository: component-helpers
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
@@ -1448,10 +1662,10 @@ rules:
       branch: release-1.20
     - repository: component-helpers
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -1470,10 +1684,10 @@ rules:
       branch: release-1.21
     - repository: component-helpers
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
@@ -1492,10 +1706,10 @@ rules:
       branch: release-1.22
     - repository: component-helpers
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
@@ -1514,148 +1728,187 @@ rules:
       branch: release-1.23
     - repository: component-helpers
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/kube-controller-manager
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: apiserver
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: controller-manager
+      branch: release-1.24
+    - repository: cloud-provider
+      branch: release-1.24
+    - repository: component-helpers
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/kube-controller-manager
+  library: true
 - destination: cluster-bootstrap
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/cluster-bootstrap
-    name: master
+  - name: master
     dependencies:
     - repository: apimachinery
       branch: master
     - repository: api
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/cluster-bootstrap
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: apimachinery
       branch: release-1.20
     - repository: api
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/cluster-bootstrap
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.21
     - repository: api
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/cluster-bootstrap
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: apimachinery
       branch: release-1.22
     - repository: api
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/cluster-bootstrap
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: apimachinery
       branch: release-1.23
     - repository: api
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/cluster-bootstrap
+  - name: release-1.24
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: api
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/cluster-bootstrap
+  library: true
 - destination: csi-translation-lib
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/csi-translation-lib
-    name: master
+  - name: master
     dependencies:
     - repository: api
       branch: master
     - repository: apimachinery
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/csi-translation-lib
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: api
       branch: release-1.20
     - repository: apimachinery
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/csi-translation-lib
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.21
     - repository: apimachinery
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/csi-translation-lib
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: api
       branch: release-1.22
     - repository: apimachinery
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/csi-translation-lib
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: api
       branch: release-1.23
     - repository: apimachinery
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/csi-translation-lib
+  - name: release-1.24
+    dependencies:
+    - repository: api
+      branch: release-1.24
+    - repository: apimachinery
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/csi-translation-lib
+  library: true
 - destination: mount-utils
-  library: true
   branches:
-  - source:
+  - name: master
+    source:
       branch: master
       dir: staging/src/k8s.io/mount-utils
-    name: master
-  - source:
+  - name: release-1.20
+    go: 1.15.15
+    source:
       branch: release-1.20
       dir: staging/src/k8s.io/mount-utils
-    name: release-1.20
-    go: 1.15.15
-  - source:
+  - name: release-1.21
+    go: 1.16.15
+    source:
       branch: release-1.21
       dir: staging/src/k8s.io/mount-utils
-    name: release-1.21
+  - name: release-1.22
     go: 1.16.15
-  - source:
+    source:
       branch: release-1.22
       dir: staging/src/k8s.io/mount-utils
-    name: release-1.22
-    go: 1.16.15
-  - source:
+  - name: release-1.23
+    go: 1.17.9
+    source:
       branch: release-1.23
       dir: staging/src/k8s.io/mount-utils
-    name: release-1.23
-    go: 1.17.9
-
+  - name: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/mount-utils
+  library: true
 - destination: legacy-cloud-providers
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/legacy-cloud-providers
-    name: master
+  - name: master
     dependencies:
     - repository: api
       branch: master
@@ -1677,10 +1930,10 @@ rules:
       branch: master
     - repository: component-helpers
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/legacy-cloud-providers
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: api
@@ -1701,10 +1954,10 @@ rules:
       branch: release-1.20
     - repository: component-helpers
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/legacy-cloud-providers
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: api
@@ -1725,10 +1978,10 @@ rules:
       branch: release-1.21
     - repository: component-helpers
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/legacy-cloud-providers
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: api
@@ -1751,10 +2004,10 @@ rules:
       branch: release-1.22
     - repository: component-helpers
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/legacy-cloud-providers
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: api
@@ -1777,42 +2030,69 @@ rules:
       branch: release-1.23
     - repository: component-helpers
       branch: release-1.23
-
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/legacy-cloud-providers
+  - name: release-1.24
+    dependencies:
+    - repository: api
+      branch: release-1.24
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: cloud-provider
+      branch: release-1.24
+    - repository: csi-translation-lib
+      branch: release-1.24
+    - repository: apiserver
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    - repository: controller-manager
+      branch: release-1.24
+    - repository: mount-utils
+      branch: release-1.24
+    - repository: component-helpers
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/legacy-cloud-providers
+  library: true
 - destination: cri-api
-  library: true
   branches:
-  - source:
+  - name: master
+    source:
       branch: master
       dir: staging/src/k8s.io/cri-api
-    name: master
-  - source:
+  - name: release-1.20
+    go: 1.15.15
+    source:
       branch: release-1.20
       dir: staging/src/k8s.io/cri-api
-    name: release-1.20
-    go: 1.15.15
-  - source:
+  - name: release-1.21
+    go: 1.16.15
+    source:
       branch: release-1.21
       dir: staging/src/k8s.io/cri-api
-    name: release-1.21
+  - name: release-1.22
     go: 1.16.15
-  - source:
+    source:
       branch: release-1.22
       dir: staging/src/k8s.io/cri-api
-    name: release-1.22
-    go: 1.16.15
-  - source:
+  - name: release-1.23
+    go: 1.17.9
+    source:
       branch: release-1.23
       dir: staging/src/k8s.io/cri-api
-    name: release-1.23
-    go: 1.17.9
-
+  - name: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/cri-api
+  library: true
 - destination: kubectl
-  library: true
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/kubectl
-    name: master
+  - name: master
     dependencies:
     - repository: api
       branch: master
@@ -1830,10 +2110,10 @@ rules:
       branch: master
     - repository: metrics
       branch: master
-  - source:
-      branch: release-1.20
+    source:
+      branch: master
       dir: staging/src/k8s.io/kubectl
-    name: release-1.20
+  - name: release-1.20
     go: 1.15.15
     dependencies:
     - repository: api
@@ -1852,10 +2132,10 @@ rules:
       branch: release-1.20
     - repository: metrics
       branch: release-1.20
-  - source:
-      branch: release-1.21
+    source:
+      branch: release-1.20
       dir: staging/src/k8s.io/kubectl
-    name: release-1.21
+  - name: release-1.21
     go: 1.16.15
     dependencies:
     - repository: api
@@ -1874,10 +2154,10 @@ rules:
       branch: release-1.21
     - repository: metrics
       branch: release-1.21
-  - source:
-      branch: release-1.22
+    source:
+      branch: release-1.21
       dir: staging/src/k8s.io/kubectl
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: api
@@ -1896,10 +2176,10 @@ rules:
       branch: release-1.22
     - repository: metrics
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/kubectl
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: api
@@ -1918,14 +2198,34 @@ rules:
       branch: release-1.23
     - repository: metrics
       branch: release-1.23
-
-- destination: pod-security-admission
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/kubectl
+  - name: release-1.24
+    dependencies:
+    - repository: api
+      branch: release-1.24
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: cli-runtime
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: code-generator
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    - repository: component-helpers
+      branch: release-1.24
+    - repository: metrics
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/kubectl
   library: true
+- destination: pod-security-admission
   branches:
-  - source:
-      branch: master
-      dir: staging/src/k8s.io/pod-security-admission
-    name: master
+  - name: master
     dependencies:
     - repository: api
       branch: master
@@ -1937,10 +2237,10 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.22
+    source:
+      branch: master
       dir: staging/src/k8s.io/pod-security-admission
-    name: release-1.22
+  - name: release-1.22
     go: 1.16.15
     dependencies:
     - repository: api
@@ -1953,10 +2253,10 @@ rules:
       branch: release-1.22
     - repository: component-base
       branch: release-1.22
-  - source:
-      branch: release-1.23
+    source:
+      branch: release-1.22
       dir: staging/src/k8s.io/pod-security-admission
-    name: release-1.23
+  - name: release-1.23
     go: 1.17.9
     dependencies:
     - repository: api
@@ -1969,3 +2269,30 @@ rules:
       branch: release-1.23
     - repository: component-base
       branch: release-1.23
+    source:
+      branch: release-1.23
+      dir: staging/src/k8s.io/pod-security-admission
+  - name: release-1.24
+    dependencies:
+    - repository: api
+      branch: release-1.24
+    - repository: apimachinery
+      branch: release-1.24
+    - repository: apiserver
+      branch: release-1.24
+    - repository: client-go
+      branch: release-1.24
+    - repository: component-base
+      branch: release-1.24
+    source:
+      branch: release-1.24
+      dir: staging/src/k8s.io/pod-security-admission
+  library: true
+recursive-delete-patterns:
+- BUILD
+- '*/BUILD'
+- BUILD.bazel
+- '*/BUILD.bazel'
+- Gopkg.toml
+- '*/.gitattributes'
+default-go-version: 1.18.1


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update publishing-bot rules


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This change has been generated by the `update-rules` command in `publishing-bot` repository. Since this is the first time we are updating the rules using a script, there is a considerable amount of diff, which is caused because of the YAML marshaller.

This diff is one-time as next iterations of using the tooling wouldn't result in reordering of map keys.

xref: https://github.com/kubernetes/publishing-bot/pull/253

#### Does this PR introduce a user-facing change?


```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE

/priority critical-urgent
/sig release
/area release-eng
/milestone v1.24