### PR TITLE
kubeadm: cleanup OldControlPlaneTaint from unit tests

### DIFF
--- a/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane_test.go
+++ b/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane_test.go
@@ -45,24 +45,10 @@ func TestMarkControlPlane(t *testing.T) {
 		expectedPatch  string
 	}{
 		{
-			name:           "control-plane label and taint missing",
-			existingLabels: []string{""},
-			existingTaints: nil,
-			newTaints:      []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
-			expectedPatch:  `{"metadata":{"labels":{"node-role.kubernetes.io/control-plane":"","node.kubernetes.io/exclude-from-external-load-balancers":""}},"spec":{"taints":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"}]}}`,
-		},
-		{
-			name:           "control-plane label and taint missing but taint not wanted",
+			name:           "apply default labels",
 			existingLabels: []string{""},
 			existingTaints: nil,
 			newTaints:      nil,
-			expectedPatch:  `{"metadata":{"labels":{"node-role.kubernetes.io/control-plane":"","node.kubernetes.io/exclude-from-external-load-balancers":""}}}`,
-		},
-		{
-			name:           "control-plane label missing",
-			existingLabels: []string{""},
-			existingTaints: []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
-			newTaints:      []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
 			expectedPatch:  `{"metadata":{"labels":{"node-role.kubernetes.io/control-plane":"","node.kubernetes.io/exclude-from-external-load-balancers":""}}}`,
 		},
 		{
@@ -72,8 +58,8 @@ func TestMarkControlPlane(t *testing.T) {
 				kubeadmconstants.LabelExcludeFromExternalLB,
 			},
 			existingTaints: nil,
-			newTaints:      []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
-			expectedPatch:  `{"spec":{"taints":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"}]}}`,
+			newTaints:      []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+			expectedPatch:  `{"spec":{"taints":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane"}]}}`,
 		},
 		{
 			name: "nothing missing",
@@ -81,8 +67,8 @@ func TestMarkControlPlane(t *testing.T) {
 				kubeadmconstants.LabelNodeRoleControlPlane,
 				kubeadmconstants.LabelExcludeFromExternalLB,
 			},
-			existingTaints: []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
-			newTaints:      []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
+			existingTaints: []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+			newTaints:      []v1.Taint{kubeadmconstants.ControlPlaneTaint},
 			expectedPatch:  `{}`,
 		},
 		{
@@ -113,8 +99,8 @@ func TestMarkControlPlane(t *testing.T) {
 					Effect: v1.TaintEffectNoSchedule,
 				},
 			},
-			newTaints:     []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
-			expectedPatch: `{"spec":{"taints":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"},{"effect":"NoSchedule","key":"node.cloudprovider.kubernetes.io/uninitialized"}]}}`,
+			newTaints:     []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+			expectedPatch: `{"spec":{"taints":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane"},{"effect":"NoSchedule","key":"node.cloudprovider.kubernetes.io/uninitialized"}]}}`,
 		},
 	}
 

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -304,7 +304,7 @@ func TestGetNodeRegistration(t *testing.T) {
 					},
 				},
 				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
+					Taints: []v1.Taint{kubeadmconstants.ControlPlaneTaint},
 				},
 			},
 		},
@@ -559,7 +559,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
+					Taints: []v1.Taint{kubeadmconstants.ControlPlaneTaint},
 				},
 			},
 		},
@@ -636,7 +636,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
+					Taints: []v1.Taint{kubeadmconstants.ControlPlaneTaint},
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The OldControlPlaneTaint taint (master) can be replaced
with the new ControlPlaneTaint (control-plane) taint.

Adapt unit tests in markcontrolplane_test.go and cluster_test.go.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2200

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
