### PR TITLE
Removal of github.com/chai2010/gettext-go from kubectl client lib

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/override_options.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/override_options.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util/i18n"
 )
 
 type OverrideType string
@@ -47,7 +46,7 @@ type OverrideOptions struct {
 }
 
 func (o *OverrideOptions) AddOverrideFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Overrides, "overrides", "", i18n.T("An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field."))
+	cmd.Flags().StringVar(&o.Overrides, "overrides", "", "An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field.")
 	cmd.Flags().StringVar((*string)(&o.OverrideType), "override-type", string(DefaultOverrideType), fmt.Sprintf("The method used to override the generated object: %s, %s, or %s.", OverrideTypeJSON, OverrideTypeMerge, OverrideTypeStrategic))
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

PR removes github.com/chai2010/gettext-go from client library for kubectl. 
Before the change kubectl client lib was including github.com/chai2010/gettext-go library (BSD), this lib was introduced in v0.23 of kubectl.

#### Special notes for your reviewer:
This fix is quite important for us. (some internal checks are failing)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

