### PR TITLE
fix: reflector to return wrapped list errors

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -322,7 +322,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 		initTrace.Step("Objects listed", trace.Field{Key: "error", Value: err})
 		if err != nil {
 			klog.Warningf("%s: failed to list %v: %v", r.name, r.expectedTypeName, err)
-			return fmt.Errorf("failed to list %v: %v", r.expectedTypeName, err)
+			return fmt.Errorf("failed to list %v: %w", r.expectedTypeName, err)
 		}
 
 		// We check if the list was paginated and if so set the paginatedResult based on that.


### PR DESCRIPTION
This fix allows Reflector/Informer callers to detect API errors using the standard Go errors.As unwrapping methods used by the apimachinery helper methods. Combined with a custom WatchErrorHandler, this can be used to stop an informer that encounters specific errors, like resource not found or forbidden.

Without this change, in order to catch errors, the caller needs to do string matching or even regex on the error string, in order to detect certain API errors that should be terminal.

/kind bug

```release-note
Fix bug that prevented informer/reflector callers from unwrapping and catching specific API errors by type.
```