### PR TITLE
avoid to set non-exist key for timed_workers of taintManager

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/timed_workers.go
+++ b/pkg/controller/nodelifecycle/scheduler/timed_workers.go
@@ -99,7 +99,9 @@ func (q *TimedWorkerQueue) getWrappedWorkerFunc(key string) func(ctx context.Con
 		if err == nil {
 			// To avoid duplicated calls we keep the key in the queue, to prevent
 			// subsequent additions.
-			q.workers[key] = nil
+			if _, exists := q.workers[key]; exists {
+				q.workers[key] = nil
+			}
 		} else {
 			delete(q.workers, key)
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
avoid to set a non-exist key to timed_workers, especially for statefulset pod, because the name of statefulset will never change.

#### Which issue(s) this PR fixes:
Fixes #
https://github.com/kubernetes/kubernetes/issues/110401
