### PR TITLE
Remove `newlineReporter` custom report

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/apply/parse/suite_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/apply/parse/suite_test.go
@@ -18,32 +18,12 @@ package parse_test
 
 import (
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/config"
-	. "github.com/onsi/ginkgo/types"
 	. "github.com/onsi/gomega"
 
-	"fmt"
 	"testing"
 )
 
 func TestApplyParse(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Apply Parse Suite", []Reporter{newlineReporter{}})
+	RunSpecs(t, "Apply Parse Suite")
 }
-
-// Print a newline after the default newlineReporter due to issue
-// https://github.com/jstemmer/go-junit-report/issues/31
-type newlineReporter struct{}
-
-func (newlineReporter) SpecSuiteWillBegin(config GinkgoConfigType, summary *SuiteSummary) {}
-
-func (newlineReporter) BeforeSuiteDidRun(setupSummary *SetupSummary) {}
-
-func (newlineReporter) AfterSuiteDidRun(setupSummary *SetupSummary) {}
-
-func (newlineReporter) SpecWillRun(specSummary *SpecSummary) {}
-
-func (newlineReporter) SpecDidComplete(specSummary *SpecSummary) {}
-
-// SpecSuiteDidEnd Prints a newline between "35 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:"
-func (newlineReporter) SpecSuiteDidEnd(summary *SuiteSummary) { fmt.Printf("\n") }

--- a/staging/src/k8s.io/kubectl/pkg/apply/parse/suite_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/apply/parse/suite_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 )
 
-func TestOpenapi(t *testing.T) {
+func TestApplyParse(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Openapi Suite", []Reporter{newlineReporter{}})
+	RunSpecsWithDefaultAndCustomReporters(t, "Apply Parse Suite", []Reporter{newlineReporter{}})
 }
 
 // Print a newline after the default newlineReporter due to issue

--- a/staging/src/k8s.io/kubectl/pkg/apply/strategy/suite_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/apply/strategy/suite_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 )
 
