### PR TITLE
Remove warning log for crd merging

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/merge_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/merge_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+func TestMergeSpecV3(t *testing.T) {
+	tests := []struct {
+		name     string
+		specs    []*spec3.OpenAPI
+		expected *spec3.OpenAPI
+	}{
+		{
+			name: "oneCRD",
+			specs: []*spec3.OpenAPI{{
+				Paths: &spec3.Paths{
+					Paths: map[string]*spec3.Path{
+						"/apis/stable.example.com/v1/crd1": {},
+					},
+				},
+				Components: &spec3.Components{
+					Schemas: map[string]*spec.Schema{
+						"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {},
+					},
+				},
+			},
+			},
+			expected: &spec3.OpenAPI{
+				Paths: &spec3.Paths{
+					Paths: map[string]*spec3.Path{
+						"/apis/stable.example.com/v1/crd1": {},
+					},
+				},
+				Components: &spec3.Components{
+					Schemas: map[string]*spec.Schema{
+						"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {},
+					},
+				},
+			},
+		},
+		{
+			name: "two CRDs same gv",
+			specs: []*spec3.OpenAPI{{
+				Paths: &spec3.Paths{
+					Paths: map[string]*spec3.Path{
+						"/apis/stable.example.com/v1/crd1": {},
+					},
+				},
+				Components: &spec3.Components{
+					Schemas: map[string]*spec.Schema{
+						"com.example.stable.v1.CRD1": {},
+
+						"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {},
+					},
+				},
+			},
+				{
+					Paths: &spec3.Paths{
+						Paths: map[string]*spec3.Path{
+							"/apis/stable.example.com/v1/crd2": {},
+						},
+					},
+					Components: &spec3.Components{
+						Schemas: map[string]*spec.Schema{
+							"com.example.stable.v1.CRD2":                      {},
+							"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {},
+						},
+					},
+				},
+			},
+			expected: &spec3.OpenAPI{
+				Paths: &spec3.Paths{
+					Paths: map[string]*spec3.Path{
+						"/apis/stable.example.com/v1/crd1": {},
+						"/apis/stable.example.com/v1/crd2": {},
+					},
+				},
+				Components: &spec3.Components{
+					Schemas: map[string]*spec.Schema{
+						"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {},
+						"com.example.stable.v1.CRD1":                      {},
+						"com.example.stable.v1.CRD2":                      {},
+					},
+				},
+			},
+		},
+		{
+			name: "two CRDs with scale",
+			specs: []*spec3.OpenAPI{{
+				Paths: &spec3.Paths{
+					Paths: map[string]*spec3.Path{
+						"/apis/stable.example.com/v1/crd1": {},
+					},
+				},
+				Components: &spec3.Components{
+					Schemas: map[string]*spec.Schema{
+						"com.example.stable.v1.CRD1": {},
+
+						"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {},
+						"io.k8s.api.autoscaling.v1.Scale":                 {},
+					},
+				},
+			},
+				{
+					Paths: &spec3.Paths{
+						Paths: map[string]*spec3.Path{
+							"/apis/stable.example.com/v1/crd2": {},
+						},
+					},
+					Components: &spec3.Components{
+						Schemas: map[string]*spec.Schema{
+							"com.example.stable.v1.CRD2":                      {},
+							"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {},
+							"io.k8s.api.autoscaling.v1.Scale":                 {},
+						},
+					},
+				},
+			},
+			expected: &spec3.OpenAPI{
+				Paths: &spec3.Paths{
+					Paths: map[string]*spec3.Path{
+						"/apis/stable.example.com/v1/crd1": {},
+						"/apis/stable.example.com/v1/crd2": {},
+					},
+				},
+				Components: &spec3.Components{
+					Schemas: map[string]*spec.Schema{
+						"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {},
+						"com.example.stable.v1.CRD1":                      {},
+						"com.example.stable.v1.CRD2":                      {},
+						"io.k8s.api.autoscaling.v1.Scale":                 {},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			merged, err := MergeSpecsV3(tt.specs...)
+			if err != nil {
+				t.Error(err)
+			}
+			if !reflect.DeepEqual(merged, tt.expected) {
+				t.Error("Merged spec is different from expected spec")
+			}
+
+		})
+	}
+}

--- a/test/integration/apiserver/openapi/openapi_merge_test.go
+++ b/test/integration/apiserver/openapi/openapi_merge_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapi
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/dynamic"
+	kubernetes "k8s.io/client-go/kubernetes"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kube-openapi/pkg/spec3"
+	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+const scaleSchemaName = "io.k8s.api.autoscaling.v1.Scale"
+const statusSchemaName = "io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+const objectMetaSchemaName = "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+
+func TestOpenAPIV3MultipleCRDsSameGV(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.OpenAPIV3, true)()
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.TearDownFn()
+	config := server.ClientConfig
+
+	apiExtensionClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fooWithSubresourceCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foosubs.cr.bar.com",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "cr.bar.com",
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "foosubs",
+				Kind:   "FooSub",
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer",
+										},
+									},
+								},
+								"status": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer",
+										},
+									},
+								},
+							},
+						},
+					},
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+						Scale: &apiextensionsv1.CustomResourceSubresourceScale{
+							SpecReplicasPath:   ".spec.replicas",
+							StatusReplicasPath: ".status.replicas",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	bazWithSubresourceCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bazsubs.cr.bar.com",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "cr.bar.com",
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "bazsubs",
+				Kind:   "BazSub",
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer",
+										},
+									},
+								},
+								"status": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer",
+										},
+									},
+								},
+							},
+						},
+					},
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+						Scale: &apiextensionsv1.CustomResourceSubresourceScale{
+							SpecReplicasPath:   ".spec.replicas",
+							StatusReplicasPath: ".status.replicas",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(fooWithSubresourceCRD, apiExtensionClient, dynamicClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(bazWithSubresourceCRD, apiExtensionClient, dynamicClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// It takes a second for CRD specs to propagate to the aggregator
+	time.Sleep(4 * time.Second)
+
+	jsonData, err := clientset.RESTClient().Get().AbsPath("/openapi/v3/apis/cr.bar.com/v1").Do(context.TODO()).Raw()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	openAPISpec := spec3.OpenAPI{}
+	err = json.Unmarshal(jsonData, &openAPISpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure both CRD schemas are present in the OpenAPI
+	// Scale, status, and metadata dependencies must also be present
+	assert.Contains(t, openAPISpec.Components.Schemas, scaleSchemaName)
+	assert.Contains(t, openAPISpec.Components.Schemas, statusSchemaName)
+	assert.Contains(t, openAPISpec.Components.Schemas, objectMetaSchemaName)
+	assert.Contains(t, openAPISpec.Components.Schemas, "com.bar.cr.v1.BazSub")
+	assert.Contains(t, openAPISpec.Components.Schemas, "com.bar.cr.v1.FooSub")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Remove warning log for merging in OpenAPI V3. There should be no conflicts when merging CRDs since the naming controller would prevent it. (https://github.com/Jefftree/kubernetes/blob/86da34b54a6678a404098569a424c1932f427411/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/merge.go#L104) Referenced resources like ObjectMeta should be on the same version since the apiextensions server serves all CRDs. (https://github.com/Jefftree/kubernetes/blob/86da34b54a6678a404098569a424c1932f427411/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/merge.go#L95-L96)

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/109871

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix 1.24 regression causing spurious kube-apiserver log warnings related to openapi v3 merging when creating or modifying CustomResourceDefinition objects
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
