### PR TITLE
enhance assertions in test/e2e/windows

### DIFF
--- a/test/e2e/windows/density.go
+++ b/test/e2e/windows/density.go
@@ -131,7 +131,9 @@ func runDensityBatchTest(f *framework.Framework, testArg densityTest) (time.Dura
 
 	for name, create := range createTimes {
 		watch, ok := watchTimes[name]
-		framework.ExpectEqual(ok, true)
+		if !ok {
+			framework.Failf("pod %s failed to be observed by the watch", name)
+		}
 
 		e2eLags = append(e2eLags,
 			e2emetrics.PodLatencyData{Name: name, Latency: watch.Time.Sub(create.Time)})
@@ -201,12 +203,16 @@ func newInformerWatchPod(f *framework.Framework, mutex *sync.Mutex, watchTimes m
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				p, ok := obj.(*v1.Pod)
-				framework.ExpectEqual(ok, true)
+				if !ok {
+					framework.Failf("expected Pod, got %T", obj)
+				}
 				go checkPodRunning(p)
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				p, ok := newObj.(*v1.Pod)
-				framework.ExpectEqual(ok, true)
+				if !ok {
+					framework.Failf("expected Pod, got %T", newObj)
+				}
 				go checkPodRunning(p)
 			},
 		},

--- a/test/e2e/windows/host_process.go
+++ b/test/e2e/windows/host_process.go
@@ -19,6 +19,7 @@ package windows
 import (
 	"context"
 	"fmt"
+	"github.com/onsi/gomega"
 	"strings"
 	"time"
 
@@ -568,10 +569,10 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 		// Note: This test performs relative comparisons to ensure metrics values were logged and does not validate specific values.
 		// This done so the test can be run in parallel with other tests which may start HostProcess containers on the same node.
 		ginkgo.By("Ensuring metrics were updated")
-		framework.ExpectEqual(beforeMetrics.StartedContainersCount < afterMetrics.StartedContainersCount, true, "Count of started HostProcess containers should increase")
-		framework.ExpectEqual(beforeMetrics.StartedContainersErrorCount < afterMetrics.StartedContainersErrorCount, true, "Count of started HostProcess errors containers should increase")
-		framework.ExpectEqual(beforeMetrics.StartedInitContainersCount < afterMetrics.StartedInitContainersCount, true, "Count of started HostProcess init containers should increase")
-		framework.ExpectEqual(beforeMetrics.StartedInitContainersErrorCount < afterMetrics.StartedInitContainersErrorCount, true, "Count of started HostProcess errors init containers should increase")
+		gomega.Expect(beforeMetrics.StartedContainersCount).To(gomega.BeNumerically("<", afterMetrics.StartedContainersCount), "Count of started HostProcess containers should increase")
+		gomega.Expect(beforeMetrics.StartedContainersErrorCount).To(gomega.BeNumerically("<", afterMetrics.StartedContainersErrorCount), "Count of started HostProcess errors containers should increase")
+		gomega.Expect(beforeMetrics.StartedInitContainersCount).To(gomega.BeNumerically("<", afterMetrics.StartedInitContainersCount), "Count of started HostProcess init containers should increase")
+		gomega.Expect(beforeMetrics.StartedInitContainersErrorCount).To(gomega.BeNumerically("<", afterMetrics.StartedInitContainersErrorCount), "Count of started HostProcess errors init containers should increase")
 	})
 
 })

--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -126,7 +126,9 @@ var _ = SIGDescribe("[Feature:Windows] Kubelet-Stats", func() {
 				framework.Logf("Using node: %v", targetNode.Name)
 
 				ginkgo.By("Getting bootid")
-				framework.ExpectEqual(len(targetNode.Status.NodeInfo.BootID) != 0, true, "Should find bootId in kubelet stats")
+				if len(targetNode.Status.NodeInfo.BootID) == 0 {
+					framework.Failf("expected bootId in kubelet stats, got none")
+				}
 			})
 		})
 


### PR DESCRIPTION
Signed-off-by: hunknownz <klercc37@gmail.com>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Better output for developers when tests fail.

#### Which issue(s) this PR fixes:

Fixes part of https://github.com/kubernetes/kubernetes/issues/105678

#### Special notes for your reviewer:

After this PR:
```
.../kubernetes/test/e2e/windows$ git grep 'Expect.*Equal([^,]*, *\(true\|false\)' | wc -l
0
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
