### PR TITLE
Fix: kubectl checkErr handle wrapped invalid error

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -139,8 +139,8 @@ func isInvalidReasonStatusError(err error) bool {
 	if !apierrors.IsInvalid(err) {
 		return false
 	}
-	statusError, isStatusError := err.(*apierrors.StatusError)
-	if !isStatusError {
+	var statusError *apierrors.StatusError
+	if !errors.As(err, &statusError) {
 		return false
 	}
 	status := statusError.Status()
@@ -163,7 +163,9 @@ func checkErr(err error, handleErr func(string, int)) {
 	case err == ErrExit:
 		handleErr("", DefaultErrorExitCode)
 	case isInvalidReasonStatusError(err):
-		status := err.(*apierrors.StatusError).Status()
+		var statusError *apierrors.StatusError
+		_ = errors.As(err, &statusError)
+		status := statusError.Status()
 		details := status.Details
 		s := "The request is invalid"
 		if details == nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
@@ -401,6 +401,11 @@ func TestCheckInvalidErr(t *testing.T) {
 			`The request is invalid: admission webhook "my.webhook" denied the request without explanation`,
 			DefaultErrorExitCode,
 		},
+		{
+			fmt.Errorf("wrapped error: %w", errors.NewInvalid(corev1.SchemeGroupVersion.WithKind("Invalid6").GroupKind(), "invalidation", field.ErrorList{})),
+			"The Invalid6 \"invalidation\" is invalid",
+			DefaultErrorExitCode,
+		},
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

In kubectl checkErr function, if the given error is a wrapped invalid error, a nil pointer will be used which will cause panic. This PR fixes it to let the wrapped invalid error be handled properly.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1205

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
