### PR TITLE
kubeadm: graduate the UnversionedKubeletConfigMap FG to GA

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
+++ b/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
@@ -361,8 +361,7 @@ func TestGeneratedConfigFromCluster(t *testing.T) {
 				}
 
 				client := clientsetfake.NewSimpleClientset(configMap)
-				legacyKubeletConfigMap := true
-				cfg, err := clusterConfigHandler.FromCluster(client, testClusterCfg(legacyKubeletConfigMap))
+				cfg, err := clusterConfigHandler.FromCluster(client, testClusterCfg())
 				if err != nil {
 					t.Fatalf("unexpected failure of FromCluster: %v", err)
 				}
@@ -487,8 +486,7 @@ func TestLoadingFromCluster(t *testing.T) {
 			testClusterConfigMap(in, false),
 		)
 
-		legacyKubeletConfigMap := true
-		return clusterConfigHandler.FromCluster(client, testClusterCfg(legacyKubeletConfigMap))
+		return clusterConfigHandler.FromCluster(client, testClusterCfg())
 	})
 }
 
@@ -581,8 +579,7 @@ func TestFetchFromClusterWithLocalOverwrites(t *testing.T) {
 					t.Fatalf("unexpected failure of SplitYAMLDocuments: %v", err)
 				}
 
-				legacyKubeletConfigMap := true
-				clusterCfg := testClusterCfg(legacyKubeletConfigMap)
+				clusterCfg := testClusterCfg()
 
 				err = FetchFromClusterWithLocalOverwrites(clusterCfg, client, docmap)
 				if err != nil {
@@ -716,8 +713,7 @@ func TestGetVersionStates(t *testing.T) {
 					t.Fatalf("unexpected failure of SplitYAMLDocuments: %v", err)
 				}
 
-				legacyKubeletConfigMap := true
-				clusterCfg := testClusterCfg(legacyKubeletConfigMap)
+				clusterCfg := testClusterCfg()
 
 				got, err := GetVersionStates(clusterCfg, client, docmap)
 				if err != nil {

--- a/cmd/kubeadm/app/componentconfigs/kubelet_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_test.go
@@ -36,12 +36,10 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
-// TODO: cleanup after UnversionedKubeletConfigMap goes GA:
-// https://github.com/kubernetes/kubeadm/issues/1582
-func testKubeletConfigMap(contents string, legacyKubeletConfigMap bool) *v1.ConfigMap {
+func testKubeletConfigMap(contents string) *v1.ConfigMap {
 	return &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.GetKubeletConfigMapName(constants.CurrentKubernetesVersion, legacyKubeletConfigMap),
+			Name:      constants.KubeletBaseConfigurationConfigMap,
 			Namespace: metav1.NamespaceSystem,
 		},
 		Data: map[string]string{
@@ -285,16 +283,8 @@ func TestKubeletFromDocumentMap(t *testing.T) {
 func TestKubeletFromCluster(t *testing.T) {
 	runKubeletFromTest(t, func(_ schema.GroupVersionKind, yaml string) (kubeadmapi.ComponentConfig, error) {
 		client := clientsetfake.NewSimpleClientset(
-			testKubeletConfigMap(yaml, true),
+			testKubeletConfigMap(yaml),
 		)
-		legacyKubeletConfigMap := true
-		return kubeletHandler.FromCluster(client, testClusterCfg(legacyKubeletConfigMap))
-	})
-	runKubeletFromTest(t, func(_ schema.GroupVersionKind, yaml string) (kubeadmapi.ComponentConfig, error) {
-		client := clientsetfake.NewSimpleClientset(
-			testKubeletConfigMap(yaml, false),
-		)
-		legacyKubeletConfigMap := false
-		return kubeletHandler.FromCluster(client, testClusterCfg(legacyKubeletConfigMap))
+		return kubeletHandler.FromCluster(client, testClusterCfg())
 	})
 }

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
@@ -163,7 +163,6 @@ func TestKubeProxyFromCluster(t *testing.T) {
 			testKubeProxyConfigMap(yaml),
 		)
 
-		legacyKubeletConfigMap := true
-		return kubeProxyHandler.FromCluster(client, testClusterCfg(legacyKubeletConfigMap))
+		return kubeProxyHandler.FromCluster(client, testClusterCfg())
 	})
 }

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -190,10 +190,6 @@ const (
 	NodesClusterRoleBinding = "system:node"
 
 	// KubeletBaseConfigMapRolePrefix defines the base kubelet configuration ConfigMap.
-	// TODO: Remove once UnversionedKubeletConfigMap graduates to GA:
-	// https://github.com/kubernetes/kubeadm/issues/1582
-	KubeletBaseConfigMapRolePrefix = "kubeadm:kubelet-config-"
-	// KubeletBaseConfigMapRolePrefix defines the base kubelet configuration ConfigMap.
 	KubeletBaseConfigMapRole = "kubeadm:kubelet-config"
 	// KubeProxyClusterRoleBindingName sets the name for the kube-proxy CluterRoleBinding
 	KubeProxyClusterRoleBindingName = "kubeadm:node-proxier"
@@ -285,11 +281,6 @@ const (
 
 	// KubeProxyConfigMapKey specifies in what ConfigMap key the component config of kube-proxy should be stored
 	KubeProxyConfigMapKey = "config.conf"
-
-	// KubeletBaseConfigurationConfigMapPrefix specifies in what ConfigMap in the kube-system namespace the initial remote configuration of kubelet should be stored
-	// TODO: Remove once UnversionedKubeletConfigMap graduates to GA:
-	// https://github.com/kubernetes/kubeadm/issues/1582
-	KubeletBaseConfigurationConfigMapPrefix = "kubelet-config-"
 
 	// KubeletBaseConfigurationConfigMap specifies in what ConfigMap in the kube-system namespace the initial remote configuration of kubelet should be stored
 	KubeletBaseConfigurationConfigMap = "kubelet-config"
@@ -696,14 +687,4 @@ func GetAPIServerVirtualIP(svcSubnetList string) (net.IP, error) {
 		return nil, errors.Wrapf(err, "unable to get the first IP address from the given CIDR: %s", svcSubnet.String())
 	}
 	return internalAPIServerVirtualIP, nil
-}
-
-// GetKubeletConfigMapName returns the right ConfigMap name for the right branch of k8s
-// TODO: Remove the legacy arg once UnversionedKubeletConfigMap graduates to GA:
-// https://github.com/kubernetes/kubeadm/issues/1582
-func GetKubeletConfigMapName(k8sVersion *version.Version, legacy bool) string {
-	if !legacy {
-		return KubeletBaseConfigurationConfigMap
-	}
-	return fmt.Sprintf("%s%d.%d", KubeletBaseConfigurationConfigMapPrefix, k8sVersion.Major(), k8sVersion.Minor())
 }

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -33,7 +33,7 @@ const (
 	PublicKeysECDSA = "PublicKeysECDSA"
 	// RootlessControlPlane is expected to be in alpha in v1.22
 	RootlessControlPlane = "RootlessControlPlane"
-	// UnversionedKubeletConfigMap is expected to be beta in 1.24
+	// UnversionedKubeletConfigMap is expected to be GA in 1.25
 	UnversionedKubeletConfigMap = "UnversionedKubeletConfigMap"
 )
 
@@ -41,7 +41,7 @@ const (
 var InitFeatureGates = FeatureList{
 	PublicKeysECDSA:             {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 	RootlessControlPlane:        {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
-	UnversionedKubeletConfigMap: {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta}},
+	UnversionedKubeletConfigMap: {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta, LockToDefault: true}},
 }
 
 // Feature represents a feature being gated

--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -26,13 +26,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 )
 
@@ -59,23 +57,8 @@ func WriteConfigToDisk(cfg *kubeadmapi.ClusterConfiguration, kubeletDir string) 
 // CreateConfigMap creates a ConfigMap with the generic kubelet configuration.
 // Used at "kubeadm init" and "kubeadm upgrade" time
 func CreateConfigMap(cfg *kubeadmapi.ClusterConfiguration, client clientset.Interface) error {
-
-	k8sVersion, err := version.ParseSemantic(cfg.KubernetesVersion)
-	if err != nil {
-		return err
-	}
-
-	// TODO: cleanup after UnversionedKubeletConfigMap goes GA:
-	// https://github.com/kubernetes/kubeadm/issues/1582
-	legacyKubeletCM := !features.Enabled(cfg.FeatureGates, features.UnversionedKubeletConfigMap)
-	configMapName := kubeadmconstants.GetKubeletConfigMapName(k8sVersion, legacyKubeletCM)
+	configMapName := kubeadmconstants.KubeletBaseConfigurationConfigMap
 	fmt.Printf("[kubelet] Creating a ConfigMap %q in namespace %s with the configuration for the kubelets in the cluster\n", configMapName, metav1.NamespaceSystem)
-	if legacyKubeletCM {
-		fmt.Printf("NOTE: The %q naming of the kubelet ConfigMap is deprecated. "+
-			"Once the UnversionedKubeletConfigMap feature gate graduates to Beta the default name will become just %q. "+
-			"Kubeadm upgrade will handle this transition transparently.\n",
-			configMapName, kubeadmconstants.KubeletBaseConfigurationConfigMap)
-	}
 
 	kubeletCfg, ok := cfg.ComponentConfigs[componentconfigs.KubeletGroup]
 	if !ok {
@@ -105,19 +88,17 @@ func CreateConfigMap(cfg *kubeadmapi.ClusterConfiguration, client clientset.Inte
 		return err
 	}
 
-	if err := createConfigMapRBACRules(client, k8sVersion, legacyKubeletCM); err != nil {
+	if err := createConfigMapRBACRules(client); err != nil {
 		return errors.Wrap(err, "error creating kubelet configuration configmap RBAC rules")
 	}
 	return nil
 }
 
 // createConfigMapRBACRules creates the RBAC rules for exposing the base kubelet ConfigMap in the kube-system namespace to unauthenticated users
-// TODO: Remove the legacy arg once UnversionedKubeletConfigMap graduates to GA:
-// https://github.com/kubernetes/kubeadm/issues/1582
-func createConfigMapRBACRules(client clientset.Interface, k8sVersion *version.Version, legacy bool) error {
+func createConfigMapRBACRules(client clientset.Interface) error {
 	if err := apiclient.CreateOrUpdateRole(client, &rbac.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMapRBACName(k8sVersion, legacy),
+			Name:      kubeadmconstants.KubeletBaseConfigMapRole,
 			Namespace: metav1.NamespaceSystem,
 		},
 		Rules: []rbac.PolicyRule{
@@ -125,7 +106,7 @@ func createConfigMapRBACRules(client clientset.Interface, k8sVersion *version.Ve
 				Verbs:         []string{"get"},
 				APIGroups:     []string{""},
 				Resources:     []string{"configmaps"},
-				ResourceNames: []string{kubeadmconstants.GetKubeletConfigMapName(k8sVersion, legacy)},
+				ResourceNames: []string{kubeadmconstants.KubeletBaseConfigurationConfigMap},
 			},
 		},
 	}); err != nil {
@@ -134,13 +115,13 @@ func createConfigMapRBACRules(client clientset.Interface, k8sVersion *version.Ve
 
 	return apiclient.CreateOrUpdateRoleBinding(client, &rbac.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMapRBACName(k8sVersion, legacy),
+			Name:      kubeadmconstants.KubeletBaseConfigMapRole,
 			Namespace: metav1.NamespaceSystem,
 		},
 		RoleRef: rbac.RoleRef{
 			APIGroup: rbac.GroupName,
 			Kind:     "Role",
-			Name:     configMapRBACName(k8sVersion, legacy),
+			Name:     kubeadmconstants.KubeletBaseConfigMapRole,
 		},
 		Subjects: []rbac.Subject{
 			{
@@ -153,16 +134,6 @@ func createConfigMapRBACRules(client clientset.Interface, k8sVersion *version.Ve
 			},
 		},
 	})
-}
-
-// configMapRBACName returns the name for the Role/RoleBinding for the kubelet config configmap for the right branch of k8s
-// TODO: Remove the legacy arg once UnversionedKubeletConfigMap graduates to GA:
-// https://github.com/kubernetes/kubeadm/issues/1582
-func configMapRBACName(k8sVersion *version.Version, legacy bool) string {
-	if !legacy {
-		return kubeadmconstants.KubeletBaseConfigMapRole
-	}
-	return fmt.Sprintf("%s%d.%d", kubeadmconstants.KubeletBaseConfigMapRolePrefix, k8sVersion.Major(), k8sVersion.Minor())
 }
 
 // writeConfigBytesToDisk writes a byte slice down to disk at the specific location of the kubelet config file

--- a/cmd/kubeadm/app/phases/kubelet/config_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/config_test.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 
@@ -69,7 +68,7 @@ func TestCreateConfigMapRBACRules(t *testing.T) {
 		return true, nil, nil
 	})
 
-	if err := createConfigMapRBACRules(client, version.MustParseSemantic("v1.11.0"), false); err != nil {
+	if err := createConfigMapRBACRules(client); err != nil {
 		t.Errorf("createConfigMapRBACRules: unexpected error %v", err)
 	}
 }

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -32,7 +32,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -46,7 +45,6 @@ import (
 )
 
 var k8sVersionString = kubeadmconstants.MinimumControlPlaneVersion.String()
-var k8sVersion = version.MustParseGeneric(k8sVersionString)
 var nodeName = "mynode"
 var cfgFiles = map[string][]byte{
 	"InitConfiguration_v1beta2": []byte(fmt.Sprintf(`
@@ -544,7 +542,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				{
-					Name: kubeadmconstants.GetKubeletConfigMapName(k8sVersion, false), // Kubelet component config from corresponding ConfigMap.
+					Name: kubeadmconstants.KubeletBaseConfigurationConfigMap, // Kubelet component config from corresponding ConfigMap.
 					Data: map[string]string{
 						kubeadmconstants.KubeletBaseConfigurationConfigMapKey: string(cfgFiles["Kubelet_componentconfig"]),
 					},
@@ -588,7 +586,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				{
-					Name: kubeadmconstants.GetKubeletConfigMapName(k8sVersion, false), // Kubelet component config from corresponding ConfigMap.
+					Name: kubeadmconstants.KubeletBaseConfigurationConfigMap, // Kubelet component config from corresponding ConfigMap.
 					Data: map[string]string{
 						kubeadmconstants.KubeletBaseConfigurationConfigMapKey: string(cfgFiles["Kubelet_componentconfig"]),
 					},
@@ -621,7 +619,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				{
-					Name: kubeadmconstants.GetKubeletConfigMapName(k8sVersion, false), // Kubelet component config from corresponding ConfigMap.
+					Name: kubeadmconstants.KubeletBaseConfigurationConfigMap, // Kubelet component config from corresponding ConfigMap.
 					Data: map[string]string{
 						kubeadmconstants.KubeletBaseConfigurationConfigMapKey: string(cfgFiles["Kubelet_componentconfig"]),
 					},
@@ -665,7 +663,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				{
-					Name: kubeadmconstants.GetKubeletConfigMapName(k8sVersion, false), // Kubelet component config from corresponding ConfigMap.
+					Name: kubeadmconstants.KubeletBaseConfigurationConfigMap, // Kubelet component config from corresponding ConfigMap.
 					Data: map[string]string{
 						kubeadmconstants.KubeletBaseConfigurationConfigMapKey: string(cfgFiles["Kubelet_componentconfig"]),
 					},

--- a/test/e2e_kubeadm/kubelet_config_test.go
+++ b/test/e2e_kubeadm/kubelet_config_test.go
@@ -17,12 +17,7 @@ limitations under the License.
 package kubeadm
 
 import (
-	"context"
-	"fmt"
-
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -38,13 +33,6 @@ var (
 	kubeletConfigConfigMapName   string
 	kubeletConfigRoleName        string
 	kubeletConfigRoleBindingName string
-
-	// TODO: remove these versioned strings and related logic once the UnversionedKubeletConfigMap
-	// feature gate goes GA:
-	// https://github.com/kubernetes/kubeadm/issues/1582
-	kubeletConfigConfigMapNameVersioned   string
-	kubeletConfigRoleNameVersioned        string
-	kubeletConfigRoleBindingNameVersioned string
 )
 
 // Define container for all the test specification aimed at verifying
@@ -68,68 +56,19 @@ var _ = Describe("kubelet-config ConfigMap", func() {
 			return
 		}
 
-		// gets the ClusterConfiguration from the kubeadm kubeadm-config ConfigMap as a untyped map
-		m := getClusterConfiguration(f.ClientSet)
-
-		// Extract the kubernetesVersion
-		// TODO: remove this after the UnversionedKubeletConfigMap feature gate goes GA:
-		// https://github.com/kubernetes/kubeadm/issues/1582
-		// At that point parsing the k8s version will no longer be needed in this test.
-		gomega.Expect(m).To(gomega.HaveKey("kubernetesVersion"))
-		k8sVersionString := m["kubernetesVersion"].(string)
-		k8sVersion, err := version.ParseSemantic(k8sVersionString)
-		if err != nil {
-			framework.Failf("error reading kubernetesVersion from %s ConfigMap: %v", kubeadmConfigName, err)
-		}
-
 		kubeletConfigConfigMapName = "kubelet-config"
 		kubeletConfigRoleName = "kubeadm:kubelet-config"
 		kubeletConfigRoleBindingName = kubeletConfigRoleName
-
-		kubeletConfigConfigMapNameVersioned = fmt.Sprintf("kubelet-config-%d.%d", k8sVersion.Major(), k8sVersion.Minor())
-		kubeletConfigRoleNameVersioned = fmt.Sprintf("kubeadm:kubelet-config-%d.%d", k8sVersion.Major(), k8sVersion.Minor())
-		kubeletConfigRoleBindingNameVersioned = kubeletConfigRoleNameVersioned
 	})
 
 	ginkgo.It("should exist and be properly configured", func() {
-		// TODO: switch to GetConfigMap once UnversionedKubeletConfigMap feature gate goes GA:
-		// https://github.com/kubernetes/kubeadm/issues/1582
-		cm, err := f.ClientSet.CoreV1().
-			ConfigMaps(kubeSystemNamespace).
-			Get(context.TODO(), kubeletConfigConfigMapName, metav1.GetOptions{})
-		if err != nil {
-			cm, err = f.ClientSet.CoreV1().
-				ConfigMaps(kubeSystemNamespace).
-				Get(context.TODO(), kubeletConfigConfigMapNameVersioned, metav1.GetOptions{})
-			framework.ExpectNoError(err, "error getting ConfigMap %q or %q from namespace %q",
-				kubeletConfigConfigMapName, kubeletConfigConfigMapNameVersioned, kubeSystemNamespace)
-		}
+		cm := GetConfigMap(f.ClientSet, kubeSystemNamespace, kubeletConfigConfigMapName)
 		gomega.Expect(cm.Data).To(gomega.HaveKey(kubeletConfigConfigMapKey))
 	})
 
 	ginkgo.It("should have related Role and RoleBinding", func() {
-		// TODO: switch to ExpectRole(Binding) once UnversionedKubeletConfigMap feature gate goes GA:
-		// https://github.com/kubernetes/kubeadm/issues/1582
-		_, err := f.ClientSet.RbacV1().
-			Roles(kubeSystemNamespace).
-			Get(context.TODO(), kubeletConfigRoleName, metav1.GetOptions{})
-		if err != nil {
-			_, err = f.ClientSet.RbacV1().
-				Roles(kubeSystemNamespace).
-				Get(context.TODO(), kubeletConfigRoleNameVersioned, metav1.GetOptions{})
-			framework.ExpectNoError(err, "error getting Role %q or %q from namespace %q",
-				kubeletConfigRoleName, kubeletConfigRoleNameVersioned, kubeSystemNamespace)
-		}
-		_, err = f.ClientSet.RbacV1().
-			Roles(kubeSystemNamespace).
-			Get(context.TODO(), kubeletConfigRoleBindingName, metav1.GetOptions{})
-		if err != nil {
-			_, err = f.ClientSet.RbacV1().
-				Roles(kubeSystemNamespace).
-				Get(context.TODO(), kubeletConfigRoleBindingNameVersioned, metav1.GetOptions{})
-			framework.ExpectNoError(err, "error getting RoleBinding %q or %q from namespace %q",
-				kubeletConfigRoleBindingName, kubeletConfigRoleBindingNameVersioned, kubeSystemNamespace)
-		}
+		ExpectRole(f.ClientSet, kubeSystemNamespace, kubeletConfigRoleName)
+		ExpectRoleBinding(f.ClientSet, kubeSystemNamespace, kubeletConfigRoleBindingName)
 	})
 
 	ginkgo.It("should be accessible for bootstrap tokens", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind deprecation cleanup feature

#### What this PR does / why we need it:

cmd/kubeadm

- lock the FG to true by default
- cleanup wrappers and logic related to versioned vs unversioned
naming of API objects (CMs and RBAC)
- update unit tests

test/e2e_kubeadm

- don't require clusteconfiguration.kubernetesVersion
- use the helper functions GetConfigMap, ExpectRole, ExpectRoleBinding
(these were used before UnversionedKubeletConfig went Beta)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/1582

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: graduate the kubeadm specific feature gate UnversionedKubeletConfigMap to GA and lock it to "true" by default. The kubelet related ConfigMap and RBAC rules are now locked to have a simplified naming "*kubelet-config" instead of the legacy naming "*kubelet-config-x.yy", where "x.yy" was the version of the control plane. If you have previously used the old naming format with UnversionedKubeletConfigMap=false, you must manually copy the config map from kube-system/kubelet-config-x.yy to kube-system/kubelet-config before upgrading to 1.25.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2915
```
