### PR TITLE
apiserver/storage: add myself to the reviewers list

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/storage/OWNERS
@@ -15,6 +15,7 @@ reviewers:
   - ncdc
   - ingvagabund
   - enj
+  - stevekuznetsov
 emeritus_approvers:
   - xiang90
   - timothysc


### PR DESCRIPTION
I've been active in this corner of the code-base for a while now, with a number of changes:

```
$ git log --pretty=%H --author=skuznets@redhat.com -- staging/src/k8s.io/apiserver/pkg/storage | wc -l
35
```

I'd love the chance to help review incoming PRs to this space.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind cleanup
/sig api-machinery

```release-note
NONE
```

```docs

```

/assign @lavalamp @wojtek-t @liggitt 
