### PR TITLE
kubeadm: perform dockershim cleanup for 1.25

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -96,10 +96,6 @@ func runCleanupNode(c workflow.RunData) error {
 		fmt.Println("[reset] Would remove Kubernetes-managed containers")
 	}
 
-	// TODO: remove the dockershim directory cleanup in 1.25
-	// https://github.com/kubernetes/kubeadm/issues/2626
-	r.AddDirsToClean("/var/lib/dockershim", "/var/run/kubernetes", "/var/lib/cni")
-
 	// Remove contents from the config and pki directories
 	if certsDir != kubeadmapiv1.DefaultCertificatesDir {
 		klog.Warningf("[reset] WARNING: Cleaning a non-default certificates directory: %q\n", certsDir)

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -20,20 +20,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/pkg/errors"
 
-	versionutil "k8s.io/apimachinery/pkg/util/version"
-	componentversion "k8s.io/component-base/version"
 	"k8s.io/klog/v2"
-	utilsexec "k8s.io/utils/exec"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
-	preflight "k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
@@ -41,9 +36,6 @@ type kubeletFlagsOpts struct {
 	nodeRegOpts              *kubeadmapi.NodeRegistrationOptions
 	pauseImage               string
 	registerTaintsUsingFlags bool
-	// This is a temporary measure until kubeadm no longer supports a kubelet version with built-in dockershim.
-	// TODO: https://github.com/kubernetes/kubeadm/issues/2626
-	kubeletVersion *versionutil.Version
 }
 
 // GetNodeNameAndHostname obtains the name for this Node using the following precedence
@@ -67,24 +59,10 @@ func GetNodeNameAndHostname(cfg *kubeadmapi.NodeRegistrationOptions) (string, st
 // WriteKubeletDynamicEnvFile writes an environment file with dynamic flags to the kubelet.
 // Used at "kubeadm init" and "kubeadm join" time.
 func WriteKubeletDynamicEnvFile(cfg *kubeadmapi.ClusterConfiguration, nodeReg *kubeadmapi.NodeRegistrationOptions, registerTaintsUsingFlags bool, kubeletDir string) error {
-	// This is a temporary measure until kubeadm no longer supports a kubelet version with built-in dockershim.
-	// TODO: https://github.com/kubernetes/kubeadm/issues/2626
-	kubeletVersion, err := preflight.GetKubeletVersion(utilsexec.New())
-	if err != nil {
-		// We cannot return an error here, due to the k/k CI, where /cmd/kubeadm/test tests run without
-		// a kubelet built on the host. On error, we assume a kubelet version equal to the version
-		// of the kubeadm binary. During normal cluster creation this should not happens as kubeadm needs
-		// the kubelet binary for init / join.
-		kubeletVersion = versionutil.MustParseSemantic(componentversion.Get().GitVersion)
-		klog.Warningf("cannot obtain the version of the kubelet while writing dynamic environment file: %v."+
-			" Using the version of the kubeadm binary: %s", err, kubeletVersion.String())
-	}
-
 	flagOpts := kubeletFlagsOpts{
 		nodeRegOpts:              nodeReg,
 		pauseImage:               images.GetPauseImage(cfg),
 		registerTaintsUsingFlags: registerTaintsUsingFlags,
-		kubeletVersion:           kubeletVersion,
 	}
 	stringMap := buildKubeletArgMap(flagOpts)
 	argList := kubeadmutil.BuildArgumentListFromMap(stringMap, nodeReg.KubeletExtraArgs)
@@ -97,23 +75,7 @@ func WriteKubeletDynamicEnvFile(cfg *kubeadmapi.ClusterConfiguration, nodeReg *k
 //that are common to both Linux and Windows
 func buildKubeletArgMapCommon(opts kubeletFlagsOpts) map[string]string {
 	kubeletFlags := map[string]string{}
-
-	// This is a temporary measure until kubeadm no longer supports a kubelet version with built-in dockershim.
-	// Once that happens only the "remote" branch option should be left.
-	// TODO: https://github.com/kubernetes/kubeadm/issues/2626
-	hasDockershim := opts.kubeletVersion.Major() == 1 && opts.kubeletVersion.Minor() < 24
-	var dockerSocket string
-	if runtime.GOOS == "windows" {
-		dockerSocket = "npipe:////./pipe/dockershim"
-	} else {
-		dockerSocket = "unix:///var/run/dockershim.sock"
-	}
-	if opts.nodeRegOpts.CRISocket == dockerSocket && hasDockershim {
-		kubeletFlags["network-plugin"] = "cni"
-	} else {
-		kubeletFlags["container-runtime"] = "remote"
-		kubeletFlags["container-runtime-endpoint"] = opts.nodeRegOpts.CRISocket
-	}
+	kubeletFlags["container-runtime-endpoint"] = opts.nodeRegOpts.CRISocket
 
 	// This flag passes the pod infra container image (e.g. "pause" image) to the kubelet
 	// and prevents its garbage collection


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

Given kubeadm 1.25 only supports kubelet 1.25 and 1.24,
1.23 related logic around dockershim can be removed.

- Don't clean the directories
/var/lib/dockershim, /var/runkubernetes, /var/lib/cni
- Pass the CRISocket directly to the kubelet
--container-runtime-endpoint flag without extra handling
of dockershim
- No longer apply the --container-runtime=remote flag
as that is the only possible value in 1.24 and 1.25
- Update unit tests

Note: we are still passing --pod-infra-container-image
to avoid the pause image to be GCed by the kubelet.
https://github.com/kubernetes/kubernetes/issues/106893

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2626

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: perform additional dockershim cleanup. Treat all container runtimes as remote by using the flag "--container-runtime=remote", given dockershim was removed in 1.24 and given kubeadm 1.25 supports a kubelet version of 1.24 and 1.25. The flag "--network-plugin" will no longer be used for new clusters. Stop cleaning up the following dockershim related directories on "kubeadm reset": "/var/lib/dockershim", "/var/runkubernetes", "/var/lib/cni"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
