### PR TITLE
build: Adds Windows kube-proxy image

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -107,21 +107,23 @@ readonly KUBE_APISERVER_BASE_IMAGE="${KUBE_APISERVER_BASE_IMAGE:-$KUBE_GORUNNER_
 readonly KUBE_CONTROLLER_MANAGER_BASE_IMAGE="${KUBE_CONTROLLER_MANAGER_BASE_IMAGE:-$KUBE_GORUNNER_IMAGE}"
 readonly KUBE_SCHEDULER_BASE_IMAGE="${KUBE_SCHEDULER_BASE_IMAGE:-$KUBE_GORUNNER_IMAGE}"
 readonly KUBE_PROXY_BASE_IMAGE="${KUBE_PROXY_BASE_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/distroless-iptables:$__default_distroless_iptables_version}"
+readonly KUBE_PROXY_WINDOWS_BASE_IMAGE="${KUBE_PROXY_WINDOWS_BASE_IMAGE:-mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0}"
 readonly KUBECTL_BASE_IMAGE="${KUBECTL_BASE_IMAGE:-$KUBE_GORUNNER_IMAGE}"
 
 # This is the image used in a multi-stage build to apply capabilities to Docker-wrapped binaries.
 readonly KUBE_BUILD_SETCAP_IMAGE="${KUBE_BUILD_SETCAP_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/setcap:$__default_setcap_version}"
 
-# Get the set of master binaries that run in Docker (on Linux)
+# Get the set of master binaries that run in Docker (on Linux), or as Host Process Containers (on Windows).
 # Entry format is "<binary-name>,<base-image>".
-# Binaries are placed in /usr/local/bin inside the image.
+# Binaries are placed in /usr/local/bin inside the image (Linux), or C:\hpc (Windows).
 # `make` users can override any or all of the base images using the associated
 # environment variables.
 #
