### PR TITLE
[WIP] Populate OpenAPI in integration tests

### DIFF
--- a/test/integration/apiserver/openapi/openapi_test.go
+++ b/test/integration/apiserver/openapi/openapi_test.go
@@ -75,7 +75,6 @@ func TestEnablingOpenAPIEnumTypes(t *testing.T) {
 
 			_, kubeConfig, tearDownFn := framework.StartTestServer(t, framework.TestServerSetup{
 				ModifyServerConfig: func(config *controlplane.Config) {
-					config.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 					config.GenericConfig.OpenAPIConfig.GetDefinitions = getDefinitionsFn
 				},
 			})

--- a/test/integration/framework/controlplane_utils.go
+++ b/test/integration/framework/controlplane_utils.go
@@ -382,6 +382,10 @@ func NewControlPlaneConfigWithOptions(opts *ControlPlaneConfigOptions) *controlp
 	genericConfig.SecureServing = &genericapiserver.SecureServingInfo{Listener: fakeLocalhost443Listener{}}
 	// if using endpoint reconciler the service subnet IP family must match the Public address
 	genericConfig.PublicAddress = netutils.ParseIPSloppy("10.1.1.1")
+
+	// Populate OpenAPI
+	genericConfig.OpenAPIConfig = DefaultOpenAPIConfig()
+
 	err = etcdOptions.ApplyWithStorageFactoryTo(storageFactory, genericConfig)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

Populate OpenAPI in integration tests so SSA can be enabled for all tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
