### PR TITLE
Cleanup feature gate check for SelectorIndex

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -35,11 +35,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	genericfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	podutil "k8s.io/kubernetes/pkg/api/pod"
@@ -293,12 +291,9 @@ func NodeNameIndexFunc(obj interface{}) ([]string, error) {
 
 // Indexers returns the indexers for pod storage.
 func Indexers() *cache.Indexers {
-	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.SelectorIndex) {
-		return &cache.Indexers{
-			storage.FieldIndex("spec.nodeName"): NodeNameIndexFunc,
-		}
+	return &cache.Indexers{
+		storage.FieldIndex("spec.nodeName"): NodeNameIndexFunc,
 	}
-	return nil
 }
 
 // ToSelectableFields returns a field set that represents the object

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -139,14 +139,6 @@ const (
 	// Deprecates and removes SelfLink from ObjectMeta and ListMeta.
 	RemoveSelfLink featuregate.Feature = "RemoveSelfLink"
 
-	// owner: @shaloulcy, @wojtek-t
-	// alpha: v1.18
-	// beta: v1.19
-	// GA: v1.20
-	//
-	// Allows label and field based indexes in apiserver watch cache to accelerate list operations.
-	SelectorIndex featuregate.Feature = "SelectorIndex"
-
 	// owner: @apelisse, @lavalamp
 	// alpha: v1.14
 	// beta: v1.16
@@ -218,8 +210,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	RemainingItemCount: {Default: true, PreRelease: featuregate.Beta},
 
 	RemoveSelfLink: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-
-	SelectorIndex: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 
 	ServerSideApply: {Default: true, PreRelease: featuregate.GA},
 


### PR DESCRIPTION
The feature is GA since 1.20

https://github.com/kubernetes/kubernetes/blob/522cd18f87d0ffe1bc6d92471a4a2b540e5dcaec/staging/src/k8s.io/apiserver/pkg/features/kube_features.go#L142-L148


/kind cleanup
```release-note
NONE
```
