### PR TITLE
update to new level of agnhost

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -233,7 +233,7 @@ const (
 
 func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
 	configs := map[ImageID]Config{}
-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.36"}
+	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.38"}
 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
 	configs[AuthenticatedAlpine] = Config{list.GcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[AuthenticatedWindowsNanoServer] = Config{list.GcAuthenticatedRegistry, "windows-nanoserver", "v1"}


### PR DESCRIPTION
updating to use https://github.com/kubernetes/kubernetes/pull/110174 .

Following directions from https://github.com/kubernetes/kubernetes/tree/master/test/images#promoting-images

```release-note
NONE
```