### PR TITLE
authn: fix cache mutation by AuthenticatedGroupAdder

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/authenticated_group_adder.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/authenticated_group_adder.go
@@ -51,11 +51,16 @@ func (g *AuthenticatedGroupAdder) AuthenticateRequest(req *http.Request) (*authe
 		}
 	}
 
-	r.User = &user.DefaultInfo{
+	newGroups := make([]string, 0, len(r.User.GetGroups())+1)
+	newGroups = append(newGroups, r.User.GetGroups()...)
+	newGroups = append(newGroups, user.AllAuthenticated)
+
+	ret := *r // shallow copy
+	ret.User = &user.DefaultInfo{
 		Name:   r.User.GetName(),
 		UID:    r.User.GetUID(),
-		Groups: append(r.User.GetGroups(), user.AllAuthenticated),
+		Groups: newGroups,
 		Extra:  r.User.GetExtra(),
 	}
-	return r, true, nil
+	return &ret, true, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder.go
@@ -41,11 +41,17 @@ func (g *GroupAdder) AuthenticateRequest(req *http.Request) (*authenticator.Resp
 	if err != nil || !ok {
 		return nil, ok, err
 	}
-	r.User = &user.DefaultInfo{
+
+	newGroups := make([]string, 0, len(r.User.GetGroups())+len(g.Groups))
+	newGroups = append(newGroups, r.User.GetGroups()...)
+	newGroups = append(newGroups, g.Groups...)
+
+	ret := *r // shallow copy
+	ret.User = &user.DefaultInfo{
 		Name:   r.User.GetName(),
 		UID:    r.User.GetUID(),
-		Groups: append(r.User.GetGroups(), g.Groups...),
+		Groups: newGroups,
 		Extra:  r.User.GetExtra(),
 	}
-	return r, true, nil
+	return &ret, true, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/token_group_adder.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/token_group_adder.go
@@ -41,11 +41,17 @@ func (g *TokenGroupAdder) AuthenticateToken(ctx context.Context, token string) (
 	if err != nil || !ok {
 		return nil, ok, err
 	}
-	r.User = &user.DefaultInfo{
+
+	newGroups := make([]string, 0, len(r.User.GetGroups())+len(g.Groups))
+	newGroups = append(newGroups, r.User.GetGroups()...)
+	newGroups = append(newGroups, g.Groups...)
+
+	ret := *r // shallow copy
+	ret.User = &user.DefaultInfo{
 		Name:   r.User.GetName(),
 		UID:    r.User.GetUID(),
-		Groups: append(r.User.GetGroups(), g.Groups...),
+		Groups: newGroups,
 		Extra:  r.User.GetExtra(),
 	}
-	return r, true, nil
+	return &ret, true, nil
 }


### PR DESCRIPTION
The cached token authenticator returns a cache value. The group adder changes it.

```release-notes
Fix a data race in authentication between AuthenticatedGroupAdder and cached token authenticator.
```