### PR TITLE
add warning to kubectl auth can-i if a subresource does not exist

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
@@ -233,9 +233,10 @@ func TestRunAccessList(t *testing.T) {
 
 func TestRunResourceFor(t *testing.T) {
 	tests := []struct {
-		name        string
-		o           *CanIOptions
-		resourceArg string
+		name           string
+		o              *CanIOptions
+		resourceArg    string
+		subResourceArg string
 
 		expectGVR      schema.GroupVersionResource
 		expectedErrOut string
@@ -300,7 +301,7 @@ func TestRunResourceFor(t *testing.T) {
 				t.Errorf("got unexpected error when do tf.ToRESTMapper(): %v", err)
 				return
 			}
-			gvr := test.o.resourceFor(restMapper, test.resourceArg)
+			gvr := test.o.resourceFor(restMapper, test.resourceArg, test.subResourceArg)
 			if gvr != test.expectGVR {
 				t.Errorf("expected %v\n but got %v\n", test.expectGVR, gvr)
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -477,6 +477,11 @@ func (f *TestFactory) WithDiscoveryClient(discoveryClient discovery.CachedDiscov
 	return f
 }
 
+func (f *TestFactory) WithRESTMapper(mapper meta.RESTMapper) *TestFactory {
+	f.kubeConfigFlags.WithRESTMapper(mapper)
+	return f
+}
+
 // Cleanup cleans up TestFactory temp config file
 func (f *TestFactory) Cleanup() {
 	if f.tempConfigFile == nil {

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -832,6 +832,7 @@ runTests() {
 
     output_message=$(kubectl auth can-i get pods --subresource=log 2>&1 "${kube_flags[@]}")
     kube::test::if_has_string "${output_message}" "yes"
+    kube::test::if_has_not_string "${output_message}" "Warning"
 
     output_message=$(kubectl auth can-i get invalid_resource 2>&1 "${kube_flags[@]}")
     kube::test::if_has_string "${output_message}" "the server doesn't have a resource type"
@@ -871,6 +872,11 @@ runTests() {
     # kubectl auth can-i get nodes --all-namespaces does not print a namespaced warning message
     output_message=$(kubectl auth can-i get nodes --all-namespaces 2>&1 "${kube_flags[@]}")
     kube::test::if_has_not_string "${output_message}" "Warning: resource 'nodes' is not namespace scoped"
+
+    # kubectl auth can-i get pods --subresource=invalid prints a warning message
+    output_message=$(kubectl auth can-i get pods --subresource=invalid 2>&1 "${kube_flags[@]}")
+    kube::test::if_has_string "${output_message}" "yes"
+    kube::test::if_has_string "${output_message}" "Warning: the server doesn't have a subresource 'pods/invalid'"
   fi
 
   # kubectl auth reconcile


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds a warning if a subresource is specified in `kubectl auth can-i ` that does not exist, but still preserves API behaviour and outputing result from SubjectAccessReview

Prefer builtin non-discoverable resources instead of custom resources (users, groups) when versionGroup is not specified.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1217

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
TBD after reviews

```release-note
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
