### PR TITLE
Update Metrics doc as there is a typo in package

### DIFF
--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/doc.go
@@ -17,5 +17,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +groupName=metrics.k8s.io
 
-// Package metrics defines an API for exposing metics.
+// Package metrics defines an API for exposing metrics.
 package metrics // import "k8s.io/metrics/pkg/apis/metrics"


### PR DESCRIPTION
Package header typo is very visible looking at docs. 

https://pkg.go.dev/k8s.io/metrics/pkg/apis/metrics

#### What type of PR is this?


/kind cleanup
/kind documentation

#### What this PR does / why we need it:
Visible typo

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
