### PR TITLE
Handle TaintExternalCloudProvider in node-lifecycle-controller

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5147,6 +5147,8 @@ const (
 	NodePIDPressure NodeConditionType = "PIDPressure"
 	// NodeNetworkUnavailable means that network for the node is not correctly configured.
 	NodeNetworkUnavailable NodeConditionType = "NetworkUnavailable"
+	// NodeCloudProviderUninitialized means that cloud provider has not initialized the node.
+	NodeCloudProviderUninitialized NodeConditionType = "Uninitialized"
 )
 
 // NodeCondition contains condition information for a node.

--- a/staging/src/k8s.io/cloud-provider/api/well_known_taints.go
+++ b/staging/src/k8s.io/cloud-provider/api/well_known_taints.go
@@ -18,9 +18,8 @@ package api
 
 const (
 	// TaintExternalCloudProvider sets this taint on a node to mark it as unusable,
-	// when kubelet is started with the "external" cloud provider, until a controller
-	// from the cloud-controller-manager intitializes this node, and then removes
-	// the taint
+	// when kubelet is started with the "external" cloud provider, until cloud-node-manager
+	// intitializes this node, and then node-lifecycle-controller removes the taint
 	TaintExternalCloudProvider = "node.cloudprovider.kubernetes.io/uninitialized"
 
 	// TaintNodeShutdown when node is shutdown in external cloud provider


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
-->

#### What this PR does / why we need it:
This PR introduces a new stage("Initialized") during the whole node lifecycle. Other in cluster components can notify node-lifecycle-controller through node condition whether the initialization tasks have been finished, so that this controller will go ahead and finish the initialization by removing the corresponding taint.

One use case is that, currently we are initializing nodes in azure-cloud-node-manager by removing [a well known taint](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/vendor/k8s.io/cloud-provider/api/well_known_taints.go#L24). However, azure-cloud-node-manager is a DaemonSet which runs on node pool nodes. DaemonSets usually should not own the permission to modify/delete node taints. Granting DaemonSets permission to modify/delete taints can cause security concerns. For example, attackers who already have control over the credentials used by such DaemonSets can delete the taints on specific nodes and thus schedule more powerful Pods onto them. This PR provides a work around for that.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
