### PR TITLE
Add parameter to set SecurityContext for containers in tests

### DIFF
--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -182,8 +182,11 @@ type RCConfig struct {
 
 	ServiceAccountTokenProjections int
 
-	//Additional containers to run in the pod
+	// Additional containers to run in the pod
 	AdditionalContainers []v1.Container
+
+	// Security context for created pods
+	SecurityContext *v1.SecurityContext
 }
 
 func (rc *RCConfig) RCConfigLog(fmt string, args ...interface{}) {
@@ -334,11 +337,12 @@ func (config *DeploymentConfig) create() error {
 					TerminationGracePeriodSeconds: config.getTerminationGracePeriodSeconds(nil),
 					Containers: []v1.Container{
 						{
-							Name:      config.Name,
-							Image:     config.Image,
-							Command:   config.Command,
-							Ports:     []v1.ContainerPort{{ContainerPort: 80}},
-							Lifecycle: config.Lifecycle,
+							Name:            config.Name,
+							Image:           config.Image,
+							Command:         config.Command,
+							Ports:           []v1.ContainerPort{{ContainerPort: 80}},
+							Lifecycle:       config.Lifecycle,
+							SecurityContext: config.SecurityContext,
 						},
 					},
 				},
@@ -420,11 +424,12 @@ func (config *ReplicaSetConfig) create() error {
 					TerminationGracePeriodSeconds: config.getTerminationGracePeriodSeconds(nil),
 					Containers: []v1.Container{
 						{
-							Name:      config.Name,
-							Image:     config.Image,
-							Command:   config.Command,
-							Ports:     []v1.ContainerPort{{ContainerPort: 80}},
-							Lifecycle: config.Lifecycle,
+							Name:            config.Name,
+							Image:           config.Image,
+							Command:         config.Command,
+							Ports:           []v1.ContainerPort{{ContainerPort: 80}},
+							Lifecycle:       config.Lifecycle,
+							SecurityContext: config.SecurityContext,
 						},
 					},
 				},
@@ -498,10 +503,11 @@ func (config *JobConfig) create() error {
 					TerminationGracePeriodSeconds: config.getTerminationGracePeriodSeconds(nil),
 					Containers: []v1.Container{
 						{
-							Name:      config.Name,
-							Image:     config.Image,
-							Command:   config.Command,
-							Lifecycle: config.Lifecycle,
+							Name:            config.Name,
+							Image:           config.Image,
+							Command:         config.Command,
+							Lifecycle:       config.Lifecycle,
+							SecurityContext: config.SecurityContext,
 						},
 					},
 					RestartPolicy: v1.RestartPolicyOnFailure,
@@ -611,12 +617,13 @@ func (config *RCConfig) create() error {
 					Affinity: config.Affinity,
 					Containers: []v1.Container{
 						{
-							Name:           config.Name,
-							Image:          config.Image,
-							Command:        config.Command,
-							Ports:          []v1.ContainerPort{{ContainerPort: 80}},
-							ReadinessProbe: config.ReadinessProbe,
-							Lifecycle:      config.Lifecycle,
+							Name:            config.Name,
+							Image:           config.Image,
+							Command:         config.Command,
+							Ports:           []v1.ContainerPort{{ContainerPort: 80}},
+							ReadinessProbe:  config.ReadinessProbe,
+							Lifecycle:       config.Lifecycle,
+							SecurityContext: config.SecurityContext,
 						},
 					},
 					DNSPolicy:                     *config.DNSPolicy,


### PR DESCRIPTION
After #106454 tests run with e2e tests run under the restricted pod security
policy level by default.

In order for containers to start with this security policy they must set
appropriate SecurityContext.

See
https://groups.google.com/a/kubernetes.io/g/dev/c/BZlDyz9FK1U/m/57PgQlA4BgAJ

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
