### PR TITLE
[GO] Update Go to 1.18.2

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.24.0-go1.18.1-bullseye.0
+v1.25.0-go1.18.2-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -91,7 +91,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
 readonly __default_debian_iptables_version=bullseye-v1.3.0
-readonly __default_go_runner_version=v2.3.1-go1.18.1-bullseye.0
+readonly __default_go_runner_version=v2.3.1-go1.18.2-bullseye.0
 readonly __default_setcap_version=bullseye-v1.2.0
 
 # These are the base images for the Docker-wrapped binaries.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -88,7 +88,7 @@ dependencies:
 
   # Golang
   - name: "golang: upstream version"
-    version: 1.18.1
+    version: 1.18.2
     refPaths:
     - path: build/build-image/cross/VERSION
     - path: staging/publishing/rules.yaml
@@ -110,7 +110,7 @@ dependencies:
     #  match: minimum_go_version=go([0-9]+\.[0-9]+)
 
   - name: "k8s.gcr.io/kube-cross: dependents"
-    version: v1.24.0-go1.18.1-bullseye.0
+    version: v1.25.0-go1.18.2-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -140,7 +140,7 @@ dependencies:
       match: configs\[DebianIptables\] = Config{list\.BuildImageRegistry, "debian-iptables", "[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"}
 
   - name: "k8s.gcr.io/go-runner: dependents"
-    version: v2.3.1-go1.18.1-bullseye.0
+    version: v2.3.1-go1.18.2-bullseye.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -2295,4 +2295,4 @@ recursive-delete-patterns:
 - '*/BUILD.bazel'
 - Gopkg.toml
 - '*/.gitattributes'
-default-go-version: 1.18.1
+default-go-version: 1.18.2

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -16,7 +16,7 @@ REGISTRY ?= k8s.gcr.io/e2e-test-images
 GOARM ?= 7
 DOCKER_CERT_BASE_PATH ?=
 QEMUVERSION=v5.1.0-2
-GOLANG_VERSION=1.18.1
+GOLANG_VERSION=1.18.2
 export
 
 ifndef WHAT


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Update Go to 1.18.2

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2520

#### Does this PR introduce a user-facing change?
```release-note
Kubernetes is now built with Golang 1.18.2
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assign @Verolop  @saschagrunert @palnabarun @puerco @justaugustus @dims 
cc @kubernetes/release-engineering 