### PR TITLE
cluster/gce: add startup probe for etcd (to be consistent with kubeadm install)

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1901,6 +1901,7 @@ def resolve(host):
   sed -i -e "s@{{ *etcdctl_certs *}}@$etcdctl_certs@g" "${temp_file}"
   sed -i -e "s@{{ *etcd_apiserver_creds *}}@$etcd_apiserver_creds@g" "${temp_file}"
   sed -i -e "s@{{ *etcd_extra_args *}}@$etcd_extra_args@g" "${temp_file}"
+  sed -i -e "s@{{ *etcd_listen_metrics_port *}}@$etcd_listen_metrics_port@g" "${temp_file}"
   if [[ -n "${ETCD_VERSION:-}" ]]; then
     sed -i -e "s@{{ *pillar\.get('etcd_version', '\(.*\)') *}}@${ETCD_VERSION}@g" "${temp_file}"
   else

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -82,6 +82,18 @@
       "periodSeconds": 5,
       "failureThreshold": 5
     },
+    "startupProbe": {
+      "httpGet": {
+        "host": "127.0.0.1",
+        "path": "/health?serializable=false",
+        "port": {{ etcd_listen_metrics_port }},
+        "scheme": "HTTP"
+      },
+      "initialDelaySeconds": 10,
+      "periodSeconds": 10,
+      "timeoutSeconds": 15,
+      "failureThreshold": 24
+    },
     "ports": [
       { "name": "serverport",
         "containerPort": {{ server_port }},


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
xref #110744

We have already added a startup probe in kubeadm for etcd.

See https://github.com/etcd-io/etcd/issues/14048#issuecomment-1158439700.

#### Special notes for your reviewer:
- startup probe is beta since v1.18.



#### Does this PR introduce a user-facing change?

```release-note
None
```

