### PR TITLE
cleanup: move scheduler unit tests to use PodWrapper

### DIFF
--- a/pkg/scheduler/extender_test.go
+++ b/pkg/scheduler/extender_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -352,56 +351,23 @@ func TestIsInterested(t *testing.T) {
 		{
 			label:    "Managed memory, empty resources",
 			extender: mem,
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name: "app",
-						},
-					},
-				},
-			},
-			want: false,
+			pod:      st.MakePod().Container("app").Obj(),
+			want:     false,
 		},
 		{
 			label:    "Managed memory, container memory",
 			extender: mem,
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name: "app",
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{"memory": resource.Quantity{}},
-								Limits:   v1.ResourceList{"memory": resource.Quantity{}},
-							},
-						},
-					},
-				},
-			},
+			pod: st.MakePod().Req(map[v1.ResourceName]string{
+				"memory": "0",
+			}).Obj(),
 			want: true,
 		},
 		{
 			label:    "Managed memory, init container memory",
 			extender: mem,
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name: "app",
-						},
-					},
-					InitContainers: []v1.Container{
-						{
-							Name: "init",
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{"memory": resource.Quantity{}},
-								Limits:   v1.ResourceList{"memory": resource.Quantity{}},
-							},
-						},
-					},
-				},
-			},
+			pod: st.MakePod().Container("app").InitReq(map[v1.ResourceName]string{
+				"memory": "0",
+			}).Obj(),
 			want: true,
 		},
 	} {
@@ -424,15 +390,15 @@ func TestConvertToMetaVictims(t *testing.T) {
 			nodeNameToVictims: map[string]*extenderv1.Victims{
 				"node1": {
 					Pods: []*v1.Pod{
-						{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: "uid1"}},
-						{ObjectMeta: metav1.ObjectMeta{Name: "pod3", UID: "uid3"}},
+						st.MakePod().Name("pod1").UID("uid1").Obj(),
+						st.MakePod().Name("pod3").UID("uid3").Obj(),
 					},
 					NumPDBViolations: 1,
 				},
 				"node2": {
 					Pods: []*v1.Pod{
-						{ObjectMeta: metav1.ObjectMeta{Name: "pod2", UID: "uid2"}},
-						{ObjectMeta: metav1.ObjectMeta{Name: "pod4", UID: "uid4"}},
+						st.MakePod().Name("pod2").UID("uid2").Obj(),
+						st.MakePod().Name("pod4").UID("uid4").Obj(),
 					},
 					NumPDBViolations: 2,
 				},
@@ -496,24 +462,24 @@ func TestConvertToVictims(t *testing.T) {
 			},
 			nodeNames: []string{"node1", "node2"},
 			podsInNodeList: []*v1.Pod{
-				{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: "uid1"}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "pod2", UID: "uid2"}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "pod3", UID: "uid3"}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "pod4", UID: "uid4"}},
+				st.MakePod().Name("pod1").UID("uid1").Obj(),
+				st.MakePod().Name("pod2").UID("uid2").Obj(),
+				st.MakePod().Name("pod3").UID("uid3").Obj(),
+				st.MakePod().Name("pod4").UID("uid4").Obj(),
 			},
 			nodeInfos: nil,
 			want: map[string]*extenderv1.Victims{
 				"node1": {
 					Pods: []*v1.Pod{
-						{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: "uid1"}},
-						{ObjectMeta: metav1.ObjectMeta{Name: "pod3", UID: "uid3"}},
+						st.MakePod().Name("pod1").UID("uid1").Obj(),
+						st.MakePod().Name("pod3").UID("uid3").Obj(),
 					},
 					NumPDBViolations: 1,
 				},
 				"node2": {
 					Pods: []*v1.Pod{
-						{ObjectMeta: metav1.ObjectMeta{Name: "pod2", UID: "uid2"}},
-						{ObjectMeta: metav1.ObjectMeta{Name: "pod4", UID: "uid4"}},
+						st.MakePod().Name("pod2").UID("uid2").Obj(),
+						st.MakePod().Name("pod4").UID("uid4").Obj(),
 					},
 					NumPDBViolations: 2,
 				},

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
@@ -28,12 +28,11 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
 func TestDefaultBinder(t *testing.T) {
-	testPod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "ns"},
-	}
+	testPod := st.MakePod().Name("foo").Namespace("ns").Obj()
 	testNode := "foohost.kubernetes.mydomain.com"
 	tests := []struct {
 		name        string

--- a/pkg/scheduler/framework/plugins/helper/spread_test.go
+++ b/pkg/scheduler/framework/plugins/helper/spread_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
 func TestGetPodServices(t *testing.T) {
@@ -48,16 +49,11 @@ func TestGetPodServices(t *testing.T) {
 	}
 	var pods []*v1.Pod
 	for i := 0; i < 5; i++ {
-		pod := &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "test",
-				Name:      fmt.Sprintf("test-pod-%d", i),
-				Labels: map[string]string{
-					"app":   fmt.Sprintf("test-%d", i),
-					"label": fmt.Sprintf("label-%d", i),
-				},
-			},
-		}
+		pod := st.MakePod().Name(fmt.Sprintf("test-pod-%d", i)).
+			Namespace("test").
+			Label("app", fmt.Sprintf("test-%d", i)).
+			Label("label", fmt.Sprintf("label-%d", i)).
+			Obj()
 		pods = append(pods, pod)
 	}
 

--- a/pkg/scheduler/framework/plugins/imagelocality/image_locality_test.go
+++ b/pkg/scheduler/framework/plugins/imagelocality/image_locality_test.go
@@ -240,8 +240,8 @@ func TestImageLocalityPriority(t *testing.T) {
 			// Image: gcr.io/250:latest 250MB
 			// Score: 100 * (250M/2 - 23M)/(1000M * 2 - 23M) = 5
 			pod:          &v1.Pod{Spec: test40250},
-			nodes:        []*v1.Node{makeImageNode("machine1", node403002000), makeImageNode("machine2", node25010)},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 0}, {Name: "machine2", Score: 5}},
+			nodes:        []*v1.Node{makeImageNode("node1", node403002000), makeImageNode("node2", node25010)},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 0}, {Name: "node2", Score: 5}},
 			name:         "two images spread on two nodes, prefer the larger image one",
 		},
 		{
@@ -255,8 +255,8 @@ func TestImageLocalityPriority(t *testing.T) {
 			// Image: not present
 			// Score: 0
 			pod:          &v1.Pod{Spec: test40300},
-			nodes:        []*v1.Node{makeImageNode("machine1", node403002000), makeImageNode("machine2", node25010)},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 7}, {Name: "machine2", Score: 0}},
+			nodes:        []*v1.Node{makeImageNode("node1", node403002000), makeImageNode("node2", node25010)},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 7}, {Name: "node2", Score: 0}},
 			name:         "two images on one node, prefer this node",
 		},
 		{
@@ -270,8 +270,8 @@ func TestImageLocalityPriority(t *testing.T) {
 			// Image: gcr.io/10:latest 10MB
 			// Score: 0 (10M/2 < 23M, min-threshold)
 			pod:          &v1.Pod{Spec: testMinMax},
-			nodes:        []*v1.Node{makeImageNode("machine1", node400030), makeImageNode("machine2", node25010)},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MaxNodeScore}, {Name: "machine2", Score: 0}},
+			nodes:        []*v1.Node{makeImageNode("node1", node400030), makeImageNode("node2", node25010)},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: framework.MaxNodeScore}, {Name: "node2", Score: 0}},
 			name:         "if exceed limit, use limit",
 		},
 		{
@@ -289,8 +289,8 @@ func TestImageLocalityPriority(t *testing.T) {
 			// Image:
 			// Score: 0
 			pod:          &v1.Pod{Spec: testMinMax},
-			nodes:        []*v1.Node{makeImageNode("machine1", node400030), makeImageNode("machine2", node25010), makeImageNode("machine3", nodeWithNoImages)},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 66}, {Name: "machine2", Score: 0}, {Name: "machine3", Score: 0}},
+			nodes:        []*v1.Node{makeImageNode("node1", node400030), makeImageNode("node2", node25010), makeImageNode("node3", nodeWithNoImages)},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 66}, {Name: "node2", Score: 0}, {Name: "node3", Score: 0}},
 			name:         "if exceed limit, use limit (with node which has no images present)",
 		},
 		{
@@ -308,9 +308,9 @@ func TestImageLocalityPriority(t *testing.T) {
 			// Image:
 			// Score: 0
 			pod:          &v1.Pod{Spec: test300600900},
-			nodes:        []*v1.Node{makeImageNode("machine1", node60040900), makeImageNode("machine2", node300600900), makeImageNode("machine3", nodeWithNoImages)},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 32}, {Name: "machine2", Score: 36}, {Name: "machine3", Score: 0}},
-			name:         "pod with multiple large images, machine2 is preferred",
+			nodes:        []*v1.Node{makeImageNode("node1", node60040900), makeImageNode("node2", node300600900), makeImageNode("node3", nodeWithNoImages)},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 32}, {Name: "node2", Score: 36}, {Name: "node3", Score: 0}},
+			name:         "pod with multiple large images, node2 is preferred",
 		},
 		{
 			// Pod: gcr.io/30 gcr.io/40
@@ -323,8 +323,8 @@ func TestImageLocalityPriority(t *testing.T) {
 			// Image: 100 * (30M - 23M) / (1000M * 2 - 23M) = 0
 			// Score: 0
 			pod:          &v1.Pod{Spec: test3040},
-			nodes:        []*v1.Node{makeImageNode("machine1", node203040), makeImageNode("machine2", node400030)},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 1}, {Name: "machine2", Score: 0}},
+			nodes:        []*v1.Node{makeImageNode("node1", node203040), makeImageNode("node2", node400030)},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 1}, {Name: "node2", Score: 0}},
 			name:         "pod with multiple small images",
 		},
 	}

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
 // TODO: Add test case for RequiredDuringSchedulingRequiredDuringExecution after it's implemented.
