### PR TITLE
Revert "Automated cherry pick of #109124: Winkernel proxier cache HNS data to improve syncProxyRules"

### DIFF
--- a/pkg/proxy/winkernel/hnsV2.go
+++ b/pkg/proxy/winkernel/hnsV2.go
@@ -67,39 +67,6 @@ func (hns hnsV2) getNetworkByName(name string) (*hnsNetworkInfo, error) {
 		remoteSubnets: remoteSubnets,
 	}, nil
 }
-
-func (hns hnsV2) getAllEndpointsByNetwork(networkName string) (map[string]*(endpointsInfo), error) {
-	hcnnetwork, err := hcn.GetNetworkByName(networkName)
-	if err != nil {
-		klog.ErrorS(err, "failed to get HNS network by name", "name", networkName)
-		return nil, err
-	}
-	endpoints, err := hcn.ListEndpointsOfNetwork(hcnnetwork.Id)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list endpoints: %w", err)
-	}
-	endpointInfos := make(map[string]*(endpointsInfo))
-	for _, ep := range endpoints {
-		// Add to map with key endpoint ID or IP address
-		// Storing this is expensive in terms of memory, however there is a bug in Windows Server 2019 that can cause two endpoints to be created with the same IP address.
-		// TODO: Store by IP only and remove any lookups by endpoint ID.
-		endpointInfos[ep.Id] = &endpointsInfo{
-			ip:         ep.IpConfigurations[0].IpAddress,
-			isLocal:    uint32(ep.Flags&hcn.EndpointFlagsRemoteEndpoint) == 0,
-			macAddress: ep.MacAddress,
-			hnsID:      ep.Id,
-			hns:        hns,
-			// only ready and not terminating endpoints were added to HNS
-			ready:       true,
-			serving:     true,
-			terminating: false,
-		}
-		endpointInfos[ep.IpConfigurations[0].IpAddress] = endpointInfos[ep.Id]
-	}
-	klog.V(3).InfoS("Queried endpoints from network", "network", networkName)
-	return endpointInfos, nil
-}
-
 func (hns hnsV2) getEndpointByID(id string) (*endpointsInfo, error) {
 	hnsendpoint, err := hcn.GetEndpointByID(id)
 	if err != nil {
@@ -143,6 +110,7 @@ func (hns hnsV2) getEndpointByIpAddress(ip string, networkName string) (*endpoin
 			}, nil
 		}
 	}
+
 	return nil, fmt.Errorf("Endpoint %v not found on network %s", ip, networkName)
 }
 func (hns hnsV2) createEndpoint(ep *endpointsInfo, networkName string) (*endpointsInfo, error) {
@@ -213,43 +181,45 @@ func (hns hnsV2) deleteEndpoint(hnsID string) error {
 	}
 	return err
 }
