### PR TITLE
Make ExpectNoError explainable

### DIFF
--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -31,19 +31,69 @@ func ExpectNotEqual(actual interface{}, extra interface{}, explain ...interface{
 }
 
 // ExpectError expects an error happens, otherwise an exception raises
+//
+// Should not be used anymore. Instead call ExpectErrorExplained
+// with an explanation. That helps understand failures when the
+// error is not descriptive enough by itself. Even when most errors
+// that can occur are descriptive, that is hard to be certain about,
+// so it's better to err on the side of caution and always provide
+// an explanation.
 func ExpectError(err error, explain ...interface{}) {
 	gomega.ExpectWithOffset(1, err).To(gomega.HaveOccurred(), explain...)
 }
 
+// ExpectErrorExplained checks that an error happened, otherwise the test fails.
+// An additional printf-style explanation must be provided because often errors
+// cannot be understood without it. If you're unsure what to put for the explanation,
+// try to explain the error to a hypothetical person reading failure logs without any other context about the test
+func ExpectErrorExplained(err error, explainFormatStr string, explainArgs ...interface{}) {
+	ExpectNotEqual(explainFormatStr, "", "An explanation for the error is required.")
+	explainArgs = append([]interface{}{explainFormatStr}, explainArgs...)
+	gomega.ExpectWithOffset(1, err).To(gomega.HaveOccurred(), explainArgs...)
+}
+
 // ExpectNoError checks if "err" is set, and if so, fails assertion while logging the error.
+//
+// Should not be used anymore. Instead call ExpectNoErrorExplained
+// with an explanation. That helps understand failures when the
+// error is not descriptive enough by itself. Even when most errors
+// that can occur are descriptive, that is hard to be certain about,
+// so it's better to err on the side of caution and always provide
+// an explanation.
 func ExpectNoError(err error, explain ...interface{}) {
 	ExpectNoErrorWithOffset(1, err, explain...)
 }
 
+// ExpectNoErrorExplained checks if "err" is set, and if so, fails the assertion while logging the error.
+// An additional printf-style explanation must be provided because often errors
+// cannot be understood without it. If you're unsure what to put for the explanation,
+// try to explain the error to a hypothetical person reading failure logs without any other context about the test
+func ExpectNoErrorExplained(err error, explainFormatStr string, explainArgs ...interface{}) {
+	ExpectNoErrorWithOffsetExplained(1, err, explainFormatStr, explainArgs...)
+}
+
 // ExpectNoErrorWithOffset checks if "err" is set, and if so, fails assertion while logging the error at "offset" levels above its caller
 // (for example, for call chain f -> g -> ExpectNoErrorWithOffset(1, ...) error would be logged for "f").
+//
+// Should not be used anymore. Instead call ExpectNoErrorWithOffsetExplained
+// with an explanation. That helps understand failures when the
+// error is not descriptive enough by itself. Even when most errors
+// that can occur are descriptive, that is hard to be certain about,
+// so it's better to err on the side of caution and always provide
+// an explanation.
 func ExpectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
 	gomega.ExpectWithOffset(1+offset, err).NotTo(gomega.HaveOccurred(), explain...)
+}
+
+// ExpectNoErrorWithOffsetExplained checks if "err" is set, and if so, fails assertion while logging the error at "offset" levels above its caller
+// (for example, for call chain f -> g -> ExpectNoErrorWithOffsetExplained(1, ...) error would be logged for "f").
+// An additional printf-style explanation must be provided because often errors
+// cannot be understood without it. If you're unsure what to put for the explanation,
+// try to explain the error to a hypothetical person reading failure logs without any other context about the test
+func ExpectNoErrorWithOffsetExplained(offset int, err error, explainFormatStr string, explainArgs ...interface{}) {
+	ExpectNotEqual(explainFormatStr, "", "An explanation for the error is required.")
+	explainArgs = append([]interface{}{explainFormatStr}, explainArgs...)
+	gomega.ExpectWithOffset(1+offset, err).NotTo(gomega.HaveOccurred(), explainArgs...)
 }
 
 // ExpectConsistOf expects actual contains precisely the extra elements.  The ordering of the elements does not matter.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Make it always require a non-empty explain string in framework.ExpectNoError.
This makes errors in tests carry more information
See discussion in #109600 
#### Which issue(s) this PR fixes:
Part of #109600 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
See first commit to know about the code changes
The second commit is to just pass a "TODO" string  to the funtion callers.
```
