### PR TITLE
Automated cherry pick of #109836: Fix OpenAPI loading error caused by empty APIService

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -61,11 +61,11 @@ func IsLocalAPIService(apiServiceName string) bool {
 	return strings.HasPrefix(apiServiceName, localDelegateChainNamePrefix)
 }
 
-// GetAPIServicesName returns the names of APIServices recorded in specAggregator.openAPISpecs.
+// GetAPIServiceNames returns the names of APIServices recorded in specAggregator.openAPISpecs.
 // We use this function to pass the names of local APIServices to the controller in this package,
 // so that the controller can periodically sync the OpenAPI spec from delegation API servers.
 func (s *specAggregator) GetAPIServiceNames() []string {
-	names := make([]string, len(s.openAPISpecs))
+	names := make([]string, 0, len(s.openAPISpecs))
 	for key := range s.openAPISpecs {
 		names = append(names, key)
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator.go
@@ -57,14 +57,14 @@ func IsLocalAPIService(apiServiceName string) bool {
 	return strings.HasPrefix(apiServiceName, localDelegateChainNamePrefix)
 }
 
-// GetAPIServicesName returns the names of APIServices recorded in apiServiceInfo.
+// GetAPIServiceNames returns the names of APIServices recorded in apiServiceInfo.
 // We use this function to pass the names of local APIServices to the controller in this package,
 // so that the controller can periodically sync the OpenAPI spec from delegation API servers.
 func (s *specProxier) GetAPIServiceNames() []string {
 	s.rwMutex.RLock()
 	defer s.rwMutex.RUnlock()
 
-	names := make([]string, len(s.apiServiceInfo))
+	names := make([]string, 0, len(s.apiServiceInfo))
 	for key := range s.apiServiceInfo {
 		names = append(names, key)
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator_test.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/mux"
 	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -117,6 +119,9 @@ func TestV2APIService(t *testing.T) {
 	if bytes.Compare(gotSpecJSON, expectedV3Bytes) != 0 {
 		t.Errorf("Spec mismatch, expected %s, got %s", expectedV3Bytes, gotSpecJSON)
 	}
+
+	apiServiceNames := specProxier.GetAPIServiceNames()
+	assert.ElementsMatch(t, []string{openAPIV2Converter, apiService.Name}, apiServiceNames)
 }
 
 func TestV3APIService(t *testing.T) {
@@ -156,6 +161,9 @@ func TestV3APIService(t *testing.T) {
 	if bytes.Compare(gotSpecJSON, specJSON) != 0 {
 		t.Errorf("Spec mismatch, expected %s, got %s", specJSON, gotSpecJSON)
 	}
+
+	apiServiceNames := specProxier.GetAPIServiceNames()
+	assert.ElementsMatch(t, []string{openAPIV2Converter, apiService.Name}, apiServiceNames)
 }
 
 func sendReq(t *testing.T, handler http.Handler, path string) []byte {


### PR DESCRIPTION
Cherry pick of #109836 on release-1.24.

#109836: Fix OpenAPI loading error caused by empty APIService

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```