-
-func (hns hnsV2) getAllLoadBalancers() (map[loadBalancerIdentifier]*loadBalancerInfo, error) {
-	lbs, err := hcn.ListLoadBalancers()
-	var id loadBalancerIdentifier
+func (hns hnsV2) getLoadBalancer(endpoints []endpointsInfo, flags loadBalancerFlags, sourceVip string, vip string, protocol uint16, internalPort uint16, externalPort uint16) (*loadBalancerInfo, error) {
+	plists, err := hcn.ListLoadBalancers()
 	if err != nil {
 		return nil, err
 	}
-	loadBalancers := make(map[loadBalancerIdentifier]*(loadBalancerInfo))
-	for _, lb := range lbs {
-		portMap := lb.PortMappings[0]
-		if len(lb.FrontendVIPs) == 0 {
-			// Leave VIP uninitialized
-			id = loadBalancerIdentifier{protocol: uint16(portMap.Protocol), internalPort: portMap.InternalPort, externalPort: portMap.ExternalPort, endpointsCount: len(lb.HostComputeEndpoints)}
-		} else {
-			id = loadBalancerIdentifier{protocol: uint16(portMap.Protocol), internalPort: portMap.InternalPort, externalPort: portMap.ExternalPort, vip: lb.FrontendVIPs[0], endpointsCount: len(lb.HostComputeEndpoints)}
+
+	for _, plist := range plists {
+		if len(plist.HostComputeEndpoints) != len(endpoints) {
+			continue
 		}
-		loadBalancers[id] = &loadBalancerInfo{
-			hnsID: lb.Id,
+		// Validate if input meets any of the policy lists
+		lbPortMapping := plist.PortMappings[0]
+		if lbPortMapping.Protocol == uint32(protocol) && lbPortMapping.InternalPort == internalPort && lbPortMapping.ExternalPort == externalPort && (lbPortMapping.Flags&1 != 0) == flags.isILB {
+			if len(vip) > 0 {
+				if len(plist.FrontendVIPs) == 0 || plist.FrontendVIPs[0] != vip {
+					continue
+				}
+			} else if len(plist.FrontendVIPs) != 0 {
+				continue
+			}
+			LogJson("policyList", plist, "Found existing Hns loadbalancer policy resource", 1)
+			return &loadBalancerInfo{
+				hnsID: plist.Id,
+			}, nil
 		}
 	}
-	klog.V(3).InfoS("Queried load balancers", "count", len(lbs))
-	return loadBalancers, nil
-}
 
-func (hns hnsV2) getLoadBalancer(endpoints []endpointsInfo, flags loadBalancerFlags, sourceVip string, vip string, protocol uint16, internalPort uint16, externalPort uint16, previousLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo) (*loadBalancerInfo, error) {
-	var id loadBalancerIdentifier
+	var hnsEndpoints []hcn.HostComputeEndpoint
+	for _, ep := range endpoints {
+		endpoint, err := hcn.GetEndpointByID(ep.hnsID)
+		if err != nil {
+			return nil, err
+		}
+		hnsEndpoints = append(hnsEndpoints, *endpoint)
+	}
+
 	vips := []string{}
 	if len(vip) > 0 {
-		id = loadBalancerIdentifier{protocol: protocol, internalPort: internalPort, externalPort: externalPort, vip: vip, endpointsCount: len(endpoints)}
 		vips = append(vips, vip)
-	} else {
-		id = loadBalancerIdentifier{protocol: protocol, internalPort: internalPort, externalPort: externalPort, endpointsCount: len(endpoints)}
-	}
-
-	if lb, found := previousLoadBalancers[id]; found {
-		klog.V(1).InfoS("Found cached Hns loadbalancer policy resource", "policies", lb)
-		return lb, nil
 	}
 
 	lbPortMappingFlags := hcn.LoadBalancerPortMappingFlagsNone
@@ -300,8 +270,8 @@ func (hns hnsV2) getLoadBalancer(endpoints []endpointsInfo, flags loadBalancerFl
 		Flags: lbFlags,
 	}
 
-	for _, ep := range endpoints {
-		loadBalancer.HostComputeEndpoints = append(loadBalancer.HostComputeEndpoints, ep.hnsID)
+	for _, endpoint := range hnsEndpoints {
+		loadBalancer.HostComputeEndpoints = append(loadBalancer.HostComputeEndpoints, endpoint.Id)
 	}
 
 	lb, err := loadBalancer.Create()
@@ -310,15 +280,12 @@ func (hns hnsV2) getLoadBalancer(endpoints []endpointsInfo, flags loadBalancerFl
 		return nil, err
 	}
 
-	klog.V(1).InfoS("Created Hns loadbalancer policy resource", "loadBalancer", lb)
-	lbInfo := &loadBalancerInfo{
-		hnsID: lb.Id,
-	}
-	// Add to map of load balancers
-	previousLoadBalancers[id] = lbInfo
-	return lbInfo, err
-}
+	LogJson("hostComputeLoadBalancer", lb, "Hns loadbalancer policy resource", 1)
 
+	return &loadBalancerInfo{
+		hnsID: lb.Id,
+	}, err
+}
 func (hns hnsV2) deleteLoadBalancer(hnsID string) error {
 	lb, err := hcn.GetLoadBalancerByID(hnsID)
 	if err != nil {

--- a/pkg/proxy/winkernel/hns_test.go
+++ b/pkg/proxy/winkernel/hns_test.go
@@ -315,7 +315,6 @@ func testDeleteEndpoint(t *testing.T, hns HostNetworkService) {
 
 func testGetLoadBalancerExisting(t *testing.T, hns HostNetworkService) {
 	Network := mustTestNetwork(t)
-	lbs := make(map[loadBalancerIdentifier]*(loadBalancerInfo))
 
 	ipConfig := &hcn.IpConfig{
 		IpAddress: epIpAddress,
@@ -347,16 +346,13 @@ func testGetLoadBalancerExisting(t *testing.T, hns HostNetworkService) {
 	if err != nil {
 		t.Error(err)
 	}
-	// We populate this to ensure we test for getting existing load balancer
-	id := loadBalancerIdentifier{protocol: protocol, internalPort: internalPort, externalPort: externalPort, vip: serviceVip, endpointsCount: len(Endpoints)}
-	lbs[id] = &loadBalancerInfo{hnsID: LoadBalancer.Id}
 
 	endpoint := &endpointsInfo{
 		ip:    Endpoint.IpConfigurations[0].IpAddress,
 		hnsID: Endpoint.Id,
 	}
 	endpoints := []endpointsInfo{*endpoint}
-	lb, err := hns.getLoadBalancer(endpoints, loadBalancerFlags{}, sourceVip, serviceVip, protocol, internalPort, externalPort, lbs)
+	lb, err := hns.getLoadBalancer(endpoints, loadBalancerFlags{}, sourceVip, serviceVip, protocol, internalPort, externalPort)
 	if err != nil {
 		t.Error(err)
 	}
@@ -380,8 +376,6 @@ func testGetLoadBalancerExisting(t *testing.T, hns HostNetworkService) {
 }
 func testGetLoadBalancerNew(t *testing.T, hns HostNetworkService) {
 	Network := mustTestNetwork(t)
-	// We keep this empty to ensure we test for new load balancer creation.
-	lbs := make(map[loadBalancerIdentifier]*(loadBalancerInfo))
 
 	ipConfig := &hcn.IpConfig{
 		IpAddress: epIpAddress,
@@ -403,7 +397,7 @@ func testGetLoadBalancerNew(t *testing.T, hns HostNetworkService) {
 		hnsID: Endpoint.Id,
 	}
 	endpoints := []endpointsInfo{*endpoint}
-	lb, err := hns.getLoadBalancer(endpoints, loadBalancerFlags{}, sourceVip, serviceVip, protocol, internalPort, externalPort, lbs)
+	lb, err := hns.getLoadBalancer(endpoints, loadBalancerFlags{}, sourceVip, serviceVip, protocol, internalPort, externalPort)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -97,14 +97,6 @@ type loadBalancerInfo struct {
 	hnsID string
 }
 
-type loadBalancerIdentifier struct {
-	protocol       uint16
-	internalPort   uint16
-	externalPort   uint16
-	vip            string
-	endpointsCount int
-}
-
 type loadBalancerFlags struct {
 	isILB           bool
 	isDSR           bool
@@ -1075,32 +1067,15 @@ func (proxier *Proxier) syncProxyRules() {
 			staleServices.Insert(svcInfo.ClusterIP().String())
 		}
 	}
-	// Query HNS for endpoints and load balancers
-	queriedEndpoints, err := hns.getAllEndpointsByNetwork(hnsNetworkName)
-	if err != nil {
-		klog.ErrorS(err, "Querying HNS for endpoints failed")
-		return
-	}
-	if queriedEndpoints == nil {
-		klog.V(4).InfoS("No existing endpoints found in HNS")
-		queriedEndpoints = make(map[string]*(endpointsInfo))
-	}
-	queriedLoadBalancers, err := hns.getAllLoadBalancers()
-	if queriedLoadBalancers == nil {
-		klog.V(4).InfoS("No existing load balancers found in HNS")
-		queriedLoadBalancers = make(map[loadBalancerIdentifier]*(loadBalancerInfo))
-	}
-	if err != nil {
-		klog.ErrorS(err, "Querying HNS for load balancers failed")
-		return
-	}
+
 	if strings.EqualFold(proxier.network.networkType, NETWORK_TYPE_OVERLAY) {
-		if _, ok := queriedEndpoints[proxier.sourceVip]; !ok {
+		existingSourceVip, err := hns.getEndpointByIpAddress(proxier.sourceVip, hnsNetworkName)
+		if existingSourceVip == nil {
 			_, err = newSourceVIP(hns, hnsNetworkName, proxier.sourceVip, proxier.hostMac, proxier.nodeIP.String())
-			if err != nil {
-				klog.ErrorS(err, "Source Vip endpoint creation failed")
-				return
-			}
+		}
+		if err != nil {
+			klog.ErrorS(err, "Source Vip endpoint creation failed")
+			return
 		}
 	}
 
@@ -1120,7 +1095,7 @@ func (proxier *Proxier) syncProxyRules() {
 		}
 
 		if strings.EqualFold(proxier.network.networkType, NETWORK_TYPE_OVERLAY) {
-			serviceVipEndpoint := queriedEndpoints[svcInfo.ClusterIP().String()]
+			serviceVipEndpoint, _ := hns.getEndpointByIpAddress(svcInfo.ClusterIP().String(), hnsNetworkName)
 			if serviceVipEndpoint == nil {
 				klog.V(4).InfoS("No existing remote endpoint", "ip", svcInfo.ClusterIP().String())
 				hnsEndpoint := &endpointsInfo{
@@ -1139,9 +1114,6 @@ func (proxier *Proxier) syncProxyRules() {
 				newHnsEndpoint.refCount = proxier.endPointsRefCount.getRefCount(newHnsEndpoint.hnsID)
 				*newHnsEndpoint.refCount++
 				svcInfo.remoteEndpoint = newHnsEndpoint
-				// store newly created endpoints in queriedEndpoints
-				queriedEndpoints[newHnsEndpoint.hnsID] = newHnsEndpoint
-				queriedEndpoints[newHnsEndpoint.ip] = newHnsEndpoint
 			}
 		}
 
@@ -1162,6 +1134,7 @@ func (proxier *Proxier) syncProxyRules() {
 			if !ep.IsReady() {
 				continue
 			}
+
 			var newHnsEndpoint *endpointsInfo
 			hnsNetworkName := proxier.network.name
 			var err error
@@ -1172,19 +1145,17 @@ func (proxier *Proxier) syncProxyRules() {
 			if svcInfo.targetPort == 0 {
 				svcInfo.targetPort = int(ep.port)
 			}
-			// There is a bug in Windows Server 2019 that can cause two endpoints to be created with the same IP address, so we need to check using endpoint ID first.
-			// TODO: Remove lookup by endpoint ID, and use the IP address only, so we don't need to maintain multiple keys for lookup.
+
 			if len(ep.hnsID) > 0 {
-				newHnsEndpoint = queriedEndpoints[ep.hnsID]
+				newHnsEndpoint, err = hns.getEndpointByID(ep.hnsID)
 			}
 
 			if newHnsEndpoint == nil {
 				// First check if an endpoint resource exists for this IP, on the current host
 				// A Local endpoint could exist here already
 				// A remote endpoint was already created and proxy was restarted
-				newHnsEndpoint = queriedEndpoints[ep.IP()]
+				newHnsEndpoint, err = hns.getEndpointByIpAddress(ep.IP(), hnsNetworkName)
 			}
-
 			if newHnsEndpoint == nil {
 				if ep.GetIsLocal() {
 					klog.ErrorS(err, "Local endpoint not found: on network", "ip", ep.IP(), "hnsNetworkName", hnsNetworkName)
@@ -1234,6 +1205,7 @@ func (proxier *Proxier) syncProxyRules() {
 					}
 				}
 			}
+
 			// For Overlay networks 'SourceVIP' on an Load balancer Policy can either be chosen as
 			// a) Source VIP configured on kube-proxy (or)
 			// b) Node IP of the current node
@@ -1304,7 +1276,6 @@ func (proxier *Proxier) syncProxyRules() {
 			Enum(svcInfo.Protocol()),
 			uint16(svcInfo.targetPort),
 			uint16(svcInfo.Port()),
-			queriedLoadBalancers,
 		)
 		if err != nil {
 			klog.ErrorS(err, "Policy creation failed")
@@ -1332,7 +1303,6 @@ func (proxier *Proxier) syncProxyRules() {
 					Enum(svcInfo.Protocol()),
 					uint16(svcInfo.targetPort),
 					uint16(svcInfo.NodePort()),
-					queriedLoadBalancers,
 				)
 				if err != nil {
 					klog.ErrorS(err, "Policy creation failed")
@@ -1364,7 +1334,6 @@ func (proxier *Proxier) syncProxyRules() {
 					Enum(svcInfo.Protocol()),
 					uint16(svcInfo.targetPort),
 					uint16(svcInfo.Port()),
-					queriedLoadBalancers,
 				)
 				if err != nil {
 					klog.ErrorS(err, "Policy creation failed")
@@ -1393,7 +1362,6 @@ func (proxier *Proxier) syncProxyRules() {
 					Enum(svcInfo.Protocol()),
 					uint16(svcInfo.targetPort),
 					uint16(svcInfo.Port()),
-					queriedLoadBalancers,
 				)
 				if err != nil {
 					klog.ErrorS(err, "Policy creation failed")
@@ -1404,6 +1372,7 @@ func (proxier *Proxier) syncProxyRules() {
 			} else {
 				klog.V(3).InfoS("Skipped creating Hns LoadBalancer for loadBalancer Ingress resources", "lbIngressIP", lbIngressIP)
 			}
+
 		}
 		svcInfo.policyApplied = true
 		Log(svcInfo, "+++Policy Successfully applied for service +++", 2)

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -68,24 +68,7 @@ func (hns fakeHNS) getNetworkByName(name string) (*hnsNetworkInfo, error) {
 	}, nil
 }
 
-func (hns fakeHNS) getAllEndpointsByNetwork(networkName string) (map[string]*(endpointsInfo), error) {
-	return nil, nil
-}
-
 func (hns fakeHNS) getEndpointByID(id string) (*endpointsInfo, error) {
-	return nil, nil
-}
-
-func (hns fakeHNS) getEndpointByName(name string) (*endpointsInfo, error) {
-	return &endpointsInfo{
-		isLocal:    true,
-		macAddress: macAddress,
-		hnsID:      guid,
-		hns:        hns,
-	}, nil
-}
-
-func (hns fakeHNS) getAllLoadBalancers() (map[loadBalancerIdentifier]*loadBalancerInfo, error) {
 	return nil, nil
 }
 
@@ -119,7 +102,7 @@ func (hns fakeHNS) deleteEndpoint(hnsID string) error {
 	return nil
 }
 
-func (hns fakeHNS) getLoadBalancer(endpoints []endpointsInfo, flags loadBalancerFlags, sourceVip string, vip string, protocol uint16, internalPort uint16, externalPort uint16, previousLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo) (*loadBalancerInfo, error) {
+func (hns fakeHNS) getLoadBalancer(endpoints []endpointsInfo, flags loadBalancerFlags, sourceVip string, vip string, protocol uint16, internalPort uint16, externalPort uint16) (*loadBalancerInfo, error) {
 	return &loadBalancerInfo{
 		hnsID: guid,
 	}, nil


### PR DESCRIPTION
Reverts kubernetes/kubernetes#109985 for 1.22 branch

We have noticed this is failing on our dockershim related tests: https://testgrid.k8s.io/sig-windows-1.22-release#aks-engine-windows-dockershim-1.22 

the changeset when this started failing: https://github.com/kubernetes/kubernetes/compare/af521aa4f...6de0e5ae1

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-1-22-windows/1536521484288135168

Release-note
```release-note
NONE
```

/sig windows
/assign @marosset @daschott 