### PR TITLE
Update Debian base images to latest

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -90,9 +90,9 @@ readonly KUBE_RSYNC_PORT="${KUBE_RSYNC_PORT:-}"
 readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_debian_iptables_version=bullseye-v1.3.0
+readonly __default_debian_iptables_version=bullseye-v1.4.0
 readonly __default_go_runner_version=v2.3.1-go1.18.3-bullseye.0
-readonly __default_setcap_version=bullseye-v1.2.0
+readonly __default_setcap_version=bullseye-v1.3.0
 
 # These are the base images for the Docker-wrapped binaries.
 readonly KUBE_GORUNNER_IMAGE="${KUBE_GORUNNER_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/go-runner:$__default_go_runner_version}"

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -116,7 +116,7 @@ dependencies:
 
   # Base images
   - name: "registry.k8s.io/debian-base: dependents"
-    version: bullseye-v1.2.0
+    version: bullseye-v1.3.0
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: BASEIMAGE\?\=registry\.k8s\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -132,7 +132,7 @@ dependencies:
       match: BASE_IMAGE_VERSION\?=
 
   - name: "registry.k8s.io/debian-iptables: dependents"
-    version: bullseye-v1.3.0
+    version: bullseye-v1.4.0
     refPaths:
     - path: build/common.sh
       match: __default_debian_iptables_version=
@@ -208,7 +208,7 @@ dependencies:
       match: configs\[Pause\] = Config{list\.GcRegistry, "pause", "\d+\.\d+(.\d+)?"}
 
   - name: "registry.k8s.io/setcap: dependents"
-    version: bullseye-v1.2.0
+    version: bullseye-v1.3.0
     refPaths:
     - path: build/common.sh
       match: __default_setcap_version=

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -92,19 +92,19 @@ DOCKERFILE.windows = Dockerfile.windows
 DOCKERFILE := ${DOCKERFILE.${OS}}
 
 ifeq ($(ARCH),amd64)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base:bullseye-v1.2.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base:bullseye-v1.3.0
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm:bullseye-v1.2.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm:bullseye-v1.3.0
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm64:bullseye-v1.2.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm64:bullseye-v1.3.0
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-ppc64le:bullseye-v1.2.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-ppc64le:bullseye-v1.3.0
 endif
 ifeq ($(ARCH),s390x)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-s390x:bullseye-v1.2.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-s390x:bullseye-v1.3.0
 endif
 
 BASE.windows = mcr.microsoft.com/windows/nanoserver

--- a/test/conformance/image/Makefile
+++ b/test/conformance/image/Makefile
@@ -33,7 +33,7 @@ CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
 # This is defined in root Makefile, but some build contexts do not refer to them
 KUBE_BASE_IMAGE_REGISTRY?=registry.k8s.io
-BASE_IMAGE_VERSION?=bullseye-v1.2.0
+BASE_IMAGE_VERSION?=bullseye-v1.3.0
 BASEIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:${BASE_IMAGE_VERSION}
 
 # Keep debian releases (e.g. debian 11 == bullseye) consistent 

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -242,7 +242,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.29-2"}
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.2"}
-	configs[DebianIptables] = Config{list.BuildImageRegistry, "debian-iptables", "bullseye-v1.3.0"}
+	configs[DebianIptables] = Config{list.BuildImageRegistry, "debian-iptables", "bullseye-v1.4.0"}
 	configs[EchoServer] = Config{list.PromoterE2eRegistry, "echoserver", "2.4"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.4-0"}
 	configs[GlusterDynamicProvisioner] = Config{list.PromoterE2eRegistry, "glusterdynamic-provisioner", "v1.3"}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Updating base images to latest to patch a number of CVEs.

- debian-base:bullseye-v1.3.0
- debian-iptables:bullseye-v1.4.0
- setcap:bullseye-v1.3.0

This is a continuation of:
- https://github.com/kubernetes/release/pull/2518
- https://github.com/kubernetes/release/pull/2543

/sig release
/area release-eng
/area security
/area dependency

/cc https://github.com/orgs/kubernetes/teams/release-managers

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Updat debian-base, debian-iptables, and setcap images:
- debian-base:bullseye-v1.3.0
- debian-iptables:bullseye-v1.4.0
- setcap:bullseye-v1.3.0
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
