### PR TITLE
Update managedFields time when field value is modified

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/managedfieldsupdater_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/managedfieldsupdater_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package fieldmanager
 
 import (
+	"fmt"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
 	"time"
@@ -29,42 +31,395 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func TestNoManagedFieldsUpdateDoesntUpdateTime(t *testing.T) {
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", nil)
+func TestManagedFieldsUpdateDoesModifyTime(t *testing.T) {
+	var err error
+	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
 
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
-	if err := yaml.Unmarshal([]byte(`{
+	err = updateObject(&f, "fieldmanager_test", []byte(`{
 		"apiVersion": "v1",
-		"kind": "Pod",
+		"kind": "ConfigMap",
 		"metadata": {
-			"name": "pod",
-			"labels": {"app": "nginx"}
+			"name": "configmap"
 		},
-	}`), &obj.Object); err != nil {
-		t.Fatalf("error decoding YAML: %v", err)
+		"data": {
+			"key": "value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
 	}
+	previousManagedFields := f.ManagedFields()
 
-	if err := f.Update(obj, "fieldmanager_test"); err != nil {
-		t.Fatalf("failed to update object: %v", err)
-	}
-	managed := f.ManagedFields()
-	obj2 := &unstructured.Unstructured{Object: map[string]interface{}{}}
-	if err := yaml.Unmarshal([]byte(`{
-		"apiVersion": "v1",
-		"kind": "Pod",
-		"metadata": {
-			"name": "pod",
-			"labels": {"app": "nginx2"}
-		},
-	}`), &obj2.Object); err != nil {
-		t.Fatalf("error decoding YAML: %v", err)
-	}
 	time.Sleep(time.Second)
-	if err := f.Update(obj2, "fieldmanager_test"); err != nil {
-		t.Fatalf("failed to update object: %v", err)
+
+	err = updateObject(&f, "fieldmanager_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key": "new-value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(managed, f.ManagedFields()) {
-		t.Errorf("ManagedFields changed:\nBefore:\n%v\nAfter:\n%v", managed, f.ManagedFields())
+	newManagedFields := f.ManagedFields()
+
+	if previousManagedFields[0].Time.Equal(newManagedFields[0].Time) {
+		t.Errorf("ManagedFields time has not been updated:\n%v", newManagedFields)
+	}
+}
+
+func TestManagedFieldsApplyDoesModifyTime(t *testing.T) {
+	var err error
+	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+
+	err = applyObject(&f, "fieldmanager_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key": "value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousManagedFields := f.ManagedFields()
+
+	time.Sleep(time.Second)
+
+	err = applyObject(&f, "fieldmanager_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key": "new-value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	newManagedFields := f.ManagedFields()
+
+	if previousManagedFields[0].Time.Equal(newManagedFields[0].Time) {
+		t.Errorf("ManagedFields time has not been updated:\n%v", newManagedFields)
+	}
+}
+
+func TestManagedFieldsUpdateWithoutChangesDoesNotModifyTime(t *testing.T) {
+	var err error
+	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+
+	err = updateObject(&f, "fieldmanager_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key": "value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousManagedFields := f.ManagedFields()
+
+	time.Sleep(time.Second)
+
+	err = updateObject(&f, "fieldmanager_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key": "value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	newManagedFields := f.ManagedFields()
+
+	if !previousManagedFields[0].Time.Equal(newManagedFields[0].Time) {
+		t.Errorf("ManagedFields time has changed:\nBefore:\n%v\nAfter:\n%v", previousManagedFields, newManagedFields)
+	}
+}
+
+func TestManagedFieldsApplyWithoutChangesDoesNotModifyTime(t *testing.T) {
+	var err error
+	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+
+	err = applyObject(&f, "fieldmanager_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key": "value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousManagedFields := f.ManagedFields()
+
+	time.Sleep(time.Second)
+
+	err = applyObject(&f, "fieldmanager_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key": "value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	newManagedFields := f.ManagedFields()
+
+	if !previousManagedFields[0].Time.Equal(newManagedFields[0].Time) {
+		t.Errorf("ManagedFields time has changed:\nBefore:\n%v\nAfter:\n%v", previousManagedFields, newManagedFields)
+	}
+}
+
+func TestNonManagedFieldsUpdateDoesNotModifyTime(t *testing.T) {
+	var err error
+	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+
+	err = updateObject(&f, "fieldmanager_a_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key_a": "value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = updateObject(&f, "fieldmanager_b_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key_b": "value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousManagedFields := f.ManagedFields()
+	previousEntries := map[string]v1.ManagedFieldsEntry{}
+	for _, entry := range previousManagedFields {
+		previousEntries[entry.Manager] = entry
+	}
+
+	time.Sleep(time.Second)
+
+	err = updateObject(&f, "fieldmanager_a_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key_a": "value",
+			"key_b": "new-value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	newManagedFields := f.ManagedFields()
+	newEntries := map[string]v1.ManagedFieldsEntry{}
+	for _, entry := range newManagedFields {
+		newEntries[entry.Manager] = entry
+	}
+
+	if _, ok := newEntries["fieldmanager_b_test"]; ok {
+		t.Errorf("FieldManager B ManagedFields has changed:\n%v", newEntries["fieldmanager_b_test"])
+	}
+}
+
+func TestNonManagedFieldsApplyDoesNotModifyTime(t *testing.T) {
+	var err error
+	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+
+	err = applyObject(&f, "fieldmanager_a_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key_a": "value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = applyObject(&f, "fieldmanager_b_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key_b": "value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousManagedFields := f.ManagedFields()
+	previousEntries := map[string]v1.ManagedFieldsEntry{}
+	for _, entry := range previousManagedFields {
+		previousEntries[entry.Manager] = entry
+	}
+
+	time.Sleep(time.Second)
+
+	err = applyObject(&f, "fieldmanager_a_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key_a": "new-value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	newManagedFields := f.ManagedFields()
+	newEntries := map[string]v1.ManagedFieldsEntry{}
+	for _, entry := range newManagedFields {
+		newEntries[entry.Manager] = entry
+	}
+
+	if !previousEntries["fieldmanager_b_test"].Time.Equal(newEntries["fieldmanager_b_test"].Time) {
+		t.Errorf("FieldManager B ManagedFields time changed:\nBefore:\n%v\nAfter:\n%v",
+			previousEntries["fieldmanager_b_test"], newEntries["fieldmanager_b_test"])
+	}
+}
+
+func TestTakingOverManagedFieldsDuringUpdateDoesNotModifyPreviousManagerTime(t *testing.T) {
+	var err error
+	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+
+	err = updateObject(&f, "fieldmanager_a_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key_a": "value",
+			"key_b": value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousManagedFields := f.ManagedFields()
+	previousEntries := map[string]v1.ManagedFieldsEntry{}
+	for _, entry := range previousManagedFields {
+		previousEntries[entry.Manager] = entry
+	}
+
+	time.Sleep(time.Second)
+
+	err = updateObject(&f, "fieldmanager_b_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key_b": "new-value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	newManagedFields := f.ManagedFields()
+	newEntries := map[string]v1.ManagedFieldsEntry{}
+	for _, entry := range newManagedFields {
+		newEntries[entry.Manager] = entry
+	}
+
+	if !previousEntries["fieldmanager_a_test"].Time.Equal(newEntries["fieldmanager_a_test"].Time) {
+		t.Errorf("FieldManager A ManagedFields time has been updated:\nBefore:\n%v\nAfter:\n%v",
+			previousEntries["fieldmanager_a_test"], newEntries["fieldmanager_a_test"])
+	}
+}
+
+func TestTakingOverManagedFieldsDuringApplyDoesNotModifyPreviousManagerTime(t *testing.T) {
+	var err error
+	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+
+	err = applyObject(&f, "fieldmanager_a_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key_a": "value",
+			"key_b": value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousManagedFields := f.ManagedFields()
+	previousEntries := map[string]v1.ManagedFieldsEntry{}
+	for _, entry := range previousManagedFields {
+		previousEntries[entry.Manager] = entry
+	}
+
+	time.Sleep(time.Second)
+
+	err = applyObject(&f, "fieldmanager_b_test", []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "configmap"
+		},
+		"data": {
+			"key_b": "new-value"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	newManagedFields := f.ManagedFields()
+	newEntries := map[string]v1.ManagedFieldsEntry{}
+	for _, entry := range newManagedFields {
+		newEntries[entry.Manager] = entry
+	}
+
+	if !previousEntries["fieldmanager_a_test"].Time.Equal(newEntries["fieldmanager_a_test"].Time) {
+		t.Errorf("FieldManager A ManagedFields time has been updated:\nBefore:\n%v\nAfter:\n%v",
+			previousEntries["fieldmanager_a_test"], newEntries["fieldmanager_a_test"])
 	}
 }
 
@@ -76,6 +431,28 @@ func (NoopManager) Apply(liveObj, appliedObj runtime.Object, managed Managed, fi
 
 func (NoopManager) Update(liveObj, newObj runtime.Object, managed Managed, manager string) (runtime.Object, Managed, error) {
 	return nil, nil, nil
+}
+
+func updateObject(f *TestFieldManager, fieldManagerName string, object []byte) error {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	if err := yaml.Unmarshal(object, &obj.Object); err != nil {
+		return fmt.Errorf("error decoding YAML: %v", err)
+	}
+	if err := f.Update(obj, fieldManagerName); err != nil {
+		return fmt.Errorf("failed to update object: %v", err)
+	}
+	return nil
+}
+
+func applyObject(f *TestFieldManager, fieldManagerName string, object []byte) error {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	if err := yaml.Unmarshal(object, &obj.Object); err != nil {
+		return fmt.Errorf("error decoding YAML: %v", err)
+	}
+	if err := f.Apply(obj, fieldManagerName, true); err != nil {
+		return fmt.Errorf("failed to apply object: %v", err)
+	}
+	return nil
 }
 
 // Ensures that if ManagedFieldsUpdater gets a nil value from its nested manager


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `managedFields.time` is not updated if only the value of a managed field is changed during apply. [According to the doc](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L1229-L1233), the time field should be updated during creation, when a field is added or removed, or when a field value is changed.
This PR detects if a managed field has been modified and updates the time accordingly.

#### Which issue(s) this PR fixes:

Fixes #109576

#### Special notes for your reviewer:
I had to remove the unit test validating that when a non-managed field is updated, the time is not changed. It seems impossible to validate that we either have a conflict exception if a non-managed field is updated or the time should be updated.

#### Does this PR introduce a user-facing change?

```release-note
ManagedFields time is correctly updated when the value of a managed field is modified.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
/sig api-machinery
```
