### PR TITLE
add verify-licenses.sh to the EXCLUDED_PATTERNS in make-rules/verify.sh

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -35,6 +35,7 @@ EXCLUDED_PATTERNS=(
   "verify-linkcheck.sh"          # runs in separate Jenkins job once per day due to high network usage
   "verify-*-dockerized.sh"       # Don't run any scripts that intended to be run dockerized
   "verify-govet-levee.sh"        # Do not run levee analysis by default while KEP-1933 implementation is in alpha.
+  "verify-licenses.sh"           # runs in a separate job to monitor availability of the dependencies periodically
   )
 
 # Exclude generated-files-remake in certain cases, if they're running in a separate job.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR adds `hack/verify-licenses.sh` utility script under the `EXCLUDED_PATTERNS` in the `make-rules/verify.sh` file.

Since we are adding a [separate periodic job](https://github.com/kubernetes/test-infra/pull/26220) for running `verify-licenses.sh` script, this PR will exclude the script from running as part of the umbrella `pull-kubernetes-verify` pre-submit job.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

