### PR TITLE
Implement advanced field selectors for Service resources

### DIFF
--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -88,6 +88,7 @@ func NewREST(
 	store := &genericregistry.Store{
 		NewFunc:                  func() runtime.Object { return &api.Service{} },
 		NewListFunc:              func() runtime.Object { return &api.ServiceList{} },
+		PredicateFunc:            svcreg.Matcher,
 		DefaultQualifiedResource: api.Resource("services"),
 		ReturnDeletedObject:      true,
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces the feature to query Services with the `spec.type` field selector.

`kubectl get service --field-selector=spec.type=ClusterIP`

Superficially, all Services work they same way, but under the hood they can have quite different implementations (ClusterIP vs. LoadBalancerService),
At the moment, there is no efficient way to retrieve Services of a particular type in the cluster or the namespace.
The only workaround is listing ALL services and then manually performing the selection client-side (e.g. with `jq` on the command-line).
However, this is inefficient (especially in large and very dense clusters) and places additional load on the API server since the full Service spec needs to be retrieved for all Services.

Example use-cases:
* cloud-controllers / loadbalancer implementation need to list all Services of type "LoadBalancerService" in the cluster (so they can `sync` them according to the desired state), but are not interested in services of other types (they are not responsible for them).
* cluster administrators want to view usage of "LoadBalancerServices" and "NodePort" services in their clusters, since these are shared and limited resources (possibly these are also restricted by quotas)


#### Which issue(s) this PR fixes:

The feature was previously requested in https://github.com/kubernetes/kubernetes/issues/77662.
A similar feature was also discussed in https://github.com/kubernetes/kubernetes/issues/85552 (and possibly elsewhere).

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Implement "spec.type" field selector for Service resources
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
