### PR TITLE
kubeadm: use staticpod known tags for upgrade/init phases

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -56,14 +56,13 @@ func WriteConfigToDisk(cfg *kubeadmapi.ClusterConfiguration, kubeletDir, patches
 
 	// Apply patches to the KubeletConfiguration
 	if len(patchesDir) != 0 {
-		target := "kubeletconfiguration"
-		knownTargets := []string{target}
-		patchManager, err := patches.GetPatchManagerForPath(patchesDir, knownTargets, output)
+		patchManager, err := patches.GetPatchManagerForPath(patchesDir, patches.KnownTargets(), output)
 		if err != nil {
 			return err
 		}
+
 		patchTarget := &patches.PatchTarget{
-			Name:                      target,
+			Name:                      patches.KubeletConfiguration,
 			StrategicMergePatchObject: kubeletconfig.KubeletConfiguration{},
 			Data:                      kubeletBytes,
 		}

--- a/cmd/kubeadm/app/util/patches/patches.go
+++ b/cmd/kubeadm/app/util/patches/patches.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"sigs.k8s.io/yaml"
 )
 
@@ -74,6 +75,8 @@ func (ps *patchSet) String() string {
 	)
 }
 
+const KubeletConfiguration = "kubeletconfiguration"
+
 var (
 	pathLock  = &sync.RWMutex{}
 	pathCache = map[string]*PatchManager{}
@@ -89,7 +92,19 @@ var (
 	knownExtensions  = []string{"json", "yaml"}
 
 	regExtension = regexp.MustCompile(`.+\.(` + strings.Join(knownExtensions, "|") + `)$`)
+
+	knownTargets = []string{
+		kubeadmconstants.Etcd,
+		kubeadmconstants.KubeAPIServer,
+		kubeadmconstants.KubeControllerManager,
+		kubeadmconstants.KubeScheduler,
+		KubeletConfiguration,
+	}
 )
+
+func KnownTargets() []string {
+	return knownTargets
+}
 
 // GetPatchManagerForPath creates a patch manager that can be used to apply patches to "knownTargets".
 // "path" should contain patches that can be used to patch the "knownTargets".
@@ -97,8 +112,6 @@ var (
 func GetPatchManagerForPath(path string, knownTargets []string, output io.Writer) (*PatchManager, error) {
 	pathLock.RLock()
 	if pm, known := pathCache[path]; known {
-		// in case known targets are changed
-		pm.knownTargets = knownTargets
 		pathLock.RUnlock()
 		return pm, nil
 	}

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -168,14 +168,7 @@ func PatchStaticPod(pod *v1.Pod, patchesDir string, output io.Writer) (*v1.Pod, 
 		return pod, errors.Wrapf(err, "failed to marshal Pod manifest to YAML")
 	}
 
-	var knownTargets = []string{
-		kubeadmconstants.Etcd,
-		kubeadmconstants.KubeAPIServer,
-		kubeadmconstants.KubeControllerManager,
-		kubeadmconstants.KubeScheduler,
-	}
-
-	patchManager, err := patches.GetPatchManagerForPath(patchesDir, knownTargets, output)
+	patchManager, err := patches.GetPatchManagerForPath(patchesDir, patches.KnownTargets(), output)
 	if err != nil {
 		return pod, err
 	}


### PR DESCRIPTION
/kind bug
/release-note-none

See more in https://github.com/kubernetes/kubernetes/pull/110442#issuecomment-1150491847
```
time="21:01:54" level=debug msg="Running: docker exec kinder-patches-control-plane-1 /kinder/verify-patches.sh"
ERROR: /etc/kubernetes/manifests/etcd.yaml is not patched
ERROR: /etc/kubernetes/manifests/kube-apiserver.yaml is not patched
ERROR: /etc/kubernetes/manifests/kube-controller-manager.yaml is not patched
ERROR: /etc/kubernetes/manifests/kube-scheduler.yaml is not patched
```

fix https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-patches-latest