### PR TITLE
Wait for cache sync in TestSyncPastDeadlineJobFinished

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -1840,6 +1840,7 @@ func TestSyncPastDeadlineJobFinished(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sharedInformerFactory.Start(ctx.Done())
+	sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
 	go manager.Run(ctx, 1)
 
@@ -1878,7 +1879,7 @@ func TestSyncPastDeadlineJobFinished(t *testing.T) {
 				t.Fatalf("Failed to insert job in index: %v", err)
 			}
 			var j *batch.Job
-			err = wait.Poll(200*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+			err = wait.Poll(200*time.Millisecond, 3*time.Second, func() (done bool, err error) {
 				j, err = clientset.BatchV1().Jobs(metav1.NamespaceDefault).Get(ctx, job.GetName(), metav1.GetOptions{})
 				if err != nil {
 					return false, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

Waits for cache to sync before starting the job controller. Otherwise it might miss events.

#### Which issue(s) this PR fixes:

Mitigation to #109943

#### Special notes for your reviewer:

This also reverts #109947, which didn't reduce flakiness at all.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
