### PR TITLE
Create an abstraction for resource versions

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/semanticrv/comparison.go
+++ b/staging/src/k8s.io/apimachinery/pkg/semanticrv/comparison.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package semanticrv
+
+// Comparison is the result of comparing two values in a partial order.
+type Comparison struct {
+	LE bool // less than or equal
+	GE bool // greater than or equal
+}
+
+func Equal() Comparison { return Comparison{LE: true, GE: true} }
+
+func Less() Comparison { return Comparison{LE: true, GE: false} }
+
+func Greater() Comparison { return Comparison{LE: false, GE: true} }
+
+func Incomparable() Comparison { return Comparison{LE: false, GE: false} }
+
+func (c Comparison) IsLess() bool { return c.LE && !c.GE }
+
+func (c Comparison) IsLessOrEqual() bool { return c.LE }
+
+func (c Comparison) IsGreater() bool { return c.GE && !c.LE }
+
+func (c Comparison) IsGreaterOrEqual() bool { return c.GE }
+
+func (c Comparison) IsEqual() bool { return c.LE && c.GE }
+
+func (c Comparison) IsComparable() bool { return c.LE || c.GE }
+
+func (c Comparison) IsStrictlyOrdered() bool { return c.LE != c.GE }
+
+func (c Comparison) And(d Comparison) Comparison {
+	return Comparison{LE: c.LE && d.LE, GE: c.GE && d.GE}
+}
+
+func (c Comparison) Implies(d Comparison) bool {
+	return (!c.LE || d.LE) && (!c.GE || d.GE)
+}
+
+func (c Comparison) Reverse() Comparison {
+	return Comparison{LE: c.GE, GE: c.LE}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/semanticrv/rvbytes.go
+++ b/staging/src/k8s.io/apimachinery/pkg/semanticrv/rvbytes.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package semanticrv
+
+import (
+	"bytes"
+	"strings"
+)
+
+// ResourceVersion, except for two special values, identifies a closed set of
+// write transactions on an API service and thus is associated with
+// the state that those transactions collectively produce.
+// Here "closed" means that for every included write X,
+// every write W that happens-before X is also included.
+//
+// This definition contemplates that write transactions might not be
+// totally ordered.
+// This does not preclude the notifications from a WATCH from having
+// the properties that:
+// (1) a notification with RV1 preceding a notification with RV2 implies that
+//     RV2 is not a subset of RV1; and
+// (2) in a WATCH that starts from a specific RV0, every notification carries
+//     a ResourceVersion that is a superset of RV0.
+// These properties are enough to allow a reflector to maintain a single ResourceVersion
+// that tracks the accumulation of what the reflector has seen.
+//
+// There are two special values of ResourceVersion,
+// which do not identify a set of transactions but are used
+// by a client in a position that _may_ specify a set of transactions; see
+// https://kubernetes.io/docs/reference/using-api/api-concepts/#the-resourceversion-parameter
+// for the two special values and their meaning.
+type ResourceVersion struct {
+	// The concrete representation used here is slice of byte.
+	// Ordering among non-special values is first by slice length and second,
+	// among equal length slices, by lexicographic comparison.
+	// This has the property that values produced by `fmt.Sprintf("%d", .)` applied
+	// to positive integers are ordered the same as those integers.
+	rep []byte
+}
+
+// UndefinedAsString is the string representation of "undefined"
+const UndefinedAsString = ""
+
+// AnyAsString is the string representation of "any"
+const AnyAsString = "0"
+
+// Parse parses the given string into a ResourceVersion, returning an error
+// if the input is not a valid string representation of a ResourceVersion.
+func Parse(str string) (ResourceVersion, error) {
+	return ResourceVersion{rep: []byte(str)}, nil
+}
+
+// IsUndefined tells whether the receiver is the special value that means
+// "unspecified" or "undefined".
+// This is true for the zero value of this type.
+func (rv ResourceVersion) IsUndefined() bool {
+	return len(rv.rep) == 0
+}
+
+// IsAny tells whether the receiver is the special value that means any
+// closed set of write transactions is acceptable.
+func (rv ResourceVersion) IsAny() bool {
+	return string(rv.rep) == AnyAsString
+}
+
+// IsSpecial tells whether the receiver is either of the special values.
+func (rv ResourceVersion) IsSpecial() bool {
+	return rv.IsAny() || rv.IsUndefined()
+}
+
+// String returns the string representation of the receiver.
+// For every string S: if `R, err := Parse(S); err == nil`
+// then `S == R.String()`.
+// For every pair of ResourceVersions X and Y,
+// `X.Compare(Y).IsEqual() == (X.String() == Y.String())`.
+func (rv ResourceVersion) String() string {
+	return string(rv.rep)
+}
+
+// StringForFilename returns a string representation of the receiver
+// that is safe to put in a filename in Linux, MacOS, and Windows.
+// The returned string will not include a directory delimiter.
+func (rv ResourceVersion) StringForFilename() string {
+	if rv.IsUndefined() {
+		return "%NDEF"
+	}
+	var bld strings.Builder
+	for _, b := range rv.rep {
+		if b >= '0' && b <= '9' ||
+			b >= 'A' && b <= 'Z' {
+			bld.WriteByte(b)
+			continue
+		}
+		switch b {
+		case '!', '@', '#', '$', '^', '&', '*', '(', ')',
+			'-', '_', '=', '+', '.', ',':
+			bld.WriteByte(b)
+			continue
+		}
+		bld.WriteRune('%')
+		bld.WriteByte(hexDigits[b/16])
+		bld.WriteByte(hexDigits[b%16])
+	}
+	return bld.String()
+}
+
+const hexDigits = "0123456789ABCDEF"
+
+// Compare compares the write transaction sets identified by two ResourceVersions.
+// If the transaction set of RV X is a subset of the transaction set of RV Y then X.Compare(Y).LE.
+// Naturally, this is reflexive ( X.Compare(X).IsEqual() )
+// and anti-symmetric ( X.Compare(Y) == Y.Compare(X).Reverse() ).
+// Also naturally, these chain: X.Compare(Y).And(Y.Compare(Z)).Implies(X.Compare(Z)).
+// The special values are equal to themselves and incomparable with all other values.
+func (rv ResourceVersion) Compare(other ResourceVersion) Comparison {
+	if rv.IsUndefined() {
+		otherIsUndef := other.IsUndefined()
+		return Comparison{LE: otherIsUndef, GE: otherIsUndef}
+	}
+	if rv.IsAny() {
+		otherIsAny := other.IsAny()
+		return Comparison{LE: otherIsAny, GE: otherIsAny}
+	}
+	if other.IsSpecial() {
+		return Incomparable()
+	}
+	l1 := len(rv.rep)
+	l2 := len(other.rep)
+	if l1 < l2 {
+		return Less()
+	}
+	if l1 > l2 {
+		return Greater()
+	}
+	c := bytes.Compare(rv.rep, other.rep)
+	return Comparison{LE: c <= 0, GE: c >= 0}
+}
+
+// Union returns the ResourceVersion that identifies the union of the two
+// input transaction sets, with the two special values handled as follows.
+// For every ResourceVersion X: X.Union(undefined) = undfined.Union(X) = X.
+// For every ResourceVersion X other than undefined: X.Union(any) = any.Union(X) = X.
+func (rv ResourceVersion) Union(other ResourceVersion) ResourceVersion {
+	if rv.IsUndefined() {
+		return other
+	}
+	if other.IsSpecial() {
+		return rv
+	}
+	cmp := rv.Compare(other)
+	if cmp.GE {
+		return rv
+	}
+	return other
+}

--- a/staging/src/k8s.io/apimachinery/pkg/semanticrv/rvbytes_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/semanticrv/rvbytes_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package semanticrv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEm(t *testing.T) {
+	anUndef, _ := Parse(UndefinedAsString)
+	anAny, _ := Parse(AnyAsString)
+	for _, testCase := range []struct {
+		str      string
+		parseErr bool
+		isUndef  bool
+		isAny    bool
+	}{
+		{UndefinedAsString, false, true, false},
+		{AnyAsString, false, false, true},
+		{"1", false, false, false},
+		{"10", false, false, false},
+		{"10.01", false, false, false},
+		{"XYZ", false, false, false},
+	} {
+		parsed, err := Parse(testCase.str)
+		if (err != nil) != testCase.parseErr {
+			t.Errorf("Parse of %q produced error %#+v", testCase.str, err)
+		}
+		if err != nil {
+			continue
+		}
+		if a, e := parsed.IsUndefined(), testCase.isUndef; a != e {
+			t.Errorf("%q.IsUndefined()==%v but expected %v", testCase.str, a, e)
+		}
+		if a, e := parsed.IsAny(), testCase.isAny; a != e {
+			t.Errorf("%q.IsAny()==%v but expected %v", testCase.str, a, e)
+		}
+		if a, e := parsed.String(), testCase.str; a != e {
+			t.Errorf("%q.String()==%q", e, a)
+		}
+		efile := testCase.str
+		if efile == UndefinedAsString {
+			efile = "%NDEF"
+		}
+		if a := parsed.StringForFilename(); a != efile {
+			t.Errorf("%q.String()==%q", testCase.str, a)
+		}
+		if a, e := parsed.Compare(anUndef), c(parsed.IsUndefined(), parsed.IsUndefined()); a != e {
+			t.Errorf("%q.Compare(%q)==%v but expected %v", testCase.str, anUndef, a, e)
+		}
+		if a, e := parsed.Compare(anAny), c(parsed.IsAny(), parsed.IsAny()); a != e {
+			t.Errorf("%q.Compare(%q)==%v but expected %v", testCase.str, anAny, a, e)
+		}
+		if a, e := parsed.Compare(parsed), c(true, true); a != e {
+			t.Errorf("%q.Compare(itself)==%v but expected %v", testCase.str, a, e)
+		}
+		eunion := []ResourceVersion{parsed}
+		if parsed.IsAny() {
+			eunion = append(eunion, anUndef)
+		}
+		if m := parsed.Union(anUndef); !(m.Compare(eunion[0]).IsEqual() || m.Compare(eunion[len(eunion)-1]).IsEqual()) {
+			t.Errorf("%q.Union(%q)==%#+v but expected one of %#+v", testCase.str, anUndef, m, eunion)
+		}
+		eunion = []ResourceVersion{parsed}
+		if parsed.IsUndefined() {
+			eunion = append(eunion, anAny)
+		}
+		if m := parsed.Union(anAny); !(m.Compare(eunion[0]).IsEqual() || m.Compare(eunion[len(eunion)-1]).IsEqual()) {
+			t.Errorf("%q.Union(%q)==%#+v but expected itself", testCase.str, anAny, m)
+		}
+		if m := parsed.Union(parsed); !m.Compare(parsed).IsEqual() {
+			t.Errorf("%q.Union(itself)==%#+v but expected itself", testCase.str, m)
+		}
+	}
+	for _, testCase := range []struct {
+		str1, str2 string
+		union      string
+		comp       Comparison
+	}{
+		{"10", "2", "10", Greater()},
+		{"2", "10", "10", Less()},
+		{"7", "5.6", "5.6", Less()},
+		{"5.6", "7", "5.6", Greater()},
+		{"9", strings.Repeat("8", 100), strings.Repeat("8", 100), Less()},
+		{strings.Repeat("8", 100), "9", strings.Repeat("8", 100), Greater()},
+	} {
+		p1, err := Parse(testCase.str1)
+		if err != nil {
+			t.Error(err)
+		}
+		p2, err := Parse(testCase.str2)
+		if err != nil {
+			t.Error(err)
+		}
+		acomp := p1.Compare(p2)
+		if acomp != testCase.comp {
+			t.Errorf("%q.Compare(%q)=%v not %v", testCase.str1, testCase.str2, acomp, testCase.comp)
+		}
+		aunion := p1.Union(p2)
+		if a, e := aunion.String(), testCase.union; a != e {
+			t.Errorf("%q.Union(%q)=%q not %q", testCase.str1, testCase.str2, a, e)
+		}
+	}
+}
+
+func c(le, ge bool) Comparison {
+	return Comparison{LE: le, GE: ge}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR introduces a package for dealing with ResourceVersion values.
We need this so that clients can stop parsing ResourceVersion strings as int64 or uint64.
This package has the additional virtue that it accepts a superset of the strings that parse as 64-bit integers, while treating formatted 64-bit integers as before.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
This release introduces the package `k8s.io/apimachinery/pkg/semanticrv` that should be used by clients that need more semantics from ResourceVersion strings than simply comparison for equality.  This package adds the abilities to compare and to combine ResourceVersions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig api-machinery
