### PR TITLE
e2e: add storage capability for offline volume expansion

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -147,6 +147,7 @@ func InitHostPathCSIDriver() storageframework.TestDriver {
 		storageframework.CapBlock:               true,
 		storageframework.CapPVCDataSource:       true,
 		storageframework.CapControllerExpansion: true,
+		storageframework.CapOfflineExpansion:    true,
 		storageframework.CapOnlineExpansion:     true,
 		storageframework.CapSingleNodeVolume:    true,
 
@@ -810,6 +811,7 @@ func InitGcePDCSIDriver() storageframework.TestDriver {
 				storageframework.CapVolumeLimits:        false,
 				storageframework.CapTopology:            true,
 				storageframework.CapControllerExpansion: true,
+				storageframework.CapOfflineExpansion:    true,
 				storageframework.CapOnlineExpansion:     true,
 				storageframework.CapNodeExpansion:       true,
 				storageframework.CapSnapshotDataSource:  true,

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1251,6 +1251,7 @@ func InitGcePdDriver() storageframework.TestDriver {
 				storageframework.CapExec:                true,
 				storageframework.CapMultiPODs:           true,
 				storageframework.CapControllerExpansion: true,
+				storageframework.CapOfflineExpansion:    true,
 				storageframework.CapOnlineExpansion:     true,
 				storageframework.CapNodeExpansion:       true,
 				// GCE supports volume limits, but the test creates large
@@ -1702,6 +1703,7 @@ func InitAwsDriver() storageframework.TestDriver {
 				storageframework.CapMultiPODs:           true,
 				storageframework.CapControllerExpansion: true,
 				storageframework.CapNodeExpansion:       true,
+				storageframework.CapOfflineExpansion:    true,
 				storageframework.CapOnlineExpansion:     true,
 				// AWS supports volume limits, but the test creates large
 				// number of volumes and times out test suites.

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -203,11 +203,18 @@ func loadDriverDefinition(filename string) (*driverDefinition, error) {
 		return nil, fmt.Errorf("%s: %w", filename, err)
 	}
 
-	// to ensure backward compatibility if controller expansion is enabled then set online expansion to true
+	// To ensure backward compatibility: if controller expansion is enabled,
+	// then set both online and offline expansion to true
 	if _, ok := driver.GetDriverInfo().Capabilities[storageframework.CapOnlineExpansion]; !ok &&
 		driver.GetDriverInfo().Capabilities[storageframework.CapControllerExpansion] {
 		caps := driver.DriverInfo.Capabilities
 		caps[storageframework.CapOnlineExpansion] = true
+		driver.DriverInfo.Capabilities = caps
+	}
+	if _, ok := driver.GetDriverInfo().Capabilities[storageframework.CapOfflineExpansion]; !ok &&
+		driver.GetDriverInfo().Capabilities[storageframework.CapControllerExpansion] {
+		caps := driver.DriverInfo.Capabilities
+		caps[storageframework.CapOfflineExpansion] = true
 		driver.DriverInfo.Capabilities = caps
 	}
 	return driver, nil

--- a/test/e2e/storage/framework/testdriver.go
+++ b/test/e2e/storage/framework/testdriver.go
@@ -166,10 +166,18 @@ const (
 	CapRWX                 Capability = "RWX"                 // support ReadWriteMany access modes
 	CapControllerExpansion Capability = "controllerExpansion" // support volume expansion for controller
 	CapNodeExpansion       Capability = "nodeExpansion"       // support volume expansion for node
-	CapOnlineExpansion     Capability = "onlineExpansion"     // supports online volume expansion
-	CapVolumeLimits        Capability = "volumeLimits"        // support volume limits (can be *very* slow)
-	CapSingleNodeVolume    Capability = "singleNodeVolume"    // support volume that can run on single node (like hostpath)
-	CapTopology            Capability = "topology"            // support topology
+
+	// offlineExpansion and onlineExpansion both default to true when
+	// controllerExpansion is true. The only reason to set offlineExpansion
+	// to false is when a CSI driver can only expand a volume while it's
+	// attached to a pod. Conversely, onlineExpansion can be set to false
+	// if the driver can only expand a volume while it is detached.
+	CapOfflineExpansion Capability = "offlineExpansion" // supports offline volume expansion (default: true)
+	CapOnlineExpansion  Capability = "onlineExpansion"  // supports online volume expansion (default: true)
+
+	CapVolumeLimits     Capability = "volumeLimits"     // support volume limits (can be *very* slow)
+	CapSingleNodeVolume Capability = "singleNodeVolume" // support volume that can run on single node (like hostpath)
+	CapTopology         Capability = "topology"         // support topology
 
 	// The driver publishes storage capacity information: when the storage class
 	// for dynamic provisioning exists, the driver is expected to provide

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -177,6 +177,10 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			init()
 			defer cleanup()
 
+			if !driver.GetDriverInfo().Capabilities[storageframework.CapOfflineExpansion] {
+				e2eskipper.Skipf("Driver %q does not support offline volume expansion - skipping", driver.GetDriverInfo().Name)
+			}
+
 			var err error
 			ginkgo.By("Creating a pod with dynamically provisioned volume")
 			podConfig := e2epod.Config{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

Some CSI drivers support online volume expansion, but do not support offline expansion.
The main example I know of is the [IBM VPC Block CSI driver](https://github.com/kubernetes-sigs/ibm-vpc-block-csi-driver), which documents offline expansion as [not supported](https://cloud.ibm.com/docs/openshift?topic=openshift-vpc-block#vpc-block-volume-expand). As a result, these tests are failing:
```
External Storage [Driver: vpc.block.csi.ibm.io] [Testpattern: Dynamic PV (block volmode)(allowExpansion)] volume-expand Verify if offline PVC expansion works
External Storage [Driver: vpc.block.csi.ibm.io] [Testpattern: Dynamic PV (default fs)(allowExpansion)] volume-expand Verify if offline PVC expansion works
```
There may be other drivers in a similar state, now or in the future.
This PR provides a way to disable offline volume expansion tests in the test manifest.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

I ran these tests against an IBM VPC cluster to make sure that:
1) Setting `offlineExpansion: false` in the test manifest skips those tests as expected.
2) Omitting `offlineExpansion` from the test manifest defaults to true and runs the offline expansion tests.
```
./hack/ginkgo-e2e.sh --provider=$KUBERNETES_PROVIDER --ginkgo.focus="External.Storage.*vpc\.block\.csi\.ibm\.io.*Dynamic.PV.*allowExpansion.*volume-expand.*" --storage.testdriver=/home/jon/workspace/ibm-vpc-block-csi-driver-operator/test/e2e/manifest.yaml
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
