### PR TITLE
Fix iSCSI over ipv6

### DIFF
--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -406,10 +406,16 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 				klog.Errorf("iscsi: could not find transport name in iface %s", b.Iface)
 				return "", fmt.Errorf("could not parse iface file for %s", b.Iface)
 			}
+
+			addr := tp
+			if strings.HasPrefix(tp, "[") {
+				// Delete [] from IP address, links in /dev/disk/by-path do not have it.
+				addr = strings.NewReplacer("[", "", "]", "").Replace(tp)
+			}
 			if iscsiTransport == "tcp" {
-				devicePath = strings.Join([]string{"/dev/disk/by-path/ip", tp, "iscsi", b.Iqn, "lun", b.Lun}, "-")
+				devicePath = strings.Join([]string{"/dev/disk/by-path/ip", addr, "iscsi", b.Iqn, "lun", b.Lun}, "-")
 			} else {
-				devicePath = strings.Join([]string{"/dev/disk/by-path/pci", "*", "ip", tp, "iscsi", b.Iqn, "lun", b.Lun}, "-")
+				devicePath = strings.Join([]string{"/dev/disk/by-path/pci", "*", "ip", addr, "iscsi", b.Iqn, "lun", b.Lun}, "-")
 			}
 
 			if exist := waitForPathToExist(&devicePath, deviceDiscoveryTimeout, iscsiTransport); !exist {

--- a/pkg/volume/iscsi/iscsi_util_test.go
+++ b/pkg/volume/iscsi/iscsi_util_test.go
@@ -68,6 +68,11 @@ func TestExtractPortalAndIqn(t *testing.T) {
 	if err != nil || portal != "127.0.0.1:3260" || iqn != "eui.02004567A425678D" {
 		t.Errorf("extractPortalAndIqn: got %v %s %s", err, portal, iqn)
 	}
+	devicePath = "[2001:db8:0:f101::1]:3260-iqn.2014-12.com.example:test.tgt00-lun-0"
+	portal, iqn, err = extractPortalAndIqn(devicePath)
+	if err != nil || portal != "[2001:db8:0:f101::1]:3260" || iqn != "iqn.2014-12.com.example:test.tgt00" {
+		t.Errorf("extractPortalAndIqn: got %v %s %s", err, portal, iqn)
+	}
 }
 
 func TestRemoveDuplicate(t *testing.T) {

--- a/pkg/volume/util/device_util_linux.go
+++ b/pkg/volume/util/device_util_linux.go
@@ -22,6 +22,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -199,12 +200,11 @@ func (handler *deviceHandler) GetISCSIPortalHostMapForTarget(targetIqn string) (
 
 				// Add entries to the map for both the current and persistent portals
 				// pointing to the SCSI host for those connections
-				portal := strings.TrimSpace(string(addr)) + ":" +
-					strings.TrimSpace(string(port))
+				// JoinHostPort will add `[]` around IPv6 addresses.
+				portal := net.JoinHostPort(strings.TrimSpace(string(addr)), strings.TrimSpace(string(port)))
 				portalHostMap[portal] = hostNumber
 
-				persistentPortal := strings.TrimSpace(string(persistentAddr)) + ":" +
-					strings.TrimSpace(string(persistentPort))
+				persistentPortal := net.JoinHostPort(strings.TrimSpace(string(persistentAddr)), strings.TrimSpace(string(persistentPort)))
 				portalHostMap[persistentPortal] = hostNumber
 			}
 		}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Addresses in the Kubernetes API objects (PV, Pod) have `[]` around IPv6 addresses, while addresses in `/dev/` and `/sys/` don't have them.

Add/remove `[]` as needed.


#### Which issue(s) this PR fixes:
Fixes #110687

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed mounting of iSCSI volumes over IPv6 networks.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

cc @bswartz @rootfs for iSCSI knowledge. I tested it on Fedora and RHEL with a single PV, but I am not an iSCSI expert.