### PR TITLE
Automated cherry pick of #110469: add missing error handling steps

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
@@ -161,7 +161,12 @@ func (cnc *CloudNodeController) Run(stopCh <-chan struct{}) {
 	// The periodic loop for updateNodeStatus communicates with the APIServer with a worst case complexity
 	// of O(num_nodes) per cycle. These functions are justified here because these events fire
 	// very infrequently. DO NOT MODIFY this to perform frequent operations.
-	go wait.Until(func() { cnc.UpdateNodeStatus(context.TODO()) }, cnc.nodeStatusUpdateFrequency, stopCh)
+	go wait.Until(func() {
+		if err := cnc.UpdateNodeStatus(context.TODO()); err != nil {
+			klog.Errorf("failed to update node status")
+		}
+	}, cnc.nodeStatusUpdateFrequency, stopCh)
+
 	go wait.Until(cnc.runWorker, time.Second, stopCh)
 
 	<-stopCh

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
@@ -163,7 +163,7 @@ func (cnc *CloudNodeController) Run(stopCh <-chan struct{}) {
 	// very infrequently. DO NOT MODIFY this to perform frequent operations.
 	go wait.Until(func() {
 		if err := cnc.UpdateNodeStatus(context.TODO()); err != nil {
-			klog.Errorf("failed to update node status")
+			klog.Errorf("failed to update node status: %v", err)
 		}
 	}, cnc.nodeStatusUpdateFrequency, stopCh)
 

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -269,7 +269,7 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 				defer wg.Done()
 				klog.Infof("node %v has no routes assigned to it. NodeNetworkUnavailable will be set to true", n.Name)
 				if err := rc.updateNetworkingCondition(n, false); err != nil {
-					klog.Errorf("failed to update networking condition when no nodeRoutes")
+					klog.Errorf("failed to update networking condition when no nodeRoutes: %v", err)
 				}
 			}(node)
 			continue
@@ -285,7 +285,7 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 		go func(n *v1.Node) {
 			defer wg.Done()
 			if err := rc.updateNetworkingCondition(n, allRoutesCreated); err != nil {
-				klog.Errorf("failed to update networking condition")
+				klog.Errorf("failed to update networking condition: %v", err)
 			}
 		}(node)
 	}

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -268,7 +268,9 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 			go func(n *v1.Node) {
 				defer wg.Done()
 				klog.Infof("node %v has no routes assigned to it. NodeNetworkUnavailable will be set to true", n.Name)
-				rc.updateNetworkingCondition(n, false)
+				if err := rc.updateNetworkingCondition(n, false); err != nil {
+					klog.Errorf("failed to update networking condition when no nodeRoutes")
+				}
 			}(node)
 			continue
 		}
@@ -282,7 +284,9 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 		}
 		go func(n *v1.Node) {
 			defer wg.Done()
-			rc.updateNetworkingCondition(n, allRoutesCreated)
+			if err := rc.updateNetworkingCondition(n, allRoutesCreated); err != nil {
+				klog.Errorf("failed to update networking condition")
+			}
 		}(node)
 	}
 	wg.Wait()


### PR DESCRIPTION
Cherry pick of #110469 on release-1.23.

#110469: add missing error handling steps

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```