### PR TITLE
Fix discovery cache TTL to 6 hours

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -72,8 +72,8 @@ var (
 		rest of the resource.
 
 		After a CustomResourceDefinition is deleted, invalidation of discovery cache may take up
-		to 10 minutes. If you don't want to wait, you might want to run "kubectl api-resources"
-		to refresh the discovery cache.`))
+		to 6 hours. If you don't want to wait, you might want to run "kubectl api-resources" to refresh
+		the discovery cache.`))
 
 	deleteExample = templates.Examples(i18n.T(`
 		# Delete a pod using the type and name specified in pod.json

--- a/test/cmd/discovery.sh
+++ b/test/cmd/discovery.sh
@@ -110,7 +110,7 @@ run_crd_deletion_recreation_tests() {
   output_message=$(kubectl delete -f hack/testdata/CRD/example-crd-1-cluster-scoped.yaml)
   kube::test::if_has_string "${output_message}" 'deleted'
   # Invalidate local cache because cluster scoped CRD in cache is stale.
-  # Invalidation of cache may take up to 10 minutes and we are manually
+  # Invalidation of cache may take up to 6 hours and we are manually
   # invalidate cache and expect that scope changed CRD should be created without problem.
   kubectl api-resources
   output_message=$(kubectl apply -f hack/testdata/CRD/example-crd-1-namespaced.yaml)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

Since v1.24, discovery cache TTL has been changed from 10 minutes to 6 hours.

ref https://github.com/kubernetes/kubernetes/pull/107162, https://github.com/kubernetes/kubernetes/pull/107141

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
