### PR TITLE
Define NoOptDefVal for validate flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -407,6 +407,8 @@ func AddValidateFlags(cmd *cobra.Command) {
 		"warn" will warn about unknown or duplicate fields without blocking the request if server-side field validation is enabled on the API server, and behave as "ignore" otherwise.
 		"false" or "ignore" will not perform any schema validation, silently dropping any unknown or duplicate fields.`,
 	)
+
+	cmd.Flags().Lookup("validate").NoOptDefVal = "strict"
 }
 
 func AddFilenameOptionFlags(cmd *cobra.Command, options *resource.FilenameOptions, usage string) {
@@ -584,6 +586,8 @@ func GetValidationDirective(cmd *cobra.Command) (string, error) {
 	b, err := strconv.ParseBool(validateFlag)
 	if err != nil {
 		switch validateFlag {
+		case "":
+			return metav1.FieldValidationStrict, nil
 		case cmd.Flag("validate").NoOptDefVal:
 			return metav1.FieldValidationStrict, nil
 		case "strict":

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -586,10 +586,6 @@ func GetValidationDirective(cmd *cobra.Command) (string, error) {
 	b, err := strconv.ParseBool(validateFlag)
 	if err != nil {
 		switch validateFlag {
-		case "":
-			return metav1.FieldValidationStrict, nil
-		case cmd.Flag("validate").NoOptDefVal:
-			return metav1.FieldValidationStrict, nil
 		case "strict":
 			return metav1.FieldValidationStrict, nil
 		case "warn":

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
@@ -517,7 +517,9 @@ func TestGetValidationDirective(t *testing.T) {
 	for _, tc := range tests {
 		cmd := &cobra.Command{}
 		AddValidateFlags(cmd)
-		cmd.Flags().Set("validate", tc.validateFlag)
+		if tc.validateFlag != "" {
+			cmd.Flags().Set("validate", tc.validateFlag)
+		}
 		directive, err := GetValidationDirective(cmd)
 		if directive != tc.expectedDirective {
 			t.Errorf("validation directive, expected: %v, but got: %v", tc.expectedDirective, directive)

--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -170,6 +170,12 @@ run_kubectl_create_validate_tests() {
 
   create_and_use_new_namespace
 
+   ## test --validate no value expects default strict is used
+   kube::log::status "Testing kubectl create --validate"
+   # create and verify
+   output_message=$(! kubectl create -f hack/testdata/invalid-deployment-unknown-and-duplicate-fields.yaml --validate 2>&1)
+   has_one_of_error_message "${output_message}" 'strict decoding error' 'error validating data'
+
   ## test --validate=true
   kube::log::status "Testing kubectl create --validate=true"
   # create and verify


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
validate flag does not have default value defined when there is no
parameter passed, therefore it tries to use next irrelevant flag.

This PR defines NoOptDefVal for validate flag which is set "strict".

#### Which issue(s) this PR fixes:
Fixes [#1211](https://github.com/kubernetes/kubectl/issues/1211)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```