### PR TITLE
move hostname in topology to nodename when nodename is nil

### DIFF
--- a/pkg/apis/discovery/v1beta1/conversion.go
+++ b/pkg/apis/discovery/v1beta1/conversion.go
@@ -40,12 +40,16 @@ func Convert_v1beta1_Endpoint_To_discovery_Endpoint(in *v1beta1.Endpoint, out *d
 			delete(out.DeprecatedTopology, corev1.LabelTopologyZone)
 		}
 
+		// Move hostname from topology map if nodename in v1beta1 is nil.
 		// Remove hostname from the topology map ONLY IF it is the same value as
 		// nodeName.  This preserves the (rather odd) ability to have different
 		// values for topology[hostname] and nodename in v1beta1, without showing
 		// duplicate values in v1.
 		if node, ok := in.Topology[corev1.LabelHostname]; ok {
-			if out.NodeName != nil && node == *out.NodeName {
+			if out.NodeName == nil {
+				out.NodeName = &node
+				delete(out.DeprecatedTopology, corev1.LabelHostname)
+			} else if node == *out.NodeName {
 				delete(out.DeprecatedTopology, corev1.LabelHostname)
 			}
 		}

--- a/pkg/apis/discovery/v1beta1/conversion_test.go
+++ b/pkg/apis/discovery/v1beta1/conversion_test.go
@@ -112,9 +112,7 @@ func TestEndpointZoneConverstion(t *testing.T) {
 				},
 			},
 			internal: discovery.Endpoint{
-				DeprecatedTopology: map[string]string{
-					corev1.LabelHostname: "node-1",
-				},
+				NodeName: utilpointer.StringPtr("node-1"),
 			},
 		},
 		{


### PR DESCRIPTION
fix #110208

Retain the `topology.hostname` to `discovery.v1.endpoint.nodename` to prevent `kube-proxy` remove all `Local` endpoint from `NodePort`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig network

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #110208

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix LoadBalancer&NodePort network issue after upgrade to version>1.22 from <=1.20.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
