### PR TITLE
Do not wrap lines if we can't read term size

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
@@ -223,7 +223,7 @@ func flagsUsages(f *flag.FlagSet) (string, error) {
 	flagBuf := new(bytes.Buffer)
 	wrapLimit, err := term.GetWordWrapperLimit()
 	if err != nil {
-		return "", err
+		wrapLimit = 0
 	}
 	printer := NewHelpFlagPrinter(flagBuf, wrapLimit)
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression
/sig cli

#### What this PR does / why we need it:
In https://github.com/kubernetes/kubernetes/pull/104736 we introduced pretty printed help messages for kubectl.
Unfortunately, in some scripts it's possible that this will return the following error:
```
Error: template: usage:12:43: executing "usage" at <flagsUsages $visibleFlags>: error calling flagsUsages: file descriptor is not a terminal
```
I've noticed that while changing introducing this change into OpenShift (https://github.com/openshift/oc/pull/1121, specifically failures from https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_oc/1121/pull-ci-openshift-oc-master-e2e-agnostic-cmd/1519729283440840704). This PR make it so that when we can't read the term size, we just set the limit to 0 which make the wrapping not to happen at all, which is consistent with previous mechanism. 

#### Special notes for your reviewer:
/assign @ardaguclu @eddiezane 
/cc @lauchokyip 

#### Does this PR introduce a user-facing change?
```release-note
Fix 1.24 regression in kubectl help output
```