### PR TITLE
Fix issue that Audit Server could not correctly encode metav1.DeleteOption

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -239,7 +239,7 @@ func encodeObject(obj runtime.Object, gv schema.GroupVersion, serializer runtime
 
 	return &runtime.Unknown{
 		Raw:         buf.Bytes(),
-		ContentType: runtime.ContentTypeJSON,
+		ContentType: mediaType,
 	}, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
@@ -103,7 +103,7 @@ func DeleteResource(r rest.GracefulDeleter, allowsOptions bool, scope *RequestSc
 				trace.Step("Decoded delete options")
 
 				objGV := gvk.GroupVersion()
-				audit.LogRequestObject(req.Context(), obj, objGV, scope.Resource, scope.Subresource, scope.Serializer)
+				audit.LogRequestObject(req.Context(), obj, objGV, scope.Resource, scope.Subresource, metainternalversionscheme.Codecs)
 				trace.Step("Recorded the audit event")
 			} else {
 				if err := metainternalversionscheme.ParameterCodec.DecodeParameters(req.URL.Query(), scope.MetaGroupVersion, options); err != nil {
@@ -238,8 +238,8 @@ func DeleteCollection(r rest.CollectionDeleter, checkBody bool, scope *RequestSc
 				}
 				// For backwards compatibility, we need to allow existing clients to submit per group DeleteOptions
 				// It is also allowed to pass a body with meta.k8s.io/v1.DeleteOptions
-				defaultGVK := scope.Kind.GroupVersion().WithKind("DeleteOptions")
-				obj, gvk, err := scope.Serializer.DecoderToVersion(s.Serializer, defaultGVK.GroupVersion()).Decode(body, &defaultGVK, options)
+				defaultGVK := scope.MetaGroupVersion.WithKind("DeleteOptions")
+				obj, gvk, err := metainternalversionscheme.Codecs.DecoderToVersion(s.Serializer, defaultGVK.GroupVersion()).Decode(body, &defaultGVK, options)
 				if err != nil {
 					scope.err(err, w, req)
 					return
@@ -250,7 +250,7 @@ func DeleteCollection(r rest.CollectionDeleter, checkBody bool, scope *RequestSc
 				}
 
 				objGV := gvk.GroupVersion()
-				audit.LogRequestObject(req.Context(), obj, objGV, scope.Resource, scope.Subresource, scope.Serializer)
+				audit.LogRequestObject(req.Context(), obj, objGV, scope.Resource, scope.Subresource, metainternalversionscheme.Codecs)
 			} else {
 				if err := metainternalversionscheme.ParameterCodec.DecodeParameters(req.URL.Query(), scope.MetaGroupVersion, options); err != nil {
 					err = errors.NewBadRequest(err.Error())

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	metainternalversionscheme "k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	auditapis "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/utils/pointer"
+)
+
+type mockCodecs struct {
+	serializer.CodecFactory
+	err error
+}
+
+type mockCodec struct {
+	runtime.Codec
+	codecs *mockCodecs
+}
+
+func (p mockCodec) Encode(obj runtime.Object, w io.Writer) error {
+	err := p.Codec.Encode(obj, w)
+	p.codecs.err = err
+	return err
+}
+
+func (s *mockCodecs) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	out := s.CodecFactory.CodecForVersions(encoder, nil, gv, nil)
+	return &mockCodec{
+		Codec:  out,
+		codecs: s,
+	}
+}
+
+func TestDeleteResourceAuditLogRequestObject(t *testing.T) {
+
+	ctx := audit.WithAuditContext(context.TODO(), &audit.AuditContext{
+		Event: &auditapis.Event{
+			Level: auditapis.LevelRequestResponse,
+		},
+	})
+
+	policy := metav1.DeletePropagationBackground
+	deleteOption := &metav1.DeleteOptions{
+		GracePeriodSeconds: pointer.Int64Ptr(30),
+		PropagationPolicy:  &policy,
+	}
+
+	fakeCorev1GroupVersion := schema.GroupVersion{
+		Group:   "",
+		Version: "v1",
+	}
+	testScheme := runtime.NewScheme()
+	metav1.AddToGroupVersion(testScheme, fakeCorev1GroupVersion)
+	testCodec := serializer.NewCodecFactory(testScheme)
+
+	tests := []struct {
+		name       string
+		object     runtime.Object
+		gv         schema.GroupVersion
+		serializer serializer.CodecFactory
+		ok         bool
+	}{
+		{
+			name: "meta built-in Codec encode v1.DeleteOptions",
+			object: &metav1.DeleteOptions{
+				GracePeriodSeconds: pointer.Int64Ptr(30),
+				PropagationPolicy:  &policy,
+			},
+			gv:         metav1.SchemeGroupVersion,
+			serializer: metainternalversionscheme.Codecs,
+			ok:         true,
+		},
+		{
+			name: "fake corev1 registered codec encode v1 DeleteOptions",
+			object: &metav1.DeleteOptions{
+				GracePeriodSeconds: pointer.Int64Ptr(30),
+				PropagationPolicy:  &policy,
+			},
+			gv:         metav1.SchemeGroupVersion,
+			serializer: testCodec,
+			ok:         false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			codecs := &mockCodecs{}
+			codecs.CodecFactory = test.serializer
+
+			audit.LogRequestObject(ctx, deleteOption, test.gv, schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "pods",
+			}, "", codecs)
+
+			err := codecs.err
+			if err != nil {
+				if test.ok {
+					t.Errorf("expect nil but got %#v", err)
+				}
+				t.Logf("encode object: %#v", err)
+			} else {
+				if !test.ok {
+					t.Errorf("expect err but got nil")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When using kube-apiserver audit webhook, the following logs were found:

```
W0518 20:34:43.069379   20982 request.go:169] Auditing failed of  request: encoding failed: v1.DeleteOptions is not suitable for converting to "meta.k8s.io/v1" in scheme "pkg/api/legacyscheme/scheme.go:30"
W0518 20:34:49.597520   20982 request.go:169] Auditing failed of  request: encoding failed: request to convert CR to an invalid group/version: v1
W0518 20:34:49.600364   20982 request.go:169] Auditing failed of  request: encoding failed: request to convert CR to an invalid group/version: v1
W0518 20:34:49.614399   20982 request.go:169] Auditing failed of  request: encoding failed: request to convert CR to an invalid group/version: v1
W0518 20:34:49.625765   20982 request.go:169] Auditing failed of  request: encoding failed: request to convert CR to an invalid group/version: v1
W0518 20:34:49.628741   20982 request.go:169] Auditing failed of  request: encoding failed: request to convert CR to an invalid group/version: v1
W0518 20:34:49.648162   20982 request.go:169] Auditing failed of  request: encoding failed: request to convert CR to an invalid group/version: v1
W0518 20:34:49.661601   20982 request.go:169] Auditing failed of  request: encoding failed: request to convert CR to an invalid group/version: v1
W0518 20:34:49.669906   20982 request.go:169] Auditing failed of  request: encoding failed: request to convert CR to an invalid group/version: v1
W0518 20:34:49.686909   20982 request.go:169] Auditing failed of  request: encoding failed: request to convert CR to an invalid group/version: v1
W0518 20:34:49.689894   20982 request.go:169] Auditing failed of  request: encoding failed: request to convert CR to an invalid group/version: v1
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

The first log is triggered by Delete Namespace, and the rest can be triggered by installing any CRD and Delete Namespace.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
