### PR TITLE
kubeadm: remove RemoveOldControlPlaneLabel

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -207,30 +207,6 @@ func rollbackFiles(files map[string]string, originalErr error) error {
 	return errors.Errorf("couldn't move these files: %v. Got errors: %v", files, errorsutil.NewAggregate(errs))
 }
 
-// RemoveOldControlPlaneLabel finds all nodes with the legacy node-role label and removes it
-// TODO: https://github.com/kubernetes/kubeadm/issues/2200
-func RemoveOldControlPlaneLabel(client clientset.Interface) error {
-	selectorOldControlPlane := labels.SelectorFromSet(labels.Set(map[string]string{
-		kubeadmconstants.LabelNodeRoleOldControlPlane: "",
-	}))
-	nodesWithOldLabel, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selectorOldControlPlane.String(),
-	})
-	if err != nil {
-		return errors.Wrapf(err, "could not list nodes labeled with %q", kubeadmconstants.LabelNodeRoleOldControlPlane)
-	}
-
-	for _, n := range nodesWithOldLabel.Items {
-		err = apiclient.PatchNode(client, n.Name, func(n *v1.Node) {
-			delete(n.ObjectMeta.Labels, kubeadmconstants.LabelNodeRoleOldControlPlane)
-		})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // RemoveOldControlPlaneTaint finds all nodes with the new "control-plane" node-role label
 // and removes the old "control-plane" taint to them.
 // TODO: https://github.com/kubernetes/kubeadm/issues/2200


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

The function is no longer used and was missed in a
1.25 cleanup PR.
https://github.com/kubernetes/kubernetes/pull/110095#discussion_r875445998

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2200

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
