### PR TITLE
Replaces http disk cache with CompactableDiskCache

### DIFF
--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -55,6 +55,7 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/staging/src/k8s.io/cli-runtime/go.sum
+++ b/staging/src/k8s.io/cli-runtime/go.sum
@@ -291,6 +291,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/compactable_disk_cache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/compactable_disk_cache.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/gregjones/httpcache"
+	"github.com/peterbourgon/diskv"
+	"k8s.io/klog/v2"
+)
+
+const (
+	oneDay                 = 24 * time.Hour
+	lastCompactionFilename = "lastcompactiontime"
+)
+
+// CompactableDiskCache implements the httpcache.Cache interface. It delegates to
+// sumDiskCache for Cache functions (Get, Set, Delete), and occasionally removes
+// old cached files. The specified "cacheSize" is NOT a hard limit; the disk
+// cache can breach this threshold. When cache compaction occurs, it will resize
+// the disk cache below this "cacheSize".
+//
+// Trigger:
+//
+//	disk cache compactions are triggered when a file is accessed and the
+//	last compaction occurred over a day ago. Every cache file access checks
+//	when the last compaction occurred by checking the modification time
+//	on an empty file in the cache -- "lastcompactiontime". File access
+//	time for a cached file is not used directly because it is not well
+//	supported by all OSes.
+//
+// Concurrency:
+//
+//	Within the same process: the goroutines of a single process are
+//	coordinated using "sync/singleflight" functionality.
+//
+//	Among different processes: if (for example) a separate kubectl command
+//	compacts the disk cache at the same time, separate processes can compete
+//	to delete the same files. This code must be tolerant to attempting to
+//	delete files already deleted.
+type CompactableDiskCache struct {
+	cacheDir  string
+	cacheSize int64
+	delegate  httpcache.Cache
+}
+
+// Get returns the []byte representation of a cached response and a bool
+// set to true if the value isn't empty. This function can trigger a
+// disk cache compaction which runs in a separate goroutine. Touches
+// cached file to update file modification to match access time.
+func (cdc *CompactableDiskCache) Get(key string) ([]byte, bool) {
+	// If the file exists, update file modification time = access time.
+	_ = touchFile(sanitize(key))
+	go possiblyCompactDiskCache(cdc.cacheDir, cdc.cacheSize)
+	return cdc.delegate.Get(key)
+}
+
+// Set stores the []byte representation of a response against a key.
+func (cdc *CompactableDiskCache) Set(key string, responseBytes []byte) {
+	cdc.delegate.Set(key, responseBytes)
+}
+
+// Delete removes the value associated with the key.
+func (cdc *CompactableDiskCache) Delete(key string) {
+	cdc.delegate.Delete(key)
+}
+
+// NewCompactableDiskCache returns a newly created CompactableDiskCache,
+// which includes a newly created sumDiskCache delegate.
+func NewCompactableDiskCache(cacheDir string, cacheSize int64) *CompactableDiskCache {
+	return &CompactableDiskCache{
+		cacheDir:  cacheDir,
+		cacheSize: cacheSize,
+		delegate: &sumDiskCache{
+			disk: diskv.New(diskv.Options{
+				PathPerm: os.FileMode(0750),
+				FilePerm: os.FileMode(0660),
+				BasePath: cacheDir,
+				TempDir:  filepath.Join(cacheDir, ".diskv-temp"),
+			}),
+		},
+	}
+}
+
+// possiblyCompactDiskCache checks if the disk cache compaction
+// trigger condition has occurred, and if it has, it runs (only
+// one) compaction.
+func possiblyCompactDiskCache(cacheDir string, cacheSize int64) {
+	compactionFile := filepath.Join(cacheDir, lastCompactionFilename)
+	if shouldCompactCache(compactionFile) {
+		klog.V(7).Infoln("Disk cache compaction triggered")
+		// "singleflight" ensures that only one disk compaction occurs at a time within
+		// the current process.
+		var requestGroup singleflight.Group
+		begin := time.Now()
+		numFilesEvicted, err, _ := requestGroup.Do("disk-cache-compaction", func() (interface{}, error) {
+			return compactDiskCache(cacheDir, cacheSize)
+		})
+		finish := time.Now()
+		if err != nil {
+			klog.Errorf("Error during disk cache compaction: %s", err)
+		}
+		klog.V(7).Infof("%d files evicted from cache, compaction time: %s",
+			numFilesEvicted.(int), finish.Sub(begin))
+		// Set new, current modification time for "lastcompactiontime" file.
+		if err := touchFile(compactionFile); err != nil {
+			klog.Errorf("error touching last compaction file: %s", err)
+		}
+	}
+}
+
+// shouldCompactCache returns true if the disk cache compaction
+// trigger condition is met; false otherwise. The trigger condition
+// is if the modification time of the passed empty "lastcompactiontime"
+// file is greater than one day. If the file is created for the first
+// time, we will not trigger a compaction.
+func shouldCompactCache(compactionFile string) bool {
+	fileInfo, err := os.Stat(compactionFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// First time creating empty "lastcompactiontime" file.
+			_, _ = os.Create(compactionFile)
+		}
+		return false
+	}
+	durationSinceLastChange := time.Now().Sub(fileInfo.ModTime())
+	if durationSinceLastChange > oneDay {
+		return true
+	}
+	return false
+}
+
+// touchFile updates the passed file's access time and modification
+// time to the current time. Returns an error if one occurred while
+// updating the file.
+func touchFile(fullFilePath string) error {
+	currentTime := time.Now()
+	return os.Chtimes(fullFilePath, currentTime, currentTime)
+}
+
+// compactDiskCache removes old cache files (determined by modification time)
+// if the current cache size is larger than "cacheSize". Walks the entire
+// disk cache, and sorts files by ascending modification time. Removes files
+// until the disk cache is compacted below the "cacheSize" threshold. Returns
+// the number of files evicted from the cache and an error if one occurred.
+func compactDiskCache(cacheDir string, cacheSize int64) (int, error) {
+	currentCacheSize := int64(0)
+	files := []*fileInfo{}
+	// Walk the disk cache files to determine the cache size and file
+	// modification times.
+	err := filepath.Walk(cacheDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		fileSize := info.Size()
+		files = append(files, &fileInfo{
+			filePath: path,
+			modTime:  info.ModTime(),
+			fileSize: fileSize,
+		})
+		currentCacheSize += fileSize
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	// Only compact disk cache if it is beyond the "cacheSize" threshold. This
+	// threshold is NOT a hard limit. The cache will breach this threshold, but
+	// the compaction will return the disk cache size below the "cacheSize".
+	klog.V(7).Infof("Disk cache current size: %d", currentCacheSize)
+	klog.V(7).Infof("Disk cache threshold size: %d", cacheSize)
+	numFilesEvicted := 0
+	if currentCacheSize > cacheSize {
+		klog.V(7).Infoln("Removing old cache files...")
+		// Starting with the oldest files (by modification time), delete each
+		// file until the disk cache size is below the "cacheSize" threshold.
+		// Other processes may be deleting the same cache files at the same time.
+		files = sortFiles(files)
+		for i := 0; currentCacheSize > cacheSize && i < len(files); i++ {
+			fileInfo := files[i]
+			// Another process may have already deleted the file, so we only
+			// log error, and we always decrement the currentCacheSize.
+			err := os.Remove(fileInfo.filePath)
+			currentCacheSize -= fileInfo.fileSize
+			if err != nil {
+				klog.Errorf("error deleting cached file: %s", err)
+			} else {
+				numFilesEvicted++
+			}
+		}
+	}
+	return numFilesEvicted, nil
+}
+
+// sortFiles returns a slice of *fileInfo sorted by increasing
+// file modification time; oldest files (by modtime) are first.
+func sortFiles(fileInfos []*fileInfo) []*fileInfo {
+	// Sort the fileInfo's by ascending file modification time, so the
+	// oldest files will be at the beginning of the slice.
+	sort.Slice(fileInfos, func(i, j int) bool {
+		return fileInfos[i].modTime.Before(fileInfos[j].modTime)
+	})
+	return fileInfos
+}
+
+// fileInfo aggregates pertinent information about a cached file.
+type fileInfo struct {
+	filePath string
+	fileSize int64
+	modTime  time.Time
+}

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/compactable_disk_cache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/compactable_disk_cache_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicCacheOperations(t *testing.T) {
+	assert := assert.New(t)
+	var file1 = []byte("abcd")
+	var file2 = []byte("1234")
+	var file3 = []byte("fghijklmno")
+	testCacheSize := int64(1000)
+	testCacheDir, err := ioutil.TempDir("", "cache")
+	defer os.RemoveAll(testCacheDir)
+	assert.NoError(err)
+	cache := NewCompactableDiskCache(testCacheDir, testCacheSize)
+	// Check basic structure variables are set.
+	assert.Equal(testCacheDir, cache.cacheDir)
+	assert.Equal(testCacheSize, cache.cacheSize)
+	// Check "Get()" for non-existent key
+	_, found := cache.Get("non-existent")
+	assert.False(found, "Non-existent file should not be found in cache")
+	// Set file1 into the disk cache, and validate we can "Get()" it.
+	cache.Set("file1", file1)
+	actualFile1, found := cache.Get("file1")
+	assert.True(found, "Expected 'file1' to be found in cache")
+	assert.Equal(file1, actualFile1)
+	// Set file2 into the disk cache, and validate we can "Get()" it.
+	cache.Set("file2", file2)
+	actualFile2, found := cache.Get("file2")
+	assert.True(found, "Expected 'file2' to be found in cache")
+	assert.Equal(file2, actualFile2)
+	// Set file3 into the disk cache, and validate we can "Get()" it
+	// and the other files.
+	cache.Set("file3", file3)
+	_, found = cache.Get("file1")
+	assert.True(found, "Expected 'file1' to be found in cache")
+	_, found = cache.Get("file2")
+	assert.True(found, "Expected 'file2' to be found in cache")
+	actualFile3, found := cache.Get("file3")
+	assert.True(found, "Expected 'file3' to be found in cache")
+	assert.Equal(file3, actualFile3)
+	// Delete file2, and validate it is no longer in the cache, while
+	// file1 and file3 are still in the cache.
+	cache.Delete("file2")
+	_, found = cache.Get("file2")
+	assert.False(found, "Expected 'file2' to NOT be found in cache")
+	_, found = cache.Get("file1")
+	assert.True(found, "Expected 'file1' to be found in cache")
+	_, found = cache.Get("file3")
+	assert.True(found, "Expected 'file3' to be found in cache")
+}
+
+func TestDiskCacheCompaction(t *testing.T) {
+	assert := assert.New(t)
+	testCacheDir, err := ioutil.TempDir("", "compaction-cache")
+	defer os.RemoveAll(testCacheDir)
+	assert.NoError(err)
+	var file1 = []byte("abcdefghijklmno") // 15 chars
+	var file2 = []byte("1234567890")      // 10 chars
+	var file3 = []byte("fghijklm")        // 8 chars
+	var file4 = []byte("0987654321")      // 10 chars
+	fullFilePath1 := filepath.Join(testCacheDir, sanitize("file1"))
+	err = ioutil.WriteFile(fullFilePath1, file1, 0644)
+	assert.NoError(err)
+	fullFilePath2 := filepath.Join(testCacheDir, sanitize("file2"))
+	err = ioutil.WriteFile(fullFilePath2, file2, 0644)
+	assert.NoError(err)
+	fullFilePath3 := filepath.Join(testCacheDir, sanitize("file3"))
+	err = ioutil.WriteFile(fullFilePath3, file3, 0644)
+	assert.NoError(err)
+	fullFilePath4 := filepath.Join(testCacheDir, sanitize("file4"))
+	err = ioutil.WriteFile(fullFilePath4, file4, 0644)
+	assert.NoError(err)
+	// Files by oldest modTime: file2, file4, file1, file3
+	now := time.Now()
+	setFileModTime(t, fullFilePath1, now.Add(5*time.Hour))
+	setFileModTime(t, fullFilePath2, now.Add(-10*time.Hour))
+	setFileModTime(t, fullFilePath3, now.Add(10*time.Hour))
+	setFileModTime(t, fullFilePath4, now.Add(-5*time.Hour))
+	cacheSize := len(file1) + len(file2) + len(file3) + len(file4)
+	// Set the cache size threshold above the sizes of all files.
+	actualNumEvictedFiles, err := compactDiskCache(testCacheDir, int64(cacheSize+10))
+	assert.NoError(err)
+	assert.Equal(0, actualNumEvictedFiles)
+	assert.FileExists(fullFilePath1, "Expected file1 NOT to be evicted")
+	assert.FileExists(fullFilePath2, "Expected file2 NOT to be evicted")
+	assert.FileExists(fullFilePath3, "Expected file3 NOT to be evicted")
+	assert.FileExists(fullFilePath3, "Expected file4 NOT to be evicted")
+	// Set the cache size threshold small enough to evict two files.
+	// Files 2 and 4 should be evicted since they are the oldest.
+	actualNumEvictedFiles, err = compactDiskCache(testCacheDir, int64(cacheSize-15))
+	assert.NoError(err)
+	assert.Equal(2, actualNumEvictedFiles)
+	assert.FileExists(fullFilePath1, "Expected file1 NOT to be evicted")
+	assert.NoFileExists(fullFilePath2, "Expected file2 to be evicted")
+	assert.FileExists(fullFilePath3, "Expected file3 NOT to be evicted")
+	assert.NoFileExists(fullFilePath4, "Expected file4 to be evicted")
+}
+
+func TestShouldCompactCache(t *testing.T) {
+	assert := assert.New(t)
+	testCacheDir, err := ioutil.TempDir("", "cache")
+	defer os.RemoveAll(testCacheDir)
+	assert.NoError(err)
+	var file1 = []byte("abcd")
+	fullFilePath := filepath.Join(testCacheDir, sanitize("file1"))
+	err = ioutil.WriteFile(fullFilePath, file1, 0644)
+	assert.NoError(err)
+	// First, check shouldCompactCache first-time non-existent
+	// compaction file.
+	compactionFile := filepath.Join(testCacheDir, lastCompactionFilename)
+	assert.NoFileExists(compactionFile, "Zero-length compaction file should not exist yet.")
+	actual := shouldCompactCache(compactionFile)
+	assert.False(actual, "First create of compaction file should NOT trigger compaction")
+	assert.FileExists(compactionFile, "Zero-length compaction file should be created.")
+	// Next, check shoulCompactCache with file mod time set to current time.
+	now := time.Now()
+	setFileModTime(t, compactionFile, now)
+	actual = shouldCompactCache(compactionFile)
+	assert.False(actual, "File with recent modTime should NOT trigger compaction")
+	// Finally, check shoulCompactCache with file mod time set over a day ago.
+	setFileModTime(t, compactionFile, now.Add(-25*time.Hour))
+	actual = shouldCompactCache(compactionFile)
+	assert.True(actual, "File modTime older than one day should trigger compaction")
+}
+
+func TestTouchFile(t *testing.T) {
+	assert := assert.New(t)
+	testCacheDir, err := ioutil.TempDir("", "cache")
+	defer os.RemoveAll(testCacheDir)
+	assert.NoError(err)
+	var file1 = []byte("abcd")
+	fullFilePath := filepath.Join(testCacheDir, sanitize("file1"))
+	err = ioutil.WriteFile(fullFilePath, file1, 0644)
+	assert.NoError(err)
+	// First, check the set mod time from two days ago.
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	setFileModTime(t, fullFilePath, twoDaysAgo)
+	fileInfo, err := os.Stat(fullFilePath)
+	assert.NoError(err)
+	assert.Equal((0 * time.Second), twoDaysAgo.Sub(fileInfo.ModTime()))
+	// Next, check after touching the same file, the mod time
+	// is very close to now.
+	err = touchFile(fullFilePath)
+	assert.NoError(err)
+	fileInfo, err = os.Stat(fullFilePath)
+	assert.NoError(err)
+	assert.Greater((1 * time.Minute), time.Now().Sub(fileInfo.ModTime()))
+}
+
+func TestFileModTimeSorting(t *testing.T) {
+	now := time.Now()
+	info1 := createFileInfo("fake1", int64(10), now)
+	info2 := createFileInfo("fake2", int64(20), now.Add(-2*time.Hour))
+	info3 := createFileInfo("fake3", int64(30), now.Add(24*time.Hour))
+	info4 := createFileInfo("fake4", int64(40), now.Add(-48*time.Hour))
+	info5 := createFileInfo("fake5", int64(50), now.Add(16*time.Hour))
+	fileInfos := []*fileInfo{info1, info2, info3, info4, info5}
+	// Sort files by mod time.
+	sortedFileInfos := sortFiles(fileInfos)
+	assert := assert.New(t)
+	// Validate fileInfo ordering: info4, info2, info1, info5, info3
+	assert.Equal(info4, sortedFileInfos[0])
+	assert.Equal(info2, sortedFileInfos[1])
+	assert.Equal(info1, sortedFileInfos[2])
+	assert.Equal(info5, sortedFileInfos[3])
+	assert.Equal(info3, sortedFileInfos[4])
+}
+
+func createFileInfo(filePath string, fileSize int64, modTime time.Time) *fileInfo {
+	return &fileInfo{
+		filePath: filePath,
+		fileSize: fileSize,
+		modTime:  modTime,
+	}
+}
+
+func setFileModTime(t *testing.T, filePath string, modTime time.Time) {
+	err := os.Chtimes(filePath, modTime, modTime)
+	assert := assert.New(t)
+	assert.NoError(err)
+}

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.7.0
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
+	golang.org/x/sync v0.1.0
 	golang.org/x/term v0.5.0
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8
 	google.golang.org/protobuf v1.28.1

--- a/staging/src/k8s.io/client-go/go.sum
+++ b/staging/src/k8s.io/client-go/go.sum
@@ -278,6 +278,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -80,6 +80,7 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/staging/src/k8s.io/kubectl/go.sum
+++ b/staging/src/k8s.io/kubectl/go.sum
@@ -334,6 +334,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/staging/src/k8s.io/sample-cli-plugin/go.mod
+++ b/staging/src/k8s.io/sample-cli-plugin/go.mod
@@ -45,6 +45,7 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/staging/src/k8s.io/sample-cli-plugin/go.sum
+++ b/staging/src/k8s.io/sample-cli-plugin/go.sum
@@ -291,6 +291,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
* Replaces current http disk cache with `CompactableDiskCache`, which can perform occasional cleanup of old cached files. Updating this cache attempts to keep the disk cache from growing without bound. Disk cache files are usually stored at `$HOME/.kube/cache/http`.
* `CompactableDiskCache` implements the `httpcache.Cache` interface, which includes `Get`, `Set`, and `Delete`.
* Delegating to the current `sumDiskCache`, this cache runs exactly as the previous http disk cache. The only difference is that during `Get()` we run in parallel a check of a trigger condition, and a possible disk compaction (as well as touching the retrieved file).
* When disk compaction is triggered, it is run  in a separate goroutine as a `singleflight` to ensure a only one compaction runs at a time within a process.
* Specifies a threshold disk cache size of 100MB, which is **NOT** a hard limit.
* Unit test coverage has increased slightly from `75.8%` to `77.4%`.

Example check/disk compaction for 496 files
```
 Disk cache current size: 93324617
 Disk cache threshold size: 89128960
 Removing old cache files...
 496 files evicted from cache, compaction time: 34.426372ms
```

Example check/disk compaction without evicting any files
```
 Disk cache current size: 85847007
 Disk cache threshold size: 89128960
 0 files evicted from cache, compaction time: 27.672859ms
```

/kind feature

```release-note
NONE
```