### PR TITLE
Validate dry-run and force flags can not be used same time in replace

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -227,6 +227,10 @@ func (o *ReplaceOptions) Validate() error {
 		return fmt.Errorf("--timeout must have --force specified")
 	}
 
+	if o.DeleteOptions.ForceDeletion && o.DryRunStrategy != cmdutil.DryRunNone {
+		return fmt.Errorf("dry-run can not be used when --force is set")
+	}
+
 	if cmdutil.IsFilenameSliceEmpty(o.DeleteOptions.FilenameOptions.Filenames, o.DeleteOptions.FilenameOptions.Kustomize) {
 		return fmt.Errorf("Must specify --filename to replace")
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -228,11 +228,11 @@ func (o *ReplaceOptions) Validate() error {
 	}
 
 	if o.DeleteOptions.ForceDeletion && o.DryRunStrategy != cmdutil.DryRunNone {
-		return fmt.Errorf("dry-run can not be used when --force is set")
+		return fmt.Errorf("--dry-run can not be used when --force is set")
 	}
 
 	if cmdutil.IsFilenameSliceEmpty(o.DeleteOptions.FilenameOptions.Filenames, o.DeleteOptions.FilenameOptions.Kustomize) {
-		return fmt.Errorf("Must specify --filename to replace")
+		return fmt.Errorf("must specify --filename to replace")
 	}
 
 	if len(o.Raw) > 0 {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR adds validation to check that `dry-run` and `force` flags
are not used at the same time. Because when `force` flag is set,
`dry-run` is discarded and objects are replaced already.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1222

#### Does this PR introduce a user-facing change?
```release-note
Adds error message "dry-run can not be used when --force is set" when dry-run and force flags are set in replace command.
```