### PR TITLE
Add logging for plugin statuses on scheduler initialization

### DIFF
--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -794,10 +794,13 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 			wantErr: "already registered",
 		},
 	}
-
+	captureProfileOpt := WithCaptureProfile(func(profile config.KubeSchedulerProfile) {
+		println() // fake callback for CaptureProfile func
+	})
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fw, err := NewFramework(registry, &config.KubeSchedulerProfile{Plugins: tc.plugins}, wait.NeverStop)
+
+			fw, err := NewFramework(registry, &config.KubeSchedulerProfile{Plugins: tc.plugins}, wait.NeverStop, captureProfileOpt)
 			if err != nil {
 				if tc.wantErr == "" || !strings.Contains(err.Error(), tc.wantErr) {
 					t.Fatalf("Unexpected error, got %v, expect: %s", err, tc.wantErr)
@@ -1159,7 +1162,9 @@ func TestRunScorePlugins(t *testing.T) {
 			},
 		},
 	}
-
+	captureProfileOpt := WithCaptureProfile(func(profile config.KubeSchedulerProfile) {
+		println()
+	})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Inject the results via Args in PluginConfig.
@@ -1167,7 +1172,7 @@ func TestRunScorePlugins(t *testing.T) {
 				Plugins:      tt.plugins,
 				PluginConfig: tt.pluginConfigs,
 			}
-			f, err := newFrameworkWithQueueSortAndBind(registry, profile)
+			f, err := newFrameworkWithQueueSortAndBind(registry, profile, captureProfileOpt)
 			if err != nil {
 				t.Fatalf("Failed to create framework for testing: %v", err)
 			}


### PR DESCRIPTION
Log default plugins, multipoint and ommited plugins status enable/disable.

For a scheduler with
```go
	command := app.NewSchedulerCommand(
		app.WithPlugin(loadvariationriskbalancing.Name, loadvariationriskbalancing.New),
		app.WithPlugin(targetloadpacking.Name, targetloadpacking.New),
	)
```
and
<details>
  <summary>Sample kubescheduler config</summary>

```yaml
apiVersion: kubescheduler.config.k8s.io/v1beta3
clientConnection:
  acceptContentTypes: ""
  burst: 100
  contentType: application/vnd.kubernetes.protobuf
  kubeconfig: /Users/denstorti/.kube/config
  qps: 50
enableContentionProfiling: true
enableProfiling: true
kind: KubeSchedulerConfiguration
parallelism: 16
percentageOfNodesToScore: 0
podInitialBackoffSeconds: 1
podMaxBackoffSeconds: 10
profiles:
- pluginConfig:
  - name: TargetLoadPacking
    args:
      defaultRequests:
        cpu: "2000m"
      defaultRequestsMultiplier: "2"
      targetUtilization: 70
      watcherAddress: http://127.0.0.1:2020
  plugins:
    bind: {}
    filter: {}
    multiPoint:
      enabled:
      - name: NodeResourcesBalancedAllocation
      # disabled:
      # # NON EXISTING
      #  - name: LoadVariationRiskBalancing
    permit: {}
    postBind: {}
    postFilter: {}
    preBind: {}
    preFilter: {}
    preScore: {}
    queueSort: {}
    reserve: {}
    score:
      disabled:
      # NodeResourcesBalancedAllocation disabled in Score, enabled in multiPoint
      - name: NodeResourcesBalancedAllocation
      - name: NodeResourcesLeastAllocated
      # Example of out of tree plugin not explicit in the config file
      # - name: LoadVariationRiskBalancing
      enabled:
       - name: TargetLoadPacking
```
</details>

the output is:
<details>
  <summary>Sample output!</summary>

