### PR TITLE
graduate ServiceIPStaticSubrange to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -692,6 +692,7 @@ const (
 	// owner: @aojea
 	// kep: http://kep.k8s.io/3070
 	// alpha: v1.24
+	// beta: v1.25
 	//
 	// Subdivide the ClusterIP range for dynamic and static IP allocation.
 	ServiceIPStaticSubrange featuregate.Feature = "ServiceIPStaticSubrange"
@@ -981,7 +982,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	SeccompDefault: {Default: false, PreRelease: featuregate.Alpha},
 
-	ServiceIPStaticSubrange: {Default: false, PreRelease: featuregate.Alpha},
+	ServiceIPStaticSubrange: {Default: false, PreRelease: featuregate.Beta},
 
 	ServiceInternalTrafficPolicy: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION

/kind feature

```release-note
graduate ServiceIPStaticSubrange feature to beta (disabled by default)
```

It seems that the feature had some external users testing and found an important bug

https://github.com/kubernetes/kubernetes/pull/109928

since then, no more issues were reported matching the criteria 

https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3070-reserved-service-ip-range#beta

Ref: https://github.com/kubernetes/enhancements/issues/3070