### PR TITLE
auth e2e: node_authn test: don't expect a SA secret

### DIFF
--- a/test/e2e/auth/node_authn.go
+++ b/test/e2e/auth/node_authn.go
@@ -51,13 +51,6 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 
 		nodeIPs := e2enode.GetAddressesByTypeAndFamily(&nodes.Items[0], v1.NodeInternalIP, family)
 		framework.ExpectNotEqual(len(nodeIPs), 0)
-
-		// make sure ServiceAccount admission controller is enabled, so secret generation on SA creation works
-		saName := "default"
-		sa, err := f.ClientSet.CoreV1().ServiceAccounts(ns).Get(context.TODO(), saName, metav1.GetOptions{})
-		framework.ExpectNoError(err, "failed to retrieve service account (%s:%s)", ns, saName)
-		framework.ExpectNotEqual(len(sa.Secrets), 0)
-
 	})
 
 	ginkgo.It("The kubelet's main port 10250 should reject requests with no credentials", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind failing-test

#### What this PR does / why we need it:
The test was expecting an SA token in a secret but pods are getting
their SA tokens via projected volumes by default. Also, the SA token
controller function is getting reduced so the original check is likely
to fail.

#### Which issue(s) this PR fixes:
No issue was created for this PR

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

