### PR TITLE
GIT-109936: enable configurable image GC for kubelet

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -52844,6 +52844,13 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 							Format:      "int32",
 						},
 					},
+					"imageGCConfig": {
+						SchemaProps: spec.SchemaProps{
+							Description: "imageGCConfig is the configuration file used to control the behavior of the image GC manager. This configuration file can be used to exempt images from getting GC'ed once the image GC threshold configuration have been met. This file enables you to safe guard system critical images from getting GC'ed by kubelet. Default: \"\"",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"volumeStatsAggPeriod": {
 						SchemaProps: spec.SchemaProps{
 							Description: "volumeStatsAggPeriod is the frequency for calculating and caching volume disk usage for all pods. Default: \"1m\"",

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -156,6 +156,7 @@ var (
 		"TLSCertFile",
 		"TLSPrivateKeyFile",
 		"ResolverConfig",
+		"ImageGCConfig",
 	)
 
 	// KubeletConfiguration fields that do not contain file paths.

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -201,6 +201,12 @@ type KubeletConfiguration struct {
 	// image garbage collection is never run. Lowest disk usage to garbage
 	// collect to. The percent is calculated as this field value out of 100.
 	ImageGCLowThresholdPercent int32
+	// imageGCConfig is the configuration file used to control the behavior of the
+	// image GC manager. This configuration file can be used to exempt images from
+	// getting GC'ed once the image GC threshold configuration have been met. This
+	// file enables you to safe guard system critical images from getting GC'ed by
+	// kubelet.
+	ImageGCConfig string
 	// How frequently to calculate and cache volume disk usage for all pods
 	VolumeStatsAggPeriod metav1.Duration
 	// KubeletCgroups is the absolute name of cgroups to isolate the kubelet in

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -397,6 +397,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	if err := v1.Convert_Pointer_int32_To_int32(&in.ImageGCLowThresholdPercent, &out.ImageGCLowThresholdPercent, s); err != nil {
 		return err
 	}
+	out.ImageGCConfig = in.ImageGCConfig
 	out.VolumeStatsAggPeriod = in.VolumeStatsAggPeriod
 	out.KubeletCgroups = in.KubeletCgroups
 	out.SystemCgroups = in.SystemCgroups
@@ -573,6 +574,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	if err := v1.Convert_int32_To_Pointer_int32(&in.ImageGCLowThresholdPercent, &out.ImageGCLowThresholdPercent, s); err != nil {
 		return err
 	}
+	out.ImageGCConfig = in.ImageGCConfig
 	out.VolumeStatsAggPeriod = in.VolumeStatsAggPeriod
 	out.KubeletCgroups = in.KubeletCgroups
 	out.SystemCgroups = in.SystemCgroups

--- a/pkg/kubelet/images/testdata/gc-exempt-config.yaml
+++ b/pkg/kubelet/images/testdata/gc-exempt-config.yaml
@@ -1,0 +1,6 @@
+exemptByTag:
+- image1:tag1
+- image2:tag2
+exemptByID:
+- "1"
+- "2"

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -403,6 +403,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		MinAge:               kubeCfg.ImageMinimumGCAge.Duration,
 		HighThresholdPercent: int(kubeCfg.ImageGCHighThresholdPercent),
 		LowThresholdPercent:  int(kubeCfg.ImageGCLowThresholdPercent),
+		ImageGCConfig:        kubeCfg.ImageGCConfig,
 	}
 
 	enforceNodeAllocatable := kubeCfg.EnforceNodeAllocatable

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -304,6 +304,14 @@ type KubeletConfiguration struct {
 	// Default: 80
 	// +optional
 	ImageGCLowThresholdPercent *int32 `json:"imageGCLowThresholdPercent,omitempty"`
+	// imageGCConfig is the configuration file used to control the behavior of the
+	// image GC manager. This configuration file can be used to exempt images from
+	// getting GC'ed once the image GC threshold configuration have been met. This
+	// file enables you to safe guard system critical images from getting GC'ed by
+	// kubelet.
+	// Default: ""
+	// +optional
+	ImageGCConfig string `json:"imageGCConfig,omitempty"`
 	// volumeStatsAggPeriod is the frequency for calculating and caching volume
 	// disk usage for all pods.
 	// Default: "1m"


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Currently, the way the Kubernetes performs a GC operation of the Images if the GC threshold is met is partially uncontrolled. i.e It excludes the sandbox images, and performs a `minAge` check before performing the GC of the images. However, this can lead to some serious breakdown of the cluster depending on what images have been GC'ed. 

In cases such as AirGap cluster it is important that there is a provision to be able to instruct kubelet which images to exempt from GC workflow. This is required to ensure that we can retain some cluster critical images on the cluster always.

#### Which issue(s) this PR fixes:

Fixes #109936

#### Special notes for your reviewer:
```yaml
exemptByTag:
- image1:tag1
- image2:tag2
exemptByID:
- "1"
- "2"
```
Above is the format of the GC Configuration file.  The PR in current state doesn't support wildcarding the image tags. 

TODO: 

- [ ] Version the GC Configuration spec

#### Does this PR introduce a user-facing change?
Yes

```release-note
kubelet will  provide a configurable way to indicate the exemption configuration for the Container Images. This configuration can be provided either using the tags or the Images ID using suitable structure of the GC Configuration file
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NA for now. PoC to identify if we really need a KEP as suggested by @dims 
```
