### PR TITLE
Fix container log parse error

### DIFF
--- a/pkg/kubelet/kuberuntime/logs/logs.go
+++ b/pkg/kubelet/kuberuntime/logs/logs.go
@@ -27,6 +27,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -383,6 +384,10 @@ func ReadLogs(ctx context.Context, path, containerID string, opts *LogOptions, r
 			klog.InfoS("Incomplete line in log file", "path", path, "line", l)
 		}
 		if parse == nil {
+			if strings.Trim(string(l), string(eol[0])) == "" {
+				// If the line is empty, we should read next line to reach the real log line
+				continue
+			}
 			// Initialize the log parsing function.
 			parse, err = getParseFunc(l)
 			if err != nil {

--- a/pkg/kubelet/kuberuntime/logs/logs_test.go
+++ b/pkg/kubelet/kuberuntime/logs/logs_test.go
@@ -77,6 +77,7 @@ func TestReadLogs(t *testing.T) {
 		t.Fatalf("unable to create temp file")
 	}
 	defer os.Remove(file.Name())
+	file.WriteString("\n\n")
 	file.WriteString(`{"log":"line1\n","stream":"stdout","time":"2020-09-27T11:18:01.00000000Z"}` + "\n")
 	file.WriteString(`{"log":"line2\n","stream":"stdout","time":"2020-09-27T11:18:02.00000000Z"}` + "\n")
 	file.WriteString(`{"log":"line3\n","stream":"stdout","time":"2020-09-27T11:18:03.00000000Z"}` + "\n")


### PR DESCRIPTION
Signed-off-by: He Xiaoxi <xxhe@alauda.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We have encoutered the error `failed to get parse function: unsupported log format: "\n"` with `kubectl logs`, but `docker logs` is ok. The root cause is the docker container log have empty head lines, and the parse function did not skip the blank lines. The containerd/cri-o is also influenced with this issue.

This fix will skip the blank head lines to ensure the log is parsed successfully.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

To reproduce the bug, open the docker json log file of a running pod,
```console
# docker inspect {your container id} |grep log
        "LogPath": "/var/lib/docker/containers/17718123a6717d92c678346bfd1e317aa817d40ab358fa670c7848d130c72331/17718123a6717d92c678346bfd1e317aa817d40ab358fa670c7848d130c72331-json.log",
                "/var/lib/kubelet/pods/61f61373-5655-4f56-85a3-a75bb30f7b60/containers/nginx/113dc6cc:/dev/termination-log"
```
`/var/lib/docker/containers/17718123a6717d92c678346bfd1e317aa817d40ab358fa670c7848d130c72331/17718123a6717d92c678346bfd1e317aa817d40ab358fa670c7848d130c72331-json.log` is the container log.

Add some blank lines to the head of the log, such as:
```

{"log":"/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration\n","stream":"stdout","time":"2022-02-16T14:35:08.997236865Z"}
{"log":"/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/\n","stream":"stdout","time":"2022-02-16T14:35:08.997263966Z"}
{"log":"/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh\n","stream":"stdout","time":"2022-02-16T14:35:09.048533039Z"}
{"log":"10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf\n","stream":"stdout","time":"2022-02-16T14:35:09.06177909Z"}
{"log":"10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf\n","stream":"stdout","time":"2022-02-16T14:35:09.151197177Z"}
```

Use kubectl to query the log of your pod, you will get the error:
```console
# kubectl logs {pod name}
failed to get parse function: unsupported log format: "\n"
```
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix docker container log parse error if logs have blank head lines.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