-# $1 - server architecture
+# $1 - OS name - the targets returned will be based on the OS name given.
 kube::build::get_docker_wrapped_binaries() {
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets
+  local os_name="${1:-}"
   local targets=(
     "kube-apiserver,${KUBE_APISERVER_BASE_IMAGE}"
     "kube-controller-manager,${KUBE_CONTROLLER_MANAGER_BASE_IMAGE}"
@@ -129,6 +131,11 @@ kube::build::get_docker_wrapped_binaries() {
     "kube-proxy,${KUBE_PROXY_BASE_IMAGE}"
     "kubectl,${KUBECTL_BASE_IMAGE}"
   )
+  if [[ "${os_name}" = "windows" ]]; then
+    targets=(
+      "kube-proxy.exe,${KUBE_PROXY_WINDOWS_BASE_IMAGE}"
+    )
+  fi
 
   echo "${targets[@]}"
 }

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -29,6 +29,7 @@ readonly RELEASE_TARS="${LOCAL_OUTPUT_ROOT}/release-tars"
 readonly RELEASE_IMAGES="${LOCAL_OUTPUT_ROOT}/release-images"
 
 KUBE_BUILD_CONFORMANCE=${KUBE_BUILD_CONFORMANCE:-n}
+KUBE_BUILD_WINDOWS=${KUBE_BUILD_WINDOWS:-n}
 KUBE_BUILD_PULL_LATEST_IMAGES=${KUBE_BUILD_PULL_LATEST_IMAGES:-y}
 
 # ---------------------------------------------------------------------------
@@ -146,7 +147,7 @@ function kube::release::package_node_tarballs() {
       "${release_stage}/node/bin/"
 
     # TODO: Docker images here
-    # kube::release::create_docker_images_for_server "${release_stage}/server/bin" "${arch}"
+    # kube::release::create_docker_images_for_server "${release_stage}/server/bin" "${arch}" "${os}"
 
     # Include the client binaries here too as they are useful debugging tools.
     local client_bins=("${KUBE_CLIENT_BINARIES[@]}")
@@ -173,14 +174,24 @@ function kube::release::package_node_tarballs() {
 # Package up all of the server binaries in docker images
 function kube::release::build_server_images() {
   kube::util::ensure-docker-buildx
+  docker buildx create --name img-builder --use || true
+  docker buildx inspect --bootstrap
+  kube::util::trap_add 'docker buildx rm' EXIT
+
+  platforms=("${KUBE_SERVER_PLATFORMS[@]}")
+  if [[ "${KUBE_BUILD_WINDOWS}" =~ [yY] ]]; then
+    platforms=("${KUBE_SERVER_PLATFORMS[@]}" "windows/amd64")
+  fi
 
   # Clean out any old images
   rm -rf "${RELEASE_IMAGES}"
   local platform
-  for platform in "${KUBE_SERVER_PLATFORMS[@]}"; do
+  for platform in "${platforms[@]}"; do
     local platform_tag
+    local os
     local arch
     platform_tag=${platform/\//-} # Replace a "/" for a "-"
+    os=$(dirname "${platform}")
     arch=$(basename "${platform}")
     kube::log::status "Building images: $platform_tag"
 
@@ -191,11 +202,16 @@ function kube::release::build_server_images() {
 
     # This fancy expression will expand to prepend a path
     # (${LOCAL_OUTPUT_BINPATH}/${platform}/) to every item in the
-    # KUBE_SERVER_IMAGE_BINARIES array.
-    cp "${KUBE_SERVER_IMAGE_BINARIES[@]/#/${LOCAL_OUTPUT_BINPATH}/${platform}/}" \
-      "${release_stage}/server/bin/"
+    # KUBE_SERVER_LINUX_IMAGE_BINARIES / KUBE_SERVER_WINDOWS_IMAGE_BINARIES array.
+    if [[ "${os}" = "windows" ]]; then
+      cp "${KUBE_SERVER_WINDOWS_IMAGE_BINARIES[@]/#/${LOCAL_OUTPUT_BINPATH}/${platform}/}" \
+        "${release_stage}/server/bin/"
+    else
+      cp "${KUBE_SERVER_LINUX_IMAGE_BINARIES[@]/#/${LOCAL_OUTPUT_BINPATH}/${platform}/}" \
+        "${release_stage}/server/bin/"
+    fi
 
-    kube::release::create_docker_images_for_server "${release_stage}/server/bin" "${arch}"
+    kube::release::create_docker_images_for_server "${release_stage}/server/bin" "${arch}" "${os}"
   done
 }
 
@@ -283,16 +299,19 @@ function kube::release::build_conformance_image() {
 # Args:
 #  $1 - binary_dir, the directory to save the tared images to.
 #  $2 - arch, architecture for which we are building docker images.
+#  $3 - os, the OS for which we are building docker images.
 function kube::release::create_docker_images_for_server() {
   # Create a sub-shell so that we don't pollute the outer environment
   (
     local binary_dir
+    local os
     local arch
     local binaries
     local images_dir
     binary_dir="$1"
     arch="$2"
-    binaries=$(kube::build::get_docker_wrapped_binaries)
+    os="${3:-linux}"
+    binaries=$(kube::build::get_docker_wrapped_binaries "${os}")
     images_dir="${RELEASE_IMAGES}/${arch}"
     mkdir -p "${images_dir}"
 
@@ -318,51 +337,65 @@ function kube::release::create_docker_images_for_server() {
 
     for wrappable in $binaries; do
 
-      local binary_name=${wrappable%%,*}
+      # The full binary name might have a file extension (.exe).
+      local full_binary_name=${wrappable%%,*}
+      local binary_name=${full_binary_name%%.*}
       local base_image=${wrappable##*,}
-      local binary_file_path="${binary_dir}/${binary_name}"
+      local binary_file_path="${binary_dir}/${full_binary_name}"
+      local tar_path="${binary_dir}/${full_binary_name}.tar"
       local docker_build_path="${binary_file_path}.dockerbuild"
       local docker_image_tag="${docker_registry}/${binary_name}-${arch}:${docker_tag}"
 
       local docker_file_path="${KUBE_ROOT}/build/server-image/Dockerfile"
       # If this binary has its own Dockerfile use that else use the generic Dockerfile.
-      if [[ -f "${KUBE_ROOT}/build/server-image/${binary_name}/Dockerfile" ]]; then
+      if [[ "${os}" = "windows" && -f "${KUBE_ROOT}/build/server-image/${binary_name}/Dockerfile_windows" ]]; then
+          docker_file_path="${KUBE_ROOT}/build/server-image/${binary_name}/Dockerfile_windows"
+      elif [[ -f "${KUBE_ROOT}/build/server-image/${binary_name}/Dockerfile" ]]; then
           docker_file_path="${KUBE_ROOT}/build/server-image/${binary_name}/Dockerfile"
       fi
 
-      kube::log::status "Starting docker build for image: ${binary_name}-${arch}"
+      kube::log::status "Starting docker build for image: ${binary_name}-${os}-${arch}"
       (
         rm -rf "${docker_build_path}"
         mkdir -p "${docker_build_path}"
-        ln "${binary_file_path}" "${docker_build_path}/${binary_name}"
+        ln "${binary_file_path}" "${docker_build_path}/${full_binary_name}"
+
+        # If we are building an official/alpha/beta release we want to keep
+        # docker images and tag them appropriately.
+        local additional_tag=()
+        local release_docker_image_tag="${KUBE_DOCKER_REGISTRY-$docker_registry}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG-$docker_tag}"
+
+	# append the OS name only for Windows images into the image name.
+        if [[ "${os}" = "windows" ]]; then
+          docker_image_tag="${docker_registry}/${binary_name}-${os}-${arch}:${docker_tag}"
+          release_docker_image_tag="${KUBE_DOCKER_REGISTRY-$docker_registry}/${binary_name}-${os}-${arch}:${KUBE_DOCKER_IMAGE_TAG-$docker_tag}"
+	fi
+
+        if [[ "${release_docker_image_tag}" != "${docker_image_tag}" ]]; then
+          kube::log::status "Adding additional tag ${release_docker_image_tag} for docker image ${docker_image_tag}"
+          "${DOCKER[@]}" rmi "${release_docker_image_tag}" 2>/dev/null || true
+          additional_tag=("-t" "${release_docker_image_tag}")
+        fi
 
         local build_log="${docker_build_path}/build.log"
         if ! DOCKER_CLI_EXPERIMENTAL=enabled "${DOCKER[@]}" buildx build \
           -f "${docker_file_path}" \
-          --platform linux/"${arch}" \
-          --load ${docker_build_opts:+"${docker_build_opts}"} \
-          -t "${docker_image_tag}" \
+          --platform "${os}/${arch}" \
+          --output type=docker,dest="${tar_path}" \
+          ${docker_build_opts:+"${docker_build_opts}"} \
+          -t "${docker_image_tag}" "${additional_tag[@]}" \
           --build-arg BASEIMAGE="${base_image}" \
           --build-arg SETCAP_IMAGE="${KUBE_BUILD_SETCAP_IMAGE}" \
-          --build-arg BINARY="${binary_name}" \
+          --build-arg BINARY="${full_binary_name}" \
           "${docker_build_path}" >"${build_log}" 2>&1; then
             cat "${build_log}"
             exit 1
         fi
         rm "${build_log}"
 
-        # If we are building an official/alpha/beta release we want to keep
-        # docker images and tag them appropriately.
-        local -r release_docker_image_tag="${KUBE_DOCKER_REGISTRY-$docker_registry}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG-$docker_tag}"
-        if [[ "${release_docker_image_tag}" != "${docker_image_tag}" ]]; then
-          kube::log::status "Tagging docker image ${docker_image_tag} as ${release_docker_image_tag}"
-          "${DOCKER[@]}" rmi "${release_docker_image_tag}" 2>/dev/null || true
-          "${DOCKER[@]}" tag "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
-        fi
-        "${DOCKER[@]}" save -o "${binary_file_path}.tar" "${docker_image_tag}" "${release_docker_image_tag}"
         echo "${docker_tag}" > "${binary_file_path}.docker_tag"
         rm -rf "${docker_build_path}"
-        ln "${binary_file_path}.tar" "${images_dir}/"
+        ln "${tar_path}" "${images_dir}/"
 
         kube::log::status "Deleting docker image ${docker_image_tag}"
         "${DOCKER[@]}" rmi "${docker_image_tag}" &>/dev/null || true

--- a/build/release-images.sh
+++ b/build/release-images.sh
@@ -39,6 +39,10 @@ kube::build::verify_prereqs
 kube::build::build_image
 kube::build::run_build_command make all WHAT="${CMD_TARGETS}" KUBE_BUILD_PLATFORMS="${KUBE_SERVER_PLATFORMS[*]}" DBG="${DBG:-}"
 
+if [[ "${KUBE_BUILD_WINDOWS}" =~ [yY] ]]; then
+  kube::build::run_build_command make all WHAT="cmd/kube-proxy" KUBE_BUILD_PLATFORMS="windows/amd64"
+fi
+
 kube::build::copy_output
 
 kube::release::build_server_images

--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -384,6 +384,7 @@ define RELEASE_IMAGES_HELP_INFO
 # Args:
 #   KUBE_BUILD_CONFORMANCE: Whether to build conformance testing image as well. Set to 'n' to skip.
 #   DBG: If set to "1", build with optimizations disabled for easier debugging. Any other value is ignored.
+#   KUBE_BUILD_WINDOWS: Whether to build images for Windows as well. Set to 'y' to enable.
 #
 # Example:
 #   make release-images
@@ -433,6 +434,7 @@ define QUICK_RELEASE_IMAGES_HELP_INFO
 #   KUBE_FASTBUILD: Whether to cross-compile for other architectures. Set to 'false' to do so.
 #   KUBE_BUILD_CONFORMANCE: Whether to build conformance testing image as well. Set to 'y' to do so.
 #   DBG: If set to "1", build with optimizations disabled for easier debugging. Any other value is ignored.
+#   KUBE_BUILD_WINDOWS: Whether to build images for Windows as well. Set to 'y' to enable.
 #
 # Example:
 #   make quick-release-images

--- a/build/server-image/kube-proxy/Dockerfile_windows
+++ b/build/server-image/kube-proxy/Dockerfile_windows
@@ -1,0 +1,28 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile used for the server images.
+
+# Note that the image doesn't really matter for Windows Host Process containers
+# # the files in the image are copied to C:\hpc (containerd 1.7+) on the host
+# # but the file system is the Host, NOT the container
+ARG BASEIMAGE
+ARG BINARY
+
+FROM $BASEIMAGE
+
+ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;"
+COPY ${BINARY} /kube-proxy/${BINARY}
+
+ENTRYPOINT ["c:/hpc/kube-proxy/kube-proxy.exe"]

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -101,7 +101,8 @@ kube::golang::server_image_targets() {
 
 IFS=" " read -ra KUBE_SERVER_IMAGE_TARGETS <<< "$(kube::golang::server_image_targets)"
 readonly KUBE_SERVER_IMAGE_TARGETS
-readonly KUBE_SERVER_IMAGE_BINARIES=("${KUBE_SERVER_IMAGE_TARGETS[@]##*/}")
+readonly KUBE_SERVER_LINUX_IMAGE_BINARIES=("${KUBE_SERVER_IMAGE_TARGETS[@]##*/}")
+readonly KUBE_SERVER_WINDOWS_IMAGE_BINARIES=("kube-proxy.exe")
 
 # The set of conformance targets we build docker image for
 kube::golang::conformance_image_targets() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/sig windows

/kind feature

#### What this PR does / why we need it:

Adds the ``KUBE_BUILD_WINDOWS`` option to ``make release-images`` and ``quick-release-images``, which will allow it to build the a Windows kube-proxy image as well. That image can then be used with Windows Host Process Containers to start the kube-proxy service on Windows nodes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support for building Windows kube-proxy container image.
A container image for kube-proxy on Windows can now be built with the command
`make release-images KUBE_BUILD_WINDOWS=y`.
The Windows kube-proxy image can be used with Windows Host Process Containers.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
