### PR TITLE
verify-golangci-lint.sh: support stricter checking in new code

### DIFF
--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -1,0 +1,38 @@
+# This file configures checks that all new code for Kubernetes is meant to
+# pass, in contrast to .golangci.yaml which defines checks that also the
+# existing code passes.
+
+run:
+  timeout: 30m
+  skip-files:
+    - "^zz_generated.*"
+
+issues:
+  max-same-issues: 0
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # exclude ineffassing linter for generated files for conversion
+    - path: conversion\.go
+      linters:
+        - ineffassign
+
+linters:
+  enable: # please keep this alphabetized
+    - gocritic
+    - govet
+    - ineffassign
+    - logcheck
+    - staticcheck
+    - unused
+
+linters-settings: # please keep this alphabetized
+  custom:
+    logcheck:
+      # Installed there by hack/verify-golangci-lint.sh.
+      path: ../_output/local/bin/logcheck.so
+      description: structured logging checker
+      original-url: k8s.io/logtools/logcheck
+  staticcheck:
+    checks: [
+      "all",
+    ]

--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -33,6 +33,7 @@ source "${KUBE_ROOT}/third_party/forked/shell2junit/sh2ju.sh"
 EXCLUDED_PATTERNS=(
   "verify-all.sh"                # this script calls the make rule and would cause a loop
   "verify-*-dockerized.sh"       # Don't run any scripts that intended to be run dockerized
+  "verify-golangci-lint-pr.sh"   # Don't run this as part of the block pull-kubernetes-verify yet. TODO(pohly): try this in a non-blocking job and then reconsider this.
   "verify-licenses.sh"           # runs in a separate job to monitor availability of the dependencies periodically
   )
 

--- a/hack/verify-golangci-lint-pr.sh
+++ b/hack/verify-golangci-lint-pr.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script checks a PR for the coding style for the Go language files using
+# golangci-lint. It does nothing when invoked as part of a normal "make
+# verify".
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ ! "${PULL_NUMBER:-}" ]; then
+  echo 'Not testing anything because this is not a pull request.'
+  exit 0
+fi
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+# TODO (https://github.com/kubernetes/test-infra/issues/17056):
+# take this additional artifact and convert it to GitHub annotations
+# to make it easier to see these problems during a PR review.
+#
+# -g "${ARTIFACTS}/golangci-lint-githubactions.log"
+"${KUBE_ROOT}/hack/verify-golangci-lint.sh" -r "${PULL_BASE_SHA}" -s


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

It is useful to check new code with a stricter configuration because we want it
to be of higher quality. Code reviews also become easier when reviewers don't
need to point out inefficient code manually.

What exactly should be enabled is up for debate. The current config uses the
golangci-lint defaults plus everything that is enabled explicitly by the normal
.golangci.yaml, just to be on the safe side.

#### Special notes for your reviewer:

As a first step we could add a non-blocking pull job which runs with the stricter configuration for the new code, using `-r PULL_BASE_REF`.

https://github.com/kubernetes/test-infra/issues/17056 would have been nice, but hasn't made much progress. Let's move forward by enabling strict linting in [an optional job](https://github.com/kubernetes/test-infra/pull/28914).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
