### PR TITLE
Fix OpenAPI loading error caused by empty APIService

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -61,11 +61,11 @@ func IsLocalAPIService(apiServiceName string) bool {
 	return strings.HasPrefix(apiServiceName, localDelegateChainNamePrefix)
 }
 
-// GetAPIServicesName returns the names of APIServices recorded in specAggregator.openAPISpecs.
+// GetAPIServiceNames returns the names of APIServices recorded in specAggregator.openAPISpecs.
 // We use this function to pass the names of local APIServices to the controller in this package,
 // so that the controller can periodically sync the OpenAPI spec from delegation API servers.
 func (s *specAggregator) GetAPIServiceNames() []string {
-	names := make([]string, len(s.openAPISpecs))
+	names := make([]string, 0, len(s.openAPISpecs))
 	for key := range s.openAPISpecs {
 		names = append(names, key)
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator.go
@@ -57,14 +57,14 @@ func IsLocalAPIService(apiServiceName string) bool {
 	return strings.HasPrefix(apiServiceName, localDelegateChainNamePrefix)
 }
 
-// GetAPIServicesName returns the names of APIServices recorded in apiServiceInfo.
+// GetAPIServiceNames returns the names of APIServices recorded in apiServiceInfo.
 // We use this function to pass the names of local APIServices to the controller in this package,
 // so that the controller can periodically sync the OpenAPI spec from delegation API servers.
 func (s *specProxier) GetAPIServiceNames() []string {
 	s.rwMutex.RLock()
 	defer s.rwMutex.RUnlock()
 
-	names := make([]string, len(s.apiServiceInfo))
+	names := make([]string, 0, len(s.apiServiceInfo))
 	for key := range s.apiServiceInfo {
 		names = append(names, key)
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator_test.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/mux"
 	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -117,6 +119,9 @@ func TestV2APIService(t *testing.T) {
 	if bytes.Compare(gotSpecJSON, expectedV3Bytes) != 0 {
 		t.Errorf("Spec mismatch, expected %s, got %s", expectedV3Bytes, gotSpecJSON)
 	}
+
+	apiServiceNames := specProxier.GetAPIServiceNames()
+	assert.ElementsMatch(t, []string{openAPIV2Converter, apiService.Name}, apiServiceNames)
 }
 
 func TestV3APIService(t *testing.T) {
@@ -156,6 +161,9 @@ func TestV3APIService(t *testing.T) {
 	if bytes.Compare(gotSpecJSON, specJSON) != 0 {
 		t.Errorf("Spec mismatch, expected %s, got %s", specJSON, gotSpecJSON)
 	}
+
+	apiServiceNames := specProxier.GetAPIServiceNames()
+	assert.ElementsMatch(t, []string{openAPIV2Converter, apiService.Name}, apiServiceNames)
 }
 
 func sendReq(t *testing.T, handler http.Handler, path string) []byte {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

SpecAggregator's GetAPIServiceNames method returned empty APIService name by mistake, causing OpenAPI controller handling an invalid APIService continuously:

```
# kubectl -n kube-system logs kube-apiserver-control-plane -f |grep "^E"
E0505 17:09:58.347623       1 controller.go:113] loading OpenAPI spec for "" failed with: APIService  does not exist for update
E0505 17:10:58.348592       1 controller.go:113] loading OpenAPI spec for "" failed with: APIService  does not exist for update
E0505 17:12:58.349038       1 controller.go:113] loading OpenAPI spec for "" failed with: APIService  does not exist for update
E0505 17:16:58.350123       1 controller.go:113] loading OpenAPI spec for "" failed with: APIService  does not exist for update
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