@@ -49,37 +50,25 @@ func TestNodeAffinity(t *testing.T) {
 		},
 		{
 			name: "missing labels",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					NodeSelector: map[string]string{
-						"foo": "bar",
-					},
-				},
-			},
+			pod: st.MakePod().NodeSelector(map[string]string{
+				"foo": "bar",
+			}).Obj(),
 			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
 		},
 		{
 			name: "same labels",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					NodeSelector: map[string]string{
-						"foo": "bar",
-					},
-				},
-			},
+			pod: st.MakePod().NodeSelector(map[string]string{
+				"foo": "bar",
+			}).Obj(),
 			labels: map[string]string{
 				"foo": "bar",
 			},
 		},
 		{
 			name: "node labels are superset",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					NodeSelector: map[string]string{
-						"foo": "bar",
-					},
-				},
-			},
+			pod: st.MakePod().NodeSelector(map[string]string{
+				"foo": "bar",
+			}).Obj(),
 			labels: map[string]string{
 				"foo": "bar",
 				"baz": "blah",
@@ -87,14 +76,10 @@ func TestNodeAffinity(t *testing.T) {
 		},
 		{
 			name: "node labels are subset",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					NodeSelector: map[string]string{
-						"foo": "bar",
-						"baz": "blah",
-					},
-				},
-			},
+			pod: st.MakePod().NodeSelector(map[string]string{
+				"foo": "bar",
+				"baz": "blah",
+			}).Obj(),
 			labels: map[string]string{
 				"foo": "bar",
 			},
@@ -1029,69 +1014,69 @@ func TestNodeAffinityPriority(t *testing.T) {
 		disablePreScore bool
 	}{
 		{
-			name: "all machines are same priority as NodeAffinity is nil",
+			name: "all nodes are same priority as NodeAffinity is nil",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{},
 				},
 			},
 			nodes: []*v1.Node{
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: label1}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: label2}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: label3}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: label1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: label2}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: label3}},
 			},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 0}, {Name: "machine2", Score: 0}, {Name: "machine3", Score: 0}},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 0}, {Name: "node2", Score: 0}, {Name: "node3", Score: 0}},
 		},
 		{
-			name: "no machine matches preferred scheduling requirements in NodeAffinity of pod so all machines' priority is zero",
+			name: "no node matches preferred scheduling requirements in NodeAffinity of pod so all nodes' priority is zero",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
 					Affinity: affinity1,
 				},
 			},
 			nodes: []*v1.Node{
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: label4}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: label2}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: label3}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: label4}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: label2}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: label3}},
 			},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 0}, {Name: "machine2", Score: 0}, {Name: "machine3", Score: 0}},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 0}, {Name: "node2", Score: 0}, {Name: "node3", Score: 0}},
 		},
 		{
-			name: "only machine1 matches the preferred scheduling requirements of pod",
+			name: "only node1 matches the preferred scheduling requirements of pod",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
 					Affinity: affinity1,
 				},
 			},
 			nodes: []*v1.Node{
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: label1}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: label2}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: label3}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: label1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: label2}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: label3}},
 			},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MaxNodeScore}, {Name: "machine2", Score: 0}, {Name: "machine3", Score: 0}},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: framework.MaxNodeScore}, {Name: "node2", Score: 0}, {Name: "node3", Score: 0}},
 		},
 		{
-			name: "all machines matches the preferred scheduling requirements of pod but with different priorities ",
+			name: "all nodes matches the preferred scheduling requirements of pod but with different priorities ",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
 					Affinity: affinity2,
 				},
 			},
 			nodes: []*v1.Node{
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: label1}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine5", Labels: label5}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: label2}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: label1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node5", Labels: label5}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: label2}},
 			},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 18}, {Name: "machine5", Score: framework.MaxNodeScore}, {Name: "machine2", Score: 36}},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 18}, {Name: "node5", Score: framework.MaxNodeScore}, {Name: "node2", Score: 36}},
 		},
 		{
 			name: "added affinity",
 			pod:  &v1.Pod{},
 			nodes: []*v1.Node{
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: label1}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: label2}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: label1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: label2}},
 			},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MaxNodeScore}, {Name: "machine2", Score: 0}},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: framework.MaxNodeScore}, {Name: "node2", Score: 0}},
 			args: config.NodeAffinityArgs{
 				AddedAffinity: affinity1.NodeAffinity,
 			},
@@ -1104,11 +1089,11 @@ func TestNodeAffinityPriority(t *testing.T) {
 				},
 			},
 			nodes: []*v1.Node{
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: label1}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: label2}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: label5}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: label1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: label2}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: label5}},
 			},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 40}, {Name: "machine2", Score: 60}, {Name: "machine3", Score: framework.MaxNodeScore}},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 40}, {Name: "node2", Score: 60}, {Name: "node3", Score: framework.MaxNodeScore}},
 			args: config.NodeAffinityArgs{
 				AddedAffinity: &v1.NodeAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
@@ -1136,11 +1121,11 @@ func TestNodeAffinityPriority(t *testing.T) {
 				},
 			},
 			nodes: []*v1.Node{
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: label1}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine5", Labels: label5}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: label2}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: label1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node5", Labels: label5}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: label2}},
 			},
-			expectedList:    []framework.NodeScore{{Name: "machine1", Score: 18}, {Name: "machine5", Score: framework.MaxNodeScore}, {Name: "machine2", Score: 36}},
+			expectedList:    []framework.NodeScore{{Name: "node1", Score: 18}, {Name: "node5", Score: framework.MaxNodeScore}, {Name: "node2", Score: 36}},
 			disablePreScore: true,
 		},
 	}

--- a/pkg/scheduler/framework/plugins/nodename/node_name_test.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
 func TestNodeName(t *testing.T) {
@@ -39,29 +39,13 @@ func TestNodeName(t *testing.T) {
 			name: "no host specified",
 		},
 		{
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					NodeName: "foo",
-				},
-			},
-			node: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-			},
+			pod:  st.MakePod().Node("foo").Obj(),
+			node: st.MakeNode().Name("foo").Obj(),
 			name: "host matches",
 		},
 		{
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					NodeName: "bar",
-				},
-			},
-			node: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-			},
+			pod:        st.MakePod().Node("bar").Obj(),
+			node:       st.MakeNode().Name("foo").Obj(),
 			name:       "host doesn't match",
 			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReason),
 		},

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
 func newPod(host string, hostPortInfos ...string) *v1.Pod {
@@ -41,16 +42,7 @@ func newPod(host string, hostPortInfos ...string) *v1.Pod {
 			Protocol: v1.Protocol(splited[0]),
 		})
 	}
