### PR TITLE
hack: make test-e2e-node: remove old project refs

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -223,8 +223,6 @@ define TEST_E2E_NODE_HELP_INFO
 #  ARTIFACTS: Local directory to scp test artifacts into from the remote hosts
 #    for REMOTE=true. Local directory to write juntil xml results into for REMOTE=false.
 #    Defaults to "/tmp/_artifacts/$$(date +%y%m%dT%H%M%S)".
-#  LIST_IMAGES: For REMOTE=true only. If true, don't run tests. Just output the
-#    list of available images for testing.  Defaults to false.
 #  TIMEOUT: For REMOTE=true only. How long (in golang duration format) to wait
 #    for ginkgo tests to complete. Defaults to 45m.
 #  PARALLELISM: The number of ginkgo nodes to run.  Defaults to 8.
@@ -250,7 +248,7 @@ define TEST_E2E_NODE_HELP_INFO
 #  CLEANUP: For REMOTE=true only.  If false, do not stop processes or delete
 #    test files on remote hosts.  Defaults to true.
 #  IMAGE_PROJECT: For REMOTE=true only.  Project containing images provided to
-#    $$IMAGES.  Defaults to "kubernetes-node-e2e-images".
+#    $$IMAGES.  Defaults to "cos-cloud".
 #  INSTANCE_PREFIX: For REMOTE=true only.  Instances created from images will
 #    have the name "$${INSTANCE_PREFIX}-$${IMAGE_NAME}".  Defaults to "test".
 #  INSTANCE_METADATA: For REMOTE=true and running on GCE only.

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -89,19 +89,13 @@ if [ "${remote}" = true ] && [ "${remote_mode}" = gce ] ; then
   # The following options are only valid in remote GCE run.
   images=${IMAGES:-""}
   hosts=${HOSTS:-""}
-  image_project=${IMAGE_PROJECT:-"kubernetes-node-e2e-images"}
+  image_project=${IMAGE_PROJECT:-"cos-cloud"}
   metadata=${INSTANCE_METADATA:-""}
-  list_images=${LIST_IMAGES:-false}
-  if  [[ ${list_images} == "true" ]]; then
-    gcloud compute images list --project="${image_project}" | grep "e2e-node"
-    exit 0
-  fi
   gubernator=${GUBERNATOR:-"false"}
   image_config_file=${IMAGE_CONFIG_FILE:-""}
   image_config_dir=${IMAGE_CONFIG_DIR:-""}
   runtime_config=${RUNTIME_CONFIG:-""}
   if [[ ${hosts} == "" && ${images} == "" && ${image_config_file} == "" ]]; then
-    image_project="${IMAGE_PROJECT:-"cos-cloud"}"
     gci_image=$(gcloud compute images list --project "${image_project}" \
     --no-standard-images --filter="name ~ 'cos-beta.*'" --format="table[no-heading](name)")
     images=${gci_image}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node
/cc @dims @ameukam 

#### What this PR does / why we need it:

This commit cleans up references to the old kubernetes-node-e2e-images
project. In the process it removes the `LIST_IMAGES` mode as listing
large numbers of public cloud projects is not particularly useful, and
has been somewhat broken for a long period of time - as we defaulted
launching a VM to a different project than listing regardless.

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/k8s.io/issues/1527

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/1330683/164565858-6d1589a8-c71e-465d-964c-8a04ad2aeedf.png">

