### PR TITLE
Fix requests scope classification

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -577,7 +577,7 @@ func InstrumentHandlerFunc(verb, group, version, resource, subresource, scope, c
 
 // CleanScope returns the scope of the request.
 func CleanScope(requestInfo *request.RequestInfo) string {
-	if requestInfo.Name != "" {
+	if requestInfo.Name != "" || requestInfo.Verb == "create" {
 		return "resource"
 	}
 	if requestInfo.Namespace != "" {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -178,6 +178,15 @@ func TestCleanScope(t *testing.T) {
 			expectedScope: "resource",
 		},
 		{
+			name: "POST resource scope",
+			requestInfo: &request.RequestInfo{
+				Verb:              "create",
+				Namespace:         "my-namespace",
+				IsResourceRequest: false,
+			},
+			expectedScope: "resource",
+		},
+		{
 			name: "namespace scope",
 			requestInfo: &request.RequestInfo{
 				Namespace:         "my-namespace",
@@ -293,6 +302,7 @@ func TestRecordDroppedRequests(t *testing.T) {
 				},
 			},
 			requestInfo: &request.RequestInfo{
+				Verb:              "list",
 				APIGroup:          "",
 				APIVersion:        "v1",
 				Resource:          "pods",
@@ -317,6 +327,7 @@ func TestRecordDroppedRequests(t *testing.T) {
 				},
 			},
 			requestInfo: &request.RequestInfo{
+				Verb:              "create",
 				APIGroup:          "",
 				APIVersion:        "v1",
 				Resource:          "pods",
@@ -329,7 +340,7 @@ func TestRecordDroppedRequests(t *testing.T) {
 			            apiserver_dropped_requests_total{request_kind="mutating"} 1
 			            # HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.
 			            # TYPE apiserver_request_total counter
-			            apiserver_request_total{code="429",component="apiserver",dry_run="",group="",resource="pods",scope="cluster",subresource="",verb="POST",version="v1"} 1
+			            apiserver_request_total{code="429",component="apiserver",dry_run="",group="",resource="pods",scope="resource",subresource="",verb="POST",version="v1"} 1
 				`,
 		},
 		{
@@ -337,14 +348,16 @@ func TestRecordDroppedRequests(t *testing.T) {
 			request: &http.Request{
 				Method: "PATCH",
 				URL: &url.URL{
-					RawPath:  "/apis/batch/v1/namespaces/foo/pods/status",
+					RawPath:  "/apis/batch/v1/namespaces/foo/jobs/bar/status",
 					RawQuery: "dryRun=All",
 				},
 			},
 			requestInfo: &request.RequestInfo{
+				Verb:              "patch",
 				APIGroup:          "batch",
 				APIVersion:        "v1",
 				Resource:          "jobs",
+				Name:              "bar",
 				Subresource:       "status",
 				IsResourceRequest: true,
 			},
@@ -355,7 +368,7 @@ func TestRecordDroppedRequests(t *testing.T) {
 			            apiserver_dropped_requests_total{request_kind="mutating"} 1
 			            # HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.
 			            # TYPE apiserver_request_total counter
-			            apiserver_request_total{code="429",component="apiserver",dry_run="All",group="batch",resource="jobs",scope="cluster",subresource="status",verb="PATCH",version="v1"} 1
+			            apiserver_request_total{code="429",component="apiserver",dry_run="All",group="batch",resource="jobs",scope="resource",subresource="status",verb="PATCH",version="v1"} 1
 				`,
 		},
 	}


### PR DESCRIPTION
create (POST) custom resources should be `scope:resource`

#### What type of PR is this?

/kind bug

#### Which issue(s) this PR fixes:

Fixes #110001

```release-note
Fix incorrectly report scope for request_duration_seconds and request_slo_duration_seconds metrics for POST custom resources API calls.
```

#### Special notes for your reviewer:

It's essentially a replication of:
https://github.com/kubernetes/kubernetes/blob/release-1.23/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go#L640

#### Does this PR introduce a user-facing change?

Yes. After this change requests related metrics (like `apiserver_request_duration_seconds`) would have different scope label for "POST custom resource" type of requests