### PR TITLE
Add unittest for k/k/pkg/kubelet/cm/cgroup_manager_linux.go

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux_test.go
@@ -174,7 +174,7 @@ func TestParseSystemdToCgroupName(t *testing.T) {
 	}
 }
 
-func TestName(t *testing.T) {
+func TestCgroupManagerName(t *testing.T) {
 	testCases := []struct {
 		name       string
 		input      CgroupName

--- a/pkg/kubelet/cm/cgroup_manager_linux_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux_test.go
@@ -205,3 +205,31 @@ func TestName(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSystemdStyleName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "test systemd style cgroup name",
+			input:    "/parent/parent-child.slice",
+			expected: true,
+		},
+		{
+			name:     "test cgroupfs style cgroup name",
+			input:    "/parent/child",
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := IsSystemdStyleName(testCase.input)
+			if actual != testCase.expected {
+				t.Errorf("got: %t, want: %t", actual, testCase.expected)
+			}
+		})
+	}
+}

--- a/pkg/kubelet/cm/cgroup_manager_linux_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux_test.go
@@ -169,3 +169,35 @@ func TestParseSystemdToCgroupName(t *testing.T) {
 		}
 	}
 }
+
+func TestName(t *testing.T) {
+	testCases := []struct {
+		name       string
+		input      CgroupName
+		useSystemd bool
+		expected   string
+	}{
+		{
+			name:       "test systemd style cgroup name",
+			input:      NewCgroupName(RootCgroupName, "Burstable", "pod-123"),
+			useSystemd: true,
+			expected:   "/Burstable.slice/Burstable-pod_123.slice",
+		},
+		{
+			name:       "test cgroupfs style cgroup name",
+			input:      NewCgroupName(RootCgroupName, "Burstable", "pod-123"),
+			useSystemd: false,
+			expected:   "/Burstable/pod-123",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			manager := cgroupManagerImpl{&CgroupSubsystems{}, testCase.useSystemd}
+			actual := manager.Name(testCase.input)
+			if actual != testCase.expected {
+				t.Errorf("got: %s, want: %s", actual, testCase.expected)
+			}
+		})
+	}
+}

--- a/pkg/kubelet/cm/cgroup_manager_linux_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux_test.go
@@ -161,6 +161,10 @@ func TestParseSystemdToCgroupName(t *testing.T) {
 			input:    "/test.slice",
 			expected: []string{"test"},
 		},
+		{
+			input:    "/parent.slice/parent-child.slice",
+			expected: []string{"parent", "child"},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds tests to k/k/pkg/kubelet/cm/cgroup_manager_linux.go.
- Add test for cgroupManagerImpl.Name
- Add test for IsSystemdStyleName
- Append test case for TestParseSystemdToCgroupName

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fix part of #109717

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
