### PR TITLE
Use typed ImageID for imageutils images

### DIFF
--- a/test/e2e/framework/pod/create.go
+++ b/test/e2e/framework/pod/create.go
@@ -28,11 +28,6 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
-var (
-	// BusyBoxImage is the image URI of BusyBox.
-	BusyBoxImage = imageutils.GetE2EImage(imageutils.BusyBox)
-)
-
 // Config is a struct containing all arguments for creating a pod.
 // SELinux testing requires to pass HostIPC and HostPID as boolean arguments.
 type Config struct {
@@ -47,7 +42,7 @@ type Config struct {
 	SeLinuxLabel           *v1.SELinuxOptions
 	FsGroup                *int64
 	NodeSelection          NodeSelection
-	ImageID                int
+	ImageID                imageutils.ImageID
 	PodFSGroupChangePolicy *v1.PodFSGroupChangePolicy
 }
 

--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -56,14 +56,14 @@ func GetDefaultTestImage() string {
 // If the node OS is windows, currently we return Agnhost image for Windows node
 // due to the issue of #https://github.com/kubernetes-sigs/windows-testing/pull/35.
 // If the node OS is linux, return busybox image
-func GetDefaultTestImageID() int {
+func GetDefaultTestImageID() imageutils.ImageID {
 	return GetTestImageID(imageutils.BusyBox)
 }
 
 // GetTestImage returns the image name with the given input
 // If the Node OS is windows, currently we return Agnhost image for Windows node
 // due to the issue of #https://github.com/kubernetes-sigs/windows-testing/pull/35.
-func GetTestImage(id int) string {
+func GetTestImage(id imageutils.ImageID) string {
 	if NodeOSDistroIs("windows") {
 		return imageutils.GetE2EImage(imageutils.Agnhost)
 	}
@@ -73,7 +73,7 @@ func GetTestImage(id int) string {
 // GetTestImageID returns the image id with the given input
 // If the Node OS is windows, currently we return Agnhost image for Windows node
 // due to the issue of #https://github.com/kubernetes-sigs/windows-testing/pull/35.
-func GetTestImageID(id int) int {
+func GetTestImageID(id imageutils.ImageID) imageutils.ImageID {
 	if NodeOSDistroIs("windows") {
 		return imageutils.Agnhost
 	}

--- a/test/utils/image/csi_manifest.go
+++ b/test/utils/image/csi_manifest.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/kubernetes/test/e2e/testing-manifests"
+	e2etestingmanifests "k8s.io/kubernetes/test/e2e/testing-manifests"
 )
 
 // All of the image tags are of the format k8s.gcr.io/sig-storage/hostpathplugin:v1.7.3.
@@ -33,11 +33,11 @@ var imageRE = regexp.MustCompile(`^(.*)/([^/:]*):(.*)$`)
 // appendCSIImageConfigs extracts image repo, name and version from
 // the YAML files under test/e2e/testing-manifests/storage-csi and
 // creates new config entries  for them.
-func appendCSIImageConfigs(configs map[int]Config) {
-	embeddedFS := testing_manifests.GetE2ETestingManifestsFS().EmbeddedFS
+func appendCSIImageConfigs(configs map[ImageID]Config) {
+	embeddedFS := e2etestingmanifests.GetE2ETestingManifestsFS().EmbeddedFS
 
-	// We add our images with index numbers that start after the highest existing number.
-	index := 0
+	// We add our images with ImageID numbers that start after the highest existing number.
+	index := ImageID(0)
 	for i := range configs {
 		if i > index {
 			index = i

--- a/test/utils/image/csi_manifests_test.go
+++ b/test/utils/image/csi_manifests_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCSIImageConfigs(t *testing.T) {
-	configs := map[int]Config{}
+	configs := map[ImageID]Config{}
 	appendCSIImageConfigs(configs)
 
 	// We expect at least one entry for each of these images. There may be

--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -163,8 +163,8 @@ func TestGetOriginalImageConfigs(t *testing.T) {
 }
 
 func TestGetMappedImageConfigs(t *testing.T) {
-	originals := map[int]Config{
-		0: {registry: "docker.io", name: "source/repo", version: "1.0"},
+	originals := map[ImageID]Config{
+		10: {registry: "docker.io", name: "source/repo", version: "1.0"},
 	}
 	mapping := GetMappedImageConfigs(originals, "quay.io/repo/for-test")
 
@@ -174,7 +174,7 @@ func TestGetMappedImageConfigs(t *testing.T) {
 		actual[source.GetE2EImage()] = mapping.GetE2EImage()
 	}
 	expected := map[string]string{
-		"docker.io/source/repo:1.0": "quay.io/repo/for-test:e2e-0-docker-io-source-repo-1-0-72R4aXm7YnxQ4_ek",
+		"docker.io/source/repo:1.0": "quay.io/repo/for-test:e2e-10-docker-io-source-repo-1-0-72R4aXm7YnxQ4_ek",
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatal(diff.ObjectReflectDiff(expected, actual))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add an `ImageID` type for the test imageutils images. Benefits: self documenting code, better static type checking support.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig testing