### PR TITLE
apimachinery: fix UnsafeGuessKindToResource for some classes of words

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -137,10 +137,19 @@ func UnsafeGuessKindToResource(kind schema.GroupVersionKind) ( /*plural*/ schema
 		}
 	}
 
-	switch string(singularName[len(singularName)-1]) {
-	case "s":
+	switch {
+	case strings.HasSuffix(singularName, "s"),
+		strings.HasSuffix(singularName, "z"),
+		strings.HasSuffix(singularName, "ch"),
+		strings.HasSuffix(singularName, "sh"),
+		strings.HasSuffix(singularName, "x"):
 		return kind.GroupVersion().WithResource(singularName + "es"), singular
-	case "y":
+	case strings.HasSuffix(singularName, "ay"),
+		strings.HasSuffix(singularName, "ey"),
+		strings.HasSuffix(singularName, "iy"),
+		strings.HasSuffix(singularName, "oy"),
+		strings.HasSuffix(singularName, "uy"):
+	case strings.HasSuffix(singularName, "y"):
 		return kind.GroupVersion().WithResource(strings.TrimSuffix(singularName, "y") + "ies"), singular
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper_test.go
@@ -448,6 +448,8 @@ func TestKindToResource(t *testing.T) {
 
 		// Add "ies" when ending with "y"
 		{Kind: "ImageRepository", Plural: "imagerepositories", Singular: "imagerepository"},
+		// except if a vowel comes before y
+		{Kind: "Gateway", Plural: "gateways", Singular: "gateway"},
 		// Add "es" when ending with "s"
 		{Kind: "miss", Plural: "misses", Singular: "miss"},
 		// Add "s" otherwise


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes guesses that `apimachinery` makes about resource names from a GVK.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/client-go/issues/1082

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```