-func TestOpenapi(t *testing.T) {
+func TestStrategy(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Openapi Suite", []Reporter{newlineReporter{}})
+	RunSpecsWithDefaultAndCustomReporters(t, "Apply Strategy Suite", []Reporter{newlineReporter{}})
 }
 
 // Print a newline after the default newlineReporter due to issue

--- a/staging/src/k8s.io/kubectl/pkg/apply/strategy/suite_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/apply/strategy/suite_test.go
@@ -18,32 +18,12 @@ package strategy_test
 
 import (
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/config"
-	. "github.com/onsi/ginkgo/types"
 	. "github.com/onsi/gomega"
 
-	"fmt"
 	"testing"
 )
 
 func TestStrategy(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Apply Strategy Suite", []Reporter{newlineReporter{}})
+	RunSpecs(t, "Apply Strategy Suite")
 }
-
-// Print a newline after the default newlineReporter due to issue
-// https://github.com/jstemmer/go-junit-report/issues/31
-type newlineReporter struct{}
-
-func (newlineReporter) SpecSuiteWillBegin(config GinkgoConfigType, summary *SuiteSummary) {}
-
-func (newlineReporter) BeforeSuiteDidRun(setupSummary *SetupSummary) {}
-
-func (newlineReporter) AfterSuiteDidRun(setupSummary *SetupSummary) {}
-
-func (newlineReporter) SpecWillRun(specSummary *SpecSummary) {}
-
-func (newlineReporter) SpecDidComplete(specSummary *SpecSummary) {}
-
-// SpecSuiteDidEnd Prints a newline between "35 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:"
-func (newlineReporter) SpecSuiteDidEnd(summary *SuiteSummary) { fmt.Printf("\n") }

--- a/staging/src/k8s.io/kubectl/pkg/apps/apps_suite_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/apps/apps_suite_test.go
@@ -18,32 +18,12 @@ package apps
 
 import (
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/config"
-	. "github.com/onsi/ginkgo/types"
 	. "github.com/onsi/gomega"
 
-	"fmt"
 	"testing"
 )
 
 func TestApps(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Apps Suite", []Reporter{newlineReporter{}})
+	RunSpecs(t, "Apps Suite")
 }
-
-// Print a newline after the default newlineReporter due to issue
-// https://github.com/jstemmer/go-junit-report/issues/31
-type newlineReporter struct{}
-
-func (newlineReporter) SpecSuiteWillBegin(config GinkgoConfigType, summary *SuiteSummary) {}
-
-func (newlineReporter) BeforeSuiteDidRun(setupSummary *SetupSummary) {}
-
-func (newlineReporter) AfterSuiteDidRun(setupSummary *SetupSummary) {}
-
-func (newlineReporter) SpecWillRun(specSummary *SpecSummary) {}
-
-func (newlineReporter) SpecDidComplete(specSummary *SpecSummary) {}
-
-// SpecSuiteDidEnd Prints a newline between "35 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:"
-func (newlineReporter) SpecSuiteDidEnd(summary *SuiteSummary) { fmt.Printf("\n") }

--- a/staging/src/k8s.io/kubectl/pkg/util/openapi/openapi_suite_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/openapi/openapi_suite_test.go
@@ -18,32 +18,12 @@ package openapi_test
 
 import (
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/config"
-	. "github.com/onsi/ginkgo/types"
 	. "github.com/onsi/gomega"
 
-	"fmt"
 	"testing"
 )
 
 func TestOpenapi(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Openapi Suite", []Reporter{newlineReporter{}})
+	RunSpecs(t, "Openapi Suite")
 }
-
-// Print a newline after the default newlineReporter due to issue
-// https://github.com/jstemmer/go-junit-report/issues/31
-type newlineReporter struct{}
-
-func (newlineReporter) SpecSuiteWillBegin(config GinkgoConfigType, summary *SuiteSummary) {}
-
-func (newlineReporter) BeforeSuiteDidRun(setupSummary *SetupSummary) {}
-
-func (newlineReporter) AfterSuiteDidRun(setupSummary *SetupSummary) {}
-
-func (newlineReporter) SpecWillRun(specSummary *SpecSummary) {}
-
-func (newlineReporter) SpecDidComplete(specSummary *SpecSummary) {}
-
-// SpecSuiteDidEnd Prints a newline between "35 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:"
-func (newlineReporter) SpecSuiteDidEnd(summary *SuiteSummary) { fmt.Printf("\n") }

--- a/staging/src/k8s.io/kubectl/pkg/util/openapi/validation/validation_suite_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/openapi/validation/validation_suite_test.go
@@ -18,32 +18,12 @@ package validation
 
 import (
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/config"
-	. "github.com/onsi/ginkgo/types"
 	. "github.com/onsi/gomega"
 
-	"fmt"
 	"testing"
 )
 
 func TestOpenapiValidation(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Openapi Validation Suite", []Reporter{newlineReporter{}})
+	RunSpecs(t, "Openapi Validation Suite")
 }
-
-// Print a newline after the default newlineReporter due to issue
-// https://github.com/jstemmer/go-junit-report/issues/31
-type newlineReporter struct{}
-
-func (newlineReporter) SpecSuiteWillBegin(config GinkgoConfigType, summary *SuiteSummary) {}
-
-func (newlineReporter) BeforeSuiteDidRun(setupSummary *SetupSummary) {}
-
-func (newlineReporter) AfterSuiteDidRun(setupSummary *SetupSummary) {}
-
-func (newlineReporter) SpecWillRun(specSummary *SpecSummary) {}
-
-func (newlineReporter) SpecDidComplete(specSummary *SpecSummary) {}
-
-// SpecSuiteDidEnd Prints a newline between "35 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:"
-func (newlineReporter) SpecSuiteDidEnd(summary *SuiteSummary) { fmt.Printf("\n") }

--- a/staging/src/k8s.io/kubectl/pkg/util/openapi/validation/validation_suite_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/openapi/validation/validation_suite_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 )
 