```
Starting: /Users/denstorti/go/bin/dlv dap --check-go-version=false --listen=127.0.0.1:57766 --log-dest=3 from /Users/denstorti/src/minimal-scheduler
DAP server listening at: 127.0.0.1:57766
I0605 20:00:07.249787   69878 flags.go:64] FLAG: --add_dir_header="false"
I0605 20:00:07.249885   69878 flags.go:64] FLAG: --allow-metric-labels="[]"
I0605 20:00:07.249890   69878 flags.go:64] FLAG: --alsologtostderr="false"
I0605 20:00:07.249893   69878 flags.go:64] FLAG: --authentication-kubeconfig=""
I0605 20:00:07.249896   69878 flags.go:64] FLAG: --authentication-skip-lookup="false"
I0605 20:00:07.249899   69878 flags.go:64] FLAG: --authentication-token-webhook-cache-ttl="10s"
I0605 20:00:07.249903   69878 flags.go:64] FLAG: --authentication-tolerate-lookup-failure="true"
I0605 20:00:07.249906   69878 flags.go:64] FLAG: --authorization-always-allow-paths="[/healthz,/readyz,/livez]"
I0605 20:00:07.249913   69878 flags.go:64] FLAG: --authorization-kubeconfig=""
I0605 20:00:07.249915   69878 flags.go:64] FLAG: --authorization-webhook-cache-authorized-ttl="10s"
I0605 20:00:07.249917   69878 flags.go:64] FLAG: --authorization-webhook-cache-unauthorized-ttl="10s"
I0605 20:00:07.249919   69878 flags.go:64] FLAG: --bind-address="0.0.0.0"
I0605 20:00:07.250047   69878 flags.go:64] FLAG: --cert-dir=""
I0605 20:00:07.250053   69878 flags.go:64] FLAG: --client-ca-file=""
I0605 20:00:07.250056   69878 flags.go:64] FLAG: --config="../schconfig.yaml"
I0605 20:00:07.250076   69878 flags.go:64] FLAG: --contention-profiling="true"
I0605 20:00:07.250079   69878 flags.go:64] FLAG: --disabled-metrics="[]"
I0605 20:00:07.250083   69878 flags.go:64] FLAG: --feature-gates=""
I0605 20:00:07.250086   69878 flags.go:64] FLAG: --help="false"
I0605 20:00:07.250089   69878 flags.go:64] FLAG: --http2-max-streams-per-connection="0"
I0605 20:00:07.250092   69878 flags.go:64] FLAG: --kube-api-burst="100"
I0605 20:00:07.250096   69878 flags.go:64] FLAG: --kube-api-content-type="application/vnd.kubernetes.protobuf"
I0605 20:00:07.250099   69878 flags.go:64] FLAG: --kube-api-qps="50"
I0605 20:00:07.250103   69878 flags.go:64] FLAG: --kubeconfig=""
I0605 20:00:07.250105   69878 flags.go:64] FLAG: --leader-elect="true"
I0605 20:00:07.250108   69878 flags.go:64] FLAG: --leader-elect-lease-duration="15s"
I0605 20:00:07.250185   69878 flags.go:64] FLAG: --leader-elect-renew-deadline="10s"
I0605 20:00:07.250190   69878 flags.go:64] FLAG: --leader-elect-resource-lock="leases"
I0605 20:00:07.250193   69878 flags.go:64] FLAG: --leader-elect-resource-name="kube-scheduler"
I0605 20:00:07.250195   69878 flags.go:64] FLAG: --leader-elect-resource-namespace="kube-system"
I0605 20:00:07.250198   69878 flags.go:64] FLAG: --leader-elect-retry-period="2s"
I0605 20:00:07.250200   69878 flags.go:64] FLAG: --lock-object-name="kube-scheduler"
I0605 20:00:07.250202   69878 flags.go:64] FLAG: --lock-object-namespace="kube-system"
I0605 20:00:07.250204   69878 flags.go:64] FLAG: --log-flush-frequency="5s"
I0605 20:00:07.250207   69878 flags.go:64] FLAG: --log_backtrace_at=":0"
I0605 20:00:07.250213   69878 flags.go:64] FLAG: --log_dir=""
I0605 20:00:07.250216   69878 flags.go:64] FLAG: --log_file=""
I0605 20:00:07.250337   69878 flags.go:64] FLAG: --log_file_max_size="1800"
I0605 20:00:07.250341   69878 flags.go:64] FLAG: --logging-format="text"
I0605 20:00:07.250343   69878 flags.go:64] FLAG: --logtostderr="true"
I0605 20:00:07.250345   69878 flags.go:64] FLAG: --master=""
I0605 20:00:07.250347   69878 flags.go:64] FLAG: --one_output="false"
I0605 20:00:07.250349   69878 flags.go:64] FLAG: --permit-address-sharing="false"
I0605 20:00:07.250352   69878 flags.go:64] FLAG: --permit-port-sharing="false"
I0605 20:00:07.250354   69878 flags.go:64] FLAG: --pod-max-in-unschedulable-pods-duration="5m0s"
I0605 20:00:07.250357   69878 flags.go:64] FLAG: --profiling="true"
I0605 20:00:07.250359   69878 flags.go:64] FLAG: --requestheader-allowed-names="[]"
I0605 20:00:07.250456   69878 flags.go:64] FLAG: --requestheader-client-ca-file=""
I0605 20:00:07.250458   69878 flags.go:64] FLAG: --requestheader-extra-headers-prefix="[x-remote-extra-]"
I0605 20:00:07.250462   69878 flags.go:64] FLAG: --requestheader-group-headers="[x-remote-group]"
I0605 20:00:07.251077   69878 flags.go:64] FLAG: --requestheader-username-headers="[x-remote-user]"
I0605 20:00:07.251083   69878 flags.go:64] FLAG: --secure-port="10259"
I0605 20:00:07.251086   69878 flags.go:64] FLAG: --show-hidden-metrics-for-version=""
I0605 20:00:07.251088   69878 flags.go:64] FLAG: --skip_headers="false"
I0605 20:00:07.251090   69878 flags.go:64] FLAG: --skip_log_headers="false"
I0605 20:00:07.251092   69878 flags.go:64] FLAG: --stderrthreshold="2"
I0605 20:00:07.251094   69878 flags.go:64] FLAG: --tls-cert-file=""
I0605 20:00:07.251096   69878 flags.go:64] FLAG: --tls-cipher-suites="[]"
I0605 20:00:07.251100   69878 flags.go:64] FLAG: --tls-min-version=""
I0605 20:00:07.251102   69878 flags.go:64] FLAG: --tls-private-key-file=""
I0605 20:00:07.251104   69878 flags.go:64] FLAG: --tls-sni-cert-key="[]"
I0605 20:00:07.251108   69878 flags.go:64] FLAG: --v="4"
I0605 20:00:07.251111   69878 flags.go:64] FLAG: --version="false"
I0605 20:00:07.251262   69878 flags.go:64] FLAG: --vmodule=""
I0605 20:00:07.251270   69878 flags.go:64] FLAG: --write-config-to=""
I0605 20:00:08.057495   69878 serving.go:348] Generated self-signed cert in-memory
I0605 20:00:08.062215   69878 default_plugins.go:117] "Default plugin is explicitly re-configured; overriding" plugin="NodeResourcesBalancedAllocation"
W0605 20:00:09.016259   69878 authentication.go:317] No authentication-kubeconfig provided in order to lookup client-ca-file in configmap/extension-apiserver-authentication in kube-system, so client certificate authentication won't work.
W0605 20:00:09.016277   69878 authentication.go:341] No authentication-kubeconfig provided in order to lookup requestheader-client-ca-file in configmap/extension-apiserver-authentication in kube-system, so request-header client certificate authentication won't work.
W0605 20:00:09.016287   69878 authorization.go:193] No authorization-kubeconfig provided, so SubjectAccessReview of authorization tokens won't work.
E0605 20:00:27.659953   69878 targetloadpacking.go:128] "Unable to populate metrics initially" err="Get \"http://127.0.0.1:2020/watcher\": dial tcp 127.0.0.1:2020: connect: connection refused"
I0605 20:00:30.696141   69878 framework.go:515] "plugin disabled for extension point" plugin="NodeResourcesBalancedAllocation" extension="framework.ScorePlugin"
I0605 20:00:41.301487   69878 framework.go:382] "Plugin enabled" plugin="TargetLoadPacking" extension="framework.ScorePlugin"
I0605 20:00:41.301570   69878 framework.go:387] "Plugin disabled" plugin="NodeResourcesBalancedAllocation" extension="framework.ScorePlugin"
I0605 20:00:41.301577   69878 framework.go:387] "Plugin disabled" plugin="NodeResourcesLeastAllocated" extension="framework.ScorePlugin"
I0605 20:00:41.301585   69878 framework.go:393] "Plugin enabled" plugin="PrioritySort" extension="MultiPoint"
I0605 20:00:41.301592   69878 framework.go:393] "Plugin enabled" plugin="NodeUnschedulable" extension="MultiPoint"
I0605 20:00:41.301597   69878 framework.go:393] "Plugin enabled" plugin="NodeName" extension="MultiPoint"
I0605 20:00:41.301602   69878 framework.go:393] "Plugin enabled" plugin="TaintToleration" extension="MultiPoint"
I0605 20:00:41.301606   69878 framework.go:393] "Plugin enabled" plugin="NodeAffinity" extension="MultiPoint"
I0605 20:00:41.301611   69878 framework.go:393] "Plugin enabled" plugin="NodePorts" extension="MultiPoint"
I0605 20:00:41.301761   69878 framework.go:393] "Plugin enabled" plugin="NodeResourcesFit" extension="MultiPoint"
I0605 20:00:41.301787   69878 framework.go:393] "Plugin enabled" plugin="VolumeRestrictions" extension="MultiPoint"
I0605 20:00:41.301801   69878 framework.go:393] "Plugin enabled" plugin="EBSLimits" extension="MultiPoint"
I0605 20:00:41.301814   69878 framework.go:393] "Plugin enabled" plugin="GCEPDLimits" extension="MultiPoint"
I0605 20:00:41.301827   69878 framework.go:393] "Plugin enabled" plugin="NodeVolumeLimits" extension="MultiPoint"
I0605 20:00:41.301840   69878 framework.go:393] "Plugin enabled" plugin="AzureDiskLimits" extension="MultiPoint"
I0605 20:00:41.301852   69878 framework.go:393] "Plugin enabled" plugin="VolumeBinding" extension="MultiPoint"
I0605 20:00:41.301892   69878 framework.go:393] "Plugin enabled" plugin="VolumeZone" extension="MultiPoint"
I0605 20:00:41.301905   69878 framework.go:393] "Plugin enabled" plugin="PodTopologySpread" extension="MultiPoint"
I0605 20:00:41.301918   69878 framework.go:393] "Plugin enabled" plugin="InterPodAffinity" extension="MultiPoint"
I0605 20:00:41.302133   69878 framework.go:393] "Plugin enabled" plugin="DefaultPreemption" extension="MultiPoint"
I0605 20:00:41.302152   69878 framework.go:393] "Plugin enabled" plugin="NodeResourcesBalancedAllocation" extension="MultiPoint"
I0605 20:00:41.302166   69878 framework.go:393] "Plugin enabled" plugin="ImageLocality" extension="MultiPoint"
I0605 20:00:41.302180   69878 framework.go:393] "Plugin enabled" plugin="DefaultBinder" extension="MultiPoint"
I0605 20:00:44.982971   69878 framework.go:405] "Plugin disabled, not declared in configuration" plugin="LoadVariationRiskBalancing" extension="MultiPoint"
I0605 20:00:46.332394   69878 framework.go:405] "Plugin disabled, not declared in configuration" plugin="SelectorSpread" extension="MultiPoint"
I0605 20:00:48.921124   69878 framework.go:405] "Plugin disabled, not declared in configuration" plugin="CinderLimits" extension="MultiPoint"
I0605 20:00:48.926715   69878 configfile.go:96] "Using component config" config=<
	apiVersion: kubescheduler.config.k8s.io/v1beta3
	clientConnection:
	  acceptContentTypes: ""
	  burst: 100
	  contentType: application/vnd.kubernetes.protobuf
	  kubeconfig: /Users/denstorti/.kube/config
	  qps: 50
	enableContentionProfiling: true
	enableProfiling: true
	kind: KubeSchedulerConfiguration
	leaderElection:
	  leaderElect: true
	  leaseDuration: 15s
	  renewDeadline: 10s
	  resourceLock: leases
	  resourceName: kube-scheduler
	  resourceNamespace: kube-system
	  retryPeriod: 2s
	parallelism: 16
	percentageOfNodesToScore: 0
	podInitialBackoffSeconds: 1
	podMaxBackoffSeconds: 10
	profiles:
	- pluginConfig:
	  - args:
	      apiVersion: kubescheduler.config.k8s.io/v1beta3
	      kind: DefaultPreemptionArgs
	      minCandidateNodesAbsolute: 100
	      minCandidateNodesPercentage: 10
	    name: DefaultPreemption
	  - args:
	      apiVersion: kubescheduler.config.k8s.io/v1beta3
	      hardPodAffinityWeight: 1
	      kind: InterPodAffinityArgs
	    name: InterPodAffinity
	  - args:
	      apiVersion: kubescheduler.config.k8s.io/v1beta3
	      kind: NodeAffinityArgs
	    name: NodeAffinity
	  - args:
	      apiVersion: kubescheduler.config.k8s.io/v1beta3
	      kind: NodeResourcesBalancedAllocationArgs
	      resources:
	      - name: cpu
	        weight: 1
	      - name: memory
	        weight: 1
	    name: NodeResourcesBalancedAllocation
	  - args:
	      apiVersion: kubescheduler.config.k8s.io/v1beta3
	      kind: NodeResourcesFitArgs
	      scoringStrategy:
	        resources:
	        - name: cpu
	          weight: 1
	        - name: memory
	          weight: 1
	        type: LeastAllocated
	    name: NodeResourcesFit
	  - args:
	      apiVersion: kubescheduler.config.k8s.io/v1beta3
	      defaultingType: System
	      kind: PodTopologySpreadArgs
	    name: PodTopologySpread
	  - args:
	      apiVersion: kubescheduler.config.k8s.io/v1beta3
	      defaultRequests:
	        cpu: "2"
	      defaultRequestsMultiplier: "2"
	      kind: TargetLoadPackingArgs
	      metricProvider:
	        address: ""
	        insecureSkipVerify: false
	        token: ""
	      targetUtilization: 70
	      watcherAddress: http://127.0.0.1:2020
	    name: TargetLoadPacking
	  - args:
	      apiVersion: kubescheduler.config.k8s.io/v1beta3
	      bindTimeoutSeconds: 600
	      kind: VolumeBindingArgs
	    name: VolumeBinding
	  plugins:
	    bind: {}
	    filter: {}
	    multiPoint:
	      enabled:
	      - name: PrioritySort
	        weight: 0
	      - name: NodeUnschedulable
	        weight: 0
	      - name: NodeName
	        weight: 0
	      - name: TaintToleration
	        weight: 3
	      - name: NodeAffinity
	        weight: 2
	      - name: NodePorts
	        weight: 0
	      - name: NodeResourcesFit
	        weight: 1
	      - name: VolumeRestrictions
	        weight: 0
	      - name: EBSLimits
	        weight: 0
	      - name: GCEPDLimits
	        weight: 0
	      - name: NodeVolumeLimits
	        weight: 0
	      - name: AzureDiskLimits
	        weight: 0
	      - name: VolumeBinding
	        weight: 0
	      - name: VolumeZone
	        weight: 0
	      - name: PodTopologySpread
	        weight: 2
	      - name: InterPodAffinity
	        weight: 2
	      - name: DefaultPreemption
	        weight: 0
	      - name: NodeResourcesBalancedAllocation
	        weight: 0
	      - name: ImageLocality
	        weight: 1
	      - name: DefaultBinder
	        weight: 0
	    permit: {}
	    postBind: {}
	    postFilter: {}
	    preBind: {}
	    preFilter: {}
	    preScore: {}
	    queueSort: {}
	    reserve: {}
	    score:
	      disabled:
	      - name: NodeResourcesBalancedAllocation
	        weight: 0
	      - name: NodeResourcesLeastAllocated
	        weight: 0
	      enabled:
	      - name: TargetLoadPacking
	        weight: 0
	  schedulerName: default-scheduler
 >
I0605 20:00:48.927287   69878 server.go:147] "Starting Kubernetes Scheduler" version="v0.0.0-master+$Format:%H$"
I0605 20:00:48.927802   69878 server.go:149] "Golang settings" GOGC="" GOMAXPROCS="" GOTRACEBACK=""
I0605 20:00:48.929085   69878 tlsconfig.go:200] "Loaded serving cert" certName="Generated self signed cert" certDetail="\"localhost@1654423208\" [serving] validServingFor=[127.0.0.1,localhost,localhost] issuer=\"localhost-ca@1654423207\" (2022-06-05 09:00:07 +0000 UTC to 2023-06-05 09:00:07 +0000 UTC (now=2022-06-05 10:00:48.92904 +0000 UTC))"
I0605 20:00:48.929223   69878 named_certificates.go:53] "Loaded SNI cert" index=0 certName="self-signed loopback" certDetail="\"apiserver-loopback-client@1654423209\" [serving] validServingFor=[apiserver-loopback-client] issuer=\"apiserver-loopback-client-ca@1654423208\" (2022-06-05 09:00:08 +0000 UTC to 2023-06-05 09:00:08 +0000 UTC (now=2022-06-05 10:00:48.9292 +0000 UTC))"
I0605 20:00:48.929280   69878 secure_serving.go:210] Serving securely on [::]:10259
I0605 20:00:48.929322   69878 tlsconfig.go:240] "Starting DynamicServingCertificateController"
I0605 20:00:48.929679   69878 reflector.go:219] Starting reflector *v1.CSIStorageCapacity (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.929687   69878 reflector.go:219] Starting reflector *v1.ReplicationController (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.929704   69878 reflector.go:255] Listing and watching *v1.CSIStorageCapacity from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.929843   69878 reflector.go:219] Starting reflector *v1.CSIDriver (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.929852   69878 reflector.go:255] Listing and watching *v1.CSIDriver from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.929880   69878 reflector.go:219] Starting reflector *v1.StatefulSet (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.929888   69878 reflector.go:255] Listing and watching *v1.StatefulSet from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930016   69878 reflector.go:219] Starting reflector *v1.PodDisruptionBudget (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930024   69878 reflector.go:255] Listing and watching *v1.PodDisruptionBudget from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.929704   69878 reflector.go:255] Listing and watching *v1.ReplicationController from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930051   69878 reflector.go:219] Starting reflector *v1.PersistentVolume (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930382   69878 reflector.go:219] Starting reflector *v1.Node (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930389   69878 reflector.go:255] Listing and watching *v1.Node from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930388   69878 reflector.go:255] Listing and watching *v1.PersistentVolume from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930418   69878 reflector.go:219] Starting reflector *v1.Service (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930425   69878 reflector.go:219] Starting reflector *v1.CSINode (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930440   69878 reflector.go:255] Listing and watching *v1.CSINode from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930071   69878 reflector.go:219] Starting reflector *v1.ReplicaSet (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930551   69878 reflector.go:219] Starting reflector *v1.Pod (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930558   69878 reflector.go:255] Listing and watching *v1.ReplicaSet from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930157   69878 reflector.go:219] Starting reflector *v1.StorageClass (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930426   69878 reflector.go:255] Listing and watching *v1.Service from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930604   69878 reflector.go:255] Listing and watching *v1.StorageClass from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930300   69878 reflector.go:219] Starting reflector *v1.Namespace (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930689   69878 reflector.go:255] Listing and watching *v1.Namespace from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930559   69878 reflector.go:255] Listing and watching *v1.Pod from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930328   69878 reflector.go:219] Starting reflector *v1.PersistentVolumeClaim (0s) from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.930735   69878 reflector.go:255] Listing and watching *v1.PersistentVolumeClaim from k8s.io/client-go/informers/factory.go:134
I0605 20:00:48.998514   69878 node_tree.go:65] "Added node in listed group to NodeTree" node="kind-control-plane" zone=""
I0605 20:00:48.998634   69878 eventhandlers.go:69] "Add event for node" node="kind-control-plane"
I0605 20:00:48.998654   69878 node_tree.go:65] "Added node in listed group to NodeTree" node="kind-worker" zone=""
I0605 20:00:48.998676   69878 eventhandlers.go:69] "Add event for node" node="kind-worker"
I0605 20:00:49.029908   69878 shared_informer.go:285] caches populated
I0605 20:00:49.029937   69878 shared_informer.go:285] caches populated
I0605 20:00:49.029977   69878 shared_informer.go:285] caches populated
I0605 20:00:49.029982   69878 shared_informer.go:285] caches populated
I0605 20:00:49.029993   69878 shared_informer.go:285] caches populated
I0605 20:00:49.029997   69878 shared_informer.go:285] caches populated
I0605 20:00:49.030000   69878 shared_informer.go:285] caches populated
I0605 20:00:49.030017   69878 shared_informer.go:285] caches populated
I0605 20:00:49.030020   69878 shared_informer.go:285] caches populated
I0605 20:00:49.037775   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="default/test3"
I0605 20:00:49.037823   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="kube-system/kube-apiserver-kind-control-plane"
I0605 20:00:49.037869   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="kube-system/kindnet-nbp8g"
I0605 20:00:49.037894   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="kube-system/etcd-kind-control-plane"
I0605 20:00:49.037947   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="kube-system/kube-proxy-5pffr"
I0605 20:00:49.037970   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="kube-system/kube-proxy-szrg8"
I0605 20:00:49.037981   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="local-path-storage/local-path-provisioner-8687fd6488-nq9hg"
I0605 20:00:49.037988   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="default/test"
I0605 20:00:49.037994   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="default/test2"
I0605 20:00:49.038003   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="kube-system/coredns-6d4b75cb6d-dgn9n"
I0605 20:00:49.038010   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="kube-system/coredns-6d4b75cb6d-nbx7r"
I0605 20:00:49.038019   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="kube-system/kindnet-g4sqn"
I0605 20:00:49.038048   69878 eventhandlers.go:184] "Add event for scheduled pod" pod="kube-system/kube-controller-manager-kind-control-plane"
I0605 20:00:49.134526   69878 shared_informer.go:285] caches populated
I0605 20:00:49.134557   69878 shared_informer.go:285] caches populated
I0605 20:00:49.134563   69878 shared_informer.go:285] caches populated
I0605 20:00:49.134567   69878 shared_informer.go:285] caches populated
I0605 20:00:49.134572   69878 shared_informer.go:285] caches populated
I0605 20:00:49.134607   69878 leaderelection.go:248] attempting to acquire leader lease kube-system/kube-scheduler...
I0605 20:00:49.151116   69878 leaderelection.go:352] lock is held by Deniss-Air_4eeaac6f-6c32-486e-8db3-38e287f7903e and has not yet expired
I0605 20:00:49.151131   69878 leaderelection.go:253] failed to acquire lease kube-system/kube-scheduler
I0605 20:00:53.393792   69878 leaderelection.go:352] lock is held by Deniss-Air_4eeaac6f-6c32-486e-8db3-38e287f7903e and has not yet expired
I0605 20:00:53.393815   69878 leaderelection.go:253] failed to acquire lease kube-system/kube-scheduler
I0605 20:00:56.916349   69878 leaderelection.go:352] lock is held by Deniss-Air_4eeaac6f-6c32-486e-8db3-38e287f7903e and has not yet expired
I0605 20:00:56.916374   69878 leaderelection.go:253] failed to acquire lease kube-system/kube-scheduler
E0605 20:00:57.666056   69878 targetloadpacking.go:135] "Unable to update metrics" err="Get \"http://127.0.0.1:2020/watcher\": dial tcp 127.0.0.1:2020: connect: connection refused"
I0605 20:00:59.443186   69878 leaderelection.go:352] lock is held by Deniss-Air_4eeaac6f-6c32-486e-8db3-38e287f7903e and has not yet expired
I0605 20:00:59.443214   69878 leaderelection.go:253] failed to acquire lease kube-system/kube-scheduler
I0605 20:01:02.498809   69878 leaderelection.go:352] lock is held by Deniss-Air_4eeaac6f-6c32-486e-8db3-38e287f7903e and has not yet expired
I0605 20:01:02.498865   69878 leaderelection.go:253] failed to acquire lease kube-system/kube-scheduler
I0605 20:01:06.233912   69878 leaderelection.go:258] successfully acquired lease kube-system/kube-scheduler
E0605 20:01:27.662452   69878 targetloadpacking.go:135] "Unable to update metrics" err="Get \"http://127.0.0.1:2020/watcher\": dial tcp 127.0.0.1:2020: connect: connection refused"
E0605 20:01:57.685973   69878 targetloadpacking.go:135] "Unable to update metrics" err="Get \"http://127.0.0.1:2020/watcher\": dial tcp 127.0.0.1:2020: connect: connection refused"

```
</details>

<!--  Thanks for sending a pull request!  Here are some tips for you:


3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

/sig scheduling

#### What this PR does / why we need it:
Add extra logging for making it explicit what plugins are initialized.

#### Which issue(s) this PR fixes:
Fixes #109285

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
