### PR TITLE
Use OpenAPI to determine patch type in kubectl apply patching

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -200,6 +200,10 @@ func (f FakeResources) LookupResource(s schema.GroupVersionKind) proto.Schema {
 	return f.resources[s]
 }
 
+func (f FakeResources) GetConsumes(gvk schema.GroupVersionKind, operation string) []string {
+	return nil
+}
+
 var _ openapi.Resources = &FakeResources{}
 
 func testOpenAPISchemaData() (openapi.Resources, error) {

--- a/staging/src/k8s.io/kubectl/pkg/util/openapi/openapi.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/openapi/openapi.go
@@ -21,12 +21,14 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kube-openapi/pkg/util/proto"
+	"sigs.k8s.io/yaml"
 )
 
 // Resources interface describe a resources provider, that can give you
 // resource based on group-version-kind.
 type Resources interface {
 	LookupResource(gvk schema.GroupVersionKind) proto.Schema
+	GetConsumes(gvk schema.GroupVersionKind, operation string) []string
 }
 
 // groupVersionKindExtensionKey is the key used to lookup the
@@ -40,6 +42,7 @@ type document struct {
 	// Maps gvk to model name
 	resources map[schema.GroupVersionKind]string
 	models    proto.Models
+	doc       *openapi_v2.Document
 }
 
 var _ Resources = &document{}
@@ -68,6 +71,7 @@ func NewOpenAPIData(doc *openapi_v2.Document) (Resources, error) {
 	return &document{
 		resources: resources,
 		models:    models,
+		doc:       doc,
 	}, nil
 }
 
@@ -77,6 +81,44 @@ func (d *document) LookupResource(gvk schema.GroupVersionKind) proto.Schema {
 		return nil
 	}
 	return d.models.LookupModel(modelName)
+}
+
+func (d *document) GetConsumes(gvk schema.GroupVersionKind, operation string) []string {
+	for _, path := range d.doc.GetPaths().GetPath() {
+		for _, ex := range path.GetValue().GetPatch().GetVendorExtension() {
+			if ex.GetValue().GetYaml() == "" ||
+				ex.GetName() != "x-kubernetes-group-version-kind" {
+				continue
+			}
+
+			var value map[string]string
+			err := yaml.Unmarshal([]byte(ex.GetValue().GetYaml()), &value)
+			if err != nil {
+				continue
+			}
+
+			if value["group"] == gvk.Group && value["kind"] == gvk.Kind && value["version"] == gvk.Version {
+				switch operation {
+				case "GET":
+					return path.GetValue().GetGet().GetConsumes()
+				case "PATCH":
+					return path.GetValue().GetPatch().GetConsumes()
+				case "HEAD":
+					return path.GetValue().GetHead().GetConsumes()
+				case "PUT":
+					return path.GetValue().GetPut().GetConsumes()
+				case "POST":
+					return path.GetValue().GetPost().GetConsumes()
+				case "OPTIONS":
+					return path.GetValue().GetOptions().GetConsumes()
+				case "DELETE":
+					return path.GetValue().GetDelete().GetConsumes()
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 // Get and parse GroupVersionKind from the extension. Returns empty if it doesn't have one.

--- a/staging/src/k8s.io/kubectl/pkg/util/openapi/openapi_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/openapi/openapi_test.go
@@ -50,6 +50,9 @@ var _ = Describe("Reading apps/v1/Deployment from openAPIData", func() {
 		schema = resources.LookupResource(gvk)
 		Expect(schema).ToNot(BeNil())
 		Expect(schema.(*proto.Kind)).ToNot(BeNil())
+		consumes := resources.GetConsumes(gvk, "PATCH")
+		Expect(consumes).ToNot(BeNil())
+		Expect(len(consumes)).To(Equal(4))
 	})
 })
 

--- a/staging/src/k8s.io/kubectl/pkg/util/openapi/testing/openapi.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/openapi/testing/openapi.go
@@ -53,6 +53,19 @@ func (f *FakeResources) LookupResource(gvk schema.GroupVersionKind) proto.Schema
 	return resources.LookupResource(gvk)
 }
 
+func (f *FakeResources) GetConsumes(gvk schema.GroupVersionKind, operation string) []string {
+	s, err := f.fake.OpenAPISchema()
+	if err != nil {
+		panic(err)
+	}
+
+	resources, err := openapi.NewOpenAPIData(s)
+	if err != nil {
+		panic(err)
+	}
+	return resources.GetConsumes(gvk, operation)
+}
+
 // EmptyResources implement a Resources that just doesn't have any resources.
 type EmptyResources struct{}
 
@@ -60,6 +73,10 @@ var _ openapi.Resources = EmptyResources{}
 
 // LookupResource will always return nil. It doesn't have any resources.
 func (f EmptyResources) LookupResource(gvk schema.GroupVersionKind) proto.Schema {
+	return nil
+}
+
+func (f EmptyResources) GetConsumes(gvk schema.GroupVersionKind, operation string) []string {
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently `kubectl apply` determines correct patch type for given
GVKs by trying to register schema and if it succeeds, it uses
strategic-merge-patch.

But OpenAPI endpoint already stores which patch types are supported
by GVKs. This PR checks OpenAPI endpoint to retrieve patch type,
if OpenAPI is enabled. If it is not enabled, patch type determination
will be done as conventional registration method.

#### Which issue(s) this PR fixes:
Fixes #100012

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
