### PR TITLE
egress_selector.go: support a maximum lifetime for UDS + grpc tunnels.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
@@ -105,6 +105,10 @@ type Transport struct {
 	// Requires at least one of TCP or UDS to be set
 	// +optional
 	UDS *UDSTransport
+
+	// MaxTunnelLifetime is the maximum tunnel lifetime, after which underlying connections will be closed and resources cleaned up.
+	// This option is an extra guard against resource leaks.
+	MaxTunnelLifetime *metav1.Duration
 }
 
 // TCPTransport provides the information to connect to konnectivity server via TCP

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -106,6 +106,10 @@ type Transport struct {
 	// Requires at least one of TCP or UDS to be set
 	// +optional
 	UDS *UDSTransport `json:"uds,omitempty"`
+
+	// MaxTunnelLifetime is the maximum tunnel lifetime, after which underlying connections will be closed and resources cleaned up.
+	// This option is an extra guard against resource leaks.
+	MaxTunnelLifetime *metav1.Duration `json:"maxTunnelLifetime,omitempty"`
 }
 
 // TCPTransport provides the information to connect to konnectivity server via TCP

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
@@ -24,6 +24,7 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	apiserver "k8s.io/apiserver/pkg/apis/apiserver"
@@ -337,6 +338,7 @@ func Convert_apiserver_TracingConfiguration_To_v1alpha1_TracingConfiguration(in 
 func autoConvert_v1alpha1_Transport_To_apiserver_Transport(in *Transport, out *apiserver.Transport, s conversion.Scope) error {
 	out.TCP = (*apiserver.TCPTransport)(unsafe.Pointer(in.TCP))
 	out.UDS = (*apiserver.UDSTransport)(unsafe.Pointer(in.UDS))
+	out.MaxTunnelLifetime = (*v1.Duration)(unsafe.Pointer(in.MaxTunnelLifetime))
 	return nil
 }
 
@@ -348,6 +350,7 @@ func Convert_v1alpha1_Transport_To_apiserver_Transport(in *Transport, out *apise
 func autoConvert_apiserver_Transport_To_v1alpha1_Transport(in *apiserver.Transport, out *Transport, s conversion.Scope) error {
 	out.TCP = (*TCPTransport)(unsafe.Pointer(in.TCP))
 	out.UDS = (*UDSTransport)(unsafe.Pointer(in.UDS))
+	out.MaxTunnelLifetime = (*v1.Duration)(unsafe.Pointer(in.MaxTunnelLifetime))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -231,6 +232,11 @@ func (in *Transport) DeepCopyInto(out *Transport) {
 	if in.UDS != nil {
 		in, out := &in.UDS, &out.UDS
 		*out = new(UDSTransport)
+		**out = **in
+	}
+	if in.MaxTunnelLifetime != nil {
+		in, out := &in.MaxTunnelLifetime, &out.MaxTunnelLifetime
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	return

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
@@ -77,6 +77,10 @@ type Transport struct {
 	// Requires at least one of TCP or UDS to be set
 	// +optional
 	UDS *UDSTransport `json:"uds,omitempty"`
+
+	// MaxTunnelLifetime is the maximum tunnel lifetime, after which underlying connections will be closed and resources cleaned up.
+	// This option is an extra guard against resource leaks.
+	MaxTunnelLifetime *metav1.Duration `json:"maxTunnelLifetime,omitempty"`
 }
 
 // TCPTransport provides the information to connect to konnectivity server via TCP

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.conversion.go
@@ -24,6 +24,7 @@ package v1beta1
 import (
 	unsafe "unsafe"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	apiserver "k8s.io/apiserver/pkg/apis/apiserver"
@@ -241,6 +242,7 @@ func Convert_apiserver_TLSConfig_To_v1beta1_TLSConfig(in *apiserver.TLSConfig, o
 func autoConvert_v1beta1_Transport_To_apiserver_Transport(in *Transport, out *apiserver.Transport, s conversion.Scope) error {
 	out.TCP = (*apiserver.TCPTransport)(unsafe.Pointer(in.TCP))
 	out.UDS = (*apiserver.UDSTransport)(unsafe.Pointer(in.UDS))
+	out.MaxTunnelLifetime = (*v1.Duration)(unsafe.Pointer(in.MaxTunnelLifetime))
 	return nil
 }
 
@@ -252,6 +254,7 @@ func Convert_v1beta1_Transport_To_apiserver_Transport(in *Transport, out *apiser
 func autoConvert_apiserver_Transport_To_v1beta1_Transport(in *apiserver.Transport, out *Transport, s conversion.Scope) error {
 	out.TCP = (*TCPTransport)(unsafe.Pointer(in.TCP))
 	out.UDS = (*UDSTransport)(unsafe.Pointer(in.UDS))
+	out.MaxTunnelLifetime = (*v1.Duration)(unsafe.Pointer(in.MaxTunnelLifetime))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -143,6 +144,11 @@ func (in *Transport) DeepCopyInto(out *Transport) {
 	if in.UDS != nil {
 		in, out := &in.UDS, &out.UDS
 		*out = new(UDSTransport)
+		**out = **in
+	}
+	if in.MaxTunnelLifetime != nil {
+		in, out := &in.MaxTunnelLifetime, &out.MaxTunnelLifetime
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	return

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package apiserver
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -231,6 +232,11 @@ func (in *Transport) DeepCopyInto(out *Transport) {
 	if in.UDS != nil {
 		in, out := &in.UDS, &out.UDS
 		*out = new(UDSTransport)
+		**out = **in
+	}
+	if in.MaxTunnelLifetime != nil {
+		in, out := &in.MaxTunnelLifetime, &out.MaxTunnelLifetime
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	return


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature
-->

#### What this PR does / why we need it:

This feature adds an additional guard against leaked tunnels.

#### Which issue(s) this PR fixes:

https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/357

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
