### PR TITLE
storage/testing: move cancelled watch test to generic package

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -137,30 +137,7 @@ func TestWatchError(t *testing.T) {
 
 func TestWatchContextCancel(t *testing.T) {
 	ctx, store, _ := testSetup(t)
-	RunTestWatchContextCancel(ctx, t, store)
-}
-
-func RunTestWatchContextCancel(ctx context.Context, t *testing.T, store storage.Interface) {
-	canceledCtx, cancel := context.WithCancel(ctx)
-	cancel()
-	// When we watch with a canceled context, we should detect that it's context canceled.
-	// We won't take it as error and also close the watcher.
-	w, err := store.Watch(canceledCtx, "/abc", storage.ListOptions{
-		ResourceVersion:      "0",
-		Predicate:            storage.Everything,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	select {
-	case _, ok := <-w.ResultChan():
-		if ok {
-			t.Error("ResultChan() should be closed")
-		}
-	case <-time.After(wait.ForeverTestTimeout):
-		t.Errorf("timeout after %v", wait.ForeverTestTimeout)
-	}
+	storagetesting.RunTestWatchContextCancel(ctx, t, store)
 }
 
 func TestWatchErrResultNotBlockAfterCancel(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -137,6 +137,10 @@ func TestWatchError(t *testing.T) {
 
 func TestWatchContextCancel(t *testing.T) {
 	ctx, store, _ := testSetup(t)
+	RunTestWatchContextCancel(ctx, t, store)
+}
+
+func RunTestWatchContextCancel(ctx context.Context, t *testing.T, store storage.Interface) {
 	canceledCtx, cancel := context.WithCancel(ctx)
 	cancel()
 	// When we watch with a canceled context, we should detect that it's context canceled.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -141,7 +141,10 @@ func TestWatchContextCancel(t *testing.T) {
 	cancel()
 	// When we watch with a canceled context, we should detect that it's context canceled.
 	// We won't take it as error and also close the watcher.
-	w, err := store.watcher.Watch(canceledCtx, "/abc", 0, false, false, storage.Everything)
+	w, err := store.Watch(canceledCtx, "/abc", storage.ListOptions{
+		ResourceVersion:      "0",
+		Predicate:            storage.Everything,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
etcd3/store: update cancelled watch test to be generic

There's no reason to create the watch using the underlying watcher.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

etcd3/store: call a generic cancelled watch test

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

storage/testing: move cancelled watch test to a generic spot

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


/kind cleanup

```release-note
NONE
```

```docs

```

/sig api-machinery
/assign @wojtek-t 
/cc @liggitt 
Part of https://github.com/kubernetes/kubernetes/issues/109831