-	return &v1.Pod{
-		Spec: v1.PodSpec{
-			NodeName: host,
-			Containers: []v1.Container{
-				{
-					Ports: networkPorts,
-				},
-			},
-		},
-	}
+	return st.MakePod().Node(host).ContainerPort(networkPorts).Obj()
 }
 
 func TestNodePorts(t *testing.T) {
@@ -184,66 +176,42 @@ func TestGetContainerPorts(t *testing.T) {
 		expected []*v1.ContainerPort
 	}{
 		{
-			pod1: &v1.Pod{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Ports: []v1.ContainerPort{
-								{
-									ContainerPort: 8001,
-									Protocol:      v1.ProtocolTCP,
-								},
-								{
-									ContainerPort: 8002,
-									Protocol:      v1.ProtocolTCP,
-								},
-							},
-						},
-						{
-							Ports: []v1.ContainerPort{
-								{
-									ContainerPort: 8003,
-									Protocol:      v1.ProtocolTCP,
-								},
-								{
-									ContainerPort: 8004,
-									Protocol:      v1.ProtocolTCP,
-								},
-							},
-						},
-					},
+			pod1: st.MakePod().ContainerPort([]v1.ContainerPort{
+				{
+					ContainerPort: 8001,
+					Protocol:      v1.ProtocolTCP,
 				},
-			},
-			pod2: &v1.Pod{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Ports: []v1.ContainerPort{
-								{
-									ContainerPort: 8011,
-									Protocol:      v1.ProtocolTCP,
-								},
-								{
-									ContainerPort: 8012,
-									Protocol:      v1.ProtocolTCP,
-								},
-							},
-						},
-						{
-							Ports: []v1.ContainerPort{
-								{
-									ContainerPort: 8013,
-									Protocol:      v1.ProtocolTCP,
-								},
-								{
-									ContainerPort: 8014,
-									Protocol:      v1.ProtocolTCP,
-								},
-							},
-						},
-					},
+				{
+					ContainerPort: 8002,
+					Protocol:      v1.ProtocolTCP,
+				}}).ContainerPort([]v1.ContainerPort{
+				{
+					ContainerPort: 8003,
+					Protocol:      v1.ProtocolTCP,
 				},
-			},
+				{
+					ContainerPort: 8004,
+					Protocol:      v1.ProtocolTCP,
+				},
+			}).Obj(),
+			pod2: st.MakePod().ContainerPort([]v1.ContainerPort{
+				{
+					ContainerPort: 8011,
+					Protocol:      v1.ProtocolTCP,
+				},
+				{
+					ContainerPort: 8012,
+					Protocol:      v1.ProtocolTCP,
+				}}).ContainerPort([]v1.ContainerPort{
+				{
+					ContainerPort: 8013,
+					Protocol:      v1.ProtocolTCP,
+				},
+				{
+					ContainerPort: 8014,
+					Protocol:      v1.ProtocolTCP,
+				},
+			}).Obj(),
 			expected: []*v1.ContainerPort{
 				{
 					ContainerPort: 8001,

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
@@ -81,7 +81,7 @@ func TestLeastAllocatedScoringStrategy(t *testing.T) {
 			// CPU Score: ((6000 - 3000) * MaxNodeScore) / 6000 = 50
 			// Memory Score: ((10000 - 5000) * MaxNodeScore) / 10000 = 50
 			// Node2 Score: (50 + 50) / 2 = 50
-			name: "nothing scheduled, resources requested, differently sized machines",
+			name: "nothing scheduled, resources requested, differently sized nodes",
 			requestedPod: st.MakePod().
 				Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).
 				Req(map[v1.ResourceName]string{"cpu": "2000", "memory": "3000"}).
@@ -95,7 +95,7 @@ func TestLeastAllocatedScoringStrategy(t *testing.T) {
 			resources:      defaultResources,
 		},
 		{
-			name: "Resources not set, nothing scheduled, resources requested, differently sized machines",
+			name: "Resources not set, nothing scheduled, resources requested, differently sized nodes",
 			requestedPod: st.MakePod().
 				Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).
 				Req(map[v1.ResourceName]string{"cpu": "2000", "memory": "3000"}).
@@ -190,7 +190,7 @@ func TestLeastAllocatedScoringStrategy(t *testing.T) {
 			// CPU Score: ((10000 - 6000) * MaxNodeScore) / 10000 = 40
 			// Memory Score: ((50000 - 10000) * MaxNodeScore) / 50000 = 80
 			// Node2 Score: (40 + 80) / 2 = 60
-			name: "resources requested, pods scheduled with resources, differently sized machines",
+			name: "resources requested, pods scheduled with resources, differently sized nodes",
 			requestedPod: st.MakePod().
 				Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).
 				Req(map[v1.ResourceName]string{"cpu": "2000", "memory": "3000"}).
@@ -249,7 +249,7 @@ func TestLeastAllocatedScoringStrategy(t *testing.T) {
 			// CPU Score: ((6000 - 3000) *100) / 6000 = 50
 			// Memory Score: ((10000 - 5000) *100) / 10000 = 50
 			// Node2 Score: (50 * 1 + 50 * 2) / (1 + 2) = 50
-			name: "nothing scheduled, resources requested with different weight on CPU and memory, differently sized machines",
+			name: "nothing scheduled, resources requested with different weight on CPU and memory, differently sized nodes",
 			requestedPod: st.MakePod().Node("node1").
 				Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).
 				Req(map[v1.ResourceName]string{"cpu": "2000", "memory": "3000"}).

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
@@ -80,7 +80,7 @@ func TestMostAllocatedScoringStrategy(t *testing.T) {
 			// CPU Score: (3000 * MaxNodeScore) / 6000 = 50
 			// Memory Score: (5000 * MaxNodeScore) / 10000 = 50
 			// Node2 Score: (50 + 50) / 2 = 50
-			name: "nothing scheduled, resources requested, differently sized machines",
+			name: "nothing scheduled, resources requested, differently sized nodes",
 			requestedPod: st.MakePod().
 				Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).
 				Req(map[v1.ResourceName]string{"cpu": "2000", "memory": "3000"}).
@@ -94,7 +94,7 @@ func TestMostAllocatedScoringStrategy(t *testing.T) {
 			resources:      defaultResources,
 		},
 		{
-			name: "Resources not set, nothing scheduled, resources requested, differently sized machines",
+			name: "Resources not set, nothing scheduled, resources requested, differently sized nodes",
 			requestedPod: st.MakePod().
 				Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).
 				Req(map[v1.ResourceName]string{"cpu": "2000", "memory": "3000"}).
@@ -185,7 +185,7 @@ func TestMostAllocatedScoringStrategy(t *testing.T) {
 			// CPU Score: (3000 *100) / 6000 = 50
 			// Memory Score: (5000 *100) / 10000 = 50
 			// Node2 Score: (50 * 1 + 50 * 2) / (1 + 2) = 50
-			name: "nothing scheduled, resources requested, differently sized machines",
+			name: "nothing scheduled, resources requested, differently sized nodes",
 			requestedPod: st.MakePod().
 				Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).
 				Req(map[v1.ResourceName]string{"cpu": "2000", "memory": "3000"}).

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
@@ -18,6 +18,7 @@ package nodevolumelimits
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"reflect"
 	"strings"
@@ -29,7 +30,52 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	utilpointer "k8s.io/utils/pointer"
+)
+
+var (
+	oneVolPod = st.MakePod().Volume(v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "ovp"},
+		},
+	}).Obj()
+	twoVolPod = st.MakePod().Volume(v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "tvp1"},
+		},
+	}).Volume(v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "tvp2"},
+		},
+	}).Obj()
+	splitVolsPod = st.MakePod().Volume(v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{},
+		},
+	}).Volume(v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "svp"},
+		},
+	}).Obj()
+	nonApplicablePod = st.MakePod().Volume(v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{},
+		},
+	}).Obj()
+
+	deletedPVCPod    = st.MakePod().PVC("deletedPVC").Obj()
+	twoDeletedPVCPod = st.MakePod().PVC("deletedPVC").PVC("anotherDeletedPVC").Obj()
+	deletedPVPod     = st.MakePod().PVC("pvcWithDeletedPV").Obj()
+	// deletedPVPod2 is a different pod than deletedPVPod but using the same PVC
+	deletedPVPod2       = st.MakePod().PVC("pvcWithDeletedPV").Obj()
+	anotherDeletedPVPod = st.MakePod().PVC("anotherPVCWithDeletedPV").Obj()
+	emptyPod            = st.MakePod().Obj()
+	unboundPVCPod       = st.MakePod().PVC("unboundPVC").Obj()
+	// Different pod than unboundPVCPod, but using the same unbound PVC
+	unboundPVCPod2 = st.MakePod().PVC("unboundPVC").Obj()
+	// pod with unbound PVC that's different to unboundPVC
+	anotherUnboundPVCPod = st.MakePod().PVC("anotherUnboundPVC").Obj()
 )
 
 func TestEphemeralLimits(t *testing.T) {
@@ -38,23 +84,13 @@ func TestEphemeralLimits(t *testing.T) {
 	filterName := gcePDVolumeFilterType
 	driverName := csilibplugins.GCEPDInTreePluginName
 
-	ephemeralVolumePod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "test",
-			Name:      "abc",
-			UID:       "12345",
+	ephemeralVolumePod := st.MakePod().Name("abc").Namespace("test").UID("12345").Volume(v1.Volume{
+		Name: "xyz",
+		VolumeSource: v1.VolumeSource{
+			Ephemeral: &v1.EphemeralVolumeSource{},
 		},
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					Name: "xyz",
-					VolumeSource: v1.VolumeSource{
-						Ephemeral: &v1.EphemeralVolumeSource{},
-					},
-				},
-			},
-		},
-	}
+	}).Obj()
+
 	controller := true
 	ephemeralClaim := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -130,180 +166,6 @@ func TestEphemeralLimits(t *testing.T) {
 }
 
 func TestAzureDiskLimits(t *testing.T) {
-	oneVolPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "ovp"},
-					},
-				},
-			},
-		},
-	}
-	twoVolPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "tvp1"},
-					},
-				},
-				{
-					VolumeSource: v1.VolumeSource{
-						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "tvp2"},
-					},
-				},
-			},
-		},
-	}
-	splitVolsPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{},
-					},
-				},
-				{
-					VolumeSource: v1.VolumeSource{
-						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "svp"},
-					},
-				},
-			},
-		},
-	}
-	nonApplicablePod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{},
-					},
-				},
-			},
-		},
-	}
-	deletedPVCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "deletedPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-	twoDeletedPVCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "deletedPVC",
-						},
-					},
-				},
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "anotherDeletedPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-	deletedPVPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "pvcWithDeletedPV",
-						},
-					},
-				},
-			},
-		},
-	}
-	// deletedPVPod2 is a different pod than deletedPVPod but using the same PVC
-	deletedPVPod2 := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "pvcWithDeletedPV",
-						},
-					},
-				},
-			},
-		},
-	}
-	// anotherDeletedPVPod is a different pod than deletedPVPod and uses another PVC
-	anotherDeletedPVPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "anotherPVCWithDeletedPV",
-						},
-					},
-				},
-			},
-		},
-	}
-	emptyPod := &v1.Pod{
-		Spec: v1.PodSpec{},
-	}
-	unboundPVCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "unboundPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-	// Different pod than unboundPVCPod, but using the same unbound PVC
-	unboundPVCPod2 := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "unboundPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// pod with unbound PVC that's different to unboundPVC
-	anotherUnboundPVCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "anotherUnboundPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-
 	tests := []struct {
 		newPod       *v1.Pod
 		existingPods []*v1.Pod
@@ -468,205 +330,8 @@ func TestAzureDiskLimits(t *testing.T) {
 }
 
 func TestEBSLimits(t *testing.T) {
-	oneVolPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "ovp"},
-					},
-				},
-			},
-		},
-	}
-	twoVolPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "tvp1"},
-					},
-				},
-				{
-					VolumeSource: v1.VolumeSource{
-						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "tvp2"},
-					},
-				},
-			},
-		},
-	}
-	unboundPVCwithInvalidSCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "unboundPVCwithInvalidSCPod",
-						},
-					},
-				},
-			},
-		},
-	}
-	unboundPVCwithDefaultSCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "unboundPVCwithDefaultSCPod",
-						},
-					},
-				},
-			},
-		},
-	}
-	splitVolsPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{},
-					},
-				},
-				{
-					VolumeSource: v1.VolumeSource{
-						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "svp"},
-					},
-				},
-			},
-		},
-	}
-	nonApplicablePod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{},
-					},
-				},
-			},
-		},
-	}
-	deletedPVCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "deletedPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-	twoDeletedPVCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "deletedPVC",
-						},
-					},
-				},
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "anotherDeletedPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-	deletedPVPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "pvcWithDeletedPV",
-						},
-					},
-				},
-			},
-		},
-	}
-	// deletedPVPod2 is a different pod than deletedPVPod but using the same PVC
-	deletedPVPod2 := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "pvcWithDeletedPV",
-						},
-					},
-				},
-			},
-		},
-	}
-	// anotherDeletedPVPod is a different pod than deletedPVPod and uses another PVC
-	anotherDeletedPVPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "anotherPVCWithDeletedPV",
-						},
-					},
-				},
-			},
-		},
-	}
-	emptyPod := &v1.Pod{
-		Spec: v1.PodSpec{},
-	}
-	unboundPVCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "unboundPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-	// Different pod than unboundPVCPod, but using the same unbound PVC
-	unboundPVCPod2 := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "unboundPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// pod with unbound PVC that's different to unboundPVC
-	anotherUnboundPVCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "anotherUnboundPVC",
-						},
-					},
-				},
-			},
-		},
-	}
+	unboundPVCWithInvalidSCPod := st.MakePod().PVC("unboundPVCWithInvalidSCPod").Obj()
+	unboundPVCWithDefaultSCPod := st.MakePod().PVC("unboundPVCWithDefaultSCPod").Obj()
 
 	tests := []struct {
 		newPod       *v1.Pod
@@ -777,7 +442,7 @@ func TestEBSLimits(t *testing.T) {
 			test:         "two missing PVCs are not counted towards the PV limit twice",
 		},
 		{
-			newPod:       unboundPVCwithInvalidSCPod,
+			newPod:       unboundPVCWithInvalidSCPod,
 			existingPods: []*v1.Pod{oneVolPod},
 			filterName:   ebsVolumeFilterType,
 			driverName:   csilibplugins.AWSEBSInTreePluginName,
@@ -785,14 +450,13 @@ func TestEBSLimits(t *testing.T) {
 			test:         "unbound PVC with invalid SC is not counted towards the PV limit",
 		},
 		{
-			newPod:       unboundPVCwithDefaultSCPod,
+			newPod:       unboundPVCWithDefaultSCPod,
 			existingPods: []*v1.Pod{oneVolPod},
 			filterName:   ebsVolumeFilterType,
 			driverName:   csilibplugins.AWSEBSInTreePluginName,
 			maxVols:      1,
 			test:         "unbound PVC from different provisioner is not counted towards the PV limit",
 		},
-
 		{
 			newPod:       onePVCPod(ebsVolumeFilterType),
 			existingPods: []*v1.Pod{oneVolPod, deletedPVPod},
@@ -876,180 +540,6 @@ func TestEBSLimits(t *testing.T) {
 }
 
 func TestGCEPDLimits(t *testing.T) {
-	oneVolPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "ovp"},
-					},
-				},
-			},
-		},
-	}
-	twoVolPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "tvp1"},
-					},
-				},
-				{
-					VolumeSource: v1.VolumeSource{
-						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "tvp2"},
-					},
-				},
-			},
-		},
-	}
-	splitVolsPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{},
-					},
-				},
-				{
-					VolumeSource: v1.VolumeSource{
-						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{VolumeID: "svp"},
-					},
-				},
-			},
-		},
-	}
-	nonApplicablePod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{},
-					},
-				},
-			},
-		},
-	}
-	deletedPVCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "deletedPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-	twoDeletedPVCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "deletedPVC",
-						},
-					},
-				},
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "anotherDeletedPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-	deletedPVPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "pvcWithDeletedPV",
-						},
-					},
-				},
-			},
-		},
-	}
-	// deletedPVPod2 is a different pod than deletedPVPod but using the same PVC
-	deletedPVPod2 := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "pvcWithDeletedPV",
-						},
-					},
-				},
-			},
-		},
-	}
-	// anotherDeletedPVPod is a different pod than deletedPVPod and uses another PVC
-	anotherDeletedPVPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "anotherPVCWithDeletedPV",
-						},
-					},
-				},
-			},
-		},
-	}
-	emptyPod := &v1.Pod{
-		Spec: v1.PodSpec{},
-	}
-	unboundPVCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "unboundPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-	// Different pod than unboundPVCPod, but using the same unbound PVC
-	unboundPVCPod2 := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "unboundPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// pod with unbound PVC that's different to unboundPVC
-	anotherUnboundPVCPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "anotherUnboundPVC",
-						},
-					},
-				},
-			},
-		},
-	}
-
 	tests := []struct {
 		newPod       *v1.Pod
 		existingPods []*v1.Pod
@@ -1299,14 +789,14 @@ func getFakePVCLister(filterName string) fakeframework.PersistentVolumeClaimList
 			},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "unboundPVCwithDefaultSCPod"},
