### PR TITLE
e2e_node: remote runner: Require containerd/crio

### DIFF
--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -705,15 +705,14 @@ func createInstance(imageConfig *internalGCEImage) (string, error) {
 
 		var output string
 		output, err = remote.SSH(name, "sh", "-c",
-			"'systemctl list-units  --type=service  --state=running | grep -e docker -e containerd -e crio'")
+			"'systemctl list-units  --type=service  --state=running | grep -e containerd -e crio'")
 		if err != nil {
-			err = fmt.Errorf("instance %s not running docker/containerd/crio daemon - Command failed: %s", name, output)
+			err = fmt.Errorf("instance %s not running containerd/crio daemon - Command failed: %s", name, output)
 			continue
 		}
-		if !strings.Contains(output, "docker.service") &&
-			!strings.Contains(output, "containerd.service") &&
+		if !strings.Contains(output, "containerd.service") &&
 			!strings.Contains(output, "crio.service") {
-			err = fmt.Errorf("instance %s not running docker/containerd/crio daemon: %s", name, output)
+			err = fmt.Errorf("instance %s not running containerd/crio daemon: %s", name, output)
 			continue
 		}
 		instanceRunning = true


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig node

#### What this PR does / why we need it:

Runner cleanup, validating the presence of a docker daemon doesn't help us any more - a CRI is required, and we don't test with cri-docker or similar.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```