### PR TITLE
Adding windows clusterIP service test and statefulset test

### DIFF
--- a/test/e2e/windows/service.go
+++ b/test/e2e/windows/service.go
@@ -37,17 +37,56 @@ var _ = SIGDescribe("Services", func() {
 	f := framework.NewDefaultFramework("services")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var cs clientset.Interface
+	var (
+		cs      clientset.Interface
+		testPod *v1.Pod
+	)
 
 	ginkgo.BeforeEach(func() {
 		//Only for Windows containers
 		e2eskipper.SkipUnlessNodeOSDistroIs("windows")
 		cs = f.ClientSet
+
+		//using hybrid_network methods
+		ginkgo.By("creating Windows testing Pod")
+		testPod = createTestPod(f, windowsBusyBoximage, windowsOS)
+		testPod = f.PodClient().CreateSync(testPod)
+
+		ginkgo.By("verifying that pod has the correct nodeSelector")
+		// Admission controllers may sometimes do the wrong thing
+		framework.ExpectEqual(testPod.Spec.NodeSelector["kubernetes.io/os"], "windows")
 	})
+
+	ginkgo.It("should be able to create a functioning Cluster IP service for Windows", func() {
+		serviceName := "clusterip-test"
+		ns := f.Namespace.Name
+		jig := e2eservice.NewTestJig(cs, ns, serviceName)
+
+		ginkgo.By("creating service " + serviceName + " with type=ClusterIP in namespace " + ns)
+		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeClusterIP
+		})
+		framework.ExpectNoError(err)
+
+		svcIP := svc.Spec.ClusterIP
+
+		ginkgo.By("creating Pod to be part of service " + serviceName)
+		// tweak the Jig to use windows...
+		windowsNodeSelectorTweak := func(rc *v1.ReplicationController) {
+			rc.Spec.Template.Spec.NodeSelector = map[string]string{
+				"kubernetes.io/os": "windows",
+			}
+		}
+		_, err = jig.Run(windowsNodeSelectorTweak)
+		framework.ExpectNoError(err)
+
+		ginkgo.By(fmt.Sprintf("checking connectivity Pod to curl http://%s", svcIP))
+		assertConsistentConnectivity(f, testPod.ObjectMeta.Name, windowsOS, windowsCheck(fmt.Sprintf("http://%s", svcIP)))
+	})
+
 	ginkgo.It("should be able to create a functioning NodePort service for Windows", func() {
 		serviceName := "nodeport-test"
 		ns := f.Namespace.Name
-
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 		nodeIP, err := e2enode.PickIP(jig.Client)
 		framework.ExpectNoError(err)
@@ -69,15 +108,6 @@ var _ = SIGDescribe("Services", func() {
 		}
 		_, err = jig.Run(windowsNodeSelectorTweak)
 		framework.ExpectNoError(err)
-
-		//using hybrid_network methods
-		ginkgo.By("creating Windows testing Pod")
-		testPod := createTestPod(f, windowsBusyBoximage, windowsOS)
-		testPod = f.PodClient().CreateSync(testPod)
-
-		ginkgo.By("verifying that pod has the correct nodeSelector")
-		// Admission controllers may sometimes do the wrong thing
-		framework.ExpectEqual(testPod.Spec.NodeSelector["kubernetes.io/os"], "windows")
 
 		ginkgo.By(fmt.Sprintf("checking connectivity Pod to curl http://%s:%d", nodeIP, nodePort))
 		assertConsistentConnectivity(f, testPod.ObjectMeta.Name, windowsOS, windowsCheck(fmt.Sprintf("http://%s", net.JoinHostPort(nodeIP, strconv.Itoa(nodePort)))))

--- a/test/e2e/windows/statefulset.go
+++ b/test/e2e/windows/statefulset.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package windows
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	e2estatefulset "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = SIGDescribe("StatefulSets", func() {
+	f := framework.NewDefaultFramework("statefulsets")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var ns string
+	var c clientset.Interface
+
+	ginkgo.BeforeEach(func() {
+		e2eskipper.SkipUnlessNodeOSDistroIs("windows")
+		c = f.ClientSet
+		ns = f.Namespace.Name
+	})
+
+	ssName := "windows-ss"
+	labels := map[string]string{
+		"app": "agnhost",
+	}
+	headlessSvcName := "svc"
+
+	ginkgo.It("should have the ability to delete and recreate pods for StatefulSets which preserve their ability to serve as routed endpoints for services", func() {
+
+		ginkgo.By("Creating service " + headlessSvcName + " in namespace " + ns)
+		headlessService := e2eservice.CreateServiceSpec(headlessSvcName, "", true, labels)
+		_, err := c.CoreV1().Services(ns).Create(context.TODO(), headlessService, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("creating a statefulset")
+		ss := newStatefulSet(ssName, ns, headlessSvcName, 3, labels)
+		_, err = c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		e2estatefulset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
+
+		ginkgo.By("getting that endpoints of the statefulset")
+		pods1 := e2estatefulset.GetPodList(c, ss)
+		gomega.Expect(pods1.Items).To(gomega.HaveLen(int(*ss.Spec.Replicas)))
+
+		ginkgo.By("deleting one of the endpoints of the statefulset")
+		err = c.CoreV1().Pods(ns).Delete(context.TODO(), ssName+"-1", metav1.DeleteOptions{})
+		framework.ExpectNoError(err)
+		time.Sleep(10 * time.Second)
+		err = e2epod.WaitForPodNameRunningInNamespace(c, ssName+"-1", ns)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("checking the length of the endpoints of the statefulset")
+		pods2 := e2estatefulset.GetPodList(c, ss)
+		gomega.Expect(pods2.Items).To(gomega.HaveLen(int(*ss.Spec.Replicas)))
+
+	})
+})
+
+func newStatefulSet(name, ns, governingSvcName string, replicas int32, labels map[string]string) *appsv1.StatefulSet {
+
+	return &appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StatefulSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Replicas: func(i int32) *int32 { return &i }(replicas),
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      labels,
+					Annotations: map[string]string{},
+				},
+				Spec: v1.PodSpec{
+					NodeSelector: map[string]string{
+						"kubernetes.io/os": "windows",
+					},
+					Containers: []v1.Container{
+						{
+							Name:  "agnhost",
+							Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						},
+					},
+				},
+			},
+			ServiceName: governingSvcName,
+		},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adding clusterIP service test and statefulset test to e2e/windows to increase the test coverage of windows operational readiness test.

- clusterIP service test case is testing the following items in [KEP-2578](https://github.com/knabben/enhancements/blob/3ee6784895d650caa99e3ad23a361465478effb5/keps/sig-windows/2578-windows-conformance/README.md#basic-networking):

`Ability to access Linux container IPs by service IP from Windows containers`
`Ability to access Windows container IPs by service IP from Linux containers`

- statefulset test case is testing the following items in [KEP-2578](https://github.com/knabben/enhancements/blob/3ee6784895d650caa99e3ad23a361465478effb5/keps/sig-windows/2578-windows-conformance/README.md#basic-networking):
`Ability to delete and recreate pods for StatefulSets which preserve their ability to serve as routed endpoints for services, while also having unchanging IP addresses.`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/2578-windows-conformance
```
