### PR TITLE
Clarify that Quantity supports 'n' and 'u' suffixes

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -45,7 +45,7 @@ import (
 // <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI>
 // <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
 //   (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
-// <decimalSI>       ::= m | "" | k | M | G | T | P | E
+// <decimalSI>       ::= n | u | m | "" | k | M | G | T | P | E
 //   (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
 // <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
 // ```


### PR DESCRIPTION
This is a very minor clarification of the comment documentation in `apimachinery/pkg/api/resource/quantity.go`, because decimal quantities also support `n` (nano, 10**-9) and `u` (micro, 10**-6) suffixes. For example, `n`-suffixed values can be seen in the `usage.cpu` field of `NodeMetrics`:

```
$ kubectl get nodemetrics <node> -o "go-template={{.usage.cpu}}"
95647727n
```

In attempting to understand this the first inclination was that it was indeed nanocores, but the documentation seemed to imply that `n` was invalid. Digging deeper on the code proved that `n` was indeed a valid `Quantity` suffix (and so too `u`).

The suffix-handling code in `apimachinery/pkg/api/resource/suffix.go` knows about these suffixes:

https://github.com/kubernetes/kubernetes/blob/cfda5bc1d8f07c422c174c68ebf5d27385525570/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go#L92-L95

https://github.com/kubernetes/kubernetes/blob/cfda5bc1d8f07c422c174c68ebf5d27385525570/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go#L123-L124

And this is what is used by `Quantity` in its parsing and formatting code, e.g.:

https://github.com/kubernetes/kubernetes/blob/cfda5bc1d8f07c422c174c68ebf5d27385525570/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go#L282

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The current documentation is somewhat incorrect and can confuse users encountering values using these suffixes.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
