### PR TITLE
disruptioncontroller: check for scale subresource correctly

### DIFF
--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -666,6 +666,25 @@ func TestScaleFinderNoResource(t *testing.T) {
 			apiResources: []metav1.APIResource{
 				{
 					Kind: customGVK.Kind,
+					Name: resourceName + "/status",
+				},
+				{
+					Kind:    "Scale",
+					Group:   autoscalingapi.GroupName,
+					Version: "v1",
+					Name:    resourceName + "/scale",
+				},
+				{
+					Kind: customGVK.Kind,
+					Name: resourceName,
+				},
+			},
+			expectError: false,
+		},
+		"resource implements unsupported data format for scale subresource": {
+			apiResources: []metav1.APIResource{
+				{
+					Kind: customGVK.Kind,
 					Name: resourceName,
 				},
 				{
@@ -673,7 +692,7 @@ func TestScaleFinderNoResource(t *testing.T) {
 					Name: resourceName + "/scale",
 				},
 			},
-			expectError: false,
+			expectError: true,
 		},
 		"resource does not implement scale": {
 			apiResources: []metav1.APIResource{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Updates the logic which checks if a resource implements the scale subresource to look for the main resource first, then find the scale subresource from that, expecting an autoscaling/v1 Scale Kind rather than the main resource Kind.

Without this, core API types are listed as not supporting the Scale subresource when they in fact do.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially addresses #109954, in that it will not produce the incorrect error message that "replicasets.apps does not implement the scale subresource", however does not fix the cause of the race condition and an error will still occur after this PR.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
