### PR TITLE
client-go: fix panic in ConfirmUsable validation

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
@@ -204,8 +204,19 @@ func ConfirmUsable(config clientcmdapi.Config, passedContextName string) error {
 
 	if exists {
 		validationErrors = append(validationErrors, validateContext(contextName, *context, config)...)
-		validationErrors = append(validationErrors, validateAuthInfo(context.AuthInfo, *config.AuthInfos[context.AuthInfo])...)
-		validationErrors = append(validationErrors, validateClusterInfo(context.Cluster, *config.Clusters[context.Cluster])...)
+
+		// Default to empty users and clusters and let the validation function report an error.
+		authInfo := config.AuthInfos[context.AuthInfo]
+		if authInfo == nil {
+			authInfo = &clientcmdapi.AuthInfo{}
+		}
+		validationErrors = append(validationErrors, validateAuthInfo(context.AuthInfo, *authInfo)...)
+
+		cluster := config.Clusters[context.Cluster]
+		if cluster == nil {
+			cluster = &clientcmdapi.Cluster{}
+		}
+		validationErrors = append(validationErrors, validateClusterInfo(context.Cluster, *cluster)...)
 	}
 
 	return newErrConfigurationInvalid(validationErrors)

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation_test.go
@@ -65,6 +65,42 @@ func TestConfirmUsableBadInfoButOkConfig(t *testing.T) {
 	badValidation.testConfig(t)
 }
 
+func TestConfirmUsableMissingObjects(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["kind-cluster"] = &clientcmdapi.Cluster{
+		Server: "anything",
+	}
+	config.AuthInfos["kind-user"] = &clientcmdapi.AuthInfo{
+		Token: "any-value",
+	}
+	config.Contexts["missing-user"] = &clientcmdapi.Context{
+		Cluster:  "kind-cluster",
+		AuthInfo: "garbage",
+	}
+	config.Contexts["missing-cluster"] = &clientcmdapi.Context{
+		Cluster:  "garbage",
+		AuthInfo: "kind-user",
+	}
+
+	missingUser := configValidationTest{
+		config: config,
+		expectedErrorSubstring: []string{
+			`user "garbage" was not found for context "missing-user"`,
+		},
+	}
+	missingUser.testConfirmUsable("missing-user", t)
+	missingUser.testConfig(t)
+
+	missingCluster := configValidationTest{
+		config: config,
+		expectedErrorSubstring: []string{
+			`cluster "garbage" was not found for context "missing-cluster"`,
+		},
+	}
+	missingCluster.testConfirmUsable("missing-cluster", t)
+	missingCluster.testConfig(t)
+}
+
 func TestConfirmUsableBadInfoConfig(t *testing.T) {
 	config := clientcmdapi.NewConfig()
 	config.Clusters["missing ca"] = &clientcmdapi.Cluster{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes a panic. Hopefully should be straightforward!! :smile: 

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/client-go/issues/1108

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
