### PR TITLE
users of watchtools.NewIndexerInformerWatcher should wait for the informer to sync

### DIFF
--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -249,20 +249,10 @@ var _ = SIGDescribe("Pods", func() {
 		framework.ExpectNoError(err, "failed to query for pods")
 		framework.ExpectEqual(len(pods.Items), 0)
 
-		listCompleted := make(chan bool, 1)
 		lw := &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.LabelSelector = selector.String()
 				podList, err := podClient.List(context.TODO(), options)
-				if err == nil {
-					select {
-					case listCompleted <- true:
-						framework.Logf("observed the pod list")
-						return podList, err
-					default:
-						framework.Logf("channel blocked")
-					}
-				}
 				return podList, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
@@ -270,8 +260,14 @@ var _ = SIGDescribe("Pods", func() {
 				return podClient.Watch(context.TODO(), options)
 			},
 		}
-		_, _, w, _ := watchtools.NewIndexerInformerWatcher(lw, &v1.Pod{})
+		_, informer, w, _ := watchtools.NewIndexerInformerWatcher(lw, &v1.Pod{})
 		defer w.Stop()
+
+		ctx, cancelCtx := context.WithTimeout(context.TODO(), wait.ForeverTestTimeout)
+		defer cancelCtx()
+		if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+			framework.Failf("Timeout while waiting to Pod informer to sync")
+		}
 
 		ginkgo.By("submitting the pod to kubernetes")
 		podClient.Create(pod)
@@ -285,17 +281,12 @@ var _ = SIGDescribe("Pods", func() {
 
 		ginkgo.By("verifying pod creation was observed")
 		select {
-		case <-listCompleted:
-			select {
-			case event := <-w.ResultChan():
-				if event.Type != watch.Added {
-					framework.Failf("Failed to observe pod creation: %v", event)
-				}
-			case <-time.After(framework.PodStartTimeout):
-				framework.Failf("Timeout while waiting for pod creation")
+		case event := <-w.ResultChan():
+			if event.Type != watch.Added {
+				framework.Failf("Failed to observe pod creation: %v", event)
 			}
-		case <-time.After(10 * time.Second):
-			framework.Failf("Timeout while waiting to observe pod list")
+		case <-time.After(framework.PodStartTimeout):
+			framework.Failf("Timeout while waiting for pod creation")
 		}
 
 		// We need to wait for the pod to be running, otherwise the deletion

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -75,20 +75,10 @@ var _ = SIGDescribe("LimitRange", func() {
 		framework.ExpectNoError(err, "failed to query for limitRanges")
 		framework.ExpectEqual(len(limitRanges.Items), 0)
 
-		listCompleted := make(chan bool, 1)
 		lw := &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.LabelSelector = selector.String()
 				limitRanges, err := f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).List(context.TODO(), options)
-				if err == nil {
-					select {
-					case listCompleted <- true:
-						framework.Logf("observed the limitRanges list")
-						return limitRanges, err
-					default:
-						framework.Logf("channel blocked")
-					}
-				}
 				return limitRanges, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
@@ -96,8 +86,14 @@ var _ = SIGDescribe("LimitRange", func() {
 				return f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Watch(context.TODO(), options)
 			},
 		}
-		_, _, w, _ := watchtools.NewIndexerInformerWatcher(lw, &v1.LimitRange{})
+		_, informer, w, _ := watchtools.NewIndexerInformerWatcher(lw, &v1.LimitRange{})
 		defer w.Stop()
+
+		ctx, cancelCtx := context.WithTimeout(context.TODO(), wait.ForeverTestTimeout)
+		defer cancelCtx()
+		if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+			framework.Failf("Timeout while waiting for LimitRange informer to sync")
+		}
 
 		ginkgo.By("Submitting a LimitRange")
 		limitRange, err = f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Create(context.TODO(), limitRange, metav1.CreateOptions{})
@@ -105,17 +101,12 @@ var _ = SIGDescribe("LimitRange", func() {
 
 		ginkgo.By("Verifying LimitRange creation was observed")
 		select {
-		case <-listCompleted:
-			select {
-			case event, _ := <-w.ResultChan():
-				if event.Type != watch.Added {
-					framework.Failf("Failed to observe limitRange creation : %v", event)
-				}
-			case <-time.After(e2eservice.RespondingTimeout):
-				framework.Failf("Timeout while waiting for LimitRange creation")
+		case event, _ := <-w.ResultChan():
+			if event.Type != watch.Added {
+				framework.Failf("Failed to observe limitRange creation : %v", event)
 			}
 		case <-time.After(e2eservice.RespondingTimeout):
-			framework.Failf("Timeout while waiting for LimitRange list complete")
+			framework.Failf("Timeout while waiting for LimitRange creation")
 		}
 
 		ginkgo.By("Fetching the LimitRange to ensure it has proper values")

--- a/test/integration/apimachinery/watch_restart_test.go
+++ b/test/integration/apimachinery/watch_restart_test.go
@@ -198,7 +198,12 @@ func TestWatchRestartsIfTimeoutNotReached(t *testing.T) {
 						return getWatchFunc(c, secret)(options)
 					},
 				}
-				_, _, w, done := watchtools.NewIndexerInformerWatcher(lw, &corev1.Secret{})
+				// there is an inherent race between a producer (generateEvents) and a consumer (the watcher) that needs to be solved here
+				// since the watcher is driven by an informer it is crucial to start producing only after the informer has synced
+				// otherwise we might not get all expected events since the informer LIST (or watchelist) and only then WATCHES
+				// all events received during the initial LIST (or watchlist) will be seen as a single event (to most recent version of an obj)
+				_, informer, w, done := watchtools.NewIndexerInformerWatcher(lw, &corev1.Secret{})
+				cache.WaitForCacheSync(context.TODO().Done(), informer.HasSynced)
 				return w, nil, func() { <-done }
 			},
 			normalizeOutputFunc: normalizeInformerOutputFunc(initialCount),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
previously users of this method were relying on the fact that a call to LIST was made.
Instead, users should use the dedicated `HasSynced` method.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
