### PR TITLE
Fix cluster IP allocator metrics

### DIFF
--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -213,6 +213,7 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(apiResourceConfigSource 
 	if err != nil {
 		return LegacyRESTStorage{}, genericapiserver.APIGroupInfo{}, fmt.Errorf("cannot create cluster IP allocator: %v", err)
 	}
+	serviceClusterIPAllocator.EnableMetrics()
 	restStorage.ServiceClusterIPAllocator = serviceClusterIPRegistry
 
 	// allocator for secondary service ip range
@@ -233,6 +234,7 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(apiResourceConfigSource 
 		if err != nil {
 			return LegacyRESTStorage{}, genericapiserver.APIGroupInfo{}, fmt.Errorf("cannot create cluster secondary IP allocator: %v", err)
 		}
+		secondaryServiceClusterIPAllocator.EnableMetrics()
 		restStorage.SecondaryServiceClusterIPAllocator = secondaryServiceClusterIPRegistry
 	}
 

--- a/pkg/registry/core/service/ipallocator/metrics.go
+++ b/pkg/registry/core/service/ipallocator/metrics.go
@@ -85,3 +85,38 @@ func registerMetrics() {
 		legacyregistry.MustRegister(clusterIPAllocationErrors)
 	})
 }
+
+// metricsRecorderInterface is the interface to record metrics.
+type metricsRecorderInterface interface {
+	setAllocated(cidr string, allocated int)
+	setAvailable(cidr string, available int)
+	incrementAllocations(cidr, scope string)
+	incrementAllocationErrors(cidr, scope string)
+}
+
+// metricsRecorder implements metricsRecorderInterface.
+type metricsRecorder struct{}
+
+func (m *metricsRecorder) setAllocated(cidr string, allocated int) {
+	clusterIPAllocated.WithLabelValues(cidr).Set(float64(allocated))
+}
+
+func (m *metricsRecorder) setAvailable(cidr string, available int) {
+	clusterIPAvailable.WithLabelValues(cidr).Set(float64(available))
+}
+
+func (m *metricsRecorder) incrementAllocations(cidr, scope string) {
+	clusterIPAllocations.WithLabelValues(cidr, scope).Inc()
+}
+
+func (m *metricsRecorder) incrementAllocationErrors(cidr, scope string) {
+	clusterIPAllocationErrors.WithLabelValues(cidr, scope).Inc()
+}
+
+// emptyMetricsRecorder is a null object implements metricsRecorderInterface.
+type emptyMetricsRecorder struct{}
+
+func (*emptyMetricsRecorder) setAllocated(cidr string, allocated int)      {}
+func (*emptyMetricsRecorder) setAvailable(cidr string, available int)      {}
+func (*emptyMetricsRecorder) incrementAllocations(cidr, scope string)      {}
+func (*emptyMetricsRecorder) incrementAllocationErrors(cidr, scope string) {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix the bug that the metrics for the cluster IP allocator are incorrectly reported.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #109994

#### Special notes for your reviewer:
It seems [the repair loop](https://github.com/kubernetes/kubernetes/blob/v1.24.0/pkg/registry/core/service/ipallocator/controller/repair.go#L41-L42) unintentionally overwrote the metrics. I made the metrics recording disabled by default and made it enabled in only [LegacyRESTStorage](https://github.com/kubernetes/kubernetes/blob/v1.24.0/pkg/registry/core/rest/storage_core.go#L106).

I verified the metrics no longer changed after [the repair interval (3m)](https://github.com/kubernetes/kubernetes/blob/v1.24.0/pkg/controlplane/instance.go#L125-L126) on kind.

<details>
I verified with the following script after creating two dual-stack services.

```bash
echo "# $(date)"
kubectl get --raw /metrics | egrep "^kube_apiserver_clusterip_allocator" | tee prev.txt
for i in $(seq 1 5); do
  sleep 60
  echo "# $(date)"
  kubectl get --raw /metrics | egrep "^kube_apiserver_clusterip_allocator" > current.txt
  diff prev.txt current.txt
  cp current.txt prev.txt
done
```

#### After fix
After this fix, the metrics no longer changed within 5 minutes.

```
# Fri May 13 09:17:21 JST 2022
kube_apiserver_clusterip_allocator_allocated_ips{cidr="10.96.0.0/20"} 4
kube_apiserver_clusterip_allocator_allocated_ips{cidr="fd03::/112"} 2
kube_apiserver_clusterip_allocator_allocation_total{cidr="10.96.0.0/20",scope="dynamic"} 2
kube_apiserver_clusterip_allocator_allocation_total{cidr="10.96.0.0/20",scope="static"} 2
kube_apiserver_clusterip_allocator_allocation_total{cidr="fd03::/112",scope="dynamic"} 2
kube_apiserver_clusterip_allocator_available_ips{cidr="10.96.0.0/20"} 4090
kube_apiserver_clusterip_allocator_available_ips{cidr="fd03::/112"} 65533
# Fri May 13 09:18:22 JST 2022
# Fri May 13 09:19:22 JST 2022
# Fri May 13 09:20:22 JST 2022
# Fri May 13 09:21:22 JST 2022
# Fri May 13 09:22:22 JST 2022
```


#### Before fix
Before this fix, the metrics was incorrectly changed after a while (0 - 3 m).

```
# Fri May 13 08:55:40 JST 2022
kube_apiserver_clusterip_allocator_allocated_ips{cidr="10.96.0.0/20"} 4
kube_apiserver_clusterip_allocator_allocated_ips{cidr="fd03::/112"} 2
kube_apiserver_clusterip_allocator_allocation_total{cidr="10.96.0.0/20",scope="dynamic"} 2
kube_apiserver_clusterip_allocator_allocation_total{cidr="10.96.0.0/20",scope="static"} 2
kube_apiserver_clusterip_allocator_allocation_total{cidr="fd03::/112",scope="dynamic"} 2
kube_apiserver_clusterip_allocator_available_ips{cidr="10.96.0.0/20"} 4090
kube_apiserver_clusterip_allocator_available_ips{cidr="fd03::/112"} 65533
# Fri May 13 08:56:40 JST 2022
1,2c1,2
< kube_apiserver_clusterip_allocator_allocated_ips{cidr="10.96.0.0/20"} 4
< kube_apiserver_clusterip_allocator_allocated_ips{cidr="fd03::/112"} 2
---
> kube_apiserver_clusterip_allocator_allocated_ips{cidr="10.96.0.0/20"} 0
> kube_apiserver_clusterip_allocator_allocated_ips{cidr="fd03::/112"} 0
4c4
< kube_apiserver_clusterip_allocator_allocation_total{cidr="10.96.0.0/20",scope="static"} 2
---
> kube_apiserver_clusterip_allocator_allocation_total{cidr="10.96.0.0/20",scope="static"} 6
6,7c6,8
< kube_apiserver_clusterip_allocator_available_ips{cidr="10.96.0.0/20"} 4090
< kube_apiserver_clusterip_allocator_available_ips{cidr="fd03::/112"} 65533
---
> kube_apiserver_clusterip_allocator_allocation_total{cidr="fd03::/112",scope="static"} 2
> kube_apiserver_clusterip_allocator_available_ips{cidr="10.96.0.0/20"} 4094
> kube_apiserver_clusterip_allocator_available_ips{cidr="fd03::/112"} 65535
# Fri May 13 08:57:40 JST 2022
# Fri May 13 08:58:40 JST 2022
# Fri May 13 08:59:40 JST 2022
4c4
< kube_apiserver_clusterip_allocator_allocation_total{cidr="10.96.0.0/20",scope="static"} 6
---
> kube_apiserver_clusterip_allocator_allocation_total{cidr="10.96.0.0/20",scope="static"} 10
6c6
< kube_apiserver_clusterip_allocator_allocation_total{cidr="fd03::/112",scope="static"} 2
---
> kube_apiserver_clusterip_allocator_allocation_total{cidr="fd03::/112",scope="static"} 4
# Fri May 13 09:00:40 JST 2022
```

</details>


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix the bug that the metrics for the cluster IP allocator are incorrectly reported.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
