### PR TITLE
statefulset persistent volume claim resize

### DIFF
--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -179,11 +179,13 @@ func ValidateStatefulSetUpdate(statefulSet, oldStatefulSet *apps.StatefulSet, op
 	newStatefulSetClone.Spec.Template = oldStatefulSet.Spec.Template             // +k8s:verify-mutation:reason=clone
 	newStatefulSetClone.Spec.UpdateStrategy = oldStatefulSet.Spec.UpdateStrategy // +k8s:verify-mutation:reason=clone
 
-	oldStatefulSetPVCRequestsMap := getPVCTemplatesRequestsMap(oldStatefulSet.Spec.VolumeClaimTemplates)
-	for idx, _ := range newStatefulSetClone.Spec.VolumeClaimTemplates {
-		oldRequests, ok := oldStatefulSetPVCRequestsMap[newStatefulSetClone.Spec.VolumeClaimTemplates[idx].Name]
-		if ok {
-			newStatefulSetClone.Spec.VolumeClaimTemplates[idx].Spec.Resources.Requests = oldRequests.DeepCopy()
+	if utilfeature.DefaultFeatureGate.Enabled(features.ResizeStatefulSetPVCs) {
+		oldStatefulSetPVCRequestsMap := getPVCTemplatesRequestsMap(oldStatefulSet.Spec.VolumeClaimTemplates)
+		for idx, _ := range newStatefulSetClone.Spec.VolumeClaimTemplates {
+			oldRequests, ok := oldStatefulSetPVCRequestsMap[newStatefulSetClone.Spec.VolumeClaimTemplates[idx].Name]
+			if ok {
+				newStatefulSetClone.Spec.VolumeClaimTemplates[idx].Spec.Resources.Requests = oldRequests.DeepCopy()
+			}
 		}
 	}
 

--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -47,7 +47,7 @@ type StatefulPodControlObjectManager interface {
 	CreateClaim(claim *v1.PersistentVolumeClaim) error
 	GetClaim(namespace, claimName string) (*v1.PersistentVolumeClaim, error)
 	UpdateClaim(claim *v1.PersistentVolumeClaim) error
-	PatchClaim(namespace, claimName string, patchType types.PatchType, data []byte, opts metav1.PatchOptions) error
+	PatchClaim(namespace, claimName string, data []byte) error
 }
 
 // StatefulPodControl defines the interface that StatefulSetController uses to create, update, and delete Pods,
@@ -114,8 +114,8 @@ func (om *realStatefulPodControlObjectManager) UpdateClaim(claim *v1.PersistentV
 	return err
 }
 
-func (om *realStatefulPodControlObjectManager) PatchClaim(namespace, claimName string, patchType types.PatchType, data []byte, opts metav1.PatchOptions) error {
-	_, err := om.client.CoreV1().PersistentVolumeClaims(namespace).Patch(context.TODO(), claimName, patchType, data, opts)
+func (om *realStatefulPodControlObjectManager) PatchClaim(namespace, claimName string, data []byte) error {
+	_, err := om.client.CoreV1().PersistentVolumeClaims(namespace).Patch(context.TODO(), claimName, types.StrategicMergePatchType, data, metav1.PatchOptions{})
 	return err
 }
 

--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -783,7 +783,7 @@ func newPVC(name string) v1.PersistentVolumeClaim {
 		Spec: v1.PersistentVolumeClaimSpec{
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
-					v1.ResourceStorage: *resource.NewQuantity(1, resource.BinarySI),
+					v1.ResourceStorage: *resource.NewQuantity(2, resource.BinarySI),
 				},
 			},
 		},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -666,6 +666,9 @@ const (
 	// Allow users to recover from volume expansion failure
 	RecoverVolumeExpansionFailure featuregate.Feature = "RecoverVolumeExpansionFailure"
 
+	// TODO: add details
+	ResizeStatefulSetPVCs featuregate.Feature = "ResizeStatefulSetPVCs"
+
 	// owner: @mikedanese
 	// alpha: v1.7
 	// beta: v1.12
@@ -977,6 +980,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ReadWriteOncePod: {Default: false, PreRelease: featuregate.Alpha},
 
 	RecoverVolumeExpansionFailure: {Default: false, PreRelease: featuregate.Alpha},
+
+	ResizeStatefulSetPVCs: {Default: false, PreRelease: featuregate.Alpha},
 
 	RotateKubeletServerCertificate: {Default: true, PreRelease: featuregate.Beta},
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -348,7 +348,7 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 				rbacv1helpers.NewRule("update").Groups(appsGroup).Resources("statefulsets/finalizers").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "create", "delete", "update", "patch").Groups(legacyGroup).Resources("pods").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "create", "delete", "update", "patch", "list", "watch").Groups(appsGroup).Resources("controllerrevisions").RuleOrDie(),
-				rbacv1helpers.NewRule("get", "create").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "create", "patch").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie(),
 				eventsRule(),
 			},
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Today when resizing a persistent volume claim that's created by a stateful set template, by modifying the size in the template, the users gets back a generic error, saying that they're only allowed to modify number of replicas or statefulset spec template.
This PR allows users to also modify the request size in a PVC template of a statefulset, and it modifies the statefulset controller to be able to reconcile request size differences (i.e. patches the PVC if the size in the template changes)

In addition,

1. Those kind of changes aren't affected by rollback (i.e. if you rollback a PVC resize, it won't actually resize back)
2. If the PVC patch fails during statefulset reconciliation (e.g. the user tries to decrease the PVC size and the storage driver doesn't support that), all other changes to the statefulset are blocked from being reconciled, until the user addresses the other (e.g. increase the PVC size back up in the statefulset template)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
