### PR TITLE
Add additional CRD validation E2E tests

### DIFF
--- a/test/e2e/apimachinery/crd_validation_rules.go
+++ b/test/e2e/apimachinery/crd_validation_rules.go
@@ -170,14 +170,14 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin][Alp
 	ginkgo.It("MUST fail create of a custom resource definition that contains an x-kubernetes-validations rule that contains a syntax error", func() {
 		ginkgo.By("Defining a custom resource definition that contains a validation rule with a syntax error")
 		var schemaWithSyntaxErrorRule = unmarshallSchema([]byte(`{
-			"type":"object",
-			"properties":{
-			   "spec":{
-				  "type":"object",
-				  "x-kubernetes-validations":[
-					{ "rule":"self = 42" }
-				  ]
-			   }
+		   "type":"object",
+		   "properties":{
+		      "spec":{
+			    "type":"object",
+				"x-kubernetes-validations":[
+				  { "rule":"self = 42" }
+				]
+			  }
 			}
 		}`))
 		crd := fixtures.NewRandomNameV1CustomResourceDefinitionWithSchema(v1.NamespaceScoped, schemaWithSyntaxErrorRule, false)
@@ -192,26 +192,26 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin][Alp
 	ginkgo.It("MUST fail create of a custom resource definition that contains an x-kubernetes-validations rule that exceeds the estimated cost limit", func() {
 		ginkgo.By("Defining a custom resource definition that contains a validation rule that exceeds the cost limit")
 		var schemaWithExpensiveRule = unmarshallSchema([]byte(`{
-			"type": "object",
-			"properties": {
-				"spec": {
-					"type": "object",
-					"properties": {
-						"x": {
-							"type": "array",
-							"items": {
-								"type": "array",
-								"items": {
-									"type": "string"
-								},
-								"x-kubernetes-validations": [{
-									"rule": "self.all(s, s == \"string constant\")"
-								}]
-							}
-						}
-					}
-				}
-			}
+		   "type":"object",
+		   "properties":{
+			  "spec":{
+			    "type":"object",
+			    "properties":{
+				  "x":{
+				    "type":"array",
+				    "items":{
+				      "type":"array",
+					  "items":{
+					    "type":"string"
+					  },
+					  "x-kubernetes-validations":[
+					    { "rule":"self.all(s, s == \"string constant\")" }
+					  ]
+				    }
+				  }
+			    }
+			  }
+		    }
 		}`))
 		crd := fixtures.NewRandomNameV1CustomResourceDefinitionWithSchema(v1.NamespaceScoped, schemaWithExpensiveRule, false)
 		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)

--- a/test/e2e/apimachinery/crd_validation_rules.go
+++ b/test/e2e/apimachinery/crd_validation_rules.go
@@ -183,7 +183,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin][Alp
 		crd := fixtures.NewRandomNameV1CustomResourceDefinitionWithSchema(v1.NamespaceScoped, schemaWithSyntaxErrorRule, false)
 		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
 		framework.ExpectError(err, "creating a CustomResourceDefinition with a validation rule that contains a syntax error")
-		expectedErrMsg := "syntax error"
+		expectedErrMsg := "Syntax error"
 		if !strings.Contains(err.Error(), expectedErrMsg) {
 			framework.Failf("expected error message to contain %q, got %q", expectedErrMsg, err.Error())
 		}

--- a/test/e2e/apimachinery/crd_validation_rules.go
+++ b/test/e2e/apimachinery/crd_validation_rules.go
@@ -205,7 +205,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin][Alp
 					    "type":"string"
 					  },
 					  "x-kubernetes-validations":[
-					    { "rule":"self.all(s, s == \"string constant\")" }
+					    { "rule":"self.all(s, s == 'string constant')" }
 					  ]
 				    }
 				  }

--- a/test/e2e/apimachinery/crd_validation_rules.go
+++ b/test/e2e/apimachinery/crd_validation_rules.go
@@ -196,14 +196,17 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin][Alp
 			"properties": {
 				"spec": {
 					"type": "object",
-					"x-kubernetes-validations": [{
-						"rule": "self.x.all(s, s == \"string constant\")"
-					}],
 					"properties": {
 						"x": {
 							"type": "array",
 							"items": {
-								"type": "string"
+								"type": "array",
+								"items": {
+									"type": "string"
+								},
+								"x-kubernetes-validations": [{
+									"rule": "self.all(s, s == \"string constant\")"
+								}]
 							}
 						}
 					}

--- a/test/e2e/apimachinery/crd_validation_rules.go
+++ b/test/e2e/apimachinery/crd_validation_rules.go
@@ -201,7 +201,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin][Alp
 					}],
 					"properties": {
 						"x": {
-							"type": "list",
+							"type": "array",
 							"items": {
 								"type": "string"
 							}
@@ -213,7 +213,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin][Alp
 		crd := fixtures.NewRandomNameV1CustomResourceDefinitionWithSchema(v1.NamespaceScoped, schemaWithExpensiveRule, false)
 		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
 		framework.ExpectError(err, "creating a CustomResourceDefinition with a validation rule that exceeds the cost limit")
-		expectedErrMsg := "syntax error"
+		expectedErrMsg := "exceeded budget"
 		if !strings.Contains(err.Error(), expectedErrMsg) {
 			framework.Failf("expected error message to contain %q, got %q", expectedErrMsg, err.Error())
 		}

--- a/test/e2e/apimachinery/crd_validation_rules.go
+++ b/test/e2e/apimachinery/crd_validation_rules.go
@@ -216,7 +216,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin][Alp
 		crd := fixtures.NewRandomNameV1CustomResourceDefinitionWithSchema(v1.NamespaceScoped, schemaWithExpensiveRule, false)
 		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
 		framework.ExpectError(err, "creating a CustomResourceDefinition with a validation rule that exceeds the cost limit")
-		expectedErrMsg := "exceeded budget"
+		expectedErrMsg := "exceeds budget"
 		if !strings.Contains(err.Error(), expectedErrMsg) {
 			framework.Failf("expected error message to contain %q, got %q", expectedErrMsg, err.Error())
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds additional E2E tests as part of the [test plan for KEP-2876](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2876-crd-validation-expression-language#test-plan), with the long-term goal of getting the tests into conformance.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
