### PR TITLE
update kubectl api-resources help info

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
@@ -53,7 +53,7 @@ var (
 		kubectl api-resources --namespaced=false
 
 		# Print the supported API resources with a specific APIGroup
-		kubectl api-resources --api-group=extensions`)
+		kubectl api-resources --api-group=rbac.authorization.k8s.io`)
 )
 
 // APIResourceOptions is the start of the data required to perform the operation.


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
```bash
# 1. In k8s 1.24, the following example command returns nothing, because the extensions/v1beta1  API versions of Ingress is no longer served as of v1.22.
$ kubectl api-resources --api-group=extensions
NAME   SHORTNAMES   APIVERSION   NAMESPACED   KIND

# 2. Compare with k8s 1.20.15.
$ kubectl api-resources --api-group=extensions
NAME        SHORTNAMES   APIVERSION           NAMESPACED   KIND
ingresses   ing          extensions/v1beta1   true         Ingress

# 3. I think the example help command should be updated, I chose rbac.authorization.k8s.io because this API is relatively stable and is installed by default.
$ kubectl api-resources --api-group=rbac.authorization.k8s.io
NAME                  SHORTNAMES   APIVERSION                     NAMESPACED   KIND
clusterrolebindings                rbac.authorization.k8s.io/v1   false        ClusterRoleBinding
clusterroles                       rbac.authorization.k8s.io/v1   false        ClusterRole
rolebindings                       rbac.authorization.k8s.io/v1   true         RoleBinding
roles                              rbac.authorization.k8s.io/v1   true         Role
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
No
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
