### PR TITLE
Fix grammar in K8s OpenAPI spec doc

### DIFF
--- a/api/openapi-spec/README.md
+++ b/api/openapi-spec/README.md
@@ -5,7 +5,7 @@ This folder contains an [OpenAPI specification](https://github.com/OAI/OpenAPI-S
 ## Vendor Extensions
 
 Kubernetes extends OpenAPI using these extensions. Note the version that
-extensions has been added.
+extensions have been added.
 
 ### `x-kubernetes-group-version-kind`
 


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
This PR addresses the grammatical error in the Kubernetes OpenAPI Spec documentation.

#### Original Statement
Note the version that extensions **has** been added.

#### Updated Statement
Note the version that extensions **have** been added.