### PR TITLE
unit tests for Class E IP addresses

### DIFF
--- a/cmd/kube-apiserver/app/options/validation_test.go
+++ b/cmd/kube-apiserver/app/options/validation_test.go
@@ -95,6 +95,11 @@ func TestClusterServiceIPRange(t *testing.T) {
 			options:      makeOptionsWithCIDRs("10.0.0.0/16", ""),
 		},
 		{
+			name:         "valid primary, class E range",
+			expectErrors: false,
+			options:      makeOptionsWithCIDRs("244.0.0.0/16", ""),
+		},
+		{
 			name:         "valid v4-v6 dual stack",
 			expectErrors: false,
 			options:      makeOptionsWithCIDRs("10.0.0.0/16", "3000::/108"),

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -19893,6 +19893,7 @@ func TestValidateNonSpecialIP(t *testing.T) {
 		ip   string
 	}{
 		{"ipv4", "10.1.2.3"},
+		{"ipv4 class E", "244.1.2.3"},
 		{"ipv6", "2000::1"},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
/kind cleanup

```release-note
NONE
```

It seems to be valid to use Class E IP addresses, but just adding test cases to avoid regression on the future, is not something commonly used and we don't know if it can break.

xref: https://github.com/kubernetes/kubernetes/issues/110456