### PR TITLE
remove deprecated metric and promote the replacement to STABLE

### DIFF
--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -202,6 +202,19 @@
   stabilityLevel: STABLE
   labels:
   - request_kind
+- name: apiserver_longrunning_requests
+  help: Gauge of all active long-running apiserver requests broken out by verb, group,
+    version, resource, scope and component. Not all requests are tracked this way.
+  type: Gauge
+  stabilityLevel: STABLE
+  labels:
+  - component
+  - group
+  - resource
+  - scope
+  - subresource
+  - verb
+  - version
 - name: apiserver_request_duration_seconds
   help: Response latency distribution in seconds for each verb, dry run value, group,
     version, resource, subresource, scope and component.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR removes the deprecated `apiserver_longrunning_gauge` metric and promotes its replacement `apiserver_longrunning_requests`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
apiserver_longrunning_gauge is removed from the codebase. Please use apiserver_longrunning_requests instead. 
```