### PR TITLE
Automated cherry pick of #109836: Fix OpenAPI loading error caused by empty APIService

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -61,11 +61,11 @@ func IsLocalAPIService(apiServiceName string) bool {
 	return strings.HasPrefix(apiServiceName, localDelegateChainNamePrefix)
 }
 
-// GetAPIServicesName returns the names of APIServices recorded in specAggregator.openAPISpecs.
+// GetAPIServiceNames returns the names of APIServices recorded in specAggregator.openAPISpecs.
 // We use this function to pass the names of local APIServices to the controller in this package,
 // so that the controller can periodically sync the OpenAPI spec from delegation API servers.
 func (s *specAggregator) GetAPIServiceNames() []string {
-	names := make([]string, len(s.openAPISpecs))
+	names := make([]string, 0, len(s.openAPISpecs))
 	for key := range s.openAPISpecs {
 		names = append(names, key)
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator.go
@@ -53,14 +53,14 @@ func IsLocalAPIService(apiServiceName string) bool {
 	return strings.HasPrefix(apiServiceName, localDelegateChainNamePrefix)
 }
 
-// GetAPIServicesName returns the names of APIServices recorded in openAPIV3Specs.
+// GetAPIServiceNames returns the names of APIServices recorded in openAPIV3Specs.
 // We use this function to pass the names of local APIServices to the controller in this package,
 // so that the controller can periodically sync the OpenAPI spec from delegation API servers.
 func (s *specAggregator) GetAPIServiceNames() []string {
 	s.rwMutex.Lock()
 	defer s.rwMutex.Unlock()
 
-	names := make([]string, len(s.openAPIV3Specs))
+	names := make([]string, 0, len(s.openAPIV3Specs))
 	for key := range s.openAPIV3Specs {
 		names = append(names, key)
 	}


### PR DESCRIPTION
Cherry pick of #109836 on release-1.23.

#109836: Fix OpenAPI loading error caused by empty APIService

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```