### PR TITLE
Cleanup CRD storage on shutdown

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -211,6 +211,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	}
 	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle("/apis", crdHandler)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.HandlePrefix("/apis/", crdHandler)
+	s.GenericAPIServer.RegisterDestroyFunc(crdHandler.destroy)
 
 	discoveryController := NewDiscoveryController(s.Informers.Apiextensions().V1().CustomResourceDefinitions(), versionDiscoveryHandler, groupDiscoveryHandler)
 	namingController := status.NewNamingConditionController(s.Informers.Apiextensions().V1().CustomResourceDefinitions(), crdClient.ApiextensionsV1())

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -317,6 +317,12 @@ func (s *GenericAPIServer) MuxAndDiscoveryCompleteSignals() map[string]<-chan st
 	return s.muxAndDiscoveryCompleteSignals
 }
 
+// RegisterDestroyFunc registers a function that will be called during Destroy().
+// The function have to be idempotent and prepared to be called more than once.
+func (s *GenericAPIServer) RegisterDestroyFunc(destroyFn func()) {
+	s.destroyFns = append(s.destroyFns, destroyFn)
+}
+
 // Destroy cleans up all its and its delegation target resources on shutdown.
 // It starts with destroying its own resources and later proceeds with
 // its delegation target.
@@ -617,7 +623,7 @@ func (s *GenericAPIServer) installAPIResources(apiPrefix string, apiGroupInfo *A
 		resourceInfos = append(resourceInfos, r...)
 	}
 
-	s.destroyFns = append(s.destroyFns, apiGroupInfo.destroyStorage)
+	s.RegisterDestroyFunc(apiGroupInfo.destroyStorage)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.StorageVersionAPI) &&
 		utilfeature.DefaultFeatureGate.Enabled(features.APIServerIdentity) {


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/kubernetes/pull/109303

This effectively does exactly the same for CRDs what was done in #109303 for built-in resources.

Ref https://github.com/kubernetes/kubernetes/issues/108483

```release-note
NONE
```

/sig api-machinery
/priority important-longterm
/kind cleanup