### PR TITLE
client-go: Modify FakeEvents to Work Event Sink started with `""` namespace

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event_expansion.go
@@ -17,7 +17,7 @@ limitations under the License.
 package fake
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,9 +26,11 @@ import (
 )
 
 func (c *FakeEvents) CreateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
-	action := core.NewRootCreateAction(eventsResource, event)
+	var action core.CreateActionImpl
 	if c.ns != "" {
 		action = core.NewCreateAction(eventsResource, c.ns, event)
+	} else {
+		action = core.NewCreateAction(eventsResource, event.GetNamespace(), event)
 	}
 	obj, err := c.Fake.Invokes(action, event)
 	if obj == nil {
@@ -40,9 +42,11 @@ func (c *FakeEvents) CreateWithEventNamespace(event *v1.Event) (*v1.Event, error
 
 // Update replaces an existing event. Returns the copy of the event the server returns, or an error.
 func (c *FakeEvents) UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
-	action := core.NewRootUpdateAction(eventsResource, event)
+	var action core.UpdateActionImpl
 	if c.ns != "" {
 		action = core.NewUpdateAction(eventsResource, c.ns, event)
+	} else {
+		action = core.NewUpdateAction(eventsResource, event.GetNamespace(), event)
 	}
 	obj, err := c.Fake.Invokes(action, event)
 	if obj == nil {
@@ -57,9 +61,11 @@ func (c *FakeEvents) UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error
 func (c *FakeEvents) PatchWithEventNamespace(event *v1.Event, data []byte) (*v1.Event, error) {
 	// TODO: Should be configurable to support additional patch strategies.
 	pt := types.StrategicMergePatchType
-	action := core.NewRootPatchAction(eventsResource, event.Name, pt, data)
+	var action core.PatchActionImpl
 	if c.ns != "" {
 		action = core.NewPatchAction(eventsResource, c.ns, event.Name, pt, data)
+	} else {
+		action = core.NewPatchAction(eventsResource, event.GetNamespace(), event.Name, pt, data)
 	}
 	obj, err := c.Fake.Invokes(action, event)
 	if obj == nil {
@@ -71,9 +77,11 @@ func (c *FakeEvents) PatchWithEventNamespace(event *v1.Event, data []byte) (*v1.
 
 // Search returns a list of events matching the specified object.
 func (c *FakeEvents) Search(scheme *runtime.Scheme, objOrRef runtime.Object) (*v1.EventList, error) {
-	action := core.NewRootListAction(eventsResource, eventsKind, metav1.ListOptions{})
+	var action core.ListActionImpl
 	if c.ns != "" {
 		action = core.NewListAction(eventsResource, eventsKind, c.ns, metav1.ListOptions{})
+	} else {
+		action = core.NewListAction(eventsResource, eventsKind, v1.NamespaceDefault, metav1.ListOptions{})
 	}
 	obj, err := c.Fake.Invokes(action, &v1.EventList{})
 	if obj == nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Current implementation of the `fake_event_expansion.go` doesn't account for cases where the Event Broadcaster is started via `broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})` and the recorder generated events are name-spaced. This causes the `fixture.go` to detect a namespace mismatch and trigger an error instead of actually recording the event accordingly.

This PR changes the behavior of  for the `fake_event_expansion.go` handle the namespaced event operation.

In case if the `FakeEvents` is created with namespace `""` then we default to using the `event.Namespace` for Create/Update/Patch operation.  While search defaults to `v1.NamespaceAll` to avoid additional type conversion to get the namespace from `objOrRef runtime.Object`


#### Which issue(s) this PR fixes:
Fixes #110335 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
