### PR TITLE
Automated cherry pick of #110145: fix audit union loop variables in closures

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/union.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/union.go
@@ -48,6 +48,7 @@ func (u union) ProcessEvents(events ...*auditinternal.Event) bool {
 func (u union) Run(stopCh <-chan struct{}) error {
 	var funcs []func() error
 	for _, backend := range u.backends {
+		backend := backend
 		funcs = append(funcs, func() error {
 			return backend.Run(stopCh)
 		})


### PR DESCRIPTION
Cherry pick of #110145 on release-1.24.

#110145: fix audit union loop variables in closures

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```