### PR TITLE
Comment out BenchmarkPerfScheduling/PreemptionPVs/5000Nodes temporarily

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -430,11 +430,11 @@
       initNodes: 500
       initPods: 2000
       measurePods: 500
-  - name: 5000Nodes
-    params:
-      initNodes: 5000
-      initPods: 20000
-      measurePods: 5000
+#  - name: 5000Nodes
+#    params:
+#      initNodes: 5000
+#      initPods: 20000
+#      measurePods: 5000
 
 - name: Unschedulable
   workloadTemplate:


### PR DESCRIPTION
#### What type of PR is this?

Comment out BenchmarkPerfScheduling/PreemptionPVs/5000Nodes temporarily, to buy us time figuring out why it keeps timing out: https://testgrid.k8s.io/sig-scalability-benchmarks#scheduler-perf 

/kind failing-test
/kind flake
/sig scheduling
/sig scalability

#### What this PR does / why we need it:

Per https://kubernetes.slack.com/archives/C09QZTRH7/p1651023713888349, we're seeing consistent scheduler_perf test failures.

The root cause is that subtest "BenchmarkPerfScheduling/PreemptionPVs/5000Nodes" keeps failing due to unknown timeout ([10mins](https://github.com/kubernetes/kubernetes/blob/546e4fa1ef4d9be1679bf73a6a84a71063a68922/test/integration/scheduler_perf/scheduler_perf_test.go#L909)). That aborted subtest then generates a math.NaN value as float (in internal struct DataItem), and then it fatals when calling json.Marshall(), which ends up with failing the entire test.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
