### PR TITLE
Update ineligible_endpoints.yaml

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -434,12 +434,12 @@
   reason: endpoints is currently feature gated and and will only receive e2e & conformance test in 1.25
   link: https://github.com/kubernetes/kubernetes/pull/107963
 - endpoint: readCoreV1NodeStatus
-  reason: Kubernetes distribution would reasonably not allow this actions via the API
+  reason: Kubernetes distribution would reasonably not allow this action via the API
   link: https://github.com/kubernetes/kubernetes/issues/109379
 - endpoint: replaceCoreV1NodeStatus
-  reason: Kubernetes distribution would reasonably not allow this actions via the API
+  reason: Kubernetes distribution would reasonably not allow this action via the API
   link: https://github.com/kubernetes/kubernetes/issues/109379
 - endpoint: deleteCoreV1CollectionNode
-  reason: Kubernetes distribution would reasonably not allow this actions via the API
+  reason: Kubernetes distribution would reasonably not allow this action via the API
   link: https://github.com/kubernetes/kubernetes/issues/109379 
   

--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -433,3 +433,13 @@
 - endpoint: replaceNetworkingV1NamespacedNetworkPolicyStatus
   reason: endpoints is currently feature gated and and will only receive e2e & conformance test in 1.25
   link: https://github.com/kubernetes/kubernetes/pull/107963
+- endpoint: readCoreV1NodeStatus
+  reason: Kubernetes distribution would reasonably not allow this actions via the API
+  link: https://github.com/kubernetes/kubernetes/issues/109379
+- endpoint: replaceCoreV1NodeStatus
+  reason: Kubernetes distribution would reasonably not allow this actions via the API
+  link: https://github.com/kubernetes/kubernetes/issues/109379
+- endpoint: deleteCoreV1CollectionNode
+  reason: Kubernetes distribution would reasonably not allow this actions via the API
+  link: https://github.com/kubernetes/kubernetes/issues/109379 
+  


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Add Node endpoints to list of ineligible endpoints. Was discussed in #109379 and in [SIG Node mailing group](https://groups.google.com/u/0/g/kubernetes-sig-node/c/5c00B0_ARiA).
- readCoreV1NodeStatus
- replaceCoreV1NodeStatus
- deleteCoreV1CollectionNode

**Special notes for your reviewer:**

**Which issue(s) this PR fixes:**
Fixes #109379

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig architecture
/area conformance
/sig node