### PR TITLE
Drop unnecessary json.Marshal

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/yaml.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/yaml.go
@@ -17,7 +17,6 @@ limitations under the License.
 package printers
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
@@ -58,11 +57,7 @@ func (p *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		if InternalObjectPreventer.IsForbidden(reflect.Indirect(reflect.ValueOf(obj.Object.Object)).Type().PkgPath()) {
 			return fmt.Errorf(InternalObjectPrinterErr)
 		}
-		data, err := json.Marshal(obj)
-		if err != nil {
-			return err
-		}
-		data, err = yaml.JSONToYAML(data)
+		data, err := yaml.Marshal(obj)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli

#### What this PR does / why we need it:
I've spotted that while looking through @brianpursley 's https://github.com/kubernetes/kubernetes/pull/109085

`yaml.Marshal` under the covers invokes `json.Marshal` and then `JSONToYAML` conversion which was done here manually.
See here: https://github.com/kubernetes/kubernetes/blob/03d0e2c3389db981fbc6234a9e121a99243d7aab/vendor/sigs.k8s.io/yaml/yaml.go#L16-L28

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```