+			ObjectMeta: metav1.ObjectMeta{Name: "unboundPVCWithDefaultSCPod"},
 			Spec: v1.PersistentVolumeClaimSpec{
 				VolumeName:       "",
 				StorageClassName: utilpointer.StringPtr("standard-sc"),
 			},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "unboundPVCwithInvalidSCPod"},
+			ObjectMeta: metav1.ObjectMeta{Name: "unboundPVCWithInvalidSCPod"},
 			Spec: v1.PersistentVolumeClaimSpec{
 				VolumeName:       "",
 				StorageClassName: utilpointer.StringPtr("invalid-sc"),
@@ -1335,40 +825,9 @@ func getFakePVLister(filterName string) fakeframework.PersistentVolumeLister {
 }
 
 func onePVCPod(filterName string) *v1.Pod {
-	return &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "some" + filterName + "Vol",
-						},
-					},
-				},
-			},
-		},
-	}
+	return st.MakePod().PVC(fmt.Sprintf("some%sVol", filterName)).Obj()
 }
 
 func splitPVCPod(filterName string) *v1.Pod {
-	return &v1.Pod{
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "someNon" + filterName + "Vol",
-						},
-					},
-				},
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "some" + filterName + "Vol",
-						},
-					},
-				},
-			},
-		},
-	}
+	return st.MakePod().PVC(fmt.Sprintf("someNon%sVol", filterName)).PVC(fmt.Sprintf("some%sVol", filterName)).Obj()
 }

