### PR TITLE
remove OptionsExternalVersion

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -252,7 +252,6 @@ func handleInternal(storage map[string]rest.Storage, admissionControl admission.
 		group := template
 		group.Root = "/" + grouplessPrefix
 		group.GroupVersion = grouplessGroupVersion
-		group.OptionsExternalVersion = &grouplessGroupVersion
 		group.Serializer = codecs
 		if _, err := (&group).InstallREST(container); err != nil {
 			panic(fmt.Sprintf("unable to install container %s: %v", group.GroupVersion, err))
@@ -264,7 +263,6 @@ func handleInternal(storage map[string]rest.Storage, admissionControl admission.
 		group := template
 		group.Root = "/" + prefix
 		group.GroupVersion = testGroupVersion
-		group.OptionsExternalVersion = &testGroupVersion
 		group.Serializer = codecs
 		if _, err := (&group).InstallREST(container); err != nil {
 			panic(fmt.Sprintf("unable to install container %s: %v", group.GroupVersion, err))
@@ -276,7 +274,6 @@ func handleInternal(storage map[string]rest.Storage, admissionControl admission.
 		group := template
 		group.Root = "/" + prefix
 		group.GroupVersion = newGroupVersion
-		group.OptionsExternalVersion = &newGroupVersion
 		group.Serializer = codecs
 		if _, err := (&group).InstallREST(container); err != nil {
 			panic(fmt.Sprintf("unable to install container %s: %v", group.GroupVersion, err))
@@ -3303,8 +3300,7 @@ func TestParentResourceIsRequired(t *testing.T) {
 
 		Admit: admissionControl,
 
-		GroupVersion:           newGroupVersion,
-		OptionsExternalVersion: &newGroupVersion,
+		GroupVersion: newGroupVersion,
 
 		Serializer:     codecs,
 		ParameterCodec: parameterCodec,
@@ -3335,8 +3331,7 @@ func TestParentResourceIsRequired(t *testing.T) {
 
 		Admit: admissionControl,
 
-		GroupVersion:           newGroupVersion,
-		OptionsExternalVersion: &newGroupVersion,
+		GroupVersion: newGroupVersion,
 
 		Serializer:     codecs,
 		ParameterCodec: parameterCodec,
@@ -4382,10 +4377,9 @@ func TestXGSubresource(t *testing.T) {
 
 		Admit: admissionControl,
 
-		Root:                   "/" + prefix,
-		GroupVersion:           testGroupVersion,
-		OptionsExternalVersion: &testGroupVersion,
-		Serializer:             codecs,
+		Root:         "/" + prefix,
+		GroupVersion: testGroupVersion,
+		Serializer:   codecs,
 	}
 
 	if _, err := (&group).InstallREST(container); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
@@ -56,11 +56,6 @@ type APIGroupVersion struct {
 	// GroupVersion is the external group version
 	GroupVersion schema.GroupVersion
 
-	// OptionsExternalVersion controls the Kubernetes APIVersion used for common objects in the apiserver
-	// schema like api.Status, api.DeleteOptions, and metav1.ListOptions. Other implementors may
-	// define a version "v1beta1" but want to use the Kubernetes "v1" internal objects. If
-	// empty, defaults to GroupVersion.
-	OptionsExternalVersion *schema.GroupVersion
 	// MetaGroupVersion defaults to "meta.k8s.io/v1" and is the scheme group version used to decode
 	// common API implementations like ListOptions. Future changes will allow this to vary by group
 	// version (for when the inevitable meta/v2 group emerges).

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -190,11 +190,6 @@ func GetResourceKind(groupVersion schema.GroupVersion, storage rest.Storage, typ
 func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storage, ws *restful.WebService) (*metav1.APIResource, *storageversion.ResourceInfo, error) {
 	admit := a.group.Admit
 
-	optionsExternalVersion := a.group.GroupVersion
-	if a.group.OptionsExternalVersion != nil {
-		optionsExternalVersion = *a.group.OptionsExternalVersion
-	}
-
 	resource, subresource, err := splitSubresource(path)
 	if err != nil {
 		return nil, nil, err
@@ -280,19 +275,20 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		versionedList = indirectArbitraryPointer(versionedListPtr)
 	}
 
-	versionedListOptions, err := a.group.Creater.New(optionsExternalVersion.WithKind("ListOptions"))
+	builtinGroupVersion := &schema.GroupVersion{Version: "v1"}
+	versionedListOptions, err := a.group.Creater.New(builtinGroupVersion.WithKind("ListOptions"))
 	if err != nil {
 		return nil, nil, err
 	}
-	versionedCreateOptions, err := a.group.Creater.New(optionsExternalVersion.WithKind("CreateOptions"))
+	versionedCreateOptions, err := a.group.Creater.New(builtinGroupVersion.WithKind("CreateOptions"))
 	if err != nil {
 		return nil, nil, err
 	}
-	versionedPatchOptions, err := a.group.Creater.New(optionsExternalVersion.WithKind("PatchOptions"))
+	versionedPatchOptions, err := a.group.Creater.New(builtinGroupVersion.WithKind("PatchOptions"))
 	if err != nil {
 		return nil, nil, err
 	}
-	versionedUpdateOptions, err := a.group.Creater.New(optionsExternalVersion.WithKind("UpdateOptions"))
+	versionedUpdateOptions, err := a.group.Creater.New(builtinGroupVersion.WithKind("UpdateOptions"))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -301,7 +297,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 	var versionedDeleterObject interface{}
 	deleteReturnsDeletedObject := false
 	if isGracefulDeleter {
-		versionedDeleteOptions, err = a.group.Creater.New(optionsExternalVersion.WithKind("DeleteOptions"))
+		versionedDeleteOptions, err = a.group.Creater.New(builtinGroupVersion.WithKind("DeleteOptions"))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -312,7 +308,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		}
 	}
 
-	versionedStatusPtr, err := a.group.Creater.New(optionsExternalVersion.WithKind("Status"))
+	versionedStatusPtr, err := a.group.Creater.New(builtinGroupVersion.WithKind("Status"))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -332,7 +328,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		getOptionsInternalKind = getOptionsInternalKinds[0]
 		versionedGetOptions, err = a.group.Creater.New(a.group.GroupVersion.WithKind(getOptionsInternalKind.Kind))
 		if err != nil {
-			versionedGetOptions, err = a.group.Creater.New(optionsExternalVersion.WithKind(getOptionsInternalKind.Kind))
+			versionedGetOptions, err = a.group.Creater.New(builtinGroupVersion.WithKind(getOptionsInternalKind.Kind))
 			if err != nil {
 				return nil, nil, err
 			}
@@ -366,7 +362,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			connectOptionsInternalKind = connectOptionsInternalKinds[0]
 			versionedConnectOptions, err = a.group.Creater.New(a.group.GroupVersion.WithKind(connectOptionsInternalKind.Kind))
 			if err != nil {
-				versionedConnectOptions, err = a.group.Creater.New(optionsExternalVersion.WithKind(connectOptionsInternalKind.Kind))
+				versionedConnectOptions, err = a.group.Creater.New(builtinGroupVersion.WithKind(connectOptionsInternalKind.Kind))
 				if err != nil {
 					return nil, nil, err
 				}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -64,12 +64,6 @@ type APIGroupInfo struct {
 	PrioritizedVersions []schema.GroupVersion
 	// Info about the resources in this group. It's a map from version to resource to the storage.
 	VersionedResourcesStorageMap map[string]map[string]rest.Storage
-	// OptionsExternalVersion controls the APIVersion used for common objects in the
-	// schema like api.Status, api.DeleteOptions, and metav1.ListOptions. Other implementors may
-	// define a version "v1beta1" but want to use the Kubernetes "v1" internal objects.
-	// If nil, defaults to groupMeta.GroupVersion.
-	// TODO: Remove this when https://github.com/kubernetes/kubernetes/issues/19018 is fixed.
-	OptionsExternalVersion *schema.GroupVersion
 	// MetaGroupVersion defaults to "meta.k8s.io/v1" and is the scheme group version used to decode
 	// common API implementations like ListOptions. Future changes will allow this to vary by group
 	// version (for when the inevitable meta/v2 group emerges).
@@ -658,9 +652,6 @@ func (s *GenericAPIServer) installAPIResources(apiPrefix string, apiGroupInfo *A
 		if err != nil {
 			return err
 		}
-		if apiGroupInfo.OptionsExternalVersion != nil {
-			apiGroupVersion.OptionsExternalVersion = apiGroupInfo.OptionsExternalVersion
-		}
 		apiGroupVersion.OpenAPIModels = openAPIModels
 
 		if openAPIModels != nil && utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
@@ -822,11 +813,9 @@ func NewDefaultAPIGroupInfo(group string, scheme *runtime.Scheme, parameterCodec
 	return APIGroupInfo{
 		PrioritizedVersions:          scheme.PrioritizedVersionsForGroup(group),
 		VersionedResourcesStorageMap: map[string]map[string]rest.Storage{},
-		// TODO unhardcode this.  It was hardcoded before, but we need to re-evaluate
-		OptionsExternalVersion: &schema.GroupVersion{Version: "v1"},
-		Scheme:                 scheme,
-		ParameterCodec:         parameterCodec,
-		NegotiatedSerializer:   codecs,
+		Scheme:                       scheme,
+		ParameterCodec:               parameterCodec,
+		NegotiatedSerializer:         codecs,
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -194,10 +194,9 @@ func TestInstallAPIGroups(t *testing.T) {
 					"noverbs": &testNoVerbsStorage{Version: gv.Version},
 				},
 			},
-			OptionsExternalVersion: &schema.GroupVersion{Version: "v1"},
-			ParameterCodec:         parameterCodec,
-			NegotiatedSerializer:   codecs,
-			Scheme:                 scheme,
+			ParameterCodec:       parameterCodec,
+			NegotiatedSerializer: codecs,
+			Scheme:               scheme,
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR simply respects an old [TODO comment](https://github.com/kubernetes/kubernetes/blob/10c37c5942399e55290c88606243e638d92008a4/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go#L71)'s wishes and removes `OptionsExternalVersion`. Instead of allowing this to be configurable, the builtin group version is used instead unconditionally (previously the default).

Years ago it seemed the intention was to remove this: https://github.com/smarterclayton/kubernetes/commit/96a1674da2399623a53207421851d744d40f6aa2#r15308641

but unfortunately a dependency from `ThirdPartyResourceVersion` [prevented removal](https://github.com/kubernetes/kubernetes/issues/19434#issuecomment-174740531). 

Now that I'm not seeing that dependency anywhere I figure it would be nice to remove unnecessary code.

#### Which issue(s) this PR fixes:

Fixes #19434

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
