### PR TITLE
WIP: strip kubectl to use uncached DiscoveryInterface

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -316,7 +316,7 @@ func (f *ConfigFlags) toRESTMapper() (meta.RESTMapper, error) {
 		return nil, err
 	}
 
-	mapper := restmapper.NewDeferredBustedDiscoveryRESTMapper(discoveryClient)
+	mapper := restmapper.NewDeferredUncachedDiscoveryRESTMapper(discoveryClient)
 	expander := restmapper.NewShortcutExpander(mapper, discoveryClient)
 	return expander, nil
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
@@ -31,7 +31,7 @@ import (
 // and interfaces that implements RESTClientGetter
 type TestConfigFlags struct {
 	clientConfig    clientcmd.ClientConfig
-	discoveryClient discovery.CachedDiscoveryInterface
+	discoveryClient discovery.DiscoveryInterface
 	restMapper      meta.RESTMapper
 }
 
@@ -54,7 +54,7 @@ func (f *TestConfigFlags) ToRESTConfig() (*rest.Config, error) {
 
 // ToDiscoveryClient implements RESTClientGetter.
 // Returns a CachedDiscoveryInterface
-func (f *TestConfigFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+func (f *TestConfigFlags) ToDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	return f.discoveryClient, nil
 }
 
@@ -65,7 +65,7 @@ func (f *TestConfigFlags) ToRESTMapper() (meta.RESTMapper, error) {
 		return f.restMapper, nil
 	}
 	if f.discoveryClient != nil {
-		mapper := restmapper.NewDeferredDiscoveryRESTMapper(f.discoveryClient)
+		mapper := restmapper.NewDeferredBustedDiscoveryRESTMapper(f.discoveryClient)
 		expander := restmapper.NewShortcutExpander(mapper, f.discoveryClient)
 		return expander, nil
 	}
@@ -85,7 +85,7 @@ func (f *TestConfigFlags) WithRESTMapper(mapper meta.RESTMapper) *TestConfigFlag
 }
 
 // WithDiscoveryClient sets the discoveryClient flag
-func (f *TestConfigFlags) WithDiscoveryClient(c discovery.CachedDiscoveryInterface) *TestConfigFlags {
+func (f *TestConfigFlags) WithDiscoveryClient(c discovery.DiscoveryInterface) *TestConfigFlags {
 	f.discoveryClient = c
 	return f
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
@@ -65,7 +65,7 @@ func (f *TestConfigFlags) ToRESTMapper() (meta.RESTMapper, error) {
 		return f.restMapper, nil
 	}
 	if f.discoveryClient != nil {
-		mapper := restmapper.NewDeferredBustedDiscoveryRESTMapper(f.discoveryClient)
+		mapper := restmapper.NewDeferredUncachedDiscoveryRESTMapper(f.discoveryClient)
 		expander := restmapper.NewShortcutExpander(mapper, f.discoveryClient)
 		return expander, nil
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -191,7 +191,7 @@ type noopClientGetter struct{}
 func (noopClientGetter) ToRESTConfig() (*rest.Config, error) {
 	return nil, fmt.Errorf("local operation only")
 }
-func (noopClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+func (noopClientGetter) ToDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	return nil, fmt.Errorf("local operation only")
 }
 func (noopClientGetter) ToRESTMapper() (meta.RESTMapper, error) {

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/interfaces.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/interfaces.go
@@ -26,7 +26,7 @@ import (
 
 type RESTClientGetter interface {
 	ToRESTConfig() (*rest.Config, error)
-	ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
+	ToDiscoveryClient() (discovery.DiscoveryInterface, error)
 	ToRESTMapper() (meta.RESTMapper, error)
 }
 

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -38,6 +38,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 )
 
+// TODO: nuke this whole struct
 // CachedDiscoveryClient implements the functions that discovery server-supported API groups,
 // versions and resources.
 type CachedDiscoveryClient struct {
@@ -63,7 +64,7 @@ type CachedDiscoveryClient struct {
 	openapiClient openapi.Client
 }
 
-var _ discovery.CachedDiscoveryInterface = &CachedDiscoveryClient{}
+var _ discovery.DiscoveryInterface = &CachedDiscoveryClient{}
 
 // ServerResourcesForGroupVersion returns the supported resources for a group and version.
 func (d *CachedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
@@ -282,7 +283,7 @@ func (d *CachedDiscoveryClient) Invalidate() {
 // CachedDiscoveryClient cache data. If httpCacheDir is empty, the restconfig's transport will not
 // be updated with a roundtripper that understands cache responses.
 // If discoveryCacheDir is empty, cached server resource data will be looked up in the current directory.
-func NewCachedDiscoveryClientForConfig(config *restclient.Config, discoveryCacheDir, httpCacheDir string, ttl time.Duration) (*CachedDiscoveryClient, error) {
+func NewCachedDiscoveryClientForConfig(config *restclient.Config, discoveryCacheDir, httpCacheDir string, ttl time.Duration) (discovery.DiscoveryInterface, error) {
 	if len(httpCacheDir) > 0 {
 		// update the given restconfig with a custom roundtripper that
 		// understands how to handle cache responses.
@@ -292,21 +293,11 @@ func NewCachedDiscoveryClientForConfig(config *restclient.Config, discoveryCache
 		})
 	}
 
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return nil, err
-	}
+	return discovery.NewDiscoveryClientForConfig(config)
+	//discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	//if err != nil {
+	//	return nil, err
+	//}
 
-	return newCachedDiscoveryClient(discoveryClient, discoveryCacheDir, ttl), nil
-}
-
-// NewCachedDiscoveryClient creates a new DiscoveryClient.  cacheDirectory is the directory where discovery docs are held.  It must be unique per host:port combination to work well.
-func newCachedDiscoveryClient(delegate discovery.DiscoveryInterface, cacheDirectory string, ttl time.Duration) *CachedDiscoveryClient {
-	return &CachedDiscoveryClient{
-		delegate:       delegate,
-		cacheDirectory: cacheDirectory,
-		ttl:            ttl,
-		ourFiles:       map[string]struct{}{},
-		fresh:          true,
-	}
+	//return newCachedDiscoveryClient(discoveryClient, discoveryCacheDir, ttl), nil
 }

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -19,7 +19,6 @@ package disk
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -40,93 +39,93 @@ import (
 	testutil "k8s.io/client-go/util/testing"
 )
 
-func TestCachedDiscoveryClient_Fresh(t *testing.T) {
-	assert := assert.New(t)
-
-	d, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(d)
-
-	c := fakeDiscoveryClient{}
-	cdc := newCachedDiscoveryClient(&c, d, 60*time.Second)
-	assert.True(cdc.Fresh(), "should be fresh after creation")
-
-	cdc.ServerGroups()
-	assert.True(cdc.Fresh(), "should be fresh after groups call without cache")
-	assert.Equal(c.groupCalls, 1)
-
-	cdc.ServerGroups()
-	assert.True(cdc.Fresh(), "should be fresh after another groups call")
-	assert.Equal(c.groupCalls, 1)
-
-	cdc.ServerGroupsAndResources()
-	assert.True(cdc.Fresh(), "should be fresh after resources call")
-	assert.Equal(c.resourceCalls, 1)
-
-	cdc.ServerGroupsAndResources()
-	assert.True(cdc.Fresh(), "should be fresh after another resources call")
-	assert.Equal(c.resourceCalls, 1)
-
-	cdc = newCachedDiscoveryClient(&c, d, 60*time.Second)
-	cdc.ServerGroups()
-	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing groups cache")
-	assert.Equal(c.groupCalls, 1)
-
-	cdc.ServerGroupsAndResources()
-	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing resources cache")
-	assert.Equal(c.resourceCalls, 1)
-
-	cdc.Invalidate()
-	assert.True(cdc.Fresh(), "should be fresh after cache invalidation")
-
-	cdc.ServerGroupsAndResources()
-	assert.True(cdc.Fresh(), "should ignore existing resources cache after invalidation")
-	assert.Equal(c.resourceCalls, 2)
-}
-
-func TestNewCachedDiscoveryClient_TTL(t *testing.T) {
-	assert := assert.New(t)
-
-	d, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(d)
-
-	c := fakeDiscoveryClient{}
-	cdc := newCachedDiscoveryClient(&c, d, 1*time.Nanosecond)
-	cdc.ServerGroups()
-	assert.Equal(c.groupCalls, 1)
-
-	time.Sleep(1 * time.Second)
-
-	cdc.ServerGroups()
-	assert.Equal(c.groupCalls, 2)
-}
-
-func TestNewCachedDiscoveryClient_PathPerm(t *testing.T) {
-	assert := assert.New(t)
-
-	d, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	os.RemoveAll(d)
-	defer os.RemoveAll(d)
-
-	c := fakeDiscoveryClient{}
-	cdc := newCachedDiscoveryClient(&c, d, 1*time.Nanosecond)
-	cdc.ServerGroups()
-
-	err = filepath.Walk(d, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			assert.Equal(os.FileMode(0750), info.Mode().Perm())
-		} else {
-			assert.Equal(os.FileMode(0660), info.Mode().Perm())
-		}
-		return nil
-	})
-	assert.NoError(err)
-}
+//func TestCachedDiscoveryClient_Fresh(t *testing.T) {
+//	assert := assert.New(t)
+//
+//	d, err := ioutil.TempDir("", "")
+//	assert.NoError(err)
+//	defer os.RemoveAll(d)
+//
+//	c := fakeDiscoveryClient{}
+//	cdc := newCachedDiscoveryClient(&c, d, 60*time.Second)
+//	assert.True(cdc.Fresh(), "should be fresh after creation")
+//
+//	cdc.ServerGroups()
+//	assert.True(cdc.Fresh(), "should be fresh after groups call without cache")
+//	assert.Equal(c.groupCalls, 1)
+//
+//	cdc.ServerGroups()
+//	assert.True(cdc.Fresh(), "should be fresh after another groups call")
+//	assert.Equal(c.groupCalls, 1)
+//
+//	cdc.ServerGroupsAndResources()
+//	assert.True(cdc.Fresh(), "should be fresh after resources call")
+//	assert.Equal(c.resourceCalls, 1)
+//
+//	cdc.ServerGroupsAndResources()
+//	assert.True(cdc.Fresh(), "should be fresh after another resources call")
+//	assert.Equal(c.resourceCalls, 1)
+//
+//	cdc = newCachedDiscoveryClient(&c, d, 60*time.Second)
+//	cdc.ServerGroups()
+//	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing groups cache")
+//	assert.Equal(c.groupCalls, 1)
+//
+//	cdc.ServerGroupsAndResources()
+//	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing resources cache")
+//	assert.Equal(c.resourceCalls, 1)
+//
+//	cdc.Invalidate()
+//	assert.True(cdc.Fresh(), "should be fresh after cache invalidation")
+//
+//	cdc.ServerGroupsAndResources()
+//	assert.True(cdc.Fresh(), "should ignore existing resources cache after invalidation")
+//	assert.Equal(c.resourceCalls, 2)
+//}
+//
+//func TestNewCachedDiscoveryClient_TTL(t *testing.T) {
+//	assert := assert.New(t)
+//
+//	d, err := ioutil.TempDir("", "")
+//	assert.NoError(err)
+//	defer os.RemoveAll(d)
+//
+//	c := fakeDiscoveryClient{}
+//	cdc := newCachedDiscoveryClient(&c, d, 1*time.Nanosecond)
+//	cdc.ServerGroups()
+//	assert.Equal(c.groupCalls, 1)
+//
+//	time.Sleep(1 * time.Second)
+//
+//	cdc.ServerGroups()
+//	assert.Equal(c.groupCalls, 2)
+//}
+//
+//func TestNewCachedDiscoveryClient_PathPerm(t *testing.T) {
+//	assert := assert.New(t)
+//
+//	d, err := ioutil.TempDir("", "")
+//	assert.NoError(err)
+//	os.RemoveAll(d)
+//	defer os.RemoveAll(d)
+//
+//	c := fakeDiscoveryClient{}
+//	cdc := newCachedDiscoveryClient(&c, d, 1*time.Nanosecond)
+//	cdc.ServerGroups()
+//
+//	err = filepath.Walk(d, func(path string, info os.FileInfo, err error) error {
+//		if err != nil {
+//			return err
+//		}
+//		if info.IsDir() {
+//			assert.Equal(os.FileMode(0750), info.Mode().Perm())
+//		} else {
+//			assert.Equal(os.FileMode(0660), info.Mode().Perm())
+//		}
+//		return nil
+//	})
+//	assert.NoError(err)
+//}
 
 // Tests that schema instances returned by openapi cached and returned after
 // successive calls
@@ -170,7 +169,8 @@ func TestOpenAPIDiskCache(t *testing.T) {
 	// should be cached in memory.
 	paths, err := openapiClient.Paths()
 	require.NoError(t, err)
-	assert.Equal(t, 1, fakeServer.RequestCounters["/openapi/v3"])
+	//assert.Equal(t, 1, fakeServer.RequestCounters["/openapi/v3"])
+	assert.Equal(t, 2, fakeServer.RequestCounters["/openapi/v3"])
 
 	require.Greater(t, len(paths), 0)
 	i := 0
@@ -188,7 +188,7 @@ func TestOpenAPIDiskCache(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, fakeServer.RequestCounters[path])
 
-		client.Invalidate()
+		//client.Invalidate()
 
 		// Refetch the schema from a new openapi client to try to force a new
 		// http request
@@ -200,7 +200,8 @@ func TestOpenAPIDiskCache(t *testing.T) {
 		// Ensure schema call is still served from disk
 		_, err = newPaths[k].Schema()
 		assert.NoError(t, err)
-		assert.Equal(t, 1+i, fakeServer.RequestCounters["/openapi/v3"])
+		//assert.Equal(t, 1+i, fakeServer.RequestCounters["/openapi/v3"])
+		assert.Equal(t, 2+i, fakeServer.RequestCounters["/openapi/v3"])
 		assert.Equal(t, 1, fakeServer.RequestCounters[path])
 	}
 }

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -65,6 +65,8 @@ type DiscoveryInterface interface {
 	OpenAPIV3SchemaInterface
 }
 
+// TODO: nuke this
+// TODO: can't yet kill this until mem cached discovery is off of it
 // CachedDiscoveryInterface is a DiscoveryInterface with cache invalidation and freshness.
 // Note that If the ServerResourcesForGroupVersion method returns a cache miss
 // error, the user needs to explicitly call Invalidate to clear the cache,

--- a/staging/src/k8s.io/client-go/restmapper/discovery.go
+++ b/staging/src/k8s.io/client-go/restmapper/discovery.go
@@ -173,19 +173,19 @@ func GetAPIGroupResources(cl discovery.DiscoveryInterface) ([]*APIGroupResources
 	return result, nil
 }
 
-type DeferredBustedDiscoveryRESTMapper struct {
+type DeferredUncachedDiscoveryRESTMapper struct {
 	initMu   sync.Mutex
 	delegate meta.RESTMapper
 	client   discovery.DiscoveryInterface
 }
 
-func NewDeferredBustedDiscoveryRESTMapper(client discovery.DiscoveryInterface) *DeferredBustedDiscoveryRESTMapper {
-	return &DeferredBustedDiscoveryRESTMapper{
+func NewDeferredUncachedDiscoveryRESTMapper(client discovery.DiscoveryInterface) *DeferredUncachedDiscoveryRESTMapper {
+	return &DeferredUncachedDiscoveryRESTMapper{
 		client: client,
 	}
 }
 
-func (d *DeferredBustedDiscoveryRESTMapper) getDelegate() (meta.RESTMapper, error) {
+func (d *DeferredUncachedDiscoveryRESTMapper) getDelegate() (meta.RESTMapper, error) {
 	d.initMu.Lock()
 	defer d.initMu.Unlock()
 
@@ -207,7 +207,7 @@ func (d *DeferredBustedDiscoveryRESTMapper) getDelegate() (meta.RESTMapper, erro
 // TODO: see if this actually gets used anywhere externally
 // Reset resets the internally cached Discovery information and will
 // cause the next mapping request to re-discover.
-//func (d *DeferredBustedDiscoveryRESTMapper) Reset() {
+//func (d *DeferredUncachedDiscoveryRESTMapper) Reset() {
 //	klog.V(5).Info("Invalidating discovery information")
 //
 //	d.initMu.Lock()
@@ -219,7 +219,7 @@ func (d *DeferredBustedDiscoveryRESTMapper) getDelegate() (meta.RESTMapper, erro
 
 // KindFor takes a partial resource and returns back the single match.
 // It returns an error if there are multiple matches.
-func (d *DeferredBustedDiscoveryRESTMapper) KindFor(resource schema.GroupVersionResource) (gvk schema.GroupVersionKind, err error) {
+func (d *DeferredUncachedDiscoveryRESTMapper) KindFor(resource schema.GroupVersionResource) (gvk schema.GroupVersionKind, err error) {
 	del, err := d.getDelegate()
 	if err != nil {
 		return schema.GroupVersionKind{}, err
@@ -229,7 +229,7 @@ func (d *DeferredBustedDiscoveryRESTMapper) KindFor(resource schema.GroupVersion
 
 // KindsFor takes a partial resource and returns back the list of
 // potential kinds in priority order.
-func (d *DeferredBustedDiscoveryRESTMapper) KindsFor(resource schema.GroupVersionResource) (gvks []schema.GroupVersionKind, err error) {
+func (d *DeferredUncachedDiscoveryRESTMapper) KindsFor(resource schema.GroupVersionResource) (gvks []schema.GroupVersionKind, err error) {
 	del, err := d.getDelegate()
 	if err != nil {
 		return nil, err
@@ -239,7 +239,7 @@ func (d *DeferredBustedDiscoveryRESTMapper) KindsFor(resource schema.GroupVersio
 
 // ResourceFor takes a partial resource and returns back the single
 // match. It returns an error if there are multiple matches.
-func (d *DeferredBustedDiscoveryRESTMapper) ResourceFor(input schema.GroupVersionResource) (gvr schema.GroupVersionResource, err error) {
+func (d *DeferredUncachedDiscoveryRESTMapper) ResourceFor(input schema.GroupVersionResource) (gvr schema.GroupVersionResource, err error) {
 	del, err := d.getDelegate()
 	if err != nil {
 		return schema.GroupVersionResource{}, err
@@ -249,7 +249,7 @@ func (d *DeferredBustedDiscoveryRESTMapper) ResourceFor(input schema.GroupVersio
 
 // ResourcesFor takes a partial resource and returns back the list of
 // potential resource in priority order.
-func (d *DeferredBustedDiscoveryRESTMapper) ResourcesFor(input schema.GroupVersionResource) (gvrs []schema.GroupVersionResource, err error) {
+func (d *DeferredUncachedDiscoveryRESTMapper) ResourcesFor(input schema.GroupVersionResource) (gvrs []schema.GroupVersionResource, err error) {
 	del, err := d.getDelegate()
 	if err != nil {
 		return nil, err
@@ -259,7 +259,7 @@ func (d *DeferredBustedDiscoveryRESTMapper) ResourcesFor(input schema.GroupVersi
 
 // RESTMapping identifies a preferred resource mapping for the
 // provided group kind.
-func (d *DeferredBustedDiscoveryRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (m *meta.RESTMapping, err error) {
+func (d *DeferredUncachedDiscoveryRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (m *meta.RESTMapping, err error) {
 	del, err := d.getDelegate()
 	if err != nil {
 		return nil, err
@@ -270,7 +270,7 @@ func (d *DeferredBustedDiscoveryRESTMapper) RESTMapping(gk schema.GroupKind, ver
 // RESTMappings returns the RESTMappings for the provided group kind
 // in a rough internal preferred order. If no kind is found, it will
 // return a NoResourceMatchError.
-func (d *DeferredBustedDiscoveryRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) (ms []*meta.RESTMapping, err error) {
+func (d *DeferredUncachedDiscoveryRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) (ms []*meta.RESTMapping, err error) {
 	del, err := d.getDelegate()
 	if err != nil {
 		return nil, err
@@ -280,7 +280,7 @@ func (d *DeferredBustedDiscoveryRESTMapper) RESTMappings(gk schema.GroupKind, ve
 
 // ResourceSingularizer converts a resource name from plural to
 // singular (e.g., from pods to pod).
-func (d *DeferredBustedDiscoveryRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+func (d *DeferredUncachedDiscoveryRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
 	del, err := d.getDelegate()
 	if err != nil {
 		return resource, err
@@ -288,12 +288,12 @@ func (d *DeferredBustedDiscoveryRESTMapper) ResourceSingularizer(resource string
 	return del.ResourceSingularizer(resource)
 }
 
-func (d *DeferredBustedDiscoveryRESTMapper) String() string {
+func (d *DeferredUncachedDiscoveryRESTMapper) String() string {
 	del, err := d.getDelegate()
 	if err != nil {
-		return fmt.Sprintf("DeferredBustedDiscoveryRESTMapper{%v}", err)
+		return fmt.Sprintf("DeferredUncachedDiscoveryRESTMapper{%v}", err)
 	}
-	return fmt.Sprintf("DeferredBustedDiscoveryRESTMapper{\n\t%v\n}", del)
+	return fmt.Sprintf("DeferredUncachedDiscoveryRESTMapper{\n\t%v\n}", del)
 }
 
 // DeferredDiscoveryRESTMapper is a RESTMapper that will defer

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
@@ -145,10 +145,10 @@ func (o *APIResourceOptions) RunAPIResources(cmd *cobra.Command, f cmdutil.Facto
 		return err
 	}
 
-	if !o.Cached {
-		// Always request fresh data from the server
-		discoveryclient.Invalidate()
-	}
+	//if !o.Cached {
+	//	// Always request fresh data from the server
+	//	discoveryclient.Invalidate()
+	//}
 
 	errs := []error{}
 	lists, err := discoveryclient.ServerPreferredResources()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiversions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiversions.go
@@ -38,7 +38,7 @@ var (
 
 // APIVersionsOptions have the data required for API versions
 type APIVersionsOptions struct {
-	discoveryClient discovery.CachedDiscoveryInterface
+	discoveryClient discovery.DiscoveryInterface
 
 	genericclioptions.IOStreams
 }
@@ -83,7 +83,7 @@ func (o *APIVersionsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, arg
 // RunAPIVersions does the work
 func (o *APIVersionsOptions) RunAPIVersions() error {
 	// Always request fresh data from the server
-	o.discoveryClient.Invalidate()
+	//o.discoveryClient.Invalidate()
 
 	groupList, err := o.discoveryClient.ServerGroups()
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -368,12 +368,12 @@ type fakeCachedDiscoveryClient struct {
 	discovery.DiscoveryInterface
 }
 
-func (d *fakeCachedDiscoveryClient) Fresh() bool {
-	return true
-}
-
-func (d *fakeCachedDiscoveryClient) Invalidate() {
-}
+//func (d *fakeCachedDiscoveryClient) Fresh() bool {
+//	return true
+//}
+//
+//func (d *fakeCachedDiscoveryClient) Invalidate() {
+//}
 
 func (d *fakeCachedDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	return []*metav1.APIGroup{}, []*metav1.APIResourceList{}, nil
@@ -593,7 +593,7 @@ func (f *TestFactory) RESTClient() (*restclient.RESTClient, error) {
 }
 
 // DiscoveryClient returns a discovery client from TestFactory
-func (f *TestFactory) DiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+func (f *TestFactory) DiscoveryClient() (discovery.DiscoveryInterface, error) {
 	fakeClient := f.Client.(*fake.RESTClient)
 
 	cacheDir := filepath.Join("", ".kube", "cache", "discovery")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
@@ -66,7 +66,8 @@ func (f *factoryImpl) ToRESTMapper() (meta.RESTMapper, error) {
 	return f.clientGetter.ToRESTMapper()
 }
 
-func (f *factoryImpl) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+// this will return just a DiscoveryInterface
+func (f *factoryImpl) ToDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	return f.clientGetter.ToDiscoveryClient()
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/kubectl_match_version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/kubectl_match_version.go
@@ -84,7 +84,7 @@ func (f *MatchVersionFlags) ToRawKubeConfigLoader() clientcmd.ClientConfig {
 	return f.Delegate.ToRawKubeConfigLoader()
 }
 
-func (f *MatchVersionFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+func (f *MatchVersionFlags) ToDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	if err := f.checkMatchingServerVersion(); err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -57,7 +57,7 @@ type Options struct {
 	Short      bool
 	Output     string
 
-	discoveryClient discovery.CachedDiscoveryInterface
+	discoveryClient discovery.DiscoveryInterface
 
 	genericclioptions.IOStreams
 }
@@ -130,8 +130,8 @@ func (o *Options) Run() error {
 	versionInfo.KustomizeVersion = getKustomizeVersion()
 
 	if !o.ClientOnly && o.discoveryClient != nil {
-		// Always request fresh data from the server
-		o.discoveryClient.Invalidate()
+		//// Always request fresh data from the server
+		//o.discoveryClient.Invalidate()
 		versionInfo.ServerVersion, serverErr = o.discoveryClient.ServerVersion()
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
