### PR TITLE
Don't use KUBE-MARK-DROP for LoadBalancerSourceRanges

### DIFF
--- a/pkg/proxy/iptables/number_generated_rules_test.go
+++ b/pkg/proxy/iptables/number_generated_rules_test.go
@@ -158,8 +158,8 @@ func TestNumberIptablesRules(t *testing.T) {
 			},
 			services:            1,
 			epPerService:        1,
-			expectedFilterRules: 3,
-			expectedNatRules:    17,
+			expectedFilterRules: 4,
+			expectedNatRules:    16,
 		},
 		{
 			name: "1 Services 2 EndpointPerService - LoadBalancer",
@@ -173,8 +173,8 @@ func TestNumberIptablesRules(t *testing.T) {
 			},
 			services:            1,
 			epPerService:        2,
-			expectedFilterRules: 3,
-			expectedNatRules:    20,
+			expectedFilterRules: 4,
+			expectedNatRules:    19,
 		},
 		{
 			name: "1 Services 10 EndpointPerService - LoadBalancer",
@@ -188,8 +188,8 @@ func TestNumberIptablesRules(t *testing.T) {
 			},
 			services:            1,
 			epPerService:        10,
-			expectedFilterRules: 3,
-			expectedNatRules:    44,
+			expectedFilterRules: 4,
+			expectedNatRules:    43,
 		},
 		{
 			name: "10 Services 0 EndpointsPerService - LoadBalancer",
@@ -218,8 +218,8 @@ func TestNumberIptablesRules(t *testing.T) {
 			},
 			services:            10,
 			epPerService:        1,
-			expectedFilterRules: 3,
-			expectedNatRules:    125,
+			expectedFilterRules: 13,
+			expectedNatRules:    115,
 		},
 		{
 			name: "10 Services 2 EndpointPerService - LoadBalancer",
@@ -233,8 +233,8 @@ func TestNumberIptablesRules(t *testing.T) {
 			},
 			services:            10,
 			epPerService:        2,
-			expectedFilterRules: 3,
-			expectedNatRules:    155,
+			expectedFilterRules: 13,
+			expectedNatRules:    145,
 		},
 		{
 			name: "10 Services 10 EndpointPerService - LoadBalancer",
@@ -248,8 +248,8 @@ func TestNumberIptablesRules(t *testing.T) {
 			},
 			services:            10,
 			epPerService:        10,
-			expectedFilterRules: 3,
-			expectedNatRules:    395,
+			expectedFilterRules: 13,
+			expectedNatRules:    385,
 		},
 	}
 

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -70,9 +70,6 @@ const (
 	// kubeMarkMasqChain is the mark-for-masquerade chain
 	kubeMarkMasqChain utiliptables.Chain = "KUBE-MARK-MASQ"
 
-	// kubeMarkDropChain is the mark-for-drop chain
-	kubeMarkDropChain utiliptables.Chain = "KUBE-MARK-DROP"
-
 	// the kubernetes forward chain
 	kubeForwardChain utiliptables.Chain = "KUBE-FORWARD"
 
@@ -395,13 +392,6 @@ var iptablesJumpChains = []iptablesJumpChain{
 	{utiliptables.TableNAT, kubeServicesChain, utiliptables.ChainOutput, "kubernetes service portals", nil},
 	{utiliptables.TableNAT, kubeServicesChain, utiliptables.ChainPrerouting, "kubernetes service portals", nil},
 	{utiliptables.TableNAT, kubePostroutingChain, utiliptables.ChainPostrouting, "kubernetes postrouting rules", nil},
-}
-
-var iptablesEnsureChains = []struct {
-	table utiliptables.Table
-	chain utiliptables.Chain
-}{
-	{utiliptables.TableNAT, kubeMarkDropChain},
 }
 
 var iptablesCleanupOnlyChains = []iptablesJumpChain{
@@ -879,14 +869,6 @@ func (proxier *Proxier) syncProxyRules() {
 		)
 		if _, err := proxier.iptables.EnsureRule(utiliptables.Prepend, jump.table, jump.srcChain, args...); err != nil {
 			klog.ErrorS(err, "Failed to ensure chain jumps", "table", jump.table, "srcChain", jump.srcChain, "dstChain", jump.dstChain)
-			return
-		}
-	}
-
-	// ensure KUBE-MARK-DROP chain exist but do not change any rules
-	for _, ch := range iptablesEnsureChains {
-		if _, err := proxier.iptables.EnsureChain(ch.table, ch.chain); err != nil {
-			klog.ErrorS(err, "Failed to ensure chain exists", "table", ch.table, "chain", ch.chain)
 			return
 		}
 	}

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -76,6 +76,9 @@ const (
 	// the kubernetes forward chain
 	kubeForwardChain utiliptables.Chain = "KUBE-FORWARD"
 
+	// kubeProxyFirewallChain is the kube-proxy firewall chain
+	kubeProxyFirewallChain utiliptables.Chain = "KUBE-PROXY-FIREWALL"
+
 	// kube proxy canary chain is used for monitoring rule reload
 	kubeProxyCanaryChain utiliptables.Chain = "KUBE-PROXY-CANARY"
 
@@ -386,6 +389,9 @@ var iptablesJumpChains = []iptablesJumpChain{
 	{utiliptables.TableFilter, kubeServicesChain, utiliptables.ChainForward, "kubernetes service portals", []string{"-m", "conntrack", "--ctstate", "NEW"}},
 	{utiliptables.TableFilter, kubeServicesChain, utiliptables.ChainOutput, "kubernetes service portals", []string{"-m", "conntrack", "--ctstate", "NEW"}},
 	{utiliptables.TableFilter, kubeForwardChain, utiliptables.ChainForward, "kubernetes forwarding rules", nil},
+	{utiliptables.TableFilter, kubeProxyFirewallChain, utiliptables.ChainInput, "kubernetes load balancer firewall", []string{"-m", "conntrack", "--ctstate", "NEW"}},
+	{utiliptables.TableFilter, kubeProxyFirewallChain, utiliptables.ChainOutput, "kubernetes load balancer firewall", []string{"-m", "conntrack", "--ctstate", "NEW"}},
+	{utiliptables.TableFilter, kubeProxyFirewallChain, utiliptables.ChainForward, "kubernetes load balancer firewall", []string{"-m", "conntrack", "--ctstate", "NEW"}},
 	{utiliptables.TableNAT, kubeServicesChain, utiliptables.ChainOutput, "kubernetes service portals", nil},
 	{utiliptables.TableNAT, kubeServicesChain, utiliptables.ChainPrerouting, "kubernetes service portals", nil},
 	{utiliptables.TableNAT, kubePostroutingChain, utiliptables.ChainPostrouting, "kubernetes postrouting rules", nil},
@@ -896,9 +902,8 @@ func (proxier *Proxier) syncProxyRules() {
 	proxier.natChains.Reset()
 	proxier.natRules.Reset()
 
-	// Make sure we keep stats for the top-level chains, if they existed
-	// (which most should have because we created them above).
-	for _, chainName := range []utiliptables.Chain{kubeServicesChain, kubeExternalServicesChain, kubeForwardChain, kubeNodePortsChain} {
+	// Write chain lines for all the "top-level" chains we'll be filling in
+	for _, chainName := range []utiliptables.Chain{kubeServicesChain, kubeExternalServicesChain, kubeForwardChain, kubeNodePortsChain, kubeProxyFirewallChain} {
 		proxier.filterChains.Write(utiliptables.MakeChainLine(chainName))
 	}
 	for _, chainName := range []utiliptables.Chain{kubeServicesChain, kubeNodePortsChain, kubePostroutingChain, kubeMarkMasqChain} {
@@ -1158,6 +1163,15 @@ func (proxier *Proxier) syncProxyRules() {
 					"-j", string(loadBalancerTrafficChain))
 
 			}
+			if usesFWChain {
+				proxier.filterRules.Write(
+					"-A", string(kubeProxyFirewallChain),
+					"-m", "comment", "--comment", fmt.Sprintf(`"%s traffic not accepted by %s"`, svcPortNameString, svcInfo.firewallChainName),
+					"-m", protocol, "-p", protocol,
+					"-d", lbip,
+					"--dport", strconv.Itoa(svcInfo.Port()),
+					"-j", "DROP")
+			}
 		}
 		if !hasExternalEndpoints {
 			// Either no endpoints at all (REJECT) or no endpoints for
@@ -1339,9 +1353,8 @@ func (proxier *Proxier) syncProxyRules() {
 				}
 			}
 			// If the packet was able to reach the end of firewall chain,
-			// then it did not get DNATed.  It means the packet cannot go
-			// thru the firewall, then mark it for DROP.
-			proxier.natRules.Write(args, "-j", string(kubeMarkDropChain))
+			// then it did not get DNATed and will be dropped later by the
+			// corresponding KUBE-PROXY-FIREWALL rule.
 		}
 
 		// If Cluster policy is in use, create the chain and create rules jumping


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind feature

#### What this PR does / why we need it:
As part of [KEP-3178](https://github.com/kubernetes/enhancements/issues/3178) this removes the use of `KUBE-MARK-DROP` in the handling of the service LoadBalancerSourceRanges feature.

Old behavior:
- If `LoadBalancerSourceRanges` is enabled, then traffic to the LB IP goes to a `KUBE-FW-*` chain that matches each allowed source range and jumps to the `KUBE-EXT-*` chain on a match.
- If none of the source ranges match, the last rule in the `KUBE-FW-*` chain calls `KUBE-MARK-DROP` to mark the packet to be dropped.
- Later, in the `filter` table, the `KUBE-FIREWALL` chain sees the mark and (regardless of what else has happened to the packet in the meantime), calls `-j DROP` on the packet
- (Note that the short-circuit to `ClusterIP` doesn't happen until the `KUBE-EXT-*` chain, so pod-to-LB-IP packets that don't match any `LoadBalancerSourceRanges` ranges will get dropped, not short-circuited.)

New behavior:
- [SAME] If `LoadBalancerSourceRanges` is enabled, then traffic to the LB IP goes to a `KUBE-FW-*` chain that matches each allowed source range and jumps to the `KUBE-EXT-*` chain on a match.
- If none of the source ranges match, the `KUBE-FW-*` chain (implicitly) returns. No other rules in the `nat` table should end up matching the packet, so it will arrive in the `filter` table un-rewritten.
- In the `filter` table, a rule in ~`KUBE-EXTERNAL-SERVICES`~ `KUBE-PROXY-FIREWALL` will see the packet still addressed to the LB IP and call `-j DROP` on it.
  - (`KUBE-EXTERNAL-SERVICES` doesn't work because it only runs from `INPUT` and `FORWARD`, whereas we need to intercept `OUTPUT` too in this case to catch disallowed pod-to-LB-IP traffic. So we create a new firewall chain (with the same name as the one added for ipvs KEP-3178.)
- [SAME] (Note that the short-circuit to `ClusterIP` doesn't happen until the `KUBE-EXT-*` chain, so pod-to-LB-IP packets that don't match any `LoadBalancerSourceRanges` ranges will get dropped, not short-circuited.)

#### Which issue(s) this PR fixes:
none

#### Special notes for your reviewer:
In the past, the e2e test that is supposed to make sure this feature works didn't actually work (#85572) (in the sense that the test would pass even if we didn't explicitly drop the packet), and I think that is still true with this PR; if we failed to drop the packet, it would just get blackholed rather than actually being incorrectly delivered to a service endpoint. It is possible that there is not (and never has been) any situation where this DROP rule is actually _needed_...

At any rate, it should be possible to manually test this by doing:
1. create a LoadBalancer service with LoadBalancerSourceRanges that allow connections from outside the cluster but not from node/pod IPs
2. create a test pod
3. on the test pod's node, `kill -STOP` kube-proxy to prevent it from deleting and recreating rules while we're trying to monitor their counts
4. on the test pod's node, `iptables-save -c -t filter| grep <LB-IP>` to see the current counter on the drop rule
5. from the test pod, try to connect to the LB IP
6. on the test pod's node, `iptables-save -c -t filter| grep <LB-IP>` to confirm that the counter on the rule went up

This actually doesn't work in OpenShift, because of changes we made to the way that GCP VIPs work to make apiserver failover work better during upgrades, which apparently have side effects that affect local-to-LB-IP connections that don't get matched by any kube-proxy rules. (The packet still gets dropped, it just doesn't get dropped by the right rule.) So I need to fix that, but even then, OpenShift's behavior won't be identical to "normal" GCP, so I still need someone to test this on "normal" GCP. (**EDIT**: actually, probably testing on bare metal with MetalLB is beter anyway, so I need to test that. **EDIT 2**: and now tested)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3178
```
