### PR TITLE
structured-logging: replace KObjs with KObjSlice for logging

### DIFF
--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -235,10 +235,8 @@ func (rsc *ReplicaSetController) getReplicaSetsWithSameController(rs *apps.Repli
 		relatedRSs = append(relatedRSs, obj.(*apps.ReplicaSet))
 	}
 
-	// The if check is used to avoid the overhead for the KObjs call, see
-	// https://github.com/kubernetes/kubernetes/issues/106945.
 	if klogV := klog.V(2); klogV.Enabled() {
-		klogV.InfoS("Found related ReplicaSets", "replicaSet", klog.KObj(rs), "relatedReplicaSets", klog.KObjs(relatedRSs))
+		klogV.InfoS("Found related ReplicaSets", "replicaSet", klog.KObj(rs), "relatedReplicaSets", klog.KObjSlice(relatedRSs))
 	}
 
 	return relatedRSs
@@ -806,7 +804,7 @@ func (rsc *ReplicaSetController) getIndirectlyRelatedPods(rs *apps.ReplicaSet) (
 			relatedPods = append(relatedPods, pod)
 		}
 	}
-	klog.V(4).InfoS("Found related pods", "kind", rsc.Kind, "object", klog.KObj(rs), "pods", klog.KObjs(relatedPods))
+	klog.V(4).InfoS("Found related pods", "kind", rsc.Kind, "object", klog.KObj(rs), "pods", klog.KObjSlice(relatedPods))
 	return relatedPods, nil
 }
 

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -414,5 +414,5 @@ func (rc *reconciler) reportMultiAttachError(volumeToAttach cache.VolumeToAttach
 	}
 
 	// Log all pods for system admin
