### PR TITLE
[#110149] - condition if imagePullPolicy is set to Always

### DIFF
--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -229,6 +229,7 @@ var ExpandedPluginsV1beta3 = &config.Plugins{
 			{Name: names.NodeAffinity},
 			{Name: names.PodTopologySpread},
 			{Name: names.InterPodAffinity},
+			{Name: names.ImageLocality},
 		},
 	},
 	Score: config.PluginSet{
@@ -400,6 +401,7 @@ var ExpandedPluginsV1 = &config.Plugins{
 			{Name: names.NodeAffinity},
 			{Name: names.PodTopologySpread},
 			{Name: names.InterPodAffinity},
+			{Name: names.ImageLocality},
 		},
 	},
 	Score: config.PluginSet{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If ``imagePullPolicy`` is set to ``Always``, ``image_locality`` plugin should score it with zero points, because image will be either way pulled. To sum up, previously ``image_locality`` scored nodes, not taking in the consideration the ``ImagePullPolicy``. This PR fixed this issue. 

https://github.com/kubernetes/kubernetes/blob/9af00439cc430e7e643bb2357de619da7d5975cc/pkg/scheduler/framework/plugins/imagelocality/image_locality.go#L100-L103


#### Which issue(s) this PR fixes:

Fixes #110149 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
