### PR TITLE
Close events recording sink in integration tests

### DIFF
--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -424,8 +424,7 @@ func InitTestSchedulerWithOptions(
 		t.Fatalf("Couldn't create scheduler: %v", err)
 	}
 
-	stopCh := make(chan struct{})
-	eventBroadcaster.StartRecordingToSink(stopCh)
+	eventBroadcaster.StartRecordingToSink(testCtx.Ctx.Done())
 
 	return testCtx
 }


### PR DESCRIPTION
Found when debugging https://github.com/kubernetes/kubernetes/pull/109760

Ref https://github.com/kubernetes/kubernetes/issues/108483

```release-note
NONE
```

/kind cleanup
/priority important-longterm
/sig scheduling