### PR TITLE
Set PVC size to 1Gi in StatefulSet tests

### DIFF
--- a/test/e2e/framework/statefulset/fixtures.go
+++ b/test/e2e/framework/statefulset/fixtures.go
@@ -104,7 +104,7 @@ func NewStatefulSetPVC(name string) v1.PersistentVolumeClaim {
 			},
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
-					v1.ResourceStorage: *resource.NewQuantity(1, resource.BinarySI),
+					v1.ResourceStorage: resource.MustParse("1Gi"),
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind failing-test

#### What this PR does / why we need it:
Current size for the PVCs create during the StatefulSet tests is too small for some cloud providers and not really realistic.
Setting it to `1Gi` should ensure better compatibility.

To be more specific, the DIgitalOcean tests fail the StatefulSet tests because of `invalid capacity range: required (1) can not be less than minimum supported volume size (1Gi)`:
https://testgrid.k8s.io/kops-misc#e2e-kops-do-calico
```
I0528 21:09:03.511410       1 controller.go:1279] provision "statefulset-8627/datadir-ss-0" class "do-block-storage": started
I0528 21:09:03.511489       1 connection.go:183] GRPC call: /csi.v1.Controller/CreateVolume
I0528 21:09:03.511548       1 event.go:282] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"statefulset-8627", Name:"datadir-ss-0", UID:"c8f229a8-1a48-4127-8350-10f834bcec15", APIVersion:"v1", ResourceVersion:"4132", FieldPath:""}): type: 'Normal' reason: 'Provisioning' External provisioner is provisioning volume for claim "statefulset-8627/datadir-ss-0"
I0528 21:09:03.511493       1 connection.go:184] GRPC request: {"capacity_range":{"required_bytes":1},"name":"pvc-c8f229a8-1a48-4127-8350-10f834bcec15","volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"ext4"}},"access_mode":{"mode":1}}]}
I0528 21:09:03.512071       1 connection.go:186] GRPC response: {}
I0528 21:09:03.512098       1 connection.go:187] GRPC error: rpc error: code = OutOfRange desc = invalid capacity range: required (1) can not be less than minimum supported volume size (1Gi)
I0528 21:09:03.512117       1 controller.go:767] CreateVolume failed, supports topology = false, node selected false => may reschedule = false => state = Finished: rpc error: code = OutOfRange desc = invalid capacity range: required (1) can not be less than minimum supported volume size (1Gi)
I0528 21:09:03.512155       1 controller.go:1074] Final error received, removing PVC c8f229a8-1a48-4127-8350-10f834bcec15 from claims in progress
```

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
