### PR TITLE
Wrap weighted histograms

### DIFF
--- a/hack/verify-prometheus-imports.sh
+++ b/hack/verify-prometheus-imports.sh
@@ -66,6 +66,7 @@ allowed_prometheus_importers=(
   ./staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
   ./staging/src/k8s.io/component-base/metrics/testutil/promlint.go
   ./staging/src/k8s.io/component-base/metrics/testutil/testutil.go
+  ./staging/src/k8s.io/component-base/metrics/timing_histogram_test.go
   ./staging/src/k8s.io/component-base/metrics/value.go
   ./staging/src/k8s.io/component-base/metrics/wrappers.go
   ./test/e2e/apimachinery/flowcontrol.go

--- a/staging/src/k8s.io/component-base/metrics/gauge.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -33,7 +34,11 @@ type Gauge struct {
 	selfCollector
 }
 
-// NewGauge returns an object which satisfies the kubeCollector and KubeGauge interfaces.
+var _ GaugeMetric = &Gauge{}
+var _ Registerable = &Gauge{}
+var _ kubeCollector = &Gauge{}
+
+// NewGauge returns an object which satisfies the kubeCollector, Registerable, and Gauge interfaces.
 // However, the object returned will not measure anything unless the collector is first
 // registered, since the metric is lazily instantiated.
 func NewGauge(opts *GaugeOpts) *Gauge {
@@ -88,9 +93,14 @@ type GaugeVec struct {
 	originalLabels []string
 }
 
-// NewGaugeVec returns an object which satisfies the kubeCollector and KubeGaugeVec interfaces.
+var _ GaugeVecMetric = &GaugeVec{}
+var _ Registerable = &GaugeVec{}
+var _ kubeCollector = &GaugeVec{}
+
+// NewGaugeVec returns an object which satisfies the kubeCollector, Registerable, and GaugeVecMetric interfaces.
 // However, the object returned will not measure anything unless the collector is first
-// registered, since the metric is lazily instantiated.
+// registered, since the metric is lazily instantiated, and only members extracted after
+// registration will actually measure anything.
 func NewGaugeVec(opts *GaugeOpts, labels []string) *GaugeVec {
 	opts.StabilityLevel.setDefaults()
 
@@ -130,26 +140,55 @@ func (v *GaugeVec) initializeDeprecatedMetric() {
 	v.initializeMetric()
 }
 
-// Default Prometheus behavior actually results in the creation of a new metric
-// if a metric with the unique label values is not found in the underlying stored metricMap.
+func (v *GaugeVec) WithLabelValuesChecked(lvs ...string) (GaugeMetric, error) {
+	if v.IsHidden() {
+		return noop, nil
+	}
+	if !v.IsCreated() {
+		return noop, errNotRegistered // return no-op gauge
+	}
+	if v.LabelValueAllowLists != nil {
+		v.LabelValueAllowLists.ConstrainToAllowedList(v.originalLabels, lvs)
+	}
+	elt, err := v.GaugeVec.GetMetricWithLabelValues(lvs...)
+	return elt, err
+}
+
+// Default Prometheus Vec behavior is that member extraction results in creation of a new element
+// if one with the unique label values is not found in the underlying stored metricMap.
 // This means  that if this function is called but the underlying metric is not registered
 // (which means it will never be exposed externally nor consumed), the metric will exist in memory
 // for perpetuity (i.e. throughout application lifecycle).
 //
 // For reference: https://github.com/prometheus/client_golang/blob/v0.9.2/prometheus/gauge.go#L190-L208
+//
+// In contrast, the Vec behavior in this package is that member extraction before registration
+// returns a permanent noop object.
 
 // WithLabelValues returns the GaugeMetric for the given slice of label
 // values (same order as the VariableLabels in Desc). If that combination of
 // label values is accessed for the first time, a new GaugeMetric is created IFF the gaugeVec
 // has been registered to a metrics registry.
 func (v *GaugeVec) WithLabelValues(lvs ...string) GaugeMetric {
+	ans, err := v.WithLabelValuesChecked(lvs...)
+	if err == nil || ErrIsNotRegistered(err) {
+		return ans
+	}
+	panic(err)
+}
+
+func (v *GaugeVec) WithChecked(labels map[string]string) (GaugeMetric, error) {
+	if v.IsHidden() {
+		return noop, nil
+	}
 	if !v.IsCreated() {
-		return noop // return no-op gauge
+		return noop, errNotRegistered // return no-op gauge
 	}
 	if v.LabelValueAllowLists != nil {
-		v.LabelValueAllowLists.ConstrainToAllowedList(v.originalLabels, lvs)
+		v.LabelValueAllowLists.ConstrainLabelMap(labels)
 	}
-	return v.GaugeVec.WithLabelValues(lvs...)
+	elt, err := v.GaugeVec.GetMetricWith(labels)
+	return elt, err
 }
 
 // With returns the GaugeMetric for the given Labels map (the label names
@@ -157,13 +196,11 @@ func (v *GaugeVec) WithLabelValues(lvs ...string) GaugeMetric {
 // accessed for the first time, a new GaugeMetric is created IFF the gaugeVec has
 // been registered to a metrics registry.
 func (v *GaugeVec) With(labels map[string]string) GaugeMetric {
-	if !v.IsCreated() {
-		return noop // return no-op gauge
+	ans, err := v.WithChecked(labels)
+	if err == nil || ErrIsNotRegistered(err) {
+		return ans
 	}
-	if v.LabelValueAllowLists != nil {
-		v.LabelValueAllowLists.ConstrainLabelMap(labels)
-	}
-	return v.GaugeVec.With(labels)
+	panic(err)
 }
 
 // Delete deletes the metric where the variable labels are the same as those
@@ -217,6 +254,10 @@ func (v *GaugeVec) WithContext(ctx context.Context) *GaugeVecWithContext {
 		ctx:      ctx,
 		GaugeVec: v,
 	}
+}
+
+func (v *GaugeVec) InterfaceWithContext(ctx context.Context) GaugeVecMetric {
+	return v.WithContext(ctx)
 }
 
 // GaugeVecWithContext is the wrapper of GaugeVec with context.

--- a/staging/src/k8s.io/component-base/metrics/gauge.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge.go
@@ -141,10 +141,10 @@ func (v *GaugeVec) initializeDeprecatedMetric() {
 }
 
 func (v *GaugeVec) WithLabelValuesChecked(lvs ...string) (GaugeMetric, error) {
-	if v.IsHidden() {
-		return noop, nil
-	}
 	if !v.IsCreated() {
+		if v.IsHidden() {
+			return noop, nil
+		}
 		return noop, errNotRegistered // return no-op gauge
 	}
 	if v.LabelValueAllowLists != nil {
@@ -178,10 +178,10 @@ func (v *GaugeVec) WithLabelValues(lvs ...string) GaugeMetric {
 }
 
 func (v *GaugeVec) WithChecked(labels map[string]string) (GaugeMetric, error) {
-	if v.IsHidden() {
-		return noop, nil
-	}
 	if !v.IsCreated() {
+		if v.IsHidden() {
+			return noop, nil
+		}
 		return noop, errNotRegistered // return no-op gauge
 	}
 	if v.LabelValueAllowLists != nil {

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -101,7 +101,10 @@ type HistogramVec struct {
 
 // NewHistogramVec returns an object which satisfies kubeCollector and wraps the
 // prometheus.HistogramVec object. However, the object returned will not measure
-// anything unless the collector is first registered, since the metric is lazily instantiated.
+// anything unless the collector is first registered, since the metric is lazily instantiated,
+// and only members extracted after
+// registration will actually measure anything.
+
 func NewHistogramVec(opts *HistogramOpts, labels []string) *HistogramVec {
 	opts.StabilityLevel.setDefaults()
 
@@ -137,13 +140,16 @@ func (v *HistogramVec) initializeDeprecatedMetric() {
 	v.initializeMetric()
 }
 
-// Default Prometheus behavior actually results in the creation of a new metric
-// if a metric with the unique label values is not found in the underlying stored metricMap.
+// Default Prometheus Vec behavior is that member extraction results in creation of a new element
+// if one with the unique label values is not found in the underlying stored metricMap.
 // This means  that if this function is called but the underlying metric is not registered
 // (which means it will never be exposed externally nor consumed), the metric will exist in memory
 // for perpetuity (i.e. throughout application lifecycle).
 //
 // For reference: https://github.com/prometheus/client_golang/blob/v0.9.2/prometheus/histogram.go#L460-L470
+//
+// In contrast, the Vec behavior in this package is that member extraction before registration
+// returns a permanent noop object.
 
 // WithLabelValues returns the ObserverMetric for the given slice of label
 // values (same order as the VariableLabels in Desc). If that combination of

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -22,6 +22,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	promext "k8s.io/component-base/metrics/prometheusextension"
 
 	"k8s.io/klog/v2"
 )
@@ -203,6 +204,7 @@ func (c *selfCollector) Collect(ch chan<- prometheus.Metric) {
 // no-op vecs for convenience
 var noopCounterVec = &prometheus.CounterVec{}
 var noopHistogramVec = &prometheus.HistogramVec{}
+var noopTimingHistogramVec = &promext.TimingHistogramVec{}
 var noopGaugeVec = &prometheus.GaugeVec{}
 var noopObserverVec = &noopObserverVector{}
 
@@ -211,17 +213,18 @@ var noop = &noopMetric{}
 
 type noopMetric struct{}
 
-func (noopMetric) Inc()                             {}
-func (noopMetric) Add(float64)                      {}
-func (noopMetric) Dec()                             {}
-func (noopMetric) Set(float64)                      {}
-func (noopMetric) Sub(float64)                      {}
-func (noopMetric) Observe(float64)                  {}
-func (noopMetric) SetToCurrentTime()                {}
-func (noopMetric) Desc() *prometheus.Desc           { return nil }
-func (noopMetric) Write(*dto.Metric) error          { return nil }
-func (noopMetric) Describe(chan<- *prometheus.Desc) {}
-func (noopMetric) Collect(chan<- prometheus.Metric) {}
+func (noopMetric) Inc()                              {}
+func (noopMetric) Add(float64)                       {}
+func (noopMetric) Dec()                              {}
+func (noopMetric) Set(float64)                       {}
+func (noopMetric) Sub(float64)                       {}
+func (noopMetric) Observe(float64)                   {}
+func (noopMetric) ObserveWithWeight(float64, uint64) {}
+func (noopMetric) SetToCurrentTime()                 {}
+func (noopMetric) Desc() *prometheus.Desc            { return nil }
+func (noopMetric) Write(*dto.Metric) error           { return nil }
+func (noopMetric) Describe(chan<- *prometheus.Desc)  {}
+func (noopMetric) Collect(chan<- prometheus.Metric)  {}
 
 type noopObserverVector struct{}
 

--- a/staging/src/k8s.io/component-base/metrics/summary.go
+++ b/staging/src/k8s.io/component-base/metrics/summary.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -93,7 +94,9 @@ type SummaryVec struct {
 
 // NewSummaryVec returns an object which satisfies kubeCollector and wraps the
 // prometheus.SummaryVec object. However, the object returned will not measure
-// anything unless the collector is first registered, since the metric is lazily instantiated.
+// anything unless the collector is first registered, since the metric is lazily instantiated,
+// and only members extracted after
+// registration will actually measure anything.
 //
 // DEPRECATED: as per the metrics overhaul KEP
 func NewSummaryVec(opts *SummaryOpts, labels []string) *SummaryVec {
@@ -130,13 +133,16 @@ func (v *SummaryVec) initializeDeprecatedMetric() {
 	v.initializeMetric()
 }
 
-// Default Prometheus behavior actually results in the creation of a new metric
-// if a metric with the unique label values is not found in the underlying stored metricMap.
+// Default Prometheus Vec behavior is that member extraction results in creation of a new element
+// if one with the unique label values is not found in the underlying stored metricMap.
 // This means  that if this function is called but the underlying metric is not registered
 // (which means it will never be exposed externally nor consumed), the metric will exist in memory
 // for perpetuity (i.e. throughout application lifecycle).
 //
-// For reference: https://github.com/prometheus/client_golang/blob/v0.9.2/prometheus/summary.go#L485-L495
+// For reference: https://github.com/prometheus/client_golang/blob/v0.9.2/prometheus/histogram.go#L460-L470
+//
+// In contrast, the Vec behavior in this package is that member extraction before registration
+// returns a permanent noop object.
 
 // WithLabelValues returns the ObserverMetric for the given slice of label
 // values (same order as the VariableLabels in Desc). If that combination of

--- a/staging/src/k8s.io/component-base/metrics/timing_histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/timing_histogram.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/blang/semver/v4"
+	promext "k8s.io/component-base/metrics/prometheusextension"
+)
+
+// TimingHistogram is our internal representation for our wrapping struct around timing
+// histograms. It implements both kubeCollector and GaugeMetric
+type TimingHistogram struct {
+	GaugeMetric
+	*TimingHistogramOpts
+	nowFunc func() time.Time
+	lazyMetric
+	selfCollector
+}
+
+// NewTimingHistogram returns an object which is TimingHistogram-like. However, nothing
+// will be measured until the histogram is registered somewhere.
+func NewTimingHistogram(opts *TimingHistogramOpts) *TimingHistogram {
+	return NewTestableTimingHistogram(time.Now, opts)
+}
+
+// NewTestableTimingHistogram adds injection of the clock
+func NewTestableTimingHistogram(nowFunc func() time.Time, opts *TimingHistogramOpts) *TimingHistogram {
+	opts.StabilityLevel.setDefaults()
+
+	h := &TimingHistogram{
+		TimingHistogramOpts: opts,
+		nowFunc:             nowFunc,
+		lazyMetric:          lazyMetric{},
+	}
+	h.setPrometheusHistogram(noopMetric{})
+	h.lazyInit(h, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
+	return h
+}
+
+// setPrometheusHistogram sets the underlying KubeGauge object, i.e. the thing that does the measurement.
+func (h *TimingHistogram) setPrometheusHistogram(histogram promext.TimingHistogram) {
+	h.GaugeMetric = histogram
+	h.initSelfCollection(histogram)
+}
+
+// DeprecatedVersion returns a pointer to the Version or nil
+func (h *TimingHistogram) DeprecatedVersion() *semver.Version {
+	return parseSemver(h.TimingHistogramOpts.DeprecatedVersion)
+}
+
+// initializeMetric invokes the actual prometheus.Histogram object instantiation
+// and stores a reference to it
+func (h *TimingHistogram) initializeMetric() {
+	h.TimingHistogramOpts.annotateStabilityLevel()
+	// this actually creates the underlying prometheus gauge.
+	histogram, err := promext.NewTestableTimingHistogram(h.nowFunc, h.TimingHistogramOpts.toPromHistogramOpts())
+	if err != nil {
+		panic(err) // handle as for regular histograms
+	}
+	h.setPrometheusHistogram(histogram)
+}
+
+// initializeDeprecatedMetric invokes the actual prometheus.Histogram object instantiation
+// but modifies the Help description prior to object instantiation.
+func (h *TimingHistogram) initializeDeprecatedMetric() {
+	h.TimingHistogramOpts.markDeprecated()
+	h.initializeMetric()
+}
+
+// WithContext allows the normal TimingHistogram metric to pass in context. The context is no-op now.
+func (h *TimingHistogram) WithContext(ctx context.Context) GaugeMetric {
+	return h.GaugeMetric
+}
+
+// timingHistogramVec is the internal representation of our wrapping struct around prometheus
+// TimingHistogramVecs.
+type timingHistogramVec struct {
+	*promext.TimingHistogramVec
+	*TimingHistogramOpts
+	nowFunc func() time.Time
+	lazyMetric
+	originalLabels []string
+}
+
+// NewTimingHistogramVec returns an object which satisfies kubeCollector and
+// wraps the promext.timingHistogramVec object.  Note well the way that
+// behavior depends on registration and whether this is hidden.
+func NewTimingHistogramVec(opts *TimingHistogramOpts, labels []string) PreContextAndRegisterableGaugeMetricVec {
+	return NewTestableTimingHistogramVec(time.Now, opts, labels)
+}
+
+// NewTestableTimingHistogramVec adds injection of the clock.
+func NewTestableTimingHistogramVec(nowFunc func() time.Time, opts *TimingHistogramOpts, labels []string) PreContextAndRegisterableGaugeMetricVec {
+	opts.StabilityLevel.setDefaults()
+
+	fqName := BuildFQName(opts.Namespace, opts.Subsystem, opts.Name)
+	allowListLock.RLock()
+	if allowList, ok := labelValueAllowLists[fqName]; ok {
+		opts.LabelValueAllowLists = allowList
+	}
+	allowListLock.RUnlock()
+
+	v := &timingHistogramVec{
+		TimingHistogramVec:  noopTimingHistogramVec,
+		TimingHistogramOpts: opts,
+		nowFunc:             nowFunc,
+		originalLabels:      labels,
+		lazyMetric:          lazyMetric{},
+	}
+	v.lazyInit(v, fqName)
+	return v
+}
+
+// DeprecatedVersion returns a pointer to the Version or nil
+func (v *timingHistogramVec) DeprecatedVersion() *semver.Version {
+	return parseSemver(v.TimingHistogramOpts.DeprecatedVersion)
+}
+
+func (v *timingHistogramVec) initializeMetric() {
+	v.TimingHistogramOpts.annotateStabilityLevel()
+	v.TimingHistogramVec = promext.NewTestableTimingHistogramVec(v.nowFunc, v.TimingHistogramOpts.toPromHistogramOpts(), v.originalLabels...)
+}
+
+func (v *timingHistogramVec) initializeDeprecatedMetric() {
+	v.TimingHistogramOpts.markDeprecated()
+	v.initializeMetric()
+}
+
+func (v *timingHistogramVec) Set(value float64, labelValues ...string) {
+	gm, _ := v.WithLabelValues(labelValues...)
+	gm.Set(value)
+}
+
+func (v *timingHistogramVec) Inc(labelValues ...string) {
+	gm, _ := v.WithLabelValues(labelValues...)
+	gm.Inc()
+}
+
+func (v *timingHistogramVec) Dec(labelValues ...string) {
+	gm, _ := v.WithLabelValues(labelValues...)
+	gm.Dec()
+}
+
+func (v *timingHistogramVec) Add(delta float64, labelValues ...string) {
+	gm, _ := v.WithLabelValues(labelValues...)
+	gm.Add(delta)
+}
+func (v *timingHistogramVec) SetToCurrentTime(labelValues ...string) {
+	gm, _ := v.WithLabelValues(labelValues...)
+	gm.SetToCurrentTime()
+}
+
+func (v *timingHistogramVec) SetForLabels(value float64, labels map[string]string) {
+	gm, _ := v.With(labels)
+	gm.Set(value)
+}
+
+func (v *timingHistogramVec) IncForLabels(labels map[string]string) {
+	gm, _ := v.With(labels)
+	gm.Inc()
+}
+
+func (v *timingHistogramVec) DecForLabels(labels map[string]string) {
+	gm, _ := v.With(labels)
+	gm.Dec()
+}
+
+func (v *timingHistogramVec) AddForLabels(delta float64, labels map[string]string) {
+	gm, _ := v.With(labels)
+	gm.Add(delta)
+}
+func (v *timingHistogramVec) SetToCurrentTimeForLabels(labels map[string]string) {
+	gm, _ := v.With(labels)
+	gm.SetToCurrentTime()
+}
+
+// WithLabelValues, if called after this vector has been
+// registered in at least one registry and this vector is not
+// hidden, will return a GaugeMetric that is NOT a noop along
+// with nil error.  If called on a hidden vector then it will
+// return a noop and a nil error.  Otherwise it returns a noop
+// and an error that passes ErrIsNotReady.
+func (v *timingHistogramVec) WithLabelValues(lvs ...string) (GaugeMetric, error) {
+	if v.IsHidden() {
+		return noop, nil
+	}
+	if !v.IsCreated() {
+		return noop, errNotReady
+	}
+	if v.LabelValueAllowLists != nil {
+		v.LabelValueAllowLists.ConstrainToAllowedList(v.originalLabels, lvs)
+	}
+	return v.TimingHistogramVec.WithLabelValues(lvs...).(GaugeMetric), nil
+}
+
+// With, if called after this vector has been
+// registered in at least one registry and this vector is not
+// hidden, will return a GaugeMetric that is NOT a noop along
+// with nil error.  If called on a hidden vector then it will
+// return a noop and a nil error.  Otherwise it returns a noop
+// and an error that passes ErrIsNotReady.
+func (v *timingHistogramVec) With(labels map[string]string) (GaugeMetric, error) {
+	if v.IsHidden() {
+		return noop, nil
+	}
+	if !v.IsCreated() {
+		return noop, errNotReady
+	}
+	if v.LabelValueAllowLists != nil {
+		v.LabelValueAllowLists.ConstrainLabelMap(labels)
+	}
+	return v.TimingHistogramVec.With(labels).(GaugeMetric), nil
+}
+
+// Delete deletes the metric where the variable labels are the same as those
+// passed in as labels. It returns true if a metric was deleted.
+//
+// It is not an error if the number and names of the Labels are inconsistent
+// with those of the VariableLabels in Desc. However, such inconsistent Labels
+// can never match an actual metric, so the method will always return false in
+// that case.
+func (v *timingHistogramVec) Delete(labels map[string]string) bool {
+	if !v.IsCreated() {
+		return false // since we haven't created the metric, we haven't deleted a metric with the passed in values
+	}
+	return v.TimingHistogramVec.Delete(labels)
+}
+
+// Reset deletes all metrics in this vector.
+func (v *timingHistogramVec) Reset() {
+	if !v.IsCreated() {
+		return
+	}
+
+	v.TimingHistogramVec.Reset()
+}
+
+// WithContext returns wrapped timingHistogramVec with context
+func (v *timingHistogramVec) WithContext(ctx context.Context) GaugeMetricVec {
+	return &TimingHistogramVecWithContext{
+		ctx:                ctx,
+		timingHistogramVec: v,
+	}
+}
+
+// TimingHistogramVecWithContext is the wrapper of timingHistogramVec with context.
+// Currently the context is ignored.
+type TimingHistogramVecWithContext struct {
+	*timingHistogramVec
+	ctx context.Context
+}

--- a/staging/src/k8s.io/component-base/metrics/timing_histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/timing_histogram.go
@@ -196,13 +196,13 @@ func (v *timingHistogramVec) SetToCurrentTimeForLabels(labels map[string]string)
 // hidden, will return a GaugeMetric that is NOT a noop along
 // with nil error.  If called on a hidden vector then it will
 // return a noop and a nil error.  Otherwise it returns a noop
-// and an error that passes ErrIsNotReady.
+// and an error that passes ErrIsNotRegistered.
 func (v *timingHistogramVec) WithLabelValues(lvs ...string) (GaugeMetric, error) {
 	if v.IsHidden() {
 		return noop, nil
 	}
 	if !v.IsCreated() {
-		return noop, errNotReady
+		return noop, errNotRegistered
 	}
 	if v.LabelValueAllowLists != nil {
 		v.LabelValueAllowLists.ConstrainToAllowedList(v.originalLabels, lvs)
@@ -215,13 +215,13 @@ func (v *timingHistogramVec) WithLabelValues(lvs ...string) (GaugeMetric, error)
 // hidden, will return a GaugeMetric that is NOT a noop along
 // with nil error.  If called on a hidden vector then it will
 // return a noop and a nil error.  Otherwise it returns a noop
-// and an error that passes ErrIsNotReady.
+// and an error that passes ErrIsNotRegistered.
 func (v *timingHistogramVec) With(labels map[string]string) (GaugeMetric, error) {
 	if v.IsHidden() {
 		return noop, nil
 	}
 	if !v.IsCreated() {
-		return noop, errNotReady
+		return noop, errNotRegistered
 	}
 	if v.LabelValueAllowLists != nil {
 		v.LabelValueAllowLists.ConstrainLabelMap(labels)

--- a/staging/src/k8s.io/component-base/metrics/timing_histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/timing_histogram_test.go
@@ -102,8 +102,8 @@ func TestTimingHistogram(t *testing.T) {
 			}()
 			m1 := <-metricChan
 			gm1, ok := m1.(GaugeMetric)
-			if !ok || gm1 != c.GaugeMetric {
-				t.Error("Unexpected metric", m1, c.GaugeMetric)
+			if !ok || gm1 != c.PrometheusTimingHistogram {
+				t.Error("Unexpected metric", m1, c.PrometheusTimingHistogram)
 			}
 			m2, ok := <-metricChan
 			if ok {

--- a/staging/src/k8s.io/component-base/metrics/wrappers.go
+++ b/staging/src/k8s.io/component-base/metrics/wrappers.go
@@ -91,7 +91,7 @@ type GaugeMetricVec interface {
 	// hidden, will return a GaugeMetric that is NOT a noop along
 	// with nil error.  If called on a hidden vector then it will
 	// return a noop and a nil error.  Otherwise it returns a noop
-	// and an error that passes ErrIsNotReady.
+	// and an error that passes ErrIsNotRegistered.
 	WithLabelValues(labelValues ...string) (GaugeMetric, error)
 
 	// With, if called after this vector has been
@@ -99,7 +99,7 @@ type GaugeMetricVec interface {
 	// hidden, will return a GaugeMetric that is NOT a noop along
 	// with nil error.  If called on a hidden vector then it will
 	// return a noop and a nil error.  Otherwise it returns a noop
-	// and an error that passes ErrIsNotReady.
+	// and an error that passes ErrIsNotRegistered.
 	With(labels map[string]string) (GaugeMetric, error)
 
 	// Delete asserts that the vec should have no member for the given label set.
@@ -161,8 +161,8 @@ type GaugeFunc interface {
 	Collector
 }
 
-func ErrIsNotReady(err error) bool {
-	return err == errNotReady
+func ErrIsNotRegistered(err error) bool {
+	return err == errNotRegistered
 }
 
-var errNotReady = errors.New("metric vec is not registered yet")
+var errNotRegistered = errors.New("metric vec is not registered yet")

--- a/staging/src/k8s.io/component-base/metrics/wrappers.go
+++ b/staging/src/k8s.io/component-base/metrics/wrappers.go
@@ -80,11 +80,11 @@ type GaugeVecMetric interface {
 	// In contrast, the Vec behavior in this package is that member extraction before registration
 	// returns a permanent noop object.
 
-	// WithLabelValuesChecked, if called on a hidden vector,
-	// will return a noop gauge and a nil error.
-	// If called before this vector has been registered in
+	// WithLabelValuesChecked, if called before this vector has been registered in
 	// at least one registry, will return a noop gauge and
 	// an error that passes ErrIsNotRegistered.
+	// If called on a hidden vector,
+	// will return a noop gauge and a nil error.
 	// If called with a syntactic problem in the labels, will
 	// return a noop gauge and an error about the labels.
 	// If none of the above apply, this method will return
@@ -98,11 +98,11 @@ type GaugeVecMetric interface {
 	// all other errors cause a panic.
 	WithLabelValues(labelValues ...string) GaugeMetric
 
-	// WithChecked, if called on a hidden vector,
-	// will return a noop gauge and a nil error.
-	// If called before this vector has been registered in
+	// WithChecked, if called before this vector has been registered in
 	// at least one registry, will return a noop gauge and
 	// an error that passes ErrIsNotRegistered.
+	// If called on a hidden vector,
+	// will return a noop gauge and a nil error.
 	// If called with a syntactic problem in the labels, will
 	// return a noop gauge and an error about the labels.
 	// If none of the above apply, this method will return

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1954,6 +1954,7 @@ k8s.io/component-base/metrics/prometheus/ratelimiter
 k8s.io/component-base/metrics/prometheus/restclient
 k8s.io/component-base/metrics/prometheus/version
 k8s.io/component-base/metrics/prometheus/workqueue
+k8s.io/component-base/metrics/prometheusextension
 k8s.io/component-base/metrics/testutil
 k8s.io/component-base/term
 k8s.io/component-base/traces


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR adds kube wrappers around the new WeightedHistograms and TimingHistograms (introduced in #109277), along the lines of the existing wrappers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This partially addresses #108272

#### Special notes for your reviewer:

This currently builds on #109277 , and after that merges I will rebase this onto master.
This is the middle of three steps.
The last step will be replacing the sample-and-watermark histograms with uses of the timing histograms.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
