### PR TITLE
Add CRI check to healthz

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -423,6 +423,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 	fs.BoolVar(&c.EnableContentionProfiling, "contention-profiling", c.EnableContentionProfiling, "Enable block profiling, if profiling is enabled")
 	fs.Int32Var(&c.HealthzPort, "healthz-port", c.HealthzPort, "The port of the localhost healthz endpoint (set to 0 to disable)")
 	fs.Var(&utilflag.IPVar{Val: &c.HealthzBindAddress}, "healthz-bind-address", "The IP address for the healthz server to serve on (set to '0.0.0.0' or '::' for listening in all interfaces and IP families)")
+	fs.BoolVar(&c.HealthzCRI, "healthz-cri", c.HealthzCRI, "Enables CRI check for the healthz server.")
 	fs.Int32Var(&c.OOMScoreAdj, "oom-score-adj", c.OOMScoreAdj, "The oom-score-adj value for kubelet process. Values must be within the range [-1000, 1000]")
 	fs.StringVar(&c.ClusterDomain, "cluster-domain", c.ClusterDomain, "Domain for this cluster.  If set, kubelet will configure all containers to search this domain in addition to the host's search domains")
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -58264,6 +58264,13 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 							Format:      "",
 						},
 					},
+					"healthzCRI": {
+						SchemaProps: spec.SchemaProps{
+							Description: "healthzCRI enables cri check for the healthz server. Default: false",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"oomScoreAdj": {
 						SchemaProps: spec.SchemaProps{
 							Description: "oomScoreAdj is The oom-score-adj value for kubelet process. Values must be within the range [-1000, 1000]. Default: -999",

--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -59,6 +59,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.FileCheckFrequency = metav1.Duration{Duration: 20 * time.Second}
 			obj.HealthzBindAddress = "127.0.0.1"
 			obj.HealthzPort = 10248
+			obj.HealthzCRI = false
 			obj.HTTPCheckFrequency = metav1.Duration{Duration: 20 * time.Second}
 			obj.ImageMinimumGCAge = metav1.Duration{Duration: 2 * time.Minute}
 			obj.ImageGCHighThresholdPercent = 85

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -210,6 +210,7 @@ var (
 		"HairpinMode",
 		"HealthzBindAddress",
 		"HealthzPort",
+		"HealthzCRI",
 		"Logging.FlushFrequency",
 		"Logging.Format",
 		"Logging.Options.JSON.InfoBufferSize.Quantity.Format",

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -166,6 +166,8 @@ type KubeletConfiguration struct {
 	HealthzPort int32
 	// healthzBindAddress is the IP address for the healthz server to serve on
 	HealthzBindAddress string
+	// HealthzCRI enables cri check for the healthz server.
+	HealthzCRI bool
 	// oomScoreAdj is The oom-score-adj value for kubelet process. Values
 	// must be within the range [-1000, 1000].
 	OOMScoreAdj int32

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -382,6 +382,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 		return err
 	}
 	out.HealthzBindAddress = in.HealthzBindAddress
+	out.HealthzCRI = in.HealthzCRI
 	if err := v1.Convert_Pointer_int32_To_int32(&in.OOMScoreAdj, &out.OOMScoreAdj, s); err != nil {
 		return err
 	}
@@ -569,6 +570,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 		return err
 	}
 	out.HealthzBindAddress = in.HealthzBindAddress
+	out.HealthzCRI = in.HealthzCRI
 	if err := v1.Convert_int32_To_Pointer_int32(&in.OOMScoreAdj, &out.OOMScoreAdj, s); err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -235,6 +235,10 @@ type KubeletConfiguration struct {
 	// Default: "127.0.0.1"
 	// +optional
 	HealthzBindAddress string `json:"healthzBindAddress,omitempty"`
+	// healthzCRI enables cri check for the healthz server.
+	// Default: false
+	// +optional
+	HealthzCRI bool `json:"healthzCRI,omitempty"`
 	// oomScoreAdj is The oom-score-adj value for kubelet process. Values
 	// must be within the range [-1000, 1000].
 	// Default: -999


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

See #109640

#### Which issue(s) this PR fixes:

Fixes #109640

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Added '--healthz-cri' for kubelet to enable cri check in localhost healthz

Note, using this flag changes the health check result when container runtime is not ready, which causes some health check scripts (e.g. cluster/gce/gci/health-monitor.sh) to restart kubelet.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

