### PR TITLE
minimize iptables-restore input

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -567,6 +567,13 @@ const (
 	// Enable MinDomains in Pod Topology Spread.
 	MinDomainsInPodTopologySpread featuregate.Feature = "MinDomainsInPodTopologySpread"
 
+	// owner: @danwinship
+	// kep: http://kep.k8s.io/3453
+	// alpha: v1.26
+	//
+	// Enables new performance-improving code in kube-proxy iptables mode
+	MinimizeIPTablesRestore featuregate.Feature = "MinimizeIPTablesRestore"
+
 	// owner: @janosi @bridgetkromhout
 	// kep: http://kep.k8s.io/1435
 	// alpha: v1.20
@@ -1029,6 +1036,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	MemoryQoS: {Default: false, PreRelease: featuregate.Alpha},
 
 	MinDomainsInPodTopologySpread: {Default: false, PreRelease: featuregate.Beta},
+
+	MinimizeIPTablesRestore: {Default: false, PreRelease: featuregate.Alpha},
 
 	MixedProtocolLBService: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/proxy/endpoints.go
+++ b/pkg/proxy/endpoints.go
@@ -302,6 +302,24 @@ func (ect *EndpointChangeTracker) EndpointSliceUpdate(endpointSlice *discovery.E
 	return changeNeeded
 }
 
+// PendingChanges returns a set whose keys are the names of the services whose endpoints
+// have changed since the last time ect was used to update an EndpointsMap. (You must call
+// this _before_ calling em.Update(ect).)
+func (ect *EndpointChangeTracker) PendingChanges() sets.String {
+	if ect.endpointSliceCache != nil {
+		return ect.endpointSliceCache.pendingChanges()
+	}
+
+	ect.lock.Lock()
+	defer ect.lock.Unlock()
+
+	changes := sets.NewString()
+	for name := range ect.items {
+		changes.Insert(name.String())
+	}
+	return changes
+}
+
 // checkoutChanges returns a list of pending endpointsChanges and marks them as
 // applied.
 func (ect *EndpointChangeTracker) checkoutChanges() []*endpointsChange {

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -825,6 +825,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedStaleEndpoints    []ServiceEndpoint
 		expectedStaleServiceNames map[ServicePortName]bool
 		expectedHealthchecks      map[types.NamespacedName]int
+		expectedChangedEndpoints  sets.String
 	}{{
 		name:                      "empty",
 		oldEndpoints:              map[ServicePortName][]*BaseEndpointInfo{},
@@ -832,6 +833,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedStaleEndpoints:    []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedChangedEndpoints:  sets.NewString(),
 	}, {
 		name: "no change, unnamed port",
 		previousEndpoints: []*v1.Endpoints{
@@ -853,6 +855,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedStaleEndpoints:    []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedChangedEndpoints:  sets.NewString(),
 	}, {
 		name: "no change, named port, local",
 		previousEndpoints: []*v1.Endpoints{
@@ -876,6 +879,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
+		expectedChangedEndpoints: sets.NewString(),
 	}, {
 		name: "no change, multiple subsets",
 		previousEndpoints: []*v1.Endpoints{
@@ -903,6 +907,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedStaleEndpoints:    []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedChangedEndpoints:  sets.NewString(),
 	}, {
 		name: "no change, multiple subsets, multiple ports, local",
 		previousEndpoints: []*v1.Endpoints{
@@ -938,6 +943,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
+		expectedChangedEndpoints: sets.NewString(),
 	}, {
 		name: "no change, multiple endpoints, subsets, IPs, and ports",
 		previousEndpoints: []*v1.Endpoints{
@@ -1006,6 +1012,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeNSN("ns1", "ep1"): 2,
 			makeNSN("ns2", "ep2"): 1,
 		},
+		expectedChangedEndpoints: sets.NewString(),
 	}, {
 		name: "add an Endpoints",
 		previousEndpoints: []*v1.Endpoints{
@@ -1027,6 +1034,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
+		expectedChangedEndpoints: sets.NewString("ns1/ep1"),
 	}, {
 		name: "remove an Endpoints",
 		previousEndpoints: []*v1.Endpoints{
@@ -1047,6 +1055,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedChangedEndpoints:  sets.NewString("ns1/ep1"),
 	}, {
 		name: "add an IP and port",
 		previousEndpoints: []*v1.Endpoints{
@@ -1077,6 +1086,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
+		expectedChangedEndpoints: sets.NewString("ns1/ep1"),
 	}, {
 		name: "remove an IP and port",
 		previousEndpoints: []*v1.Endpoints{
@@ -1112,6 +1122,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedChangedEndpoints:  sets.NewString("ns1/ep1"),
 	}, {
 		name: "add a subset",
 		previousEndpoints: []*v1.Endpoints{
@@ -1140,6 +1151,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
+		expectedChangedEndpoints: sets.NewString("ns1/ep1"),
 	}, {
 		name: "remove a subset",
 		previousEndpoints: []*v1.Endpoints{
@@ -1167,6 +1179,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedChangedEndpoints:  sets.NewString("ns1/ep1"),
 	}, {
 		name: "rename a port",
 		previousEndpoints: []*v1.Endpoints{
@@ -1192,7 +1205,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedStaleServiceNames: map[ServicePortName]bool{
 			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{},
+		expectedHealthchecks:     map[types.NamespacedName]int{},
+		expectedChangedEndpoints: sets.NewString("ns1/ep1"),
 	}, {
 		name: "renumber a port",
 		previousEndpoints: []*v1.Endpoints{
@@ -1217,6 +1231,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedChangedEndpoints:  sets.NewString("ns1/ep1"),
 	}, {
 		name: "complex add and remove",
 		previousEndpoints: []*v1.Endpoints{
@@ -1292,6 +1307,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns4", "ep4"): 1,
 		},
+		expectedChangedEndpoints: sets.NewString("ns1/ep1", "ns2/ep2", "ns3/ep3", "ns4/ep4"),
 	}, {
 		name: "change from 0 endpoint address to 1 unnamed port",
 		previousEndpoints: []*v1.Endpoints{
@@ -1310,7 +1326,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedStaleServiceNames: map[ServicePortName]bool{
 			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{},
+		expectedHealthchecks:     map[types.NamespacedName]int{},
+		expectedChangedEndpoints: sets.NewString("ns1/ep1"),
 	},
 	}
 
@@ -1346,6 +1363,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 					fp.updateEndpoints(prev, curr)
 				}
 			}
+
+			pendingChanges := fp.endpointsChanges.PendingChanges()
+			if !pendingChanges.Equal(tc.expectedChangedEndpoints) {
+				t.Errorf("[%d] expected changed endpoints %q, got %q", tci, tc.expectedChangedEndpoints.List(), pendingChanges.List())
+			}
+
 			result := fp.endpointsMap.Update(fp.endpointsChanges)
 			newMap := fp.endpointsMap
 			compareEndpointsMapsStr(t, newMap, tc.expectedResult)
@@ -1520,13 +1543,14 @@ func TestEndpointSliceUpdate(t *testing.T) {
 	fqdnSlice.AddressType = discovery.AddressTypeFQDN
 
 	testCases := map[string]struct {
-		startingSlices        []*discovery.EndpointSlice
-		endpointChangeTracker *EndpointChangeTracker
-		namespacedName        types.NamespacedName
-		paramEndpointSlice    *discovery.EndpointSlice
-		paramRemoveSlice      bool
-		expectedReturnVal     bool
-		expectedCurrentChange map[ServicePortName][]*BaseEndpointInfo
+		startingSlices           []*discovery.EndpointSlice
+		endpointChangeTracker    *EndpointChangeTracker
+		namespacedName           types.NamespacedName
+		paramEndpointSlice       *discovery.EndpointSlice
+		paramRemoveSlice         bool
+		expectedReturnVal        bool
+		expectedCurrentChange    map[ServicePortName][]*BaseEndpointInfo
+		expectedChangedEndpoints sets.String
 	}{
 		// test starting from an empty state
 		"add a simple slice that doesn't already exist": {
@@ -1548,30 +1572,33 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:443", IsLocal: false, Ready: true, Serving: true, Terminating: false},
 				},
 			},
+			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// test no modification to state - current change should be nil as nothing changes
 		"add the same slice that already exists": {
 			startingSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:    generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-			paramRemoveSlice:      false,
-			expectedReturnVal:     false,
-			expectedCurrentChange: nil,
+			endpointChangeTracker:    NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:           types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:       generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramRemoveSlice:         false,
+			expectedReturnVal:        false,
+			expectedCurrentChange:    nil,
+			expectedChangedEndpoints: sets.NewString(),
 		},
 		// ensure that only valide address types are processed
 		"add an FQDN slice (invalid address type)": {
 			startingSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:    fqdnSlice,
-			paramRemoveSlice:      false,
-			expectedReturnVal:     false,
-			expectedCurrentChange: nil,
+			endpointChangeTracker:    NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:           types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:       fqdnSlice,
+			paramRemoveSlice:         false,
+			expectedReturnVal:        false,
+			expectedCurrentChange:    nil,
+			expectedChangedEndpoints: sets.NewString(),
 		},
 		// test additions to existing state
 		"add a slice that overlaps with existing state": {
@@ -1604,6 +1631,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:443", IsLocal: true, Ready: true, Serving: true, Terminating: false},
 				},
 			},
+			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// test additions to existing state with partially overlapping slices and ports
 		"add a slice that overlaps with existing state and partial ports": {
@@ -1634,6 +1662,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:443", IsLocal: true, Ready: true, Serving: true, Terminating: false},
 				},
 			},
+			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// test deletions from existing state with partially overlapping slices and ports
 		"remove a slice that overlaps with existing state": {
@@ -1656,6 +1685,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:443", IsLocal: true, Ready: true, Serving: true, Terminating: false},
 				},
 			},
+			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// ensure a removal that has no effect turns into a no-op
 		"remove a slice that doesn't even exist in current state": {
@@ -1663,12 +1693,13 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:    generateEndpointSlice("svc1", "ns1", 3, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-			paramRemoveSlice:      true,
-			expectedReturnVal:     false,
-			expectedCurrentChange: nil,
+			endpointChangeTracker:    NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:           types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:       generateEndpointSlice("svc1", "ns1", 3, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramRemoveSlice:         true,
+			expectedReturnVal:        false,
+			expectedCurrentChange:    nil,
+			expectedChangedEndpoints: sets.NewString(),
 		},
 		// start with all endpoints ready, transition to no endpoints ready
 		"transition all endpoints to unready state": {
@@ -1692,6 +1723,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:443", IsLocal: true, Ready: false, Serving: false, Terminating: false},
 				},
 			},
+			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// start with no endpoints ready, transition to all endpoints ready
 		"transition all endpoints to ready state": {
@@ -1713,6 +1745,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:443", IsLocal: true, Ready: true, Serving: true, Terminating: false},
 				},
 			},
+			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// start with some endpoints ready, transition to more endpoints ready
 		"transition some endpoints to ready state": {
@@ -1741,6 +1774,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:443", IsLocal: true, Ready: false, Serving: false, Terminating: false},
 				},
 			},
+			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// start with some endpoints ready, transition to some terminating
 		"transition some endpoints to terminating state": {
@@ -1769,6 +1803,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:443", IsLocal: true, Ready: false, Serving: false, Terminating: true},
 				},
 			},
+			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 	}
 
@@ -1783,6 +1818,12 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			if tc.endpointChangeTracker.items == nil {
 				t.Errorf("Expected ect.items to not be nil")
 			}
+
+			pendingChanges := tc.endpointChangeTracker.PendingChanges()
+			if !pendingChanges.Equal(tc.expectedChangedEndpoints) {
+				t.Errorf("expected changed endpoints %q, got %q", tc.expectedChangedEndpoints.List(), pendingChanges.List())
+			}
+
 			changes := tc.endpointChangeTracker.checkoutChanges()
 			if tc.expectedCurrentChange == nil {
 				if len(changes) != 0 {

--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -188,6 +188,21 @@ func (cache *EndpointSliceCache) updatePending(endpointSlice *discovery.Endpoint
 	return changed
 }
 
+// pendingChanges returns a set whose keys are the names of the services whose endpoints
+// have changed since the last time checkoutChanges was called
+func (cache *EndpointSliceCache) pendingChanges() sets.String {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+
+	changes := sets.NewString()
+	for serviceNN, esTracker := range cache.trackerByServiceMap {
+		if len(esTracker.pending) > 0 {
+			changes.Insert(serviceNN.String())
+		}
+	}
+	return changes
+}
+
 // checkoutChanges returns a list of all endpointsChanges that are
 // pending and then marks them as applied.
 func (cache *EndpointSliceCache) checkoutChanges() []*endpointsChange {

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -846,6 +846,9 @@ func (proxier *Proxier) syncProxyRules() {
 		if !success {
 			klog.InfoS("Sync failed", "retryingTime", proxier.syncPeriod)
 			proxier.syncRunner.RetryAfter(proxier.syncPeriod)
+			if tryPartialSync {
+				metrics.IptablesPartialRestoreFailuresTotal.Inc()
+			}
 			// proxier.serviceChanges and proxier.endpointChanges have already
 			// been flushed, so we've lost the state needed to be able to do
 			// a partial sync.

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -38,9 +38,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/events"
 	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/proxy"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
@@ -163,6 +165,7 @@ type Proxier struct {
 	// updating iptables with some partial data after kube-proxy restart.
 	endpointSlicesSynced bool
 	servicesSynced       bool
+	needFullSync         bool
 	initialized          int32
 	syncRunner           *async.BoundedFrequencyRunner // governs calls to syncProxyRules
 	syncPeriod           time.Duration
@@ -298,7 +301,7 @@ func NewProxier(ipt utiliptables.Interface,
 	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, time.Hour, burstSyncs)
 
 	go ipt.Monitor(kubeProxyCanaryChain, []utiliptables.Table{utiliptables.TableMangle, utiliptables.TableNAT, utiliptables.TableFilter},
-		proxier.syncProxyRules, syncPeriod, wait.NeverStop)
+		proxier.forceSyncProxyRules, syncPeriod, wait.NeverStop)
 
 	if ipt.HasRandomFully() {
 		klog.V(2).InfoS("Iptables supports --random-fully", "ipFamily", ipt.Protocol())
@@ -539,7 +542,7 @@ func (proxier *Proxier) OnServiceSynced() {
 	proxier.mu.Unlock()
 
 	// Sync unconditionally - this is called once per lifetime.
-	proxier.syncProxyRules()
+	proxier.forceSyncProxyRules()
 }
 
 // OnEndpointSliceAdd is called whenever creation of a new endpoint slice object
@@ -575,7 +578,7 @@ func (proxier *Proxier) OnEndpointSlicesSynced() {
 	proxier.mu.Unlock()
 
 	// Sync unconditionally - this is called once per lifetime.
-	proxier.syncProxyRules()
+	proxier.forceSyncProxyRules()
 }
 
 // OnNodeAdd is called whenever creation of new node object
@@ -596,6 +599,7 @@ func (proxier *Proxier) OnNodeAdd(node *v1.Node) {
 	for k, v := range node.Labels {
 		proxier.nodeLabels[k] = v
 	}
+	proxier.needFullSync = true
 	proxier.mu.Unlock()
 	klog.V(4).InfoS("Updated proxier node labels", "labels", node.Labels)
 
@@ -620,6 +624,7 @@ func (proxier *Proxier) OnNodeUpdate(oldNode, node *v1.Node) {
 	for k, v := range node.Labels {
 		proxier.nodeLabels[k] = v
 	}
+	proxier.needFullSync = true
 	proxier.mu.Unlock()
 	klog.V(4).InfoS("Updated proxier node labels", "labels", node.Labels)
 
@@ -636,6 +641,7 @@ func (proxier *Proxier) OnNodeDelete(node *v1.Node) {
 	}
 	proxier.mu.Lock()
 	proxier.nodeLabels = nil
+	proxier.needFullSync = true
 	proxier.mu.Unlock()
 
 	proxier.Sync()
@@ -769,6 +775,17 @@ func (proxier *Proxier) appendServiceCommentLocked(args []string, svcName string
 	return append(args, "-m", "comment", "--comment", svcName)
 }
 
+// Called by the iptables.Monitor, and in response to topology changes; this calls
+// syncProxyRules() and tells it to resync all services, regardless of whether the
+// Service or Endpoints/EndpointSlice objects themselves have changed
+func (proxier *Proxier) forceSyncProxyRules() {
+	proxier.mu.Lock()
+	proxier.needFullSync = true
+	proxier.mu.Unlock()
+
+	proxier.syncProxyRules()
+}
+
 // This is where all of the iptables-save/restore calls happen.
 // The only other iptables rules are those that are setup in iptablesInit()
 // This assumes proxier.mu is NOT held
@@ -789,9 +806,12 @@ func (proxier *Proxier) syncProxyRules() {
 		klog.V(2).InfoS("SyncProxyRules complete", "elapsed", time.Since(start))
 	}()
 
-	// We assume that if this was called, we really want to sync them,
-	// even if nothing changed in the meantime. In other words, callers are
-	// responsible for detecting no-op changes and not calling this function.
+	tryPartialSync := !proxier.needFullSync && utilfeature.DefaultFeatureGate.Enabled(features.MinimizeIPTablesRestore)
+	var serviceChanged, endpointsChanged sets.String
+	if tryPartialSync {
+		serviceChanged = proxier.serviceChanges.PendingChanges()
+		endpointsChanged = proxier.endpointsChanges.PendingChanges()
+	}
 	serviceUpdateResult := proxier.serviceMap.Update(proxier.serviceChanges)
 	endpointUpdateResult := proxier.endpointsMap.Update(proxier.endpointsChanges)
 
@@ -826,6 +846,10 @@ func (proxier *Proxier) syncProxyRules() {
 		if !success {
 			klog.InfoS("Sync failed", "retryingTime", proxier.syncPeriod)
 			proxier.syncRunner.RetryAfter(proxier.syncPeriod)
+			// proxier.serviceChanges and proxier.endpointChanges have already
+			// been flushed, so we've lost the state needed to be able to do
+			// a partial sync.
+			proxier.needFullSync = true
 		}
 	}()
 
@@ -1184,6 +1208,13 @@ func (proxier *Proxier) syncProxyRules() {
 			)
 		}
 
+		// If the SVC/SVL/EXT/FW/SEP chains have not changed since the last sync
+		// then we can omit them from the restore input. (We have already marked
+		// them in activeNATChains, so they won't get deleted.)
+		if tryPartialSync && !serviceChanged.Has(svcName.NamespacedName.String()) && !endpointsChanged.Has(svcName.NamespacedName.String()) {
+			continue
+		}
+
 		// Set up internal traffic handling.
 		if hasInternalEndpoints {
 			args = append(args[:0],
@@ -1479,6 +1510,7 @@ func (proxier *Proxier) syncProxyRules() {
 		return
 	}
 	success = true
+	proxier.needFullSync = false
 
 	for name, lastChangeTriggerTimes := range endpointUpdateResult.LastChangeTriggerTimes {
 		for _, lastChangeTriggerTime := range lastChangeTriggerTimes {

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -126,6 +126,17 @@ var (
 		},
 	)
 
+	// IptablesPartialRestoreFailuresTotal is the number of iptables *partial* restore
+	// failures (resulting in a fall back to a full restore) that the proxy has seen.
+	IptablesPartialRestoreFailuresTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      kubeProxySubsystem,
+			Name:           "sync_proxy_rules_iptables_partial_restore_failures_total",
+			Help:           "Cumulative proxy iptables partial restore failures",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
 	// IptablesRulesTotal is the number of iptables rules that the iptables proxy installs.
 	IptablesRulesTotal = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
@@ -177,6 +188,7 @@ func RegisterMetrics() {
 		legacyregistry.MustRegister(ServiceChangesTotal)
 		legacyregistry.MustRegister(IptablesRulesTotal)
 		legacyregistry.MustRegister(IptablesRestoreFailuresTotal)
+		legacyregistry.MustRegister(IptablesPartialRestoreFailuresTotal)
 		legacyregistry.MustRegister(SyncProxyRulesLastQueuedTimestamp)
 		legacyregistry.MustRegister(SyncProxyRulesNoLocalEndpointsTotal)
 	})

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -327,6 +327,20 @@ func (sct *ServiceChangeTracker) Update(previous, current *v1.Service) bool {
 	return len(sct.items) > 0
 }
 
+// PendingChanges returns a set whose keys are the names of the services that have changed
+// since the last time sct was used to update a ServiceMap. (You must call this _before_
+// calling sm.Update(sct).)
+func (sct *ServiceChangeTracker) PendingChanges() sets.String {
+	sct.lock.Lock()
+	defer sct.lock.Unlock()
+
+	changes := sets.NewString()
+	for name := range sct.items {
+		changes.Insert(name.String())
+	}
+	return changes
+}
+
 // UpdateServiceMapResult is the updated results after applying service changes.
 type UpdateServiceMapResult struct {
 	// HCServiceNodePorts is a map of Service names to node port numbers which indicate the health of that Service on this Node.

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -564,6 +564,10 @@ func TestServiceMapUpdateHeadless(t *testing.T) {
 	)
 
 	// Headless service should be ignored
+	pending := fp.serviceChanges.PendingChanges()
+	if pending.Len() != 0 {
+		t.Errorf("expected 0 pending service changes, got %d", pending.Len())
+	}
 	result := fp.serviceMap.Update(fp.serviceChanges)
 	if len(fp.serviceMap) != 0 {
 		t.Errorf("expected service map length 0, got %d", len(fp.serviceMap))
@@ -591,6 +595,10 @@ func TestUpdateServiceTypeExternalName(t *testing.T) {
 		}),
 	)
 
+	pending := fp.serviceChanges.PendingChanges()
+	if pending.Len() != 0 {
+		t.Errorf("expected 0 pending service changes, got %d", pending.Len())
+	}
 	result := fp.serviceMap.Update(fp.serviceChanges)
 	if len(fp.serviceMap) != 0 {
 		t.Errorf("expected service map length 0, got %v", fp.serviceMap)
@@ -651,6 +659,18 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	for i := range services {
 		fp.addService(services[i])
 	}
+
+	pending := fp.serviceChanges.PendingChanges()
+	for i := range services {
+		name := services[i].Namespace + "/" + services[i].Name
+		if !pending.Has(name) {
+			t.Errorf("expected pending change for %q", name)
+		}
+	}
+	if pending.Len() != len(services) {
+		t.Errorf("expected %d pending service changes, got %d", len(services), pending.Len())
+	}
+
 	result := fp.serviceMap.Update(fp.serviceChanges)
 	if len(fp.serviceMap) != 8 {
 		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
@@ -684,6 +704,10 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	fp.deleteService(services[2])
 	fp.deleteService(services[3])
 
+	pending = fp.serviceChanges.PendingChanges()
+	if pending.Len() != 4 {
+		t.Errorf("expected 4 pending service changes, got %d", pending.Len())
+	}
 	result = fp.serviceMap.Update(fp.serviceChanges)
 	if len(fp.serviceMap) != 1 {
 		t.Errorf("expected service map length 1, got %v", fp.serviceMap)
@@ -733,6 +757,10 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	fp.addService(servicev1)
 
+	pending := fp.serviceChanges.PendingChanges()
+	if pending.Len() != 1 {
+		t.Errorf("expected 1 pending service change, got %d", pending.Len())
+	}
 	result := fp.serviceMap.Update(fp.serviceChanges)
 	if len(fp.serviceMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
@@ -747,6 +775,10 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// Change service to load-balancer
 	fp.updateService(servicev1, servicev2)
+	pending = fp.serviceChanges.PendingChanges()
+	if pending.Len() != 1 {
+		t.Errorf("expected 1 pending service change, got %d", pending.Len())
+	}
 	result = fp.serviceMap.Update(fp.serviceChanges)
 	if len(fp.serviceMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
@@ -761,6 +793,10 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	// No change; make sure the service map stays the same and there are
 	// no health-check changes
 	fp.updateService(servicev2, servicev2)
+	pending = fp.serviceChanges.PendingChanges()
+	if pending.Len() != 0 {
+		t.Errorf("expected 0 pending service changes, got %d", pending.Len())
+	}
 	result = fp.serviceMap.Update(fp.serviceChanges)
 	if len(fp.serviceMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
@@ -774,6 +810,10 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// And back to ClusterIP
 	fp.updateService(servicev2, servicev1)
+	pending = fp.serviceChanges.PendingChanges()
+	if pending.Len() != 1 {
+		t.Errorf("expected 1 pending service change, got %d", pending.Len())
+	}
 	result = fp.serviceMap.Update(fp.serviceChanges)
 	if len(fp.serviceMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.serviceMap)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
?

#### What this PR does / why we need it:
Currently, kube-proxy rewrites every iptables rule on every resync. In very large clusters, this ends up being a very large number of rules, and `iptables-restore` is not very efficient.

Most of the time, most of the rules that kube-proxy rewrites have not changed since the last sync; generally speaking, some small number of services will have gained or lost one endpoint since the last sync, and the other 10,000 minus N services have exactly the same iptables rules as they did last time.

`iptables-restore` doesn't require you to rewrite _every_ chain; it just enforces the rule that if you want to update _any_ rule in a chain, you have to update _every_ rule in that chain. But if a chain doesn't need to change at all, you can just not include any rules for it, and `iptables-restore` will leave it untouched.

So, following up on #110266, which reorganized the internal `syncProxyRules` loop logic, this fixes the loop so that if a service hasn't changed since the last sync, then we don't rewrite its rules. (With this PR, we still rewrite all of `KUBE-SERVICES` / `KUBE-EXTERNAL-SERVICES` / `KUBE-NODEPORTS` on every sync, though in theory we could avoid doing that if _only_ endpoints changed.)

If we somehow get out of sync and, eg, fail to create a chain we should have created and then forget that we failed, this will be caught on the next sync. (`KUBE-SERVICES` will contain a rule to jump to the non-existent chain, which will cause the `iptables-restore` to fail, which will cause the proxier to force a full resync.)

#### Which issue(s) this PR fixes:
none

#### Special notes for your reviewer:
The branch includes both #110266 and #109844, both of which should merge (in either order) before this merges. Only the last two commits are new to this branch.

#### Does this PR introduce a user-facing change?
```release-note
The iptables kube-proxy backend should process service/endpoint changes
more efficiently in very large clusters.
```

/sig network
/priority important-longterm