### PR TITLE
overwrite known targets in patch manager cache in case it changes

### DIFF
--- a/cmd/kubeadm/app/util/patches/patches.go
+++ b/cmd/kubeadm/app/util/patches/patches.go
@@ -97,6 +97,8 @@ var (
 func GetPatchManagerForPath(path string, knownTargets []string, output io.Writer) (*PatchManager, error) {
 	pathLock.RLock()
 	if pm, known := pathCache[path]; known {
+		// in case known targets are changed
+		pm.knownTargets = knownTargets
 		pathLock.RUnlock()
 		return pm, nil
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
#110405 add a new calling for `GetPatchManagerForPath` and there is a cache patch manager map which is used in PatchStaticPod as well with different known targest.

#### Which issue(s) this PR fixes:
https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-latest-on-1-24


#### Special notes for your reviewer:
```
[control-plane] Creating static Pod manifest for "kube-apiserver"
I0608 00:49:59.881252     176 certs.go:522] validating certificate period for CA certificate
I0608 00:49:59.881454     176 manifests.go:125] [control-plane] adding volume "ca-certs" for component "kube-apiserver"
I0608 00:49:59.881471     176 manifests.go:125] [control-plane] adding volume "etc-ca-certificates" for component "kube-apiserver"
I0608 00:49:59.881480     176 manifests.go:125] [control-plane] adding volume "k8s-certs" for component "kube-apiserver"
I0608 00:49:59.881487     176 manifests.go:125] [control-plane] adding volume "usr-local-share-ca-certificates" for component "kube-apiserver"
I0608 00:49:59.881495     176 manifests.go:125] [control-plane] adding volume "usr-share-ca-certificates" for component "kube-apiserver"
unknown patch target name "kube-apiserver", must be one of [kubeletconfiguration]
k8s.io/kubernetes/cmd/kubeadm/app/util/patches.(*PatchManager).ApplyPatchesToTarget
	cmd/kubeadm/app/util/patches/patches.go:150
k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod.PatchStaticPod
	cmd/kubeadm/app/util/staticpod/utils.go:188
k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane.CreateStaticPodFiles
	cmd/kubeadm/app/phases/controlplane/manifests.go:142
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/init.runControlPlaneSubphase.func1
	cmd/kubeadm/app/cmd/phases/init/controlplane.go:149
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).Run.func1
	cmd/kubeadm/app/cmd/phases/workflow/runner.go:234
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).visitAll
	cmd/kubeadm/app/cmd/phases/workflow/runner.go:421
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).Run
	cmd/kubeadm/app/cmd/phases/workflow/runner.go:207
k8s.io/kubernetes/cmd/kubeadm/app/cmd.newCmdInit.func1
	cmd/kubeadm/app/cmd/init.go:153
github.com/spf13/cobra.(*Command).execute
	vendor/github.com/spf13/cobra/command.go:856
github.com/spf13/cobra.(*Command).ExecuteC
	vendor/github.com/spf13/cobra/command.go:974
github.com/spf13/cobra.(*Command).Execute
	vendor/github.com/spf13/cobra/command.go:902
k8s.io/kubernetes/cmd/kubeadm/app.Run
	cmd/kubeadm/app/kubeadm.go:50
main.main
	cmd/kubeadm/kubeadm.go:25
runtime.main
	/usr/local/go/src/runtime/proc.go:250
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1571
failed to patch static Pod manifest file for "kube-apiserver"
k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane.CreateStaticPodFiles
	cmd/kubeadm/app/phases/controlplane/manifests.go:144
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/init.runControlPlaneSubphase.func1
	cmd/kubeadm/app/cmd/phases/init/controlplane.go:149
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).Run.func1
	cmd/kubeadm/app/cmd/phases/workflow/runner.go:234
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).visitAll
	cmd/kubeadm/app/cmd/phases/workflow/runner.go:421
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).Run
	cmd/kubeadm/app/cmd/phases/workflow/runner.go:207
k8s.io/kubernetes/cmd/kubeadm/app/cmd.newCmdInit.func1
	cmd/kubeadm/app/cmd/init.go:153
github.com/spf13/cobra.(*Command).execute
	vendor/github.com/spf13/cobra/command.go:856
github.com/spf13/cobra.(*Command).ExecuteC
	vendor/github.com/spf13/cobra/command.go:974
github.com/spf13/cobra.(*Command).Execute
	vendor/github.com/spf13/cobra/command.go:902
k8s.io/kubernetes/cmd/kubeadm/app.Run
	cmd/kubeadm/app/kubeadm.go:50
main.main
	cmd/kubeadm/kubeadm.go:25
runtime.main
	/usr/local/go/src/runtime/proc.go:250
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1571
error execution phase control-plane/apiserver
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).Run.func1
	cmd/kubeadm/app/cmd/phases/workflow/runner.go:235
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).visitAll
	cmd/kubeadm/app/cmd/phases/workflow/runner.go:421
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).Run
	cmd/kubeadm/app/cmd/phases/workflow/runner.go:207
k8s.io/kubernetes/cmd/kubeadm/app/cmd.newCmdInit.func1
	cmd/kubeadm/app/cmd/init.go:153
github.com/spf13/cobra.(*Command).execute
	vendor/github.com/spf13/cobra/command.go:856
github.com/spf13/cobra.(*Command).ExecuteC
	vendor/github.com/spf13/cobra/command.go:974
github.com/spf13/cobra.(*Command).Execute
	vendor/github.com/spf13/cobra/command.go:902
k8s.io/kubernetes/cmd/kubeadm/app.Run
	cmd/kubeadm/app/kubeadm.go:50
main.main
	cmd/kubeadm/kubeadm.go:25
runtime.main
	/usr/local/go/src/runtime/proc.go:250
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1571
Error: failed to exec action kubeadm-init: exit status 1
 exit status 1

```

#### Does this PR introduce a user-facing change?

```release-note
None
```