### PR TITLE
[fix] fix and refactor TestValidateStatefulSet and TestValidateStatefulSet test cases

### DIFF
--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -33,6 +33,7 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
 )
@@ -1405,7 +1406,7 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 			testCase.old.ObjectMeta.ResourceVersion = "1"
 			testCase.update.ObjectMeta.ResourceVersion = "1"
 
-			errs := ValidateStatefulSetUpdate(&testCase.update, &testCase.old)
+			errs := ValidateStatefulSetUpdate(&testCase.update, &testCase.old, apivalidation.PodValidationOptions{})
 			wantErrs := testCase.errs
 			if diff := cmp.Diff(wantErrs, errs, cmpOpts...); diff != "" {
 				t.Errorf("Unexpected validation errors (-want,+got):\n%s", diff)

--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -206,7 +206,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Required(field.NewPath("metadata", "name"), ""),
 			},
 		},
 		{
@@ -221,7 +221,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Required(field.NewPath("metadata", "namespace"), ""),
 			},
 		},
 		{
@@ -235,7 +235,8 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Required(field.NewPath("spec", "selector"), ""),
+				field.Invalid(field.NewPath("spec", "template", "metadata", "labels"), nil, ""),
 			},
 		},
 		{
@@ -250,7 +251,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("spec", "template", "metadata", "labels"), nil, ""),
 			},
 		},
 		{
@@ -264,7 +265,8 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("spec", "template", "metadata", "labels"), nil, ""),
+				field.NotSupported(field.NewPath("spec", "template", "spec", "restartPolicy"), nil, nil),
 			},
 		},
 		{
@@ -279,7 +281,9 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("spec", "replicas"), nil, ""),
+				field.Invalid(field.NewPath("spec", "template", "metadata", "labels"), nil, ""),
+				field.NotSupported(field.NewPath("spec", "template", "spec", "restartPolicy"), nil, nil),
 			},
 		},
 		{
@@ -300,7 +304,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("metadata", "labels"), nil, ""),
 			},
 		},
 		{
@@ -320,7 +324,10 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("metadata", "labels"), nil, ""),
+				field.Required(field.NewPath("spec", "selector"), ""),
+				field.Invalid(field.NewPath("spec", "template", "labels"), nil, ""),
+				field.Invalid(field.NewPath("spec", "template", "metadata", "labels"), nil, ""),
 			},
 		},
 		{
@@ -341,7 +348,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("metadata", "annotations"), nil, ""),
 			},
 		},
 		{
@@ -368,7 +375,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.NotSupported(field.NewPath("spec", "template", "spec", "restartPolicy"), nil, nil),
 			},
 		},
 		{
@@ -395,7 +402,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.NotSupported(field.NewPath("spec", "template", "spec", "restartPolicy"), nil, nil),
 			},
 		},
 		{
@@ -411,7 +418,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("spec", "updateStrategy"), nil, ""),
 			},
 		},
 		{
@@ -427,7 +434,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Required(field.NewPath("spec", "updateStrategy"), ""),
 			},
 		},
 		{
@@ -446,7 +453,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("spec", "updateStrategy", "rollingUpdate"), nil, ""),
 			},
 		},
 		{
@@ -465,7 +472,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("spec", "updateStrategy", "rollingUpdate", "partition"), nil, ""),
 			},
 		},
 		{
@@ -481,7 +488,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Required(field.NewPath("spec", "podManagementPolicy"), ""),
 			},
 		},
 		{
@@ -497,7 +504,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("spec", "podManagementPolicy"), nil, ""),
 			},
 		},
 		{
@@ -513,7 +520,10 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("spec", "podManagementPolicy"), nil, ""),
+				field.Invalid(field.NewPath("spec", "template", "metadata", "labels"), nil, ""),
+				field.Forbidden(field.NewPath("spec", "template", "spec", "activeDeadlineSeconds"), ""),
+				field.NotSupported(field.NewPath("spec", "template", "spec", "restartPolicy"), nil, nil),
 			},
 		},
 		{
@@ -529,7 +539,8 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.NotSupported(field.NewPath("spec", "persistentVolumeClaimRetentionPolicy", "whenDeleted"), nil, nil),
+				field.NotSupported(field.NewPath("spec", "persistentVolumeClaimRetentionPolicy", "whenScaled"), nil, nil),
 			},
 		},
 		{
@@ -547,7 +558,8 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.NotSupported(field.NewPath("spec", "persistentVolumeClaimRetentionPolicy", "whenDeleted"), nil, nil),
+				field.NotSupported(field.NewPath("spec", "persistentVolumeClaimRetentionPolicy", "whenScaled"), nil, nil),
 			},
 		},
 		{
@@ -568,7 +580,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("spec", "updateStrategy", "rollingUpdate", "maxUnavailable"), nil, ""),
 			},
 		},
 		{
@@ -589,7 +601,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("spec", "updateStrategy", "rollingUpdate", "maxUnavailable"), nil, ""),
 			},
 		},
 		{
@@ -610,7 +622,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("spec", "updateStrategy", "rollingUpdate", "maxUnavailable"), nil, ""),
 			},
 		},
 	}
