### PR TITLE
kubeadm: fix error adding extra prefix unix://

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
@@ -101,12 +101,19 @@ func runKubeletConfigPhase() func(c workflow.RunData) error {
 		// TODO: this workaround can be removed in 1.25 once all user node sockets have a URL scheme:
 		// https://github.com/kubernetes/kubeadm/issues/2426
 		var missingURLScheme bool
+		// Handle a dupliate prefix URL scheme in the Node CRI socket.
+		// Older versions of kubeadm(v1.24.0~1) upgrade may add one or two extra prefix `unix://`
+		// TODO: this fix can be removed in 1.26 once all user node sockets have a correct URL scheme:
+		// https://github.com/kubernetes/kubeadm/issues/2426
+		var dupURLScheme bool
+
 		nro := &kubeadmapi.NodeRegistrationOptions{}
 		if !dryRun {
 			if err := configutil.GetNodeRegistration(data.KubeConfigPath(), data.Client(), nro); err != nil {
 				return errors.Wrap(err, "could not retrieve the node registration options for this node")
 			}
 			missingURLScheme = !strings.HasPrefix(nro.CRISocket, kubeadmapiv1.DefaultContainerRuntimeURLScheme)
+			dupURLScheme = strings.HasPrefix(nro.CRISocket, kubeadmapiv1.DefaultContainerRuntimeURLScheme+"://"+kubeadmapiv1.DefaultContainerRuntimeURLScheme+"://")
 		}
 		if missingURLScheme {
 			if !dryRun {
@@ -117,6 +124,17 @@ func runKubeletConfigPhase() func(c workflow.RunData) error {
 				}
 			} else {
 				fmt.Println("[upgrade] Would update the node CRI socket path to include an URL scheme")
+			}
+		} else if dupURLScheme {
+			if !dryRun {
+				newSocket := strings.ReplaceAll(nro.CRISocket, kubeadmapiv1.DefaultContainerRuntimeURLScheme+"://", "")
+				newSocket = kubeadmapiv1.DefaultContainerRuntimeURLScheme + "://" + newSocket
+				klog.V(2).Infof("ensuring that Node %q has a CRI socket annotation with correct URL scheme %q", nro.Name, newSocket)
+				if err := patchnodephase.AnnotateCRISocket(data.Client(), nro.Name, newSocket); err != nil {
+					return errors.Wrapf(err, "error updating the CRI socket for Node %q", nro.Name)
+				}
+			} else {
+				fmt.Println("[upgrade] Would update the node CRI socket path to remove dup URL scheme prefix")
 			}
 		}
 

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
@@ -106,7 +106,7 @@ func runKubeletConfigPhase() func(c workflow.RunData) error {
 			if err := configutil.GetNodeRegistration(data.KubeConfigPath(), data.Client(), nro); err != nil {
 				return errors.Wrap(err, "could not retrieve the node registration options for this node")
 			}
-			missingURLScheme = strings.HasPrefix(nro.CRISocket, kubeadmapiv1.DefaultContainerRuntimeURLScheme)
+			missingURLScheme = !strings.HasPrefix(nro.CRISocket, kubeadmapiv1.DefaultContainerRuntimeURLScheme)
 		}
 		if missingURLScheme {
 			if !dryRun {

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -35,11 +35,13 @@ import (
 	"k8s.io/klog/v2"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+	patchnodephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/patchnode"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
@@ -210,6 +212,23 @@ func enforceRequirements(flags *applyPlanFlags, args []string, dryRun bool, upgr
 	// If the user told us to print this information out; do it!
 	if flags.printConfig {
 		printConfiguration(&cfg.ClusterConfiguration, os.Stdout)
+	}
+
+	// Handle a dupliate prefix URL scheme in the Node CRI socket.
+	// Older versions of kubeadm(v1.24.0~2) upgrade may add one or two extra prefix `unix://`
+	dupURLScheme := strings.HasPrefix(cfg.NodeRegistration.CRISocket, kubeadmapiv1.DefaultContainerRuntimeURLScheme+"://"+kubeadmapiv1.DefaultContainerRuntimeURLScheme+"://")
+	if dupURLScheme {
+		socket := strings.ReplaceAll(cfg.NodeRegistration.CRISocket, kubeadmapiv1.DefaultContainerRuntimeURLScheme+"://", "")
+		cfg.NodeRegistration.CRISocket = kubeadmapiv1.DefaultContainerRuntimeURLScheme + "://" + socket
+		hostname, err := os.Hostname()
+		if err != nil {
+			return nil, nil, nil, errors.Wrapf(err, "failed to get hostname")
+		}
+		klog.V(2).Infof("ensuring that Node %q has a CRI socket annotation with correct URL scheme %q", hostname, cfg.NodeRegistration.CRISocket)
+		if err := patchnodephase.AnnotateCRISocket(client, hostname, cfg.NodeRegistration.CRISocket); err != nil {
+			return nil, nil, nil, errors.Wrapf(err, "error updating the CRI socket for Node %q", cfg.NodeRegistration.CRISocket)
+		}
+
 	}
 
 	// Use a real version getter interface that queries the API server, the kubeadm client and the Kubernetes CI system for latest versions


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

The code in v1.25 was removed. So only v1.24 needs to be fixed.

#### What this PR does / why we need it:

After upgrade to v1.24.0, a node annotation was changed to `unix://unix://unix:///run/containerd/containerd.sock`

Then `kubeadm upgrade apply v1.24.1` failed.
> [ERROR ImagePull]: failed to pull image k8s-gcr.m.daocloud.io/coredns:v1.8.6: output: time="2022-06-17T09:22:51+08:00" level=fatal msg="connect: connect endpoint 'unix://unix://unix:///run/containerd/containerd.sock', make sure you are running as root and the endpoint has been started: context deadline exceeded"


#### Which issue(s) this PR fixes:
xref #107295 & https://github.com/kubernetes/kubeadm/issues/2426

#### Special notes for your reviewer:
https://github.com/pacoxu/kubeadm-operator/issues/82

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: fix error adding extra prefix unix:// to CRI endpoints that were missing URL scheme
```
