### PR TITLE
Prevent dirty service object leaking between reconciles

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -876,7 +876,10 @@ func (s *Controller) syncService(ctx context.Context, key string) error {
 	case err != nil:
 		runtime.HandleError(fmt.Errorf("Unable to retrieve service %v from store: %v", key, err))
 	default:
-		err = s.processServiceCreateOrUpdate(ctx, service, key)
+		// It is not safe to modify an object returned from an informer.
+		// As reconcilers may modify the service object we need to copy
+		// it first.
+		err = s.processServiceCreateOrUpdate(ctx, service.DeepCopy(), key)
 	}
 
 	return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We were passing a Service object returned from the Service informer directly to the Service controller loop. This loop is expected to modify the Service object during execution, but [this is not safe](https://github.com/kubernetes/kubernetes/blob/f0791b50143856177878e21bb44beb5e3e36cc78/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go#L26-L40). Specifically any modification to the Service object by the controller will pollute the Service informer's cache and result in a potentially dirty object being passed to subsequent invocation of the controller loop.

We fix this issue by passing a copy of the object from the informer instead.

I have described in the comments how this bug affected cloud-provider-openstack, but I suspect it affects multiple cloud providers.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/cloud-provider/issues/59

#### Special notes for your reviewer:

Only manually tested. See manual test description in comment below.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a bug which could have allowed an improperly annotated LoadBalancer service to become active.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
