### PR TITLE
kubeadm: remove checking legacy taint for kubeadm-kinder-latest-on-1-24

### DIFF
--- a/test/e2e_kubeadm/controlplane_nodes_test.go
+++ b/test/e2e_kubeadm/controlplane_nodes_test.go
@@ -32,9 +32,6 @@ import (
 
 const (
 	controlPlaneLabel = "node-role.kubernetes.io/control-plane"
-	// TODO: remove the legacy label in 1.25:
-	// https://github.com/kubernetes/kubeadm/issues/2200
-	controlPlaneLabelLegacy = "node-role.kubernetes.io/master"
 )
 
 // Define container for all the test specification aimed at verifying
@@ -59,11 +56,8 @@ var _ = Describe("control-plane node", func() {
 		gomega.Expect(controlPlanes.Items).NotTo(gomega.BeEmpty(), "at least one node with label %s should exist. if you are running test on a single-node cluster, you can skip this test with SKIP=multi-node", controlPlaneLabel)
 
 		// checks that the control-plane nodes have the expected taints
-		// TODO: remove the legacy taint check in 1.25:
-		// https://github.com/kubernetes/kubeadm/issues/2200
 		for _, cp := range controlPlanes.Items {
 			framework.ExpectNodeHasTaint(f.ClientSet, cp.GetName(), &corev1.Taint{Key: controlPlaneLabel, Effect: corev1.TaintEffectNoSchedule})
-			framework.ExpectNodeHasTaint(f.ClientSet, cp.GetName(), &corev1.Taint{Key: controlPlaneLabelLegacy, Effect: corev1.TaintEffectNoSchedule})
 		}
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/kubernetes/pull/110095/files#r875034086

#### Special notes for your reviewer:

the 1.24 test suite will try to find both old + new taint on the CP nodes, but kubeadm 1.25 will only add the new taint. 

#### Does this PR introduce a user-facing change?

```release-note
None
```
