### PR TITLE
Add a new method to check ipvs modules via proc-fs

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -625,9 +625,15 @@ func (handle *LinuxKernelHandler) GetModules() ([]string, error) {
 	ipvsModules := utilipvs.GetRequiredIPVSModules(kernelVersion)
 
 	var bmods, lmods []string
+	
+	// ipvs can load required modules automatically and ipvs denpends on nf_conntrack
+	modulesFile, err := os.Open("/proc/net/ip_vs")
+	if err == nil {
+		return ipvsModules, nil
+	}
 
 	// Find out loaded kernel modules. If this is a full static kernel it will try to verify if the module is compiled using /boot/config-KERNELVERSION
-	modulesFile, err := os.Open("/proc/modules")
+	modulesFile, err = os.Open("/proc/modules")
 	if err == os.ErrNotExist {
 		klog.ErrorS(err, "Failed to read file /proc/modules, assuming this is a kernel without loadable modules support enabled")
 		kernelConfigFile := fmt.Sprintf("/boot/config-%s", kernelVersionStr)


### PR DESCRIPTION
What type of PR is this?

/kind feature

What this PR does / why we need it:

Add a new method to check ipvs modules via proc-fs.
It is not necessary to check each module, to a large extent, ipvs's modules are built entirely and can load its own module automatically.
Anyway it is hard to cover every environment, for example  kernel and modules are built-in, but no kernel config file, like ipvs proxyer runs in a container.
Check-up on running environment is better than check-up on specific files, it may introduce new dependency. So this patch take proc-fs into consideration.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:
Does this PR introduce a user-facing change?
No