### PR TITLE
spdyroundtripper: don't need to verify server hostname twice

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -264,18 +264,8 @@ func (s *SpdyRoundTripper) tlsConn(ctx context.Context, rwc net.Conn, targetHost
 
 	tlsConn := tls.Client(rwc, tlsConfig)
 
-	// need to manually call Handshake() so we can call VerifyHostname() below
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		tlsConn.Close()
-		return nil, err
-	}
-
-	// Return if we were configured to skip validation
-	if tlsConfig.InsecureSkipVerify {
-		return tlsConn, nil
-	}
-
-	if err := tlsConn.VerifyHostname(tlsConfig.ServerName); err != nil {
 		return nil, err
 	}
 
@@ -303,23 +293,6 @@ func (s *SpdyRoundTripper) dialWithoutProxy(ctx context.Context, url *url.URL) (
 	} else {
 		conn, err = tls.DialWithDialer(s.Dialer, "tcp", dialAddr, s.tlsConfig)
 	}
-	if err != nil {
-		return nil, err
-	}
-
-	// Return if we were configured to skip validation
-	if s.tlsConfig != nil && s.tlsConfig.InsecureSkipVerify {
-		return conn, nil
-	}
-
-	host, _, err := net.SplitHostPort(dialAddr)
-	if err != nil {
-		return nil, err
-	}
-	if s.tlsConfig != nil && len(s.tlsConfig.ServerName) > 0 {
-		host = s.tlsConfig.ServerName
-	}
-	err = conn.VerifyHostname(host)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -266,6 +266,7 @@ func (s *SpdyRoundTripper) tlsConn(ctx context.Context, rwc net.Conn, targetHost
 
 	// need to manually call Handshake() so we can call VerifyHostname() below
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		tlsConn.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
/kind cleanup
```release-note
NONE
```

`tls.HandshakeContext()` already validates the hostname, no need to do it twice

playground https://gist.github.com/aojea/4e172d7f3835cd3ffc6ea4f83eea6608


xref https://groups.google.com/g/golang-nuts/c/4vnt7NdLvVU/m/b1SJ4u0ikb0J

