### PR TITLE
kubeadm: add support for patching a "kubeletconfiguration" target

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -421,8 +421,8 @@ type HostPathMount struct {
 type Patches struct {
 	// Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
 	// For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
-	// "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
-	// of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+	// "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd", "kubeletconfiguration".
+	// "patchtype" can be one of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
 	// The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
 	// "suffix" is an optional string that can be used to determine which patches are applied
 	// first alpha-numerically.

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/types.go
@@ -435,8 +435,8 @@ type HostPathMount struct {
 type Patches struct {
 	// Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
 	// For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
-	// "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
-	// of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+	// "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd", "kubeletconfiguration".
+	// "patchtype" can be one of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
 	// The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
 	// "suffix" is an optional string that can be used to determine which patches are applied
 	// first alpha-numerically.

--- a/cmd/kubeadm/app/cmd/options/generic.go
+++ b/cmd/kubeadm/app/cmd/options/generic.go
@@ -96,7 +96,7 @@ func AddPatchesFlag(fs *pflag.FlagSet, patchesDir *string) {
 	const usage = `Path to a directory that contains files named ` +
 		`"target[suffix][+patchtype].extension". For example, ` +
 		`"kube-apiserver0+merge.yaml" or just "etcd.json". ` +
-		`"target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". ` +
+		`"target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd", "kubeletconfiguration". ` +
 		`"patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats ` +
 		`supported by kubectl. The default "patchtype" is "strategic". "extension" must be either ` +
 		`"json" or "yaml". "suffix" is an optional string that can be used to determine ` +

--- a/cmd/kubeadm/app/cmd/phases/init/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubelet.go
@@ -74,7 +74,7 @@ func runKubeletStart(c workflow.RunData) error {
 	}
 
 	// Write the kubelet configuration file to disk.
-	if err := kubeletphase.WriteConfigToDisk(&data.Cfg().ClusterConfiguration, data.KubeletDir()); err != nil {
+	if err := kubeletphase.WriteConfigToDisk(&data.Cfg().ClusterConfiguration, data.KubeletDir(), data.PatchesDir(), data.OutputWriter()); err != nil {
 		return errors.Wrap(err, "error writing kubelet configuration to disk")
 	}
 

--- a/cmd/kubeadm/app/cmd/phases/init/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubelet.go
@@ -48,6 +48,7 @@ func NewKubeletStartPhase() workflow.Phase {
 			options.CfgPath,
 			options.NodeCRISocket,
 			options.NodeName,
+			options.Patches,
 		},
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -174,7 +174,7 @@ func runKubeletStartJoinPhase(c workflow.RunData) (returnErr error) {
 	}
 
 	// Write the configuration for the kubelet (using the bootstrap token credentials) to disk so the kubelet can start
-	if err := kubeletphase.WriteConfigToDisk(&initCfg.ClusterConfiguration, data.KubeletDir()); err != nil {
+	if err := kubeletphase.WriteConfigToDisk(&initCfg.ClusterConfiguration, data.KubeletDir(), data.PatchesDir(), data.OutputWriter()); err != nil {
 		return err
 	}
 

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -76,6 +76,7 @@ func NewKubeletStartPhase() workflow.Phase {
 			options.TokenDiscoverySkipCAHash,
 			options.TLSBootstrapToken,
 			options.TokenStr,
+			options.Patches,
 		},
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/data.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/data.go
@@ -17,6 +17,8 @@ limitations under the License.
 package node
 
 import (
+	"io"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 
@@ -35,4 +37,5 @@ type Data interface {
 	IgnorePreflightErrors() sets.String
 	PatchesDir() string
 	KubeConfigPath() string
+	OutputWriter() io.Writer
 }

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
@@ -48,6 +48,7 @@ func NewKubeletConfigPhase() workflow.Phase {
 		InheritFlags: []string{
 			options.DryRun,
 			options.KubeconfigPath,
+			options.Patches,
 		},
 	}
 	return phase

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
@@ -73,7 +73,7 @@ func runKubeletConfigPhase() func(c workflow.RunData) error {
 		// TODO: Checkpoint the current configuration first so that if something goes wrong it can be recovered
 
 		// Store the kubelet component configuration.
-		if err = kubeletphase.WriteConfigToDisk(&cfg.ClusterConfiguration, kubeletDir); err != nil {
+		if err = kubeletphase.WriteConfigToDisk(&cfg.ClusterConfiguration, kubeletDir, data.PatchesDir(), data.OutputWriter()); err != nil {
 			return err
 		}
 

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -168,7 +168,7 @@ func runApply(flags *applyFlags, args []string) error {
 
 	// Upgrade RBAC rules and addons.
 	klog.V(1).Infoln("[upgrade/postupgrade] upgrading RBAC rules and addons")
-	if err := upgrade.PerformPostUpgradeTasks(client, cfg, flags.dryRun); err != nil {
+	if err := upgrade.PerformPostUpgradeTasks(client, cfg, flags.patchesDir, flags.dryRun, flags.applyPlanFlags.out); err != nil {
 		return errors.Wrap(err, "[upgrade/postupgrade] FATAL post-upgrade error")
 	}
 

--- a/cmd/kubeadm/app/cmd/upgrade/upgrade.go
+++ b/cmd/kubeadm/app/cmd/upgrade/upgrade.go
@@ -60,7 +60,7 @@ func NewCmdUpgrade(out io.Writer) *cobra.Command {
 	cmd.AddCommand(newCmdApply(flags))
 	cmd.AddCommand(newCmdPlan(flags))
 	cmd.AddCommand(newCmdDiff(out))
-	cmd.AddCommand(newCmdNode())
+	cmd.AddCommand(newCmdNode(out))
 	return cmd
 }
 

--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -18,6 +18,7 @@ package kubelet
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -38,7 +39,7 @@ import (
 
 // WriteConfigToDisk writes the kubelet config object down to a file
 // Used at "kubeadm init" and "kubeadm upgrade" time
-func WriteConfigToDisk(cfg *kubeadmapi.ClusterConfiguration, kubeletDir string) error {
+func WriteConfigToDisk(cfg *kubeadmapi.ClusterConfiguration, kubeletDir, patchesDir string, output io.Writer) error {
 	kubeletCfg, ok := cfg.ComponentConfigs[componentconfigs.KubeletGroup]
 	if !ok {
 		return errors.New("no kubelet component config found")

--- a/cmd/kubeadm/app/util/patches/patches_test.go
+++ b/cmd/kubeadm/app/util/patches/patches_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -35,6 +35,7 @@ var testKnownTargets = []string{
 	"kube-apiserver",
 	"kube-controller-manager",
 	"kube-scheduler",
+	"kubeletconfiguration",
 }
 
 const testDirPattern = "patch-files"
@@ -308,6 +309,21 @@ func TestGetPatchManagerForPath(t *testing.T) {
 			files: []*file{
 				{
 					name: "kube-apiserver+json.json",
+					data: `[{"op": "replace", "path": "/foo", "value": "zzz"}]`,
+				},
+			},
+		},
+		{
+			name: "valid: kubeletconfiguration target is patched with json patch",
+			patchTarget: &PatchTarget{
+				Name:                      "kubeletconfiguration",
+				StrategicMergePatchObject: nil,
+				Data:                      []byte("foo: bar\n"),
+			},
+			expectedData: []byte(`{"foo":"zzz"}`),
+			files: []*file{
+				{
+					name: "kubeletconfiguration+json.json",
 					data: `[{"op": "replace", "path": "/foo", "value": "zzz"}]`,
 				},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Enhance the kubeadm "patches" functionality to be able to patch kubelet config files containing v1beta1.KubeletConfiguration before writing the kubelet config.yaml to disk during init/join/upgrade

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/1682

#### Special notes for your reviewer:


Please review one commit at a time.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: enhance the "patches" functionality to be able to patch kubelet config files containing v1beta1.KubeletConfiguration. The new patch target is called "kubeletconfiguration" (e.g. patch file "kubeletconfiguration+json.json"). This makes it possible to apply node specific KubeletConfiguration options during "init", "join" and "upgrade", while the main KubeletConfiguration that is passed to "init" as part of the "--config" file can still act as the global / stored in the cluster KubeletConfiguration.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/1739
```