--- a/pkg/scheduler/framework/plugins/queuesort/priority_sort_test.go
+++ b/pkg/scheduler/framework/plugins/queuesort/priority_sort_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package queuesort
 
 import (
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"testing"
 	"time"
+
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
 func TestLess(t *testing.T) {
@@ -37,55 +38,31 @@ func TestLess(t *testing.T) {
 		{
 			name: "p1.priority less than p2.priority",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: framework.NewPodInfo(&v1.Pod{
-					Spec: v1.PodSpec{
-						Priority: &lowPriority,
-					},
-				}),
+				PodInfo: framework.NewPodInfo(st.MakePod().Priority(lowPriority).Obj()),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: framework.NewPodInfo(&v1.Pod{
-					Spec: v1.PodSpec{
-						Priority: &highPriority,
-					},
-				}),
+				PodInfo: framework.NewPodInfo(st.MakePod().Priority(highPriority).Obj()),
 			},
 			expected: false, // p2 should be ahead of p1 in the queue
 		},
 		{
 			name: "p1.priority greater than p2.priority",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: framework.NewPodInfo(&v1.Pod{
-					Spec: v1.PodSpec{
-						Priority: &highPriority,
-					},
-				}),
+				PodInfo: framework.NewPodInfo(st.MakePod().Priority(highPriority).Obj()),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: framework.NewPodInfo(&v1.Pod{
-					Spec: v1.PodSpec{
-						Priority: &lowPriority,
-					},
-				}),
+				PodInfo: framework.NewPodInfo(st.MakePod().Priority(lowPriority).Obj()),
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
 		},
 		{
 			name: "equal priority. p1 is added to schedulingQ earlier than p2",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: framework.NewPodInfo(&v1.Pod{
-					Spec: v1.PodSpec{
-						Priority: &highPriority,
-					},
-				}),
+				PodInfo:   framework.NewPodInfo(st.MakePod().Priority(highPriority).Obj()),
 				Timestamp: t1,
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: framework.NewPodInfo(&v1.Pod{
-					Spec: v1.PodSpec{
-						Priority: &highPriority,
-					},
-				}),
+				PodInfo:   framework.NewPodInfo(st.MakePod().Priority(highPriority).Obj()),
 				Timestamp: t2,
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
@@ -93,19 +70,11 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority. p2 is added to schedulingQ earlier than p1",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: framework.NewPodInfo(&v1.Pod{
-					Spec: v1.PodSpec{
-						Priority: &highPriority,
-					},
-				}),
+				PodInfo:   framework.NewPodInfo(st.MakePod().Priority(highPriority).Obj()),
 				Timestamp: t2,
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: framework.NewPodInfo(&v1.Pod{
-					Spec: v1.PodSpec{
-						Priority: &highPriority,
-					},
-				}),
+				PodInfo:   framework.NewPodInfo(st.MakePod().Priority(highPriority).Obj()),
 				Timestamp: t1,
 			},
 			expected: false, // p2 should be ahead of p1 in the queue

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
@@ -32,28 +32,21 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	plugintesting "k8s.io/kubernetes/pkg/scheduler/framework/plugins/testing"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
 func TestGCEDiskConflicts(t *testing.T) {
-	volState := v1.PodSpec{
-		Volumes: []v1.Volume{
-			{
-				VolumeSource: v1.VolumeSource{
-					GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
-						PDName: "foo",
-					},
-				},
+	volState := v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+				PDName: "foo",
 			},
 		},
 	}
-	volState2 := v1.PodSpec{
-		Volumes: []v1.Volume{
-			{
-				VolumeSource: v1.VolumeSource{
-					GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
-						PDName: "bar",
-					},
-				},
+	volState2 := v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+				PDName: "bar",
 			},
 		},
 	}
@@ -66,9 +59,9 @@ func TestGCEDiskConflicts(t *testing.T) {
 		wantStatus *framework.Status
 	}{
 		{&v1.Pod{}, framework.NewNodeInfo(), true, "nothing", nil},
-		{&v1.Pod{}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "one state", nil},
-		{&v1.Pod{Spec: volState}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), false, "same state", errStatus},
-		{&v1.Pod{Spec: volState2}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "different state", nil},
+		{&v1.Pod{}, framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()), true, "one state", nil},
+		{st.MakePod().Volume(volState).Obj(), framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()), false, "same state", errStatus},
+		{st.MakePod().Volume(volState2).Obj(), framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()), true, "different state", nil},
 	}
 
 	for _, test := range tests {
@@ -85,25 +78,17 @@ func TestGCEDiskConflicts(t *testing.T) {
 }
 
 func TestAWSDiskConflicts(t *testing.T) {
-	volState := v1.PodSpec{
-		Volumes: []v1.Volume{
-			{
-				VolumeSource: v1.VolumeSource{
-					AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
-						VolumeID: "foo",
-					},
-				},
+	volState := v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
+				VolumeID: "foo",
 			},
 		},
 	}
-	volState2 := v1.PodSpec{
-		Volumes: []v1.Volume{
-			{
-				VolumeSource: v1.VolumeSource{
-					AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
-						VolumeID: "bar",
-					},
-				},
+	volState2 := v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
+				VolumeID: "bar",
 			},
 		},
 	}
