### PR TITLE
node-perf: use tf-wide-deep:1.2

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -256,7 +256,7 @@ func initImageConfigs(list RegistryList) (map[int]Config, map[int]Config) {
 	configs[NginxNew] = Config{list.PromoterE2eRegistry, "nginx", "1.15-2"}
 	configs[NodePerfNpbEp] = Config{list.PromoterE2eRegistry, "node-perf/npb-ep", "1.2"}
 	configs[NodePerfNpbIs] = Config{list.PromoterE2eRegistry, "node-perf/npb-is", "1.2"}
-	configs[NodePerfTfWideDeep] = Config{list.PromoterE2eRegistry, "node-perf/tf-wide-deep", "1.1"}
+	configs[NodePerfTfWideDeep] = Config{list.PromoterE2eRegistry, "node-perf/tf-wide-deep", "1.2"}
 	configs[Nonewprivs] = Config{list.PromoterE2eRegistry, "nonewprivs", "1.3"}
 	configs[NonRoot] = Config{list.PromoterE2eRegistry, "nonroot", "1.2"}
 	// Pause - when these values are updated, also update cmd/kubelet/app/options/container_runtime.go


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Part of https://github.com/kubernetes/kubernetes/issues/109295

#### Special notes for your reviewer:

Image promoted in https://github.com/kubernetes/k8s.io/pull/3714

Image is already pullable:

```
[danielle@mimas danielle] $ docker pull k8s.gcr.io/e2e-test-images/node-perf/tf-wide-deep:1.2
1.2: Pulling from e2e-test-images/node-perf/tf-wide-deep
9e7a560784c8: Pull complete 
f106dd115c60: Pull complete 
9446cb1d83c6: Pull complete 
804ff02ace78: Pull complete 
6988844e83a1: Pull complete 
279d469298b0: Pull complete 
428947ba2479: Pull complete 
7868a1fff986: Pull complete 
69cd27dbc9cd: Pull complete 
4f4fb700ef54: Pull complete 
Digest: sha256:44d13eac1e70b9494b9ef8eee2932c80863a01812cdcc1dfff5d1d43d97a6816
Status: Downloaded newer image for k8s.gcr.io/e2e-test-images/node-perf/tf-wide-deep:1.2
k8s.gcr.io/e2e-test-images/node-perf/tf-wide-deep:1.2
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```