### PR TITLE
add print-manifest flag to print addon manifests to STDOUT

### DIFF
--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -145,4 +145,7 @@ const (
 
 	// Patches flag sets the folder where kubeadm component patches are stored
 	Patches = "patches"
+
+	// Print the addon manifests to STDOUT instead of installing them.
+	PrintManifest = "print-manifest"
 )

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy.go
@@ -19,6 +19,7 @@ package proxy
 import (
 	"bytes"
 	"fmt"
+	"io"
 
 	"github.com/pkg/errors"
 
@@ -27,6 +28,7 @@ import (
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kuberuntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientset "k8s.io/client-go/kubernetes"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 
@@ -47,58 +49,160 @@ const (
 )
 
 // EnsureProxyAddon creates the kube-proxy addons
-func EnsureProxyAddon(cfg *kubeadmapi.ClusterConfiguration, localEndpoint *kubeadmapi.APIEndpoint, client clientset.Interface) error {
-	if err := CreateServiceAccount(client); err != nil {
-		return errors.Wrap(err, "error when creating kube-proxy service account")
-	}
-
-	if err := createKubeProxyConfigMap(cfg, localEndpoint, client); err != nil {
+func EnsureProxyAddon(cfg *kubeadmapi.ClusterConfiguration, localEndpoint *kubeadmapi.APIEndpoint, client clientset.Interface, out io.Writer, printManifest bool) error {
+	cmByte, err := createKubeProxyConfigMap(cfg, localEndpoint, client, printManifest)
+	if err != nil {
 		return err
 	}
 
-	if err := createKubeProxyAddon(cfg, client); err != nil {
+	dsByte, err := createKubeProxyAddon(cfg, client, printManifest)
+	if err != nil {
 		return err
 	}
 
-	if err := CreateRBACRules(client); err != nil {
-		return errors.Wrap(err, "error when creating kube-proxy RBAC rules")
+	if err := printOrCreateKubeProxyObjects(cmByte, dsByte, client, out, printManifest); err != nil {
+		return err
 	}
 
-	fmt.Println("[addons] Applied essential addon: kube-proxy")
 	return nil
 }
 
-// CreateServiceAccount creates the necessary serviceaccounts that kubeadm uses/might use, if they don't already exist.
-func CreateServiceAccount(client clientset.Interface) error {
+// Create SA, RBACRules or print manifests of them to out if printManifest is true
+func printOrCreateKubeProxyObjects(cmByte []byte, dsByte []byte, client clientset.Interface, out io.Writer, printManifest bool) error {
+	var saBytes, crbBytes, roleBytes, roleBindingBytes []byte
+	var err error
 
-	return apiclient.CreateOrUpdateServiceAccount(client, &v1.ServiceAccount{
+	sa := &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      KubeProxyServiceAccountName,
 			Namespace: metav1.NamespaceSystem,
 		},
-	})
+	}
+
+	crb := &rbac.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.KubeProxyClusterRoleBindingName,
+		},
+		RoleRef: rbac.RoleRef{
+			APIGroup: rbac.GroupName,
+			Kind:     "ClusterRole",
+			Name:     constants.KubeProxyClusterRoleName,
+		},
+		Subjects: []rbac.Subject{
+			{
+				Kind:      rbac.ServiceAccountKind,
+				Name:      KubeProxyServiceAccountName,
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+	}
+
+	role := &rbac.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KubeProxyConfigMapRoleName,
+			Namespace: metav1.NamespaceSystem,
+		},
+		Rules: []rbac.PolicyRule{
+			{
+				Verbs:         []string{"get"},
+				APIGroups:     []string{""},
+				Resources:     []string{"configmaps"},
+				ResourceNames: []string{constants.KubeProxyConfigMap},
+			},
+		},
+	}
+
+	rb := &rbac.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KubeProxyConfigMapRoleName,
+			Namespace: metav1.NamespaceSystem,
+		},
+		RoleRef: rbac.RoleRef{
+			APIGroup: rbac.GroupName,
+			Kind:     "Role",
+			Name:     KubeProxyConfigMapRoleName,
+		},
+		Subjects: []rbac.Subject{
+			{
+				Kind: rbac.GroupKind,
+				Name: constants.NodeBootstrapTokenAuthGroup,
+			},
+		},
+	}
+
+	// Create the objects if printManifest is false
+	if !printManifest {
+		if err := apiclient.CreateOrUpdateServiceAccount(client, sa); err != nil {
+			return errors.Wrap(err, "error when creating kube-proxy service account")
+		}
+
+		if err := apiclient.CreateOrUpdateClusterRoleBinding(client, crb); err != nil {
+			return err
+		}
+
+		if err := apiclient.CreateOrUpdateRole(client, role); err != nil {
+			return err
+		}
+
+		if err := apiclient.CreateOrUpdateRoleBinding(client, rb); err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out, "[addons] Applied essential addon: kube-proxy")
+
+		return nil
+
+	}
+
+	gv := schema.GroupVersion{Group: "", Version: "v1"}
+	if saBytes, err = kubeadmutil.MarshalToYaml(sa, gv); err != nil {
+		return err
+	}
+
+	gv = schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1"}
+	if crbBytes, err = kubeadmutil.MarshalToYaml(crb, gv); err != nil {
+		return err
+	}
+
+	if roleBytes, err = kubeadmutil.MarshalToYaml(role, gv); err != nil {
+		return err
+	}
+
+	if roleBindingBytes, err = kubeadmutil.MarshalToYaml(rb, gv); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, "---")
+	fmt.Fprintf(out, "%s", saBytes)
+	fmt.Fprintln(out, "---")
+	fmt.Fprintf(out, "%s", crbBytes)
+	fmt.Fprintln(out, "---")
+	fmt.Fprintf(out, "%s", roleBytes)
+	fmt.Fprintln(out, "---")
+	fmt.Fprintf(out, "%s", roleBindingBytes)
+	fmt.Fprint(out, "---")
+	fmt.Fprintf(out, "%s", cmByte)
+	fmt.Fprint(out, "---")
+	fmt.Fprintf(out, "%s", dsByte)
+
+	return nil
 }
 
-// CreateRBACRules creates the essential RBAC rules for a minimally set-up cluster
-func CreateRBACRules(client clientset.Interface) error {
-	return createClusterRoleBindings(client)
-}
-
-func createKubeProxyConfigMap(cfg *kubeadmapi.ClusterConfiguration, localEndpoint *kubeadmapi.APIEndpoint, client clientset.Interface) error {
+func createKubeProxyConfigMap(cfg *kubeadmapi.ClusterConfiguration, localEndpoint *kubeadmapi.APIEndpoint, client clientset.Interface, printManifest bool) ([]byte, error) {
 	// Generate ControlPlane Enpoint kubeconfig file
 	controlPlaneEndpoint, err := kubeadmutil.GetControlPlaneEndpoint(cfg.ControlPlaneEndpoint, localEndpoint)
 	if err != nil {
-		return err
+		return []byte(""), err
 	}
 
 	kubeProxyCfg, ok := cfg.ComponentConfigs[componentconfigs.KubeProxyGroup]
 	if !ok {
-		return errors.New("no kube-proxy component config found in the active component config set")
+		return []byte(""), errors.New("no kube-proxy component config found in the active component config set")
 	}
 
 	proxyBytes, err := kubeProxyCfg.Marshal()
 	if err != nil {
-		return errors.Wrap(err, "error when marshaling")
+		return []byte(""), errors.Wrap(err, "error when marshaling")
 	}
 	var prefixBytes bytes.Buffer
 	apiclient.PrintBytesWithLinePrefix(&prefixBytes, proxyBytes, "    ")
@@ -115,12 +219,16 @@ func createKubeProxyConfigMap(cfg *kubeadmapi.ClusterConfiguration, localEndpoin
 			ProxyConfigMapKey:    constants.KubeProxyConfigMapKey,
 		})
 	if err != nil {
-		return errors.Wrap(err, "error when parsing kube-proxy configmap template")
+		return []byte(""), errors.Wrap(err, "error when parsing kube-proxy configmap template")
+	}
+
+	if printManifest {
+		return configMapBytes, nil
 	}
 
 	kubeproxyConfigMap := &v1.ConfigMap{}
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), configMapBytes, kubeproxyConfigMap); err != nil {
-		return errors.Wrap(err, "unable to decode kube-proxy configmap")
+		return []byte(""), errors.Wrap(err, "unable to decode kube-proxy configmap")
 	}
 
 	if !kubeProxyCfg.IsUserSupplied() {
@@ -128,86 +236,31 @@ func createKubeProxyConfigMap(cfg *kubeadmapi.ClusterConfiguration, localEndpoin
 	}
 
 	// Create the ConfigMap for kube-proxy or update it in case it already exists
-	return apiclient.CreateOrUpdateConfigMap(client, kubeproxyConfigMap)
+	return []byte(""), apiclient.CreateOrUpdateConfigMap(client, kubeproxyConfigMap)
 }
 
-func createKubeProxyAddon(cfg *kubeadmapi.ClusterConfiguration, client clientset.Interface) error {
+func createKubeProxyAddon(cfg *kubeadmapi.ClusterConfiguration, client clientset.Interface, printManifest bool) ([]byte, error) {
 	daemonSetbytes, err := kubeadmutil.ParseTemplate(KubeProxyDaemonSet19, struct{ Image, ProxyConfigMap, ProxyConfigMapKey string }{
 		Image:             images.GetKubernetesImage(constants.KubeProxy, cfg),
 		ProxyConfigMap:    constants.KubeProxyConfigMap,
 		ProxyConfigMapKey: constants.KubeProxyConfigMapKey,
 	})
 	if err != nil {
-		return errors.Wrap(err, "error when parsing kube-proxy daemonset template")
+		return []byte(""), errors.Wrap(err, "error when parsing kube-proxy daemonset template")
+	}
+
+	if printManifest {
+		return daemonSetbytes, nil
 	}
 
 	kubeproxyDaemonSet := &apps.DaemonSet{}
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), daemonSetbytes, kubeproxyDaemonSet); err != nil {
-		return errors.Wrap(err, "unable to decode kube-proxy daemonset")
+		return []byte(""), errors.Wrap(err, "unable to decode kube-proxy daemonset")
 	}
 	// Propagate the http/https proxy host environment variables to the container
 	env := &kubeproxyDaemonSet.Spec.Template.Spec.Containers[0].Env
 	*env = append(*env, kubeadmutil.GetProxyEnvVars()...)
 
 	// Create the DaemonSet for kube-proxy or update it in case it already exists
-	return apiclient.CreateOrUpdateDaemonSet(client, kubeproxyDaemonSet)
-}
-
-func createClusterRoleBindings(client clientset.Interface) error {
-	if err := apiclient.CreateOrUpdateClusterRoleBinding(client, &rbac.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: constants.KubeProxyClusterRoleBindingName,
-		},
-		RoleRef: rbac.RoleRef{
-			APIGroup: rbac.GroupName,
-			Kind:     "ClusterRole",
-			Name:     constants.KubeProxyClusterRoleName,
-		},
-		Subjects: []rbac.Subject{
-			{
-				Kind:      rbac.ServiceAccountKind,
-				Name:      KubeProxyServiceAccountName,
-				Namespace: metav1.NamespaceSystem,
-			},
-		},
-	}); err != nil {
-		return err
-	}
-
-	// Create a role for granting read only access to the kube-proxy component config ConfigMap
-	if err := apiclient.CreateOrUpdateRole(client, &rbac.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      KubeProxyConfigMapRoleName,
-			Namespace: metav1.NamespaceSystem,
-		},
-		Rules: []rbac.PolicyRule{
-			{
-				Verbs:         []string{"get"},
-				APIGroups:     []string{""},
-				Resources:     []string{"configmaps"},
-				ResourceNames: []string{constants.KubeProxyConfigMap},
-			},
-		},
-	}); err != nil {
-		return err
-	}
-
-	// Bind the role to bootstrap tokens for allowing fetchConfiguration during join
-	return apiclient.CreateOrUpdateRoleBinding(client, &rbac.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      KubeProxyConfigMapRoleName,
-			Namespace: metav1.NamespaceSystem,
-		},
-		RoleRef: rbac.RoleRef{
-			APIGroup: rbac.GroupName,
-			Kind:     "Role",
-			Name:     KubeProxyConfigMapRoleName,
-		},
-		Subjects: []rbac.Subject{
-			{
-				Kind: rbac.GroupKind,
-				Name: constants.NodeBootstrapTokenAuthGroup,
-			},
-		},
-	})
+	return []byte(""), apiclient.CreateOrUpdateDaemonSet(client, kubeproxyDaemonSet)
 }

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -128,7 +128,7 @@ func PerformPostUpgradeTasks(client clientset.Interface, cfg *kubeadmapi.InitCon
 			metav1.NamespaceSystem)
 	} else {
 		// Upgrade CoreDNS
-		if err := dns.EnsureDNSAddon(&cfg.ClusterConfiguration, client); err != nil {
+		if err := dns.EnsureDNSAddon(&cfg.ClusterConfiguration, client, out, false); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -151,7 +151,7 @@ func PerformPostUpgradeTasks(client clientset.Interface, cfg *kubeadmapi.InitCon
 			metav1.NamespaceSystem)
 	} else {
 		// Upgrade kube-proxy
-		if err := proxy.EnsureProxyAddon(&cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, client); err != nil {
+		if err := proxy.EnsureProxyAddon(&cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, client, out, false); err != nil {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: wangyysde <net_use@bzhy.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 It can be useful to allow kubeadm users to skip addons but still be able to obtain the addon manifests that kubeadm will apply for version X. This PR add print-manifest flag to support printing addon manifests to STDOUT.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#2681

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: add support for the flag "--print-manifest" to the addon phases "kube-proxy" and "coredns" of "kubeadm init phase addon". If this flag is used kubeadm will not apply a given addon and instead print to the terminal the API objects that will be applied.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
