### PR TITLE
test/e2e/network: fix a bug in the hostport e2e test

### DIFF
--- a/test/images/agnhost/netexec/netexec.go
+++ b/test/images/agnhost/netexec/netexec.go
@@ -634,7 +634,7 @@ func redirectHandler(w http.ResponseWriter, r *http.Request) {
 // udp server supports the hostName, echo and clientIP commands.
 func startUDPServer(address string, udpPort int) {
 	serverAddress, err := net.ResolveUDPAddr("udp", net.JoinHostPort(address, strconv.Itoa(udpPort)))
-	assertNoError(err, fmt.Sprintf("failed to resolve UDP address for port %d", sctpPort))
+	assertNoError(err, fmt.Sprintf("failed to resolve UDP address for port %d", udpPort))
 	serverConn, err := net.ListenUDP("udp", serverAddress)
 	assertNoError(err, fmt.Sprintf("failed to create listener for UDP address %v", serverAddress))
 	defer serverConn.Close()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The hostport e2e test (sonobuoy run --e2e-focus 'validates that there is no
conflict between pods with same hostPort but different hostIP and protocol')
checks, in particular, that two pods with the same hostPort, the same hostIP,
but different L4 protocols can coexist on one node.

In order to do this, the test creates two pods with the same hostIP:hostPort,
one TCP-based, another UDP-based. However, both pods listen on both protocols:

    netexec --http-port=8080 --udp-port=8080

This can happen that a CNI which doesn't distinguish between TCP and UDP
hostPorts forwards all traffic, TCP or UDP, to the same pod. As this pod
listens on both protocols it will reply to both requests, and the test
will think that everything works properly while the second pod is indeed
disconnected. Fix this by executing different commands in different pods:

    TCP: netexec --http-port=8080 --udp-port=-1
    UDP: netexec --http-port=8008 --udp-port=8080

The TCP pod now doesn't listen on UDP, and the UDP pod doesn't listen on TCP on
the target hostPort. The UDP pod still needs to listen on TCP on another port
so that a pod readiness check can be made.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```