### PR TITLE
kubeadm: cleanup unused *ControlPlaneToleration

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -193,7 +193,7 @@ const (
 	// TODO: Remove once UnversionedKubeletConfigMap graduates to GA:
 	// https://github.com/kubernetes/kubeadm/issues/1582
 	KubeletBaseConfigMapRolePrefix = "kubeadm:kubelet-config-"
-	// KubeletBaseConfigMapRolePrefix defines the base kubelet configuration ConfigMap.
+	// KubeletBaseConfigMapRole defines the base kubelet configuration ConfigMap.
 	KubeletBaseConfigMapRole = "kubeadm:kubelet-config"
 	// KubeProxyClusterRoleBindingName sets the name for the kube-proxy CluterRoleBinding
 	KubeProxyClusterRoleBindingName = "kubeadm:node-proxier"
@@ -450,21 +450,8 @@ var (
 		Effect: v1.TaintEffectNoSchedule,
 	}
 
-	// OldControlPlaneToleration is the toleration to apply on the PodSpec for being able to run that Pod on the control-plane
-	// DEPRECATED: https://github.com/kubernetes/kubeadm/issues/2200
-	OldControlPlaneToleration = v1.Toleration{
-		Key:    LabelNodeRoleOldControlPlane,
-		Effect: v1.TaintEffectNoSchedule,
-	}
-
 	// ControlPlaneTaint is the taint to apply on the PodSpec for being able to run that Pod on the control-plane
 	ControlPlaneTaint = v1.Taint{
-		Key:    LabelNodeRoleControlPlane,
-		Effect: v1.TaintEffectNoSchedule,
-	}
-
-	// ControlPlaneToleration is the toleration to apply on the PodSpec for being able to run that Pod on the control-plane
-	ControlPlaneToleration = v1.Toleration{
 		Key:    LabelNodeRoleControlPlane,
 		Effect: v1.TaintEffectNoSchedule,
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
It is a cleanup for #97627, `*ControlPlaneToleration` is unused.
And fix `KubeletBaseConfigMapRole`  comment typo.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
