### PR TITLE
add some uts of diff.go

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/diff/diff_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/diff/diff_test.go
@@ -27,3 +27,26 @@ func TestStringDiff(t *testing.T) {
 		t.Errorf("diff returned %v", diff)
 	}
 }
+
+func TestLegacyDiff(t *testing.T) {
+	equalResult := legacyDiff(true, true)
+	diffResult := legacyDiff(true, "string")
+
+	if equalResult != "" {
+		t.Errorf("two param type are same, result should be empty, but now the result is: %v", equalResult)
+	}
+
+	expectDiffResult := "  interface{}(\n- \tbool(true),\n+ \tstring(\"string\"),\n  )\n"
+	if diffResult != expectDiffResult {
+		t.Errorf("two param type are not same, expect result is: %v, but now the result is: %v", expectDiffResult, diffResult)
+	}
+}
+
+func TestObjectGoPrintSideBySide(t *testing.T) {
+	result := ObjectGoPrintSideBySide("a", "ab")
+	expectResult := "(string) (len=1) \"a\" (string) (len=2) \"ab\"\n                     \n"
+
+	if expectResult != result {
+		t.Errorf("expectResult is: %v, but now the result is: %v", expectResult, result)
+	}
+}


### PR DESCRIPTION
What type of PR is this?
add some uts of diff.go

Add one of the following kinds:
/kind cleanup

What this PR does / why we need it:
LegacyDiff and ObjectGoPrintSideBySide methods do not have ut tests, so i add it.

Which issue(s) this PR fixes:
add ut test

Special notes for your reviewer:
Does this PR introduce a user-facing change?
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: