### PR TITLE
don't skip Feature:EphemeralStorage based on skipper

### DIFF
--- a/test/e2e/common/storage/downwardapi.go
+++ b/test/e2e/common/storage/downwardapi.go
@@ -23,24 +23,18 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo"
 )
 
-var _ = SIGDescribe("Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage]", func() {
+var _ = SIGDescribe("Downward API [Serial] [Disruptive] [Feature:EphemeralStorage]", func() {
 	f := framework.NewDefaultFramework("downward-api")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.Context("Downward API tests for local ephemeral storage", func() {
-		ginkgo.BeforeEach(func() {
-			e2eskipper.SkipUnlessFeatureGateEnabled(kubefeatures.LocalStorageCapacityIsolation)
-		})
-
 		ginkgo.It("should provide container's limits.ephemeral-storage and requests.ephemeral-storage as env vars", func() {
 			podName := "downward-api-" + string(uuid.NewUUID())
 			env := []v1.EnvVar{


### PR DESCRIPTION

/kind failing-test
```release-note
NONE
```
Tests are permenently failing https://testgrid.k8s.io/sig-network-gce#gci-gce-serial

```
{ Failure test/e2e/common/node/downwardapi.go:295
May 10 00:32:23.552: Feature gate checking is not enabled, don't use SkipUnlessFeatureGateEnabled(DownwardAPIHugePages). Instead use the Feature tag.
test/e2e/common/node/downwardapi.go:296}
```

Skippers are not the way to go for e2e :smile: 