### PR TITLE
pkg/controller/daemon: Errors for NodeShouldRunDaemonPod reasons

### DIFF
--- a/pkg/controller/daemon/update.go
+++ b/pkg/controller/daemon/update.go
@@ -528,8 +528,8 @@ func (dsc *DaemonSetsController) updatedDesiredNodeCounts(ds *apps.DaemonSet, no
 	var desiredNumberScheduled int
 	for i := range nodeList {
 		node := nodeList[i]
-		wantToRun, _ := NodeShouldRunDaemonPod(node, ds)
-		if !wantToRun {
+		shouldNotRun, _ := NodeShouldRunDaemonPod(node, ds)
+		if shouldNotRun != nil {
 			continue
 		}
 		desiredNumberScheduled++

--- a/test/e2e/framework/daemonset/fixtures.go
+++ b/test/e2e/framework/daemonset/fixtures.go
@@ -84,9 +84,9 @@ func SchedulableNodes(c clientset.Interface, ds *appsv1.DaemonSet) []string {
 	framework.ExpectNoError(err)
 	nodeNames := make([]string, 0)
 	for _, node := range nodeList.Items {
-		shouldRun, _ := daemon.NodeShouldRunDaemonPod(&node, ds)
-		if !shouldRun {
-			framework.Logf("DaemonSet pods can't tolerate node %s with taints %+v, skip checking this node", node.Name, node.Spec.Taints)
+		shouldNotRun, _ := daemon.NodeShouldRunDaemonPod(&node, ds)
+		if shouldNotRun != nil {
+			framework.Logf("DaemonSet pods should not run on %s: %v", node.Name, shouldNotRun)
 			continue
 		}
 		nodeNames = append(nodeNames, node.Name)


### PR DESCRIPTION
The previous boolean responses exposed "if", but not "why not?".  Returning errors for "why not?" makes it easy for anyone surprised by the decision to figure out where their expectations began diverging from reality.

In a similar debugging vein to #109681, and if there is interest in both, we should probably roll the two together or otherwise get the "why we think the pod is misscheduled" error reason into #109681's log line.

It is unfortunate that this landed after kubernetes/kubernetes@b2e2fb8d89d4 (kubernetes/kubernetes#108485), but the transition should be easy for callers, with:

```go
shouldNotRun, shouldNotContinueRunning := NodeShouldRunDaemonPod(node, ds)
shouldRun := shouldNotRun == nil
shouldContinueRunning := shouldNotContinueRunning == nil
```

as a drop-in replacement for:

```go
shouldRun, shouldNotContinueRunning := NodeShouldRunDaemonPod(node, ds)
```

```release-note
NONE
```

/kind cleanup
