### PR TITLE
Do not remove non-namespaced resources when the namespace is enforced

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -82,9 +82,11 @@ func (p *pruner) pruneAll(o *ApplyOptions) error {
 			}
 		}
 	}
-	for _, m := range nonNamespacedRESTMappings {
-		if err := p.prune(metav1.NamespaceNone, m); err != nil {
-			return fmt.Errorf("error pruning nonNamespaced object %v: %v", m.GroupVersionKind, err)
+	if !o.EnforceNamespace {
+		for _, m := range nonNamespacedRESTMappings {
+			if err := p.prune(metav1.NamespaceNone, m); err != nil {
+				return fmt.Errorf("error pruning nonNamespaced object %v: %v", m.GroupVersionKind, err)
+			}
 		}
 	}
 

--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -268,6 +268,29 @@ __EOF__
   # cleanup
   kubectl delete ns nsb
 
+  ## kubectl apply --prune --all --namespace NS can only prune resources in the namespace
+  # Pre-Condition: namespace nsb exists; no POD exists
+  kubectl create ns nsb
+  kube::test::get_object_assert pods "{{range.items}}{{${id_field:?}}}:{{end}}" ''
+  # apply a into namespace nsb
+  kubectl apply --namespace nsb -f hack/testdata/prune/a.yaml "${kube_flags[@]:?}"
+  kube::test::get_object_assert 'pods a -n nsb' "{{${id_field:?}}}" 'a'
+  # apply b with namespace
+  kubectl apply --namespace nsb -f hack/testdata/prune/b.yaml "${kube_flags[@]:?}"
+  kube::test::get_object_assert 'pods b -n nsb' "{{${id_field:?}}}" 'b'
+  # apply non-reapable type
+  kubectl apply --all --prune -f hack/testdata/prune-reap/a.yml 2>&1 "${kube_flags[@]:?}"
+  kube::test::get_object_assert 'pvc a-pvc' "{{${id_field:?}}}" 'a-pvc'
+  # apply --prune must prune a
+  kubectl apply --prune --all --namespace nsb -f hack/testdata/prune/b.yaml
+  # check wrong pod doesn't exist and right pod exists
+  kube::test::wait_object_assert 'pods -n nsb' "{{range.items}}{{${id_field:?}}}:{{end}}" 'b:'
+  kube::test::get_object_assert 'pvc a-pvc' "{{${id_field:?}}}" 'a-pvc'
+
+  # cleanup
+  kubectl delete ns nsb
+  kubectl delete pvc a-pvc 2>&1 "${kube_flags[@]:?}"
+
   ## kubectl apply -n must fail if input file contains namespace other than the one given in -n
   output_message=$(! kubectl apply -n foo -f hack/testdata/prune/b.yaml 2>&1 "${kube_flags[@]:?}")
   kube::test::if_has_string "${output_message}" 'the namespace from the provided object "nsb" does not match the namespace "foo".'


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Removing non-namespaced resources when the namespace is enforced will
lead to irreversible incidents such as removing other namespaces,
removing PVC, etc.

**Which issue(s) this PR fixes**:

Achieves what this comment doing: https://github.com/kubernetes/kubernetes/issues/74414#issuecomment-702896322

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
`kubectl apply --prune --namespace NS` will not prune non-namespaced resources anymore.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

Reopen: https://github.com/kubernetes/kubernetes/pull/95820