### PR TITLE
add explicit typing for continue tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/continue.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/continue.go
@@ -19,9 +19,17 @@ package storage
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path"
 	"strings"
+)
+
+var (
+	ErrInvalidStartRV             = errors.New("continue key is not valid: incorrect encoded start resourceVersion (version meta.k8s.io/v1)")
+	ErrEmptyStartKey              = errors.New("continue key is not valid: encoded start key empty (version meta.k8s.io/v1)")
+	ErrGenericInvalidKey          = errors.New("continue key is not valid")
+	ErrUnrecognizedEncodedVersion = errors.New("continue key is not valid: server does not recognize this encoded version")
 )
 
 // continueToken is a simple structured object for encoding the state of a continue token.
@@ -39,19 +47,19 @@ type continueToken struct {
 func DecodeContinue(continueValue, keyPrefix string) (fromKey string, rv int64, err error) {
 	data, err := base64.RawURLEncoding.DecodeString(continueValue)
 	if err != nil {
-		return "", 0, fmt.Errorf("continue key is not valid: %v", err)
+		return "", 0, fmt.Errorf("%w: %v", ErrGenericInvalidKey, err)
 	}
 	var c continueToken
 	if err := json.Unmarshal(data, &c); err != nil {
-		return "", 0, fmt.Errorf("continue key is not valid: %v", err)
+		return "", 0, fmt.Errorf("%w: %v", ErrGenericInvalidKey, err)
 	}
 	switch c.APIVersion {
 	case "meta.k8s.io/v1":
 		if c.ResourceVersion == 0 {
-			return "", 0, fmt.Errorf("continue key is not valid: incorrect encoded start resourceVersion (version meta.k8s.io/v1)")
+			return "", 0, ErrInvalidStartRV
 		}
 		if len(c.StartKey) == 0 {
-			return "", 0, fmt.Errorf("continue key is not valid: encoded start key empty (version meta.k8s.io/v1)")
+			return "", 0, ErrEmptyStartKey
 		}
 		// defend against path traversal attacks by clients - path.Clean will ensure that startKey cannot
 		// be at a higher level of the hierarchy, and so when we append the key prefix we will end up with
@@ -63,11 +71,11 @@ func DecodeContinue(continueValue, keyPrefix string) (fromKey string, rv int64, 
 		}
 		cleaned := path.Clean(key)
 		if cleaned != key {
-			return "", 0, fmt.Errorf("continue key is not valid: %s", c.StartKey)
+			return "", 0, fmt.Errorf("%w: %v", ErrGenericInvalidKey, c.StartKey)
 		}
 		return keyPrefix + cleaned[1:], c.ResourceVersion, nil
 	default:
-		return "", 0, fmt.Errorf("continue key is not valid: server does not recognize this encoded version %q", c.APIVersion)
+		return "", 0, fmt.Errorf("%w %v", ErrUnrecognizedEncodedVersion, c.APIVersion)
 	}
 }
 


### PR DESCRIPTION
Our tests are mostly error based and explicit error typing allows
us to test against error types directly. Having made this change also
makes it obvious that our test coverage was lacking in two branches,
specifically, we were previously not testing empty start keys nor were
we testing for invalid start RVs.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Our tests are mostly error based and explicit error typing allows us to test against error types directly. Having made this change also makes it obvious that our test coverage was lacking in two branches, specifically, we were previously not testing empty start keys nor were
we testing for invalid start RVs.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE 
```