### PR TITLE
add a service resolver to authentication and authorization webhook

### DIFF
--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -23,9 +23,11 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/apiserver/pkg/util/webhook"
 	versionedinformers "k8s.io/client-go/informers"
 	"k8s.io/kubernetes/pkg/kubeapiserver/authorizer"
 	authzmodes "k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
@@ -125,7 +127,7 @@ func (o *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 // ToAuthorizationConfig convert BuiltInAuthorizationOptions to authorizer.Config
-func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFactory versionedinformers.SharedInformerFactory) authorizer.Config {
+func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFactory versionedinformers.SharedInformerFactory, serviceResolver webhook.ServiceResolver, customDial net.DialFunc) authorizer.Config {
 	return authorizer.Config{
 		AuthorizationModes:          o.Modes,
 		PolicyFile:                  o.PolicyFile,
@@ -135,5 +137,6 @@ func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFac
 		WebhookCacheUnauthorizedTTL: o.WebhookCacheUnauthorizedTTL,
 		VersionedInformerFactory:    versionedInformerFactory,
 		WebhookRetryBackoff:         o.WebhookRetryBackoff,
+		CustomDial:                  newWebhookDialer(serviceResolver, customDial),
 	}
 }

--- a/pkg/kubeapiserver/options/webhook_util.go
+++ b/pkg/kubeapiserver/options/webhook_util.go
@@ -1,0 +1,62 @@
+package options
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"strings"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apiserver/pkg/util/webhook"
+	"k8s.io/klog/v2"
+)
+
+// newWebhookDialer return a DialFunc
+func newWebhookDialer(serviceResolver webhook.ServiceResolver, baseDialer utilnet.DialFunc) utilnet.DialFunc {
+	var d net.Dialer
+	delegateDialer := d.DialContext
+	if baseDialer != nil {
+		delegateDialer = baseDialer
+	}
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if serviceResolver == nil {
+			return delegateDialer(ctx, network, addr)
+		}
+		var (
+			host, port string
+			err        error
+		)
+		host, port, err = net.SplitHostPort(addr)
+		if err != nil {
+			klog.V(6).Infof("splitting hostport %s error: %v", addr, err)
+			return delegateDialer(ctx, network, addr)
+		}
+
+		portInt, err := strconv.Atoi(port)
+		if err != nil {
+			klog.V(6).Infof("port %s convert string to int failed, err: %v", port, err)
+			return delegateDialer(ctx, network, addr)
+		}
+		segs := strings.Split(host, ".")
+		if len(segs) < 3 {
+			klog.V(6).Infof("dialer address %s is not a kubernetes service reference", host)
+			return delegateDialer(ctx, network, addr)
+		}
+		if segs[2] != "svc" {
+			return delegateDialer(ctx, network, addr)
+		}
+		serviceNamespace := segs[1]
+		serviceName := segs[0]
+
+		u, err := serviceResolver.ResolveEndpoint(serviceNamespace, serviceName, int32(portInt))
+		if err != nil {
+			klog.V(5).Infof("resolving endpoint from namespace: %s, name: %s, original host: %s failed, err: %v",
+				serviceNamespace, serviceName, host, err)
+			return delegateDialer(ctx, network, addr)
+		}
+
+		klog.V(6).Infof("resolved addr %s to hostport: %s:%d",
+			addr, u.Host, portInt)
+		return delegateDialer(ctx, network, u.Host)
+	}
+}

--- a/pkg/kubeapiserver/options/webhook_util_test.go
+++ b/pkg/kubeapiserver/options/webhook_util_test.go
@@ -1,0 +1,155 @@
+package options
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apiserver/pkg/util/webhook"
+)
+
+type fakeServiceResolver struct {
+	host string
+	port string
+}
+
+// ResolveEndpoint ...
+func (i *fakeServiceResolver) ResolveEndpoint(namespace, name string, port int32) (*url.URL, error) {
+	if len(name) == 0 || len(namespace) == 0 || port == 0 {
+		return nil, errors.New("cannot resolve an empty service name or namespace or port")
+	}
+	return &url.URL{Scheme: "https", Host: fmt.Sprintf("%s:%s", i.host, i.port)}, nil
+}
+
+func newFakeServiceResolver(host, port string) *fakeServiceResolver {
+	return &fakeServiceResolver{
+		host: host,
+		port: port,
+	}
+}
+
+func Test_newWebhookDialer(t *testing.T) {
+	var tt = []struct {
+		name       string
+		dialerAddr string
+
+		withBaseDialer bool
+		withResolver   bool
+		expectedError  bool
+	}{
+		{
+			name:           "resolving a kubernetes service addr",
+			dialerAddr:     "servicename.servicenamespace.svc:777",
+			withResolver:   true,
+			withBaseDialer: true,
+		},
+		{
+			name:           "dialer's addr is not a kubernetes service reference",
+			dialerAddr:     "example.org:777",
+			withResolver:   true,
+			expectedError:  true,
+			withBaseDialer: true,
+		},
+		{
+			name:           "resolving a kubernetes service addr without a port",
+			dialerAddr:     "servicename.servicenamespace.svc",
+			withResolver:   true,
+			withBaseDialer: true,
+		},
+		{
+			name:           "resolving a kubernetes service addr",
+			dialerAddr:     "servicename.servicenamespace.pod:777",
+			withResolver:   true,
+			expectedError:  true,
+			withBaseDialer: true,
+		},
+		{
+			name:           "resolving an addr length less than 3",
+			dialerAddr:     "example.org",
+			withResolver:   true,
+			expectedError:  true,
+			withBaseDialer: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var defaultResvoler webhook.ServiceResolver
+			if tc.withResolver {
+				defaultResvoler = newFakeServiceResolver(fakeDefaultEndpointHost, fakeDefaultEndpointPort)
+			}
+			var defaultBaseDialer utilnet.DialFunc
+			if tc.withBaseDialer {
+				defaultBaseDialer = func(ctx context.Context, net, addr string) (net.Conn, error) {
+					if !tc.expectedError && tc.withResolver {
+						return &fakeConn{ip: fakeDefaultEndpointHost, port: fakeDefaultEndpointPort}, nil
+					}
+					return &fakeConn{ip: fakeDelegatedEndpointHost, port: fakeDelegatedEndpointPort}, nil
+				}
+			}
+
+			dialFunc, err := newWebhookDialer(defaultResvoler, defaultBaseDialer)(context.TODO(), "tcp", tc.dialerAddr)
+			if err != nil {
+				t.Fatalf("error got: %v", err)
+			}
+
+			remoteAddr := dialFunc.RemoteAddr().String()
+			if tc.withResolver && !tc.expectedError {
+				if remoteAddr != fmt.Sprintf("%s:%s", fakeDefaultEndpointHost, fakeDefaultEndpointPort) {
+					t.Errorf("remoteAddr %s is not expected, should be resolved by serviceResolver", remoteAddr)
+				}
+			}
+			if tc.withBaseDialer && tc.expectedError {
+				if remoteAddr != fmt.Sprintf("%s:%s", fakeDelegatedEndpointHost, fakeDelegatedEndpointPort) {
+					t.Errorf("remoteAddr %s is not expected, should be resolved by customDialer", remoteAddr)
+				}
+			}
+			if !tc.withResolver && tc.withBaseDialer {
+				if remoteAddr != fmt.Sprintf("%s:%s", fakeDelegatedEndpointHost, fakeDelegatedEndpointPort) {
+					t.Errorf("remoteAddr %s is not expected, should be resolved by customDialer", remoteAddr)
+				}
+			}
+		})
+	}
+}
+
+type fakeConn struct {
+	ip, port string
+}
+
+func (f *fakeConn) Read([]byte) (int, error)  { return 0, nil }
+func (f *fakeConn) Write([]byte) (int, error) { return 0, nil }
+func (f *fakeConn) Close() error              { return nil }
+func (fakeConn) LocalAddr() net.Addr          { return nil }
+func (f *fakeConn) RemoteAddr() net.Addr {
+	return &fakeAddr{
+		ip:   f.ip,
+		port: f.port,
+	}
+}
+
+func (fakeConn) SetDeadline(t time.Time) error      { return nil }
+func (fakeConn) SetReadDeadline(t time.Time) error  { return nil }
+func (fakeConn) SetWriteDeadline(t time.Time) error { return nil }
+
+type fakeAddr struct {
+	ip, port string
+}
+
+func (f fakeAddr) Network() string { return "" }
+
+func (f fakeAddr) String() string {
+	return fmt.Sprintf("%s:%s", f.ip, f.port)
+}
+
+var (
+	fakeDefaultEndpointHost   = "1.1.1.1"
+	fakeDefaultEndpointPort   = "443"
+	fakeDelegatedEndpointHost = "2.2.2.2"
+	fakeDelegatedEndpointPort = "8443"
+)


### PR DESCRIPTION
Signed-off-by: vanceli <vanceli@tencent.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
A kubernetes service domain can be used in dynamic admission webhooks cr.
Likewise we hope the authentication and authorization webhook can also use a kubernetes service domain in the [flag](https://github.com/kubernetes/kubernetes/blob/ba1bbb5ac67084b25a17622a6573e648f88f440b/pkg/kubeapiserver/options/authentication.go#L270) and [configuration file](https://kubernetes.io/docs/reference/access-authn-authz/webhook/#configuration-file-format) to keep consistent behavior



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/52511

also closed PR: https://github.com/kubernetes/kubernetes/pull/54163 
#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Support using a kubernetes service domain as endpoint for authentication and authorization webhook
```
