### PR TITLE
Automated cherry pick of #109987: Fix resizing of ephemeral volumes

### DIFF
--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -358,10 +358,14 @@ func (dswp *desiredStateOfWorldPopulator) checkVolumeFSResize(
 	uniquePodName volumetypes.UniquePodName,
 	mountedVolumesForPod map[volumetypes.UniquePodName]map[string]cache.MountedVolume,
 	processedVolumesForFSResize sets.String) {
-	if podVolume.PersistentVolumeClaim == nil {
+
+	// if a volumeSpec does not have PV or has InlineVolumeSpecForCSIMigration set or pvc is nil
+	// we can't resize the volume and hence resizing should be skipped.
+	if volumeSpec.PersistentVolume == nil || volumeSpec.InlineVolumeSpecForCSIMigration || pvc == nil {
 		// Only PVC supports resize operation.
 		return
 	}
+
 	uniqueVolumeName, exist := getUniqueVolumeName(uniquePodName, podVolume.Name, mountedVolumesForPod)
 	if !exist {
 		// Volume not exist in ASW, we assume it hasn't been mounted yet. If it needs resize,

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
@@ -1026,8 +1026,9 @@ func TestCheckVolumeFSResize(t *testing.T) {
 					t.Fatalf("Mark wrong volume as fsResizeRequired: %s", vols[0])
 				}
 			},
-			volumeMode: v1.PersistentVolumeFilesystem,
-			volumeType: "ephemeral",
+			enableResize: true,
+			volumeMode:   v1.PersistentVolumeFilesystem,
+			volumeType:   "ephemeral",
 		},
 	}
 

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
@@ -547,7 +547,8 @@ func TestFindAndRemoveNonattachableVolumes(t *testing.T) {
 
 func TestEphemeralVolumeOwnerCheck(t *testing.T) {
 	// create dswp
-	pod, pv, pvc := createEphemeralVolumeObjects("dswp-test-pod", "dswp-test-volume-name", false /* not owned */)
+	mode := v1.PersistentVolumeFilesystem
+	pod, pv, pvc := createEphemeralVolumeObjects("dswp-test-pod", "dswp-test-volume-name", false /* not owned */, &mode)
 	dswp, fakePodManager, _, _, _ := createDswpWithVolume(t, pv, pvc)
 	fakePodManager.AddPod(pod)
 
@@ -916,6 +917,7 @@ func TestCheckVolumeFSResize(t *testing.T) {
 		enableResize bool
 		readOnlyVol  bool
 		volumeMode   v1.PersistentVolumeMode
+		volumeType   string
 	}{
 		{
 			// No resize request for volume, volumes in ASW shouldn't be marked as fsResizeRequired
@@ -1008,60 +1010,65 @@ func TestCheckVolumeFSResize(t *testing.T) {
 			enableResize: true,
 			volumeMode:   v1.PersistentVolumeBlock,
 		},
+		{
+			// volume in ASW should be marked as fsResizeRequired
+			resize: func(_ *testing.T, pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim, _ *desiredStateOfWorldPopulator) {
+				setCapacity(pv, pvc, 2)
+			},
+			verify: func(t *testing.T, vols []v1.UniqueVolumeName, volName v1.UniqueVolumeName) {
+				if len(vols) == 0 {
+					t.Fatalf("Requested resize for volume, but volume in ASW hasn't been marked as fsResizeRequired")
+				}
+				if len(vols) != 1 {
+					t.Errorf("Some unexpected volumes are marked as fsResizeRequired: %v", vols)
+				}
+				if vols[0] != volName {
+					t.Fatalf("Mark wrong volume as fsResizeRequired: %s", vols[0])
+				}
+			},
+			volumeMode: v1.PersistentVolumeFilesystem,
+			volumeType: "ephemeral",
+		},
 	}
 
 	for _, tc := range testcases {
-		pv := &v1.PersistentVolume{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "dswp-test-volume-name",
-			},
-			Spec: v1.PersistentVolumeSpec{
-				PersistentVolumeSource: v1.PersistentVolumeSource{RBD: &v1.RBDPersistentVolumeSource{}},
-				Capacity:               volumeCapacity(1),
-				ClaimRef:               &v1.ObjectReference{Namespace: "ns", Name: "file-bound"},
-				VolumeMode:             &tc.volumeMode,
-			},
-		}
-		pvc := &v1.PersistentVolumeClaim{
-			Spec: v1.PersistentVolumeClaimSpec{
-				VolumeName: pv.Name,
-				Resources: v1.ResourceRequirements{
-					Requests: pv.Spec.Capacity,
-				},
-			},
-			Status: v1.PersistentVolumeClaimStatus{
-				Phase:    v1.ClaimBound,
-				Capacity: pv.Spec.Capacity,
-			},
+		var pod *v1.Pod
+		var pvc *v1.PersistentVolumeClaim
+		var pv *v1.PersistentVolume
+
+		if tc.volumeType == "ephemeral" {
+			pod, pv, pvc = createEphemeralVolumeObjects("dswp-test-pod", "dswp-test-volume-name", true, &tc.volumeMode)
+		} else {
+			pv, pvc = createResizeRelatedVolumes(&tc.volumeMode)
+			containers := []v1.Container{}
+
+			if tc.volumeMode == v1.PersistentVolumeFilesystem {
+				containers = append(containers, v1.Container{
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      pv.Name,
+							MountPath: "/mnt",
+							ReadOnly:  tc.readOnlyVol,
+						},
+					},
+				})
+			} else {
+				containers = append(containers, v1.Container{
+					VolumeDevices: []v1.VolumeDevice{
+						{
+							Name:       pv.Name,
+							DevicePath: "/mnt/foobar",
+						},
+					},
+				})
+			}
+
+			pod = createPodWithVolume("dswp-test-pod", "dswp-test-volume-name", "file-bound", containers)
+			pod.Spec.Volumes[0].VolumeSource.PersistentVolumeClaim.ReadOnly = tc.readOnlyVol
 		}
 
 		dswp, fakePodManager, fakeDSW, _, _ := createDswpWithVolume(t, pv, pvc)
 		fakeASW := dswp.actualStateOfWorld
-		containers := []v1.Container{}
-
-		if tc.volumeMode == v1.PersistentVolumeFilesystem {
-			containers = append(containers, v1.Container{
-				VolumeMounts: []v1.VolumeMount{
-					{
-						Name:      pv.Name,
-						MountPath: "/mnt",
-						ReadOnly:  tc.readOnlyVol,
-					},
-				},
-			})
-		} else {
-			containers = append(containers, v1.Container{
-				VolumeDevices: []v1.VolumeDevice{
-					{
-						Name:       pv.Name,
-						DevicePath: "/mnt/foobar",
-					},
-				},
-			})
-		}
-
-		pod := createPodWithVolume("dswp-test-pod", "dswp-test-volume-name", "file-bound", containers)
-		pod.Spec.Volumes[0].VolumeSource.PersistentVolumeClaim.ReadOnly = tc.readOnlyVol
 		uniquePodName := types.UniquePodName(pod.UID)
 		uniqueVolumeName := v1.UniqueVolumeName("fake-plugin/" + pod.Spec.Volumes[0].Name)
 
@@ -1080,6 +1087,33 @@ func TestCheckVolumeFSResize(t *testing.T) {
 			tc.verify(t, resizeRequiredVolumes, uniqueVolumeName)
 		}()
 	}
+}
+
+func createResizeRelatedVolumes(volumeMode *v1.PersistentVolumeMode) (pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim) {
+	pv = &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dswp-test-volume-name",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{RBD: &v1.RBDPersistentVolumeSource{}},
+			Capacity:               volumeCapacity(1),
+			ClaimRef:               &v1.ObjectReference{Namespace: "ns", Name: "file-bound"},
+			VolumeMode:             volumeMode,
+		},
+	}
+	pvc = &v1.PersistentVolumeClaim{
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: pv.Name,
+			Resources: v1.ResourceRequirements{
+				Requests: pv.Spec.Capacity,
+			},
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase:    v1.ClaimBound,
+			Capacity: pv.Spec.Capacity,
+		},
+	}
+	return
 }
 
 func volumeCapacity(size int) v1.ResourceList {
@@ -1189,7 +1223,7 @@ func createPodWithVolume(pod, pv, pvc string, containers []v1.Container) *v1.Pod
 	}
 }
 
