### PR TITLE
Add testcases for pkg/kubelet/cm/pod_container_manager_linux.go

### DIFF
--- a/pkg/kubelet/cm/pod_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux_test.go
@@ -20,6 +20,9 @@ limitations under the License.
 package cm
 
 import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 	"testing"
 
@@ -124,5 +127,162 @@ func TestIsCgroupPod(t *testing.T) {
 			}
 
 		}
+	}
+}
+
+func TestGetPodContainerName(t *testing.T) {
+	newGuaranteedPodWithUID := func(uid types.UID) *v1.Pod {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: uid,
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "container",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("1000m"),
+								v1.ResourceMemory: resource.MustParse("1G"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("1000m"),
+								v1.ResourceMemory: resource.MustParse("1G"),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	newBurstablePodWithUID := func(uid types.UID) *v1.Pod {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: uid,
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "container",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("1000m"),
+								v1.ResourceMemory: resource.MustParse("1G"),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	newBestEffortPodWithUID := func(uid types.UID) *v1.Pod {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: uid,
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "container",
+					},
+				},
+			},
+		}
+	}
+
+	qosContainersInfo := QOSContainersInfo{
+		Guaranteed: RootCgroupName,
+		Burstable:  NewCgroupName(RootCgroupName, strings.ToLower(string(v1.PodQOSBurstable))),
+		BestEffort: NewCgroupName(RootCgroupName, strings.ToLower(string(v1.PodQOSBestEffort))),
+	}
+
+	type fields struct {
+		cgroupManager CgroupManager
+	}
+	type args struct {
+		pod *v1.Pod
+	}
+
+	tests := []struct {
+		name                string
+		fields              fields
+		args                args
+		wantCgroupName      CgroupName
+		wantLiteralCgroupfs string
+	}{
+		{
+			name: "pod with qos guaranteed and cgroupfs",
+			fields: fields{
+				cgroupManager: NewCgroupManager(nil, "cgroupfs"),
+			},
+			args: args{
+				pod: newGuaranteedPodWithUID("fake-uid-1"),
+			},
+			wantCgroupName:      NewCgroupName(qosContainersInfo.Guaranteed, "podfake-uid-1"),
+			wantLiteralCgroupfs: NewCgroupName(qosContainersInfo.Guaranteed, "podfake-uid-1").ToCgroupfs(),
+		}, {
+			name: "pod with qos guaranteed and systemd",
+			fields: fields{
+				cgroupManager: NewCgroupManager(nil, "systemd"),
+			},
+			args: args{
+				pod: newGuaranteedPodWithUID("fake-uid-2"),
+			},
+			wantCgroupName:      NewCgroupName(qosContainersInfo.Guaranteed, "podfake-uid-2"),
+			wantLiteralCgroupfs: NewCgroupName(qosContainersInfo.Guaranteed, "podfake-uid-2").ToSystemd(),
+		}, {
+			name: "pod with qos burstable and cgroupfs",
+			fields: fields{
+				cgroupManager: NewCgroupManager(nil, "cgroupfs"),
+			},
+			args: args{
+				pod: newBurstablePodWithUID("fake-uid-3"),
+			},
+			wantCgroupName:      NewCgroupName(qosContainersInfo.Burstable, "podfake-uid-3"),
+			wantLiteralCgroupfs: NewCgroupName(qosContainersInfo.Burstable, "podfake-uid-3").ToCgroupfs(),
+		}, {
+			name: "pod with qos burstable and systemd",
+			fields: fields{
+				cgroupManager: NewCgroupManager(nil, "systemd"),
+			},
+			args: args{
+				pod: newBurstablePodWithUID("fake-uid-4"),
+			},
+			wantCgroupName:      NewCgroupName(qosContainersInfo.Burstable, "podfake-uid-4"),
+			wantLiteralCgroupfs: NewCgroupName(qosContainersInfo.Burstable, "podfake-uid-4").ToSystemd(),
+		}, {
+			name: "pod with qos best-effort and cgroupfs",
+			fields: fields{
+				cgroupManager: NewCgroupManager(nil, "cgroupfs"),
+			},
+			args: args{
+				pod: newBestEffortPodWithUID("fake-uid-5"),
+			},
+			wantCgroupName:      NewCgroupName(qosContainersInfo.BestEffort, "podfake-uid-5"),
+			wantLiteralCgroupfs: NewCgroupName(qosContainersInfo.BestEffort, "podfake-uid-5").ToCgroupfs(),
+		}, {
+			name: "pod with qos best-effort and systemd",
+			fields: fields{
+				cgroupManager: NewCgroupManager(nil, "systemd"),
+			},
+			args: args{
+				pod: newBestEffortPodWithUID("fake-uid-6"),
+			},
+			wantCgroupName:      NewCgroupName(qosContainersInfo.BestEffort, "podfake-uid-6"),
+			wantLiteralCgroupfs: NewCgroupName(qosContainersInfo.BestEffort, "podfake-uid-6").ToSystemd(),
+		},
+	}
+
+	for _, tt := range tests {
+		pcm := &podContainerManagerImpl{
+			cgroupManager:     tt.fields.cgroupManager,
+			qosContainersInfo: qosContainersInfo,
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			actualCgroupName, actualLiteralCgroupfs := pcm.GetPodContainerName(tt.args.pod)
+			assert.Equalf(t, tt.wantCgroupName, actualCgroupName, "Unexpected cgroup name for pod with UID %s, container resources: %v", tt.args.pod.UID, tt.args.pod.Spec.Containers[0].Resources)
+			assert.Equalf(t, tt.wantLiteralCgroupfs, actualLiteralCgroupfs, "Unexpected literal cgroupfs for pod with UID %s, container resources: %v", tt.args.pod.UID, tt.args.pod.Spec.Containers[0].Resources)
+		})
 	}
 }

