### PR TITLE
storage/etcd3: use the correct lease manager configuration

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -1790,7 +1790,7 @@ func TestListPaginationRareObject(t *testing.T) {
 	transformer := &prefixTransformer{prefix: []byte(defaultTestPrefix)}
 	recorder := &clientRecorder{KV: etcdClient.KV}
 	etcdClient.KV = recorder
-	store := newStore(etcdClient, codec, newPod, "", schema.GroupResource{Resource: "pods"}, transformer, true, NewDefaultLeaseManagerConfig())
+	store := newStore(etcdClient, codec, newPod, "", schema.GroupResource{Resource: "pods"}, transformer, true, newTestLeaseManagerConfig())
 	ctx := context.Background()
 
 	podCount := 1000


### PR DESCRIPTION
We use a specific lease manager configuration in tests. See 6aa37eb for
more details. This change landed after that one and regressed the suite.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind cleanup

```release-note
NONE
```

```docs

```

/assign @wojtek-t 
/cc @liggitt @mborsz 