### PR TITLE
Incorrect PCI device attached on ungraceful node reboot

### DIFF
--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -115,6 +115,9 @@ type ContainerManager interface {
 	// GetNodeAllocatableAbsolute returns the absolute value of Node Allocatable which is primarily useful for enforcement.
 	GetNodeAllocatableAbsolute() v1.ResourceList
 
+	// ReallocatePluginResources reallocates devices on reboot if existing allocations are found to be invalid
+	ReallocatePluginResources(pod *v1.Pod, container *v1.Container) error
+
 	// Implements the podresources Provider API for CPUs, Memory and Devices
 	podresources.CPUsProvider
 	podresources.DevicesProvider

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -660,6 +660,10 @@ func (cm *containerManagerImpl) GetResources(pod *v1.Pod, container *v1.Containe
 	return opts, nil
 }
 
+func (cm *containerManagerImpl) ReallocatePluginResources(pod *v1.Pod, container *v1.Container) error {
+	return cm.deviceManager.ReallocateDevices(pod, container)
+}
+
 func (cm *containerManagerImpl) UpdatePluginResources(node *schedulerframework.NodeInfo, attrs *lifecycle.PodAdmitAttributes) error {
 	return cm.deviceManager.UpdatePluginResources(node, attrs)
 }

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -99,6 +99,10 @@ func (cm *containerManagerStub) GetResources(pod *v1.Pod, container *v1.Containe
 	return &kubecontainer.RunContainerOptions{}, nil
 }
 
+func (cm *containerManagerStub) ReallocatePluginResources(pod *v1.Pod, container *v1.Container) error {
+	return nil
+}
+
 func (cm *containerManagerStub) UpdatePluginResources(*schedulerframework.NodeInfo, *lifecycle.PodAdmitAttributes) error {
 	return nil
 }

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -236,6 +236,10 @@ func (cm *containerManagerImpl) UpdateAllocatedDevices() {
 	return
 }
 
+func (cm *containerManagerImpl) ReallocatePluginResources(pod *v1.Pod, container *v1.Container) error {
+	return nil
+}
+
 func (cm *containerManagerImpl) GetCPUs(_, _ string) []int64 {
 	return nil
 }

--- a/pkg/kubelet/cm/devicemanager/manager_stub.go
+++ b/pkg/kubelet/cm/devicemanager/manager_stub.go
@@ -97,3 +97,7 @@ func (h *ManagerStub) ShouldResetExtendedResourceCapacity() bool {
 func (h *ManagerStub) UpdateAllocatedDevices() {
 	return
 }
+
+func (h *ManagerStub) ReallocateDevices(pod *v1.Pod, container *v1.Container) error {
+	return nil
+}

--- a/pkg/kubelet/cm/devicemanager/pod_devices.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices.go
@@ -94,6 +94,20 @@ func (pdev *podDevices) delete(pods []string) {
 	}
 }
 
+func (pdev *podDevices) deleteContainerResources(podUID string, contName string, resource string) {
+	pdev.Lock()
+	defer pdev.Unlock()
+	pod, podExists := pdev.devs[podUID]
+	if !podExists {
+		return
+	}
+	container, contExists := pod[contName]
+	if !contExists {
+		return
+	}
+	delete(container, resource)
+}
+
 // Returns list of device Ids allocated to the given pod for the given resource.
 // Returns nil if we don't have cached state for the given <podUID, resource>.
 func (pdev *podDevices) podDevices(podUID, resource string) sets.String {

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -79,6 +79,10 @@ type Manager interface {
 
 	// UpdateAllocatedDevices frees any Devices that are bound to terminated pods.
 	UpdateAllocatedDevices()
+
+	// ReallocateDevices reallocates Devices to containers on reboot if existing allocations to
+	// containers are found to be invalid
+	ReallocateDevices(pod *v1.Pod, container *v1.Container) error
 }
 
 // DeviceRunContainerOptions contains the combined container runtime settings to consume its allocated devices.

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -233,3 +233,7 @@ func (cm *FakeContainerManager) GetNodeAllocatableAbsolute() v1.ResourceList {
 	defer cm.Unlock()
 	return nil
 }
+
+func (cm *FakeContainerManager) ReallocatePluginResources(pod *v1.Pod, container *v1.Container) error {
+	return nil
+}

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -56,6 +56,7 @@ type RuntimeHelper interface {
 	// supplemental groups for the Pod. These extra supplemental groups come
 	// from annotations on persistent volumes that the pod depends on.
 	GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int64
+	ReallocateDevices(pod *v1.Pod, container *v1.Container) error
 }
 
 // ShouldContainerBeRestarted checks whether a container needs to be restarted.

--- a/pkg/kubelet/container/testing/fake_runtime_helper.go
+++ b/pkg/kubelet/container/testing/fake_runtime_helper.go
@@ -65,3 +65,7 @@ func (f *FakeRuntimeHelper) GetPodDir(podUID kubetypes.UID) string {
 func (f *FakeRuntimeHelper) GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int64 {
 	return nil
 }
+
+func (f *FakeRuntimeHelper) ReallocateDevices(pod *v1.Pod, container *v1.Container) error {
+	return nil
+}

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -517,6 +517,10 @@ func (kl *Kubelet) GenerateRunContainerOptions(pod *v1.Pod, container *v1.Contai
 	return opts, cleanupAction, nil
 }
 
+func (kl *Kubelet) ReallocateDevices(pod *v1.Pod, container *v1.Container) error {
+	return kl.containerManager.ReallocatePluginResources(pod, container)
+}
+
 var masterServices = sets.NewString("kubernetes")
 
 // getServiceEnvVarMap makes a map[string]string of env vars for services a

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -109,6 +109,14 @@ func (m *kubeGenericRuntimeManager) generatePodSandboxConfig(pod *v1.Pod, attemp
 		podSandboxConfig.Hostname = podHostname
 	}
 
+	// check if device allocations are valid, if invalid trigger new allocation
+	for _, c := range pod.Spec.Containers {
+		err := m.runtimeHelper.ReallocateDevices(pod, &c)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	logDir := BuildPodLogsDirectory(pod.Namespace, pod.Name, pod.UID)
 	podSandboxConfig.LogDirectory = logDir
 


### PR DESCRIPTION
On ungraceful node reboot in virtualized environment like openstack, the
POD continues to attach old PCI devices even though the underlying PCI
address changes.
This change addresses the above issue by detecting whether the device
allocations are valid when POD sandbox is created. On detecting invalid
device, new allocations are triggered from device manager.

Signed-off-by: Ravindra Thakur <ravindra.nath.thakur@est.tech>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #107928

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
"NONE"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
