### PR TITLE
restore endpoints topology fallback in kube-proxy 1.22

### DIFF
--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -80,6 +80,7 @@ type endpointSliceInfo struct {
 type endpointInfo struct {
 	Addresses []string
 	NodeName  *string
+	Topology  map[string]string
 	Zone      *string
 	ZoneHints sets.String
 
@@ -132,6 +133,7 @@ func newEndpointSliceInfo(endpointSlice *discovery.EndpointSlice, remove bool) *
 				Addresses: endpoint.Addresses,
 				Zone:      endpoint.Zone,
 				NodeName:  endpoint.NodeName,
+				Topology:  endpoint.DeprecatedTopology,
 
 				// conditions
 				Ready:       endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready,
@@ -284,6 +286,12 @@ func (cache *EndpointSliceCache) addEndpoints(serviceNN types.NamespacedName, po
 		if endpoint.NodeName != nil {
 			isLocal = cache.isLocal(*endpoint.NodeName)
 			nodeName = *endpoint.NodeName
+		} else {
+			deprecatedHostname, ok := endpoint.Topology[v1.LabelHostname]
+			if ok {
+				isLocal = cache.isLocal(deprecatedHostname)
+				nodeName = deprecatedHostname
+			}
 		}
 
 		zone := ""


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig network

#### What this PR does / why we need it:
This PR let kube-proxy fallback to use `endpoint.DeprecatedTopology[v1.LabelHostname]` when `endpoint.NodeName` is missing, so the kube-proxy can find local endpoints after upgrade from 1.20 to 1.22

#### Which issue(s) this PR fixes:
Fixes #110208

#### Does this PR introduce a user-facing change?
```release-note
Bug Fix: Kube-proxy dropped endpointSlice's local endpoints when upgrading from 1.20 to 1.22
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
None
```
