### PR TITLE
Automated cherry pick of #110009: Fix requests scope classification

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -458,11 +458,11 @@ func InstrumentHandlerFunc(verb, group, version, resource, subresource, scope, c
 
 // CleanScope returns the scope of the request.
 func CleanScope(requestInfo *request.RequestInfo) string {
+	if requestInfo.Name != "" || requestInfo.Verb == "create" {
+		return "resource"
+	}
 	if requestInfo.Namespace != "" {
 		return "namespace"
-	}
-	if requestInfo.Name != "" {
-		return "resource"
 	}
 	if requestInfo.IsResourceRequest {
 		return "cluster"

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -20,6 +20,8 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
 func TestCleanVerb(t *testing.T) {
@@ -128,6 +130,62 @@ func TestCleanVerb(t *testing.T) {
 			cleansedVerb := cleanVerb(tt.initialVerb, tt.suggestedVerb, req)
 			if cleansedVerb != tt.expectedVerb {
 				t.Errorf("Got %s, but expected %s", cleansedVerb, tt.expectedVerb)
+			}
+		})
+	}
+}
+
+func TestCleanScope(t *testing.T) {
+	testCases := []struct {
+		name          string
+		requestInfo   *request.RequestInfo
+		expectedScope string
+	}{
+		{
+			name:          "empty scope",
+			requestInfo:   &request.RequestInfo{},
+			expectedScope: "",
+		},
+		{
+			name: "resource scope",
+			requestInfo: &request.RequestInfo{
+				Name:              "my-resource",
+				Namespace:         "my-namespace",
+				IsResourceRequest: false,
+			},
+			expectedScope: "resource",
+		},
+		{
+			name: "POST resource scope",
+			requestInfo: &request.RequestInfo{
+				Verb:              "create",
+				Namespace:         "my-namespace",
+				IsResourceRequest: false,
+			},
+			expectedScope: "resource",
+		},
+		{
+			name: "namespace scope",
+			requestInfo: &request.RequestInfo{
+				Namespace:         "my-namespace",
+				IsResourceRequest: false,
+			},
+			expectedScope: "namespace",
+		},
+		{
+			name: "cluster scope",
+			requestInfo: &request.RequestInfo{
+				Namespace:         "",
+				IsResourceRequest: true,
+			},
+			expectedScope: "cluster",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			if CleanScope(test.requestInfo) != test.expectedScope {
+				t.Errorf("failed to clean scope: %v", test.requestInfo)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #110009 on release-1.21.

#110009: Fix requests scope classification

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```