### PR TITLE
Automated cherry pick of #110465: e2e: ensure single image for populator containers

### DIFF
--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -301,19 +301,26 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 					for i, container := range item.Spec.Template.Spec.Containers {
 						switch container.Name {
 						case "hello":
-							var found bool
 							args := []string{}
+							var foundNS, foundImage bool
 							for _, arg := range container.Args {
 								if strings.HasPrefix(arg, "--namespace=") {
 									args = append(args, fmt.Sprintf("--namespace=%s", popNamespace.Name))
-									found = true
+									foundNS = true
+								} else if strings.HasPrefix(arg, "--image-name=") {
+									args = append(args, fmt.Sprintf("--image-name=%s", container.Image))
+									foundImage = true
 								} else {
 									args = append(args, arg)
 								}
 							}
-							if !found {
+							if !foundNS {
 								args = append(args, fmt.Sprintf("--namespace=%s", popNamespace.Name))
 								framework.Logf("container name: %s", container.Name)
+							}
+							if !foundImage {
+								args = append(args, fmt.Sprintf("--image-name=%s", container.Image))
+								framework.Logf("container image: %s", container.Image)
 							}
 							container.Args = args
 							item.Spec.Template.Spec.Containers[i] = container


### PR DESCRIPTION
Cherry pick of #110465 on release-1.24.

#110465: e2e: ensure single image for populator containers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```