### PR TITLE
cleanup deprecated metrics and usages

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -163,8 +163,6 @@ type WatchServer struct {
 // or over a websocket connection.
 func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	kind := s.Scope.Kind
-	metrics.RegisteredWatchers.WithContext(req.Context()).WithLabelValues(kind.Group, kind.Version, kind.Kind).Inc()
-	defer metrics.RegisteredWatchers.WithContext(req.Context()).WithLabelValues(kind.Group, kind.Version, kind.Kind).Dec()
 
 	if wsstream.IsWebSocketRequest(req) {
 		w.Header().Set("Content-Type", s.MediaType)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -136,16 +136,6 @@ var (
 		},
 		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component"},
 	)
-	// droppedRequests is a number of requests dropped with 'Try again later' response"
-	droppedRequests = compbasemetrics.NewCounterVec(
-		&compbasemetrics.CounterOpts{
-			Name:              "apiserver_dropped_requests_total",
-			Help:              "Number of requests dropped with 'Try again later' response. Use apiserver_request_total and/or apiserver_request_terminations_total metrics instead.",
-			StabilityLevel:    compbasemetrics.ALPHA,
-			DeprecatedVersion: "1.24.0",
-		},
-		[]string{"request_kind"},
-	)
 	// TLSHandshakeErrors is a number of requests dropped with 'TLS handshake error from' error
 	TLSHandshakeErrors = compbasemetrics.NewCounter(
 		&compbasemetrics.CounterOpts{
@@ -153,16 +143,6 @@ var (
 			Help:           "Number of requests dropped with 'TLS handshake error from' error",
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
-	)
-	// RegisteredWatchers is a number of currently registered watchers splitted by resource.
-	RegisteredWatchers = compbasemetrics.NewGaugeVec(
-		&compbasemetrics.GaugeOpts{
-			Name:              "apiserver_registered_watchers",
-			Help:              "Number of currently registered watchers for a given resources",
-			StabilityLevel:    compbasemetrics.ALPHA,
-			DeprecatedVersion: "1.23.0",
-		},
-		[]string{"group", "version", "kind"},
 	)
 	WatchEvents = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
@@ -266,9 +246,7 @@ var (
 		requestSloLatencies,
 		fieldValidationRequestLatencies,
 		responseSizes,
-		droppedRequests,
 		TLSHandshakeErrors,
-		RegisteredWatchers,
 		WatchEvents,
 		WatchEventsSizes,
 		currentInflightRequests,
@@ -426,12 +404,6 @@ func RecordDroppedRequest(req *http.Request, requestInfo *request.RequestInfo, c
 		requestCounter.WithContext(req.Context()).WithLabelValues(reportedVerb, dryRun, requestInfo.APIGroup, requestInfo.APIVersion, requestInfo.Resource, requestInfo.Subresource, scope, component, codeToString(http.StatusTooManyRequests)).Inc()
 	} else {
 		requestCounter.WithContext(req.Context()).WithLabelValues(reportedVerb, dryRun, "", "", "", requestInfo.Subresource, scope, component, codeToString(http.StatusTooManyRequests)).Inc()
-	}
-
-	if isMutatingRequest {
-		droppedRequests.WithContext(req.Context()).WithLabelValues(MutatingKind).Inc()
-	} else {
-		droppedRequests.WithContext(req.Context()).WithLabelValues(ReadOnlyKind).Inc()
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -283,7 +283,6 @@ func TestResponseWriterDecorator(t *testing.T) {
 func TestRecordDroppedRequests(t *testing.T) {
 	testedMetrics := []string{
 		"apiserver_request_total",
-		"apiserver_dropped_requests_total",
 	}
 
 	testCases := []struct {
@@ -310,9 +309,6 @@ func TestRecordDroppedRequests(t *testing.T) {
 			},
 			isMutating: false,
 			want: `
-			            # HELP apiserver_dropped_requests_total [ALPHA] Number of requests dropped with 'Try again later' response. Use apiserver_request_total and/or apiserver_request_terminations_total metrics instead.
-			            # TYPE apiserver_dropped_requests_total counter
-			            apiserver_dropped_requests_total{request_kind="readOnly"} 1
 			            # HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.
 			            # TYPE apiserver_request_total counter
 			            apiserver_request_total{code="429",component="apiserver",dry_run="",group="",resource="pods",scope="cluster",subresource="",verb="LIST",version="v1"} 1
@@ -335,9 +331,6 @@ func TestRecordDroppedRequests(t *testing.T) {
 			},
 			isMutating: true,
 			want: `
-			            # HELP apiserver_dropped_requests_total [ALPHA] Number of requests dropped with 'Try again later' response. Use apiserver_request_total and/or apiserver_request_terminations_total metrics instead.
-			            # TYPE apiserver_dropped_requests_total counter
-			            apiserver_dropped_requests_total{request_kind="mutating"} 1
 			            # HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.
 			            # TYPE apiserver_request_total counter
 			            apiserver_request_total{code="429",component="apiserver",dry_run="",group="",resource="pods",scope="resource",subresource="",verb="POST",version="v1"} 1
@@ -363,9 +356,6 @@ func TestRecordDroppedRequests(t *testing.T) {
 			},
 			isMutating: true,
 			want: `
-			            # HELP apiserver_dropped_requests_total [ALPHA] Number of requests dropped with 'Try again later' response. Use apiserver_request_total and/or apiserver_request_terminations_total metrics instead.
-			            # TYPE apiserver_dropped_requests_total counter
-			            apiserver_dropped_requests_total{request_kind="mutating"} 1
 			            # HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.
 			            # TYPE apiserver_request_total counter
 			            apiserver_request_total{code="429",component="apiserver",dry_run="All",group="batch",resource="jobs",scope="resource",subresource="status",verb="PATCH",version="v1"} 1
@@ -378,12 +368,10 @@ func TestRecordDroppedRequests(t *testing.T) {
 	// This also implies that we can't run this test in parallel with other tests.
 	Register()
 	requestCounter.Reset()
-	droppedRequests.Reset()
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			defer requestCounter.Reset()
-			defer droppedRequests.Reset()
 
 			RecordDroppedRequest(test.request, test.requestInfo, APIServerComponent, test.isMutating)
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -217,7 +217,7 @@ func TestApfRejectRequest(t *testing.T) {
 
 	checkForExpectedMetrics(t, []string{
 		"apiserver_request_terminations_total",
-		"apiserver_dropped_requests_total",
+		"apiserver_request_total",
 	})
 }
 
@@ -367,7 +367,7 @@ func TestApfCancelWaitRequest(t *testing.T) {
 	checkForExpectedMetrics(t, []string{
 		"apiserver_current_inflight_requests",
 		"apiserver_request_terminations_total",
-		"apiserver_dropped_requests_total",
+		"apiserver_request_total",
 	})
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -43,15 +43,6 @@ var (
 		},
 		[]string{"operation", "type"},
 	)
-	etcdObjectCounts = compbasemetrics.NewGaugeVec(
-		&compbasemetrics.GaugeOpts{
-			Name:              "etcd_object_counts",
-			DeprecatedVersion: "1.22.0",
-			Help:              "Number of stored objects at the time of last check split by kind. This metric is replaced by apiserver_storage_object_counts.",
-			StabilityLevel:    compbasemetrics.ALPHA,
-		},
-		[]string{"resource"},
-	)
 	objectCounts = compbasemetrics.NewGaugeVec(
 		&compbasemetrics.GaugeOpts{
 			Name:           "apiserver_storage_objects",
@@ -127,7 +118,6 @@ func Register() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(etcdRequestLatency)
 		legacyregistry.MustRegister(objectCounts)
-		legacyregistry.MustRegister(etcdObjectCounts)
 		legacyregistry.MustRegister(dbTotalSize)
 		legacyregistry.MustRegister(etcdBookmarkCounts)
 		legacyregistry.MustRegister(etcdLeaseObjectCounts)
@@ -138,10 +128,9 @@ func Register() {
 	})
 }
 
-// UpdateObjectCount sets the apiserver_storage_object_counts and etcd_object_counts (deprecated) metric.
+// UpdateObjectCount sets the apiserver_storage_object_counts metric.
 func UpdateObjectCount(resourcePrefix string, count int64) {
 	objectCounts.WithLabelValues(resourcePrefix).Set(float64(count))
-	etcdObjectCounts.WithLabelValues(resourcePrefix).Set(float64(count))
 }
 
 // RecordEtcdRequestLatency sets the etcd_request_duration_seconds metrics.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

This PR removes several deprecated metrics. `apiserver_dropped_requests` is now tracked via `apiserver_request_total`. `etcd_object_counts` is also removed in favor of `apiserver_storage_objects`. `apiserver_registered_watchers` is also removed in favor of `apiserver_longrunning_requests`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`apiserver_dropped_requests` is dropped from this release since `apiserver_request_total` can now be used to track dropped requests. `etcd_object_counts` is also removed in favor of `apiserver_storage_objects`. `apiserver_registered_watchers` is also removed in favor of `apiserver_longrunning_requests`.
```
