### PR TITLE
remove deprecated label and update snapshot controller version

### DIFF
--- a/cluster/addons/volumesnapshots/volume-snapshot-controller/rbac-volume-snapshot-controller.yaml
+++ b/cluster/addons/volumesnapshots/volume-snapshot-controller/rbac-volume-snapshot-controller.yaml
@@ -53,7 +53,6 @@ metadata:
   name: volume-snapshot-controller-role
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 subjects:
   - kind: ServiceAccount
@@ -72,7 +71,6 @@ metadata:
   name: volume-snapshot-controller-leaderelection
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups: ["coordination.k8s.io"]
@@ -86,7 +84,6 @@ metadata:
   name: volume-snapshot-controller-leaderelection
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 subjects:
   - kind: ServiceAccount

--- a/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
+++ b/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccount: volume-snapshot-controller
       containers:
         - name: volume-snapshot-controller
-          image: registry.k8s.io/sig-storage/snapshot-controller:v4.0.0
+          image: registry.k8s.io/sig-storage/snapshot-controller:v6.0.1
           args:
             - "--v=5"
             - "--metrics-path=/metrics"


### PR DESCRIPTION
`kubernetes.io/cluster-service: "true"` label has been deprecated for addon manager.
https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/addon-manager/README.md
Additionally,  the manifests also have `addonmanager.kubernetes.io/mode: Reconcile` label which take care of the reconcilation.


Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


/kind cleanup

```release-note
NONE
```

