### PR TITLE
enhance assertions in test/e2e/apps

### DIFF
--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -495,7 +495,9 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 			rollbackPods[pod.Name] = true
 		}
 		for _, pod := range existingPods {
-			framework.ExpectEqual(rollbackPods[pod.Name], true, fmt.Sprintf("unexpected pod %s be restarted", pod.Name))
+			if !rollbackPods[pod.Name] {
+				framework.Failf("unexpected pod %s is restarted", pod.Name)
+			}
 		}
 	})
 

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -325,7 +325,9 @@ var _ = SIGDescribe("Deployment", func() {
 				break
 			}
 		}
-		framework.ExpectEqual(foundDeployment, true, "unable to find the Deployment in list", deploymentsList)
+		if !foundDeployment {
+			framework.Failf("unable to find the Deployment %s in list: %+v", testNamespaceName, deploymentsList)
+		}
 
 		ginkgo.By("updating the Deployment")
 		testDeploymentUpdate := testDeployment
@@ -677,7 +679,9 @@ func stopDeployment(c clientset.Interface, ns, deploymentName string) {
 	framework.Logf("Ensuring deployment %s was deleted", deploymentName)
 	_, err = c.AppsV1().Deployments(ns).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
 	framework.ExpectError(err)
-	framework.ExpectEqual(apierrors.IsNotFound(err), true)
+	if !apierrors.IsNotFound(err) {
+		framework.Failf("expected 404, got %v", err)
+	}
 	framework.Logf("Ensuring deployment %s's RSes were deleted", deploymentName)
 	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
 	framework.ExpectNoError(err)

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -163,7 +163,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 				return true, nil
 			})
 			framework.ExpectNoError(err, "Wait until condition with watch events should not return an error")
-			framework.ExpectEqual(eventFound, true, "failed to find RC %v event", watch.Added)
+			if !eventFound {
+				framework.Failf("failed to find RC %v event", watch.Added)
+			}
 
 			ginkgo.By("waiting for available Replicas")
 			eventFound = false
@@ -186,7 +188,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 				return true, nil
 			})
 			framework.ExpectNoError(err, "Wait for condition with watch events should not return an error")
-			framework.ExpectEqual(eventFound, true, "RC has not reached ReadyReplicas count of %v", testRcInitialReplicaCount)
+			if !eventFound {
+				framework.Failf("RC has not reached ReadyReplicas count of %v", testRcInitialReplicaCount)
+			}
 
 			rcLabelPatchPayload, err := json.Marshal(v1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{
@@ -212,7 +216,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 				return true, nil
 			})
 			framework.ExpectNoError(err, "Wait until condition with watch events should not return an error")
-			framework.ExpectEqual(eventFound, true, "failed to find RC %v event", watch.Added)
+			if !eventFound {
+				framework.Failf("failed to find RC %v event", watch.Added)
+			}
 
 			rcStatusPatchPayload, err := json.Marshal(map[string]interface{}{
 				"status": map[string]interface{}{
@@ -240,7 +246,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 				return true, nil
 			})
 			framework.ExpectNoError(err, "Wait until condition with watch events should not return an error")
-			framework.ExpectEqual(eventFound, true, "failed to find RC %v event", watch.Added)
+			if !eventFound {
+				framework.Failf("failed to find RC %v event", watch.Added)
+			}
 
 			ginkgo.By("waiting for available Replicas")
 			_, err = watchUntilWithoutRetry(context.TODO(), retryWatcher, func(watchEvent watch.Event) (bool, error) {
@@ -259,7 +267,6 @@ var _ = SIGDescribe("ReplicationController", func() {
 				return true, nil
 			})
 			framework.ExpectNoError(err, "Failed to find updated ready replica count")
-			framework.ExpectEqual(eventFound, true, "Failed to find updated ready replica count")
 
 			ginkgo.By("fetching ReplicationController status")
 			rcStatusUnstructured, err := dc.Resource(rcResource).Namespace(testRcNamespace).Get(context.TODO(), testRcName, metav1.GetOptions{}, "status")
@@ -294,7 +301,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 				return true, nil
 			})
 			framework.ExpectNoError(err, "Wait until condition with watch events should not return an error")
-			framework.ExpectEqual(eventFound, true, "failed to find RC %v event", watch.Added)
+			if !eventFound {
+				framework.Failf("failed to find RC %v event", watch.Added)
+			}
 
 			ginkgo.By("waiting for ReplicationController's scale to be the max amount")
 			eventFound = false
@@ -315,7 +324,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 				return true, nil
 			})
 			framework.ExpectNoError(err, "Wait until condition with watch events should not return an error")
