### PR TITLE
remove stutter from alpha metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics.go
@@ -95,7 +95,7 @@ var (
 		&metrics.CounterOpts{
 			Namespace:      namespace,
 			Subsystem:      subsystem,
-			Name:           "watch_cache_initializations_total",
+			Name:           "initializations_total",
 			Help:           "Counter of watch cache initializations broken by resource type.",
 			StabilityLevel: metrics.ALPHA,
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The subsystem field already prepends `watch_cache` to the metric name. Since this metric is new and unlikely consumed yet, let's clean it up.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Rename apiserver_watch_cache_watch_cache_initializations_total to apiserver_watch_cache_initializations_total
```