-func TestOpenapi(t *testing.T) {
+func TestOpenapiValidation(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Openapi Suite", []Reporter{newlineReporter{}})
+	RunSpecsWithDefaultAndCustomReporters(t, "Openapi Validation Suite", []Reporter{newlineReporter{}})
 }
 
 // Print a newline after the default newlineReporter due to issue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

The `newlineReporter` intends to print a new line after the test to prevent the something print to the stdout and mess up the test result while cause the tool like `go-junit-report` fail to parse the result.

But this is no longer needed based on following evidence.

Tested with this patch,

```patch
diff --git a/staging/src/k8s.io/kubectl/pkg/apps/apps_suite_test.go b/staging/src/k8s.io/kubectl/pkg/apps/apps_suite_test.go
index 86296f75f6c..850c86e8447 100644
--- a/staging/src/k8s.io/kubectl/pkg/apps/apps_suite_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/apps/apps_suite_test.go
@@ -29,6 +29,7 @@ import (
 func TestApps(t *testing.T) {
        RegisterFailHandler(Fail)
        RunSpecsWithDefaultAndCustomReporters(t, "Apps Suite", []Reporter{newlineReporter{}})
+       fmt.Print("hello world stdout")
 }

 // Print a newline after the default newlineReporter due to issue
@@ -46,4 +47,4 @@ func (newlineReporter) SpecWillRun(specSummary *SpecSummary) {}
 func (newlineReporter) SpecDidComplete(specSummary *SpecSummary) {}

 // SpecSuiteDidEnd Prints a newline between "35 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:"
-func (newlineReporter) SpecSuiteDidEnd(summary *SuiteSummary) { fmt.Printf("\n") }
+func (newlineReporter) SpecSuiteDidEnd(summary *SuiteSummary) { fmt.Printf("hello world \n") }
```

```
# go test -v
=== RUN   TestApps
Running Suite: Apps Suite
=========================
Random Seed: 1654060709
Will run 9 of 9 specs

•••••••••hello world

Ran 9 of 9 Specs in 0.000 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 0 Skipped
hello world stdout--- PASS: TestApps (0.00s)
PASS
ok      k8s.io/kubectl/pkg/apps 0.005s
```
- The issue that was first introduced in `go-junit-report` has already fixed in the version
referenced in `go.mod`.

It was fixed here, 
https://github.com/jstemmer/go-junit-report/pull/64

On the mater is here,
https://github.com/jstemmer/go-junit-report/blob/9ad16898a8044f83800984add0907d4e1c070ecb/parser/gotest/gotest.go#L22
It is `go-junit-report` v0.9.1 referenced in the `go.mod` which has already included the fix.

And I doubt that there is any direct dependency on `go-junit-report` in Kubernetes.

- The `newlineReporter` report doesn't fix anything for `Ginkgo` v1 or V2, it just prints a
new line before the test summarization.
```
# ginkgo.v1
Running Suite: Apps Suite
=========================
Random Seed: 1654062151
Will run 9 of 9 specs

•••••••••hello world

Ran 9 of 9 Specs in 0.000 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 0 Skipped
hello world stdout
PASS

Ginkgo ran 1 suite in 718.021634ms
Test Suite Passed
```

The newline is print right above the line of `Ran 9 of 9 Specs in 0.000 seconds`

ref: 
[1] https://github.com/jstemmer/go-junit-report/issues/31
[2] https://github.com/jstemmer/go-junit-report/pull/64
[3] https://github.com/jstemmer/go-junit-report/issues/63  (the output from the Ginkgo is no longer applicable for Ginkgo v1.14.0 or Ginkgo V2.1.4


/cc @pohly 
/cc @aojea 
/cc @onsi
/cc @liggitt 
/cc @BenTheElder 

A following up for this: https://github.com/kubernetes/kubernetes/pull/109111







#### What type of PR is this?
Add one of the following kinds:
/kind cleanup



#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partial fixes #https://github.com/kubernetes/kubernetes/issues/109744 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
