### PR TITLE
adjust default QPS of sched perf test

### DIFF
--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -85,8 +85,8 @@ func mustSetupScheduler(config *config.KubeSchedulerConfiguration) (util.Shutdow
 	cfg := &restclient.Config{
 		Host:          apiURL,
 		ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}},
-		QPS:           5000.0,
-		Burst:         5000,
+		QPS:           300.0,
+		Burst:         300,
 	}
 
 	// use default component config if config here is nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test
/sig scheduling

#### What this PR does / why we need it:

It doesn't make a log sense to make the default QPS for scheduler's perf test as 5000.

According to the scalability test, 300 is a reasonable value:

https://github.com/kubernetes/test-infra/blob/5f20e82ebae61f5c00247fde5386c435cf372257/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml#L117

Without these settings, PreemptionBasic/5000Nodes and PreemptionPVs/5000Nodes would throw a lot of "dial tcp XXXXX: connect: connection refused" errors, which would churn the scheduling cycles, and cause it to timeout to cause testing flakes.

#### Which issue(s) this PR fixes:

Part of #109881

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
