### PR TITLE
Add rollback logic to fix quota mismatch

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/admission.go
@@ -143,7 +143,7 @@ func (a *QuotaAdmission) Validate(ctx context.Context, attr admission.Attributes
 	if attr.GetNamespace() == "" || isNamespaceCreation(attr) {
 		return nil
 	}
-	return a.evaluator.Evaluate(attr)
+	return a.evaluator.Evaluate(ctx, attr)
 }
 
 func isNamespaceCreation(attr admission.Attributes) bool {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/admission_test.go
@@ -130,7 +130,7 @@ func TestHasUsageStats(t *testing.T) {
 
 type fakeEvaluator struct{}
 
-func (fakeEvaluator) Evaluate(a admission.Attributes) error {
+func (fakeEvaluator) Evaluate(ctx context.Context, a admission.Attributes) error {
 	return errors.New("should not be called")
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -210,6 +210,10 @@ func createHandler(r rest.NamedCreater, scope *RequestScope, admit admission.Int
 					result, err = requestFunc()
 				}
 			}
+			// If err not nil, need to rollback the quota added by QuotaAdmission.
+			if err != nil {
+				rest.AdmissionToRollbackObjectQuotaFunc(admit, admissionAttributes, scope)
+			}
 			return result, err
 		})
 		trace.Step("Write to database call finished", utiltrace.Field{"len", len(body)}, utiltrace.Field{"err", err})


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Check apiserver `Create()` return err, if err not nil, then add rollback logic to keep the ResourceQuota `status.used` consistent with actual resource num.

#### Which issue(s) this PR fixes:
Fixes #110080

#### Special notes for your reviewer:
The rollback logic is implemented by updating the quotas status based on the current usage.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```