### PR TITLE
Check for errors ahead of time

### DIFF
--- a/pkg/printers/tablegenerator_test.go
+++ b/pkg/printers/tablegenerator_test.go
@@ -51,7 +51,10 @@ func ErrorPrintHandler(obj *TestPrintType, options GenerateOptions) ([]metav1bet
 func TestCustomTypePrinting(t *testing.T) {
 	columns := []metav1beta1.TableColumnDefinition{{Name: "Data"}}
 	generator := NewTableGenerator()
-	generator.TableHandler(columns, PrintCustomType)
+	err := generator.TableHandler(columns, PrintCustomType)
+	if err != nil {
+		t.Fatalf("An error occurred when adds a print handler with a given set of columns: %#v", err)
+	}
 
 	obj := TestPrintType{"test object"}
 	table, err := generator.GenerateTable(&obj, GenerateOptions{})
@@ -71,9 +74,13 @@ func TestCustomTypePrinting(t *testing.T) {
 func TestPrintHandlerError(t *testing.T) {
 	columns := []metav1beta1.TableColumnDefinition{{Name: "Data"}}
 	generator := NewTableGenerator()
-	generator.TableHandler(columns, ErrorPrintHandler)
+	err := generator.TableHandler(columns, ErrorPrintHandler)
+	if err != nil {
+		t.Fatalf("An error occurred when adds a print handler with a given set of columns: %#v", err)
+	}
+
 	obj := TestPrintType{"test object"}
-	_, err := generator.GenerateTable(&obj, GenerateOptions{})
+	_, err = generator.GenerateTable(&obj, GenerateOptions{})
 	if err == nil || err.Error() != "ErrorPrintHandler error" {
 		t.Errorf("Did not get the expected error: %#v", err)
 	}


### PR DESCRIPTION


#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Check for errors ahead of time in the test to comply with the specification
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
