### PR TITLE
Refactor kube-proxy ServiceMap to ServicePortMap and BaseServiceInfo to BaseServicePort

### DIFF
--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -179,6 +179,7 @@ func CreateStackedEtcdStaticPodManifestFile(client clientset.Interface, manifest
 // GetEtcdPodSpec returns the etcd static Pod actualized to the context of the current configuration
 // NB. GetEtcdPodSpec methods holds the information about how kubeadm creates etcd static pod manifests.
 func GetEtcdPodSpec(cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.APIEndpoint, nodeName string, initialCluster []etcdutil.Member) v1.Pod {
+	const etcdHealthEndpoint = "/health?serializable=true"
 	pathType := v1.HostPathDirectoryOrCreate
 	etcdMounts := map[string]v1.Volume{
 		etcdVolumeName:  staticpodutil.NewVolume(etcdVolumeName, cfg.Etcd.Local.DataDir, &pathType),
@@ -203,8 +204,8 @@ func GetEtcdPodSpec(cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.A
 					v1.ResourceMemory: resource.MustParse("100Mi"),
 				},
 			},
-			LivenessProbe: staticpodutil.LivenessProbe(probeHostname, "/health", probePort, probeScheme),
-			StartupProbe:  staticpodutil.StartupProbe(probeHostname, "/health", probePort, probeScheme, cfg.APIServer.TimeoutForControlPlane),
+			LivenessProbe: staticpodutil.LivenessProbe(probeHostname, etcdHealthEndpoint, probePort, probeScheme),
+			StartupProbe:  staticpodutil.StartupProbe(probeHostname, etcdHealthEndpoint, probePort, probeScheme, cfg.APIServer.TimeoutForControlPlane),
 		},
 		etcdMounts,
 		// etcd will listen on the advertise address of the API server, in a different port (2379)

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -115,7 +115,7 @@ const sysctlBridgeCallIPTables = "net/bridge/bridge-nf-call-iptables"
 
 // internal struct for string service information
 type servicePortInfo struct {
-	*proxy.BaseServiceInfo
+	*proxy.BaseServicePort
 	// The following fields are computed and stored for performance reasons.
 	nameString             string
 	clusterPolicyChainName utiliptables.Chain
@@ -125,8 +125,8 @@ type servicePortInfo struct {
 }
 
 // returns a new proxy.ServicePort which abstracts a serviceInfo
-func newServiceInfo(port *v1.ServicePort, service *v1.Service, baseInfo *proxy.BaseServiceInfo) proxy.ServicePort {
-	svcPort := &servicePortInfo{BaseServiceInfo: baseInfo}
+func newServiceInfo(port *v1.ServicePort, service *v1.Service, baseSvcPort *proxy.BaseServicePort) proxy.ServicePort {
+	svcPort := &servicePortInfo{BaseServicePort: baseSvcPort}
 
 	// Store the following for performance reasons.
 	svcName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
@@ -180,7 +180,7 @@ type Proxier struct {
 	serviceChanges   *proxy.ServiceChangeTracker
 
 	mu           sync.Mutex // protects the following fields
-	serviceMap   proxy.ServiceMap
+	svcPortMap   proxy.ServicePortMap
 	endpointsMap proxy.EndpointsMap
 	nodeLabels   map[string]string
 	// endpointSlicesSynced, and servicesSynced are set to true
@@ -289,7 +289,7 @@ func NewProxier(ipt utiliptables.Interface,
 	}
 
 	proxier := &Proxier{
-		serviceMap:               make(proxy.ServiceMap),
+		svcPortMap:               make(proxy.ServicePortMap),
 		serviceChanges:           proxy.NewServiceChangeTracker(newServiceInfo, ipFamily, recorder, nil),
 		endpointsMap:             make(proxy.EndpointsMap),
 		endpointsChanges:         proxy.NewEndpointChangeTracker(hostname, newEndpointInfo, ipFamily, recorder, nil),
@@ -756,7 +756,7 @@ func isServiceChainName(chainString string) bool {
 // TODO: move it to util
 func (proxier *Proxier) deleteEndpointConnections(connectionMap []proxy.ServiceEndpoint) {
 	for _, epSvcPair := range connectionMap {
-		if svcInfo, ok := proxier.serviceMap[epSvcPair.ServicePortName]; ok && conntrack.IsClearConntrackNeeded(svcInfo.Protocol()) {
+		if svcInfo, ok := proxier.svcPortMap[epSvcPair.ServicePortName]; ok && conntrack.IsClearConntrackNeeded(svcInfo.Protocol()) {
 			endpointIP := utilproxy.IPPart(epSvcPair.Endpoint)
 			nodePort := svcInfo.NodePort()
 			svcProto := svcInfo.Protocol()
@@ -823,7 +823,7 @@ func (proxier *Proxier) syncProxyRules() {
 	// We assume that if this was called, we really want to sync them,
 	// even if nothing changed in the meantime. In other words, callers are
 	// responsible for detecting no-op changes and not calling this function.
-	serviceUpdateResult := proxier.serviceMap.Update(proxier.serviceChanges)
+	serviceUpdateResult := proxier.svcPortMap.Update(proxier.serviceChanges)
 	endpointUpdateResult := proxier.endpointsMap.Update(proxier.endpointsChanges)
 
 	// We need to detect stale connections to UDP Services so we
@@ -833,7 +833,7 @@ func (proxier *Proxier) syncProxyRules() {
 	// merge stale services gathered from updateEndpointsMap
 	// an UDP service that changes from 0 to non-0 endpoints is considered stale.
 	for _, svcPortName := range endpointUpdateResult.StaleServiceNames {
-		if svcInfo, ok := proxier.serviceMap[svcPortName]; ok && svcInfo != nil && conntrack.IsClearConntrackNeeded(svcInfo.Protocol()) {
+		if svcInfo, ok := proxier.svcPortMap[svcPortName]; ok && svcInfo != nil && conntrack.IsClearConntrackNeeded(svcInfo.Protocol()) {
 			klog.V(2).InfoS("Stale service", "protocol", strings.ToLower(string(svcInfo.Protocol())), "servicePortName", svcPortName, "clusterIP", svcInfo.ClusterIP())
 			conntrackCleanupServiceIPs.Insert(svcInfo.ClusterIP().String())
 			for _, extIP := range svcInfo.ExternalIPStrings() {
@@ -976,7 +976,7 @@ func (proxier *Proxier) syncProxyRules() {
 
 	// Compute total number of endpoint chains across all services.
 	proxier.endpointChainsNumber = 0
-	for svcName := range proxier.serviceMap {
+	for svcName := range proxier.svcPortMap {
 		proxier.endpointChainsNumber += len(proxier.endpointsMap[svcName])
 	}
 
@@ -1001,7 +1001,7 @@ func (proxier *Proxier) syncProxyRules() {
 	serviceNoLocalEndpointsTotalExternal := 0
 
 	// Build rules for each service-port.
-	for svcName, svc := range proxier.serviceMap {
+	for svcName, svc := range proxier.svcPortMap {
 		svcInfo, ok := svc.(*servicePortInfo)
 		if !ok {
 			klog.ErrorS(nil, "Failed to cast serviceInfo", "serviceName", svcName)
@@ -1459,7 +1459,7 @@ func (proxier *Proxier) syncProxyRules() {
 	proxier.iptablesData.WriteString("COMMIT\n")
 
 	klog.V(2).InfoS("Reloading service iptables data",
-		"numServices", len(proxier.serviceMap),
+		"numServices", len(proxier.svcPortMap),
 		"numEndpoints", proxier.endpointChainsNumber,
 		"numFilterChains", proxier.filterChains.Lines(),
 		"numFilterRules", proxier.filterRules.Lines(),

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -162,7 +162,7 @@ func TestDeleteEndpointConnectionsIPv4(t *testing.T) {
 			}),
 		)
 
-		fp.serviceMap.Update(fp.serviceChanges)
+		fp.svcPortMap.Update(fp.serviceChanges)
 	}
 
 	// Run the test cases
@@ -305,7 +305,7 @@ func TestDeleteEndpointConnectionsIPv6(t *testing.T) {
 			}),
 		)
 
-		fp.serviceMap.Update(fp.serviceChanges)
+		fp.svcPortMap.Update(fp.serviceChanges)
 	}
 
 	// Run the test cases
@@ -404,7 +404,7 @@ func NewFakeProxier(ipt utiliptables.Interface) *Proxier {
 
 	p := &Proxier{
 		exec:                     &fakeexec.FakeExec{},
-		serviceMap:               make(proxy.ServiceMap),
+		svcPortMap:               make(proxy.ServicePortMap),
 		serviceChanges:           proxy.NewServiceChangeTracker(newServiceInfo, ipfamily, nil, nil),
 		endpointsMap:             make(proxy.EndpointsMap),
 		endpointsChanges:         proxy.NewEndpointChangeTracker(testHostname, newEndpointInfo, ipfamily, nil, nil),
@@ -3705,9 +3705,9 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	for i := range services {
 		fp.OnServiceAdd(services[i])
 	}
-	result := fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 10 {
-		t.Errorf("expected service map length 10, got %v", fp.serviceMap)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 10 {
+		t.Errorf("expected service map length 10, got %v", fp.svcPortMap)
 	}
 
 	// The only-local-loadbalancer ones get added
@@ -3738,9 +3738,9 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	fp.OnServiceDelete(services[2])
 	fp.OnServiceDelete(services[3])
 
-	result = fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 1 {
-		t.Errorf("expected service map length 1, got %v", fp.serviceMap)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 1 {
+		t.Errorf("expected service map length 1, got %v", fp.svcPortMap)
 	}
 
 	if len(result.HCServiceNodePorts) != 0 {
@@ -3778,9 +3778,9 @@ func TestBuildServiceMapServiceHeadless(t *testing.T) {
 	)
 
 	// Headless service should be ignored
-	result := fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 0 {
-		t.Errorf("expected service map length 0, got %d", len(fp.serviceMap))
+	result := fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 0 {
+		t.Errorf("expected service map length 0, got %d", len(fp.svcPortMap))
 	}
 
 	// No proxied services, so no healthchecks
@@ -3806,9 +3806,9 @@ func TestBuildServiceMapServiceTypeExternalName(t *testing.T) {
 		}),
 	)
 
-	result := fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 0 {
-		t.Errorf("expected service map length 0, got %v", fp.serviceMap)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 0 {
+		t.Errorf("expected service map length 0, got %v", fp.svcPortMap)
 	}
 	// No proxied services, so no healthchecks
 	if len(result.HCServiceNodePorts) != 0 {
@@ -3846,9 +3846,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	fp.OnServiceAdd(servicev1)
 
-	result := fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 2 {
-		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 2 {
+		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
 	}
 	if len(result.HCServiceNodePorts) != 0 {
 		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)
@@ -3860,9 +3860,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// Change service to load-balancer
 	fp.OnServiceUpdate(servicev1, servicev2)
-	result = fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 2 {
-		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 2 {
+		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
 	}
 	if len(result.HCServiceNodePorts) != 1 {
 		t.Errorf("expected healthcheck ports length 1, got %v", result.HCServiceNodePorts)
@@ -3874,9 +3874,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	// No change; make sure the service map stays the same and there are
 	// no health-check changes
 	fp.OnServiceUpdate(servicev2, servicev2)
-	result = fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 2 {
-		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 2 {
+		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
 	}
 	if len(result.HCServiceNodePorts) != 1 {
 		t.Errorf("expected healthcheck ports length 1, got %v", result.HCServiceNodePorts)
@@ -3887,9 +3887,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// And back to ClusterIP
 	fp.OnServiceUpdate(servicev2, servicev1)
-	result = fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 2 {
-		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 2 {
+		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
 	}
 	if len(result.HCServiceNodePorts) != 0 {
 		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -221,7 +221,7 @@ type Proxier struct {
 	serviceChanges   *proxy.ServiceChangeTracker
 
 	mu           sync.Mutex // protects the following fields
-	serviceMap   proxy.ServiceMap
+	svcPortMap   proxy.ServicePortMap
 	endpointsMap proxy.EndpointsMap
 	nodeLabels   map[string]string
 	// endpointSlicesSynced, and servicesSynced are set to true when
@@ -466,7 +466,7 @@ func NewProxier(ipt utiliptables.Interface,
 
 	proxier := &Proxier{
 		ipFamily:              ipFamily,
-		serviceMap:            make(proxy.ServiceMap),
+		svcPortMap:            make(proxy.ServicePortMap),
 		serviceChanges:        proxy.NewServiceChangeTracker(newServiceInfo, ipFamily, recorder, nil),
 		endpointsMap:          make(proxy.EndpointsMap),
 		endpointsChanges:      proxy.NewEndpointChangeTracker(hostname, nil, ipFamily, recorder, nil),
@@ -576,14 +576,14 @@ func filterCIDRs(wantIPv6 bool, cidrs []string) []string {
 
 // internal struct for string service information
 type servicePortInfo struct {
-	*proxy.BaseServiceInfo
+	*proxy.BaseServicePort
 	// The following fields are computed and stored for performance reasons.
 	nameString string
 }
 
 // returns a new proxy.ServicePort which abstracts a serviceInfo
-func newServiceInfo(port *v1.ServicePort, service *v1.Service, baseInfo *proxy.BaseServiceInfo) proxy.ServicePort {
-	svcPort := &servicePortInfo{BaseServiceInfo: baseInfo}
+func newServiceInfo(port *v1.ServicePort, service *v1.Service, baseInfo *proxy.BaseServicePort) proxy.ServicePort {
+	svcPort := &servicePortInfo{BaseServicePort: baseInfo}
 
 	// Store the following for performance reasons.
 	svcName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
@@ -1022,13 +1022,13 @@ func (proxier *Proxier) syncProxyRules() {
 	// We assume that if this was called, we really want to sync them,
 	// even if nothing changed in the meantime. In other words, callers are
 	// responsible for detecting no-op changes and not calling this function.
-	serviceUpdateResult := proxier.serviceMap.Update(proxier.serviceChanges)
+	serviceUpdateResult := proxier.svcPortMap.Update(proxier.serviceChanges)
 	endpointUpdateResult := proxier.endpointsMap.Update(proxier.endpointsChanges)
 
 	staleServices := serviceUpdateResult.UDPStaleClusterIP
 	// merge stale services gathered from updateEndpointsMap
 	for _, svcPortName := range endpointUpdateResult.StaleServiceNames {
-		if svcInfo, ok := proxier.serviceMap[svcPortName]; ok && svcInfo != nil && conntrack.IsClearConntrackNeeded(svcInfo.Protocol()) {
+		if svcInfo, ok := proxier.svcPortMap[svcPortName]; ok && svcInfo != nil && conntrack.IsClearConntrackNeeded(svcInfo.Protocol()) {
 			klog.V(2).InfoS("Stale service", "protocol", strings.ToLower(string(svcInfo.Protocol())), "servicePortName", svcPortName, "clusterIP", svcInfo.ClusterIP())
 			staleServices.Insert(svcInfo.ClusterIP().String())
 			for _, extIP := range svcInfo.ExternalIPStrings() {
@@ -1087,7 +1087,7 @@ func (proxier *Proxier) syncProxyRules() {
 	}
 
 	hasNodePort := false
-	for _, svc := range proxier.serviceMap {
+	for _, svc := range proxier.svcPortMap {
 		svcInfo, ok := svc.(*servicePortInfo)
 		if ok && svcInfo.NodePort() != 0 {
 			hasNodePort = true
@@ -1139,7 +1139,7 @@ func (proxier *Proxier) syncProxyRules() {
 	nodeIPs = nodeIPs[:idx]
 
 	// Build IPVS rules for each service.
-	for svcPortName, svcPort := range proxier.serviceMap {
+	for svcPortName, svcPort := range proxier.svcPortMap {
 		svcInfo, ok := svcPort.(*servicePortInfo)
 		if !ok {
 			klog.ErrorS(nil, "Failed to cast serviceInfo", "servicePortName", svcPortName)
@@ -1896,7 +1896,7 @@ func (proxier *Proxier) getExistingChains(buffer *bytes.Buffer, table utiliptabl
 // This assumes the proxier mutex is held
 func (proxier *Proxier) deleteEndpointConnections(connectionMap []proxy.ServiceEndpoint) {
 	for _, epSvcPair := range connectionMap {
-		if svcInfo, ok := proxier.serviceMap[epSvcPair.ServicePortName]; ok && conntrack.IsClearConntrackNeeded(svcInfo.Protocol()) {
+		if svcInfo, ok := proxier.svcPortMap[epSvcPair.ServicePortName]; ok && conntrack.IsClearConntrackNeeded(svcInfo.Protocol()) {
 			endpointIP := utilproxy.IPPart(epSvcPair.Endpoint)
 			svcProto := svcInfo.Protocol()
 			err := conntrack.ClearEntriesForNAT(proxier.exec, svcInfo.ClusterIP().String(), endpointIP, svcProto)
@@ -1986,7 +1986,7 @@ func (proxier *Proxier) syncEndpoint(svcPortName proxy.ServicePortName, onlyNode
 	// filter endpoints if appropriate feature gates are enabled and the
 	// Service does not have conflicting configuration such as
 	// externalTrafficPolicy=Local.
-	svcInfo, ok := proxier.serviceMap[svcPortName]
+	svcInfo, ok := proxier.svcPortMap[svcPortName]
 	if !ok {
 		klog.InfoS("Unable to filter endpoints due to missing service info", "servicePortName", svcPortName)
 	} else {

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -132,7 +132,7 @@ func NewFakeProxier(ipt utiliptables.Interface, ipvs utilipvs.Interface, ipset u
 	}
 	p := &Proxier{
 		exec:                  fexec,
-		serviceMap:            make(proxy.ServiceMap),
+		svcPortMap:            make(proxy.ServicePortMap),
 		serviceChanges:        proxy.NewServiceChangeTracker(newServiceInfo, ipFamily, nil, nil),
 		endpointsMap:          make(proxy.EndpointsMap),
 		endpointsChanges:      proxy.NewEndpointChangeTracker(testHostname, nil, ipFamily, nil, nil),
@@ -2482,9 +2482,9 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	for i := range services {
 		fp.OnServiceAdd(services[i])
 	}
-	result := fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 12 {
-		t.Errorf("expected service map length 12, got %v", fp.serviceMap)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 12 {
+		t.Errorf("expected service map length 12, got %v", fp.svcPortMap)
 	}
 
 	// The only-local-loadbalancer ones get added
@@ -2515,9 +2515,9 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	fp.OnServiceDelete(services[2])
 	fp.OnServiceDelete(services[3])
 
-	result = fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 1 {
-		t.Errorf("expected service map length 1, got %v", fp.serviceMap)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 1 {
+		t.Errorf("expected service map length 1, got %v", fp.svcPortMap)
 	}
 
 	if len(result.HCServiceNodePorts) != 0 {
@@ -2562,9 +2562,9 @@ func TestBuildServiceMapServiceHeadless(t *testing.T) {
 	)
 
 	// Headless service should be ignored
-	result := fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 0 {
-		t.Errorf("expected service map length 0, got %d", len(fp.serviceMap))
+	result := fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 0 {
+		t.Errorf("expected service map length 0, got %d", len(fp.svcPortMap))
 	}
 
 	// No proxied services, so no healthchecks
@@ -2592,9 +2592,9 @@ func TestBuildServiceMapServiceTypeExternalName(t *testing.T) {
 		}),
 	)
 
-	result := fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 0 {
-		t.Errorf("expected service map length 0, got %v", fp.serviceMap)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 0 {
+		t.Errorf("expected service map length 0, got %v", fp.svcPortMap)
 	}
 	// No proxied services, so no healthchecks
 	if len(result.HCServiceNodePorts) != 0 {
@@ -2634,9 +2634,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	fp.OnServiceAdd(servicev1)
 
-	result := fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 2 {
-		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 2 {
+		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
 	}
 	if len(result.HCServiceNodePorts) != 0 {
 		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)
@@ -2648,9 +2648,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// Change service to load-balancer
 	fp.OnServiceUpdate(servicev1, servicev2)
-	result = fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 2 {
-		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 2 {
+		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
 	}
 	if len(result.HCServiceNodePorts) != 1 {
 		t.Errorf("expected healthcheck ports length 1, got %v", result.HCServiceNodePorts)
@@ -2662,9 +2662,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	// No change; make sure the service map stays the same and there are
 	// no health-check changes
 	fp.OnServiceUpdate(servicev2, servicev2)
-	result = fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 2 {
-		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 2 {
+		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
 	}
 	if len(result.HCServiceNodePorts) != 1 {
 		t.Errorf("expected healthcheck ports length 1, got %v", result.HCServiceNodePorts)
@@ -2675,9 +2675,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// And back to ClusterIP
 	fp.OnServiceUpdate(servicev2, servicev1)
-	result = fp.serviceMap.Update(fp.serviceChanges)
-	if len(fp.serviceMap) != 2 {
-		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
+	if len(fp.svcPortMap) != 2 {
+		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
 	}
 	if len(result.HCServiceNodePorts) != 0 {
 		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -37,11 +37,11 @@ import (
 	utilproxy "k8s.io/kubernetes/pkg/proxy/util"
 )
 
-// BaseServiceInfo contains base information that defines a service.
+// BaseServicePort contains base information that defines a service.
 // This could be used directly by proxier while processing services,
 // or can be used for constructing a more specific ServiceInfo struct
 // defined by the proxier if needed.
-type BaseServiceInfo struct {
+type BaseServicePort struct {
 	clusterIP                net.IP
 	port                     int
 	protocol                 v1.Protocol
@@ -58,106 +58,106 @@ type BaseServiceInfo struct {
 	hintsAnnotation          string
 }
 
-var _ ServicePort = &BaseServiceInfo{}
+var _ ServicePort = &BaseServicePort{}
 
 // String is part of ServicePort interface.
-func (info *BaseServiceInfo) String() string {
-	return fmt.Sprintf("%s:%d/%s", info.clusterIP, info.port, info.protocol)
+func (svcPort *BaseServicePort) String() string {
+	return fmt.Sprintf("%s:%d/%s", svcPort.clusterIP, svcPort.port, svcPort.protocol)
 }
 
 // ClusterIP is part of ServicePort interface.
-func (info *BaseServiceInfo) ClusterIP() net.IP {
-	return info.clusterIP
+func (svcPort *BaseServicePort) ClusterIP() net.IP {
+	return svcPort.clusterIP
 }
 
 // Port is part of ServicePort interface.
-func (info *BaseServiceInfo) Port() int {
-	return info.port
+func (svcPort *BaseServicePort) Port() int {
+	return svcPort.port
 }
 
 // SessionAffinityType is part of the ServicePort interface.
-func (info *BaseServiceInfo) SessionAffinityType() v1.ServiceAffinity {
-	return info.sessionAffinityType
+func (svcPort *BaseServicePort) SessionAffinityType() v1.ServiceAffinity {
+	return svcPort.sessionAffinityType
 }
 
 // StickyMaxAgeSeconds is part of the ServicePort interface
-func (info *BaseServiceInfo) StickyMaxAgeSeconds() int {
-	return info.stickyMaxAgeSeconds
+func (svcPort *BaseServicePort) StickyMaxAgeSeconds() int {
+	return svcPort.stickyMaxAgeSeconds
 }
 
 // Protocol is part of ServicePort interface.
-func (info *BaseServiceInfo) Protocol() v1.Protocol {
-	return info.protocol
+func (svcPort *BaseServicePort) Protocol() v1.Protocol {
+	return svcPort.protocol
 }
 
 // LoadBalancerSourceRanges is part of ServicePort interface
-func (info *BaseServiceInfo) LoadBalancerSourceRanges() []string {
-	return info.loadBalancerSourceRanges
+func (svcPort *BaseServicePort) LoadBalancerSourceRanges() []string {
+	return svcPort.loadBalancerSourceRanges
 }
 
 // HealthCheckNodePort is part of ServicePort interface.
-func (info *BaseServiceInfo) HealthCheckNodePort() int {
-	return info.healthCheckNodePort
+func (svcPort *BaseServicePort) HealthCheckNodePort() int {
+	return svcPort.healthCheckNodePort
 }
 
 // NodePort is part of the ServicePort interface.
-func (info *BaseServiceInfo) NodePort() int {
-	return info.nodePort
+func (svcPort *BaseServicePort) NodePort() int {
+	return svcPort.nodePort
 }
 
 // ExternalIPStrings is part of ServicePort interface.
-func (info *BaseServiceInfo) ExternalIPStrings() []string {
-	return info.externalIPs
+func (svcPort *BaseServicePort) ExternalIPStrings() []string {
+	return svcPort.externalIPs
 }
 
 // LoadBalancerIPStrings is part of ServicePort interface.
-func (info *BaseServiceInfo) LoadBalancerIPStrings() []string {
+func (svcPort *BaseServicePort) LoadBalancerIPStrings() []string {
 	var ips []string
-	for _, ing := range info.loadBalancerStatus.Ingress {
+	for _, ing := range svcPort.loadBalancerStatus.Ingress {
 		ips = append(ips, ing.IP)
 	}
 	return ips
 }
 
 // ExternalPolicyLocal is part of ServicePort interface.
-func (info *BaseServiceInfo) ExternalPolicyLocal() bool {
-	return info.externalPolicyLocal
+func (svcPort *BaseServicePort) ExternalPolicyLocal() bool {
+	return svcPort.externalPolicyLocal
 }
 
 // InternalPolicyLocal is part of ServicePort interface
-func (info *BaseServiceInfo) InternalPolicyLocal() bool {
-	return info.internalPolicyLocal
+func (svcPort *BaseServicePort) InternalPolicyLocal() bool {
+	return svcPort.internalPolicyLocal
 }
 
 // InternalTrafficPolicy is part of ServicePort interface
-func (info *BaseServiceInfo) InternalTrafficPolicy() *v1.ServiceInternalTrafficPolicyType {
-	return info.internalTrafficPolicy
+func (svcPort *BaseServicePort) InternalTrafficPolicy() *v1.ServiceInternalTrafficPolicyType {
+	return svcPort.internalTrafficPolicy
 }
 
 // HintsAnnotation is part of ServicePort interface.
-func (info *BaseServiceInfo) HintsAnnotation() string {
-	return info.hintsAnnotation
+func (svcPort *BaseServicePort) HintsAnnotation() string {
+	return svcPort.hintsAnnotation
 }
 
 // ExternallyAccessible is part of ServicePort interface.
-func (info *BaseServiceInfo) ExternallyAccessible() bool {
-	return info.nodePort != 0 || len(info.loadBalancerStatus.Ingress) != 0 || len(info.externalIPs) != 0
+func (svcPort *BaseServicePort) ExternallyAccessible() bool {
+	return svcPort.nodePort != 0 || len(svcPort.loadBalancerStatus.Ingress) != 0 || len(svcPort.externalIPs) != 0
 }
 
 // UsesClusterEndpoints is part of ServicePort interface.
-func (info *BaseServiceInfo) UsesClusterEndpoints() bool {
+func (svcPort *BaseServicePort) UsesClusterEndpoints() bool {
 	// The service port uses Cluster endpoints if the internal traffic policy is "Cluster",
 	// or if it accepts external traffic at all. (Even if the external traffic policy is
 	// "Local", we need Cluster endpoints to implement short circuiting.)
-	return !info.internalPolicyLocal || info.ExternallyAccessible()
+	return !svcPort.internalPolicyLocal || svcPort.ExternallyAccessible()
 }
 
 // UsesLocalEndpoints is part of ServicePort interface.
-func (info *BaseServiceInfo) UsesLocalEndpoints() bool {
-	return info.internalPolicyLocal || (info.externalPolicyLocal && info.ExternallyAccessible())
+func (svcPort *BaseServicePort) UsesLocalEndpoints() bool {
+	return svcPort.internalPolicyLocal || (svcPort.externalPolicyLocal && svcPort.ExternallyAccessible())
 }
 
-func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, service *v1.Service) *BaseServiceInfo {
+func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, service *v1.Service) *BaseServicePort {
 	externalPolicyLocal := false
 	if apiservice.ExternalPolicyLocal(service) {
 		externalPolicyLocal = true
@@ -173,7 +173,7 @@ func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, servic
 	}
 
 	clusterIP := utilproxy.GetClusterIPByFamily(sct.ipFamily, service)
-	info := &BaseServiceInfo{
+	info := &BaseServicePort{
 		clusterIP:             netutils.ParseIPSloppy(clusterIP),
 		port:                  int(port.Port),
 		protocol:              port.Protocol,
@@ -245,18 +245,18 @@ func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, servic
 	return info
 }
 
-type makeServicePortFunc func(*v1.ServicePort, *v1.Service, *BaseServiceInfo) ServicePort
+type makeServicePortFunc func(*v1.ServicePort, *v1.Service, *BaseServicePort) ServicePort
 
 // This handler is invoked by the apply function on every change. This function should not modify the
-// ServiceMap's but just use the changes for any Proxier specific cleanup.
-type processServiceMapChangeFunc func(previous, current ServiceMap)
+// ServicePortMap's but just use the changes for any Proxier specific cleanup.
+type processServiceMapChangeFunc func(previous, current ServicePortMap)
 
-// serviceChange contains all changes to services that happened since proxy rules were synced.  For a single object,
+// serviceChange contains all changes to service that happened since proxy rules were synced.  For a single object,
 // changes are accumulated, i.e. previous is state from before applying the changes,
-// current is state after applying all of the changes.
+// current is state after applying all the changes.
 type serviceChange struct {
-	previous ServiceMap
-	current  ServiceMap
+	previous ServicePortMap
+	current  ServicePortMap
 }
 
 // ServiceChangeTracker carries state about uncommitted changes to an arbitrary number of
@@ -335,13 +335,13 @@ type UpdateServiceMapResult struct {
 	UDPStaleClusterIP sets.String
 }
 
-// Update updates ServiceMap base on the given changes.
-func (sm ServiceMap) Update(changes *ServiceChangeTracker) (result UpdateServiceMapResult) {
+// Update updates ServicePortMap base on the given changes.
+func (sm ServicePortMap) Update(changes *ServiceChangeTracker) (result UpdateServiceMapResult) {
 	result.UDPStaleClusterIP = sets.NewString()
 	sm.apply(changes, result.UDPStaleClusterIP)
 
 	// TODO: If this will appear to be computationally expensive, consider
-	// computing this incrementally similarly to serviceMap.
+	// computing this incrementally similarly to svcPortMap.
 	result.HCServiceNodePorts = make(map[types.NamespacedName]uint16)
 	for svcPortName, info := range sm {
 		if info.HealthCheckNodePort() != 0 {
@@ -352,13 +352,13 @@ func (sm ServiceMap) Update(changes *ServiceChangeTracker) (result UpdateService
 	return result
 }
 
-// ServiceMap maps a service to its ServicePort.
-type ServiceMap map[ServicePortName]ServicePort
+// ServicePortMap maps a service to its ServicePort.
+type ServicePortMap map[ServicePortName]ServicePort
 
-// serviceToServiceMap translates a single Service object to a ServiceMap.
+// serviceToServiceMap translates a single Service object to a ServicePortMap.
 //
 // NOTE: service object should NOT be modified.
-func (sct *ServiceChangeTracker) serviceToServiceMap(service *v1.Service) ServiceMap {
+func (sct *ServiceChangeTracker) serviceToServiceMap(service *v1.Service) ServicePortMap {
 	if service == nil {
 		return nil
 	}
@@ -372,25 +372,25 @@ func (sct *ServiceChangeTracker) serviceToServiceMap(service *v1.Service) Servic
 		return nil
 	}
 
-	serviceMap := make(ServiceMap)
+	svcPortMap := make(ServicePortMap)
 	svcName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
 	for i := range service.Spec.Ports {
 		servicePort := &service.Spec.Ports[i]
 		svcPortName := ServicePortName{NamespacedName: svcName, Port: servicePort.Name, Protocol: servicePort.Protocol}
 		baseSvcInfo := sct.newBaseServiceInfo(servicePort, service)
 		if sct.makeServiceInfo != nil {
-			serviceMap[svcPortName] = sct.makeServiceInfo(servicePort, service, baseSvcInfo)
+			svcPortMap[svcPortName] = sct.makeServiceInfo(servicePort, service, baseSvcInfo)
 		} else {
-			serviceMap[svcPortName] = baseSvcInfo
+			svcPortMap[svcPortName] = baseSvcInfo
 		}
 	}
-	return serviceMap
+	return svcPortMap
 }
 
-// apply the changes to ServiceMap and update the stale udp cluster IP set. The UDPStaleClusterIP argument is passed in to store the
-// udp protocol service cluster ip when service is deleted from the ServiceMap.
+// apply the changes to ServicePortMap and update the stale udp cluster IP set. The UDPStaleClusterIP argument is passed in to store the
+// udp protocol service cluster ip when service is deleted from the ServicePortMap.
 // apply triggers processServiceMapChange on every change.
-func (sm *ServiceMap) apply(changes *ServiceChangeTracker, UDPStaleClusterIP sets.String) {
+func (sm *ServicePortMap) apply(changes *ServiceChangeTracker, UDPStaleClusterIP sets.String) {
 	changes.lock.Lock()
 	defer changes.lock.Unlock()
 	for _, change := range changes.items {
@@ -403,20 +403,20 @@ func (sm *ServiceMap) apply(changes *ServiceChangeTracker, UDPStaleClusterIP set
 		change.previous.filter(change.current)
 		sm.unmerge(change.previous, UDPStaleClusterIP)
 	}
-	// clear changes after applying them to ServiceMap.
+	// clear changes after applying them to ServicePortMap.
 	changes.items = make(map[types.NamespacedName]*serviceChange)
 	metrics.ServiceChangesPending.Set(0)
 }
 
-// merge adds other ServiceMap's elements to current ServiceMap.
+// merge adds other ServicePortMap's elements to current ServicePortMap.
 // If collision, other ALWAYS win. Otherwise add the other to current.
 // In other words, if some elements in current collisions with other, update the current by other.
 // It returns a string type set which stores all the newly merged services' identifier, ServicePortName.String(), to help users
 // tell if a service is deleted or updated.
-// The returned value is one of the arguments of ServiceMap.unmerge().
-// ServiceMap A Merge ServiceMap B will do following 2 things:
-//   * update ServiceMap A.
-//   * produce a string set which stores all other ServiceMap's ServicePortName.String().
+// The returned value is one of the arguments of ServicePortMap.unmerge().
+// ServicePortMap A Merge ServicePortMap B will do following 2 things:
+//   * update ServicePortMap A.
+//   * produce a string set which stores all other ServicePortMap's ServicePortName.String().
 // For example,
 //   - A{}
 //   - B{{"ns", "cluster-ip", "http"}: {"172.16.55.10", 1234, "TCP"}}
@@ -426,8 +426,8 @@ func (sm *ServiceMap) apply(changes *ServiceChangeTracker, UDPStaleClusterIP set
 //   - B{{"ns", "cluster-ip", "http"}: {"172.16.55.10", 1234, "TCP"}}
 //     - A updated to be {{"ns", "cluster-ip", "http"}: {"172.16.55.10", 1234, "TCP"}}
 //     - produce string set {"ns/cluster-ip:http"}
-func (sm *ServiceMap) merge(other ServiceMap) sets.String {
-	// existingPorts is going to store all identifiers of all services in `other` ServiceMap.
+func (sm *ServicePortMap) merge(other ServicePortMap) sets.String {
+	// existingPorts is going to store all identifiers of all services in `other` ServicePortMap.
 	existingPorts := sets.NewString()
 	for svcPortName, info := range other {
 		// Take ServicePortName.String() as the newly merged service's identifier and put it into existingPorts.
@@ -443,8 +443,8 @@ func (sm *ServiceMap) merge(other ServiceMap) sets.String {
 	return existingPorts
 }
 
-// filter filters out elements from ServiceMap base on given ports string sets.
-func (sm *ServiceMap) filter(other ServiceMap) {
+// filter filters out elements from ServicePortMap base on given ports string sets.
+func (sm *ServicePortMap) filter(other ServicePortMap) {
 	for svcPortName := range *sm {
 		// skip the delete for Update event.
 		if _, ok := other[svcPortName]; ok {
@@ -453,9 +453,9 @@ func (sm *ServiceMap) filter(other ServiceMap) {
 	}
 }
 
-// unmerge deletes all other ServiceMap's elements from current ServiceMap.  We pass in the UDPStaleClusterIP strings sets
+// unmerge deletes all other ServicePortMap's elements from current ServicePortMap.  We pass in the UDPStaleClusterIP strings sets
 // for storing the stale udp service cluster IPs. We will clear stale udp connection base on UDPStaleClusterIP later
-func (sm *ServiceMap) unmerge(other ServiceMap, UDPStaleClusterIP sets.String) {
+func (sm *ServicePortMap) unmerge(other ServicePortMap, UDPStaleClusterIP sets.String) {
 	for svcPortName := range other {
 		info, exists := (*sm)[svcPortName]
 		if exists {

--- a/pkg/proxy/topology_test.go
+++ b/pkg/proxy/topology_test.go
@@ -68,7 +68,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "hints enabled, hints annotation == auto",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "auto"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "auto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
@@ -81,7 +81,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "hints, hints annotation == disabled, hints ignored",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "disabled"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "disabled"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
@@ -94,7 +94,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "hints, hints annotation == aUto (wrong capitalization), hints ignored",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "aUto"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "aUto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
@@ -107,7 +107,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "hints, hints annotation empty, hints ignored",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{},
+		serviceInfo:  &BaseServicePort{},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
@@ -120,7 +120,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "externalTrafficPolicy: Local, topology ignored for Local endpoints",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{externalPolicyLocal: true, nodePort: 8080, hintsAnnotation: "auto"},
+		serviceInfo:  &BaseServicePort{externalPolicyLocal: true, nodePort: 8080, hintsAnnotation: "auto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true, IsLocal: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true, IsLocal: true},
@@ -134,7 +134,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "internalTrafficPolicy: Local, topology ignored for Local endpoints",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{internalPolicyLocal: true, hintsAnnotation: "auto", externalPolicyLocal: false, nodePort: 8080},
+		serviceInfo:  &BaseServicePort{internalPolicyLocal: true, hintsAnnotation: "auto", externalPolicyLocal: false, nodePort: 8080},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true, IsLocal: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true, IsLocal: true},
@@ -148,7 +148,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "empty node labels",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "auto"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "auto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
@@ -158,7 +158,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "empty zone label",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: ""},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "auto"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "auto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
@@ -168,7 +168,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "node in different zone, no endpoint filtering",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-b"},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "auto"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "auto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
@@ -178,7 +178,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "normal endpoint filtering, auto annotation",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "auto"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "auto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
@@ -191,7 +191,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "unready endpoint",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "auto"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "auto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
@@ -204,7 +204,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "only unready endpoints in same zone (should not filter)",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "auto"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "auto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: false},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
@@ -217,7 +217,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "normal endpoint filtering, Auto annotation",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "Auto"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "Auto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
@@ -230,7 +230,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "hintsAnnotation empty, no filtering applied",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: ""},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: ""},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
@@ -243,7 +243,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "hintsAnnotation disabled, no filtering applied",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "disabled"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "disabled"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
@@ -256,7 +256,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "missing hints, no filtering applied",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "auto"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "auto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
@@ -269,7 +269,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "multiple hints per endpoint, filtering includes any endpoint with zone included",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-c"},
-		serviceInfo:  &BaseServiceInfo{hintsAnnotation: "auto"},
+		serviceInfo:  &BaseServicePort{hintsAnnotation: "auto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a", "zone-b", "zone-c"), Ready: true},
 			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b", "zone-c"), Ready: true},
@@ -282,7 +282,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		name:         "conflicting topology and localness require merging allEndpoints",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{internalPolicyLocal: false, externalPolicyLocal: true, nodePort: 8080, hintsAnnotation: "auto"},
+		serviceInfo:  &BaseServicePort{internalPolicyLocal: false, externalPolicyLocal: true, nodePort: 8080, hintsAnnotation: "auto"},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", ZoneHints: sets.NewString("zone-a"), Ready: true, IsLocal: true},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", ZoneHints: sets.NewString("zone-b"), Ready: true, IsLocal: true},
@@ -294,13 +294,13 @@ func TestCategorizeEndpoints(t *testing.T) {
 		allEndpoints:     sets.NewString("10.0.0.0:80", "10.0.0.1:80", "10.0.0.2:80"),
 	}, {
 		name:             "internalTrafficPolicy: Local, with empty endpoints",
-		serviceInfo:      &BaseServiceInfo{internalPolicyLocal: true},
+		serviceInfo:      &BaseServicePort{internalPolicyLocal: true},
 		endpoints:        []Endpoint{},
 		clusterEndpoints: nil,
 		localEndpoints:   sets.NewString(),
 	}, {
 		name:        "internalTrafficPolicy: Local, but all endpoints are remote",
-		serviceInfo: &BaseServiceInfo{internalPolicyLocal: true},
+		serviceInfo: &BaseServicePort{internalPolicyLocal: true},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: false},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true, IsLocal: false},
@@ -310,7 +310,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		onlyRemoteEndpoints: true,
 	}, {
 		name:        "internalTrafficPolicy: Local, all endpoints are local",
-		serviceInfo: &BaseServiceInfo{internalPolicyLocal: true},
+		serviceInfo: &BaseServicePort{internalPolicyLocal: true},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: true},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true, IsLocal: true},
@@ -319,7 +319,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		localEndpoints:   sets.NewString("10.0.0.0:80", "10.0.0.1:80"),
 	}, {
 		name:        "internalTrafficPolicy: Local, some endpoints are local",
-		serviceInfo: &BaseServiceInfo{internalPolicyLocal: true},
+		serviceInfo: &BaseServicePort{internalPolicyLocal: true},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: true},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true, IsLocal: false},
@@ -328,7 +328,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		localEndpoints:   sets.NewString("10.0.0.0:80"),
 	}, {
 		name:        "Cluster traffic policy, endpoints not Ready",
-		serviceInfo: &BaseServiceInfo{},
+		serviceInfo: &BaseServicePort{},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: false},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: false},
@@ -337,7 +337,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		localEndpoints:   nil,
 	}, {
 		name:        "Cluster traffic policy, some endpoints are Ready",
-		serviceInfo: &BaseServiceInfo{},
+		serviceInfo: &BaseServicePort{},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: false},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true},
@@ -347,7 +347,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 	}, {
 		name:        "Cluster traffic policy, PTE enabled, all endpoints are terminating",
 		pteEnabled:  true,
-		serviceInfo: &BaseServiceInfo{},
+		serviceInfo: &BaseServicePort{},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: false, Serving: true, Terminating: true, IsLocal: true},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: false, Serving: true, Terminating: true, IsLocal: false},
@@ -357,7 +357,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 	}, {
 		name:        "Cluster traffic policy, PTE disabled, all endpoints are terminating",
 		pteEnabled:  false,
-		serviceInfo: &BaseServiceInfo{},
+		serviceInfo: &BaseServicePort{},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: false, Serving: true, Terminating: true, IsLocal: true},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: false, Serving: true, Terminating: true, IsLocal: false},
@@ -366,7 +366,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		localEndpoints:   nil,
 	}, {
 		name:        "iTP: Local, eTP: Cluster, some endpoints local",
-		serviceInfo: &BaseServiceInfo{internalPolicyLocal: true, externalPolicyLocal: false, nodePort: 8080},
+		serviceInfo: &BaseServicePort{internalPolicyLocal: true, externalPolicyLocal: false, nodePort: 8080},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: true},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true, IsLocal: false},
@@ -376,7 +376,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		allEndpoints:     sets.NewString("10.0.0.0:80", "10.0.0.1:80"),
 	}, {
 		name:        "iTP: Cluster, eTP: Local, some endpoints local",
-		serviceInfo: &BaseServiceInfo{internalPolicyLocal: false, externalPolicyLocal: true, nodePort: 8080},
+		serviceInfo: &BaseServicePort{internalPolicyLocal: false, externalPolicyLocal: true, nodePort: 8080},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: true},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true, IsLocal: false},
@@ -386,7 +386,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		allEndpoints:     sets.NewString("10.0.0.0:80", "10.0.0.1:80"),
 	}, {
 		name:        "iTP: Local, eTP: Local, some endpoints local",
-		serviceInfo: &BaseServiceInfo{internalPolicyLocal: true, externalPolicyLocal: true, nodePort: 8080},
+		serviceInfo: &BaseServicePort{internalPolicyLocal: true, externalPolicyLocal: true, nodePort: 8080},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: true},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true, IsLocal: false},
@@ -396,7 +396,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		allEndpoints:     sets.NewString("10.0.0.0:80", "10.0.0.1:80"),
 	}, {
 		name:        "iTP: Local, eTP: Local, all endpoints remote",
-		serviceInfo: &BaseServiceInfo{internalPolicyLocal: true, externalPolicyLocal: true, nodePort: 8080},
+		serviceInfo: &BaseServicePort{internalPolicyLocal: true, externalPolicyLocal: true, nodePort: 8080},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: false},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true, IsLocal: false},
@@ -406,7 +406,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		allEndpoints:     sets.NewString("10.0.0.0:80", "10.0.0.1:80"),
 	}, {
 		name:        "iTP: Local, eTP: Local, PTE disabled, all endpoints remote and terminating",
-		serviceInfo: &BaseServiceInfo{internalPolicyLocal: true, externalPolicyLocal: true, nodePort: 8080},
+		serviceInfo: &BaseServicePort{internalPolicyLocal: true, externalPolicyLocal: true, nodePort: 8080},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: false, Serving: true, Terminating: true, IsLocal: false},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: false, Serving: true, Terminating: true, IsLocal: false},
@@ -417,7 +417,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 	}, {
 		name:        "iTP: Local, eTP: Local, PTE enabled, all endpoints remote and terminating",
 		pteEnabled:  true,
-		serviceInfo: &BaseServiceInfo{internalPolicyLocal: true, externalPolicyLocal: true, nodePort: 8080},
+		serviceInfo: &BaseServicePort{internalPolicyLocal: true, externalPolicyLocal: true, nodePort: 8080},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: false, Serving: true, Terminating: true, IsLocal: false},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: false, Serving: true, Terminating: true, IsLocal: false},
@@ -428,7 +428,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		onlyRemoteEndpoints: true,
 	}, {
 		name:        "iTP: Cluster, eTP: Local, PTE disabled, with terminating endpoints",
-		serviceInfo: &BaseServiceInfo{internalPolicyLocal: false, externalPolicyLocal: true, nodePort: 8080},
+		serviceInfo: &BaseServicePort{internalPolicyLocal: false, externalPolicyLocal: true, nodePort: 8080},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: false},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: false, Serving: false, IsLocal: true},
@@ -441,7 +441,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 	}, {
 		name:        "iTP: Cluster, eTP: Local, PTE enabled, with terminating endpoints",
 		pteEnabled:  true,
-		serviceInfo: &BaseServiceInfo{internalPolicyLocal: false, externalPolicyLocal: true, nodePort: 8080},
+		serviceInfo: &BaseServicePort{internalPolicyLocal: false, externalPolicyLocal: true, nodePort: 8080},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: false},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: false, Serving: false, IsLocal: true},
@@ -453,7 +453,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		allEndpoints:     sets.NewString("10.0.0.0:80", "10.0.0.2:80"),
 	}, {
 		name:        "externalTrafficPolicy ignored if not externally accessible",
-		serviceInfo: &BaseServiceInfo{externalPolicyLocal: true},
+		serviceInfo: &BaseServicePort{externalPolicyLocal: true},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: false},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true, IsLocal: true},
@@ -463,7 +463,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 		allEndpoints:     sets.NewString("10.0.0.0:80", "10.0.0.1:80"),
 	}, {
 		name:        "no cluster endpoints for iTP:Local internal-only service",
-		serviceInfo: &BaseServiceInfo{internalPolicyLocal: true},
+		serviceInfo: &BaseServicePort{internalPolicyLocal: true},
 		endpoints: []Endpoint{
 			&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: false},
 			&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true, IsLocal: true},

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -116,7 +116,7 @@ type loadBalancerFlags struct {
 
 // internal struct for string service information
 type serviceInfo struct {
-	*proxy.BaseServiceInfo
+	*proxy.BaseServicePort
 	targetPort             int
 	externalIPs            []*externalIPInfo
 	loadBalancerIngressIPs []*loadBalancerIngressInfo
@@ -323,7 +323,7 @@ func (proxier *Proxier) endpointsMapChange(oldEndpointsMap, newEndpointsMap prox
 
 func (proxier *Proxier) onEndpointsMapChange(svcPortName *proxy.ServicePortName) {
 
-	svc, exists := proxier.serviceMap[*svcPortName]
+	svc, exists := proxier.svcPortMap[*svcPortName]
 
 	if exists {
 		svcInfo, ok := svc.(*serviceInfo)
@@ -355,7 +355,7 @@ func (proxier *Proxier) onEndpointsMapChange(svcPortName *proxy.ServicePortName)
 	}
 }
 
-func (proxier *Proxier) serviceMapChange(previous, current proxy.ServiceMap) {
+func (proxier *Proxier) serviceMapChange(previous, current proxy.ServicePortMap) {
 	for svcPortName := range current {
 		proxier.onServiceMapChange(&svcPortName)
 	}
@@ -370,7 +370,7 @@ func (proxier *Proxier) serviceMapChange(previous, current proxy.ServiceMap) {
 
 func (proxier *Proxier) onServiceMapChange(svcPortName *proxy.ServicePortName) {
 
-	svc, exists := proxier.serviceMap[*svcPortName]
+	svc, exists := proxier.svcPortMap[*svcPortName]
 
 	if exists {
 		svcInfo, ok := svc.(*serviceInfo)
@@ -458,8 +458,8 @@ func (refCountMap endPointsReferenceCountMap) getRefCount(hnsID string) *uint16 
 }
 
 // returns a new proxy.ServicePort which abstracts a serviceInfo
-func (proxier *Proxier) newServiceInfo(port *v1.ServicePort, service *v1.Service, baseInfo *proxy.BaseServiceInfo) proxy.ServicePort {
-	info := &serviceInfo{BaseServiceInfo: baseInfo}
+func (proxier *Proxier) newServiceInfo(port *v1.ServicePort, service *v1.Service, baseInfo *proxy.BaseServicePort) proxy.ServicePort {
+	info := &serviceInfo{BaseServicePort: baseInfo}
 	preserveDIP := service.Annotations["preserve-destination"] == "true"
 	localTrafficDSR := service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal
 	err := hcn.DSRSupported()
@@ -525,7 +525,7 @@ type Proxier struct {
 	serviceChanges    *proxy.ServiceChangeTracker
 	endPointsRefCount endPointsReferenceCountMap
 	mu                sync.Mutex // protects the following fields
-	serviceMap        proxy.ServiceMap
+	svcPortMap        proxy.ServicePortMap
 	endpointsMap      proxy.EndpointsMap
 	// endpointSlicesSynced and servicesSynced are set to true when corresponding
 	// objects are synced after startup. This is used to avoid updating hns policies
@@ -699,7 +699,7 @@ func NewProxier(
 	isIPv6 := netutils.IsIPv6(nodeIP)
 	proxier := &Proxier{
 		endPointsRefCount:     make(endPointsReferenceCountMap),
-		serviceMap:            make(proxy.ServiceMap),
+		svcPortMap:            make(proxy.ServicePortMap),
 		endpointsMap:          make(proxy.EndpointsMap),
 		masqueradeAll:         masqueradeAll,
 		masqueradeMark:        masqueradeMark,
@@ -965,7 +965,7 @@ func (proxier *Proxier) OnEndpointSlicesSynced() {
 }
 
 func (proxier *Proxier) cleanupAllPolicies() {
-	for svcName, svc := range proxier.serviceMap {
+	for svcName, svc := range proxier.svcPortMap {
 		svcInfo, ok := svc.(*serviceInfo)
 		if !ok {
 			klog.ErrorS(nil, "Failed to cast serviceInfo", "serviceName", svcName)
@@ -1029,13 +1029,13 @@ func (proxier *Proxier) syncProxyRules() {
 	// We assume that if this was called, we really want to sync them,
 	// even if nothing changed in the meantime. In other words, callers are
 	// responsible for detecting no-op changes and not calling this function.
-	serviceUpdateResult := proxier.serviceMap.Update(proxier.serviceChanges)
+	serviceUpdateResult := proxier.svcPortMap.Update(proxier.serviceChanges)
 	endpointUpdateResult := proxier.endpointsMap.Update(proxier.endpointsChanges)
 
 	staleServices := serviceUpdateResult.UDPStaleClusterIP
 	// merge stale services gathered from updateEndpointsMap
 	for _, svcPortName := range endpointUpdateResult.StaleServiceNames {
-		if svcInfo, ok := proxier.serviceMap[svcPortName]; ok && svcInfo != nil && svcInfo.Protocol() == v1.ProtocolUDP {
+		if svcInfo, ok := proxier.svcPortMap[svcPortName]; ok && svcInfo != nil && svcInfo.Protocol() == v1.ProtocolUDP {
 			klog.V(2).InfoS("Stale udp service", "servicePortName", svcPortName, "clusterIP", svcInfo.ClusterIP())
 			staleServices.Insert(svcInfo.ClusterIP().String())
 		}
@@ -1072,7 +1072,7 @@ func (proxier *Proxier) syncProxyRules() {
 	klog.V(3).InfoS("Syncing Policies")
 
 	// Program HNS by adding corresponding policies for each service.
-	for svcName, svc := range proxier.serviceMap {
+	for svcName, svc := range proxier.svcPortMap {
 		svcInfo, ok := svc.(*serviceInfo)
 		if !ok {
 			klog.ErrorS(nil, "Failed to cast serviceInfo", "serviceName", svcName)

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -138,7 +138,7 @@ func NewFakeProxier(syncPeriod time.Duration, minSyncPeriod time.Duration, clust
 		networkType: networkType,
 	}
 	proxier := &Proxier{
-		serviceMap:          make(proxy.ServiceMap),
+		svcPortMap:          make(proxy.ServicePortMap),
 		endpointsMap:        make(proxy.EndpointsMap),
 		clusterCIDR:         clusterCIDR,
 		hostname:            testHostName,
@@ -200,7 +200,7 @@ func TestCreateServiceVip(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 
-	svc := proxier.serviceMap[svcPortName]
+	svc := proxier.svcPortMap[svcPortName]
 	svcInfo, ok := svc.(*serviceInfo)
 	if !ok {
 		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())
@@ -706,7 +706,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 
-	svc := proxier.serviceMap[svcPortName]
+	svc := proxier.svcPortMap[svcPortName]
 	svcInfo, ok := svc.(*serviceInfo)
 	if !ok {
 		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())
@@ -769,7 +769,7 @@ func TestCreateDsrLoadBalancer(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 
-	svc := proxier.serviceMap[svcPortName]
+	svc := proxier.svcPortMap[svcPortName]
 	svcInfo, ok := svc.(*serviceInfo)
 	if !ok {
 		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())
@@ -839,7 +839,7 @@ func TestEndpointSlice(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 
-	svc := proxier.serviceMap[svcPortName]
+	svc := proxier.svcPortMap[svcPortName]
 	svcInfo, ok := svc.(*serviceInfo)
 	if !ok {
 		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())


### PR DESCRIPTION
#### What type of PR is this?

Refactoring variable name (ServiceMap to ServicePortMap; BaseServiceInfo to BaseServicePort) for meaningful map and struct.

/kind cleanup

#### What this PR does / why we need it:
Renames the various occurrence of the BaseServiceInfo struct to BaseServicePort and ServiceMap to ServicePortMap to be unanimous for better redability.

#### Which issue(s) this PR fixes:

Fixes #108806 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--

-->
```docs

```

/cc @thockin @danwinship 