### PR TITLE
Allow setting custom volume sizes for Windows containers with containerd

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go
@@ -109,6 +109,17 @@ func (m *kubeGenericRuntimeManager) generateWindowsContainerConfig(container *v1
 		wc.Resources.MemoryLimitInBytes = memoryLimit
 	}
 
+	// Windows containers use ephemeral storage by default and are created with
+	// a default volume size of 20GB.
+	// If specified - resources.limits.ephemeral-storage value will be used to
+	// override this default.
+	// https://docs.microsoft.com/virtualization/windowscontainers/manage-containers/container-storage#scratch-space
+	// https://docs.microsoft.com/virtualization/windowscontainers/manage-containers/container-storage#storage-limits
+	ephemeralStorageLimit := container.Resources.Limits.StorageEphemeral().Value()
+	if ephemeralStorageLimit != 0 {
+		wc.Resources.RootfsSizeInBytes = ephemeralStorageLimit
+	}
+
 	// setup security context
 	effectiveSc := securitycontext.DetermineEffectiveSecurityContext(pod, container)
 


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
On Windows containers are created with a default volume size of 20Gb.
With docker this can be specified per-container with `--storage-opt "size=xxGb"` or globally by specifying `storage-opts` in the dockerd config file.

https://docs.microsoft.com/virtualization/windowscontainers/manage-containers/container-storage#storage-limits

This PR allows for the container volume size to be specified in pod specs and will pass that size to CRI container create calls.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/kubernetes/pull/108894 and https://github.com/containerd/containerd/issues/6694

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow setting custom root volume size for Windows containers with containerd v1.7+ when []containers.resources.limits.ephemeral-storage is specified.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows
/area kubelet