-			framework.ExpectEqual(eventFound, true, "Failed to find updated ready replica count")
+			if !eventFound {
+				framework.Failf("Failed to find updated ready replica count")
+			}
 
 			// Get the ReplicationController
 			ginkgo.By("fetching ReplicationController; ensuring that it's patched")
@@ -345,13 +356,16 @@ var _ = SIGDescribe("ReplicationController", func() {
 				return true, nil
 			})
 			framework.ExpectNoError(err, "Wait until condition with watch events should not return an error")
-			framework.ExpectEqual(eventFound, true, "failed to find RC %v event", watch.Added)
+			if !eventFound {
+				framework.Failf("failed to find RC %v event", watch.Added)
+			}
 
 			ginkgo.By("listing all ReplicationControllers")
 			rcs, err := f.ClientSet.CoreV1().ReplicationControllers("").List(context.TODO(), metav1.ListOptions{LabelSelector: "test-rc-static=true"})
 			framework.ExpectNoError(err, "failed to list ReplicationController")
-			framework.ExpectEqual(len(rcs.Items) > 0, true)
-
+			if len(rcs.Items) <= 0 {
+				framework.Failf("got no ReplicationController")
+			}
 			ginkgo.By("checking that ReplicationController has expected values")
 			foundRc := false
 			for _, rcItem := range rcs.Items {
@@ -362,7 +376,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 					foundRc = true
 				}
 			}
-			framework.ExpectEqual(foundRc, true)
+			if !foundRc {
+				framework.Failf("failed to find RC: %s in Namespace: %s with Labels 'test-rc-static'=%s and 'test-rc'=%s", testRcName, testRcNamespace, "true", "patched")
+			}
 
 			// Delete ReplicationController
 			ginkgo.By("deleting ReplicationControllers by collection")
@@ -382,7 +398,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 				return true, nil
 			})
 			framework.ExpectNoError(err, "Wait until condition with watch events should not return an error")
-			framework.ExpectEqual(eventFound, true, "failed to find RC %v event", watch.Added)
+			if !eventFound {
+				framework.Failf("failed to find RC %v event", watch.Added)
+			}
 
 			return actualWatchEvents
 		}, func() (err error) {

--- a/test/e2e/apps/ttl_after_finished.go
+++ b/test/e2e/apps/ttl_after_finished.go
@@ -97,13 +97,17 @@ func testFinishedJob(f *framework.Framework) {
 	framework.ExpectNoError(err)
 	jobFinishTime := finishTime(job)
 	finishTimeUTC := jobFinishTime.UTC()
-	framework.ExpectNotEqual(jobFinishTime.IsZero(), true)
+	if jobFinishTime.IsZero() {
+		framework.Failf("finish time of job %s should not be zero or nil", job.Name)
+	}
 
 	deleteAtUTC := job.ObjectMeta.DeletionTimestamp.UTC()
 	framework.ExpectNotEqual(deleteAtUTC, nil)
 
 	expireAtUTC := finishTimeUTC.Add(time.Duration(ttl) * time.Second)
-	framework.ExpectEqual(deleteAtUTC.Before(expireAtUTC), false)
+	if deleteAtUTC.Before(expireAtUTC) {
+		framework.Failf("deletion time: %v of job %s should not be before expire time: %v", deleteAtUTC, job.Name, expireAtUTC)
+	}
 }
 
 // finishTime returns finish time of the specified job.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Better output for developers when tests fail.

#### Which issue(s) this PR fixes:

Fixes part of https://github.com/kubernetes/kubernetes/issues/105678

#### Special notes for your reviewer:

After this PR:
```
.../kubernetes/test/e2e/apps$ git grep 'Expect.*Equal([^,]*, *\(true\|false\)' | wc -l
0
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
