### PR TITLE
[Don't Submit] [WIP] Lower poll interval in node_shutdown_linux_test

### DIFF
--- a/test/e2e_node/node_shutdown_linux_test.go
+++ b/test/e2e_node/node_shutdown_linux_test.go
@@ -52,7 +52,7 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeFeature:GracefulNodeShut
 	ginkgo.Context("when gracefully shutting down", func() {
 
 		const (
-			pollInterval                        = 1 * time.Second
+			pollInterval                        = 10 * time.Millisecond
 			podStatusUpdateTimeout              = 30 * time.Second
 			nodeStatusUpdateTimeout             = 30 * time.Second
 			nodeShutdownGracePeriod             = 20 * time.Second
@@ -548,5 +548,9 @@ func isPodShutdown(pod *v1.Pod) bool {
 
 // Pods should never report failed phase and have ready condition = true (https://github.com/kubernetes/kubernetes/issues/108594)
 func isPodStatusAffectedByIssue108594(pod *v1.Pod) bool {
+	framework.Logf("ruiwen-zhao: pod phase %s", pod.Status.Phase)
+	for _, c := range pod.Status.Conditions {
+		framework.Logf("ruiwen-zhao: pod condition %+v", c)
+	}
 	return pod.Status.Phase == v1.PodFailed && podutils.IsPodReady(pod)
 }


### PR DESCRIPTION
Creating this PR to try to reproduce the issue where Pod condition is PodFailed while the pod is still ready. 

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
