### PR TITLE
Automated cherry pick of #108593: tests: Updates the should delete a collection of pods test

### DIFF
--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -866,14 +866,12 @@ var _ = SIGDescribe("Pods", func() {
 				}}, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "failed to create pod")
 			framework.Logf("created %v", podTestName)
-			framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, podTestName, f.Namespace.Name))
-			framework.Logf("running and ready %v", podTestName)
 		}
 
-		// wait as required for all 3 pods to be found
-		ginkgo.By("waiting for all 3 pods to be located")
-		err := wait.PollImmediate(podRetryPeriod, podRetryTimeout, checkPodListQuantity(f, "type=Testing", 3))
-		framework.ExpectNoError(err, "3 pods not found")
+		// wait as required for all 3 pods to be running
+		ginkgo.By("waiting for all 3 pods to be running")
+		err := e2epod.WaitForPodsRunningReady(f.ClientSet, f.Namespace.Name, 3, 0, framework.PodStartTimeout, nil)
+		framework.ExpectNoError(err, "3 pods not found running.")
 
 		// delete Collection of pods with a label in the current namespace
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &one}, metav1.ListOptions{


### PR DESCRIPTION
Cherry pick of #108593 on release-1.23.

#108593: tests: Updates the should delete a collection of pods test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/sig testing

#### What this PR does / why we need it:

We should wait for all 3 pods after we've spawned them, instead of spawning and waiting for them sequentially.

Based on the suggestion: https://github.com/kubernetes/kubernetes/pull/106183#discussion_r804954115

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```