### PR TITLE
Automated cherry pick of #109580: e2e: add storage capability for offline volume expansion

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -147,6 +147,7 @@ func InitHostPathCSIDriver() storageframework.TestDriver {
 		storageframework.CapBlock:               true,
 		storageframework.CapPVCDataSource:       true,
 		storageframework.CapControllerExpansion: true,
+		storageframework.CapOfflineExpansion:    true,
 		storageframework.CapOnlineExpansion:     true,
 		storageframework.CapSingleNodeVolume:    true,
 
@@ -810,6 +811,7 @@ func InitGcePDCSIDriver() storageframework.TestDriver {
 				storageframework.CapVolumeLimits:        false,
 				storageframework.CapTopology:            true,
 				storageframework.CapControllerExpansion: true,
+				storageframework.CapOfflineExpansion:    true,
 				storageframework.CapOnlineExpansion:     true,
 				storageframework.CapNodeExpansion:       true,
 				storageframework.CapSnapshotDataSource:  true,

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1251,6 +1251,7 @@ func InitGcePdDriver() storageframework.TestDriver {
 				storageframework.CapExec:                true,
 				storageframework.CapMultiPODs:           true,
 				storageframework.CapControllerExpansion: true,
+				storageframework.CapOfflineExpansion:    true,
 				storageframework.CapOnlineExpansion:     true,
 				storageframework.CapNodeExpansion:       true,
 				// GCE supports volume limits, but the test creates large
@@ -1702,6 +1703,7 @@ func InitAwsDriver() storageframework.TestDriver {
 				storageframework.CapMultiPODs:           true,
 				storageframework.CapControllerExpansion: true,
 				storageframework.CapNodeExpansion:       true,
+				storageframework.CapOfflineExpansion:    true,
 				storageframework.CapOnlineExpansion:     true,
 				// AWS supports volume limits, but the test creates large
 				// number of volumes and times out test suites.

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -203,11 +203,18 @@ func loadDriverDefinition(filename string) (*driverDefinition, error) {
 		return nil, fmt.Errorf("%s: %w", filename, err)
 	}
 
-	// to ensure backward compatibility if controller expansion is enabled then set online expansion to true
+	// To ensure backward compatibility: if controller expansion is enabled,
+	// then set both online and offline expansion to true
 	if _, ok := driver.GetDriverInfo().Capabilities[storageframework.CapOnlineExpansion]; !ok &&
 		driver.GetDriverInfo().Capabilities[storageframework.CapControllerExpansion] {
 		caps := driver.DriverInfo.Capabilities
 		caps[storageframework.CapOnlineExpansion] = true
+		driver.DriverInfo.Capabilities = caps
+	}
+	if _, ok := driver.GetDriverInfo().Capabilities[storageframework.CapOfflineExpansion]; !ok &&
+		driver.GetDriverInfo().Capabilities[storageframework.CapControllerExpansion] {
+		caps := driver.DriverInfo.Capabilities
+		caps[storageframework.CapOfflineExpansion] = true
 		driver.DriverInfo.Capabilities = caps
 	}
 	return driver, nil

--- a/test/e2e/storage/framework/testdriver.go
+++ b/test/e2e/storage/framework/testdriver.go
@@ -166,10 +166,18 @@ const (
 	CapRWX                 Capability = "RWX"                 // support ReadWriteMany access modes
 	CapControllerExpansion Capability = "controllerExpansion" // support volume expansion for controller
 	CapNodeExpansion       Capability = "nodeExpansion"       // support volume expansion for node
-	CapOnlineExpansion     Capability = "onlineExpansion"     // supports online volume expansion
-	CapVolumeLimits        Capability = "volumeLimits"        // support volume limits (can be *very* slow)
-	CapSingleNodeVolume    Capability = "singleNodeVolume"    // support volume that can run on single node (like hostpath)
-	CapTopology            Capability = "topology"            // support topology
+
+	// offlineExpansion and onlineExpansion both default to true when
+	// controllerExpansion is true. The only reason to set offlineExpansion
+	// to false is when a CSI driver can only expand a volume while it's
+	// attached to a pod. Conversely, onlineExpansion can be set to false
+	// if the driver can only expand a volume while it is detached.
+	CapOfflineExpansion Capability = "offlineExpansion" // supports offline volume expansion (default: true)
+	CapOnlineExpansion  Capability = "onlineExpansion"  // supports online volume expansion (default: true)
+
+	CapVolumeLimits     Capability = "volumeLimits"     // support volume limits (can be *very* slow)
+	CapSingleNodeVolume Capability = "singleNodeVolume" // support volume that can run on single node (like hostpath)
+	CapTopology         Capability = "topology"         // support topology
 
 	// The driver publishes storage capacity information: when the storage class
 	// for dynamic provisioning exists, the driver is expected to provide

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -177,6 +177,10 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			init()
 			defer cleanup()
 
+			if !driver.GetDriverInfo().Capabilities[storageframework.CapOfflineExpansion] {
+				e2eskipper.Skipf("Driver %q does not support offline volume expansion - skipping", driver.GetDriverInfo().Name)
+			}
+
 			var err error
 			ginkgo.By("Creating a pod with dynamically provisioned volume")
 			podConfig := e2epod.Config{


### PR DESCRIPTION
Cherry pick of #109580 on release-1.24.

#109580: e2e: add storage capability for offline volume expansion

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

IMO, this change is:
- low-risk to backport, it just adds an extra e2e test parameter with no behavior change by default
- relatively valuable in that it enables e2e testing for CSI drivers that do not support offline expansion, without disabling the other expansion tests for that driver