### PR TITLE
kubelet: set all labels from the initial node object when merging

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -111,7 +111,7 @@ func (kl *Kubelet) tryRegisterWithAPIServer(node *v1.Node) bool {
 	// the value of the controller-managed attach-detach
 	// annotation.
 	requiresUpdate := kl.reconcileCMADAnnotationWithExistingNode(node, existingNode)
-	requiresUpdate = kl.updateDefaultLabels(node, existingNode) || requiresUpdate
+	requiresUpdate = kl.updateLabels(node, existingNode) || requiresUpdate
 	requiresUpdate = kl.reconcileExtendedResource(node, existingNode) || requiresUpdate
 	requiresUpdate = kl.reconcileHugePageResource(node, existingNode) || requiresUpdate
 	if requiresUpdate {
@@ -211,29 +211,15 @@ func updateDefaultResources(initialNode, existingNode *v1.Node) bool {
 	return requiresUpdate
 }
 
-// updateDefaultLabels will set the default labels on the node
-func (kl *Kubelet) updateDefaultLabels(initialNode, existingNode *v1.Node) bool {
-	defaultLabels := []string{
-		v1.LabelHostname,
-		v1.LabelTopologyZone,
-		v1.LabelTopologyRegion,
-		v1.LabelFailureDomainBetaZone,
-		v1.LabelFailureDomainBetaRegion,
-		v1.LabelInstanceTypeStable,
-		v1.LabelInstanceType,
-		v1.LabelOSStable,
-		v1.LabelArchStable,
-		v1.LabelWindowsBuild,
-		kubeletapis.LabelOS,
-		kubeletapis.LabelArch,
-	}
-
+// updateLabels will set the labels on the node
+func (kl *Kubelet) updateLabels(initialNode, existingNode *v1.Node) bool {
 	needsUpdate := false
 	if existingNode.Labels == nil {
 		existingNode.Labels = make(map[string]string)
 	}
-	//Set default labels but make sure to not set labels with empty values
-	for _, label := range defaultLabels {
+
+	// Set labels but make sure to not set labels with empty values
+	for label := range initialNode.Labels {
 		if _, hasInitialValue := initialNode.Labels[label]; !hasInitialValue {
 			continue
 		}

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -1701,13 +1701,46 @@ func TestUpdateDefaultLabels(t *testing.T) {
 				v1.LabelArchStable:              "new-arch",
 			},
 		},
+		{
+			name: "set labels passed via command line",
+			initialNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.LabelHostname:                "new-hostname",
+						v1.LabelTopologyZone:            "new-zone-failure-domain",
+						v1.LabelTopologyRegion:          "new-zone-region",
+						v1.LabelFailureDomainBetaZone:   "new-zone-failure-domain",
+						v1.LabelFailureDomainBetaRegion: "new-zone-region",
+						v1.LabelInstanceTypeStable:      "new-instance-type",
+						v1.LabelInstanceType:            "new-instance-type",
+						v1.LabelOSStable:                "new-os",
+						v1.LabelArchStable:              "new-arch",
+						"new-command-line-label":        "foo",
+					},
+				},
+			},
+			existingNode: &v1.Node{},
+			needsUpdate:  true,
+			finalLabels: map[string]string{
+				v1.LabelHostname:                "new-hostname",
+				v1.LabelTopologyZone:            "new-zone-failure-domain",
+				v1.LabelTopologyRegion:          "new-zone-region",
+				v1.LabelFailureDomainBetaZone:   "new-zone-failure-domain",
+				v1.LabelFailureDomainBetaRegion: "new-zone-region",
+				v1.LabelInstanceTypeStable:      "new-instance-type",
+				v1.LabelInstanceType:            "new-instance-type",
+				v1.LabelOSStable:                "new-os",
+				v1.LabelArchStable:              "new-arch",
+				"new-command-line-label":        "foo",
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		defer testKubelet.Cleanup()
 		kubelet := testKubelet.kubelet
 
-		needsUpdate := kubelet.updateDefaultLabels(tc.initialNode, tc.existingNode)
+		needsUpdate := kubelet.updateLabels(tc.initialNode, tc.existingNode)
 		assert.Equal(t, tc.needsUpdate, needsUpdate, tc.name)
 		assert.Equal(t, tc.finalLabels, tc.existingNode.Labels, tc.name)
 	}


### PR DESCRIPTION
Upon restart, copy all labels from the initial node onto the
existing node.  This allows new labels set via command line
args to take effect upon kubelet restart.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This allows kubelet to use new labels that were passed on the command line after a restart.

#### Which issue(s) this PR fixes:

Fixes #109569 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug that caused kubelet to ignore changed labels from the `--node-labels` command line flag upon restart.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
