### PR TITLE
Adding systemCgroup tests

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -273,30 +273,21 @@ func TestNewSystemCgroups(t *testing.T) {
 		name   string
 		cmName string
 	}{
-		// Not sure what tests should fail here
 		{
 			name:   "Create cgroup container manager with name 'kube'",
 			cmName: "kube",
 		},
 		{
-			name:   "Create cgroup container manager with name '1234'",
+			name:   "Create root cgroup container manager with name '/'",
 			cmName: "1234",
-		},
-		// I think this should fail but there is no check for system container name
-		{
-			name:   "Create cgroup container manager with name ''",
-			cmName: "",
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			sc, err := newSystemCgroups(c.cmName)
-			if err != nil {
-				t.Errorf("Failed to create cgroup container manager 'kube': %s", err)
-			}
-			if c.cmName != sc.name {
-				t.Errorf("SystemContainer name mismatch. Expected %s, got %s.", c.cmName, sc.name)
-			}
+			assert.NoError(t, err)
+			assert.NotNil(t, sc.manager, "SystemContainer.manager should not be nil")
+			assert.Equal(t, c.cmName, sc.name, "Naming mismatch for ContainerManager and SystemContainer")
 		})
 	}
 }

--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -268,3 +268,35 @@ func TestGetCapacity(t *testing.T) {
 		})
 	}
 }
+func TestNewSystemCgroups(t *testing.T) {
+	cases := []struct {
+		name   string
+		cmName string
+	}{
+		// Not sure what tests should fail here
+		{
+			name:   "Create cgroup container manager with name 'kube'",
+			cmName: "kube",
+		},
+		{
+			name:   "Create cgroup container manager with name '1234'",
+			cmName: "1234",
+		},
+		// I think this should fail but there is no check for system container name
+		{
+			name:   "Create cgroup container manager with name ''",
+			cmName: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sc, err := newSystemCgroups(c.cmName)
+			if err != nil {
+				t.Errorf("Failed to create cgroup container manager 'kube': %s", err)
+			}
+			if c.cmName != sc.name {
+				t.Errorf("SystemContainer name mismatch. Expected %s, got %s.", c.cmName, sc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

This PR helps address kubelet test coverage by adding coverage for createManager() and newSystemCgroups().

#### Which issue(s) this PR fixes: 
https://github.com/kubernetes/kubernetes/issues/109717

#### Special notes for your reviewer:

I do have two comments in the test. I'm concerned that we don't check validity of the string in the systemContainer  name field. Should we validate or check for an empty string? I would be more than happy to handle this error in the function but would like advice on what the behavior should be so I can then also ad a relevant test for the behavior

#### Does this PR introduce a user-facing change?

```release-note
NONE
```