### PR TITLE
nrt-api: Update publishing-bot rules.yaml

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1922,6 +1922,17 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/pod-security-admission
   library: true
+- destination: noderesourcetopology-api
+  branches:
+  - name: master
+    dependencies:
+    - repository: code-generator
+      branch: master
+      dir: staging/src/k8s.io/noderesourcetopology-api
+    source:
+       branch: master
+       dir: staging/src/k8s.io/noderesourcetopology-api
+  library: true
 recursive-delete-patterns:
 - BUILD
 - '*/BUILD'


### PR DESCRIPTION
rules.yaml captures the dependencies of code in the staging repo and is used by
the publishing-bot to publish the staging repository.

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Updates publishing-bot rules to ensure noderesourcetopology-api staging repo is published.

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Depends on https://github.com/kubernetes/kubernetes/pull/110252. This change is to ensure that testing in CI (specifically the pull-publishing-bot-validate test) runs with the right rules.yaml configuration. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*

`Noderesourcetopology- api: Repo Bootstrap` PR
-->
#### Special notes for your reviewer:

Please refer to [this](https://github.com/kubernetes/kubernetes/pull/110252#issuecomment-1157812889)  comment for context.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
TODO

This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->