### PR TITLE
Reduce number of repetitions and pods in TestPreemptionRaces

### DIFF
--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -834,8 +834,8 @@ func TestPreemptionRaces(t *testing.T) {
 			// after preemption and while the higher priority pods is not scheduled yet.
 			name:              "ensures that other pods are not scheduled while preemptor is being marked as nominated (issue #72124)",
 			numInitialPods:    2,
-			numAdditionalPods: 50,
-			numRepetitions:    10,
+			numAdditionalPods: 20,
+			numRepetitions:    5,
 			preemptor: initPausePod(&pausePodConfig{
 				Name:      "preemptor-pod",
 				Namespace: testCtx.NS.Name,


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This test is very old and has fulfilled its purpose. We don't need such amount of load now.

#### Which issue(s) this PR fixes:

Part of #109783

#### Special notes for your reviewer:

I couldn't find other tests that have unnecessary load or that recreate the control plane unnecessarily.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
