### PR TITLE
Set validate functions requiring no parameters for all commands

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -193,7 +193,7 @@ func NewCmdApply(baseName string, f cmdutil.Factory, ioStreams genericclioptions
 		Run: func(cmd *cobra.Command, args []string) {
 			o, err := flags.ToOptions(cmd, baseName, args)
 			cmdutil.CheckErr(err)
-			cmdutil.CheckErr(o.Validate(cmd, args))
+			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},
 	}
@@ -230,6 +230,10 @@ func (flags *ApplyFlags) AddFlags(cmd *cobra.Command) {
 
 // ToOptions converts from CLI inputs to runtime inputs
 func (flags *ApplyFlags) ToOptions(cmd *cobra.Command, baseName string, args []string) (*ApplyOptions, error) {
+	if len(args) != 0 {
+		return nil, cmdutil.UsageErrorf(cmd, "Unexpected args: %v", args)
+	}
+
 	serverSideApply := cmdutil.GetServerSideApplyFlag(cmd)
 	forceConflicts := cmdutil.GetForceConflictsFlag(cmd)
 	dryRunStrategy, err := cmdutil.GetDryRunStrategy(cmd)
@@ -344,11 +348,7 @@ func (flags *ApplyFlags) ToOptions(cmd *cobra.Command, baseName string, args []s
 }
 
 // Validate verifies if ApplyOptions are valid and without conflicts.
-func (o *ApplyOptions) Validate(cmd *cobra.Command, args []string) error {
-	if len(args) != 0 {
-		return cmdutil.UsageErrorf(cmd, "Unexpected args: %v", args)
-	}
-
+func (o *ApplyOptions) Validate() error {
 	if o.ForceConflicts && !o.ServerSideApply {
 		return fmt.Errorf("--force-conflicts only works with --server-side")
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go
@@ -81,7 +81,7 @@ func NewCmdApplyViewLastApplied(f cmdutil.Factory, ioStreams genericclioptions.I
 		ValidArgsFunction:     completion.ResourceTypeAndNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(cmd, f, args))
-			cmdutil.CheckErr(options.Validate(cmd))
+			cmdutil.CheckErr(options.Validate())
 			cmdutil.CheckErr(options.RunApplyViewLastApplied(cmd))
 		},
 	}
@@ -141,7 +141,7 @@ func (o *ViewLastAppliedOptions) Complete(cmd *cobra.Command, f cmdutil.Factory,
 }
 
 // Validate checks ViewLastAppliedOptions for validity.
-func (o *ViewLastAppliedOptions) Validate(cmd *cobra.Command) error {
+func (o *ViewLastAppliedOptions) Validate() error {
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -77,6 +77,8 @@ type CopyOptions struct {
 	Clientset         kubernetes.Interface
 	ExecParentCmdName string
 
+	args []string
+
 	genericclioptions.IOStreams
 }
 
@@ -149,9 +151,9 @@ func NewCmdCp(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.C
 			return comps, cobra.ShellCompDirectiveNoSpace
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(o.Complete(f, cmd))
-			cmdutil.CheckErr(o.Validate(cmd, args))
-			cmdutil.CheckErr(o.Run(args))
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.Run())
 		},
 	}
 	cmdutil.AddContainerVarFlags(cmd, &o.Container, o.Container)
@@ -198,7 +200,7 @@ func extractFileSpec(arg string) (fileSpec, error) {
 }
 
 // Complete completes all the required options
-func (o *CopyOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
+func (o *CopyOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	if cmd.Parent() != nil {
 		o.ExecParentCmdName = cmd.Parent().CommandPath()
 	}
@@ -218,24 +220,26 @@ func (o *CopyOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+
+	o.args = args
 	return nil
 }
 
 // Validate makes sure provided values for CopyOptions are valid
-func (o *CopyOptions) Validate(cmd *cobra.Command, args []string) error {
-	if len(args) != 2 {
+func (o *CopyOptions) Validate() error {
+	if len(o.args) != 2 {
 		return fmt.Errorf("source and destination are required")
 	}
 	return nil
 }
 
 // Run performs the execution
-func (o *CopyOptions) Run(args []string) error {
-	srcSpec, err := extractFileSpec(args[0])
+func (o *CopyOptions) Run() error {
+	srcSpec, err := extractFileSpec(o.args[0])
 	if err != nil {
 		return err
 	}
-	destSpec, err := extractFileSpec(args[1])
+	destSpec, err := extractFileSpec(o.args[1])
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
@@ -659,9 +659,9 @@ func TestCopyToPod(t *testing.T) {
 
 	for name, test := range tests {
 		opts := NewCopyOptions(ioStreams)
-		opts.Complete(tf, cmd)
+		opts.Complete(tf, cmd, []string{test.src, fmt.Sprintf("pod-ns/pod-name:%s", test.dest)})
 		t.Run(name, func(t *testing.T) {
-			err = opts.Run([]string{test.src, fmt.Sprintf("pod-ns/pod-name:%s", test.dest)})
+			err = opts.Run()
 			//If error is NotFound error , it indicates that the
 			//request has been sent correctly.
 			//Treat this as no error.
@@ -723,7 +723,7 @@ func TestCopyToPodNoPreserve(t *testing.T) {
 		PodName:      "pod-name",
 		File:         newRemotePath("foo"),
 	}
-	opts.Complete(tf, cmd)
+	opts.Complete(tf, cmd, nil)
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -754,14 +754,13 @@ func TestValidate(t *testing.T) {
 			expectedErr: true,
 		},
 	}
-	tf := cmdtesting.NewTestFactory()
 	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
 	opts := NewCopyOptions(ioStreams)
-	cmd := NewCmdCp(tf, ioStreams)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := opts.Validate(cmd, test.args)
+			opts.args = test.args
+			err := opts.Validate()
 			if (err != nil) != test.expectedErr {
 				t.Errorf("expected error: %v, saw: %v, error: %v", test.expectedErr, err != nil, err)
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -116,8 +116,8 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 				defaultRunFunc(cmd, args)
 				return
 			}
-			cmdutil.CheckErr(o.Complete(f, cmd))
-			cmdutil.CheckErr(o.ValidateArgs(cmd, args))
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.RunCreate(f, cmd))
 		},
 	}
@@ -160,32 +160,29 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 	return cmd
 }
 
-// ValidateArgs makes sure there is no discrepency in command options
-func (o *CreateOptions) ValidateArgs(cmd *cobra.Command, args []string) error {
-	if len(args) != 0 {
-		return cmdutil.UsageErrorf(cmd, "Unexpected args: %v", args)
-	}
+// Validate makes sure there is no discrepency in command options
+func (o *CreateOptions) Validate() error {
 	if len(o.Raw) > 0 {
 		if o.EditBeforeCreate {
-			return cmdutil.UsageErrorf(cmd, "--raw and --edit are mutually exclusive")
+			return fmt.Errorf("--raw and --edit are mutually exclusive")
 		}
 		if len(o.FilenameOptions.Filenames) != 1 {
-			return cmdutil.UsageErrorf(cmd, "--raw can only use a single local file or stdin")
+			return fmt.Errorf("--raw can only use a single local file or stdin")
 		}
 		if strings.Index(o.FilenameOptions.Filenames[0], "http://") == 0 || strings.Index(o.FilenameOptions.Filenames[0], "https://") == 0 {
-			return cmdutil.UsageErrorf(cmd, "--raw cannot read from a url")
+			return fmt.Errorf("--raw cannot read from a url")
 		}
 		if o.FilenameOptions.Recursive {
-			return cmdutil.UsageErrorf(cmd, "--raw and --recursive are mutually exclusive")
+			return fmt.Errorf("--raw and --recursive are mutually exclusive")
 		}
 		if len(o.Selector) > 0 {
-			return cmdutil.UsageErrorf(cmd, "--raw and --selector (-l) are mutually exclusive")
+			return fmt.Errorf("--raw and --selector (-l) are mutually exclusive")
 		}
-		if len(cmdutil.GetFlagString(cmd, "output")) > 0 {
-			return cmdutil.UsageErrorf(cmd, "--raw and --output are mutually exclusive")
+		if o.PrintFlags.OutputFormat != nil && len(*o.PrintFlags.OutputFormat) > 0 {
+			return fmt.Errorf("--raw and --output are mutually exclusive")
 		}
 		if _, err := url.ParseRequestURI(o.Raw); err != nil {
-			return cmdutil.UsageErrorf(cmd, "--raw must be a valid URL path: %v", err)
+			return fmt.Errorf("--raw must be a valid URL path: %v", err)
 		}
 	}
 
@@ -193,7 +190,10 @@ func (o *CreateOptions) ValidateArgs(cmd *cobra.Command, args []string) error {
 }
 
 // Complete completes all the required options
-func (o *CreateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
+func (o *CreateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmdutil.UsageErrorf(cmd, "Unexpected args: %v", args)
+	}
 	var err error
 	o.RecordFlags.Complete(cmd)
 	o.Recorder, err = o.RecordFlags.ToRecorder()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_test.go
@@ -35,8 +35,9 @@ func TestExtraArgsFail(t *testing.T) {
 	defer f.Cleanup()
 
 	c := NewCmdCreate(f, genericclioptions.NewTestIOStreamsDiscard())
-	options := CreateOptions{}
-	if options.ValidateArgs(c, []string{"rc"}) == nil {
+	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	options := NewCreateOptions(ioStreams)
+	if options.Complete(f, c, []string{"rc"}) == nil {
 		t.Errorf("unexpected non-error")
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -151,7 +151,7 @@ func NewCmdDebug(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 		Example:               debugExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
-			cmdutil.CheckErr(o.Validate(cmd))
+			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run(f, cmd))
 		},
 	}
@@ -221,7 +221,7 @@ func (o *DebugOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 }
 
 // Validate checks that the provided debug options are specified.
-func (o *DebugOptions) Validate(cmd *cobra.Command) error {
+func (o *DebugOptions) Validate() error {
 	// Attach
 	if o.Attach && o.attachChanged && len(o.Image) == 0 && len(o.Container) == 0 {
 		return fmt.Errorf("you must specify --container or create a new container using --image in order to attach.")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -1538,7 +1538,7 @@ func TestCompleteAndValidate(t *testing.T) {
 					if gotError != nil {
 						return
 					}
-					gotError = opts.Validate(cmd)
+					gotError = opts.Validate()
 				},
 			}
 			cmd.SetArgs(strings.Split(tc.args, " "))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
@@ -110,6 +110,7 @@ func NewCmdDescribe(parent string, f cmdutil.Factory, streams genericclioptions.
 		ValidArgsFunction:     completion.ResourceTypeAndNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},
 	}
@@ -148,7 +149,7 @@ func (o *DescribeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 	return nil
 }
 
-func (o *DescribeOptions) Validate(args []string) error {
+func (o *DescribeOptions) Validate() error {
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -123,7 +123,7 @@ func NewCmdReplace(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 		Example:               replaceExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
-			cmdutil.CheckErr(o.Validate(cmd))
+			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run(f))
 		},
 	}
@@ -218,7 +218,7 @@ func (o *ReplaceOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	return nil
 }
 
-func (o *ReplaceOptions) Validate(cmd *cobra.Command) error {
+func (o *ReplaceOptions) Validate() error {
 	if o.DeleteOptions.GracePeriod >= 0 && !o.DeleteOptions.ForceDeletion {
 		return fmt.Errorf("--grace-period must have --force specified")
 	}
@@ -228,24 +228,24 @@ func (o *ReplaceOptions) Validate(cmd *cobra.Command) error {
 	}
 
 	if cmdutil.IsFilenameSliceEmpty(o.DeleteOptions.FilenameOptions.Filenames, o.DeleteOptions.FilenameOptions.Kustomize) {
-		return cmdutil.UsageErrorf(cmd, "Must specify --filename to replace")
+		return fmt.Errorf("Must specify --filename to replace")
 	}
 
 	if len(o.Raw) > 0 {
 		if len(o.DeleteOptions.FilenameOptions.Filenames) != 1 {
-			return cmdutil.UsageErrorf(cmd, "--raw can only use a single local file or stdin")
+			return fmt.Errorf("--raw can only use a single local file or stdin")
 		}
 		if strings.Index(o.DeleteOptions.FilenameOptions.Filenames[0], "http://") == 0 || strings.Index(o.DeleteOptions.FilenameOptions.Filenames[0], "https://") == 0 {
-			return cmdutil.UsageErrorf(cmd, "--raw cannot read from a url")
+			return fmt.Errorf("--raw cannot read from a url")
 		}
 		if o.DeleteOptions.FilenameOptions.Recursive {
-			return cmdutil.UsageErrorf(cmd, "--raw and --recursive are mutually exclusive")
+			return fmt.Errorf("--raw and --recursive are mutually exclusive")
 		}
-		if len(cmdutil.GetFlagString(cmd, "output")) > 0 {
-			return cmdutil.UsageErrorf(cmd, "--raw and --output are mutually exclusive")
+		if o.PrintFlags.OutputFormat != nil && len(*o.PrintFlags.OutputFormat) > 0 {
+			return fmt.Errorf("--raw and --output are mutually exclusive")
 		}
 		if _, err := url.ParseRequestURI(o.Raw); err != nil {
-			return cmdutil.UsageErrorf(cmd, "--raw must be a valid URL path: %v", err)
+			return fmt.Errorf("--raw must be a valid URL path: %v", err)
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
@@ -117,7 +117,7 @@ func NewCmdScale(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 		ValidArgsFunction:     completion.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
-			cmdutil.CheckErr(o.Validate(cmd))
+			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.RunScale())
 		},
 	}
@@ -181,7 +181,7 @@ func (o *ScaleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	return nil
 }
 
-func (o *ScaleOptions) Validate(cmd *cobra.Command) error {
+func (o *ScaleOptions) Validate() error {
 	if o.Replicas < 0 {
 		return fmt.Errorf("The --replicas=COUNT flag is required, and COUNT must be greater than or equal to 0")
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -57,6 +57,8 @@ type Options struct {
 	Short      bool
 	Output     string
 
+	args []string
+
 	discoveryClient discovery.CachedDiscoveryInterface
 
 	genericclioptions.IOStreams
@@ -79,8 +81,8 @@ func NewCmdVersion(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 		Long:    i18n.T("Print the client and server version information for the current context."),
 		Example: versionExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(o.Complete(f, cmd))
-			cmdutil.CheckErr(o.Validate(args))
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},
 	}
@@ -92,7 +94,7 @@ func NewCmdVersion(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 }
 
 // Complete completes all the required options
-func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
+func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	var err error
 	if o.ClientOnly {
 		return nil
@@ -103,13 +105,15 @@ func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 	if err != nil && !clientcmd.IsEmptyConfig(err) {
 		return err
 	}
+
+	o.args = args
 	return nil
 }
 
 // Validate validates the provided options
-func (o *Options) Validate(args []string) error {
-	if len(args) != 0 {
-		return errors.New(fmt.Sprintf("extra arguments: %v", args))
+func (o *Options) Validate() error {
+	if len(o.args) != 0 {
+		return errors.New(fmt.Sprintf("extra arguments: %v", o.args))
 	}
 
 	if o.Output != "" && o.Output != "yaml" && o.Output != "json" {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
@@ -31,13 +31,16 @@ func TestNewCmdVersionClientVersion(t *testing.T) {
 	defer tf.Cleanup()
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	o := NewOptions(streams)
-	if err := o.Complete(tf, &cobra.Command{}); err != nil {
+	if err := o.Complete(tf, &cobra.Command{}, nil); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if err := o.Validate(nil); err != nil {
+	if err := o.Validate(); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if err := o.Validate([]string{"extraParameter0"}); !strings.Contains(err.Error(), "extra arguments") {
+	if err := o.Complete(tf, &cobra.Command{}, []string{"extraParameter0"}); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if err := o.Validate(); !strings.Contains(err.Error(), "extra arguments") {
 		t.Errorf("Unexpected error: should fail to validate the args length greater than 0")
 	}
 	if err := o.Run(); err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Validate function is used to validate command options and should not get
any additional parameter. To preserve compatibility across all
kubectl commands, this PR removes all parameters in validate functions.

#### Which issue(s) this PR fixes:
Fixes #

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
