### PR TITLE
Prune defaults for CRDs for OpenAPI V2

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
@@ -201,8 +201,10 @@ func buildVersionSpecs(crd *apiextensionsv1.CustomResourceDefinition, oldSpecs m
 		if !v.Served {
 			continue
 		}
-		// Defaults are not pruned here, but before being served.
 		spec, err := builder.BuildOpenAPIV2(crd, v.Name, builder.Options{V2: true})
+		// Defaults must be pruned here for CRDs to cleanly merge with the static
+		// spec that already has defaults pruned
+		spec.Definitions = handler.PruneDefaults(spec.Definitions)
 		if err != nil {
 			return nil, false, err
 		}

--- a/test/integration/apiserver/openapi/openapi_v2_merge_test.go
+++ b/test/integration/apiserver/openapi/openapi_v2_merge_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapi
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	kubernetes "k8s.io/client-go/kubernetes"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestOpenAPIV2CRDMergeNoDuplicateTypes(t *testing.T) {
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.TearDownFn()
+	config := server.ClientConfig
+
+	apiExtensionClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foo := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foosubs.cr.bar.com",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "cr.bar.com",
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "foosubs",
+				Kind:   "FooSub",
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer",
+										},
+									},
+								},
+								"status": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer",
+										},
+									},
+								},
+							},
+						},
+					},
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+						Scale: &apiextensionsv1.CustomResourceSubresourceScale{
+							SpecReplicasPath:   ".spec.replicas",
+							StatusReplicasPath: ".status.replicas",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	baz := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bazsubs.cr.bar.com",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "cr.bar.com",
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "bazsubs",
+				Kind:   "BazSub",
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer",
+										},
+									},
+								},
+								"status": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer",
+										},
+									},
+								},
+							},
+						},
+					},
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+						Scale: &apiextensionsv1.CustomResourceSubresourceScale{
+							SpecReplicasPath:   ".spec.replicas",
+							StatusReplicasPath: ".status.replicas",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(foo, apiExtensionClient, dynamicClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(baz, apiExtensionClient, dynamicClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var openAPISpec spec.Swagger
+	// Poll for the OpenAPI to be updated with the new CRD
+	wait.Poll(time.Second*1, wait.ForeverTestTimeout, func() (bool, error) {
+		jsonData, err := clientset.RESTClient().Get().AbsPath("/openapi/v2").Do(context.TODO()).Raw()
+		if err != nil {
+			t.Fatal(err)
+		}
+		openAPISpec = spec.Swagger{}
+		err = json.Unmarshal(jsonData, &openAPISpec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for schemaName := range openAPISpec.Definitions {
+			if strings.HasPrefix(schemaName, "com.bar.cr.v1.BazSub") {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+
+	for schemaName := range openAPISpec.Definitions {
+		if strings.HasSuffix(schemaName, "_v2") {
+			t.Errorf("Error: Expected no _v2 types, got %s", schemaName)
+		}
+	}
+}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Prune defaults for CRDs for the OpenAPI V2 CRD controller. This allows the static spec to merge cleanly with the CRD specs (https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go#L230). A DeepEqual check is performed before deciding whether a resource needs to be renamed due to a conflict. The static spec already has its defaults pruned: (https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go#L43) The DeepEqual will fail when a resource with defaults pruned is compared to one with defaults intact. This applies for meta types shared between the static spec and CRD specs, so we have "ObjectMeta_v2", "Status_v2", etc. 

There is no user facing impact because we currently already prune defaults (later in the chain in the aggregator https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go#L188). This just shifts (left?) the pruning earlier in the openapi chain. 

I'm not aware of anything that directly uses these OpenAPI schemas published directly from the apiextensions server. SSA builds OpenAPI for CRDs directly from the structural schema and should be unaffected. (https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go#L686)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #109275

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
OpenAPI will no longer duplicate these schemas:
- io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions_v2
- io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2
- io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference_v2
- io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails_v2
- io.k8s.apimachinery.pkg.apis.meta.v1.Status_v2
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
