### PR TITLE
Fix test order in assert of prune_test.go

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/downloader_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/downloader_test.go
@@ -71,7 +71,7 @@ func TestDownloadOpenAPISpec(t *testing.T) {
 		handlerTest{data: []byte(""), etag: ""})
 	assert.NoError(t, err)
 	if assert.NotNil(t, groups) {
-		assert.Equal(t, len(groups.Paths), 1)
+		assert.Equal(t, 1, len(groups.Paths))
 		if assert.Contains(t, groups.Paths, "apis/group/version") {
 			assert.NotEmpty(t, groups.Paths["apis/group/version"].ServerRelativeURL)
 		}

--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
@@ -68,8 +68,8 @@ func TestGetRESTMappings(t *testing.T) {
 		if tc.expectederr != nil {
 			assert.NotEmptyf(t, actualerr, "getRESTMappings error expected but not fired")
 		}
-		assert.Equal(t, len(actualns), tc.expectedns, "getRESTMappings failed expected number namespaced %d actual %d", tc.expectedns, len(actualns))
-		assert.Equal(t, len(actualnns), tc.expectednns, "getRESTMappings failed expected number nonnamespaced %d actual %d", tc.expectednns, len(actualnns))
+		assert.Equal(t, tc.expectedns, len(actualns), "getRESTMappings failed expected number namespaced %d actual %d", tc.expectedns, len(actualns))
+		assert.Equal(t, tc.expectednns, len(actualnns), "getRESTMappings failed expected number nonnamespaced %d actual %d", tc.expectednns, len(actualnns))
 	}
 }
 
@@ -119,7 +119,7 @@ func TestParsePruneResources(t *testing.T) {
 		if tc.err {
 			assert.NotEmptyf(t, err, "parsePruneResources error expected but not fired")
 		} else {
-			assert.Equal(t, actual, tc.expected, "parsePruneResources failed expected %v actual %v", tc.expected, actual)
+			assert.Equal(t, tc.expected, actual,"parsePruneResources failed expected %v actual %v", tc.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Per https://pkg.go.dev/github.com/stretchr/testify/assert#Equal expected goes before actual:
func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool

Which issue(s) this PR fixes:
Fixes #


Special notes for your reviewer:
Fixes tests asserting that the expected values were the actual ones, when they were not. just like #102611

Does this PR introduce a user-facing change?:
```release-note
NONE
```

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: