### PR TITLE
Cleanup portallocator/ipallocator interfaces

### DIFF
--- a/pkg/registry/core/service/ipallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair_test.go
@@ -60,7 +60,7 @@ func TestRepair(t *testing.T) {
 	_, cidr, _ := netutils.ParseCIDRSloppy(ipregistry.item.Range)
 	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), cidr, ipregistry, nil, nil)
 
-	if err := r.RunOnce(); err != nil {
+	if err := r.runOnce(); err != nil {
 		t.Fatal(err)
 	}
 	if !ipregistry.updateCalled || ipregistry.updated == nil || ipregistry.updated.Range != cidr.String() || ipregistry.updated != ipregistry.item {
@@ -72,7 +72,7 @@ func TestRepair(t *testing.T) {
 		updateErr: fmt.Errorf("test error"),
 	}
 	r = NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), cidr, ipregistry, nil, nil)
-	if err := r.RunOnce(); !strings.Contains(err.Error(), ": test error") {
+	if err := r.runOnce(); !strings.Contains(err.Error(), ": test error") {
 		t.Fatal(err)
 	}
 }
@@ -105,7 +105,7 @@ func TestRepairLeak(t *testing.T) {
 	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), cidr, ipregistry, nil, nil)
 	// Run through the "leak detection holdoff" loops.
 	for i := 0; i < (numRepairsBeforeLeakCleanup - 1); i++ {
-		if err := r.RunOnce(); err != nil {
+		if err := r.runOnce(); err != nil {
 			t.Fatal(err)
 		}
 		after, err := ipallocator.NewFromSnapshot(ipregistry.updated)
@@ -117,7 +117,7 @@ func TestRepairLeak(t *testing.T) {
 		}
 	}
 	// Run one more time to actually remove the leak.
-	if err := r.RunOnce(); err != nil {
+	if err := r.runOnce(); err != nil {
 		t.Fatal(err)
 	}
 	after, err := ipallocator.NewFromSnapshot(ipregistry.updated)
@@ -201,7 +201,7 @@ func TestRepairWithExisting(t *testing.T) {
 		},
 	}
 	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), cidr, ipregistry, nil, nil)
-	if err := r.RunOnce(); err != nil {
+	if err := r.runOnce(); err != nil {
 		t.Fatal(err)
 	}
 	after, err := ipallocator.NewFromSnapshot(ipregistry.updated)
@@ -336,7 +336,7 @@ func TestRepairDualStack(t *testing.T) {
 	_, secondaryCIDR, _ := netutils.ParseCIDRSloppy(secondaryIPRegistry.item.Range)
 	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), cidr, ipregistry, secondaryCIDR, secondaryIPRegistry)
 
-	if err := r.RunOnce(); err != nil {
+	if err := r.runOnce(); err != nil {
 		t.Fatal(err)
 	}
 	if !ipregistry.updateCalled || ipregistry.updated == nil || ipregistry.updated.Range != cidr.String() || ipregistry.updated != ipregistry.item {
@@ -356,7 +356,7 @@ func TestRepairDualStack(t *testing.T) {
 	}
 
 	r = NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), cidr, ipregistry, secondaryCIDR, secondaryIPRegistry)
-	if err := r.RunOnce(); !strings.Contains(err.Error(), ": test error") {
+	if err := r.runOnce(); !strings.Contains(err.Error(), ": test error") {
 		t.Fatal(err)
 	}
 }
@@ -413,7 +413,7 @@ func TestRepairLeakDualStack(t *testing.T) {
 	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), cidr, ipregistry, secondaryCIDR, secondaryIPRegistry)
 	// Run through the "leak detection holdoff" loops.
 	for i := 0; i < (numRepairsBeforeLeakCleanup - 1); i++ {
-		if err := r.RunOnce(); err != nil {
+		if err := r.runOnce(); err != nil {
 			t.Fatal(err)
 		}
 		after, err := ipallocator.NewFromSnapshot(ipregistry.updated)
@@ -432,7 +432,7 @@ func TestRepairLeakDualStack(t *testing.T) {
 		}
 	}
 	// Run one more time to actually remove the leak.
-	if err := r.RunOnce(); err != nil {
+	if err := r.runOnce(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -597,7 +597,7 @@ func TestRepairWithExistingDualStack(t *testing.T) {
 	}
 
 	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), cidr, ipregistry, secondaryCIDR, secondaryIPRegistry)
-	if err := r.RunOnce(); err != nil {
+	if err := r.runOnce(); err != nil {
 		t.Fatal(err)
 	}
 	after, err := ipallocator.NewFromSnapshot(ipregistry.updated)

--- a/pkg/registry/core/service/portallocator/controller/repair.go
+++ b/pkg/registry/core/service/portallocator/controller/repair.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -71,27 +72,28 @@ func NewRepair(interval time.Duration, serviceClient corev1client.ServicesGetter
 	}
 }
 
-// Start starts events recording.
-func (c *Repair) Start(stopCh chan struct{}) {
-	c.broadcaster.StartRecordingToSink(stopCh)
-}
-
 // RunUntil starts the controller until the provided ch is closed.
-func (c *Repair) RunUntil(stopCh chan struct{}) {
-	wait.Until(func() {
-		if err := c.RunOnce(); err != nil {
-			runtime.HandleError(err)
-		}
-	}, c.interval, stopCh)
-}
+func (c *Repair) RunUntil(onFirstSuccess func(), stopCh chan struct{}) {
+	c.broadcaster.StartRecordingToSink(stopCh)
+	defer c.broadcaster.Shutdown()
 
-// RunOnce verifies the state of the port allocations and returns an error if an unrecoverable problem occurs.
-func (c *Repair) RunOnce() error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, c.runOnce)
+	var once sync.Once
+	wait.Until(func() {
+		if err := c.runOnce(); err != nil {
+			runtime.HandleError(err)
+			return
+		}
+		once.Do(onFirstSuccess)
+	}, c.interval, stopCh)
 }
 
 // runOnce verifies the state of the port allocations and returns an error if an unrecoverable problem occurs.
 func (c *Repair) runOnce() error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, c.doRunOnce)
+}
+
+// doRunOnce verifies the state of the port allocations and returns an error if an unrecoverable problem occurs.
+func (c *Repair) doRunOnce() error {
 	// TODO: (per smarterclayton) if Get() or ListServices() is a weak consistency read,
 	// or if they are executed against different leaders,
 	// the ordering guarantee required to ensure no port is allocated twice is violated.

--- a/pkg/registry/core/service/portallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/portallocator/controller/repair_test.go
@@ -60,7 +60,7 @@ func TestRepair(t *testing.T) {
 	pr, _ := net.ParsePortRange(registry.item.Range)
 	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), *pr, registry)
 
-	if err := r.RunOnce(); err != nil {
+	if err := r.runOnce(); err != nil {
 		t.Fatal(err)
 	}
 	if !registry.updateCalled || registry.updated == nil || registry.updated.Range != pr.String() || registry.updated != registry.item {
@@ -72,7 +72,7 @@ func TestRepair(t *testing.T) {
 		updateErr: fmt.Errorf("test error"),
 	}
 	r = NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), *pr, registry)
-	if err := r.RunOnce(); !strings.Contains(err.Error(), ": test error") {
+	if err := r.runOnce(); !strings.Contains(err.Error(), ": test error") {
 		t.Fatal(err)
 	}
 }
@@ -105,7 +105,7 @@ func TestRepairLeak(t *testing.T) {
 	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), *pr, registry)
 	// Run through the "leak detection holdoff" loops.
 	for i := 0; i < (numRepairsBeforeLeakCleanup - 1); i++ {
-		if err := r.RunOnce(); err != nil {
+		if err := r.runOnce(); err != nil {
 			t.Fatal(err)
 		}
 		after, err := portallocator.NewFromSnapshot(registry.updated)
@@ -117,7 +117,7 @@ func TestRepairLeak(t *testing.T) {
 		}
 	}
 	// Run one more time to actually remove the leak.
-	if err := r.RunOnce(); err != nil {
+	if err := r.runOnce(); err != nil {
 		t.Fatal(err)
 	}
 	after, err := portallocator.NewFromSnapshot(registry.updated)
@@ -191,7 +191,7 @@ func TestRepairWithExisting(t *testing.T) {
 		},
 	}
 	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), *pr, registry)
-	if err := r.RunOnce(); err != nil {
+	if err := r.runOnce(); err != nil {
 		t.Fatal(err)
 	}
 	after, err := portallocator.NewFromSnapshot(registry.updated)


### PR DESCRIPTION
Follow up from https://github.com/kubernetes/kubernetes/pull/109873

```release-note
NONE
```

/kind cleanup
/priority important-longerm
/sig network