### PR TITLE
Replaces path.Operation with filepath.Operation

### DIFF
--- a/pkg/util/removeall/removeall_test.go
+++ b/pkg/util/removeall/removeall_test.go
@@ -19,7 +19,6 @@ package removeall
 import (
 	"errors"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -117,11 +116,11 @@ func TestRemoveAllOneFilesystem(t *testing.T) {
 		for _, item := range test.items {
 			if strings.HasSuffix(item, "/") {
 				item = strings.TrimRight(item, "/")
-				if err = os.Mkdir(path.Join(tmpDir, item), 0777); err != nil {
+				if err = os.Mkdir(filepath.Join(tmpDir, item), 0777); err != nil {
 					t.Fatalf("error creating %s: %v", item, err)
 				}
 			} else {
-				f, err := os.Create(path.Join(tmpDir, item))
+				f, err := os.Create(filepath.Join(tmpDir, item))
 				if err != nil {
 					t.Fatalf("error creating %s: %v", item, err)
 				}
@@ -237,11 +236,11 @@ func TestRemoveDirsOneFilesystem(t *testing.T) {
 		for _, item := range test.items {
 			if strings.HasSuffix(item, "/") {
 				item = strings.TrimRight(item, "/")
-				if err = os.Mkdir(path.Join(tmpDir, item), 0777); err != nil {
+				if err = os.Mkdir(filepath.Join(tmpDir, item), 0777); err != nil {
 					t.Fatalf("error creating %s: %v", item, err)
 				}
 			} else {
-				f, err := os.Create(path.Join(tmpDir, item))
+				f, err := os.Create(filepath.Join(tmpDir, item))
 				if err != nil {
 					t.Fatalf("error creating %s: %v", item, err)
 				}

--- a/pkg/volume/util/hostutil/hostutil_windows.go
+++ b/pkg/volume/util/hostutil/hostutil_windows.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -72,7 +71,7 @@ func getDeviceNameFromMount(mounter mount.Interface, mountPath, pluginMountDir s
 		}
 	}
 
-	return path.Base(mountPath), nil
+	return filepath.Base(mountPath), nil
 }
 
 // DeviceOpened determines if the device is in use elsewhere


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

/sig windows
/priority important-soon
/milestone v1.25

#### What this PR does / why we need it:

The path module has a few different functions: Clean, Split, Join, Ext, Dir, Base, IsAbs. These functions do not take into account the OS-specific path separator, meaning that they won't behave as intended on Windows.

For example, Dir is supposed to return all but the last element of the path. For the path ``C:\some\dir\somewhere``, it is supposed to return ``C:\some\dir\``, however, it returns ``.``.

Instead of these functions, the ones in filepath should be used instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #110600

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
