### PR TITLE
Implement KEP-3178 "iptables cleanup" in kubelet

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -436,6 +436,13 @@ const (
 	// Allows Job controller to manage Pod completions per completion index.
 	IndexedJob featuregate.Feature = "IndexedJob"
 
+	// owner: @danwinship
+	// kep: http://kep.k8s.io/3178
+	// alpha: v1.25
+	//
+	// Causes kubelet to no longer create legacy IPTables rules
+	IPTablesOwnershipCleanup featuregate.Feature = "IPTablesOwnershipCleanup"
+
 	// owner: @ahg
 	// beta: v1.23
 	//
@@ -926,6 +933,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	InTreePluginvSphereUnregister: {Default: false, PreRelease: featuregate.Alpha},
 
 	IndexedJob: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
+
+	IPTablesOwnershipCleanup: {Default: false, PreRelease: featuregate.Alpha},
 
 	JobMutableNodeSchedulingDirectives: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/kubelet/kubelet_network_linux.go
+++ b/pkg/kubelet/kubelet_network_linux.go
@@ -24,7 +24,9 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	utilexec "k8s.io/utils/exec"
 )
@@ -57,12 +59,12 @@ func (kl *Kubelet) initNetworkUtil() {
 
 	for i := range iptClients {
 		iptClient := iptClients[i]
-		if kl.syncNetworkUtil(iptClient) {
+		if kl.syncIPTablesRules(iptClient) {
 			klog.InfoS("Initialized iptables rules.", "protocol", iptClient.Protocol())
 			go iptClient.Monitor(
 				utiliptables.Chain("KUBE-KUBELET-CANARY"),
 				[]utiliptables.Table{utiliptables.TableMangle, utiliptables.TableNAT, utiliptables.TableFilter},
-				func() { kl.syncNetworkUtil(iptClient) },
+				func() { kl.syncIPTablesRules(iptClient) },
 				1*time.Minute, wait.NeverStop,
 			)
 		} else {
@@ -71,13 +73,68 @@ func (kl *Kubelet) initNetworkUtil() {
 	}
 }
 
-// syncNetworkUtil ensures the network utility are present on host.
-// Network util includes:
+// syncIPTablesRules ensures the KUBE-IPTABLES-HINT chain exists, and the martian packet
+// protection rule is installed. If the IPTablesOwnershipCleanup feature gate is disabled
+// it will also synchronize additional deprecated iptables rules.
+func (kl *Kubelet) syncIPTablesRules(iptClient utiliptables.Interface) bool {
+	// Create hint chain so other components can see whether we are using iptables-legacy
+	// or iptables-nft.
+	if _, err := iptClient.EnsureChain(utiliptables.TableMangle, KubeIPTablesHintChain); err != nil {
+		klog.ErrorS(err, "Failed to ensure that iptables hint chain exists")
+		return false
+	}
+
+	if !iptClient.IsIPv6() { // ipv6 doesn't have this issue
+		// Set up the KUBE-FIREWALL chain and martian packet protection rule.
+		// (See below.)
+		if _, err := iptClient.EnsureChain(utiliptables.TableFilter, KubeFirewallChain); err != nil {
+			klog.ErrorS(err, "Failed to ensure that filter table KUBE-FIREWALL chain exists")
+			return false
+		}
+
+		if _, err := iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableFilter, utiliptables.ChainOutput, "-j", string(KubeFirewallChain)); err != nil {
+			klog.ErrorS(err, "Failed to ensure that OUTPUT chain jumps to KUBE-FIREWALL")
+			return false
+		}
+		if _, err := iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableFilter, utiliptables.ChainInput, "-j", string(KubeFirewallChain)); err != nil {
+			klog.ErrorS(err, "Failed to ensure that INPUT chain jumps to KUBE-FIREWALL")
+			return false
+		}
+
+		// Kube-proxy's use of `route_localnet` to enable NodePorts on localhost
+		// creates a security hole (https://issue.k8s.io/90259) which this
+		// iptables rule mitigates. This rule should have been added to
+		// kube-proxy, but it mistakenly ended up in kubelet instead, and we are
+		// keeping it in kubelet for now in case other third-party components
+		// depend on it.
+		if _, err := iptClient.EnsureRule(utiliptables.Append, utiliptables.TableFilter, KubeFirewallChain,
+			"-m", "comment", "--comment", "block incoming localnet connections",
+			"--dst", "127.0.0.0/8",
+			"!", "--src", "127.0.0.0/8",
+			"-m", "conntrack",
+			"!", "--ctstate", "RELATED,ESTABLISHED,DNAT",
+			"-j", "DROP"); err != nil {
+			klog.ErrorS(err, "Failed to ensure rule to drop invalid localhost packets in filter table KUBE-FIREWALL chain")
+			return false
+		}
+	}
+
+	if !utilfeature.DefaultFeatureGate.Enabled(features.IPTablesOwnershipCleanup) {
+		ok := kl.syncIPTablesRulesDeprecated(iptClient)
+		if !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// syncIPTablesRulesDeprecated ensures deprecated iptables rules are present:
 //  1. In nat table, KUBE-MARK-DROP rule to mark connections for dropping
 //     Marked connection will be drop on INPUT/OUTPUT Chain in filter table
 //  2. In nat table, KUBE-MARK-MASQ rule to mark connections for SNAT
 //     Marked connection will get SNAT on POSTROUTING Chain in nat table
-func (kl *Kubelet) syncNetworkUtil(iptClient utiliptables.Interface) bool {
+func (kl *Kubelet) syncIPTablesRulesDeprecated(iptClient utiliptables.Interface) bool {
 	// Setup KUBE-MARK-DROP rules
 	dropMark := getIPTablesMark(kl.iptablesDropBit)
 	if _, err := iptClient.EnsureChain(utiliptables.TableNAT, KubeMarkDropChain); err != nil {
@@ -97,30 +154,6 @@ func (kl *Kubelet) syncNetworkUtil(iptClient utiliptables.Interface) bool {
 		"-m", "mark", "--mark", fmt.Sprintf("%s/%s", dropMark, dropMark),
 		"-j", "DROP"); err != nil {
 		klog.ErrorS(err, "Failed to ensure that KUBE-FIREWALL rule exists")
-		return false
-	}
-
-	// drop all non-local packets to localhost if they're not part of an existing
-	// forwarded connection. See #90259
-	if !iptClient.IsIPv6() { // ipv6 doesn't have this issue
-		if _, err := iptClient.EnsureRule(utiliptables.Append, utiliptables.TableFilter, KubeFirewallChain,
-			"-m", "comment", "--comment", "block incoming localnet connections",
-			"--dst", "127.0.0.0/8",
-			"!", "--src", "127.0.0.0/8",
-			"-m", "conntrack",
-			"!", "--ctstate", "RELATED,ESTABLISHED,DNAT",
-			"-j", "DROP"); err != nil {
-			klog.ErrorS(err, "Failed to ensure rule to drop invalid localhost packets exists")
-			return false
-		}
-	}
-
-	if _, err := iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableFilter, utiliptables.ChainOutput, "-j", string(KubeFirewallChain)); err != nil {
-		klog.ErrorS(err, "Failed to ensure that OUTPUT chain jumps to KUBE-FIREWALL")
-		return false
-	}
-	if _, err := iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableFilter, utiliptables.ChainInput, "-j", string(KubeFirewallChain)); err != nil {
-		klog.ErrorS(err, "Failed to ensure that INPUT chain jumps to KUBE-FIREWALL")
 		return false
 	}
 
@@ -170,13 +203,6 @@ func (kl *Kubelet) syncNetworkUtil(iptClient utiliptables.Interface) bool {
 	}
 	if _, err := iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubePostroutingChain, masqRule...); err != nil {
 		klog.ErrorS(err, "Failed to ensure third masquerading rule exists")
-		return false
-	}
-
-	// Create hint chain so other components can see whether we are using iptables-legacy
-	// or iptables-nft.
-	if _, err := iptClient.EnsureChain(utiliptables.TableMangle, KubeIPTablesHintChain); err != nil {
-		klog.ErrorS(err, "Failed to ensure that iptables hint chain exists")
 		return false
 	}
 

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -618,13 +618,13 @@ var _ = common.SIGDescribe("Networking", func() {
 
 		ginkgo.By("verifying that kubelet rules are eventually recreated")
 		err = utilwait.PollImmediate(framework.Poll, framework.RestartNodeReadyAgainTimeout, func() (bool, error) {
-			result, err = e2essh.SSH("sudo iptables-save -t nat", host, framework.TestContext.Provider)
+			result, err = e2essh.SSH("sudo iptables-save -t mangle", host, framework.TestContext.Provider)
 			if err != nil || result.Code != 0 {
 				e2essh.LogResult(result)
 				return false, err
 			}
 
-			if strings.Contains(result.Stdout, "\n-A KUBE-MARK-DROP ") {
+			if strings.Contains(result.Stdout, "\n:KUBE-IPTABLES-HINT") {
 				return true, nil
 			}
 			return false, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind feature

#### What this PR does / why we need it:
This implements the kubelet side of [KEP-3178](https://github.com/kubernetes/enhancements/issues/3178) "Clean up IPTables Chain Ownership".

The feature gate will not be usable until #110289 and #110290 merge and remove kube-proxy's dependency on these rules.

#### Which issue(s) this PR fixes:
none

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
? it's not user-facing unless you enable the feature gate, but we document that elsewhere, right?

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3178
```
