### PR TITLE
Skip mount point checks when possible during mount cleanup.

### DIFF
--- a/staging/src/k8s.io/mount-utils/fake_mounter.go
+++ b/staging/src/k8s.io/mount-utils/fake_mounter.go
@@ -218,7 +218,7 @@ func (f *FakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-func (f *FakeMounter) CanSafelySkipMountPointCheck() bool {
+func (f *FakeMounter) canSafelySkipMountPointCheck() bool {
 	return f.skipMountPointCheck
 }
 

--- a/staging/src/k8s.io/mount-utils/fake_mounter.go
+++ b/staging/src/k8s.io/mount-utils/fake_mounter.go
@@ -212,6 +212,11 @@ func (f *FakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
+// CanSafelySkipMountPointCheck always returns false for FakeMounter.
+func (f *FakeMounter) CanSafelySkipMountPointCheck() bool {
+	return false
+}
+
 // GetMountRefs finds all mount references to the path, returns a
 // list of paths.
 func (f *FakeMounter) GetMountRefs(pathname string) ([]string, error) {

--- a/staging/src/k8s.io/mount-utils/fake_mounter.go
+++ b/staging/src/k8s.io/mount-utils/fake_mounter.go
@@ -32,8 +32,9 @@ type FakeMounter struct {
 	MountCheckErrors map[string]error
 	// Some tests run things in parallel, make sure the mounter does not produce
 	// any golang's DATA RACE warnings.
-	mutex       sync.Mutex
-	UnmountFunc UnmountFunc
+	mutex               sync.Mutex
+	UnmountFunc         UnmountFunc
+	skipMountPointCheck bool
 }
 
 // UnmountFunc is a function callback to be executed during the Unmount() call.
@@ -62,6 +63,11 @@ func NewFakeMounter(mps []MountPoint) *FakeMounter {
 	return &FakeMounter{
 		MountPoints: mps,
 	}
+}
+
+func (f *FakeMounter) WithSkipMountPointCheck() *FakeMounter {
+	f.skipMountPointCheck = true
+	return f
 }
 
 // ResetLog clears all the log entries in FakeMounter
@@ -212,9 +218,8 @@ func (f *FakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-// CanSafelySkipMountPointCheck always returns false for FakeMounter.
 func (f *FakeMounter) CanSafelySkipMountPointCheck() bool {
-	return false
+	return f.skipMountPointCheck
 }
 
 // GetMountRefs finds all mount references to the path, returns a

--- a/staging/src/k8s.io/mount-utils/mount.go
+++ b/staging/src/k8s.io/mount-utils/mount.go
@@ -66,10 +66,10 @@ type Interface interface {
 	// care about such situations, this is a faster alternative to calling List()
 	// and scanning that output.
 	IsLikelyNotMountPoint(file string) (bool, error)
-	// CanSafelySkipMountPointCheck indicates whether this mounter returns errors on
+	// canSafelySkipMountPointCheck indicates whether this mounter returns errors on
 	// operations for targets that are not mount points. If this returns true, no such
 	// errors will be returned.
-	CanSafelySkipMountPointCheck() bool
+	canSafelySkipMountPointCheck() bool
 	// GetMountRefs finds all mount references to pathname, returning a slice of
 	// paths. Pathname can be a mountpoint path or a normal	directory
 	// (for bind mount). On Linux, pathname is excluded from the slice.

--- a/staging/src/k8s.io/mount-utils/mount.go
+++ b/staging/src/k8s.io/mount-utils/mount.go
@@ -66,6 +66,10 @@ type Interface interface {
 	// care about such situations, this is a faster alternative to calling List()
 	// and scanning that output.
 	IsLikelyNotMountPoint(file string) (bool, error)
+	// CanSafelySkipMountPointCheck indicates whether this mounter returns errors on
+	// operations for targets that are not mount points. If this returns true, no such
+	// errors will be returned.
+	CanSafelySkipMountPointCheck() bool
 	// GetMountRefs finds all mount references to pathname, returning a slice of
 	// paths. Pathname can be a mountpoint path or a normal	directory
 	// (for bind mount). On Linux, pathname is excluded from the slice.

--- a/staging/src/k8s.io/mount-utils/mount_helper_common.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_common.go
@@ -146,7 +146,7 @@ func removePathIfNotMountPoint(mountPath string, mounter Interface, extensiveMou
 
 // removePath attempts to remove the directory. Returns nil if the directory was removed or does not exist.
 func removePath(mountPath string) error {
-	klog.Warningf("Warning: deleting mount path %q", mountPath)
+	klog.Warningf("Warning: deleting path %q", mountPath)
 	err := os.Remove(mountPath)
 	if os.IsNotExist(err) {
 		klog.V(4).Infof("%q does not exist", mountPath)

--- a/staging/src/k8s.io/mount-utils/mount_helper_common.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_common.go
@@ -53,7 +53,8 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 	}
 
 	if corruptedMnt || mounter.canSafelySkipMountPointCheck() {
-		klog.V(4).Infof("unmounting %q", mountPath)
+		klog.V(4).Infof("unmounting %q (corruptedMount: %t, mounterCanSkipMountPointChecks: %t)",
+			mountPath, corruptedMnt, mounter.canSafelySkipMountPointCheck())
 		if err := mounter.UnmountWithForce(mountPath, umountTimeout); err != nil {
 			return err
 		}
@@ -89,7 +90,8 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 // will be skipped. The mount point check will also be skipped if the mounter supports it.
 func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool, corruptedMnt bool) error {
 	if corruptedMnt || mounter.canSafelySkipMountPointCheck() {
-		klog.V(4).Infof("unmounting %q", mountPath)
+		klog.V(4).Infof("unmounting %q (corruptedMount: %t, mounterCanSkipMountPointChecks: %t)",
+			mountPath, corruptedMnt, mounter.canSafelySkipMountPointCheck())
 		if err := mounter.Unmount(mountPath); err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/mount-utils/mount_helper_common.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_common.go
@@ -31,7 +31,7 @@ import (
 func CleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool) error {
 	pathExists, pathErr := PathExists(mountPath)
 	if !pathExists && pathErr == nil {
-		klog.Warningf("Warning: Unmount skipped because path does not exist: %v", mountPath)
+		klog.Warningf("Warning: mount cleanup skipped because path does not exist: %v", mountPath)
 		return nil
 	}
 	corruptedMnt := IsCorruptedMnt(pathErr)
@@ -44,40 +44,40 @@ func CleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointC
 func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, extensiveMountPointCheck bool, umountTimeout time.Duration) error {
 	pathExists, pathErr := PathExists(mountPath)
 	if !pathExists && pathErr == nil {
-		klog.Warningf("Warning: Unmount skipped because path does not exist: %v", mountPath)
+		klog.Warningf("Warning: mount cleanup skipped because path does not exist: %v", mountPath)
 		return nil
 	}
 	corruptedMnt := IsCorruptedMnt(pathErr)
 	if pathErr != nil && !corruptedMnt {
 		return fmt.Errorf("Error checking path: %v", pathErr)
 	}
-	var notMnt bool
-	var err error
-	if !mounter.canSafelySkipMountPointCheck() && !corruptedMnt {
-		notMnt, err = removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
-		// if mountPath was not a mount point - we would have attempted to remove mountPath
-		// and hence return errors if any.
-		if err != nil || notMnt {
+
+	if corruptedMnt || mounter.canSafelySkipMountPointCheck() {
+		klog.V(4).Infof("unmounting %q", mountPath)
+		if err := mounter.UnmountWithForce(mountPath, umountTimeout); err != nil {
 			return err
 		}
+		return removePath(mountPath)
 	}
 
-	// Unmount the mount path
+	notMnt, err := removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
+	// if mountPath is not a mount point, it's just been removed or there was an error
+	if err != nil || notMnt {
+		return err
+	}
+
 	klog.V(4).Infof("%q is a mountpoint, unmounting", mountPath)
 	if err := mounter.UnmountWithForce(mountPath, umountTimeout); err != nil {
 		return err
 	}
 
-	if mounter.canSafelySkipMountPointCheck() {
-		return removePath(mountPath)
-	}
-
 	notMnt, err = removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
-	// mountPath is not a mount point we should return whatever error we saw
+	// if mountPath is not a mount point, it's either just been removed or there was an error
 	if notMnt {
 		return err
 	}
-	return fmt.Errorf("Failed to unmount path %v", mountPath)
+	// mountPath is still a mount point
+	return fmt.Errorf("failed to cleanup mount point %v", mountPath)
 }
 
 // doCleanupMountPoint unmounts the given path and
@@ -88,33 +88,32 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 // if corruptedMnt is true, it means that the mountPath is a corrupted mountpoint, and the mount point check
 // will be skipped. The mount point check will also be skipped if the mounter supports it.
 func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool, corruptedMnt bool) error {
-	var notMnt bool
-	var err error
-	if !mounter.canSafelySkipMountPointCheck() && !corruptedMnt {
-		notMnt, err = removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
-		// if mountPath was not a mount point - we would have attempted to remove mountPath
-		// and hence return errors if any.
-		if err != nil || notMnt {
+	if corruptedMnt || mounter.canSafelySkipMountPointCheck() {
+		klog.V(4).Infof("unmounting %q", mountPath)
+		if err := mounter.Unmount(mountPath); err != nil {
 			return err
 		}
+		return removePath(mountPath)
 	}
 
-	// Unmount the mount path
+	notMnt, err := removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
+	// if mountPath is not a mount point, it's just been removed or there was an error
+	if err != nil || notMnt {
+		return err
+	}
+
 	klog.V(4).Infof("%q is a mountpoint, unmounting", mountPath)
 	if err := mounter.Unmount(mountPath); err != nil {
 		return err
 	}
 
-	if mounter.canSafelySkipMountPointCheck() {
-		return removePath(mountPath)
-	}
-
 	notMnt, err = removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
-	// mountPath is not a mount point we should return whatever error we saw
+	// if mountPath is not a mount point, it's either just been removed or there was an error
 	if notMnt {
 		return err
 	}
-	return fmt.Errorf("Failed to unmount path %v", mountPath)
+	// mountPath is still a mount point
+	return fmt.Errorf("failed to cleanup mount point %v", mountPath)
 }
 
 // removePathIfNotMountPoint verifies if given mountPath is a mount point if not it attempts

--- a/staging/src/k8s.io/mount-utils/mount_helper_common.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_common.go
@@ -53,7 +53,7 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 	}
 	var notMnt bool
 	var err error
-	if !mounter.CanSafelySkipMountPointCheck() && !corruptedMnt {
+	if !mounter.canSafelySkipMountPointCheck() && !corruptedMnt {
 		notMnt, err = removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
 		// if mountPath was not a mount point - we would have attempted to remove mountPath
 		// and hence return errors if any.
@@ -68,7 +68,7 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 		return err
 	}
 
-	if mounter.CanSafelySkipMountPointCheck() {
+	if mounter.canSafelySkipMountPointCheck() {
 		return removePath(mountPath)
 	}
 
@@ -90,7 +90,7 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool, corruptedMnt bool) error {
 	var notMnt bool
 	var err error
-	if !mounter.CanSafelySkipMountPointCheck() && !corruptedMnt {
+	if !mounter.canSafelySkipMountPointCheck() && !corruptedMnt {
 		notMnt, err = removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
 		// if mountPath was not a mount point - we would have attempted to remove mountPath
 		// and hence return errors if any.
@@ -105,7 +105,7 @@ func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPoin
 		return err
 	}
 
-	if mounter.CanSafelySkipMountPointCheck() {
+	if mounter.canSafelySkipMountPointCheck() {
 		return removePath(mountPath)
 	}
 
@@ -146,7 +146,7 @@ func removePathIfNotMountPoint(mountPath string, mounter Interface, extensiveMou
 
 // removePath attempts to remove the directory. Returns nil if the directory was removed or does not exist.
 func removePath(mountPath string) error {
-	klog.Warningf("Warning: deleting path %q", mountPath)
+	klog.V(4).Infof("Warning: deleting path %q", mountPath)
 	err := os.Remove(mountPath)
 	if os.IsNotExist(err) {
 		klog.V(4).Infof("%q does not exist", mountPath)

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -22,6 +22,7 @@ package mount
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -48,14 +49,17 @@ const (
 	fsckErrorsUncorrected = 4
 	// Error thrown by exec cmd.Run() when process spawned by cmd.Start() completes before cmd.Wait() is called (see - k/k issue #103753)
 	errNoChildProcesses = "wait: no child processes"
+	// Error returned by some `umount` implementations when the specified path is not a mount point
+	errNotMounted = "not mounted"
 )
 
 // Mounter provides the default implementation of mount.Interface
 // for the linux platform.  This implementation assumes that the
 // kubelet is running in the host's root mount namespace.
 type Mounter struct {
-	mounterPath string
-	withSystemd bool
+	mounterPath                string
+	withSystemd                bool
+	withSafeNotMountedBehavior bool
 }
 
 var _ MounterForceUnmounter = &Mounter{}
@@ -65,8 +69,9 @@ var _ MounterForceUnmounter = &Mounter{}
 // mounterPath allows using an alternative to `/bin/mount` for mounting.
 func New(mounterPath string) Interface {
 	return &Mounter{
-		mounterPath: mounterPath,
-		withSystemd: detectSystemd(),
+		mounterPath:                mounterPath,
+		withSystemd:                detectSystemd(),
+		withSafeNotMountedBehavior: detectSafeNotMountedBehavior(),
 	}
 }
 
@@ -223,6 +228,37 @@ func detectSystemd() bool {
 	return true
 }
 
+// detectSafeNotMountedBehavior returns true if the umount implementation replies "not mounted"
+// when the specified path is not mounted. When not sure (permission errors, ...), it returns false.
+// When possible, we will trust umount's message and avoid doing our own mount point checks.
+// More info: https://github.com/util-linux/util-linux/blob/v2.2/mount/umount.c#L179
+func detectSafeNotMountedBehavior() bool {
+	if _, err := exec.LookPath("umount"); err != nil {
+		klog.V(2).Infof("Failed to locate umount executable to detect safe 'not mounted' behavior")
+		return false
+	}
+	// create a temp dir and try to umount it
+	path, err := ioutil.TempDir("", "kubelet-detect-safe-umount")
+	if err != nil {
+		klog.V(2).Infof("Cannot create temp dir to detect safe 'not mounted' behavior: %v", err)
+		return false
+	}
+	defer os.RemoveAll(path)
+	cmd := exec.Command("umount", path)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.V(2).Infof("Cannot run umount to detect safe 'not mounted' behavior: %v", err)
+		klog.V(4).Infof("'umount %s' output: %s, failed with: %v", path, string(output), err)
+		return false
+	}
+	if !strings.Contains(string(output), errNotMounted) {
+		klog.V(2).Infof("Detected umount with unsafe 'not mounted' behavior")
+		return false
+	}
+	klog.V(2).Infof("Detected umount with safe 'not mounted' behavior")
+	return true
+}
+
 // MakeMountArgs makes the arguments to the mount(8) command.
 // options MUST not contain sensitive material (like passwords).
 func MakeMountArgs(source, target, fstype string, options []string) (mountArgs []string) {
@@ -303,6 +339,9 @@ func (mounter *Mounter) Unmount(target string) error {
 			// Rewrite err with the actual exit error of the process.
 			err = &exec.ExitError{ProcessState: command.ProcessState}
 		}
+		if mounter.withSafeNotMountedBehavior && strings.Contains(string(output), errNotMounted) {
+			return nil
+		}
 		return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", err, target, string(output))
 	}
 	return nil
@@ -349,6 +388,11 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// CanSafelySkipMountPointCheck relies on the detected behavior of umount when given a target that is not a mount point.
+func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
+	return mounter.withSafeNotMountedBehavior
 }
 
 // GetMountRefs finds all mount references to pathname, returns a

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -233,6 +233,11 @@ func detectSystemd() bool {
 // When possible, we will trust umount's message and avoid doing our own mount point checks.
 // More info: https://github.com/util-linux/util-linux/blob/v2.2/mount/umount.c#L179
 func detectSafeNotMountedBehavior() bool {
+	return detectSafeNotMountedBehaviorWithExec(utilexec.New())
+}
+
+// detectSafeNotMountedBehaviorWithExec is for testing with FakeExec.
+func detectSafeNotMountedBehaviorWithExec(exec utilexec.Interface) bool {
 	if _, err := exec.LookPath("umount"); err != nil {
 		klog.V(2).Infof("Failed to locate umount executable to detect safe 'not mounted' behavior")
 		return false

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -393,8 +393,8 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-// CanSafelySkipMountPointCheck relies on the detected behavior of umount when given a target that is not a mount point.
-func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
+// canSafelySkipMountPointCheck relies on the detected behavior of umount when given a target that is not a mount point.
+func (mounter *Mounter) canSafelySkipMountPointCheck() bool {
 	return mounter.withSafeNotMountedBehavior
 }
 

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -247,16 +247,14 @@ func detectSafeNotMountedBehavior() bool {
 	cmd := exec.Command("umount", path)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		klog.V(2).Infof("Cannot run umount to detect safe 'not mounted' behavior: %v", err)
-		klog.V(4).Infof("'umount %s' output: %s, failed with: %v", path, string(output), err)
-		return false
+		if strings.Contains(string(output), errNotMounted) {
+			klog.V(2).Infof("Detected umount with safe 'not mounted' behavior")
+			return true
+		}
+		klog.V(4).Infof("'umount %s' failed with: %v, output: %s", path, err, string(output))
 	}
-	if !strings.Contains(string(output), errNotMounted) {
-		klog.V(2).Infof("Detected umount with unsafe 'not mounted' behavior")
-		return false
-	}
-	klog.V(2).Infof("Detected umount with safe 'not mounted' behavior")
-	return true
+	klog.V(2).Infof("Detected umount with unsafe 'not mounted' behavior")
+	return false
 }
 
 // MakeMountArgs makes the arguments to the mount(8) command.

--- a/staging/src/k8s.io/mount-utils/mount_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux_test.go
@@ -20,11 +20,15 @@ limitations under the License.
 package mount
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	utilexec "k8s.io/utils/exec"
+	testexec "k8s.io/utils/exec/testing"
 )
 
 func TestReadProcMountsFrom(t *testing.T) {
@@ -544,4 +548,67 @@ func mountArgsContainOption(t *testing.T, mountArgs []string, option string) boo
 	}
 
 	return strings.Contains(mountArgs[optionsIndex], option)
+}
+
+func TestDetectSafeNotMountedBehavior(t *testing.T) {
+	// example output for umount from util-linux 2.30.2
+	notMountedOutput := "umount: /foo: not mounted."
+
+	// Arrange
+	testcases := []struct {
+		fakeCommandAction testexec.FakeCommandAction
+		expectedSafe      bool
+	}{
+		{
+			fakeCommandAction: makeFakeCommandAction(notMountedOutput, errors.New("any error")),
+			expectedSafe:      true,
+		},
+		{
+			fakeCommandAction: makeFakeCommandAction(notMountedOutput, nil),
+			expectedSafe:      false,
+		},
+		{
+			fakeCommandAction: makeFakeCommandAction("any output", nil),
+			expectedSafe:      false,
+		},
+		{
+			fakeCommandAction: makeFakeCommandAction("any output", errors.New("any error")),
+			expectedSafe:      false,
+		},
+	}
+
+	for _, v := range testcases {
+		// Prepare
+		fakeexec := &testexec.FakeExec{
+			LookPathFunc: func(s string) (string, error) {
+				return "fake-umount", nil
+			},
+			CommandScript: []testexec.FakeCommandAction{v.fakeCommandAction},
+		}
+		// Act
+		isSafe := detectSafeNotMountedBehaviorWithExec(fakeexec)
+		// Assert
+		if isSafe != v.expectedSafe {
+			var adj string
+			if v.expectedSafe {
+				adj = "safe"
+			} else {
+				adj = "unsafe"
+			}
+			t.Errorf("Expected to detect %s umount behavior, but did not", adj)
+		}
+	}
+}
+
+func makeFakeCommandAction(stdout string, err error) testexec.FakeCommandAction {
+	c := testexec.FakeCmd{
+		CombinedOutputScript: []testexec.FakeAction{
+			func() ([]byte, []byte, error) {
+				return []byte(stdout), nil, err
+			},
+		},
+	}
+	return func(cmd string, args ...string) utilexec.Cmd {
+		return testexec.InitFakeCmd(&c, cmd, args...)
+	}
 }

--- a/staging/src/k8s.io/mount-utils/mount_unsupported.go
+++ b/staging/src/k8s.io/mount-utils/mount_unsupported.go
@@ -74,8 +74,8 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, errUnsupported
 }
 
-// CanSafelySkipMountPointCheck always returns false on unsupported platforms
-func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
+// canSafelySkipMountPointCheck always returns false on unsupported platforms
+func (mounter *Mounter) canSafelySkipMountPointCheck() bool {
 	return false
 }
 

--- a/staging/src/k8s.io/mount-utils/mount_unsupported.go
+++ b/staging/src/k8s.io/mount-utils/mount_unsupported.go
@@ -74,6 +74,11 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, errUnsupported
 }
 
+// CanSafelySkipMountPointCheck always returns false on unsupported platforms
+func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
+	return false
+}
+
 // GetMountRefs always returns an error on unsupported platforms
 func (mounter *Mounter) GetMountRefs(pathname string) ([]string, error) {
 	return nil, errUnsupported

--- a/staging/src/k8s.io/mount-utils/mount_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_windows.go
@@ -244,8 +244,8 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-// CanSafelySkipMountPointCheck always returns false on Windows
-func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
+// canSafelySkipMountPointCheck always returns false on Windows
+func (mounter *Mounter) canSafelySkipMountPointCheck() bool {
 	return false
 }
 

--- a/staging/src/k8s.io/mount-utils/mount_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_windows.go
@@ -244,6 +244,11 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
+// CanSafelySkipMountPointCheck always returns false on Windows
+func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
+	return false
+}
+
 // GetMountRefs : empty implementation here since there is no place to query all mount points on Windows
 func (mounter *Mounter) GetMountRefs(pathname string) ([]string, error) {
 	windowsPath := NormalizeWindowsPath(pathname)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind api-change

#### What this PR does / why we need it:

This is a continuation of https://github.com/kubernetes/kubernetes/pull/109117. Please see that PR for more background.

Calls to `mounter.Unmount` are preceded and followed by expensive mount point checks. These checks are not necessary on *nix-s with a `umount` implementation that performs a similar check itself. This PR adds a mechanism to detect the "safe" behavior, and avoid mount point checks when possible.

This change represents a significant optimization of `CleanupMountPoint`; enabling use-cases where pods have many mounts, and there is high pod churn. We (EKS) have observed several cases of instability and poor node health in such scenarios, which were resolved with this change.

#### Which issue(s) this PR fixes:

No issue available.

#### Special notes for your reviewer:

I chose to add a function to the `Mounter` interface in order to keep the `CleanupMountPoint` implementation generic for Unix and Windows. If the "safe" `umount` behavior is not detected, the existing code paths are unchanged.

#### Does this PR introduce a user-facing change?

```release-note
On compatible systems, a mounter's Unmount implementation is changed to not return an error when the specified target can be detected as not a mount point. On Linux, the behavior of detecting a mount point depends on `umount` command is validated when the mounter is created. Additionally, mount point checks will be skipped in CleanupMountPoint/CleanupMountWithForce if the mounter's Unmount having the changed behavior of not returning error when target is not a mount point.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
