### PR TITLE
Include event request body in EventString output

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/format.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/format.go
@@ -60,8 +60,8 @@ func EventString(ev *auditinternal.Event) string {
 		ip = ev.SourceIPs[0]
 	}
 
-	return fmt.Sprintf("%s AUDIT: id=%q stage=%q ip=%q method=%q user=%q groups=%q as=%q asgroups=%q user-agent=%q namespace=%q uri=%q response=\"%s\"",
-		ev.RequestReceivedTimestamp.Format(time.RFC3339Nano), ev.AuditID, ev.Stage, ip, ev.Verb, username, groups, asuser, asgroups, ev.UserAgent, namespace, ev.RequestURI, response)
+	return fmt.Sprintf("%s AUDIT: id=%q stage=%q ip=%q method=%q user=%q groups=%q as=%q asgroups=%q user-agent=%q namespace=%q uri=%q requestbody=\"%s\" response=\"%s\"",
+		ev.RequestReceivedTimestamp.Format(time.RFC3339Nano), ev.AuditID, ev.Stage, ip, ev.Verb, username, groups, asuser, asgroups, ev.UserAgent, namespace, ev.RequestURI, ev.RequestObject.Raw[:], response)
 }
 
 func auditStringSlice(inList []string) string {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
#### What this PR does / why we need it:
When an event's request body cannot be correctly marshaled to JSON (typically because a string value was not correctly quoted by whoever sent the request), HandlePluginError (in k8s.io/apiserver/pkg/audit/metrics.go) is called, and the event is excluded from the audit log. Currently, it's hard to see what actually caused the problem because the request body (that led to the auditing error, and also to a 400 Bad Request response being sent) isn't logged anywhere. For example:

```
E0616 21:02:21.958464       1 metrics.go:109] Error in audit plugin 'log' affecting 1 audit events: json: error calling MarshalJSON for type *runtime.Unknown: invalid character 'G' after object key:value pair
Impacted events:
2022-06-16T21:02:21.950119014Z AUDIT: id="07d7f02d-c83e-49b8-af0c-2edd71e1e254" stage="ResponseComplete" ip="16.143.22.193" method="patch" user="kubernetes-admin" groups="\"system:masters\",\"system:authenticated\"" as="<self>" asgroups="<lookup>" namespace="hpecp" uri="/apis/hpecp.hpe.com/v1/namespaces/hpecp/hpecptenants/hpecp-tenant-5" response="400"
```

With this change, the requestbody is included in the EventString representation used by HandlePluginError, and appears in the kube-apiserver debug log. In this example, it can now be seen that the unquoted value **550Gi** caused the problem:

```
E0620 15:59:45.102298       1 metrics.go:109] Error in audit plugin 'log' affecting 1 audit events: json: error calling MarshalJSON for type *runtime.Unknown: invalid character 'G' after object key:value pair
Impacted events:
2022-06-20T15:59:45.095268549Z AUDIT: id="736f47f4-d6af-44bb-a24b-e634228dd236" stage="ResponseComplete" ip="16.143.22.193" method="patch" user="kubernetes-admin" groups="\"system:masters\",\"system:authenticated\"" as="<self>" asgroups="<lookup>" namespace="hpecp" uri="/apis/hpecp.hpe.com/v1/namespaces/hpecp/hpecptenants/hpecp-tenant-6" requestbody="[{"op" : "add", "path" : "/spec/resourcesQuota", "value" : {"limits":{"cpu":"600","nvidia.com/gpu":"2","memory":"100Gi","ephemeral-storage":"200Gi"}}},{"op" : "add", "path" : "/spec/storageQuota", "value" : 550Gi}]" response="400"
```
#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/110671
#### Special notes for your reviewer:
#### Does this PR introduce a user-facing change?
```release-note
If kube-apiserver receives an API request whose JSON body is incorrectly formatted (typically with missing quotes around a value), the audit log plugin will encounter an error when trying to marshal that JSON body, and the expected audit event is not logged. To help with debugging this scenario, the offending request body is now included in the EventString written to the kube-apiserver debug log.
```