### PR TITLE
Improve run and debug attach message upon failure

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -802,7 +802,7 @@ func (o *DebugOptions) handleAttachPod(ctx context.Context, f cmdutil.Factory, n
 	}
 
 	if err := opts.Run(); err != nil {
-		fmt.Fprintf(opts.ErrOut, "Error attaching, falling back to logs: %v\n", err)
+		fmt.Fprintf(opts.ErrOut, "warning: couldn't attach to pod/%s, falling back to streaming logs: %v\n", podName, err)
 		return logOpts(f, pod, opts)
 	}
 	return nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -486,7 +486,7 @@ func handleAttachPod(f cmdutil.Factory, podClient corev1client.PodsGetter, ns, n
 	}
 
 	if err := opts.Run(); err != nil {
-		fmt.Fprintf(opts.ErrOut, "Error attaching, falling back to logs: %v\n", err)
+		fmt.Fprintf(opts.ErrOut, "warning: couldn't attach to pod/%s, falling back to streaming logs: %v\n", name, err)
 		return logOpts(f, pod, opts)
 	}
 	return nil


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli

#### What this PR does / why we need it:
Sometimes users running kubectl will see following messages:
```
kubectl run -it --rm --image=myimage test --restart=Never -- /bin/sh -c curl google.com
Error attaching, falling back to logs: Internal error occurred: error attaching to container: container is not created or running
Error attaching, falling back to logs: unable to upgrade connection: container nmcal-helper-utils-123 not found in pod nmcal-helper-utils-123_cal-shared-product
```

The error messages are not fatal, and the command finishes successfully, but this error is confusing to users.

#### Special notes for your reviewer:
/assign @ardaguclu @deejross 

#### Does this PR introduce a user-facing change?
```release-note
Improve kubectl run and debug attach problems error
```