### PR TITLE
[wip]kubectl drain --ignore-daemonsets=true: don't list daemonset if force is false

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/filter_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/filter_test.go
@@ -20,8 +20,11 @@ import (
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
 )
 
 func TestSkipDeletedFilter(t *testing.T) {
@@ -65,6 +68,120 @@ func TestSkipDeletedFilter(t *testing.T) {
 		podDeleteStatus := h.skipDeletedFilter(pod)
 		if podDeleteStatus.Delete != tc.expectedDelete {
 			t.Errorf("test %v: unexpected podDeleteStatus.delete; actual %v; expected %v", i, podDeleteStatus.Delete, tc.expectedDelete)
+		}
+	}
+}
+
+func TestDaemonSetFilter(t *testing.T) {
+	tCases := []struct {
+		ownerKind            string
+		force                bool
+		ignoreAllDaemonSets  bool
+		podPhase             corev1.PodPhase
+		expectedDelete       bool
+		expectedReason       string
+		expectedErrorMessage string
+	}{
+		{
+			ownerKind:            "DaemonSet",
+			ignoreAllDaemonSets:  true,
+			force:                true,
+			podPhase:             corev1.PodRunning,
+			expectedDelete:       false,
+			expectedReason:       PodDeleteStatusTypeWarning,
+			expectedErrorMessage: daemonSetWarning,
+		},
+		{
+			ownerKind:            "DaemonSet",
+			ignoreAllDaemonSets:  false,
+			force:                true,
+			podPhase:             corev1.PodRunning,
+			expectedDelete:       false,
+			expectedReason:       PodDeleteStatusTypeError,
+			expectedErrorMessage: daemonSetFatal,
+		},
+		{
+			ownerKind:            "DaemonSet",
+			ignoreAllDaemonSets:  false,
+			force:                false,
+			podPhase:             corev1.PodRunning,
+			expectedDelete:       false,
+			expectedReason:       PodDeleteStatusTypeError,
+			expectedErrorMessage: daemonSetFatal,
+		},
+		{
+			ownerKind:            "DaemonSet",
+			ignoreAllDaemonSets:  true,
+			force:                false,
+			podPhase:             corev1.PodRunning,
+			expectedDelete:       false,
+			expectedReason:       PodDeleteStatusTypeWarning,
+			expectedErrorMessage: daemonSetWarning,
+		},
+		{
+			ownerKind:           "DaemonSet",
+			ignoreAllDaemonSets: true,
+			force:               false,
+			podPhase:            corev1.PodFailed,
+			expectedDelete:      true,
+			expectedReason:      PodDeleteStatusTypeOkay,
+		},
+		{
+			ownerKind:           "ReplicaSet",
+			ignoreAllDaemonSets: false,
+			force:               false,
+			podPhase:            corev1.PodRunning,
+			expectedDelete:      true,
+			expectedReason:      PodDeleteStatusTypeOkay,
+		},
+		{
+			ownerKind:           "ReplicaSet",
+			ignoreAllDaemonSets: true,
+			force:               false,
+			podPhase:            corev1.PodRunning,
+			expectedDelete:      true,
+			expectedReason:      PodDeleteStatusTypeOkay,
+		},
+	}
+	for i, tc := range tCases {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "apps/v1",
+						Kind:       tc.ownerKind,
+						Controller: pointer.BoolPtr(true),
+						Name:       "bar",
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: tc.podPhase,
+			},
+		}
+
+		h := &Helper{
+			Force:               tc.force,
+			IgnoreAllDaemonSets: tc.ignoreAllDaemonSets,
+			Client: fake.NewSimpleClientset(&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: "default",
+				},
+			}),
+		}
+
+		podDeleteStatus := h.daemonSetFilter(pod)
+		if podDeleteStatus.Delete != tc.expectedDelete {
+			t.Errorf("test %v: unexpected podDeleteStatus.delete; actual %v; expected %v", i, podDeleteStatus.Delete, tc.expectedDelete)
+		}
+		if podDeleteStatus.Reason != tc.expectedReason {
+			t.Errorf("test %v: unexpected podDeleteStatus.reason; actual %v; expected %v", i, podDeleteStatus.Reason, tc.expectedReason)
+		}
+		if podDeleteStatus.Message != tc.expectedErrorMessage {
+			t.Errorf("test %v: unexpected podDeleteStatus.message; actual %v; expected %v", i, podDeleteStatus.Message, tc.expectedErrorMessage)
 		}
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/drain/filters.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/filters.go
@@ -188,18 +188,19 @@ func (d *Helper) daemonSetFilter(pod corev1.Pod) PodDeleteStatus {
 	}
 
 	if _, err := d.Client.AppsV1().DaemonSets(pod.Namespace).Get(context.TODO(), controllerRef.Name, metav1.GetOptions{}); err != nil {
-		// remove orphaned pods with a warning if --force is used
+		// if --force is used， remove orphaned pods with a warning
 		if apierrors.IsNotFound(err) && d.Force {
 			return MakePodDeleteStatusWithWarning(true, err.Error())
 		}
-
+		// if --force/--ignore-daemonsets are used, the pod can also be removed with a warning
+		if d.IgnoreAllDaemonSets && d.Force {
+			return MakePodDeleteStatusWithWarning(false, daemonSetWarning)
+		}
 		return MakePodDeleteStatusWithError(err.Error())
 	}
-
 	if !d.IgnoreAllDaemonSets {
 		return MakePodDeleteStatusWithError(daemonSetFatal)
 	}
-
 	return MakePodDeleteStatusWithWarning(false, daemonSetWarning)
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/priority backlog

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
Fixes #109605

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubectl drain: don't list daemonset if force is false when `--ignore-daemonsets` is true
```
