### PR TITLE
Fix e2e test failure

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1191,7 +1191,6 @@ metadata:
 		"kind": "Deployment",
 		"metadata": {
 			"name": "my-dep",
-			"namespace": "my-ns",
 			"unknownMeta": "foo",
 			"labels": {"app": "nginx"}
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
Fixes e2e test failure caused by manifest having namespace and a different namespace specified using `--namespace` when the test runs `kubectl create`.

Fixes this error that occurs in e2e test:
> the namespace from the provided object "my-ns" does not match the namespace "kubectl-8939". You must pass '--namespace=my-ns' to perform this operation.


#### Which issue(s) this PR fixes:
Fixes #110270 
Fixes #110467 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
