### PR TITLE
Automated cherry pick of #110009: Fix requests scope classification

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -531,7 +531,7 @@ func InstrumentHandlerFunc(verb, group, version, resource, subresource, scope, c
 
 // CleanScope returns the scope of the request.
 func CleanScope(requestInfo *request.RequestInfo) string {
-	if requestInfo.Name != "" {
+	if requestInfo.Name != "" || requestInfo.Verb == "create" {
 		return "resource"
 	}
 	if requestInfo.Namespace != "" {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -167,6 +167,15 @@ func TestCleanScope(t *testing.T) {
 			expectedScope: "resource",
 		},
 		{
+			name: "POST resource scope",
+			requestInfo: &request.RequestInfo{
+				Verb:              "create",
+				Namespace:         "my-namespace",
+				IsResourceRequest: false,
+			},
+			expectedScope: "resource",
+		},
+		{
 			name: "namespace scope",
 			requestInfo: &request.RequestInfo{
 				Namespace:         "my-namespace",


### PR DESCRIPTION
Cherry pick of #110009 on release-1.23.

#110009: Fix requests scope classification

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```