### PR TITLE
Fix test order in assert of aws_test.go

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
@@ -1954,8 +1954,8 @@ func TestFindSecurityGroupForInstance(t *testing.T) {
 	if err != nil {
 		t.Error()
 	}
-	assert.Equal(t, *id.GroupId, "sg123")
-	assert.Equal(t, *id.GroupName, "my_group")
+	assert.Equal(t, "sg123", *id.GroupId)
+	assert.Equal(t, "my_group", *id.GroupName)
 }
 
 func TestFindSecurityGroupForInstanceMultipleTagged(t *testing.T) {
@@ -2008,7 +2008,7 @@ func TestCreateDisk(t *testing.T) {
 
 	volumeID, err := c.CreateDisk(volumeOptions)
 	assert.Nil(t, err, "Error creating disk: %v", err)
-	assert.Equal(t, volumeID, KubernetesVolumeID("aws://us-east-1a/vol-volumeId0"))
+	assert.Equal(t, "aws://us-east-1a/vol-volumeId0", volumeID)
 	awsServices.ec2.(*MockedFakeEC2).AssertExpectations(t)
 }
 


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Per https://pkg.go.dev/github.com/stretchr/testify/assert#Equal expected goes before actual:
func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool

Which issue(s) this PR fixes:
Fixes #


Special notes for your reviewer:
Fixes tests asserting that the expected values were the actual ones, when they were not. just like #102611

Does this PR introduce a user-facing change?:
```release-note
NONE
```

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: