### PR TITLE
Support more auth strategies in `kubeadm join` with discovery file

### DIFF
--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
@@ -139,6 +139,11 @@ func HasAuthenticationCredentials(config *clientcmdapi.Config) bool {
 		return true
 	}
 
+	// exec authentication
+	if authInfo.Exec != nil && len(authInfo.Exec.Command) != 0 {
+		return true
+	}
+
 	return false
 }
 

--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
@@ -144,6 +144,11 @@ func HasAuthenticationCredentials(config *clientcmdapi.Config) bool {
 		return true
 	}
 
+	// authprovider authentication
+	if authInfo.AuthProvider != nil && len(authInfo.AuthProvider.Name) != 0 {
+		return true
+	}
+
 	return false
 }
 

--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
@@ -124,7 +124,7 @@ func HasAuthenticationCredentials(config *clientcmdapi.Config) bool {
 	}
 
 	// token authentication
-	if len(authInfo.Token) != 0 {
+	if len(authInfo.Token) != 0 || len(authInfo.TokenFile) != 0 {
 		return true
 	}
 
@@ -175,6 +175,14 @@ func EnsureAuthenticationInfoAreEmbedded(config *clientcmdapi.Config) error {
 		}
 		authInfo.ClientKeyData = clientKey
 		authInfo.ClientKey = ""
+	}
+	if len(authInfo.Token) == 0 && len(authInfo.TokenFile) != 0 {
+		tokenBytes, err := os.ReadFile(authInfo.TokenFile)
+		if err != nil {
+			return errors.Wrap(err, "error while reading token file defined in kubeconfig")
+		}
+		authInfo.Token = string(tokenBytes)
+		authInfo.TokenFile = ""
 	}
 
 	return nil

--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig_test.go
@@ -322,6 +322,15 @@ func TestHasCredentials(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "authprovider authentication credentials",
+			config: &clientcmdapi.Config{
+				CurrentContext: "kubernetes",
+				Contexts:       map[string]*clientcmdapi.Context{"kubernetes": {AuthInfo: "kubernetes"}},
+				AuthInfos:      map[string]*clientcmdapi.AuthInfo{"kubernetes": {AuthProvider: &clientcmdapi.AuthProviderConfig{Name: "A"}}},
+			},
+			expected: true,
+		},
 	}
 	for _, rt := range testCases {
 		t.Run(rt.name, func(t *testing.T) {

--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig_test.go
@@ -313,6 +313,15 @@ func TestHasCredentials(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "exec authentication credentials",
+			config: &clientcmdapi.Config{
+				CurrentContext: "kubernetes",
+				Contexts:       map[string]*clientcmdapi.Context{"kubernetes": {AuthInfo: "kubernetes"}},
+				AuthInfos:      map[string]*clientcmdapi.AuthInfo{"kubernetes": {Exec: &clientcmdapi.ExecConfig{Command: "command"}}},
+			},
+			expected: true,
+		},
 	}
 	for _, rt := range testCases {
 		t.Run(rt.name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds support for the remaining client-go authentication strategies in `kubeadm join` with discovery/kubeconfig file: client-go authentication plugins (`exec`), `tokenFile`, and `authProvider`. This removes unnecessary constraints on which auth strategies can be used for `kubeadm join`, and supports use cases that require one of these auth strategies.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubeadm/issues/2708

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: Added support for additional authentication strategies in `kubeadm join` with discovery/kubeconfig file: client-go authentication plugins (`exec`), `tokenFile`, and `authProvider`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
