### PR TITLE
test/e2e/auth: enhance assertions

### DIFF
--- a/test/e2e/auth/node_authz.go
+++ b/test/e2e/auth/node_authz.go
@@ -19,10 +19,10 @@ package auth
 import (
 	"context"
 	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
@@ -69,7 +69,9 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 	})
 	ginkgo.It("Getting a non-existent secret should exit with the Forbidden error, not a NotFound error", func() {
 		_, err := c.CoreV1().Secrets(ns).Get(context.TODO(), "foo", metav1.GetOptions{})
-		framework.ExpectEqual(apierrors.IsForbidden(err), true)
+		if !apierrors.IsForbidden(err) {
+			framework.Failf("should be a forbidden error, got %#v", err)
+		}
 	})
 
 	ginkgo.It("Getting an existing secret should exit with the Forbidden error", func() {
@@ -84,12 +86,16 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		_, err := f.ClientSet.CoreV1().Secrets(ns).Create(context.TODO(), secret, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create secret (%s:%s) %+v", ns, secret.Name, *secret)
 		_, err = c.CoreV1().Secrets(ns).Get(context.TODO(), secret.Name, metav1.GetOptions{})
-		framework.ExpectEqual(apierrors.IsForbidden(err), true)
+		if !apierrors.IsForbidden(err) {
+			framework.Failf("should be a forbidden error, got %#v", err)
+		}
 	})
 
 	ginkgo.It("Getting a non-existent configmap should exit with the Forbidden error, not a NotFound error", func() {
 		_, err := c.CoreV1().ConfigMaps(ns).Get(context.TODO(), "foo", metav1.GetOptions{})
-		framework.ExpectEqual(apierrors.IsForbidden(err), true)
+		if !apierrors.IsForbidden(err) {
+			framework.Failf("should be a forbidden error, got %#v", err)
+		}
 	})
 
 	ginkgo.It("Getting an existing configmap should exit with the Forbidden error", func() {
@@ -106,7 +112,9 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		_, err := f.ClientSet.CoreV1().ConfigMaps(ns).Create(context.TODO(), configmap, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create configmap (%s:%s) %+v", ns, configmap.Name, *configmap)
 		_, err = c.CoreV1().ConfigMaps(ns).Get(context.TODO(), configmap.Name, metav1.GetOptions{})
-		framework.ExpectEqual(apierrors.IsForbidden(err), true)
+		if !apierrors.IsForbidden(err) {
+			framework.Failf("should be a forbidden error, got %#v", err)
+		}
 	})
 
 	ginkgo.It("Getting a secret for a workload the node has access to should succeed", func() {
@@ -125,7 +133,9 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 
 		ginkgo.By("Node should not get the secret")
 		_, err = c.CoreV1().Secrets(ns).Get(context.TODO(), secret.Name, metav1.GetOptions{})
-		framework.ExpectEqual(apierrors.IsForbidden(err), true)
+		if !apierrors.IsForbidden(err) {
+			framework.Failf("should be a forbidden error, got %#v", err)
+		}
 
 		ginkgo.By("Create a pod that use the secret")
 		pod := &v1.Pod{
@@ -187,12 +197,16 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		defer func() {
 			f.ClientSet.CoreV1().Nodes().Delete(context.TODO(), node.Name, metav1.DeleteOptions{})
 		}()
-		framework.ExpectEqual(apierrors.IsForbidden(err), true)
+		if !apierrors.IsForbidden(err) {
+			framework.Failf("should be a forbidden error, got %#v", err)
+		}
 	})
 
 	ginkgo.It("A node shouldn't be able to delete another node", func() {
 		ginkgo.By(fmt.Sprintf("Create node foo by user: %v", asUser))
 		err := c.CoreV1().Nodes().Delete(context.TODO(), "foo", metav1.DeleteOptions{})
-		framework.ExpectEqual(apierrors.IsForbidden(err), true)
+		if !apierrors.IsForbidden(err) {
+			framework.Failf("should be a forbidden error, got %#v", err)
+		}
 	})
 })

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -113,13 +113,21 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		tokenReview := &authenticationv1.TokenReview{Spec: authenticationv1.TokenReviewSpec{Token: mountedToken}}
 		tokenReview, err = f.ClientSet.AuthenticationV1().TokenReviews().Create(context.TODO(), tokenReview, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectEqual(tokenReview.Status.Authenticated, true)
+		if !tokenReview.Status.Authenticated {
+			framework.Fail("tokenReview is not authenticated")
+		}
 		framework.ExpectEqual(tokenReview.Status.Error, "")
 		framework.ExpectEqual(tokenReview.Status.User.Username, "system:serviceaccount:"+f.Namespace.Name+":"+sa.Name)
 		groups := sets.NewString(tokenReview.Status.User.Groups...)
-		framework.ExpectEqual(groups.Has("system:authenticated"), true, fmt.Sprintf("expected system:authenticated group, had %v", groups.List()))
-		framework.ExpectEqual(groups.Has("system:serviceaccounts"), true, fmt.Sprintf("expected system:serviceaccounts group, had %v", groups.List()))
-		framework.ExpectEqual(groups.Has("system:serviceaccounts:"+f.Namespace.Name), true, fmt.Sprintf("expected system:serviceaccounts:"+f.Namespace.Name+" group, had %v", groups.List()))
+		if !groups.Has("system:authenticated") {
+			framework.Failf("expected system:authenticated group, had %v", groups.List())
+		}
+		if !groups.Has("system:serviceaccounts") {
+			framework.Failf("expected system:serviceaccounts group, had %v", groups.List())
+		}
+		if !groups.Has("system:serviceaccounts:" + f.Namespace.Name) {
+			framework.Failf("expected system:serviceaccounts:%s group, had %v", f.Namespace.Name, groups.List())
+		}
 	})
 
 	/*
@@ -671,8 +679,9 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				break
 			}
 		}
-		framework.ExpectEqual(eventFound, true, "failed to find %v event", watch.Added)
-
+		if !eventFound {
+			framework.Failf("failed to find %v event", watch.Added)
+		}
 		ginkgo.By("patching the ServiceAccount")
 		boolFalse := false
 		testServiceAccountPatchData, err := json.Marshal(v1.ServiceAccount{
@@ -688,8 +697,9 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				break
 			}
 		}
-		framework.ExpectEqual(eventFound, true, "failed to find %v event", watch.Modified)
-
+		if !eventFound {
+			framework.Failf("failed to find %v event", watch.Modified)
+		}
 		ginkgo.By("finding ServiceAccount in list of all ServiceAccounts (by LabelSelector)")
 		serviceAccountList, err := f.ClientSet.CoreV1().ServiceAccounts("").List(context.TODO(), metav1.ListOptions{LabelSelector: testServiceAccountStaticLabelsFlat})
 		framework.ExpectNoError(err, "failed to list ServiceAccounts by LabelSelector")
@@ -700,8 +710,9 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				break
 			}
 		}
-		framework.ExpectEqual(foundServiceAccount, true, "failed to find the created ServiceAccount")
-
+		if !foundServiceAccount {
+			framework.Fail("failed to find the created ServiceAccount")
+		}
 		ginkgo.By("deleting the ServiceAccount")
 		err = f.ClientSet.CoreV1().ServiceAccounts(testNamespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 		framework.ExpectNoError(err, "failed to delete the ServiceAccount by Collection")
@@ -712,7 +723,9 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				break
 			}
 		}
-		framework.ExpectEqual(eventFound, true, "failed to find %v event", watch.Deleted)
+		if !eventFound {
+			framework.Failf("failed to find %v event", watch.Deleted)
+		}
 	})
 
 	/*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Better output for developers when tests fail.
#### Which issue(s) this PR fixes:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes part of #105678 

#### Special notes for your reviewer:
Before this pr
```
git grep 'Expect.*Equal([^,]*, *\(true\|false\)' | wc -l
177
```

After this pr
```
git grep 'Expect.*Equal([^,]*, *\(true\|false\)' | wc -l
152
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