-func createEphemeralVolumeObjects(podName, volumeName string, owned bool) (pod *v1.Pod, pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim) {
+func createEphemeralVolumeObjects(podName, volumeName string, owned bool, volumeMode *v1.PersistentVolumeMode) (pod *v1.Pod, pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim) {
 	pod = &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
@@ -1222,14 +1256,14 @@ func createEphemeralVolumeObjects(podName, volumeName string, owned bool) (pod *
 			Phase: v1.PodPhase("Running"),
 		},
 	}
-	mode := v1.PersistentVolumeFilesystem
 	pv = &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: volumeName,
 		},
 		Spec: v1.PersistentVolumeSpec{
 			ClaimRef:   &v1.ObjectReference{Namespace: "ns", Name: "file-bound"},
-			VolumeMode: &mode,
+			Capacity:   volumeCapacity(1),
+			VolumeMode: volumeMode,
 		},
 	}
 	pvc = &v1.PersistentVolumeClaim{
@@ -1238,10 +1272,14 @@ func createEphemeralVolumeObjects(podName, volumeName string, owned bool) (pod *
 			Namespace: pod.Namespace,
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
-			VolumeName: "dswp-test-volume-name",
+			VolumeName: volumeName,
+			Resources: v1.ResourceRequirements{
+				Requests: pv.Spec.Capacity,
+			},
 		},
 		Status: v1.PersistentVolumeClaimStatus{
-			Phase: v1.ClaimBound,
+			Phase:    v1.ClaimBound,
+			Capacity: pv.Spec.Capacity,
 		},
 	}
 	if owned {


### PR DESCRIPTION
Cherry pick of #109987 on release-1.23.

#109987: Fix resizing of ephemeral volumes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```