@@ -116,9 +101,9 @@ func TestAWSDiskConflicts(t *testing.T) {
 		wantStatus *framework.Status
 	}{
 		{&v1.Pod{}, framework.NewNodeInfo(), true, "nothing", nil},
-		{&v1.Pod{}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "one state", nil},
-		{&v1.Pod{Spec: volState}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), false, "same state", errStatus},
-		{&v1.Pod{Spec: volState2}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "different state", nil},
+		{&v1.Pod{}, framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()), true, "one state", nil},
+		{st.MakePod().Volume(volState).Obj(), framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()), false, "same state", errStatus},
+		{st.MakePod().Volume(volState2).Obj(), framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()), true, "different state", nil},
 	}
 
 	for _, test := range tests {
@@ -135,31 +120,23 @@ func TestAWSDiskConflicts(t *testing.T) {
 }
 
 func TestRBDDiskConflicts(t *testing.T) {
-	volState := v1.PodSpec{
-		Volumes: []v1.Volume{
-			{
-				VolumeSource: v1.VolumeSource{
-					RBD: &v1.RBDVolumeSource{
-						CephMonitors: []string{"a", "b"},
-						RBDPool:      "foo",
-						RBDImage:     "bar",
-						FSType:       "ext4",
-					},
-				},
+	volState := v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			RBD: &v1.RBDVolumeSource{
+				CephMonitors: []string{"a", "b"},
+				RBDPool:      "foo",
+				RBDImage:     "bar",
+				FSType:       "ext4",
 			},
 		},
 	}
-	volState2 := v1.PodSpec{
-		Volumes: []v1.Volume{
-			{
-				VolumeSource: v1.VolumeSource{
-					RBD: &v1.RBDVolumeSource{
-						CephMonitors: []string{"c", "d"},
-						RBDPool:      "foo",
-						RBDImage:     "bar",
-						FSType:       "ext4",
-					},
-				},
+	volState2 := v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			RBD: &v1.RBDVolumeSource{
+				CephMonitors: []string{"c", "d"},
+				RBDPool:      "foo",
+				RBDImage:     "bar",
+				FSType:       "ext4",
 			},
 		},
 	}
@@ -172,9 +149,9 @@ func TestRBDDiskConflicts(t *testing.T) {
 		wantStatus *framework.Status
 	}{
 		{&v1.Pod{}, framework.NewNodeInfo(), true, "nothing", nil},
-		{&v1.Pod{}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "one state", nil},
-		{&v1.Pod{Spec: volState}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), false, "same state", errStatus},
-		{&v1.Pod{Spec: volState2}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "different state", nil},
+		{&v1.Pod{}, framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()), true, "one state", nil},
+		{st.MakePod().Volume(volState).Obj(), framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()), false, "same state", errStatus},
+		{st.MakePod().Volume(volState2).Obj(), framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()), true, "different state", nil},
 	}
 
 	for _, test := range tests {
@@ -191,31 +168,23 @@ func TestRBDDiskConflicts(t *testing.T) {
 }
 
 func TestISCSIDiskConflicts(t *testing.T) {
-	volState := v1.PodSpec{
-		Volumes: []v1.Volume{
-			{
-				VolumeSource: v1.VolumeSource{
-					ISCSI: &v1.ISCSIVolumeSource{
-						TargetPortal: "127.0.0.1:3260",
-						IQN:          "iqn.2016-12.server:storage.target01",
-						FSType:       "ext4",
-						Lun:          0,
-					},
-				},
+	volState := v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			ISCSI: &v1.ISCSIVolumeSource{
+				TargetPortal: "127.0.0.1:3260",
+				IQN:          "iqn.2016-12.server:storage.target01",
+				FSType:       "ext4",
+				Lun:          0,
 			},
 		},
 	}
-	volState2 := v1.PodSpec{
-		Volumes: []v1.Volume{
-			{
-				VolumeSource: v1.VolumeSource{
-					ISCSI: &v1.ISCSIVolumeSource{
-						TargetPortal: "127.0.0.1:3260",
-						IQN:          "iqn.2017-12.server:storage.target01",
-						FSType:       "ext4",
-						Lun:          0,
-					},
-				},
+	volState2 := v1.Volume{
+		VolumeSource: v1.VolumeSource{
+			ISCSI: &v1.ISCSIVolumeSource{
+				TargetPortal: "127.0.0.1:3260",
+				IQN:          "iqn.2017-12.server:storage.target01",
+				FSType:       "ext4",
+				Lun:          0,
 			},
 		},
 	}
@@ -228,9 +197,9 @@ func TestISCSIDiskConflicts(t *testing.T) {
 		wantStatus *framework.Status
 	}{
 		{&v1.Pod{}, framework.NewNodeInfo(), true, "nothing", nil},
-		{&v1.Pod{}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "one state", nil},
-		{&v1.Pod{Spec: volState}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), false, "same state", errStatus},
-		{&v1.Pod{Spec: volState2}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "different state", nil},
+		{&v1.Pod{}, framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()), true, "one state", nil},
+		{st.MakePod().Volume(volState).Obj(), framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()), false, "same state", errStatus},
+		{st.MakePod().Volume(volState2).Obj(), framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()), true, "different state", nil},
 	}
 
 	for _, test := range tests {
@@ -249,44 +218,10 @@ func TestISCSIDiskConflicts(t *testing.T) {
 func TestAccessModeConflicts(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ReadWriteOncePod, true)()
 
-	podWithReadWriteOncePodPVC := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			// Required for querying lister for PVCs in the same namespace.
-			Namespace: "default",
-			Name:      "pod-with-rwop",
-		},
-		Spec: v1.PodSpec{
-			NodeName: "node-1",
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "claim-with-rwop",
-						},
-					},
-				},
-			},
-		},
-	}
-	podWithReadWriteManyPVC := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			// Required for querying lister for PVCs in the same namespace.
-			Namespace: "default",
-			Name:      "pod-with-rwx",
-		},
-		Spec: v1.PodSpec{
-			NodeName: "node-1",
-			Volumes: []v1.Volume{
-				{
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "claim-with-rwx",
-						},
-					},
-				},
-			},
-		},
-	}
+	// Required for querying lister for PVCs in the same namespace.
+	podWithReadWriteOncePodPVC := st.MakePod().Name("pod-with-rwop").Namespace(metav1.NamespaceDefault).PVC("claim-with-rwop").Node("node-1").Obj()
+	// Required for querying lister for PVCs in the same namespace.
+	podWithReadWriteManyPVC := st.MakePod().Name("pod-with-rwx").Namespace(metav1.NamespaceDefault).PVC("claim-with-rwx").Node("node-1").Obj()
 
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
@@ -26,24 +26,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
 func createPodWithVolume(pod, pv, pvc string) *v1.Pod {
-	return &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: pod, Namespace: "default"},
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					Name: pv,
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvc,
-						},
-					},
-				},
-			},
-		},
-	}
+	return st.MakePod().Name(pod).Namespace(metav1.NamespaceDefault).PVC(pvc).Obj()
 }
 
 func TestSingleZone(t *testing.T) {
@@ -100,9 +87,7 @@ func TestSingleZone(t *testing.T) {
 	}{
 		{
 			name: "pod without volume",
-			Pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "pod_1", Namespace: "default"},
-			},
+			Pod:  st.MakePod().Name("pod_1").Namespace(metav1.NamespaceDefault).Obj(),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -622,7 +622,7 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueue(t *testing.T) {
 // matching label is added, the unschedulable pod is moved to activeQ.
 func TestPriorityQueue_AssignedPodAdded(t *testing.T) {
 	affinityPod := st.MakePod().Name("afp").Namespace("ns1").UID("upns1").Annotation("annot2", "val2").Priority(mediumPriority).NominatedNodeName("node1").PodAffinityExists("service", "region", st.PodAffinityWithRequiredReq).Obj()
-	labelPod := st.MakePod().Name("lbp").Namespace(affinityPod.Namespace).Label("service", "securityscan").Node("machine1").Obj()
+	labelPod := st.MakePod().Name("lbp").Namespace(affinityPod.Namespace).Label("service", "securityscan").Node("node1").Obj()
 
 	c := testingclock.NewFakeClock(time.Now())
 	m := map[framework.ClusterEvent]sets.String{AssignedPodAdd: sets.NewString("fakePlugin")}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -40,6 +40,7 @@ import (
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/internal/queue"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	testingclock "k8s.io/utils/clock/testing"
 )
 
@@ -226,7 +227,7 @@ func TestSchedulerCreation(t *testing.T) {
 }
 
 func TestDefaultErrorFunc(t *testing.T) {
-	testPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"}}
+	testPod := st.MakePod().Name("test-pod").Namespace(v1.NamespaceDefault).Obj()
 	testPodUpdated := testPod.DeepCopy()
 	testPodUpdated.Labels = map[string]string{"foo": ""}
 
@@ -307,7 +308,7 @@ func TestDefaultErrorFunc(t *testing.T) {
 func TestDefaultErrorFunc_NodeNotFound(t *testing.T) {
 	nodeFoo := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 	nodeBar := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "bar"}}
-	testPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"}}
+	testPod := st.MakePod().Name("test-pod").Namespace(v1.NamespaceDefault).Obj()
 	tests := []struct {
 		name             string
 		nodes            []v1.Node
@@ -374,7 +375,7 @@ func TestDefaultErrorFunc_PodAlreadyBound(t *testing.T) {
 	defer close(stopCh)
 
 	nodeFoo := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
-	testPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "foo"}}
+	testPod := st.MakePod().Name("test-pod").Namespace(v1.NamespaceDefault).Node("foo").Obj()
 
 	client := fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testPod}}, &v1.NodeList{Items: []v1.Node{nodeFoo}})
 	informerFactory := informers.NewSharedInformerFactory(client, 0)

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -136,6 +136,56 @@ func (s *LabelSelectorWrapper) Obj() *metav1.LabelSelector {
 	return &s.LabelSelector
 }
 
+// ContainerWrapper wraps a Container inside.
+type ContainerWrapper struct{ v1.Container }
+
+// MakeContainer creates a Container wrapper.
+func MakeContainer() *ContainerWrapper {
+	return &ContainerWrapper{v1.Container{}}
+}
+
+// Obj returns the inner Container.
+func (c *ContainerWrapper) Obj() v1.Container {
+	return c.Container
+}
+
+// Name sets `n` as the name of the inner Container.
+func (c *ContainerWrapper) Name(n string) *ContainerWrapper {
+	c.Container.Name = n
+	return c
+}
+
+// Image sets `image` as the image of the inner Container.
+func (c *ContainerWrapper) Image(image string) *ContainerWrapper {
+	c.Container.Image = image
+	return c
+}
+
+// HostPort sets `hostPort` as the host port of the inner Container.
+func (c *ContainerWrapper) HostPort(hostPort int32) *ContainerWrapper {
+	c.Container.Ports = []v1.ContainerPort{{HostPort: hostPort}}
+	return c
+}
+
+// ContainerPort sets `ports` as the ports of the inner Container.
+func (c *ContainerWrapper) ContainerPort(ports []v1.ContainerPort) *ContainerWrapper {
+	c.Container.Ports = ports
+	return c
+}
+
+// Resources sets the container resources to the given resource map.
+func (c *ContainerWrapper) Resources(resMap map[v1.ResourceName]string) *ContainerWrapper {
+	res := v1.ResourceList{}
+	for k, v := range resMap {
+		res[k] = resource.MustParse(v)
+	}
+	c.Container.Resources = v1.ResourceRequirements{
+		Requests: res,
+		Limits:   res,
+	}
+	return c
+}
+
 // PodWrapper wraps a Pod inside.
 type PodWrapper struct{ v1.Pod }
 
@@ -188,25 +238,20 @@ func (p *PodWrapper) OwnerReference(name string, gvk schema.GroupVersionKind) *P
 
 // Container appends a container into PodSpec of the inner pod.
 func (p *PodWrapper) Container(s string) *PodWrapper {
-	p.Spec.Containers = append(p.Spec.Containers, v1.Container{
-		Name:  fmt.Sprintf("con%d", len(p.Spec.Containers)),
-		Image: s,
-	})
+	name := fmt.Sprintf("con%d", len(p.Spec.Containers))
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name(name).Image(s).Obj())
+	return p
+}
+
+// Containers sets `containers` to the PodSpec of the inner pod.
+func (p *PodWrapper) Containers(containers []v1.Container) *PodWrapper {
+	p.Spec.Containers = containers
 	return p
 }
 
 // Priority sets a priority value into PodSpec of the inner pod.
 func (p *PodWrapper) Priority(val int32) *PodWrapper {
 	p.Spec.Priority = &val
-	return p
-}
-
-// Annotation adds a pair of (key, value) to a pod's Annotations.
-func (p *PodWrapper) Annotation(key, value string) *PodWrapper {
-	if p.Annotations == nil {
-		p.Annotations = make(map[string]string)
-	}
-	p.Annotations[key] = value
 	return p
 }
 
