### PR TITLE
Do test fixture setup outside cel.UnstructuredToVal benchmark loop.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/values_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/values_test.go
@@ -621,44 +621,48 @@ func TestMapper(t *testing.T) {
 }
 
 func BenchmarkUnstructuredToVal(b *testing.B) {
+	u := []interface{}{
+		map[string]interface{}{
+			"key": "a",
+			"val": 1,
+		},
+		map[string]interface{}{
+			"key": "b",
+			"val": 2,
+		},
+		map[string]interface{}{
+			"key": "@b",
+			"val": 2,
+		},
+	}
+
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		if val := UnstructuredToVal([]interface{}{
-			map[string]interface{}{
-				"key": "a",
-				"val": 1,
-			},
-			map[string]interface{}{
-				"key": "b",
-				"val": 2,
-			},
-			map[string]interface{}{
-				"key": "@b",
-				"val": 2,
-			},
-		}, &mapListSchema); val == nil {
+		if val := UnstructuredToVal(u, &mapListSchema); val == nil {
 			b.Fatal(val)
 		}
 	}
 }
 
 func BenchmarkUnstructuredToValWithEscape(b *testing.B) {
+	u := []interface{}{
+		map[string]interface{}{
+			"key": "a.1",
+			"val": "__i.1",
+		},
+		map[string]interface{}{
+			"key": "b.1",
+			"val": 2,
+		},
+	}
+
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		if val := UnstructuredToVal([]interface{}{
-			map[string]interface{}{
-				"key": "a.1",
-				"val": "__i.1",
-			},
-			map[string]interface{}{
-				"key": "b.1",
-				"val": 2,
-			},
-		}, &mapListSchema); val == nil {
+		if val := UnstructuredToVal(u, &mapListSchema); val == nil {
 			b.Fatal(val)
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

On my machine, allocating and garbage-collecting UnstructuredToVal inputs accounts for the majority of the UnstructuredToVal benchmark runtime. This patch allocates the input fixtures once before starting the benchmark timer and re-uses the same object as input for each benchmark iteration.

```
$ go test -bench UnstructuredToVal .
goos: linux
goarch: amd64
pkg: k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel
cpu: Intel(R) Core(TM) i9-10850K CPU @ 3.60GHz
BenchmarkUnstructuredToVal-20              	 1994018	       596.1 ns/op	    1208 B/op	      11 allocs/op
BenchmarkUnstructuredToValWithEscape-20    	 2646440	       455.9 ns/op	     856 B/op	       9 allocs/op
PASS
ok  	k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel	3.564s
```

```
$ go test -bench UnstructuredToVal .
goos: linux
goarch: amd64
pkg: k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel
cpu: Intel(R) Core(TM) i9-10850K CPU @ 3.60GHz
BenchmarkUnstructuredToVal-20              	 7676374	       153.1 ns/op	     152 B/op	       4 allocs/op
BenchmarkUnstructuredToValWithEscape-20    	 7862400	       152.4 ns/op	     152 B/op	       4 allocs/op
PASS
ok  	k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel	2.788s
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
