### PR TITLE
Fix winkernel proxy regression failing to query v1 endpoints created by dockershim CNI

### DIFF
--- a/pkg/proxy/winkernel/hnsV2.go
+++ b/pkg/proxy/winkernel/hnsV2.go
@@ -75,27 +75,29 @@ func (hns hnsV2) getAllEndpointsByNetwork(networkName string) (map[string]*(endp
 		klog.ErrorS(err, "failed to get HNS network by name", "name", networkName)
 		return nil, err
 	}
-	endpoints, err := hcn.ListEndpointsOfNetwork(hcnnetwork.Id)
+	endpoints, err := hcn.ListEndpoints()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list endpoints: %w", err)
 	}
 	endpointInfos := make(map[string]*(endpointsInfo))
 	for _, ep := range endpoints {
-		// Add to map with key endpoint ID or IP address
-		// Storing this is expensive in terms of memory, however there is a bug in Windows Server 2019 that can cause two endpoints to be created with the same IP address.
-		// TODO: Store by IP only and remove any lookups by endpoint ID.
-		endpointInfos[ep.Id] = &endpointsInfo{
-			ip:         ep.IpConfigurations[0].IpAddress,
-			isLocal:    uint32(ep.Flags&hcn.EndpointFlagsRemoteEndpoint) == 0,
-			macAddress: ep.MacAddress,
-			hnsID:      ep.Id,
-			hns:        hns,
-			// only ready and not terminating endpoints were added to HNS
-			ready:       true,
-			serving:     true,
-			terminating: false,
+		if strings.EqualFold(ep.HostComputeNetwork, hcnnetwork.Id) {
+			// Add to map with key endpoint ID or IP address
+			// Storing this is expensive in terms of memory, however there is a bug in Windows Server 2019 that can cause two endpoints to be created with the same IP address.
+			// TODO: Store by IP only and remove any lookups by endpoint ID.
+			endpointInfos[ep.Id] = &endpointsInfo{
+				ip:         ep.IpConfigurations[0].IpAddress,
+				isLocal:    uint32(ep.Flags&hcn.EndpointFlagsRemoteEndpoint) == 0,
+				macAddress: ep.MacAddress,
+				hnsID:      ep.Id,
+				hns:        hns,
+				// only ready and not terminating endpoints were added to HNS
+				ready:       true,
+				serving:     true,
+				terminating: false,
+			}
+			endpointInfos[ep.IpConfigurations[0].IpAddress] = endpointInfos[ep.Id]
 		}
-		endpointInfos[ep.IpConfigurations[0].IpAddress] = endpointInfos[ep.Id]
 	}
 	klog.V(3).InfoS("Queried endpoints from network", "network", networkName)
 	return endpointInfos, nil


### PR DESCRIPTION
### What happened?

https://github.com/kubernetes/kubernetes/pull/109124 has introduced a regression for Kubernetes clusters using dockershim as the runtime that invoke CNIs using the v1 HNS APIs. Winkernel proxier is unable to retrieve endpoints due to this hcsshim call failing to retrieve v1 HNS endpoints: https://pkg.go.dev/github.com/Microsoft/hcsshim@v0.8.22/hcn#ListEndpointsOfNetwork

This causes service proxy rules to not be created, as local endpoints would not be found.

Clusters using the containerD runtime and CNIs that leverage HCN APIs are not impacted.

Source:
We have noticed this is failing on our dockershim related tests: https://testgrid.k8s.io/sig-windows-1.22-release#aks-engine-windows-dockershim-1.22
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-1-22-windows/1536521484288135168

### What did you expect to happen?

Service proxy rules are created for all expected services

### How can we reproduce it (as minimally and precisely as possible)?

Create a Kubernetes cluster with Windows and dockershim runtime

### Anything else we need to know?

This issue does not occur on clusters with the containerD runtime (that use v2 CNI workflow creating HCN endpoints instead of HNS endpoints) 

### Kubernetes version

1.23, 1.22

### Cloud provider

Reproduced on Azure, but all are impacted.

### OS version

Windows Server 2019

### Install tools

<details>

</details>


### Container runtime (CRI) and version (if applicable)

Dockershim

### Related plugins (CNI, CSI, ...) and versions (if applicable)

Azure CNI + dockershim. Any CNI creating v1 HNS endpoints will be impacted.