### PR TITLE
Fix edit/patch error when imagePullSecrets contains empty item

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -394,6 +394,57 @@ testCases:
       mergingList:
         - name: 2
           value: a
+  - description: merge merging list with empty map item to empty merging list
+    original:
+      mergingList: []
+    twoWay:
+      mergingList:
+      - {}
+    modified:
+      mergingList:
+       - name: null
+  - description: merge merging list with non-empty map item to merging list with empty map item
+    original:
+      mergingList:
+      - {}
+    twoWay:
+      mergingList:
+      - name: 1
+    modified:
+      mergingList:
+      - name: 1
+      - name: null
+  - description: update empty map item in merging list with key
+    original:
+      mergingList:
+      - {}
+    twoWay:
+      mergingList:
+      - name: 1
+      - name: null
+        $patch: delete
+    modified:
+      mergingList:
+      - name: 1
+  - description: update non-empty map item with empty map item in merging list
+    original:
+      mergingList:
+      - name: 1
+    twoWay:
+      mergingList: 
+      - {}
+      - name: 1
+        $patch: delete
+    modified:
+      mergingList:
+      - name: null
+  - description: delete the empty map item in merging list
+    original:
+      mergingList:
+      - {}
+    twoWay:
+      mergingList: null
+    modified: {}
   - description: retainKeys map can add a field when no retainKeys directive present
     original:
       retainKeysMap:
@@ -758,6 +809,20 @@ nonMergingIntList:
   - 1
   - 3
 `),
+		},
+	},
+	{
+		Description: "Invaid merge causes merge key to be deleted",
+		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+			Original: []byte(`
+mergingList:
+  - {}
+`),
+			TwoWay: []byte(`
+mergingList:
+  - {}
+`),
+			ExpectedError: "does not contain declared merge key",
 		},
 	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We can use `kubectl create` to create deployment with imagePullSecrets: - {}, but failed on `kubectl edit`, in that case user won't be able to update the spec unless they delete the empty imagePullSecrets, which causes the confusion to user, so we should keep the consistency.

This PR allows user to edit spec with empty imagePullSecrets item
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #109953

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow user to edit spec with empty imagePullSecrets item
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
