### PR TITLE
Parse docs have out-of-order regex.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -851,7 +851,7 @@ func (p *Parser) parseExactValue() (sets.String, error) {
 //  <exact-match-restriction> ::= ["="|"=="|"!="] VALUE
 //
 // KEY is a sequence of one or more characters following [ DNS_SUBDOMAIN "/" ] DNS_LABEL. Max length is 63 characters.
-// VALUE is a sequence of zero or more characters "([A-Za-z0-9_-\.])". Max length is 63 characters.
+// VALUE is a sequence of zero or more characters "([A-Za-z0-9_\.-])". Max length is 63 characters.
 // Delimiter is white space: (' ', '\t')
 // Example of valid syntax:
 //  "x in (foo,,baz),y,z notin ()"


### PR DESCRIPTION
ordering of literal `dash` makes it an incorrect `range operator in regex`. Presumably this should be the literal dash.

Regex 101, compile: https://regex101.com/r/MkjK7H/1

#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:
regex issue in docs.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


