### PR TITLE
add metrics to GC to measure staleness of queue retry errors

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -35,6 +35,7 @@ import (
 
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/controller/garbagecollector/metaonly"
+	"k8s.io/kubernetes/pkg/controller/garbagecollector/metrics"
 	"k8s.io/utils/pointer"
 
 	v1 "k8s.io/api/core/v1"
@@ -2266,12 +2267,17 @@ func TestConflictingData(t *testing.T) {
 			attemptToOrphan := newTrackingWorkqueue()
 			graphChanges := newTrackingWorkqueue()
 
+			attemptToDeleteMetrics := metrics.NewQueueMetrics()
+			attemptToOrphanMetrics := metrics.NewQueueMetrics()
+
 			gc := &GarbageCollector{
-				metadataClient:   metadataClient,
-				restMapper:       restMapper,
-				attemptToDelete:  attemptToDelete,
-				attemptToOrphan:  attemptToOrphan,
-				absentOwnerCache: absentOwnerCache,
+				metadataClient:         metadataClient,
+				restMapper:             restMapper,
+				attemptToDelete:        attemptToDelete,
+				attemptToOrphan:        attemptToOrphan,
+				absentOwnerCache:       absentOwnerCache,
+				attemptToDeleteMetrics: attemptToDeleteMetrics,
+				attemptToOrphanMetrics: attemptToOrphanMetrics,
 				dependencyGraphBuilder: &GraphBuilder{
 					eventRecorder:    eventRecorder,
 					metadataClient:   metadataClient,

--- a/pkg/controller/garbagecollector/metrics/metrics.go
+++ b/pkg/controller/garbagecollector/metrics/metrics.go
@@ -19,6 +19,8 @@ package metrics
 import (
 	"sync"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -33,13 +35,88 @@ var (
 			Help:           "Number of garbage collector resources sync errors",
 			StabilityLevel: metrics.ALPHA,
 		})
+
+	deleteQueueRetrySinceSecondsOpts = prometheus.HistogramOpts{
+		Subsystem: GarbageCollectorControllerSubsystem,
+		Name:      "attempt_to_delete_queue_retry_since_seconds",
+		Help:      "How long in seconds an item has been retrying in attempt to delete workqueue.",
+		Buckets:   metrics.ExponentialBuckets(0.001, 10, 10),
+	}
+	orphanQueueRetrySinceSecondsOpts = prometheus.HistogramOpts{
+		Subsystem: GarbageCollectorControllerSubsystem,
+		Name:      "attempt_to_orphan_queue_retry_since_seconds",
+		Help:      "How long in seconds an item has been retrying in attempt to orphan workqueue.",
+		Buckets:   metrics.ExponentialBuckets(0.001, 10, 10),
+	}
+
+	deleteQueueRetrySinceSecondsDesc = metrics.NewDesc(metrics.BuildFQName(deleteQueueRetrySinceSecondsOpts.Namespace, deleteQueueRetrySinceSecondsOpts.Subsystem, deleteQueueRetrySinceSecondsOpts.Name),
+		deleteQueueRetrySinceSecondsOpts.Help,
+		nil,
+		nil,
+		metrics.ALPHA,
+		"")
+	orphanQueueRetrySinceSecondsDesc = metrics.NewDesc(metrics.BuildFQName(orphanQueueRetrySinceSecondsOpts.Namespace, orphanQueueRetrySinceSecondsOpts.Subsystem, orphanQueueRetrySinceSecondsOpts.Name),
+		orphanQueueRetrySinceSecondsOpts.Help,
+		nil,
+		nil,
+		metrics.ALPHA,
+		"")
 )
 
 var registerMetrics sync.Once
 
 // Register registers GarbageCollectorController metrics.
-func Register() {
+func Register(attemptToDeleteMetrics QueueMetrics, attemptToOrphanMetrics QueueMetrics) {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(GarbageCollectorResourcesSyncError)
+		legacyregistry.CustomMustRegister(newGCMetricsCollector(attemptToDeleteMetrics, attemptToOrphanMetrics))
 	})
+}
+
+func newGCMetricsCollector(attemptToDeleteMetrics, attemptToOrphanMetrics QueueMetrics) metrics.StableCollector {
+	return &gcMetricsCollector{
+		attemptToDeleteMetrics: attemptToDeleteMetrics,
+		attemptToOrphanMetrics: attemptToOrphanMetrics,
+	}
+}
+
+type gcMetricsCollector struct {
+	metrics.BaseStableCollector
+	attemptToDeleteMetrics QueueMetrics
+	attemptToOrphanMetrics QueueMetrics
+}
+
+func (g *gcMetricsCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
+	ch <- deleteQueueRetrySinceSecondsDesc
+	ch <- orphanQueueRetrySinceSecondsDesc
+}
+func (g *gcMetricsCollector) CollectWithStability(ch chan<- metrics.Metric) {
+	g.collectDeleteQueue(ch)
+	g.collectOrphanQueue(ch)
+}
+
+func (g *gcMetricsCollector) collectDeleteQueue(ch chan<- metrics.Metric) {
+	if deleteQueueRetrySinceSecondsDesc.IsHidden() {
+		return
+	}
+
+	histogram := prometheus.NewHistogram(deleteQueueRetrySinceSecondsOpts)
+	for _, startRetryTime := range g.attemptToDeleteMetrics.GetRetrySinceDurations() {
+		histogram.Observe(startRetryTime.Seconds())
+	}
+
+	ch <- histogram
+}
+
+func (g *gcMetricsCollector) collectOrphanQueue(ch chan<- metrics.Metric) {
+	if orphanQueueRetrySinceSecondsDesc.IsHidden() {
+		return
+	}
+
+	histogram := prometheus.NewHistogram(orphanQueueRetrySinceSecondsOpts)
+	for _, startRetryTime := range g.attemptToOrphanMetrics.GetRetrySinceDurations() {
+		histogram.Observe(startRetryTime.Seconds())
+	}
+
+	ch <- histogram
 }

--- a/pkg/controller/garbagecollector/metrics/metrics_test.go
+++ b/pkg/controller/garbagecollector/metrics/metrics_test.go
@@ -61,7 +61,7 @@ func TestGCMetricsCollector(t *testing.T) {
 	})
 
 	expectedMetrics := `
-		# HELP garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds How long in seconds an item has been retrying in attempt to delete workqueue.
+		# HELP garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds [ALPHA] How long in seconds an item has been retrying in attempt to delete workqueue.
         # TYPE garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds histogram
         garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="0.001"} 1
         garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="0.01"} 1
@@ -76,7 +76,7 @@ func TestGCMetricsCollector(t *testing.T) {
         garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="+Inf"} 6
         garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_sum 10811.101
         garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_count 6
-        # HELP garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds How long in seconds an item has been retrying in attempt to orphan workqueue.
+        # HELP garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds [ALPHA] How long in seconds an item has been retrying in attempt to orphan workqueue.
         # TYPE garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds histogram
         garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="0.001"} 0
         garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="0.01"} 0

--- a/pkg/controller/garbagecollector/metrics/metrics_test.go
+++ b/pkg/controller/garbagecollector/metrics/metrics_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
+	"strings"
+	"testing"
+	"time"
+
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+func newFakeMetrics(collectionTime time.Time, config map[string]time.Duration) QueueMetrics {
+	fakeClock := testingclock.NewFakeClock(collectionTime)
+	result := queueMetrics{
+		clock:           fakeClock,
+		startRetryTimes: map[interface{}]time.Time{},
+	}
+
+	for itemName, duration := range config {
+		item := testItem{name: itemName}
+
+		fakeClock.SetTime(collectionTime.Add(-duration))
+		result.AddRateLimited(item)
+	}
+	fakeClock.SetTime(collectionTime)
+
+	return &result
+}
+
+func TestGCMetricsCollector(t *testing.T) {
+	collectionTime := time.Now()
+
+	attemptToDeleteMetrics := newFakeMetrics(collectionTime, map[string]time.Duration{
+		"a": time.Millisecond,
+		"b": 100 * time.Millisecond,
+		"c": 2 * time.Second,
+		"d": 2 * time.Second,
+		"e": 7 * time.Second,
+		"f": 3 * time.Hour,
+	})
+	attemptToOrphanMetrics := newFakeMetrics(collectionTime, map[string]time.Duration{
+		"u": 100 * time.Second,
+		"v": time.Hour,
+	})
+
+	expectedMetrics := `
+		# HELP garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds How long in seconds an item has been retrying in attempt to delete workqueue.
+        # TYPE garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds histogram
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="0.001"} 1
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="0.01"} 1
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="0.1"} 2
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="1"} 2
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="10"} 5
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="100"} 5
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="1000"} 5
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="10000"} 5
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="100000"} 6
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="1e+06"} 6
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="+Inf"} 6
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_sum 10811.101
+        garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_count 6
+        # HELP garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds How long in seconds an item has been retrying in attempt to orphan workqueue.
+        # TYPE garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds histogram
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="0.001"} 0
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="0.01"} 0
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="0.1"} 0
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="1"} 0
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="10"} 0
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="100"} 1
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="1000"} 1
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="10000"} 2
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="100000"} 2
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="1e+06"} 2
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="+Inf"} 2
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_sum 3700
+        garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_count 2
+	`
+
+	collector := newGCMetricsCollector(attemptToDeleteMetrics, attemptToOrphanMetrics)
+	registry := metrics.NewKubeRegistry()
+	registry.CustomMustRegister(collector)
+	err := testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics))
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/controller/garbagecollector/metrics/queue_metrics.go
+++ b/pkg/controller/garbagecollector/metrics/queue_metrics.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+type QueueMetrics interface {
+	// AddRateLimited tracks adding an item to the workqueue rate limiter
+	AddRateLimited(item interface{})
+
+	// Forget tracks removing an item to the workqueue rate limiter
+	Forget(item interface{})
+
+	// GetRetrySinceDurations gets time durations for all items that are pending a retry since they were first recognized by rate limiter
+	GetRetrySinceDurations() map[interface{}]time.Duration
+}
+
+var _ QueueMetrics = &queueMetrics{}
+
+func NewQueueMetrics() QueueMetrics {
+	return &queueMetrics{
+		clock:           clock.RealClock{},
+		startRetryTimes: map[interface{}]time.Time{},
+	}
+}
+
+// queueMetrics start retry times for metrics. Its methods are thread-safe.
+type queueMetrics struct {
+	clock               clock.Clock
+	startRetryTimesLock sync.RWMutex
+	startRetryTimes     map[interface{}]time.Time
+}
+
+func (q *queueMetrics) AddRateLimited(item interface{}) {
+	q.startRetryTimesLock.Lock()
+	defer q.startRetryTimesLock.Unlock()
+	if _, ok := q.startRetryTimes[item]; !ok {
+		q.startRetryTimes[item] = q.clock.Now()
+	}
+}
+
+func (q *queueMetrics) Forget(item interface{}) {
+	q.startRetryTimesLock.Lock()
+	defer q.startRetryTimesLock.Unlock()
+	delete(q.startRetryTimes, item)
+}
+
+func (q *queueMetrics) GetRetrySinceDurations() map[interface{}]time.Duration {
+	q.startRetryTimesLock.RLock()
+	defer q.startRetryTimesLock.RUnlock()
+	now := q.clock.Now()
+	result := make(map[interface{}]time.Duration, len(q.startRetryTimes))
+	for k, startRetry := range q.startRetryTimes {
+		result[k] = now.Sub(startRetry)
+	}
+	return result
+}

--- a/pkg/controller/garbagecollector/metrics/queue_metrics_test.go
+++ b/pkg/controller/garbagecollector/metrics/queue_metrics_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+type testItem struct {
+	name string
+}
+
+func TestQueueMetrics(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	metrics := queueMetrics{
+		clock:           fakeClock,
+		startRetryTimes: map[interface{}]time.Time{},
+	}
+
+	a := testItem{name: "a"}
+	b := testItem{name: "b"}
+	c := testItem{name: "c"}
+
+	metrics.AddRateLimited(a)
+	metrics.AddRateLimited(a)
+
+	if len(metrics.GetRetrySinceDurations()) != 1 {
+		t.Errorf("metrics should list one retrying item")
+	}
+
+	metrics.AddRateLimited(b)
+	fakeClock.SetTime(fakeClock.Now().Add(5 * time.Minute))
+	metrics.AddRateLimited(c)
+	fakeClock.SetTime(fakeClock.Now().Add(1 * time.Minute))
+	metrics.Forget(a)
+
+	retryDurations := metrics.GetRetrySinceDurations()
+	if len(retryDurations) != 2 {
+		t.Errorf("metrics should list two retrying items")
+	}
+	if retryDurations[b] != 6*time.Minute {
+		t.Errorf("%v item should have been retrying for %d minutes", b.name, 6)
+	}
+	if retryDurations[c] != 1*time.Minute {
+		t.Errorf("%v item should have been retrying for %d minutes", c.name, 1)
+	}
+
+	metrics.Forget(c)
+	metrics.Forget(b)
+	metrics.Forget(b)
+
+	if len(metrics.GetRetrySinceDurations()) != 0 {
+		t.Errorf("metrics should list 0 retrying items")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In https://github.com/kubernetes/kubernetes/pull/106844, we added sync metrics for the sync errors to GC and decided to use already existing queue metrics (like `workqueue_retries_total`, `workqueue_depth`) for the delete and orphan queue errors.

Unfortunately it was found out these metrics are insufficient for tracking long term persistent errors amid a number of transient errors. These persistent errors can inhibit garbage collection of the relevant objects. 

The following new metrics can enable monitoring  of such cases and reacting accordingly.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
