### PR TITLE
Replace `DeepEqual` to `Diff` compare on scheduler-binding

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder.go
@@ -508,6 +508,7 @@ func (b *volumeBinder) bindAPIUpdate(ctx context.Context, pod *v1.Pod, bindings 
 			klog.V(4).InfoS("Updating PersistentVolume: binding to claim failed", "PV", klog.KObj(binding.pv), "PVC", klog.KObj(binding.pvc), "err", err)
 			return err
 		}
+
 		klog.V(4).InfoS("Updating PersistentVolume: bound to claim", "PV", klog.KObj(binding.pv), "PVC", klog.KObj(binding.pvc))
 		// Save updated object from apiserver for later checking.
 		binding.pv = newPV
@@ -520,8 +521,10 @@ func (b *volumeBinder) bindAPIUpdate(ctx context.Context, pod *v1.Pod, bindings 
 		klog.V(5).InfoS("Updating claims objects to trigger volume provisioning", "pod", klog.KObj(pod), "PVC", klog.KObj(claim))
 		newClaim, err := b.kubeClient.CoreV1().PersistentVolumeClaims(claim.Namespace).Update(ctx, claim, metav1.UpdateOptions{})
 		if err != nil {
+			klog.V(4).InfoS("Updating PersistentVolumeClaim: binding to volume failed", "PVC", klog.KObj(claim), "err", err)
 			return err
 		}
+
 		// Save updated object from apiserver for later checking.
 		claimsToProvision[i] = newClaim
 		lastProcessedProvisioning++

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -20,17 +20,17 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -433,13 +433,13 @@ func (env *testEnv) validatePodCache(t *testing.T, node string, pod *v1.Pod, pod
 	} else {
 		for i := 0; i < aLen; i++ {
 			// Validate PV
-			if !reflect.DeepEqual(expectedBindings[i].pv, bindings[i].pv) {
-				t.Errorf("binding.pv doesn't match [A-expected, B-got]: %s", diff.ObjectDiff(expectedBindings[i].pv, bindings[i].pv))
+			if diff := cmp.Diff(expectedBindings[i].pv, bindings[i].pv); diff != "" {
+				t.Errorf("binding.pv doesn't match (-want, +got):\n%s", diff)
 			}
 
 			// Validate PVC
-			if !reflect.DeepEqual(expectedBindings[i].pvc, bindings[i].pvc) {
-				t.Errorf("binding.pvc doesn't match [A-expected, B-got]: %s", diff.ObjectDiff(expectedBindings[i].pvc, bindings[i].pvc))
+			if diff := cmp.Diff(expectedBindings[i].pvc, bindings[i].pvc); diff != "" {
+				t.Errorf("binding.pvc doesn't match (-want, +got):\n%s", diff)
 			}
 		}
 	}
@@ -454,8 +454,8 @@ func (env *testEnv) validatePodCache(t *testing.T, node string, pod *v1.Pod, pod
 		t.Error("expected empty provisionings, got nil")
 	} else {
 		for i := 0; i < aLen; i++ {
-			if !reflect.DeepEqual(expectedProvisionings[i], provisionedClaims[i]) {
-				t.Errorf("provisioned claims doesn't match [A-expected, B-got]: %s", diff.ObjectDiff(expectedProvisionings[i], provisionedClaims[i]))
+			if diff := cmp.Diff(expectedProvisionings[i], provisionedClaims[i]); diff != "" {
+				t.Errorf("provisioned claims doesn't match (-want, +got):\n%s", diff)
 			}
 		}
 	}
@@ -540,8 +540,8 @@ func (env *testEnv) validateBind(
 		// Cache may be overridden by API object with higher version, compare but ignore resource version.
 		newCachedPV := cachedPV.DeepCopy()
 		newCachedPV.ResourceVersion = pv.ResourceVersion
-		if !reflect.DeepEqual(newCachedPV, pv) {
-			t.Errorf("cached PV check failed [A-expected, B-got]:\n%s", diff.ObjectDiff(pv, cachedPV))
+		if diff := cmp.Diff(pv, newCachedPV); diff != "" {
+			t.Errorf("cached PV check failed (-want, +got):\n%s", diff)
 		}
 	}
 
@@ -567,8 +567,8 @@ func (env *testEnv) validateProvision(
 		// Cache may be overridden by API object with higher version, compare but ignore resource version.
 		newCachedPVC := cachedPVC.DeepCopy()
 		newCachedPVC.ResourceVersion = pvc.ResourceVersion
-		if !reflect.DeepEqual(newCachedPVC, pvc) {
-			t.Errorf("cached PVC check failed [A-expected, B-got]:\n%s", diff.ObjectDiff(pvc, cachedPVC))
+		if diff := cmp.Diff(pvc, newCachedPVC); diff != "" {
+			t.Errorf("cached PVC check failed (-want, +got):\n%s", diff)
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Add retry logic when updating PVC/PV on binding pod volumes, to avoid the`FailedScheduling` backoff to improve the scheduling efficiency.

#### Which issue(s) this PR fixes:
Fixes #109661

#### Special notes for your reviewer:
When scheduler encounter `FailedScheduling`, the backoff will make it slow to schedule again.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```