### PR TITLE
Add fieldmanager related function to util for easy external consumption

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -17,11 +17,9 @@ limitations under the License.
 package fieldmanager
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -36,160 +34,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/kube-openapi/pkg/util/proto"
-	prototesting "k8s.io/kube-openapi/pkg/util/proto/testing"
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/merge"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
 	"sigs.k8s.io/yaml"
 )
-
-var kubernetesSwaggerSchema = prototesting.Fake{
-	Path: filepath.Join(
-		strings.Repeat(".."+string(filepath.Separator), 8),
-		"api", "openapi-spec", "swagger.json"),
-}
-
-type fakeObjectConvertor struct {
-	converter  merge.Converter
-	apiVersion fieldpath.APIVersion
-}
-
-//nolint:staticcheck,ineffassign // SA4009 backwards compatibility
-func (c *fakeObjectConvertor) Convert(in, out, context interface{}) error {
-	if typedValue, ok := in.(*typed.TypedValue); ok {
-		var err error
-		out, err = c.converter.Convert(typedValue, c.apiVersion)
-		return err
-	}
-	return nil
-}
-
-func (c *fakeObjectConvertor) ConvertToVersion(in runtime.Object, _ runtime.GroupVersioner) (runtime.Object, error) {
-	return in, nil
-}
-
-func (c *fakeObjectConvertor) ConvertFieldLabel(_ schema.GroupVersionKind, _, _ string) (string, string, error) {
-	return "", "", errors.New("not implemented")
-}
-
-type fakeObjectDefaulter struct{}
-
-func (d *fakeObjectDefaulter) Default(in runtime.Object) {}
-
-type TestFieldManager struct {
-	fieldManager *FieldManager
-	apiVersion   string
-	emptyObj     runtime.Object
-	liveObj      runtime.Object
-}
-
-func NewDefaultTestFieldManager(gvk schema.GroupVersionKind) TestFieldManager {
-	return NewTestFieldManager(gvk, "", nil)
-}
-
-func NewSubresourceTestFieldManager(gvk schema.GroupVersionKind) TestFieldManager {
-	return NewTestFieldManager(gvk, "scale", nil)
-}
-
-func NewTestFieldManager(gvk schema.GroupVersionKind, subresource string, chainFieldManager func(Manager) Manager) TestFieldManager {
-	m := NewFakeOpenAPIModels()
-	typeConverter := NewFakeTypeConverter(m)
-	converter := newVersionConverter(typeConverter, &fakeObjectConvertor{}, gvk.GroupVersion())
-	apiVersion := fieldpath.APIVersion(gvk.GroupVersion().String())
-	objectConverter := &fakeObjectConvertor{converter, apiVersion}
-	f, err := NewStructuredMergeManager(
-		typeConverter,
-		objectConverter,
-		&fakeObjectDefaulter{},
-		gvk.GroupVersion(),
-		gvk.GroupVersion(),
-		nil,
-	)
-	if err != nil {
-		panic(err)
-	}
-	live := &unstructured.Unstructured{}
-	live.SetKind(gvk.Kind)
-	live.SetAPIVersion(gvk.GroupVersion().String())
-	f = NewLastAppliedUpdater(
-		NewLastAppliedManager(
-			NewProbabilisticSkipNonAppliedManager(
-				NewBuildManagerInfoManager(
-					NewManagedFieldsUpdater(
-						NewStripMetaManager(f),
-					), gvk.GroupVersion(), subresource,
-				), &fakeObjectCreater{gvk: gvk}, gvk, DefaultTrackOnCreateProbability,
-			), typeConverter, objectConverter, gvk.GroupVersion(),
-		),
-	)
-	if chainFieldManager != nil {
-		f = chainFieldManager(f)
-	}
-	return TestFieldManager{
-		fieldManager: NewFieldManager(f, subresource),
-		apiVersion:   gvk.GroupVersion().String(),
-		emptyObj:     live,
-		liveObj:      live.DeepCopyObject(),
-	}
-}
-
-func NewFakeTypeConverter(m proto.Models) TypeConverter {
-	tc, err := NewTypeConverter(m, false)
-	if err != nil {
-		panic(fmt.Sprintf("Failed to build TypeConverter: %v", err))
-	}
-	return tc
-}
-
-func NewFakeOpenAPIModels() proto.Models {
-	d, err := kubernetesSwaggerSchema.OpenAPISchema()
-	if err != nil {
-		panic(err)
-	}
-	m, err := proto.NewOpenAPIData(d)
-	if err != nil {
-		panic(err)
-	}
-	return m
-}
-
-func (f *TestFieldManager) APIVersion() string {
-	return f.apiVersion
-}
-
-func (f *TestFieldManager) Reset() {
-	f.liveObj = f.emptyObj.DeepCopyObject()
-}
-
-func (f *TestFieldManager) Get() runtime.Object {
-	return f.liveObj.DeepCopyObject()
-}
-
-func (f *TestFieldManager) Apply(obj runtime.Object, manager string, force bool) error {
-	out, err := f.fieldManager.Apply(f.liveObj, obj, manager, force)
-	if err == nil {
-		f.liveObj = out
-	}
-	return err
-}
-
-func (f *TestFieldManager) Update(obj runtime.Object, manager string) error {
-	out, err := f.fieldManager.Update(f.liveObj, obj, manager)
-	if err == nil {
-		f.liveObj = out
-	}
-	return err
-}
-
-func (f *TestFieldManager) ManagedFields() []metav1.ManagedFieldsEntry {
-	accessor, err := meta.Accessor(f.liveObj)
-	if err != nil {
-		panic(fmt.Errorf("couldn't get accessor: %v", err))
-	}
-
-	return accessor.GetManagedFields()
-}
 
 // TestUpdateApplyConflict tests that applying to an object, which
 // wasn't created by apply, will give conflicts

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test_utils.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test_utils.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldmanager
+
+//NOTE: The methods and functions form this file should be used only for testing, It should not be used for Production use cases.
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kube-openapi/pkg/util/proto"
+	prototesting "k8s.io/kube-openapi/pkg/util/proto/testing"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+)
+
+var kubernetesSwaggerSchema = prototesting.Fake{
+	Path: filepath.Join(
+		strings.Repeat(".."+string(filepath.Separator), 8),
+		"api", "openapi-spec", "swagger.json"),
+}
+
+type fakeObjectConvertor struct {
+	converter  merge.Converter
+	apiVersion fieldpath.APIVersion
+}
+
+//nolint:staticcheck,ineffassign // SA4009 backwards compatibility
+func (c *fakeObjectConvertor) Convert(in, out, context interface{}) error {
+	if typedValue, ok := in.(*typed.TypedValue); ok {
+		var err error
+		out, err = c.converter.Convert(typedValue, c.apiVersion)
+		return err
+	}
+	return nil
+}
+
+func (c *fakeObjectConvertor) ConvertToVersion(in runtime.Object, _ runtime.GroupVersioner) (runtime.Object, error) {
+	return in, nil
+}
+
+func (c *fakeObjectConvertor) ConvertFieldLabel(_ schema.GroupVersionKind, _, _ string) (string, string, error) {
+	return "", "", errors.New("not implemented")
+}
+
+type fakeObjectDefaulter struct{}
+
+func (d *fakeObjectDefaulter) Default(in runtime.Object) {}
+
+type TestFieldManager struct {
+	fieldManager *FieldManager
+	apiVersion   string
+	emptyObj     runtime.Object
+	liveObj      runtime.Object
+}
+
+func NewDefaultTestFieldManager(gvk schema.GroupVersionKind) TestFieldManager {
+	return NewTestFieldManager(gvk, "", nil)
+}
+
+func NewSubresourceTestFieldManager(gvk schema.GroupVersionKind) TestFieldManager {
+	return NewTestFieldManager(gvk, "scale", nil)
+}
+
+func NewTestFieldManager(gvk schema.GroupVersionKind, subresource string, chainFieldManager func(Manager) Manager) TestFieldManager {
+	m := NewFakeOpenAPIModels()
+	typeConverter := NewFakeTypeConverter(m)
+	converter := newVersionConverter(typeConverter, &fakeObjectConvertor{}, gvk.GroupVersion())
+	apiVersion := fieldpath.APIVersion(gvk.GroupVersion().String())
+	objectConverter := &fakeObjectConvertor{converter, apiVersion}
+	f, err := NewStructuredMergeManager(
+		typeConverter,
+		objectConverter,
+		&fakeObjectDefaulter{},
+		gvk.GroupVersion(),
+		gvk.GroupVersion(),
+		nil,
+	)
+	if err != nil {
+		panic(err)
+	}
+	live := &unstructured.Unstructured{}
+	live.SetKind(gvk.Kind)
+	live.SetAPIVersion(gvk.GroupVersion().String())
+	f = NewLastAppliedUpdater(
+		NewLastAppliedManager(
+			NewProbabilisticSkipNonAppliedManager(
+				NewBuildManagerInfoManager(
+					NewManagedFieldsUpdater(
+						NewStripMetaManager(f),
+					), gvk.GroupVersion(), subresource,
+				), &fakeObjectCreater{gvk: gvk}, gvk, DefaultTrackOnCreateProbability,
+			), typeConverter, objectConverter, gvk.GroupVersion(),
+		),
+	)
+	if chainFieldManager != nil {
+		f = chainFieldManager(f)
+	}
+	return TestFieldManager{
+		fieldManager: NewFieldManager(f, subresource),
+		apiVersion:   gvk.GroupVersion().String(),
+		emptyObj:     live,
+		liveObj:      live.DeepCopyObject(),
+	}
+}
+
+func NewTestFieldManagerWithOpenApiModels(models proto.Models, gvk schema.GroupVersionKind, subresource string, chainFieldManager func(Manager) Manager) TestFieldManager {
+	typeConverter := NewFakeTypeConverter(models)
+	converter := newVersionConverter(typeConverter, &fakeObjectConvertor{}, gvk.GroupVersion())
+	apiVersion := fieldpath.APIVersion(gvk.GroupVersion().String())
+	objectConverter := &fakeObjectConvertor{converter, apiVersion}
+	f, err := NewStructuredMergeManager(
+		typeConverter,
+		objectConverter,
+		&fakeObjectDefaulter{},
+		gvk.GroupVersion(),
+		gvk.GroupVersion(),
+		nil,
+	)
+	if err != nil {
+		panic(err)
+	}
+	live := &unstructured.Unstructured{}
+	live.SetKind(gvk.Kind)
+	live.SetAPIVersion(gvk.GroupVersion().String())
+	f = NewLastAppliedUpdater(
+		NewLastAppliedManager(
+			NewProbabilisticSkipNonAppliedManager(
+				NewBuildManagerInfoManager(
+					NewManagedFieldsUpdater(
+						NewStripMetaManager(f),
+					), gvk.GroupVersion(), subresource,
+				), &fakeObjectCreater{gvk: gvk}, gvk, DefaultTrackOnCreateProbability,
+			), typeConverter, objectConverter, gvk.GroupVersion(),
+		),
+	)
+	if chainFieldManager != nil {
+		f = chainFieldManager(f)
+	}
+	return TestFieldManager{
+		fieldManager: NewFieldManager(f, subresource),
+		apiVersion:   gvk.GroupVersion().String(),
+		emptyObj:     live,
+		liveObj:      live.DeepCopyObject(),
+	}
+}
+
+func NewFakeTypeConverter(m proto.Models) TypeConverter {
+	tc, err := NewTypeConverter(m, false)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to build TypeConverter: %v", err))
+	}
+	return tc
+}
+
+func NewFakeOpenAPIModels() proto.Models {
+	d, err := kubernetesSwaggerSchema.OpenAPISchema()
+	if err != nil {
+		panic(err)
+	}
+	m, err := proto.NewOpenAPIData(d)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+func (f *TestFieldManager) APIVersion() string {
+	return f.apiVersion
+}
+
+func (f *TestFieldManager) Reset() {
+	f.liveObj = f.emptyObj.DeepCopyObject()
+}
+
+func (f *TestFieldManager) Get() runtime.Object {
+	return f.liveObj.DeepCopyObject()
+}
+
+func (f *TestFieldManager) Apply(obj runtime.Object, manager string, force bool) error {
+	out, err := f.fieldManager.Apply(f.liveObj, obj, manager, force)
+	if err == nil {
+		f.liveObj = out
+	}
+	return err
+}
+
+func (f *TestFieldManager) Update(obj runtime.Object, manager string) error {
+	out, err := f.fieldManager.Update(f.liveObj, obj, manager)
+	if err == nil {
+		f.liveObj = out
+	}
+	return err
+}
+
+func (f *TestFieldManager) ManagedFields() []metav1.ManagedFieldsEntry {
+	accessor, err := meta.Accessor(f.liveObj)
+	if err != nil {
+		panic(fmt.Errorf("couldn't get accessor: %v", err))
+	}
+
+	return accessor.GetManagedFields()
+}
+
+type fakeObjectCreater struct {
+	gvk schema.GroupVersionKind
+}
+
+var _ runtime.ObjectCreater = &fakeObjectCreater{}
+
+func (f *fakeObjectCreater) New(_ schema.GroupVersionKind) (runtime.Object, error) {
+	u := unstructured.Unstructured{Object: map[string]interface{}{}}
+	u.SetAPIVersion(f.gvk.GroupVersion().String())
+	u.SetKind(f.gvk.Kind)
+	return &u, nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied_test.go
@@ -23,23 +23,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
 )
-
-type fakeObjectCreater struct {
-	gvk schema.GroupVersionKind
-}
-
-var _ runtime.ObjectCreater = &fakeObjectCreater{}
-
-func (f *fakeObjectCreater) New(_ schema.GroupVersionKind) (runtime.Object, error) {
-	u := unstructured.Unstructured{Object: map[string]interface{}{}}
-	u.SetAPIVersion(f.gvk.GroupVersion().String())
-	u.SetKind(f.gvk.Kind)
-	return &u, nil
-}
 
 func TestNoUpdateBeforeFirstApply(t *testing.T) {
 	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m Manager) Manager {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Related to https://github.com/kubernetes/client-go/issues/992

This PR is created with intention of reusing most of the function used for server side apply test. Intention is to have server side apply function available under utils so that we can make use of existing ones and also add support for external consumer

For example from client_go we can have

```
f := applypatch.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("apps/v1", "Deployment"))

patchObj := &unstructured.Unstructured{Object: map[string]interface{}{}}
if err := yaml.Unmarshal(p.patch, &patchObj.Object); err != nil {
	return nil, errors.NewBadRequest(fmt.Sprintf("error decoding YAML: %v", err))
}

obj, err := f.Apply(obj, patchObj, p.options.FieldManager, force)
if err != nil {
	return obj, err
}
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
