### PR TITLE
Use FQDN to allow service jig to test reachability across namespaces

### DIFF
--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -830,8 +830,9 @@ func (j *TestJig) waitForPodsReady(pods []string) error {
 	return nil
 }
 
-func testReachabilityOverServiceName(serviceName string, sp v1.ServicePort, execPod *v1.Pod) error {
-	return testEndpointReachability(serviceName, sp.Port, sp.Protocol, execPod)
+func testReachabilityOverServiceName(serviceName, serviceNamespace string, sp v1.ServicePort, execPod *v1.Pod) error {
+	endpoint := fmt.Sprintf("%s.%s.svc.%s", serviceName, serviceNamespace, framework.TestContext.ClusterDNSDomain)
+	return testEndpointReachability(endpoint, sp.Port, sp.Protocol, execPod)
 }
 
 func testReachabilityOverClusterIP(clusterIP string, sp v1.ServicePort, execPod *v1.Pod) error {
@@ -940,7 +941,7 @@ func (j *TestJig) checkClusterIPServiceReachability(svc *v1.Service, pod *v1.Pod
 	}
 
 	for _, servicePort := range servicePorts {
-		err = testReachabilityOverServiceName(svc.Name, servicePort, pod)
+		err = testReachabilityOverServiceName(svc.Name, svc.Namespace, servicePort, pod)
 		if err != nil {
 			return err
 		}
@@ -981,7 +982,7 @@ func (j *TestJig) checkNodePortServiceReachability(svc *v1.Service, pod *v1.Pod)
 	}
 
 	for _, servicePort := range servicePorts {
-		err = testReachabilityOverServiceName(svc.Name, servicePort, pod)
+		err = testReachabilityOverServiceName(svc.Name, svc.Namespace, servicePort, pod)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

I run a Kubernetes cluster with complex NetworkPolicy to restrict traffic flow, and I use the service jig from the Kubernetes e2e framework to validate reachability along various network paths. Currently this only works if the service jig (the endpoint) and the exec pod (the origin) share the same namespace, but isn't able to cross the namespace boundary.

### Single Namespace Test
Service reachability test succeeds over "my-jig-service" DNS name.

```plaintext
┏━ namespace "a" ━━━━━━━━━┓
┃ (exec pod) ┄> (jig svc) ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━┛
```

### Cross-Namespace Test
Service reachability fails over "my-jig-service" DNS name.

```plaintext
┏━ namespace "a" ━┓   ┏━ namespace "b" ━━┓
┃   (exec pod) ┄┄┄╂┄┄X┃    (jig svc)     ┃
┗━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━┛
```

### Using Service FQDN

The service jig performs reachability tests using the service's unqualified name, which requires the service to exist in the same namespace as the exec pod used. By using the fully-qualified service name, the service jig and exec pod can be placed in any arbitrary namespaces.

Service reachability succeeds over "my-jig-service.b.svc.cluster.local" DNS name.
```plaintext
┏━ namespace "a" ━┓   ┏━ namespace "b" ━━┓
┃   (exec pod) ┄┄┄╂┄┄┄╂┄┄> (jig svc)     ┃
┗━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━┛
```


#### Which issue(s) this PR fixes:

n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
n/a
```
