### PR TITLE
Add flag for job and cronjob concurrent syncs to kube-controller-manager

### DIFF
--- a/cmd/kube-controller-manager/app/options/cronjobcontroller.go
+++ b/cmd/kube-controller-manager/app/options/cronjobcontroller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	cronjobconfig "k8s.io/kubernetes/pkg/controller/cronjob/config"

--- a/cmd/kube-controller-manager/app/options/cronjobcontroller.go
+++ b/cmd/kube-controller-manager/app/options/cronjobcontroller.go
@@ -54,5 +54,8 @@ func (o *CronJobControllerOptions) Validate() []error {
 	}
 
 	errs := []error{}
+	if o.ConcurrentCronJobSyncs < 1 {
+		errs = append(errs, fmt.Errorf("concurrent-cronjob-syncs must be greater than 0, but got %d", o.ConcurrentCronJobSyncs))
+	}
 	return errs
 }

--- a/cmd/kube-controller-manager/app/options/cronjobcontroller.go
+++ b/cmd/kube-controller-manager/app/options/cronjobcontroller.go
@@ -32,6 +32,8 @@ func (o *CronJobControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	if o == nil {
 		return
 	}
+
+	fs.Int32Var(&o.ConcurrentCronJobSyncs, "concurrent-cronjob-syncs", o.ConcurrentCronJobSyncs, "The number of cronjob objects that are allowed to sync concurrently. Larger number = more responsive cronjobs, but more CPU (and network) load")
 }
 
 // ApplyTo fills up JobController config with options.

--- a/cmd/kube-controller-manager/app/options/jobcontroller.go
+++ b/cmd/kube-controller-manager/app/options/jobcontroller.go
@@ -54,5 +54,8 @@ func (o *JobControllerOptions) Validate() []error {
 	}
 
 	errs := []error{}
+	if o.ConcurrentJobSyncs < 1 {
+		errs = append(errs, fmt.Errorf("concurrent-job-syncs must be greater than 0, but got %d", o.ConcurrentJobSyncs))
+	}
 	return errs
 }

--- a/cmd/kube-controller-manager/app/options/jobcontroller.go
+++ b/cmd/kube-controller-manager/app/options/jobcontroller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	jobconfig "k8s.io/kubernetes/pkg/controller/job/config"

--- a/cmd/kube-controller-manager/app/options/jobcontroller.go
+++ b/cmd/kube-controller-manager/app/options/jobcontroller.go
@@ -32,6 +32,8 @@ func (o *JobControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	if o == nil {
 		return
 	}
+
+	fs.Int32Var(&o.ConcurrentJobSyncs, "concurrent-job-syncs", o.ConcurrentJobSyncs, "The number of job objects that are allowed to sync concurrently. Larger number = more responsive jobs, but more CPU (and network) load")
 }
 
 // ApplyTo fills up JobController config with options.

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -85,6 +85,8 @@ var args = []string{
 	"--cluster-signing-legacy-unknown-key-file=/cluster-signing-legacy-unknown/key-file",
 	"--concurrent-deployment-syncs=10",
 	"--concurrent-horizontal-pod-autoscaler-syncs=10",
+	"--concurrent-job-syncs=10",
+	"--concurrent-cronjob-syncs=10",
 	"--concurrent-statefulset-syncs=15",
 	"--concurrent-endpoint-syncs=10",
 	"--concurrent-ephemeralvolume-syncs=10",
@@ -317,12 +319,12 @@ func TestAddFlags(t *testing.T) {
 		},
 		JobController: &JobControllerOptions{
 			&jobconfig.JobControllerConfiguration{
-				ConcurrentJobSyncs: 5,
+				ConcurrentJobSyncs: 10,
 			},
 		},
 		CronJobController: &CronJobControllerOptions{
 			&cronjobconfig.CronJobControllerConfiguration{
-				ConcurrentCronJobSyncs: 5,
+				ConcurrentCronJobSyncs: 10,
 			},
 		},
 		NamespaceController: &NamespaceControllerOptions{
@@ -570,10 +572,10 @@ func TestApplyTo(t *testing.T) {
 				HorizontalPodAutoscalerTolerance:                    0.1,
 			},
 			JobController: jobconfig.JobControllerConfiguration{
-				ConcurrentJobSyncs: 5,
+				ConcurrentJobSyncs: 10,
 			},
 			CronJobController: cronjobconfig.CronJobControllerConfiguration{
-				ConcurrentCronJobSyncs: 5,
+				ConcurrentCronJobSyncs: 10,
 			},
 			NamespaceController: namespaceconfig.NamespaceControllerConfiguration{
 				NamespaceSyncPeriod:      metav1.Duration{Duration: 10 * time.Minute},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

We were running into scaling limits with our Kubernetes cluster: the default number of job sync workers wasn't sufficient to keep up with our volume of created jobs.

This PR adds a `--concurrent-job-syncs` flag to kube-controller-manager so we can customize the number of workers, similar to the `--concurrent-deployment-syncs` flag.

It also adds a `--concurrent-cronjob-syncs` flag, mostly for the sake of completeness.

#### Which issue(s) this PR fixes:

Fixes #80397

#### Special notes for your reviewer:

There was a previous attempt at fixing this issue in https://github.com/kubernetes/kubernetes/pull/85815, but it looks like the PR never landed and was closed due to inactivity.

I wasn't exactly sure what the policy around reviving an old PR was, so decided to submit a fresh one. Apologies if that was incorrect.

#### Does this PR introduce a user-facing change?

```release-note
kube-controller-manager supports '--concurrent-job-sync' and '--concurrent-cronjob-sync' flags to set the number of job and cronjob controller workers
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

