### PR TITLE
Add unit tests for grace period in killContainer func

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -466,3 +466,167 @@ func TestRestartCountByLogDir(t *testing.T) {
 		assert.Equal(t, count, tc.restartCount, "count %v should equal restartCount %v", count, tc.restartCount)
 	}
 }
+
+func TestKillContainerGracePeriod(t *testing.T) {
+
+	shortGracePeriod := int64(10)
+	mediumGracePeriod := int64(30)
+	longGracePeriod := int64(60)
+
+	tests := []struct {
+		name                string
+		pod                 *v1.Pod
+		reason              containerKillReason
+		expectedGracePeriod int64
+	}{
+		{
+			name: "default termination grace period",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{Containers: []v1.Container{{Name: "foo"}}},
+			},
+			reason:              reasonUnknown,
+			expectedGracePeriod: int64(2),
+		},
+		{
+			name: "use pod termination grace period",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers:                    []v1.Container{{Name: "foo"}},
+					TerminationGracePeriodSeconds: &longGracePeriod,
+				},
+			},
+			reason:              reasonUnknown,
+			expectedGracePeriod: longGracePeriod,
+		},
+		{
+			name: "liveness probe overrides pod termination grace period",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "foo", LivenessProbe: &v1.Probe{TerminationGracePeriodSeconds: &shortGracePeriod},
+					}},
+					TerminationGracePeriodSeconds: &longGracePeriod,
+				},
+			},
+			reason:              reasonLivenessProbe,
+			expectedGracePeriod: shortGracePeriod,
+		},
+		{
+			name: "startup probe overrides pod termination grace period",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "foo", StartupProbe: &v1.Probe{TerminationGracePeriodSeconds: &shortGracePeriod},
+					}},
+					TerminationGracePeriodSeconds: &longGracePeriod,
+				},
+			},
+			reason:              reasonStartupProbe,
+			expectedGracePeriod: shortGracePeriod,
+		},
+		{
+			name: "startup probe overrides pod termination grace period, probe period > pod period",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "foo", StartupProbe: &v1.Probe{TerminationGracePeriodSeconds: &longGracePeriod},
+					}},
+					TerminationGracePeriodSeconds: &shortGracePeriod,
+				},
+			},
+			reason:              reasonStartupProbe,
+			expectedGracePeriod: longGracePeriod,
+		},
+		{
+			name: "liveness probe overrides pod termination grace period, probe period > pod period",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "foo", LivenessProbe: &v1.Probe{TerminationGracePeriodSeconds: &longGracePeriod},
+					}},
+					TerminationGracePeriodSeconds: &shortGracePeriod,
+				},
+			},
+			reason:              reasonLivenessProbe,
+			expectedGracePeriod: longGracePeriod,
+		},
+		{
+			name: "non-liveness probe failure, use pod termination grace period",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "foo", LivenessProbe: &v1.Probe{TerminationGracePeriodSeconds: &shortGracePeriod},
+					}},
+					TerminationGracePeriodSeconds: &longGracePeriod,
+				},
+			},
+			reason:              reasonUnknown,
+			expectedGracePeriod: longGracePeriod,
+		},
+		{
+			name: "non-startup probe failure, use pod termination grace period",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "foo", StartupProbe: &v1.Probe{TerminationGracePeriodSeconds: &shortGracePeriod},
+					}},
+					TerminationGracePeriodSeconds: &longGracePeriod,
+				},
+			},
+			reason:              reasonUnknown,
+			expectedGracePeriod: longGracePeriod,
+		},
+		{
+			name: "all three grace periods set, use pod termination grace period",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:          "foo",
+						StartupProbe:  &v1.Probe{TerminationGracePeriodSeconds: &shortGracePeriod},
+						LivenessProbe: &v1.Probe{TerminationGracePeriodSeconds: &mediumGracePeriod},
+					}},
+					TerminationGracePeriodSeconds: &longGracePeriod,
+				},
+			},
+			reason:              reasonUnknown,
+			expectedGracePeriod: longGracePeriod,
+		},
+		{
+			name: "all three grace periods set, use startup termination grace period",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:          "foo",
+						StartupProbe:  &v1.Probe{TerminationGracePeriodSeconds: &shortGracePeriod},
+						LivenessProbe: &v1.Probe{TerminationGracePeriodSeconds: &mediumGracePeriod},
+					}},
+					TerminationGracePeriodSeconds: &longGracePeriod,
+				},
+			},
+			reason:              reasonStartupProbe,
+			expectedGracePeriod: shortGracePeriod,
+		},
+		{
+			name: "all three grace periods set, use liveness termination grace period",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:          "foo",
+						StartupProbe:  &v1.Probe{TerminationGracePeriodSeconds: &shortGracePeriod},
+						LivenessProbe: &v1.Probe{TerminationGracePeriodSeconds: &mediumGracePeriod},
+					}},
+					TerminationGracePeriodSeconds: &longGracePeriod,
+				},
+			},
+			reason:              reasonLivenessProbe,
+			expectedGracePeriod: mediumGracePeriod,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualGracePeriod := setTerminationGracePeriod(test.pod, &test.pod.Spec.Containers[0], "", kubecontainer.ContainerID{}, test.reason)
+			require.Equal(t, test.expectedGracePeriod, actualGracePeriod)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As part of the process of defaulting the feature gate off for KEP-2238, we said we would add unit tests for setting the grace period in the `killContainer` function, as well as log when a probe-level grace period was greater than the pod-level one. 

This PR adds said unit buckets and logging. It does so by pulling the grace period logic out into a helper function to make unit testing easier. It also opts for `if` statements rather than `switch` blocks to help with readability.

#### Which issue(s) this PR fixes:

Related to updates made to https://github.com/kubernetes/enhancements/pull/3408

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
