### PR TITLE
Update publishing-bot rules for Go 1.17.10

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -21,7 +21,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/code-generator
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/code-generator
@@ -51,7 +51,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/apimachinery
@@ -94,7 +94,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/api
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -167,7 +167,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -244,7 +244,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-base
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -317,7 +317,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -398,7 +398,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apiserver
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -499,7 +499,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -627,7 +627,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -749,7 +749,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -867,7 +867,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -963,7 +963,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/metrics
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1040,7 +1040,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1121,7 +1121,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1205,7 +1205,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1290,7 +1290,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubelet
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1375,7 +1375,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1468,7 +1468,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1581,7 +1581,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1710,7 +1710,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1795,7 +1795,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1856,7 +1856,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1897,7 +1897,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/mount-utils
@@ -2008,7 +2008,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: api
       branch: release-1.23
@@ -2081,7 +2081,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cri-api
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/cri-api
@@ -2180,7 +2180,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubectl
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: api
       branch: release-1.23
@@ -2257,7 +2257,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.23
-    go: 1.17.9
+    go: 1.17.10
     dependencies:
     - repository: api
       branch: release-1.23


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Update publishing-bot rules for Go 1.17.10

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2520

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assign @xmudrii  @saschagrunert @palnabarun @Verolop @dims @nikhita 
cc @kubernetes/release-engineering 