### PR TITLE
refactor: annotation key validation should be unified

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/attributes.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/attributes.go
@@ -204,7 +204,7 @@ func checkKeyFormat(key string) error {
 	if len(parts) != 2 {
 		return fmt.Errorf("annotation key has invalid format, the right format is a DNS subdomain prefix and '/' and key name. (e.g. 'podsecuritypolicy.admission.k8s.io/admit-policy')")
 	}
-	if msgs := validation.IsQualifiedName(key); len(msgs) != 0 {
+	if msgs := validation.IsQualifiedName(strings.ToLower(key)); len(msgs) != 0 {
 		return fmt.Errorf("annotation key has invalid format %s. A qualified name like 'podsecuritypolicy.admission.k8s.io/admit-policy' is required.", strings.Join(msgs, ","))
 	}
 	return nil

--- a/staging/src/k8s.io/apiserver/pkg/admission/attributes_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/attributes_test.go
@@ -40,10 +40,9 @@ func TestAddAnnotation(t *testing.T) {
 
 	// test invalid plugin names
 	var testCases map[string]string = map[string]string{
-		"invalid dns subdomain": "INVALID-DNS-Subdomain/policy",
-		"no plugin name":        "policy",
-		"no key name":           "podsecuritypolicy.admission.k8s.io",
-		"empty key":             "",
+		"no plugin name": "policy",
+		"no key name":    "podsecuritypolicy.admission.k8s.io",
+		"empty key":      "",
 	}
 	for name, invalidKey := range testCases {
 		err := attr.AddAnnotation(invalidKey, "value-foo")

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
@@ -910,6 +910,7 @@ func NewMutatingTestCases(url *url.URL, configurationName string) []MutatingTest
 				"mutation.webhook.admission.k8s.io/round_0_index_1": mutationAnnotationValue(configurationName, "removeLabel", true),
 				"patch.webhook.admission.k8s.io/round_0_index_0":    patchAnnotationValue(configurationName, "addLabel", `[{"op": "add", "path": "/metadata/labels/added", "value": "test"}]`),
 				"patch.webhook.admission.k8s.io/round_0_index_1":    patchAnnotationValue(configurationName, "removeLabel", `[{"op": "remove", "path": "/metadata/labels/remove"}]`),
+				"removeLabel/key1": "value1",
 			},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

annotation key support uppercase letter，validate logic should  be unified.
https://github.com/kubernetes/kubernetes/blob/f173d01c011c3574dea73a6fa3e20b0ab94531bb/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go#L46-L53

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