@@ -1080,7 +1092,8 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("metadata", "name"), nil, ""),
+				field.Forbidden(field.NewPath("spec"), ""),
 			},
 		},
 		{
@@ -1102,9 +1115,9 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 					UpdateStrategy: apps.StatefulSetUpdateStrategy{Type: apps.RollingUpdateStatefulSetStrategyType},
 				},
 			},
-			errs: field.ErrorList{
-				nil, // to be filled
-			},
+			// this case doesn't return any errors after doing
+			// testCase.old.ObjectMeta.ResourceVersion = "1"
+			// testCase.update.ObjectMeta.ResourceVersion = "1"
 		},
 		{
 			name: "invalid pod creation policy",
@@ -1127,7 +1140,7 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Forbidden(field.NewPath("spec"), ""),
 			},
 		},
 		{
@@ -1151,7 +1164,8 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("metadata", "name"), nil, ""),
+				field.Forbidden(field.NewPath("spec"), ""),
 			},
 		},
 		{
@@ -1175,7 +1189,8 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Invalid(field.NewPath("metadata", "name"), nil, ""),
+				field.Forbidden(field.NewPath("spec"), ""),
 			},
 		},
 		{
@@ -1198,7 +1213,8 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				nil, // to be filled
+				field.Forbidden(field.NewPath("spec"), ""),
+				field.Invalid(field.NewPath("spec", "replicas"), nil, ""),
 			},
 		},
 	}

--- a/pkg/registry/apps/statefulset/strategy.go
+++ b/pkg/registry/apps/statefulset/strategy.go
@@ -173,9 +173,7 @@ func (statefulSetStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.
 	oldStatefulSet := old.(*apps.StatefulSet)
 
 	opts := pod.GetValidationOptionsFromPodTemplate(&newStatefulSet.Spec.Template, &oldStatefulSet.Spec.Template)
-	validationErrorList := validation.ValidateStatefulSet(newStatefulSet, opts)
-	updateErrorList := validation.ValidateStatefulSetUpdate(newStatefulSet, oldStatefulSet)
-	return append(validationErrorList, updateErrorList...)
+	return validation.ValidateStatefulSetUpdate(newStatefulSet, oldStatefulSet, opts)
 }
 
 // WarningsOnUpdate returns warnings for the given update.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

bug
test false positive

#### What this PR does / why we need it:

Fixing a false positive in the `/apis/apps` validation test suite

#### Special notes for your reviewer:

I tried adding a new error case to [TestValidateStatefulSetUpdate](https://github.com/kubernetes/kubernetes/blob/9ac6b3af5f2015530627d3362e35712393fb6887/pkg/apis/apps/validation/validation_test.go#L751) for a different feature I'm working on.  
I then discovered that all the test cases in `errorCases` succeed by default because we don't set the `ResourceVersion` like we do for the `successCases` https://github.com/kubernetes/kubernetes/blob/9ac6b3af5f2015530627d3362e35712393fb6887/pkg/apis/apps/validation/validation_test.go#L916-L917

After setting `ResourceVersion` for `errorCases`, I found out that the `empty pod creation policy` fails because there is no validation on the pod creation policy being empty (or nil). I'm not sure if that's something that's wanted. If so, I can return the test and implement the appropriate validation. Please let me know

Does this PR introduce a user-facing change?
```
NONE
```

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
```

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

## Edit

* As part of @soltysh's suggestions, I'm now validating that the expected errors are returned (not only that there are errors) (see a31cbb5fb4d05ca8f188c557134d1fbe63816a68 and 62f7f55bfc9d52be98fb4f9f505d2edfa3f6f2f1) and I've also cleaned up some of the tests in `TestValidateStatefulSet` to make sure that one test case doesn't test too many things at once (e.g. a test that's called `invalid labels` shouldn't also test that `restartPolicy` is validated) (see b2a2ec8130ca0de62c75d843143b855a3bae9130) and cleaned up tests in `TestValidateStatefulSetUpdate` to make sure that it only tests validation of allowed/disallowed transitions (e.g. testing that changing the number of replica is allowed and changing PVC template isn't. not testing stuff like invalid labels that are already covered by `TestValidateStatefulSet`).
* As part of @liggitt suggestions, I've changed the commit history to make the changes more clear and I've modified `ValidateStatefulSetUpdate` to also validate that the new Statefulset is valid so that `stategy.go#ValidateUpdate` only has to call `ValidateStatefulSetUpdate`