@@ -281,9 +326,21 @@ func (p *PodWrapper) NominatedNodeName(n string) *PodWrapper {
 	return p
 }
 
+// Phase sets `phase` as .status.Phase of the inner pod.
+func (p *PodWrapper) Phase(phase v1.PodPhase) *PodWrapper {
+	p.Status.Phase = phase
+	return p
+}
+
 // Condition adds a `condition(Type, Status, Reason)` to .Status.Conditions.
 func (p *PodWrapper) Condition(t v1.PodConditionType, s v1.ConditionStatus, r string) *PodWrapper {
 	p.Status.Conditions = append(p.Status.Conditions, v1.PodCondition{Type: t, Status: s, Reason: r})
+	return p
+}
+
+// Conditions sets `conditions` as .status.Conditions of the inner pod.
+func (p *PodWrapper) Conditions(conditions []v1.PodCondition) *PodWrapper {
+	p.Status.Conditions = append(p.Status.Conditions, conditions...)
 	return p
 }
 
@@ -300,9 +357,14 @@ func (p *PodWrapper) Toleration(key string) *PodWrapper {
 // HostPort creates a container with a hostPort valued `hostPort`,
 // and injects into the inner pod.
 func (p *PodWrapper) HostPort(port int32) *PodWrapper {
-	p.Spec.Containers = append(p.Spec.Containers, v1.Container{
-		Ports: []v1.ContainerPort{{HostPort: port}},
-	})
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name("container").Image("pause").HostPort(port).Obj())
+	return p
+}
+
+// ContainerPort creates a container with ports valued `ports`,
+// and injects into the inner pod.
+func (p *PodWrapper) ContainerPort(ports []v1.ContainerPort) *PodWrapper {
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name("container").Image("pause").ContainerPort(ports).Obj())
 	return p
 }
 
@@ -314,6 +376,12 @@ func (p *PodWrapper) PVC(name string) *PodWrapper {
 			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: name},
 		},
 	})
+	return p
+}
+
+// Volume creates volume and injects into the inner pod.
+func (p *PodWrapper) Volume(volume v1.Volume) *PodWrapper {
+	p.Spec.Volumes = append(p.Spec.Volumes, volume)
 	return p
 }
 
@@ -337,9 +405,9 @@ const (
 	PodAntiAffinityWithRequiredPreferredReq
 )
 
-// PodAffinityExists creates an PodAffinity with the operator "Exists"
+// PodAffinity creates a PodAffinity with topology key and label selector
 // and injects into the inner pod.
