### PR TITLE
storage/testing: move creation test to generic package

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -115,16 +115,11 @@ func TestCreate(t *testing.T) {
 	obj := &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", SelfLink: "testlink"}}
 
 	// verify that kv pair is empty before set
-	getResp, err := etcdClient.KV.Get(ctx, key)
-	if err != nil {
-		t.Fatalf("etcdClient.KV.Get failed: %v", err)
-	}
-	if len(getResp.Kvs) != 0 {
-		t.Fatalf("expecting empty result on key: %s", key)
+	if err := store.Get(ctx, key, storage.GetOptions{}, out); !storage.IsNotFound(err) {
+		t.Fatalf("expecting empty result on key %s, got %v", key, err)
 	}
 
-	err = store.Create(ctx, key, obj, out, 0)
-	if err != nil {
+	if err := store.Create(ctx, key, obj, out, 0); err != nil {
 		t.Fatalf("Set failed: %v", err)
 	}
 	// basic tests of the output

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -37,6 +37,35 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 )
 
+type KeyValidation func(ctx context.Context, t *testing.T, key string)
+
+func RunTestCreate(ctx context.Context, t *testing.T, store storage.Interface, validation KeyValidation) {
+	key := "/testkey"
+	out := &example.Pod{}
+	obj := &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", SelfLink: "testlink"}}
+
+	// verify that kv pair is empty before set
+	if err := store.Get(ctx, key, storage.GetOptions{}, out); !storage.IsNotFound(err) {
+		t.Fatalf("expecting empty result on key %s, got %v", key, err)
+	}
+
+	if err := store.Create(ctx, key, obj, out, 0); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+	// basic tests of the output
+	if obj.ObjectMeta.Name != out.ObjectMeta.Name {
+		t.Errorf("pod name want=%s, get=%s", obj.ObjectMeta.Name, out.ObjectMeta.Name)
+	}
+	if out.ResourceVersion == "" {
+		t.Errorf("output should have non-empty resource version")
+	}
+	if out.SelfLink != "" {
+		t.Errorf("output should have empty selfLink")
+	}
+
+	validation(ctx, t, key)
+}
+
 func RunTestCreateWithTTL(ctx context.Context, t *testing.T, store storage.Interface) {
 	input := &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 	key := "/somekey"


### PR DESCRIPTION
etcd3/store: update creation test to use storage client

There is no functional difference between checking for an empty key
using the database client and doing so with the storage interface. Using
the latter allows this test to be more portable.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

etcd3/store: make creation test validation generic

Different callers to this test may need to do different backend-specific
validation on the stored data, so we allow them a callback for this.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

storage/testing: move creation test to generic package

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


/kind cleanup
```release-note
NONE
```

```docs

```

/sig api-machinery
/assign @wojtek-t 
Part of https://github.com/kubernetes/kubernetes/issues/109831