### PR TITLE
deep copy from pod.Annotations to avoid concurrent map read and write

### DIFF
--- a/pkg/kubelet/kuberuntime/labels.go
+++ b/pkg/kubelet/kuberuntime/labels.go
@@ -89,7 +89,12 @@ func newPodLabels(pod *v1.Pod) map[string]string {
 
 // newPodAnnotations creates pod annotations from v1.Pod.
 func newPodAnnotations(pod *v1.Pod) map[string]string {
-	return pod.Annotations
+	anno := make(map[string]string, len(pod.Annotations))
+	for key, value := range pod.Annotations {
+		anno[key] = value
+	}
+
+	return anno
 }
 
 // newContainerLabels creates container labels from v1.Container and v1.Pod.


### PR DESCRIPTION
In kubelet, multiple goroutins access *v1.Pod fetched from podManager at the same time with no lock. For example, syncPod goroutin and volumeManager goroutin get *v1.Pod from podManager， when there is writing pod.Annotations operations, kubelet will panic.


/kind bug

Fixes [#110085 ](https://github.com/kubernetes/kubernetes/issues/110084)