### PR TITLE
use underscode instead of hyphen while defined function in cherry_pick_pull.sh

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -133,7 +133,7 @@ function return_to_kansas {
 trap return_to_kansas EXIT
 
 SUBJECTS=()
-function make-a-pr() {
+function make_a_pr() {
   local rel
   rel="$(basename "${BRANCH}")"
   echo
@@ -237,7 +237,7 @@ if git remote -v | grep ^"${FORK_REMOTE}" | grep "${MAIN_REPO_ORG}/${MAIN_REPO_N
   echo "where REMOTE is your personal fork (maybe ${UPSTREAM_REMOTE}? Consider swapping those.)."
   echo "OR consider setting UPSTREAM_REMOTE and FORK_REMOTE to different values."
   echo
-  make-a-pr
+  make_a_pr
   cleanbranch=""
   exit 0
 fi
@@ -254,4 +254,4 @@ if ! [[ "${REPLY}" =~ ^[yY]$ ]]; then
 fi
 
 git push "${FORK_REMOTE}" -f "${NEWBRANCHUNIQ}:${NEWBRANCH}"
-make-a-pr
+make_a_pr


### PR DESCRIPTION
Signed-off-by: wuyingjun <71485611@qq.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
I met a problem when I used sh but not bash executing check_pick_pull.sh
![image](https://user-images.githubusercontent.com/16109961/166202357-c9f136eb-c47a-49d5-8ee5-2794ac0aac9e.png)
In the shell command language, a word consisting solely of underscores, digits, and alphabetics from the portable character set. The first character of a name is not a digit.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
adapt for sh execution cherry_pick_pull.sh
```
/sig instrumentation
/sig architecture
/sig cli
/sig contributor-experience
