### PR TITLE
pkg/admission/storageclass: pick one storageclass conditionally if >1 present

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -776,23 +776,6 @@ func TestRetroactiveStorageClassAssignment(t *testing.T) {
 		{
 			storageClasses: []*storagev1.StorageClass{
 				makeDefaultStorageClass(classGold, &modeImmediate),
-				makeDefaultStorageClass(classSilver, &modeImmediate)},
-			tests: []controllerTest{
-				{
-					name:            "15-2 - pvc storage class is not assigned retroactively if there are multiple default storage classes",
-					initialVolumes:  novolumes,
-					expectedVolumes: novolumes,
-					initialClaims:   newClaimArray("claim15-2", "uid15-2", "1Gi", "", v1.ClaimPending, nil),
-					expectedClaims:  newClaimArray("claim15-2", "uid15-2", "1Gi", "", v1.ClaimPending, nil),
-					expectedEvents:  noevents,
-					errors:          noerrors,
-					test:            testSyncClaim,
-				},
-			},
-		},
-		{
-			storageClasses: []*storagev1.StorageClass{
-				makeDefaultStorageClass(classGold, &modeImmediate),
 				makeStorageClass(classSilver, &modeImmediate),
 			},
 			tests: []controllerTest{
@@ -838,6 +821,23 @@ func TestRetroactiveStorageClassAssignment(t *testing.T) {
 					expectedVolumes: novolumes,
 					initialClaims:   newClaimArray("claim15-5", "uid15-5", "1Gi", "", v1.ClaimPending, nil),
 					expectedClaims:  newClaimArray("claim15-5", "uid15-5", "1Gi", "", v1.ClaimPending, &classGold),
+					expectedEvents:  noevents,
+					errors:          noerrors,
+					test:            testSyncClaim,
+				},
+			},
+		},
+		{
+			storageClasses: []*storagev1.StorageClass{
+				makeDefaultStorageClass(classGold, &modeImmediate),
+				makeDefaultStorageClass(classSilver, &modeImmediate)},
+			tests: []controllerTest{
+				{
+					name:            "15-2 - pvc storage class is assigned retroactively if there are multiple default storage classes",
+					initialVolumes:  novolumes,
+					expectedVolumes: novolumes,
+					initialClaims:   newClaimArray("claim15-2", "uid15-2", "1Gi", "", v1.ClaimPending, nil),
+					expectedClaims:  newClaimArray("claim15-2", "uid15-2", "1Gi", "", v1.ClaimPending, &classGold),
 					expectedEvents:  noevents,
 					errors:          noerrors,
 					test:            testSyncClaim,

--- a/pkg/volume/util/storageclass.go
+++ b/pkg/volume/util/storageclass.go
@@ -55,6 +55,8 @@ func GetDefaultClass(lister storagev1listers.StorageClassLister) (*storagev1.Sto
 		return nil, nil
 	}
 
+	// Primary sort by creation timestamp, newest first
+	// Secondary sort by class name, ascending order
 	sort.Slice(defaultClasses, func(i, j int) bool {
 		if defaultClasses[i].CreationTimestamp.UnixNano() == defaultClasses[j].CreationTimestamp.UnixNano() {
 			return defaultClasses[i].Name < defaultClasses[j].Name

--- a/pkg/volume/util/storageclass.go
+++ b/pkg/volume/util/storageclass.go
@@ -17,9 +17,9 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
+	"sort"
+
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	storagev1listers "k8s.io/client-go/listers/storage/v1"
@@ -54,10 +54,17 @@ func GetDefaultClass(lister storagev1listers.StorageClassLister) (*storagev1.Sto
 	if len(defaultClasses) == 0 {
 		return nil, nil
 	}
+
+	sort.Slice(defaultClasses, func(i, j int) bool {
+		if defaultClasses[i].CreationTimestamp.UnixNano() == defaultClasses[j].CreationTimestamp.UnixNano() {
+			return defaultClasses[i].Name < defaultClasses[j].Name
+		}
+		return defaultClasses[i].CreationTimestamp.UnixNano() > defaultClasses[j].CreationTimestamp.UnixNano()
+	})
 	if len(defaultClasses) > 1 {
-		klog.V(4).Infof("GetDefaultClass %d defaults found", len(defaultClasses))
-		return nil, errors.NewInternalError(fmt.Errorf("%d default StorageClasses were found", len(defaultClasses)))
+		klog.V(4).Infof("%d default StorageClasses were found, choosing the newest: %s", len(defaultClasses), defaultClasses[0].Name)
 	}
+
 	return defaultClasses[0], nil
 }
 

--- a/plugin/pkg/admission/storage/storageclass/setdefault/admission.go
+++ b/plugin/pkg/admission/storage/storageclass/setdefault/admission.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+
 	"k8s.io/kubernetes/pkg/volume/util"
 
 	"k8s.io/klog/v2"

--- a/plugin/pkg/admission/storage/storageclass/setdefault/admission.go
+++ b/plugin/pkg/admission/storage/storageclass/setdefault/admission.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-
 	"k8s.io/kubernetes/pkg/volume/util"
 
 	"k8s.io/klog/v2"

--- a/plugin/pkg/admission/storage/storageclass/setdefault/admission_test.go
+++ b/plugin/pkg/admission/storage/storageclass/setdefault/admission_test.go
@@ -19,6 +19,7 @@ package setdefault
 import (
 	"context"
 	"testing"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -96,6 +97,30 @@ func TestAdmission(t *testing.T) {
 		},
 		Provisioner: "nondefault1",
 	}
+	classWithCreateTime1 := &storagev1.StorageClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "StorageClass",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "default1",
+			CreationTimestamp: metav1.NewTime(time.Date(2022, time.Month(1), 1, 0, 0, 0, 1, time.UTC)),
+			Annotations: map[string]string{
+				storageutil.IsDefaultStorageClassAnnotation: "true",
+			},
+		},
+	}
+	classWithCreateTime2 := &storagev1.StorageClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "StorageClass",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "default2",
+			CreationTimestamp: metav1.NewTime(time.Date(2022, time.Month(1), 1, 0, 0, 0, 0, time.UTC)),
+			Annotations: map[string]string{
+				storageutil.IsDefaultStorageClassAnnotation: "true",
+			},
+		},
+	}
 
 	claimWithClass := &api.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
@@ -167,13 +192,6 @@ func TestAdmission(t *testing.T) {
 			"foo",
 		},
 		{
-			"two defaults, error with PVC with class=nil",
-			[]*storagev1.StorageClass{defaultClass1, defaultClass2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
-			claimWithNoClass,
-			true,
-			"",
-		},
-		{
 			"two defaults, no modification of PVC with class=''",
 			[]*storagev1.StorageClass{defaultClass1, defaultClass2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
 			claimWithEmptyClass,
@@ -186,6 +204,20 @@ func TestAdmission(t *testing.T) {
 			claimWithClass,
 			false,
 			"foo",
+		},
+		{
+			"two defaults with same creation time, choose the one with smaller name",
+			[]*storagev1.StorageClass{defaultClass1, defaultClass2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
+			claimWithNoClass,
+			false,
+			defaultClass1.Name,
+		},
+		{
+			"two defaults, choose the one with newer creation time",
+			[]*storagev1.StorageClass{classWithCreateTime1, classWithCreateTime2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
+			claimWithNoClass,
+			false,
+			classWithCreateTime1.Name,
 		},
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
If there are two StorageClasses, currently we don't pick either of them as the default as part of admission control. This change picks one StorageClass at random.

#### Which issue(s) this PR fixes:
Fixes #110514 

Signed-off-by: danishprakash <grafitykoncept@gmail.com>

Does this PR introduce a user-facing change?
```release-note
Admission control plugin "DefaultStorageClass": If more than one StorageClass is designated as default (via the "storageclass.kubernetes.io/is-default-class" annotation), choose the newest one instead of throwing an error.
```