### PR TITLE
do not skip DownwardAPIHugePages

### DIFF
--- a/test/e2e/common/node/downwardapi.go
+++ b/test/e2e/common/node/downwardapi.go
@@ -23,10 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enetwork "k8s.io/kubernetes/test/e2e/framework/network"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -292,10 +290,6 @@ var _ = SIGDescribe("Downward API [Serial] [Disruptive] [NodeFeature:DownwardAPI
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.Context("Downward API tests for hugepages", func() {
-		ginkgo.BeforeEach(func() {
-			e2eskipper.SkipUnlessFeatureGateEnabled(kubefeatures.DownwardAPIHugePages)
-		})
-
 		ginkgo.It("should provide container's limits.hugepages-<pagesize> and requests.hugepages-<pagesize> as env vars", func() {
 			podName := "downward-api-" + string(uuid.NewUUID())
 			env := []v1.EnvVar{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
To fix https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache/1522104838224089088, this is caused by https://github.com/kubernetes/kubernetes/pull/109649
/cc pohly SergeyKanzhelev

#### Which issue(s) this PR fixes:
Fixes #109882

#### Special notes for your reviewer:
https://storage.googleapis.com/k8s-triage/index.html#46c6ebec3f62ee000cb3 ci-cri-containerd-e2e-cos-gce-serial
https://storage.googleapis.com/k8s-triage/index.html#16ae3f774c3255733716 ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache ci-kubernetes-e2e-gci-gce-serial-kube-dns

- https://github.com/kubernetes/test-infra/pull/26210#issuecomment-1118732221

#### Does this PR introduce a user-facing change?
```release-note
None
```
