### PR TITLE
e2e: ensure single image for populator containers

### DIFF
--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -301,19 +301,26 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 					for i, container := range item.Spec.Template.Spec.Containers {
 						switch container.Name {
 						case "hello":
-							var found bool
 							args := []string{}
+							var foundNS, foundImage bool
 							for _, arg := range container.Args {
 								if strings.HasPrefix(arg, "--namespace=") {
 									args = append(args, fmt.Sprintf("--namespace=%s", popNamespace.Name))
-									found = true
+									foundNS = true
+								} else if strings.HasPrefix(arg, "--image-name=") {
+									args = append(args, fmt.Sprintf("--image-name=%s", container.Image))
+									foundImage = true
 								} else {
 									args = append(args, arg)
 								}
 							}
-							if !found {
+							if !foundNS {
 								args = append(args, fmt.Sprintf("--namespace=%s", popNamespace.Name))
 								framework.Logf("container name: %s", container.Name)
+							}
+							if !foundImage {
+								args = append(args, fmt.Sprintf("--image-name=%s", container.Image))
+								framework.Logf("container image: %s", container.Image)
 							}
 							container.Args = args
 							item.Spec.Template.Spec.Containers[i] = container


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

This patch makes sure the populator image used by the Deployment is also used to start the populator in populate mode. 

This is useful in environments where the Deployment image is replaced by another image from an internal registry (via fixture). 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
