### PR TITLE
Correct errors in the netpol test suite

### DIFF
--- a/test/e2e/network/netpol/kubemanager.go
+++ b/test/e2e/network/netpol/kubemanager.go
@@ -179,7 +179,7 @@ func (k *kubeManager) createNamespace(ns *v1.Namespace) (*v1.Namespace, error) {
 	enforcePodSecurityBaseline(ns)
 	createdNamespace, err := k.clientSet.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to update namespace %s: %w", ns.Name, err)
+		return nil, fmt.Errorf("unable to create namespace %s: %w", ns.Name, err)
 	}
 	return createdNamespace, nil
 }
@@ -203,7 +203,7 @@ func (k *kubeManager) createPod(pod *v1.Pod) (*v1.Pod, error) {
 
 	createdPod, err := k.clientSet.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to update pod %s/%s: %w", ns, pod.Name, err)
+		return nil, fmt.Errorf("unable to create pod %s/%s: %w", ns, pod.Name, err)
 	}
 	return createdPod, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It was confusing to see message saying "unable to update pod" when it was actually trying to create a Pod.
```
May 10 10:33:14.733: unable to initialize resources
Unexpected error:
    <*fmt.wrapError | 0xc004370ce0>: {
        msg: "unable to update pod netpol-4938-x/a: pods \"a\" is forbidden: error looking up service account netpol-4938-x/default: serviceaccount \"default\" not found",
        err: {
            ErrStatus: {
                TypeMeta: {Kind: "", APIVersion: ""},
                ListMeta: {
                    SelfLink: "",
                    ResourceVersion: "",
                    Continue: "",
                    RemainingItemCount: nil,
                },
                Status: "Failure",
                Message: "pods \"a\" is forbidden: error looking up service account netpol-4938-x/default: serviceaccount \"default\" not found",
                Reason: "Forbidden",
                Details: {Name: "a", Group: "", Kind: "pods", UID: "", Causes: nil, RetryAfterSeconds: 0},
                Code: 403,
            },
        },
    }
    unable to update pod netpol-4938-x/a: pods "a" is forbidden: error looking up service account netpol-4938-x/default: serviceaccount "default" not found
occurred
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
