### PR TITLE
enable ServiceIPStaticSubrange beta by default

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -983,7 +983,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	SeccompDefault: {Default: false, PreRelease: featuregate.Alpha},
 
-	ServiceIPStaticSubrange: {Default: false, PreRelease: featuregate.Beta},
+	ServiceIPStaticSubrange: {Default: true, PreRelease: featuregate.Beta},
 
 	ServiceInternalTrafficPolicy: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION

/kind feature

```release-note
enable the beta feature ServiceIPStaticSubrange by default
```

xref : https://github.com/kubernetes/enhancements/pull/3413

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3070-reserved-service-ip-range
- [Blog]: https://kubernetes.io/blog/2022/05/23/service-ip-dynamic-and-static-allocation/
```
