### PR TITLE
kubeadm: container runtime is by default docker in kubelet v1.23

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -76,6 +76,8 @@ func WriteKubeletDynamicEnvFile(cfg *kubeadmapi.ClusterConfiguration, nodeReg *k
 func buildKubeletArgMapCommon(opts kubeletFlagsOpts) map[string]string {
 	kubeletFlags := map[string]string{}
 	kubeletFlags["container-runtime-endpoint"] = opts.nodeRegOpts.CRISocket
+	// container runtime is by default docker in kubelet v1.23, so it can be removed in v1.26
+	kubeletFlags["container-runtime"] = "remote"
 
 	// This flag passes the pod infra container image (e.g. "pause" image) to the kubelet
 	// and prevents its garbage collection

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -40,6 +40,7 @@ func TestBuildKubeletArgMap(t *testing.T) {
 				},
 			},
 			expected: map[string]string{
+				"container-runtime":          "remote",
 				"container-runtime-endpoint": "unix:///var/run/containerd/containerd.sock",
 				"hostname-override":          "override-name",
 			},
@@ -65,6 +66,7 @@ func TestBuildKubeletArgMap(t *testing.T) {
 				registerTaintsUsingFlags: true,
 			},
 			expected: map[string]string{
+				"container-runtime":          "remote",
 				"container-runtime-endpoint": "unix:///var/run/containerd/containerd.sock",
 				"register-with-taints":       "foo=bar:baz,key=val:eff",
 			},
@@ -78,6 +80,7 @@ func TestBuildKubeletArgMap(t *testing.T) {
 				pauseImage: "k8s.gcr.io/pause:3.7",
 			},
 			expected: map[string]string{
+				"container-runtime":          "remote",
 				"container-runtime-endpoint": "unix:///var/run/containerd/containerd.sock",
 				"pod-infra-container-image":  "k8s.gcr.io/pause:3.7",
 			},


### PR DESCRIPTION
- can be removed in v1.26

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #
https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1-23-on-latest

#### Special notes for your reviewer:
https://github.com/kubernetes/kubernetes/pull/110022#issuecomment-1126576964

#### Does this PR introduce a user-facing change?
```release-note
None
```