### PR TITLE
remove release-1.20 from prom bot due to eol

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -5,11 +5,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/code-generator
-  - name: release-1.20
-    go: 1.15.15
-    source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/code-generator
   - name: release-1.21
     go: 1.16.15
     source:
@@ -34,11 +29,6 @@ rules:
   - name: master
     source:
       branch: master
-      dir: staging/src/k8s.io/apimachinery
-  - name: release-1.20
-    go: 1.15.15
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.21
     go: 1.16.15
@@ -68,14 +58,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/api
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/api
   - name: release-1.21
     go: 1.16.15
@@ -119,20 +101,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/client-go
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod ./...
-      go test -mod=mod ./...
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/client-go
     smoke-test: |
       # assumes GO111MODULE=on
@@ -207,18 +175,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/component-base
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/component-base
   - name: release-1.21
     go: 1.16.15
     dependencies:
@@ -279,18 +235,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/component-helpers
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.21
     go: 1.16.15
@@ -354,20 +298,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/apiserver
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    - repository: component-base
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/apiserver
   - name: release-1.21
     go: 1.16.15
@@ -443,24 +373,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-aggregator
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    - repository: apiserver
-      branch: release-1.20
-    - repository: component-base
-      branch: release-1.20
-    - repository: code-generator
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.21
     go: 1.16.15
@@ -551,29 +463,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/sample-apiserver
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    - repository: apiserver
-      branch: release-1.20
-    - repository: code-generator
-      branch: release-1.20
-    - repository: component-base
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
@@ -691,25 +580,6 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    - repository: code-generator
-      branch: release-1.20
-    source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/sample-controller
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
   - name: release-1.21
     go: 1.16.15
     dependencies:
@@ -803,26 +673,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    required-packages:
-    - k8s.io/code-generator
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    - repository: apiserver
-      branch: release-1.20
-    - repository: code-generator
-      branch: release-1.20
-    - repository: component-base
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
@@ -920,20 +770,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/metrics
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    - repository: code-generator
-      branch: release-1.20
-    source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/metrics
   - name: release-1.21
     go: 1.16.15
     dependencies:
@@ -1003,18 +839,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/cli-runtime
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: api
-      branch: release-1.20
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/cli-runtime
   - name: release-1.21
     go: 1.16.15
     dependencies:
@@ -1077,20 +901,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/sample-cli-plugin
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: api
-      branch: release-1.20
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: cli-runtime
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.21
     go: 1.16.15
@@ -1161,20 +971,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-proxy
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: component-base
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.21
     go: 1.16.15
@@ -1247,20 +1043,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/kubelet
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    - repository: component-base
-      branch: release-1.20
-    source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/kubelet
   - name: release-1.21
     go: 1.16.15
     dependencies:
@@ -1331,20 +1113,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-scheduler
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: component-base
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.21
     go: 1.16.15
@@ -1418,22 +1186,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/controller-manager
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: api
-      branch: release-1.20
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    - repository: component-base
-      branch: release-1.20
-    - repository: apiserver
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.21
     go: 1.16.15
@@ -1519,26 +1271,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/cloud-provider
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: api
-      branch: release-1.20
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: apiserver
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    - repository: component-base
-      branch: release-1.20
-    - repository: controller-manager
-      branch: release-1.20
-    - repository: component-helpers
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.21
     go: 1.16.15
@@ -1643,28 +1375,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/kube-controller-manager
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: apiserver
-      branch: release-1.20
-    - repository: component-base
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    - repository: controller-manager
-      branch: release-1.20
-    - repository: cloud-provider
-      branch: release-1.20
-    - repository: component-helpers
-      branch: release-1.20
-    source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.21
     go: 1.16.15
     dependencies:
@@ -1764,16 +1474,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/cluster-bootstrap
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: api
-      branch: release-1.20
-    source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.21
     go: 1.16.15
     dependencies:
@@ -1825,16 +1525,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/csi-translation-lib
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: api
-      branch: release-1.20
-    - repository: apimachinery
-      branch: release-1.20
-    source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.21
     go: 1.16.15
     dependencies:
@@ -1880,11 +1570,6 @@ rules:
   - name: master
     source:
       branch: master
-      dir: staging/src/k8s.io/mount-utils
-  - name: release-1.20
-    go: 1.15.15
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.21
     go: 1.16.15
@@ -1932,30 +1617,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/legacy-cloud-providers
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: api
-      branch: release-1.20
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    - repository: cloud-provider
-      branch: release-1.20
-    - repository: csi-translation-lib
-      branch: release-1.20
-    - repository: apiserver
-      branch: release-1.20
-    - repository: component-base
-      branch: release-1.20
-    - repository: controller-manager
-      branch: release-1.20
-    - repository: component-helpers
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.21
     go: 1.16.15
@@ -2065,11 +1726,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/cri-api
-  - name: release-1.20
-    go: 1.15.15
-    source:
-      branch: release-1.20
-      dir: staging/src/k8s.io/cri-api
   - name: release-1.21
     go: 1.16.15
     source:
@@ -2112,28 +1768,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kubectl
-  - name: release-1.20
-    go: 1.15.15
-    dependencies:
-    - repository: api
-      branch: release-1.20
-    - repository: apimachinery
-      branch: release-1.20
-    - repository: cli-runtime
-      branch: release-1.20
-    - repository: client-go
-      branch: release-1.20
-    - repository: code-generator
-      branch: release-1.20
-    - repository: component-base
-      branch: release-1.20
-    - repository: component-helpers
-      branch: release-1.20
-    - repository: metrics
-      branch: release-1.20
-    source:
-      branch: release-1.20
       dir: staging/src/k8s.io/kubectl
   - name: release-1.21
     go: 1.16.15


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- remove release-1.20 from prom bot due to eol

/assign @nikhita @dims @saschagrunert @puerco 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
remove release-1.20 from prom bot due to eol
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
