### PR TITLE
Add new flags into alpha events

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/events/event_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/events/event_printer.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/duration"
+)
+
+// EventPrinter stores required fields to be used for
+// default printing for events command.
+type EventPrinter struct {
+	NoHeaders     bool
+	AllNamespaces bool
+
+	headersPrinted bool
+}
+
+// PrintObj prints different type of event objects.
+func (ep *EventPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
+	if !ep.NoHeaders && !ep.headersPrinted {
+		ep.printHeadings(out)
+		ep.headersPrinted = true
+	}
+
+	switch t := obj.(type) {
+	case *corev1.EventList:
+		for _, e := range t.Items {
+			ep.printOneEvent(out, e)
+		}
+	case *corev1.Event:
+		ep.printOneEvent(out, *t)
+	default:
+		return fmt.Errorf("unknown event type %t", t)
+	}
+
+	return nil
+}
+
+func (ep *EventPrinter) printHeadings(w io.Writer) {
+	if ep.AllNamespaces {
+		fmt.Fprintf(w, "NAMESPACE\t")
+	}
+	fmt.Fprintf(w, "LAST SEEN\tTYPE\tREASON\tOBJECT\tMESSAGE\n")
+}
+
+func (ep *EventPrinter) printOneEvent(w io.Writer, e corev1.Event) {
+	interval := getInterval(e)
+	if ep.AllNamespaces {
+		fmt.Fprintf(w, "%v\t", e.Namespace)
+	}
+	fmt.Fprintf(w, "%s\t%s\t%s\t%s/%s\t%v\n",
+		interval,
+		e.Type,
+		e.Reason,
+		e.InvolvedObject.Kind, e.InvolvedObject.Name,
+		strings.TrimSpace(e.Message),
+	)
+}
+
+func getInterval(e corev1.Event) string {
+	var interval string
+	firstTimestampSince := translateMicroTimestampSince(e.EventTime)
+	if e.EventTime.IsZero() {
+		firstTimestampSince = translateTimestampSince(e.FirstTimestamp)
+	}
+	if e.Series != nil {
+		interval = fmt.Sprintf("%s (x%d over %s)", translateMicroTimestampSince(e.Series.LastObservedTime), e.Series.Count, firstTimestampSince)
+	} else if e.Count > 1 {
+		interval = fmt.Sprintf("%s (x%d over %s)", translateTimestampSince(e.LastTimestamp), e.Count, firstTimestampSince)
+	} else {
+		interval = firstTimestampSince
+	}
+
+	return interval
+}
+
+// translateMicroTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateMicroTimestampSince(timestamp metav1.MicroTime) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+// translateTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateTimestampSince(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+func NewEventPrinter(noHeader, allNamespaces bool) *EventPrinter {
+	return &EventPrinter{
+		NoHeaders:     noHeader,
+		AllNamespaces: allNamespaces,
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/events/event_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/events/event_printer_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"bytes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
+	"time"
+)
+
+func TestPrintObj(t *testing.T) {
+	tests := []struct {
+		printer  EventPrinter
+		obj      runtime.Object
+		expected string
+	}{
+		{
+			printer: EventPrinter{
+				NoHeaders:     false,
+				AllNamespaces: false,
+			},
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar-000",
+					Namespace: "foo",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "bar",
+					Namespace:  "foo",
+					UID:        "00000000-0000-0000-0000-000000000001",
+				},
+				Type:                corev1.EventTypeNormal,
+				Reason:              "ScalingReplicaSet",
+				Message:             "Scaled up replica set bar-002 to 1",
+				ReportingController: "deployment-controller",
+				EventTime:           metav1.NewMicroTime(time.Now().Add(-20 * time.Minute)),
+				Series: &corev1.EventSeries{
+					Count:            3,
+					LastObservedTime: metav1.NewMicroTime(time.Now().Add(-12 * time.Minute)),
+				},
+			},
+			expected: `LAST SEEN	TYPE	REASON	OBJECT	MESSAGE
+12m (x3 over 20m)	Normal	ScalingReplicaSet	Deployment/bar	Scaled up replica set bar-002 to 1
+`,
+		},
+		{
+			printer: EventPrinter{
+				NoHeaders:     false,
+				AllNamespaces: true,
+			},
+			obj: &corev1.EventList{
+				Items: []corev1.Event{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar-000",
+							Namespace: "foo",
+						},
+						InvolvedObject: corev1.ObjectReference{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Name:       "bar",
+							Namespace:  "foo",
+							UID:        "00000000-0000-0000-0000-000000000001",
+						},
+						Type:                corev1.EventTypeNormal,
+						Reason:              "ScalingReplicaSet",
+						Message:             "Scaled up replica set bar-002 to 1",
+						ReportingController: "deployment-controller",
+						EventTime:           metav1.NewMicroTime(time.Now().Add(-20 * time.Minute)),
+						Series: &corev1.EventSeries{
+							Count:            3,
+							LastObservedTime: metav1.NewMicroTime(time.Now().Add(-12 * time.Minute)),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar-001",
+							Namespace: "bar",
+						},
+						InvolvedObject: corev1.ObjectReference{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Name:       "bar2",
+							Namespace:  "foo2",
+							UID:        "00000000-0000-0000-0000-000000000001",
+						},
+						Type:                corev1.EventTypeNormal,
+						Reason:              "ScalingReplicaSet",
+						Message:             "Scaled up replica set bar-002 to 1",
+						ReportingController: "deployment-controller",
+						EventTime:           metav1.NewMicroTime(time.Now().Add(-15 * time.Minute)),
+						Series: &corev1.EventSeries{
+							Count:            3,
+							LastObservedTime: metav1.NewMicroTime(time.Now().Add(-11 * time.Minute)),
+						},
+					},
+				},
+			},
+			expected: `NAMESPACE	LAST SEEN	TYPE	REASON	OBJECT	MESSAGE
+foo	12m (x3 over 20m)	Normal	ScalingReplicaSet	Deployment/bar	Scaled up replica set bar-002 to 1
+bar	11m (x3 over 15m)	Normal	ScalingReplicaSet	Deployment/bar2	Scaled up replica set bar-002 to 1
+`,
+		},
+		{
+			printer: EventPrinter{
+				NoHeaders:     true,
+				AllNamespaces: false,
+			},
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar-000",
+					Namespace: "foo",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "bar",
+					Namespace:  "foo",
+					UID:        "00000000-0000-0000-0000-000000000001",
+				},
+				Type:                corev1.EventTypeNormal,
+				Reason:              "ScalingReplicaSet",
+				Message:             "Scaled up replica set bar-002 to 1",
+				ReportingController: "deployment-controller",
+				EventTime:           metav1.NewMicroTime(time.Now().Add(-20 * time.Minute)),
+				Series: &corev1.EventSeries{
+					Count:            3,
+					LastObservedTime: metav1.NewMicroTime(time.Now().Add(-12 * time.Minute)),
+				},
+			},
+			expected: "12m (x3 over 20m)	Normal	ScalingReplicaSet	Deployment/bar	Scaled up replica set bar-002 to 1\n",
+		},
+		{
+			printer: EventPrinter{
+				NoHeaders:     false,
+				AllNamespaces: true,
+			},
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar-000",
+					Namespace: "foo",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "bar",
+					Namespace:  "foo",
+					UID:        "00000000-0000-0000-0000-000000000001",
+				},
+				Type:                corev1.EventTypeNormal,
+				Reason:              "ScalingReplicaSet",
+				Message:             "Scaled up replica set bar-002 to 1",
+				ReportingController: "deployment-controller",
+				EventTime:           metav1.NewMicroTime(time.Now().Add(-20 * time.Minute)),
+				Series: &corev1.EventSeries{
+					Count:            3,
+					LastObservedTime: metav1.NewMicroTime(time.Now().Add(-12 * time.Minute)),
+				},
+			},
+			expected: `NAMESPACE	LAST SEEN	TYPE	REASON	OBJECT	MESSAGE
+foo	12m (x3 over 20m)	Normal	ScalingReplicaSet	Deployment/bar	Scaled up replica set bar-002 to 1
+`,
+		},
+		{
+			printer: EventPrinter{
+				NoHeaders:     true,
+				AllNamespaces: true,
+			},
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar-000",
+					Namespace: "foo",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "bar",
+					Namespace:  "foo",
+					UID:        "00000000-0000-0000-0000-000000000001",
+				},
+				Type:                corev1.EventTypeNormal,
+				Reason:              "ScalingReplicaSet",
+				Message:             "Scaled up replica set bar-002 to 1",
+				ReportingController: "deployment-controller",
+				EventTime:           metav1.NewMicroTime(time.Now().Add(-20 * time.Minute)),
+				Series: &corev1.EventSeries{
+					Count:            3,
+					LastObservedTime: metav1.NewMicroTime(time.Now().Add(-12 * time.Minute)),
+				},
+			},
+			expected: `foo	12m (x3 over 20m)	Normal	ScalingReplicaSet	Deployment/bar	Scaled up replica set bar-002 to 1
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			buffer := &bytes.Buffer{}
+			if err := test.printer.PrintObj(test.obj, buffer); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if buffer.String() != test.expected {
+				t.Errorf("\nexpected:\n'%s'\nsaw\n'%s'\n", test.expected, buffer.String())
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/events/events_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/events/events_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"io"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"net/http"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+)
+
+func getFakeEvents() *corev1.EventList {
+	return &corev1.EventList{
+		Items: []corev1.Event{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar-000",
+					Namespace: "foo",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "bar",
+					Namespace:  "foo",
+					UID:        "00000000-0000-0000-0000-000000000001",
+				},
+				Type:                corev1.EventTypeNormal,
+				Reason:              "ScalingReplicaSet",
+				Message:             "Scaled up replica set bar-002 to 1",
+				ReportingController: "deployment-controller",
+				EventTime:           metav1.NewMicroTime(time.Now().Add(-30 * time.Minute)),
+				Series: &corev1.EventSeries{
+					Count:            3,
+					LastObservedTime: metav1.NewMicroTime(time.Now().Add(-20 * time.Minute)),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar-001",
+					Namespace: "foo",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "bar",
+					Namespace:  "foo",
+					UID:        "00000000-0000-0000-0000-000000000001",
+				},
+				Type:                corev1.EventTypeWarning,
+				Reason:              "ScalingReplicaSet",
+				Message:             "Scaled up replica set bar-002 to 1",
+				ReportingController: "deployment-controller",
+				EventTime:           metav1.NewMicroTime(time.Now().Add(-28 * time.Minute)),
+				Series: &corev1.EventSeries{
+					Count:            3,
+					LastObservedTime: metav1.NewMicroTime(time.Now().Add(-18 * time.Minute)),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar-002",
+					Namespace: "otherfoo",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "bar",
+					Namespace:  "otherfoo",
+					UID:        "00000000-0000-0000-0000-000000000001",
+				},
+				Type:                corev1.EventTypeNormal,
+				Reason:              "ScalingReplicaSet",
+				Message:             "Scaled up replica set bar-002 to 1",
+				ReportingController: "deployment-controller",
+				EventTime:           metav1.NewMicroTime(time.Now().Add(-25 * time.Minute)),
+				Series: &corev1.EventSeries{
+					Count:            3,
+					LastObservedTime: metav1.NewMicroTime(time.Now().Add(-15 * time.Minute)),
+				},
+			},
+		},
+	}
+}
+
+func TestEventIsSorted(t *testing.T) {
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	clientset, err := kubernetes.NewForConfig(cmdtesting.DefaultClientConfig())
+	if err != err {
+		t.Fatal(err)
+	}
+
+	clientset.CoreV1().RESTClient().(*restclient.RESTClient).Client = fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, getFakeEvents())}, nil
+	})
+
+	printer := NewEventPrinter(false, true)
+
+	options := &EventsOptions{
+		AllNamespaces: true,
+		client:        clientset,
+		PrintObj: func(object runtime.Object, writer io.Writer) error {
+			return printer.PrintObj(object, writer)
+		},
+		IOStreams: streams,
+	}
+
+	err = options.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `NAMESPACE   LAST SEEN           TYPE      REASON              OBJECT           MESSAGE
+foo         20m (x3 over 30m)   Normal    ScalingReplicaSet   Deployment/bar   Scaled up replica set bar-002 to 1
+foo         18m (x3 over 28m)   Warning   ScalingReplicaSet   Deployment/bar   Scaled up replica set bar-002 to 1
+otherfoo    15m (x3 over 25m)   Normal    ScalingReplicaSet   Deployment/bar   Scaled up replica set bar-002 to 1
+`
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
+	}
+}
+
+func TestEventNoHeaders(t *testing.T) {
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	clientset, err := kubernetes.NewForConfig(cmdtesting.DefaultClientConfig())
+	if err != err {
+		t.Fatal(err)
+	}
+
+	clientset.CoreV1().RESTClient().(*restclient.RESTClient).Client = fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, getFakeEvents())}, nil
+	})
+
+	printer := NewEventPrinter(true, true)
+
+	options := &EventsOptions{
+		AllNamespaces: true,
+		client:        clientset,
+		PrintObj: func(object runtime.Object, writer io.Writer) error {
+			return printer.PrintObj(object, writer)
+		},
+		IOStreams: streams,
+	}
+
+	err = options.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `foo        20m (x3 over 30m)   Normal    ScalingReplicaSet   Deployment/bar   Scaled up replica set bar-002 to 1
+foo        18m (x3 over 28m)   Warning   ScalingReplicaSet   Deployment/bar   Scaled up replica set bar-002 to 1
+otherfoo   15m (x3 over 25m)   Normal    ScalingReplicaSet   Deployment/bar   Scaled up replica set bar-002 to 1
+`
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
+	}
+}
+
+func TestEventFiltered(t *testing.T) {
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	clientset, err := kubernetes.NewForConfig(cmdtesting.DefaultClientConfig())
+	if err != err {
+		t.Fatal(err)
+	}
+
+	clientset.CoreV1().RESTClient().(*restclient.RESTClient).Client = fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, getFakeEvents())}, nil
+	})
+
+	printer := NewEventPrinter(false, true)
+
+	options := &EventsOptions{
+		AllNamespaces: true,
+		client:        clientset,
+		FilterTypes:   []string{"WARNING"},
+		PrintObj: func(object runtime.Object, writer io.Writer) error {
+			return printer.PrintObj(object, writer)
+		},
+		IOStreams: streams,
+	}
+
+	err = options.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `NAMESPACE   LAST SEEN           TYPE      REASON              OBJECT           MESSAGE
+foo         18m (x3 over 28m)   Warning   ScalingReplicaSet   Deployment/bar   Scaled up replica set bar-002 to 1
+`
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
+	}
+}

--- a/test/cmd/events.sh
+++ b/test/cmd/events.sh
@@ -61,6 +61,27 @@ run_kubectl_events_tests() {
     output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi --watch --request-timeout=1 "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
+    # Post-Condition: events returns event for Cronjob/pi when filtered by Warning
+    output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi --types=Warning "${kube_flags[@]:?}" 2>&1)
+    kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
+
+    # Post-Condition: events not returns event for Cronjob/pi when filtered only by Normal
+    output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi --types=Normal "${kube_flags[@]:?}" 2>&1)
+    kube::test::if_has_not_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
+
+    # Post-Condition: events returns event for Cronjob/pi without headers
+    output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi --no-headers "${kube_flags[@]:?}" 2>&1)
+    kube::test::if_has_not_string "${output_message}" "LAST SEEN" "TYPE" "REASON"
+    kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
+
+    # Post-Condition: events returns event for Cronjob/pi in json format
+    output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi --output=json "${kube_flags[@]:?}" 2>&1)
+    kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
+
+    # Post-Condition: events returns event for Cronjob/pi in yaml format
+    output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi --output=yaml "${kube_flags[@]:?}" 2>&1)
+    kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
+
     #Clean up
     kubectl delete cronjob pi --namespace=test-events
     kubectl delete namespace test-events


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind bug

#### What this PR does / why we need it:
In order to promote `kubectl alpha events` to beta, it should at least support flags which is already supported by `kubectl get events` as well as new flags.

This PR is a continuation of [initial PR]( https://github.com/kubernetes/kubernetes/pull/99557) of `kubectl alpha events` and adds some of other flags proposed in https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1440-kubectl-events#design-details

It adds new flags;

- `--output`: This PR adds `json|yaml` support and does essential refactorings to integrate other printing options easier in the future like custom-column, etc.
- `--no-headers`: `kubectl get events` can hide headers when this flag is set for default printing. This PR adds ability to hide headers also for `kubectl alpha events`. This flag has no effect when output is json or yaml for both commands.
- `--types`: This will be used to filter certain events to be printed and discard others(default behavior is same with `--event=Normal,Warning`). 

#### Which issue(s) this PR fixes:
Fixes #110622

#### Does this PR introduce a user-facing change?
```release-note
Adds new flags into alpha events such as --output, --types, --no-headers
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/1440
```
