### PR TITLE
add missing error handling steps

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
@@ -163,7 +163,12 @@ func (cnc *CloudNodeController) Run(stopCh <-chan struct{}) {
 	// The periodic loop for updateNodeStatus communicates with the APIServer with a worst case complexity
 	// of O(num_nodes) per cycle. These functions are justified here because these events fire
 	// very infrequently. DO NOT MODIFY this to perform frequent operations.
-	go wait.Until(func() { cnc.UpdateNodeStatus(context.TODO()) }, cnc.nodeStatusUpdateFrequency, stopCh)
+	go wait.Until(func() {
+		if err := cnc.UpdateNodeStatus(context.TODO()); err != nil {
+			klog.Errorf("failed to update node status")
+		}
+	}, cnc.nodeStatusUpdateFrequency, stopCh)
+
 	go wait.Until(cnc.runWorker, time.Second, stopCh)
 
 	<-stopCh

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
@@ -165,7 +165,7 @@ func (cnc *CloudNodeController) Run(stopCh <-chan struct{}) {
 	// very infrequently. DO NOT MODIFY this to perform frequent operations.
 	go wait.Until(func() {
 		if err := cnc.UpdateNodeStatus(context.TODO()); err != nil {
-			klog.Errorf("failed to update node status")
+			klog.Errorf("failed to update node status: %v", err)
 		}
 	}, cnc.nodeStatusUpdateFrequency, stopCh)
 

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -269,7 +269,7 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 				defer wg.Done()
 				klog.Infof("node %v has no routes assigned to it. NodeNetworkUnavailable will be set to true", n.Name)
 				if err := rc.updateNetworkingCondition(n, false); err != nil {
-					klog.Errorf("failed to update networking condition when no nodeRoutes")
+					klog.Errorf("failed to update networking condition when no nodeRoutes: %v", err)
 				}
 			}(node)
 			continue
@@ -285,7 +285,7 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 		go func(n *v1.Node) {
 			defer wg.Done()
 			if err := rc.updateNetworkingCondition(n, allRoutesCreated); err != nil {
-				klog.Errorf("failed to update networking condition")
+				klog.Errorf("failed to update networking condition: %v", err)
 			}
 		}(node)
 	}

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -268,7 +268,9 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 			go func(n *v1.Node) {
 				defer wg.Done()
 				klog.Infof("node %v has no routes assigned to it. NodeNetworkUnavailable will be set to true", n.Name)
-				rc.updateNetworkingCondition(n, false)
+				if err := rc.updateNetworkingCondition(n, false); err != nil {
+					klog.Errorf("failed to update networking condition when no nodeRoutes")
+				}
 			}(node)
 			continue
 		}
@@ -282,7 +284,9 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 		}
 		go func(n *v1.Node) {
 			defer wg.Done()
-			rc.updateNetworkingCondition(n, allRoutesCreated)
+			if err := rc.updateNetworkingCondition(n, allRoutesCreated); err != nil {
+				klog.Errorf("failed to update networking condition")
+			}
 		}(node)
 	}
 	wg.Wait()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- This PR adds missing error handling step for UpdateNodeStatus and updateNetworkingCondition functions. It's possible to return errors from these functions. I'm adding a log statement because I don't want to change the behavior but want to know if the errors occur.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
