### PR TITLE
Streamlined `kubectl get` error message

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -283,14 +283,7 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 		}
 	default:
 		if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
-			fmt.Fprintf(o.ErrOut, "You must specify the type of resource to get. %s\n\n", cmdutil.SuggestAPIResources(o.CmdParent))
-			fullCmdName := cmd.Parent().CommandPath()
-			usageString := "Required resource not specified."
-			if len(fullCmdName) > 0 && cmdutil.IsSiblingCommandExists(cmd, "explain") {
-				usageString = fmt.Sprintf("%s\nUse \"%s explain <resource>\" for a detailed description of that resource (e.g. %[2]s explain pods).", usageString, fullCmdName)
-			}
-
-			return cmdutil.UsageErrorf(cmd, usageString)
+			return fmt.Errorf("You must specify the type of resource to get. %s\n", cmdutil.SuggestAPIResources(o.CmdParent))
 		}
 	}
 


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
execute `kubectl get`
output message like this
```
You must specify the type of resource to get. Use "kubectl api-resources" for a complete list of supported resources.

error: Required resource not specified.
Use "kubectl explain <resource>" for a detailed description of that resource (e.g. kubectl explain pods).
See 'kubectl get -h' for help and examples
```
After streamlining, error message like this:

```
error: You must specify the type of resource to get. Use "kubectl api-resources" for a complete list of supported resources.
```

Fixes # None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
None

