### PR TITLE
kubeadm: replace *clientset.Clientset with clientset.Interface for join phase

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -145,7 +145,7 @@ type joinData struct {
 	cfg                   *kubeadmapi.JoinConfiguration
 	initCfg               *kubeadmapi.InitConfiguration
 	tlsBootstrapCfg       *clientcmdapi.Config
-	clientSet             *clientset.Clientset
+	client                clientset.Interface
 	ignorePreflightErrors sets.String
 	outputWriter          io.Writer
 	patchesDir            string
@@ -547,10 +547,10 @@ func (j *joinData) InitCfg() (*kubeadmapi.InitConfiguration, error) {
 	return initCfg, err
 }
 
-// ClientSet returns the ClientSet for accessing the cluster with the identity defined in admin.conf.
-func (j *joinData) ClientSet() (*clientset.Clientset, error) {
-	if j.clientSet != nil {
-		return j.clientSet, nil
+// Client returns the Client for accessing the cluster with the identity defined in admin.conf.
+func (j *joinData) Client() (clientset.Interface, error) {
+	if j.client != nil {
+		return j.client, nil
 	}
 	path := filepath.Join(j.KubeConfigDir(), kubeadmconstants.AdminKubeConfigFileName)
 
@@ -558,7 +558,7 @@ func (j *joinData) ClientSet() (*clientset.Clientset, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "[preflight] couldn't create Kubernetes client")
 	}
-	j.clientSet = client
+	j.client = client
 	return client, nil
 }
 

--- a/cmd/kubeadm/app/cmd/phases/join/checketcd.go
+++ b/cmd/kubeadm/app/cmd/phases/join/checketcd.go
@@ -61,7 +61,7 @@ func runCheckEtcdPhase(c workflow.RunData) error {
 	// Checks that the etcd cluster is healthy
 	// NB. this check cannot be implemented before because it requires the admin.conf and all the certificates
 	//     for connecting to etcd already in place
-	client, err := data.ClientSet()
+	client, err := data.Client()
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -116,7 +116,7 @@ func runEtcdPhase(c workflow.RunData) error {
 	}
 
 	// gets access to the cluster using the identity defined in admin.conf
-	client, err := data.ClientSet()
+	client, err := data.Client()
 	if err != nil {
 		return errors.Wrap(err, "couldn't create Kubernetes client")
 	}
@@ -180,7 +180,7 @@ func runMarkControlPlanePhase(c workflow.RunData) error {
 	}
 
 	// gets access to the cluster using the identity defined in admin.conf
-	client, err := data.ClientSet()
+	client, err := data.Client()
 	if err != nil {
 		return errors.Wrap(err, "couldn't create Kubernetes client")
 	}

--- a/cmd/kubeadm/app/cmd/phases/join/data.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data.go
@@ -33,7 +33,7 @@ type JoinData interface {
 	Cfg() *kubeadmapi.JoinConfiguration
 	TLSBootstrapCfg() (*clientcmdapi.Config, error)
 	InitCfg() (*kubeadmapi.InitConfiguration, error)
-	ClientSet() (*clientset.Clientset, error)
+	Client() (clientset.Interface, error)
 	IgnorePreflightErrors() sets.String
 	OutputWriter() io.Writer
 	PatchesDir() string

--- a/cmd/kubeadm/app/cmd/phases/join/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data_test.go
@@ -36,7 +36,7 @@ func (j *testJoinData) CertificateKey() string                          { return
 func (j *testJoinData) Cfg() *kubeadmapi.JoinConfiguration              { return nil }
 func (j *testJoinData) TLSBootstrapCfg() (*clientcmdapi.Config, error)  { return nil, nil }
 func (j *testJoinData) InitCfg() (*kubeadmapi.InitConfiguration, error) { return nil, nil }
-func (j *testJoinData) ClientSet() (*clientset.Clientset, error)        { return nil, nil }
+func (j *testJoinData) Client() (clientset.Interface, error)            { return nil, nil }
 func (j *testJoinData) IgnorePreflightErrors() sets.String              { return nil }
 func (j *testJoinData) OutputWriter() io.Writer                         { return nil }
 func (j *testJoinData) PatchesDir() string                              { return "" }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We already use the interface type in `init/upgrade/reset`, this PR replaces `*clientset.Clientset` with `clientset.Interface` for `join` to make it consistent. Using an interface type is generally recommended.

Also, make it easy to use a fake client for `join --dry-run`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
