### PR TITLE
test/e2e_kubeadm: add URL scheme test for node CRI annotations

### DIFF
--- a/test/e2e_kubeadm/nodes_test.go
+++ b/test/e2e_kubeadm/nodes_test.go
@@ -18,6 +18,7 @@ package kubeadm
 
 import (
 	"context"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -51,9 +52,11 @@ var _ = Describe("nodes", func() {
 			List(context.TODO(), metav1.ListOptions{})
 		framework.ExpectNoError(err, "error reading nodes")
 
-		// checks that the nodes have the CRI annotation
+		// Checks that the nodes have the CRI socket annotation
+		// and that it is prefixed with a URL scheme
 		for _, node := range nodes.Items {
 			gomega.Expect(node.Annotations).To(gomega.HaveKey(nodesCRISocketAnnotation))
+			gomega.Expect(node.Annotations[nodesCRISocketAnnotation]).To(gomega.HavePrefix("unix://"))
 		}
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The tests in nodes_test.go check if the Node objects
in a kubeadm cluster are annotated with a CRI socket
path. It is used by kubeadm to store a CRI socket per node.

Add a new test condition to verify if the CRI socket path
is prefixed with URL scheme "unix://".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2426

#### Special notes for your reviewer:

The changes in 1.24 were made so that we always prefix with URL scheme.
This test change will be added to 1.25, so even in our skew tests (kubeadm 1.24 vs k8s/test suite 1.25) it should be OK.
Note: "unix://" is valid here given kubeadm has no non-unix tests in CI (e.g. Windows npipes URL schemes)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
