### PR TITLE
Warn on receiving a space before the token

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
@@ -22,6 +22,11 @@ import (
 	"strings"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/warning"
+)
+
+const (
+	invalidTokenWithSpaceWarning = "the provided Authorization header contains extra space before the bearer token, and is ignored"
 )
 
 type Authenticator struct {
@@ -48,6 +53,10 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.R
 
 	// Empty bearer tokens aren't valid
 	if len(token) == 0 {
+		// The space before the token case
+		if len(parts) == 3 {
+			warning.AddWarning(req.Context(), "", invalidTokenWithSpaceWarning)
+		}
 		return nil, false, nil
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken_test.go
@@ -25,6 +25,8 @@ import (
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/warning"
 )
 
 func TestAuthenticateRequest(t *testing.T) {
@@ -128,6 +130,23 @@ func TestAuthenticateRequestBadValue(t *testing.T) {
 	}
 }
 
+type dummyRecorder struct {
+	agent string
+	text  string
+}
+
+func (r *dummyRecorder) AddWarning(agent, text string) {
+	r.agent = agent
+	r.text = text
+	return
+}
+
+func (r *dummyRecorder) getWarning() string {
+	return r.text
+}
+
+var _ warning.Recorder = &dummyRecorder{}
+
 func TestBearerToken(t *testing.T) {
 	tests := map[string]struct {
 		AuthorizationHeaders []string
@@ -137,6 +156,7 @@ func TestBearerToken(t *testing.T) {
 		ExpectedOK                   bool
 		ExpectedErr                  bool
 		ExpectedAuthorizationHeaders []string
+		ExpectedRecordedWarning      string
 	}{
 		"no header": {
 			AuthorizationHeaders:         nil,
@@ -184,6 +204,14 @@ func TestBearerToken(t *testing.T) {
 			ExpectedErr:                  true,
 			ExpectedAuthorizationHeaders: []string{"Bearer 123"},
 		},
+		"valid bearer token with a space": {
+			AuthorizationHeaders:         []string{"Bearer  token"},
+			ExpectedUserName:             "",
+			ExpectedOK:                   false,
+			ExpectedErr:                  false,
+			ExpectedAuthorizationHeaders: []string{"Bearer  token"},
+			ExpectedRecordedWarning:      invalidTokenWithSpaceWarning,
+		},
 		"error bearer token": {
 			AuthorizationHeaders: []string{"Bearer 123"},
 			TokenAuth: authenticator.TokenFunc(func(ctx context.Context, t string) (*authenticator.Response, bool, error) {
@@ -197,7 +225,10 @@ func TestBearerToken(t *testing.T) {
 	}
 
 	for k, tc := range tests {
-		req, _ := http.NewRequest("GET", "/", nil)
+		dc := dummyRecorder{agent: "", text: ""}
+		ctx := genericapirequest.NewDefaultContext()
+		ctxWithRecorder := warning.WithWarningRecorder(ctx, &dc)
+		req, _ := http.NewRequestWithContext(ctxWithRecorder, "GET", "/", nil)
 		for _, h := range tc.AuthorizationHeaders {
 			req.Header.Add("Authorization", h)
 		}
@@ -214,6 +245,10 @@ func TestBearerToken(t *testing.T) {
 		}
 		if ok && resp.User.GetName() != tc.ExpectedUserName {
 			t.Errorf("%s: Expected username=%v, got %v", k, tc.ExpectedUserName, resp.User.GetName())
+			continue
+		}
+		if len(tc.ExpectedRecordedWarning) > 0 && tc.ExpectedRecordedWarning != dc.getWarning() {
+			t.Errorf("%s: Expected recorded warning=%v, got %v", k, tc.ExpectedRecordedWarning, dc.getWarning())
 			continue
 		}
 		if !reflect.DeepEqual(req.Header["Authorization"], tc.ExpectedAuthorizationHeaders) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This Pull Request adds a warning when someone tries to send a request with a space before the token:

```
$ curl -k https://IP -H "Authorization: Bearer  asdf"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref #106142

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