-	klog.InfoS("Multi-Attach error: volume is already used by pods", "pods", klog.KObjs(pods), "attachedTo", otherNodesStr, "volume", volumeToAttach)
+	klog.InfoS("Multi-Attach error: volume is already used by pods", "pods", klog.KObjSlice(pods), "attachedTo", otherNodesStr, "volume", volumeToAttach)
 }

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
@@ -257,16 +257,16 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 	switch update.Op {
 	case kubetypes.ADD, kubetypes.UPDATE, kubetypes.DELETE:
 		if update.Op == kubetypes.ADD {
-			klog.V(4).InfoS("Adding new pods from source", "source", source, "pods", klog.KObjs(update.Pods))
+			klog.V(4).InfoS("Adding new pods from source", "source", source, "pods", klog.KObjSlice(update.Pods))
 		} else if update.Op == kubetypes.DELETE {
-			klog.V(4).InfoS("Gracefully deleting pods from source", "source", source, "pods", klog.KObjs(update.Pods))
+			klog.V(4).InfoS("Gracefully deleting pods from source", "source", source, "pods", klog.KObjSlice(update.Pods))
 		} else {
-			klog.V(4).InfoS("Updating pods from source", "source", source, "pods", klog.KObjs(update.Pods))
+			klog.V(4).InfoS("Updating pods from source", "source", source, "pods", klog.KObjSlice(update.Pods))
 		}
 		updatePodsFunc(update.Pods, pods, pods)
 
 	case kubetypes.REMOVE:
-		klog.V(4).InfoS("Removing pods from source", "source", source, "pods", klog.KObjs(update.Pods))
+		klog.V(4).InfoS("Removing pods from source", "source", source, "pods", klog.KObjSlice(update.Pods))
 		for _, value := range update.Pods {
 			if existing, found := pods[value.UID]; found {
 				// this is a delete

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -195,7 +195,7 @@ func (m *managerImpl) Start(diskInfoProvider DiskInfoProvider, podFunc ActivePod
 	go func() {
 		for {
 			if evictedPods := m.synchronize(diskInfoProvider, podFunc); evictedPods != nil {
-				klog.InfoS("Eviction manager: pods evicted, waiting for pod to be cleaned up", "pods", klog.KObjs(evictedPods))
+				klog.InfoS("Eviction manager: pods evicted, waiting for pod to be cleaned up", "pods", klog.KObjSlice(evictedPods))
 				m.waitForPodsCleanup(podCleanedUpFunc, evictedPods)
 			} else {
 				time.Sleep(monitoringInterval)
@@ -364,7 +364,7 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 	// rank the running pods for eviction for the specified resource
 	rank(activePods, statsFunc)
 
-	klog.InfoS("Eviction manager: pods ranked for eviction", "pods", klog.KObjs(activePods))
+	klog.InfoS("Eviction manager: pods ranked for eviction", "pods", klog.KObjSlice(activePods))
 
 	//record age of metrics for met thresholds that we are using for evictions.
 	for _, t := range thresholds {
@@ -399,7 +399,7 @@ func (m *managerImpl) waitForPodsCleanup(podCleanedUpFunc PodCleanedUpFunc, pods
 	for {
 		select {
 		case <-timeout.C():
-			klog.InfoS("Eviction manager: timed out waiting for pods to be cleaned up", "pods", klog.KObjs(pods))
+			klog.InfoS("Eviction manager: timed out waiting for pods to be cleaned up", "pods", klog.KObjSlice(pods))
 			return
 		case <-ticker.C():
 			for i, pod := range pods {
@@ -407,7 +407,7 @@ func (m *managerImpl) waitForPodsCleanup(podCleanedUpFunc PodCleanedUpFunc, pods
 					break
 				}
 				if i == len(pods)-1 {
-					klog.InfoS("Eviction manager: pods successfully cleaned up", "pods", klog.KObjs(pods))
+					klog.InfoS("Eviction manager: pods successfully cleaned up", "pods", klog.KObjSlice(pods))
 					return
 				}
 			}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2071,23 +2071,23 @@ func (kl *Kubelet) syncLoopIteration(configCh <-chan kubetypes.PodUpdate, handle
 
 		switch u.Op {
 		case kubetypes.ADD:
-			klog.V(2).InfoS("SyncLoop ADD", "source", u.Source, "pods", klog.KObjs(u.Pods))
+			klog.V(2).InfoS("SyncLoop ADD", "source", u.Source, "pods", klog.KObjSlice(u.Pods))
 			// After restarting, kubelet will get all existing pods through
 			// ADD as if they are new pods. These pods will then go through the
 			// admission process and *may* be rejected. This can be resolved
 			// once we have checkpointing.
 			handler.HandlePodAdditions(u.Pods)
 		case kubetypes.UPDATE:
-			klog.V(2).InfoS("SyncLoop UPDATE", "source", u.Source, "pods", klog.KObjs(u.Pods))
+			klog.V(2).InfoS("SyncLoop UPDATE", "source", u.Source, "pods", klog.KObjSlice(u.Pods))
 			handler.HandlePodUpdates(u.Pods)
 		case kubetypes.REMOVE:
-			klog.V(2).InfoS("SyncLoop REMOVE", "source", u.Source, "pods", klog.KObjs(u.Pods))
+			klog.V(2).InfoS("SyncLoop REMOVE", "source", u.Source, "pods", klog.KObjSlice(u.Pods))
 			handler.HandlePodRemoves(u.Pods)
 		case kubetypes.RECONCILE:
-			klog.V(4).InfoS("SyncLoop RECONCILE", "source", u.Source, "pods", klog.KObjs(u.Pods))
+			klog.V(4).InfoS("SyncLoop RECONCILE", "source", u.Source, "pods", klog.KObjSlice(u.Pods))
 			handler.HandlePodReconcile(u.Pods)
 		case kubetypes.DELETE:
-			klog.V(2).InfoS("SyncLoop DELETE", "source", u.Source, "pods", klog.KObjs(u.Pods))
+			klog.V(2).InfoS("SyncLoop DELETE", "source", u.Source, "pods", klog.KObjSlice(u.Pods))
 			// DELETE is treated as a UPDATE because of graceful deletion.
 			handler.HandlePodUpdates(u.Pods)
 		case kubetypes.SET:
@@ -2128,7 +2128,7 @@ func (kl *Kubelet) syncLoopIteration(configCh <-chan kubetypes.PodUpdate, handle
 		if len(podsToSync) == 0 {
 			break
 		}
-		klog.V(4).InfoS("SyncLoop (SYNC) pods", "total", len(podsToSync), "pods", klog.KObjs(podsToSync))
+		klog.V(4).InfoS("SyncLoop (SYNC) pods", "total", len(podsToSync), "pods", klog.KObjSlice(podsToSync))
 		handler.HandlePodSyncs(podsToSync)
 	case update := <-kl.livenessManager.Updates():
 		if update.Result == proberesults.Failure {

--- a/staging/src/k8s.io/component-base/logs/json/klog_test.go
+++ b/staging/src/k8s.io/component-base/logs/json/klog_test.go
@@ -153,10 +153,10 @@ func TestKlogIntegration(t *testing.T) {
 			format: `{"ts":%f,"caller":"json/klog_test.go:%d","msg":"some","v":0,"pod":{"name":"pod-1","namespace":"kube-system"}}`,
 		},
 		{
-			name: "KObjs",
+			name: "KObjSlice",
 			fun: func() {
 				klog.InfoS("several", "pods",
-					klog.KObjs([]interface{}{
+					klog.KObjSlice([]interface{}{
 						&kmeta{Name: "pod-1", Namespace: "kube-system"},
 						&kmeta{Name: "pod-2", Namespace: "kube-system"},
 					}))


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
1. This Pull request replaces the `KObjs` with their better performing counter part `KObjSlice`. Since https://github.com/kubernetes/kubernetes/pull/110724 is now merged, We can reap the benefits of the change that went into the `klog` via https://github.com/kubernetes/klog/pull/322

2. As part of the changes done to address #102430, there was a Pull request that got merged (#106978) which made some changes to how the `klog.V(x).Enabled` checks were being made.  This PR also takes second look at some of those changes to see if the `if klogV := klog.V(x); klogV.Enabled()` wrapping is actually required or they can simply be replaced with the `klog.V(x).Info{f|S}`.  Currently this PR only replaces those items that do not have additional computation done for the logging artifacts under the  `if klogV := klog.V(x); klogV.Enabled()` check with their counter part of `klog.V(x)` calls directly.


#### Which issue(s) this PR fixes:
Fixes #110737 

#### Special notes for your reviewer:
##### Benchmark for `getReplicaSetsWithSameController` under `replca_set.go`
Original changes were retained as is for the `if` condition wrapping for better performance
```bash
# With Changes
BenchmarkGetReplicaSetsWithSameController
BenchmarkGetReplicaSetsWithSameController-12    	 3291576	       355.9 ns/op	     184 B/op	       6 allocs/op
BenchmarkGetReplicaSetsWithSameController-12    	 3359475	       360.1 ns/op	     184 B/op	       6 allocs/op
BenchmarkGetReplicaSetsWithSameController-12    	 3335294	       368.1 ns/op	     184 B/op	       6 allocs/op
BenchmarkGetReplicaSetsWithSameController-12    	 3296937	       361.2 ns/op	     184 B/op	       6 allocs/op
BenchmarkGetReplicaSetsWithSameController-12    	 3275090	       389.7 ns/op	     184 B/op	       6 allocs/op

# Without Changes
BenchmarkGetReplicaSetsWithSameController
BenchmarkGetReplicaSetsWithSameController-12    	 5501926	       202.4 ns/op	      48 B/op	       2 allocs/op
BenchmarkGetReplicaSetsWithSameController-12    	 5227614	       200.0 ns/op	      48 B/op	       2 allocs/op
BenchmarkGetReplicaSetsWithSameController-12    	 6073863	       196.5 ns/op	      48 B/op	       2 allocs/op
BenchmarkGetReplicaSetsWithSameController-12    	 6055270	       199.4 ns/op	      48 B/op	       2 allocs/op
BenchmarkGetReplicaSetsWithSameController-12    	 6022762	       195.6 ns/op	      48 B/op	       2 allocs/op
```


#### Does this PR introduce a user-facing change?
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[Usage]: https://github.com/kubernetes/community/pull/6719
```

#### TODO

- [ ] Attach Benchmarking results for the changes