-func (p *PodWrapper) PodAffinityExists(labelKey, topologyKey string, kind PodAffinityKind) *PodWrapper {
+func (p *PodWrapper) PodAffinity(topologyKey string, labelSelector *metav1.LabelSelector, kind PodAffinityKind) *PodWrapper {
 	if kind == NilPodAffinity {
 		return p
 	}
@@ -350,7 +418,6 @@ func (p *PodWrapper) PodAffinityExists(labelKey, topologyKey string, kind PodAff
 	if p.Spec.Affinity.PodAffinity == nil {
 		p.Spec.Affinity.PodAffinity = &v1.PodAffinity{}
 	}
-	labelSelector := MakeLabelSelector().Exists(labelKey).Obj()
 	term := v1.PodAffinityTerm{LabelSelector: labelSelector, TopologyKey: topologyKey}
 	switch kind {
 	case PodAffinityWithRequiredReq:
@@ -376,9 +443,9 @@ func (p *PodWrapper) PodAffinityExists(labelKey, topologyKey string, kind PodAff
 	return p
 }
 
-// PodAntiAffinityExists creates an PodAntiAffinity with the operator "Exists"
+// PodAntiAffinity creates a PodAntiAffinity with topology key and label selector
 // and injects into the inner pod.
-func (p *PodWrapper) PodAntiAffinityExists(labelKey, topologyKey string, kind PodAffinityKind) *PodWrapper {
+func (p *PodWrapper) PodAntiAffinity(topologyKey string, labelSelector *metav1.LabelSelector, kind PodAffinityKind) *PodWrapper {
 	if kind == NilPodAffinity {
 		return p
 	}
@@ -389,7 +456,6 @@ func (p *PodWrapper) PodAntiAffinityExists(labelKey, topologyKey string, kind Po
 	if p.Spec.Affinity.PodAntiAffinity == nil {
 		p.Spec.Affinity.PodAntiAffinity = &v1.PodAntiAffinity{}
 	}
-	labelSelector := MakeLabelSelector().Exists(labelKey).Obj()
 	term := v1.PodAffinityTerm{LabelSelector: labelSelector, TopologyKey: topologyKey}
 	switch kind {
 	case PodAntiAffinityWithRequiredReq:
@@ -415,6 +481,70 @@ func (p *PodWrapper) PodAntiAffinityExists(labelKey, topologyKey string, kind Po
 	return p
 }
 
+// PodAffinityExists creates a PodAffinity with the operator "Exists"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAffinityExists(labelKey, topologyKey string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().Exists(labelKey).Obj()
+	p.PodAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAntiAffinityExists creates a PodAntiAffinity with the operator "Exists"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAntiAffinityExists(labelKey, topologyKey string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().Exists(labelKey).Obj()
+	p.PodAntiAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAffinityNotExists creates a PodAffinity with the operator "NotExists"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAffinityNotExists(labelKey, topologyKey string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().NotExist(labelKey).Obj()
+	p.PodAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAntiAffinityNotExists creates a PodAntiAffinity with the operator "NotExists"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAntiAffinityNotExists(labelKey, topologyKey string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().NotExist(labelKey).Obj()
+	p.PodAntiAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAffinityIn creates a PodAffinity with the operator "In"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAffinityIn(labelKey, topologyKey string, vals []string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().In(labelKey, vals).Obj()
+	p.PodAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAntiAffinityIn creates a PodAntiAffinity with the operator "In"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAntiAffinityIn(labelKey, topologyKey string, vals []string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().In(labelKey, vals).Obj()
+	p.PodAntiAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAffinityNotIn creates a PodAffinity with the operator "NotIn"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAffinityNotIn(labelKey, topologyKey string, vals []string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().NotIn(labelKey, vals).Obj()
+	p.PodAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
+// PodAntiAffinityNotIn creates a PodAntiAffinity with the operator "NotIn"
+// and injects into the inner pod.
+func (p *PodWrapper) PodAntiAffinityNotIn(labelKey, topologyKey string, vals []string, kind PodAffinityKind) *PodWrapper {
+	labelSelector := MakeLabelSelector().NotIn(labelKey, vals).Obj()
+	p.PodAntiAffinity(topologyKey, labelSelector, kind)
+	return p
+}
+
 // SpreadConstraint constructs a TopologySpreadConstraint object and injects
 // into the inner pod.
 func (p *PodWrapper) SpreadConstraint(maxSkew int, tpKey string, mode v1.UnsatisfiableConstraintAction, selector *metav1.LabelSelector, minDomains *int32) *PodWrapper {
@@ -429,12 +559,37 @@ func (p *PodWrapper) SpreadConstraint(maxSkew int, tpKey string, mode v1.Unsatis
 	return p
 }
 
-// Label sets a {k,v} pair to the inner pod.
+// Label sets a {k,v} pair to the inner pod label.
 func (p *PodWrapper) Label(k, v string) *PodWrapper {
-	if p.Labels == nil {
-		p.Labels = make(map[string]string)
+	if p.ObjectMeta.Labels == nil {
+		p.ObjectMeta.Labels = make(map[string]string)
 	}
-	p.Labels[k] = v
+	p.ObjectMeta.Labels[k] = v
+	return p
+}
+
+// Labels sets all {k,v} pair provided by `labels` to the inner pod labels.
+func (p *PodWrapper) Labels(labels map[string]string) *PodWrapper {
+	for k, v := range labels {
+		p.Label(k, v)
+	}
+	return p
+}
+
+// Annotation sets a {k,v} pair to the inner pod annotation.
+func (p *PodWrapper) Annotation(key, value string) *PodWrapper {
+	if p.ObjectMeta.Annotations == nil {
+		p.ObjectMeta.Annotations = make(map[string]string)
+	}
+	p.ObjectMeta.Annotations[key] = value
+	return p
+}
+
+// Annotations sets all {k,v} pair provided by `annotations` to the inner pod annotations.
+func (p *PodWrapper) Annotations(annotations map[string]string) *PodWrapper {
+	for k, v := range annotations {
+		p.Annotation(k, v)
+	}
 	return p
 }
 
@@ -444,18 +599,19 @@ func (p *PodWrapper) Req(resMap map[v1.ResourceName]string) *PodWrapper {
 		return p
 	}
 
-	res := v1.ResourceList{}
-	for k, v := range resMap {
-		res[k] = resource.MustParse(v)
+	name := fmt.Sprintf("con%d", len(p.Spec.Containers))
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name(name).Image(imageutils.GetPauseImageName()).Resources(resMap).Obj())
+	return p
+}
+
+// InitReq adds a new init container to the inner pod with given resource map.
+func (p *PodWrapper) InitReq(resMap map[v1.ResourceName]string) *PodWrapper {
+	if len(resMap) == 0 {
+		return p
 	}
-	p.Spec.Containers = append(p.Spec.Containers, v1.Container{
-		Name:  fmt.Sprintf("con%d", len(p.Spec.Containers)),
-		Image: imageutils.GetPauseImageName(),
-		Resources: v1.ResourceRequirements{
-			Requests: res,
-			Limits:   res,
-		},
-	})
+
+	name := fmt.Sprintf("init-con%d", len(p.Spec.InitContainers))
+	p.Spec.InitContainers = append(p.Spec.InitContainers, MakeContainer().Name(name).Image(imageutils.GetPauseImageName()).Resources(resMap).Obj())
 	return p
 }
 
@@ -465,7 +621,7 @@ func (p *PodWrapper) PreemptionPolicy(policy v1.PreemptionPolicy) *PodWrapper {
 	return p
 }
 
-// Overhead sets the give resourcelist to the inner pod
+// Overhead sets the give ResourceList to the inner pod
 func (p *PodWrapper) Overhead(rl v1.ResourceList) *PodWrapper {
 	p.Spec.Overhead = rl
 	return p

--- a/pkg/scheduler/util/pod_resources.go
+++ b/pkg/scheduler/util/pod_resources.go
@@ -25,7 +25,7 @@ import (
 // For each of these resources, a pod that doesn't request the resource explicitly
 // will be treated as having requested the amount indicated below, for the purpose
 // of computing priority only. This ensures that when scheduling zero-request pods, such
-// pods will not all be scheduled to the machine with the smallest in-use request,
+// pods will not all be scheduled to the node with the smallest in-use request,
 // and that when scheduling regular pods, such pods will not see zero-request pods as
 // consuming no resources whatsoever. We chose these values to be similar to the
 // resources that we give to cluster addon pods (#10653). But they are pretty arbitrary.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Move to use testing `PodWrapper` where applicable to
reduce duplicating pod creation code and shorten
number of lines.

Adding additional wrapper functions in PodWrapper
to ensure it covers different pod spec under different plugins
and test cases.

Signed-off-by: Yibo Zhuang <yibzhuang@gmail.com>

#### Special notes for your reviewer:

This is a follow PR and builds on top of #109536 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