--- a/pkg/kubelet/cm/pod_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux_test.go
@@ -102,6 +102,12 @@ func TestIsCgroupPod(t *testing.T) {
 			expectedResult: false,
 			expectedUID:    types.UID(""),
 		},
+		{
+			// contains reserved word "pod" in cgroup name
+			input:          NewCgroupName(RootCgroupName, GetPodCgroupNameSuffix("this-uid-contains-reserved-word-pod")),
+			expectedResult: false,
+			expectedUID:    types.UID(""),
+		},
 	}
 	for _, cgroupDriver := range []string{"cgroupfs", "systemd"} {
 		pcm := &podContainerManagerImpl{

--- a/pkg/kubelet/cm/pod_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux_test.go
@@ -20,11 +20,12 @@ limitations under the License.
 package cm
 
 import (
-	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -287,8 +288,8 @@ func TestGetPodContainerName(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			actualCgroupName, actualLiteralCgroupfs := pcm.GetPodContainerName(tt.args.pod)
-			assert.Equalf(t, tt.wantCgroupName, actualCgroupName, "Unexpected cgroup name for pod with UID %s, container resources: %v", tt.args.pod.UID, tt.args.pod.Spec.Containers[0].Resources)
-			assert.Equalf(t, tt.wantLiteralCgroupfs, actualLiteralCgroupfs, "Unexpected literal cgroupfs for pod with UID %s, container resources: %v", tt.args.pod.UID, tt.args.pod.Spec.Containers[0].Resources)
+			require.Equalf(t, tt.wantCgroupName, actualCgroupName, "Unexpected cgroup name for pod with UID %s, container resources: %v", tt.args.pod.UID, tt.args.pod.Spec.Containers[0].Resources)
+			require.Equalf(t, tt.wantLiteralCgroupfs, actualLiteralCgroupfs, "Unexpected literal cgroupfs for pod with UID %s, container resources: %v", tt.args.pod.UID, tt.args.pod.Spec.Containers[0].Resources)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR:
- appends test cases for `podContainerManagerImpl`, method `GetPodContainerName`;
  - assert that it should return the name of QoS Class as a part of CgroupName and LiteralCgroupfs 
  - assert that it could works with different cgroup drivers as `systemd` and `cgroupfs` 
- append test case for `podContainerManagerImpl`, method `IsPodCgroup`, with reserved word "pod"

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
It is a part of https://github.com/kubernetes/kubernetes/issues/109717;

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
Signed-off-by: STRRL <im@strrl.dev>