### PR TITLE
modify link

### DIFF
--- a/test/e2e/storage/drivers/csi-test/mock/service/service.go
+++ b/test/e2e/storage/drivers/csi-test/mock/service/service.go
@@ -47,7 +47,7 @@ const (
 
 // Manifest is the SP's manifest.
 var Manifest = map[string]string{
-	"url": "https://k8s.io/kubernetes/test/e2e/storage/drivers/csi-test/mock",
+	"url": "https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/drivers/csi-test/mock",
 }
 
 type Config struct {


### PR DESCRIPTION
/kind cleanup

The url "https://k8s.io/kubernetes/test/e2e/storage/drivers/csi-test/mock" seems invalid.
I didn't find the part about '/test/e2e' from the k8s documentation.
Maybe it should be "https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/drivers/csi-test/mock" ?