### PR TITLE
Fix stop signal to drained signal in genericapiserver config

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -528,9 +528,9 @@ func completeOpenAPI(config *openapicommon.Config, version *version.Info) {
 	}
 }
 
-// StopNotify returns a lifecycle signal of genericapiserver shutting down.
-func (c *Config) StopNotify() <-chan struct{} {
-	return c.lifecycleSignals.ShutdownInitiated.Signaled()
+// DrainedNotify returns a lifecycle signal of genericapiserver already drained while shutting down.
+func (c *Config) DrainedNotify() <-chan struct{} {
+	return c.lifecycleSignals.InFlightRequestsDrained.Signaled()
 }
 
 // Complete fills in any fields not set that are required to have valid data and can be derived

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -226,7 +226,7 @@ func (s *EtcdOptions) ApplyWithStorageFactoryTo(factory serverstorage.StorageFac
 }
 
 func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {
-	healthCheck, err := storagefactory.CreateHealthCheck(s.StorageConfig, c.StopNotify())
+	healthCheck, err := storagefactory.CreateHealthCheck(s.StorageConfig, c.DrainedNotify())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/108483

Split from https://github.com/kubernetes/kubernetes/pull/110125/

```release-note
NONE
```

/kind cleanup
/sig api-machinery
/priority important-longterm