### PR TITLE
Automated cherry pick of #109928: Fix ServiceIPStaticSubrange assigns duplicate IP addresses

### DIFF
--- a/pkg/registry/core/service/allocator/bitmap.go
+++ b/pkg/registry/core/service/allocator/bitmap.go
@@ -250,7 +250,7 @@ func (rss randomScanStrategyWithOffset) AllocateBit(allocated *big.Int, max, cou
 	for i := 0; i < rss.offset; i++ {
 		at := (start + i) % rss.offset
 		if allocated.Bit(at) == 0 {
-			return i, true
+			return at, true
 		}
 	}
 	return 0, false

--- a/pkg/registry/core/service/allocator/bitmap_test.go
+++ b/pkg/registry/core/service/allocator/bitmap_test.go
@@ -541,3 +541,27 @@ func TestPreAllocateReservedFull_BitmapReserved(t *testing.T) {
 		t.Errorf("expect to get %d, but got %d", max-1, f)
 	}
 }
+
+func TestAllocateUniqueness(t *testing.T) {
+	max := 128
+	dynamicOffset := 16
+	uniqueAllocated := map[int]bool{}
+	m := NewAllocationMapWithOffset(max, "test", dynamicOffset)
+
+	// Allocate all the values in both the dynamic and reserved blocks
+	for i := 0; i < max; i++ {
+		alloc, ok, _ := m.AllocateNext()
+		if !ok {
+			t.Fatalf("unexpected error")
+		}
+		if _, ok := uniqueAllocated[alloc]; ok {
+			t.Fatalf("unexpected allocated value %d", alloc)
+		} else {
+			uniqueAllocated[alloc] = true
+		}
+	}
+
+	if max != len(uniqueAllocated) {
+		t.Errorf("expect to get %d, but got %d", max, len(uniqueAllocated))
+	}
+}


### PR DESCRIPTION
Cherry pick of #109928 on release-1.24.

#109928: Fix ServiceIPStaticSubrange assigns duplicate IP addresses

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```