### PR TITLE
kubeadm: ensure kubelet config patch results are in YAML

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/config_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/config_test.go
@@ -17,6 +17,10 @@ limitations under the License.
 package kubelet
 
 import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -70,5 +74,32 @@ func TestCreateConfigMapRBACRules(t *testing.T) {
 
 	if err := createConfigMapRBACRules(client); err != nil {
 		t.Errorf("createConfigMapRBACRules: unexpected error %v", err)
+	}
+}
+
+func TestApplyKubeletConfigPatches(t *testing.T) {
+	var (
+		input          = []byte("bar: 0\nfoo: 0\n")
+		patch          = []byte("bar: 1\n")
+		expectedOutput = []byte("bar: 1\nfoo: 0\n")
+	)
+
+	dir, err := ioutil.TempDir("", "patches")
+	if err != nil {
+		t.Fatalf("could not create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "kubeletconfiguration.yaml"), patch, 0644); err != nil {
+		t.Fatalf("could not write patch file: %v", err)
+	}
+
+	output, err := applyKubeletConfigPatches(input, dir, ioutil.Discard)
+	if err != nil {
+		t.Fatalf("could not apply patch: %v", err)
+	}
+
+	if !bytes.Equal(output, expectedOutput) {
+		t.Fatalf("expected output:\n%s\ngot\n%s\n", expectedOutput, output)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Once we patch a kubelet configuration file, the patched output
is in JSON. Make sure it's converted back to YAML, given
the kubelet config in the cluster and on disk is always in YAML.

Add unit test for the new function applyKubeletConfigPatches()

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/pull/2710
xref https://github.com/kubernetes/kubeadm/issues/1682

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
