### PR TITLE
close instances of cadvisorInfoToNetworkStats returning partially constructed NetworkStats

### DIFF
--- a/pkg/kubelet/stats/helper.go
+++ b/pkg/kubelet/stats/helper.go
@@ -194,7 +194,7 @@ func cadvisorInfoToNetworkStats(info *cadvisorapiv2.ContainerInfo) *statsapi.Net
 		return nil
 	}
 
-	if cstat.Network == nil {
+	if cstat.Network == nil || len(cstat.Network.Interfaces) == 0 {
 		return nil
 	}
 
@@ -212,7 +212,7 @@ func cadvisorInfoToNetworkStats(info *cadvisorapiv2.ContainerInfo) *statsapi.Net
 			TxErrors: &inter.TxErrors,
 		}
 
-		if inter.Name == defaultNetworkInterfaceName {
+		if inter.Name == defaultNetworkInterfaceName || iStats.InterfaceStats.Name == "" {
 			iStats.InterfaceStats = iStat
 		}
 


### PR DESCRIPTION
Signed-off-by: Mike Brown <brownwm@us.ibm.com>

/kind bug
/kind flake

Partial fix for flake: https://github.com/kubernetes/kubernetes/issues/109082
Additional basis for change: https://github.com/kubernetes/kubernetes/pull/109371
Requires another commit to address summary_test ... possibly other remedies

The cadvisorInfoToNetworkStats helper could return partially constructed NetworkStats depending on the network interface name used, missing eth0 interface stats when returned from cadvisor, or just having no interface stats for a container's pod. Returning a "partially" constructed results here should be avoided.

Note: will also allow the following log to be output, which was being incorrectly filtered here https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/stats/cri_stats_provider.go#L508-L525
	```klog.V(4).InfoS("Unable to find network stats for sandbox", "sandboxID", podSandboxID)```

```release-note
Corrects the issue where an inability to find network stats for a pod sandbox was not reported by Kubelet.

```