### PR TITLE
Automated cherry pick of #109722: Do not wrap lines if we can't read term size

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
@@ -223,7 +223,7 @@ func flagsUsages(f *flag.FlagSet) (string, error) {
 	flagBuf := new(bytes.Buffer)
 	wrapLimit, err := term.GetWordWrapperLimit()
 	if err != nil {
-		return "", err
+		wrapLimit = 0
 	}
 	printer := NewHelpFlagPrinter(flagBuf, wrapLimit)
 


### PR DESCRIPTION
Cherry pick of #109722 on release-1.24.

#109722: Do not wrap lines if we can't read term size

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix 1.24 regression in kubectl help output
```