### PR TITLE
[WIP] DO NOT MERGE: Experiment: Disable client-side rate-limitting

### DIFF
--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -47,6 +47,8 @@ import (
 	garbagecollectorconfig "k8s.io/kubernetes/pkg/controller/garbagecollector/config"
 	netutils "k8s.io/utils/net"
 
+	"k8s.io/klog/v2"
+
 	// add the kubernetes feature gates
 	_ "k8s.io/kubernetes/pkg/features"
 )
@@ -440,8 +442,10 @@ func (s KubeControllerManagerOptions) Config(allControllers []string, disabledBy
 	kubeconfig.DisableCompression = true
 	kubeconfig.ContentConfig.AcceptContentTypes = s.Generic.ClientConnection.AcceptContentTypes
 	kubeconfig.ContentConfig.ContentType = s.Generic.ClientConnection.ContentType
-	kubeconfig.QPS = s.Generic.ClientConnection.QPS
-	kubeconfig.Burst = int(s.Generic.ClientConnection.Burst)
+	klog.Errorf("BBB controller-manager QPS=500")
+	kubeconfig.QPS = 500 //s.Generic.ClientConnection.QPS
+	klog.Errorf("BBB controller-manager Burst=500")
+	kubeconfig.Burst = 500 //int(s.Generic.ClientConnection.Burst)
 
 	client, err := clientset.NewForConfig(restclient.AddUserAgent(kubeconfig, KubeControllerManagerUserAgent))
 	if err != nil {

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -354,8 +354,10 @@ func createKubeConfig(config componentbaseconfig.ClientConnectionConfiguration, 
 	kubeConfig.DisableCompression = true
 	kubeConfig.AcceptContentTypes = config.AcceptContentTypes
 	kubeConfig.ContentType = config.ContentType
-	kubeConfig.QPS = config.QPS
-	kubeConfig.Burst = int(config.Burst)
+	klog.Errorf("BBB scheduler QPS=100")
+	kubeConfig.QPS = 100 //config.QPS
+	klog.Errorf("BBB scheduler Burst=100")
+	kubeConfig.Burst = 100 //int(config.Burst)
 
 	return kubeConfig, nil
 }

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -354,10 +354,10 @@ func createKubeConfig(config componentbaseconfig.ClientConnectionConfiguration, 
 	kubeConfig.DisableCompression = true
 	kubeConfig.AcceptContentTypes = config.AcceptContentTypes
 	kubeConfig.ContentType = config.ContentType
-	klog.Errorf("BBB scheduler QPS=100")
-	kubeConfig.QPS = 100 //config.QPS
-	klog.Errorf("BBB scheduler Burst=100")
-	kubeConfig.Burst = 100 //int(config.Burst)
+	klog.Errorf("BBB scheduler QPS=300")
+	kubeConfig.QPS = 300 //config.QPS
+	klog.Errorf("BBB scheduler Burst=300")
+	kubeConfig.Burst = 300 //int(config.Burst)
 
 	return kubeConfig, nil
 }

--- a/pkg/scheduler/apis/config/v1/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins.go
@@ -45,7 +45,7 @@ func getDefaultPlugins() *v1.Plugins {
 				{Name: names.AzureDiskLimits},
 				{Name: names.VolumeBinding},
 				{Name: names.VolumeZone},
-				{Name: names.PodTopologySpread, Weight: pointer.Int32(2)},
+//				{Name: names.PodTopologySpread, Weight: pointer.Int32(2)},
 				{Name: names.InterPodAffinity, Weight: pointer.Int32(2)},
 				{Name: names.DefaultPreemption},
 				{Name: names.NodeResourcesBalancedAllocation, Weight: pointer.Int32(1)},

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
@@ -174,7 +174,7 @@ var (
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
 				NominalConcurrencyShares: 30,
-				LendablePercent:          pointer.Int32(33),
+				LendablePercent:          pointer.Int32(0),
 				LimitResponse: flowcontrol.LimitResponse{
 					Type: flowcontrol.LimitResponseTypeQueue,
 					Queuing: &flowcontrol.QueuingConfiguration{
@@ -191,7 +191,7 @@ var (
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
 				NominalConcurrencyShares: 40,
-				LendablePercent:          pointer.Int32(25),
+				LendablePercent:          pointer.Int32(0),
 				LimitResponse: flowcontrol.LimitResponse{
 					Type: flowcontrol.LimitResponseTypeQueue,
 					Queuing: &flowcontrol.QueuingConfiguration{
@@ -227,7 +227,7 @@ var (
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
 				NominalConcurrencyShares: 40,
-				LendablePercent:          pointer.Int32(50),
+				LendablePercent:          pointer.Int32(0),
 				LimitResponse: flowcontrol.LimitResponse{
 					Type: flowcontrol.LimitResponseTypeQueue,
 					Queuing: &flowcontrol.QueuingConfiguration{
@@ -245,7 +245,7 @@ var (
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
 				NominalConcurrencyShares: 100,
-				LendablePercent:          pointer.Int32(90),
+				LendablePercent:          pointer.Int32(0),
 				LimitResponse: flowcontrol.LimitResponse{
 					Type: flowcontrol.LimitResponseTypeQueue,
 					Queuing: &flowcontrol.QueuingConfiguration{
@@ -263,7 +263,7 @@ var (
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
 				NominalConcurrencyShares: 20,
-				LendablePercent:          pointer.Int32(50),
+				LendablePercent:          pointer.Int32(0),
 				LimitResponse: flowcontrol.LimitResponse{
 					Type: flowcontrol.LimitResponseTypeQueue,
 					Queuing: &flowcontrol.QueuingConfiguration{


### PR DESCRIPTION
Experimental PR to better understand the effect of disabling client-side rate-limitting in scalability tests.

We will need to run a slightly tuned version of tests too as currently the tests are also artifically throttled, but we will need this PR opened for that anyone to modify run the presubmit with it.

@MikeSpreitzer @tkashem @deads2k - FYI