### PR TITLE
Change reflect.Ptr to reflect.Pointer

### DIFF
--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -389,7 +389,7 @@ func collectResourcePaths(t *testing.T, resourcename string, path *field.Path, n
 	resourcename = strings.ToLower(resourcename)
 	resourcePaths := sets.NewString()
 
-	if tp.Kind() == reflect.Ptr {
+	if tp.Kind() == reflect.Pointer {
 		resourcePaths.Insert(collectResourcePaths(t, resourcename, path, name, tp.Elem()).List()...)
 		return resourcePaths
 	}
@@ -399,7 +399,7 @@ func collectResourcePaths(t *testing.T, resourcename string, path *field.Path, n
 	}
 
 	switch tp.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		resourcePaths.Insert(collectResourcePaths(t, resourcename, path, name, tp.Elem()).List()...)
 	case reflect.Struct:
 		// ObjectMeta is generic and therefore should never have a field with a specific resource's name;

--- a/pkg/api/testing/serialization_proto_test.go
+++ b/pkg/api/testing/serialization_proto_test.go
@@ -80,7 +80,7 @@ func TestAllFieldsHaveTags(t *testing.T) {
 
 func fieldsHaveProtobufTags(obj reflect.Type) error {
 	switch obj.Kind() {
-	case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Array:
+	case reflect.Slice, reflect.Map, reflect.Pointer, reflect.Array:
 		return fieldsHaveProtobufTags(obj.Elem())
 	case reflect.Struct:
 		for i := 0; i < obj.NumField(); i++ {

--- a/pkg/api/v1/persistentvolume/util_test.go
+++ b/pkg/api/v1/persistentvolume/util_test.go
@@ -266,7 +266,7 @@ func TestPVSecrets(t *testing.T) {
 func collectSecretPaths(t *testing.T, path *field.Path, name string, tp reflect.Type) sets.String {
 	secretPaths := sets.NewString()
 
-	if tp.Kind() == reflect.Ptr {
+	if tp.Kind() == reflect.Pointer {
 		secretPaths.Insert(collectSecretPaths(t, path, name, tp.Elem()).List()...)
 		return secretPaths
 	}
@@ -276,7 +276,7 @@ func collectSecretPaths(t *testing.T, path *field.Path, name string, tp reflect.
 	}
 
 	switch tp.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		secretPaths.Insert(collectSecretPaths(t, path, name, tp.Elem()).List()...)
 	case reflect.Struct:
 		// ObjectMeta should not have any field with the word "secret" in it;

--- a/pkg/api/v1/pod/util_test.go
+++ b/pkg/api/v1/pod/util_test.go
@@ -555,7 +555,7 @@ func collectResourcePaths(t *testing.T, resourcename string, path *field.Path, n
 	resourcename = strings.ToLower(resourcename)
 	resourcePaths := sets.NewString()
 
-	if tp.Kind() == reflect.Ptr {
+	if tp.Kind() == reflect.Pointer {
 		resourcePaths.Insert(collectResourcePaths(t, resourcename, path, name, tp.Elem()).List()...)
 		return resourcePaths
 	}
@@ -565,7 +565,7 @@ func collectResourcePaths(t *testing.T, resourcename string, path *field.Path, n
 	}
 
 	switch tp.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		resourcePaths.Insert(collectResourcePaths(t, resourcename, path, name, tp.Elem()).List()...)
 	case reflect.Struct:
 		// ObjectMeta is generic and therefore should never have a field with a specific resource's name;

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -392,7 +392,7 @@ func detectDefaults(t *testing.T, obj runtime.Object, v reflect.Value) map[strin
 				t.Logf("unhandled non-primitive map type %s: %s", visit.path, visit.value.Type().Elem())
 			}
 
-		case visit.value.Kind() == reflect.Ptr:
+		case visit.value.Kind() == reflect.Pointer:
 			if visit.value.IsNil() {
 				if visit.value.Type().Elem().Kind() == reflect.Struct {
 					visit.value.Set(reflect.New(visit.value.Type().Elem()))

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -17759,7 +17759,7 @@ func collectResourcePaths(t *testing.T, skipRecurseList sets.String, tp reflect.
 
 	paths := sets.NewString()
 	switch tp.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		paths.Insert(collectResourcePaths(t, skipRecurseList, tp.Elem(), path).List()...)
 	case reflect.Struct:
 		for i := 0; i < tp.NumField(); i++ {

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -69,7 +69,7 @@ func allPrimitiveFieldPaths(t *testing.T, skipRecurseList sets.String, tp reflec
 
 	paths := sets.NewString()
 	switch tp.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		paths.Insert(allPrimitiveFieldPaths(t, skipRecurseList, tp.Elem(), path).List()...)
 	case reflect.Struct:
 		for i := 0; i < tp.NumField(); i++ {

--- a/pkg/kubelet/cri/remote/conversion_test.go
+++ b/pkg/kubelet/cri/remote/conversion_test.go
@@ -99,7 +99,7 @@ func assertEqualTypes(t *testing.T, path []string, a, b reflect.Type) {
 			path = path[:len(path)-1]
 		}
 
-	case reflect.Ptr, reflect.Slice:
+	case reflect.Pointer, reflect.Slice:
 		aElemType := a.Elem()
 		bElemType := b.Elem()
 		assertEqualTypes(t, path, aElemType, bElemType)
@@ -170,14 +170,14 @@ func fillField(field reflect.Value, v int) {
 		field.Set(slice)
 		first := slice.Index(0)
 
-		if first.Type().Kind() == reflect.Ptr {
+		if first.Type().Kind() == reflect.Pointer {
 			first.Set(reflect.New(first.Type().Elem()))
 			fillFieldsOffset(first.Interface(), v)
 		} else {
 			fillField(first, v)
 		}
 
-	case reflect.Ptr:
+	case reflect.Pointer:
 		val := reflect.New(field.Type().Elem())
 		field.Set(val)
 		fillFieldsOffset(field.Interface(), v)

--- a/pkg/util/iptables/testing/parse.go
+++ b/pkg/util/iptables/testing/parse.go
@@ -299,7 +299,7 @@ func findParamField(value reflect.Value, param string) (*reflect.Value, bool) {
 var wordRegex = regexp.MustCompile(`(?:^|\s)("[^"]*"|[^"]\S*)`)
 
 // Used by ParseRule
-var boolPtrType = reflect.PtrTo(reflect.TypeOf(true))
+var boolPtrType = reflect.PointerTo(reflect.TypeOf(true))
 var ipTablesValuePtrType = reflect.TypeOf((*IPTablesValue)(nil))
 
 // ParseRule parses rule. If strict is false, it will parse the recognized

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
@@ -118,7 +118,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 				default:
 					isValue := true
 					switch field.Type.Kind() {
-					case reflect.Interface, reflect.Map, reflect.Slice, reflect.Ptr:
+					case reflect.Interface, reflect.Map, reflect.Slice, reflect.Pointer:
 						isValue = false
 					}
 					if isValue || c.Intn(10) == 0 {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/conversion_test.go
@@ -715,7 +715,7 @@ func assertEqualTypes(t *testing.T, path []string, a, b reflect.Type) {
 			path = path[:len(path)-1]
 		}
 
-	case reflect.Ptr, reflect.Slice:
+	case reflect.Pointer, reflect.Slice:
 		aElemType := a.Elem()
 		bElemType := b.Elem()
 		assertEqualTypes(t, path, aElemType, bElemType)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
@@ -131,7 +131,7 @@ func (s *Validator) validateExpressions(ctx context.Context, fldPath *field.Path
 	if oldObj != nil {
 		v := reflect.ValueOf(oldObj)
 		switch v.Kind() {
-		case reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+		case reflect.Map, reflect.Pointer, reflect.Interface, reflect.Slice:
 			if v.IsNil() {
 				oldObj = nil // +k8s:verify-mutation:reason=clone
 			}

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/value.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/value.go
@@ -200,17 +200,17 @@ func (sv *structValue) AddField(field *Field) {
 func (sv *structValue) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	if typeDesc.Kind() != reflect.Map &&
 		typeDesc.Kind() != reflect.Struct &&
-		typeDesc.Kind() != reflect.Ptr &&
+		typeDesc.Kind() != reflect.Pointer &&
 		typeDesc.Kind() != reflect.Interface {
 		return nil, fmt.Errorf("type conversion error from object to '%v'", typeDesc)
 	}
 
 	// Unwrap pointers, but track their use.
 	isPtr := false
-	if typeDesc.Kind() == reflect.Ptr {
+	if typeDesc.Kind() == reflect.Pointer {
 		tk := typeDesc
 		typeDesc = typeDesc.Elem()
-		if typeDesc.Kind() == reflect.Ptr {
+		if typeDesc.Kind() == reflect.Pointer {
 			return nil, fmt.Errorf("unsupported type conversion to '%v'", tk)
 		}
 		isPtr = true

--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/fuzzer/valuefuzz.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/fuzzer/valuefuzz.go
@@ -40,7 +40,7 @@ func valueFuzz(obj reflect.Value) {
 				valueFuzz(obj.Index(i))
 			}
 		}
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Pointer:
 		if obj.IsNil() {
 			// TODO: set non-nil value
 		} else {

--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/naming/naming.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/naming/naming.go
@@ -76,7 +76,7 @@ func ensureNoTags(gvk schema.GroupVersionKind, tp reflect.Type, parents []reflec
 	parents = append(parents, tp)
 
 	switch tp.Kind() {
-	case reflect.Map, reflect.Slice, reflect.Ptr:
+	case reflect.Map, reflect.Slice, reflect.Pointer:
 		errs = append(errs, ensureNoTags(gvk, tp.Elem(), parents, typesAllowedTags)...)
 
 	case reflect.String, reflect.Bool, reflect.Float32, reflect.Float64, reflect.Int32, reflect.Int64, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr, reflect.Interface:
@@ -106,7 +106,7 @@ func ensureNoTags(gvk schema.GroupVersionKind, tp reflect.Type, parents []reflec
 func ensureTags(gvk schema.GroupVersionKind, tp reflect.Type, parents []reflect.Type, allowedNonstandardJSONNames map[reflect.Type]string) []error {
 	errs := []error{}
 	// This type handles its own encoding/decoding and doesn't need json tags
-	if tp.Implements(marshalerType) && (tp.Implements(unmarshalerType) || reflect.PtrTo(tp).Implements(unmarshalerType)) {
+	if tp.Implements(marshalerType) && (tp.Implements(unmarshalerType) || reflect.PointerTo(tp).Implements(unmarshalerType)) {
 		return errs
 	}
 
@@ -117,7 +117,7 @@ func ensureTags(gvk schema.GroupVersionKind, tp reflect.Type, parents []reflect.
 	parents = append(parents, tp)
 
 	switch tp.Kind() {
-	case reflect.Map, reflect.Slice, reflect.Ptr:
+	case reflect.Map, reflect.Slice, reflect.Pointer:
 		errs = append(errs, ensureTags(gvk, tp.Elem(), parents, allowedNonstandardJSONNames)...)
 
 	case reflect.String, reflect.Bool, reflect.Float32, reflect.Float64, reflect.Int32, reflect.Int64, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr, reflect.Interface:

--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/construct.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/construct.go
@@ -91,7 +91,7 @@ func fill(dataString string, dataInt int, t reflect.Type, v reflect.Value, fillF
 	defer delete(filledTypes, t)
 
 	// if nil, populate pointers with a zero-value instance of the underlying type
-	if t.Kind() == reflect.Ptr && v.IsNil() {
+	if t.Kind() == reflect.Pointer && v.IsNil() {
 		if v.CanSet() {
 			v.Set(reflect.New(t.Elem()))
 		} else if v.IsNil() {
@@ -155,10 +155,10 @@ func fill(dataString string, dataInt int, t reflect.Type, v reflect.Value, fillF
 			fieldType := field.Type
 			fieldValue := v.Field(i)
 
-			fill(dataString, dataInt, reflect.PtrTo(fieldType), fieldValue.Addr(), fillFuncs, filledTypes)
+			fill(dataString, dataInt, reflect.PointerTo(fieldType), fieldValue.Addr(), fillFuncs, filledTypes)
 		}
 
-	case reflect.Ptr:
+	case reflect.Pointer:
 		fill(dataString, dataInt, t.Elem(), v.Elem(), fillFuncs, filledTypes)
 
 	case reflect.String:

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
@@ -97,7 +97,7 @@ func getItemsPtr(list runtime.Object) (interface{}, error) {
 		return nil, errExpectFieldItems
 	}
 	switch items.Kind() {
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Pointer:
 		target := reflect.TypeOf(items.Interface()).Elem()
 		if target.Kind() != reflect.Slice {
 			return nil, errExpectSliceItems
@@ -130,7 +130,7 @@ func EachListItem(obj runtime.Object, fn func(runtime.Object) error) error {
 		return nil
 	}
 	takeAddr := false
-	if elemType := items.Type().Elem(); elemType.Kind() != reflect.Ptr && elemType.Kind() != reflect.Interface {
+	if elemType := items.Type().Elem(); elemType.Kind() != reflect.Pointer && elemType.Kind() != reflect.Interface {
 		if !items.Index(0).CanAddr() {
 			return fmt.Errorf("unable to take address of items in %T for EachListItem", obj)
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/meta.go
@@ -599,7 +599,7 @@ func (a genericAccessor) SetFinalizers(finalizers []string) {
 func (a genericAccessor) GetOwnerReferences() []metav1.OwnerReference {
 	var ret []metav1.OwnerReference
 	s := a.ownerReferences
-	if s.Kind() != reflect.Ptr || s.Elem().Kind() != reflect.Slice {
+	if s.Kind() != reflect.Pointer || s.Elem().Kind() != reflect.Slice {
 		klog.Errorf("expect %v to be a pointer to slice", s)
 		return ret
 	}
@@ -617,7 +617,7 @@ func (a genericAccessor) GetOwnerReferences() []metav1.OwnerReference {
 
 func (a genericAccessor) SetOwnerReferences(references []metav1.OwnerReference) {
 	s := a.ownerReferences
-	if s.Kind() != reflect.Ptr || s.Elem().Kind() != reflect.Slice {
+	if s.Kind() != reflect.Pointer || s.Elem().Kind() != reflect.Slice {
 		klog.Errorf("expect %v to be a pointer to slice", s)
 	}
 	s = s.Elem()

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go
@@ -115,10 +115,10 @@ type ConversionFuncs struct {
 // previously defined functions.
 func (c ConversionFuncs) AddUntyped(a, b interface{}, fn ConversionFunc) error {
 	tA, tB := reflect.TypeOf(a), reflect.TypeOf(b)
-	if tA.Kind() != reflect.Ptr {
+	if tA.Kind() != reflect.Pointer {
 		return fmt.Errorf("the type %T must be a pointer to register as an untyped conversion", a)
 	}
-	if tB.Kind() != reflect.Ptr {
+	if tB.Kind() != reflect.Pointer {
 		return fmt.Errorf("the type %T must be a pointer to register as an untyped conversion", b)
 	}
 	c.untyped[typePair{tA, tB}] = fn
@@ -179,10 +179,10 @@ func (c *Converter) RegisterGeneratedUntypedConversionFunc(a, b interface{}, fn 
 func (c *Converter) RegisterIgnoredConversion(from, to interface{}) error {
 	typeFrom := reflect.TypeOf(from)
 	typeTo := reflect.TypeOf(to)
-	if typeFrom.Kind() != reflect.Ptr {
+	if typeFrom.Kind() != reflect.Pointer {
 		return fmt.Errorf("expected pointer arg for 'from' param 0, got: %v", typeFrom)
 	}
-	if typeTo.Kind() != reflect.Ptr {
+	if typeTo.Kind() != reflect.Pointer {
 		return fmt.Errorf("expected pointer arg for 'to' param 1, got: %v", typeTo)
 	}
 	c.ignoredUntypedConversions[typePair{typeFrom, typeTo}] = struct{}{}

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/helper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/helper.go
@@ -26,7 +26,7 @@ import (
 // Returns an error if this is not possible.
 func EnforcePtr(obj interface{}) (reflect.Value, error) {
 	v := reflect.ValueOf(obj)
-	if v.Kind() != reflect.Ptr {
+	if v.Kind() != reflect.Pointer {
 		if v.Kind() == reflect.Invalid {
 			return reflect.Value{}, fmt.Errorf("expected pointer, but got invalid kind")
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/queryparams/convert.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/queryparams/convert.go
@@ -55,7 +55,7 @@ func jsonTag(field reflect.StructField) (string, bool) {
 }
 
 func isPointerKind(kind reflect.Kind) bool {
-	return kind == reflect.Ptr
+	return kind == reflect.Pointer
 }
 
 func isStructKind(kind reflect.Kind) bool {
@@ -139,7 +139,7 @@ func Convert(obj interface{}) (url.Values, error) {
 	}
 	var sv reflect.Value
 	switch reflect.TypeOf(obj).Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		sv = reflect.ValueOf(obj).Elem()
 	default:
 		return nil, fmt.Errorf("expecting a pointer or interface")

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -237,7 +237,7 @@ func (c *fromUnstructuredContext) pushKey(key string) {
 func (c *unstructuredConverter) FromUnstructuredWithValidation(u map[string]interface{}, obj interface{}, returnUnknownFields bool) error {
 	t := reflect.TypeOf(obj)
 	value := reflect.ValueOf(obj)
-	if t.Kind() != reflect.Ptr || value.IsNil() {
+	if t.Kind() != reflect.Pointer || value.IsNil() {
 		return fmt.Errorf("FromUnstructured requires a non-nil pointer to an object, got %v", t)
 	}
 
@@ -291,7 +291,7 @@ func fromUnstructured(sv, dv reflect.Value, ctx *fromUnstructuredContext) error 
 	st, dt := sv.Type(), dv.Type()
 
 	switch dt.Kind() {
-	case reflect.Map, reflect.Slice, reflect.Ptr, reflect.Struct, reflect.Interface:
+	case reflect.Map, reflect.Slice, reflect.Pointer, reflect.Struct, reflect.Interface:
 		// Those require non-trivial conversion.
 	default:
 		// This should handle all simple types.
@@ -353,7 +353,7 @@ func fromUnstructured(sv, dv reflect.Value, ctx *fromUnstructuredContext) error 
 		return mapFromUnstructured(sv, dv, ctx)
 	case reflect.Slice:
 		return sliceFromUnstructured(sv, dv, ctx)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return pointerFromUnstructured(sv, dv, ctx)
 	case reflect.Struct:
 		return structFromUnstructured(sv, dv, ctx)
@@ -496,13 +496,13 @@ func sliceFromUnstructured(sv, dv reflect.Value, ctx *fromUnstructuredContext) e
 func pointerFromUnstructured(sv, dv reflect.Value, ctx *fromUnstructuredContext) error {
 	st, dt := sv.Type(), dv.Type()
 
-	if st.Kind() == reflect.Ptr && sv.IsNil() {
+	if st.Kind() == reflect.Pointer && sv.IsNil() {
 		dv.Set(reflect.Zero(dt))
 		return nil
 	}
 	dv.Set(reflect.New(dt.Elem()))
 	switch st.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		return fromUnstructured(sv.Elem(), dv.Elem(), ctx)
 	default:
 		return fromUnstructured(sv, dv.Elem(), ctx)
@@ -579,7 +579,7 @@ func (c *unstructuredConverter) ToUnstructured(obj interface{}) (map[string]inte
 	} else {
 		t := reflect.TypeOf(obj)
 		value := reflect.ValueOf(obj)
-		if t.Kind() != reflect.Ptr || value.IsNil() {
+		if t.Kind() != reflect.Pointer || value.IsNil() {
 			return nil, fmt.Errorf("ToUnstructured requires a non-nil pointer to an object, got %v", t)
 		}
 		u = map[string]interface{}{}
@@ -686,7 +686,7 @@ func toUnstructured(sv, dv reflect.Value) error {
 		return mapToUnstructured(sv, dv)
 	case reflect.Slice:
 		return sliceToUnstructured(sv, dv)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return pointerToUnstructured(sv, dv)
 	case reflect.Struct:
 		return structToUnstructured(sv, dv)
@@ -790,7 +790,7 @@ func isZero(v reflect.Value) bool {
 	case reflect.Map, reflect.Slice:
 		// TODO: It seems that 0-len maps are ignored in it.
 		return v.IsNil() || v.Len() == 0
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		return v.IsNil()
 	}
 	return false

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -141,7 +141,7 @@ func (s *Scheme) AddKnownTypes(gv schema.GroupVersion, types ...Object) {
 	s.addObservedVersion(gv)
 	for _, obj := range types {
 		t := reflect.TypeOf(obj)
-		if t.Kind() != reflect.Ptr {
+		if t.Kind() != reflect.Pointer {
 			panic("All types must be pointers to structs.")
 		}
 		t = t.Elem()
@@ -159,7 +159,7 @@ func (s *Scheme) AddKnownTypeWithName(gvk schema.GroupVersionKind, obj Object) {
 	if len(gvk.Version) == 0 {
 		panic(fmt.Sprintf("version is required on all types: %s %v", gvk, t))
 	}
-	if t.Kind() != reflect.Ptr {
+	if t.Kind() != reflect.Pointer {
 		panic("All types must be pointers to structs.")
 	}
 	t = t.Elem()
@@ -462,7 +462,7 @@ func (s *Scheme) convertToVersion(copy bool, in Object, target GroupVersioner) (
 	} else {
 		// determine the incoming kinds with as few allocations as possible.
 		t = reflect.TypeOf(in)
-		if t.Kind() != reflect.Ptr {
+		if t.Kind() != reflect.Pointer {
 			return nil, fmt.Errorf("only pointer types may be converted: %v", t)
 		}
 		t = t.Elem()

--- a/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go
@@ -135,7 +135,7 @@ func IgnoreUnset() cmp.Option {
 				if v2.Len() == 0 {
 					return true
 				}
-			case reflect.Interface, reflect.Ptr:
+			case reflect.Interface, reflect.Pointer:
 				if v2.IsNil() {
 					return true
 				}

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go
@@ -105,7 +105,7 @@ func (s PatchMetaFromStruct) LookupPatchMetadataForSlice(key string) (LookupPatc
 	// If the underlying element is neither an array nor a slice, the pointer is pointing to a slice,
 	// e.g. https://github.com/kubernetes/kubernetes/blob/bc22e206c79282487ea0bf5696d5ccec7e839a76/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go#L2782-L2822
 	// If the underlying element is either an array or a slice, return its element type.
-	case reflect.Ptr:
+	case reflect.Pointer:
 		t = t.Elem()
 		if t.Kind() == reflect.Array || t.Kind() == reflect.Slice {
 			t = t.Elem()
@@ -129,7 +129,7 @@ func getTagStructType(dataStruct interface{}) (reflect.Type, error) {
 
 	t := reflect.TypeOf(dataStruct)
 	// Get the underlying type for pointers
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -66,7 +66,7 @@ func (v *Error) ErrorBody() string {
 		valueType := reflect.TypeOf(value)
 		if value == nil || valueType == nil {
 			value = "null"
-		} else if valueType.Kind() == reflect.Ptr {
+		} else if valueType.Kind() == reflect.Pointer {
 			if reflectValue := reflect.ValueOf(value); reflectValue.IsNil() {
 				value = "null"
 			} else {

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
@@ -28,7 +28,7 @@ const (
 // TODO: fix the returned errors to be introspectable.
 func LookupPatchMetadataForStruct(t reflect.Type, jsonField string) (
 	elemType reflect.Type, patchStrategies []string, patchMergeKey string, e error) {
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -183,7 +183,7 @@ func typeFields(t reflect.Type) []field {
 				index[len(f.index)] = i
 
 				ft := sf.Type
-				if ft.Name() == "" && ft.Kind() == reflect.Ptr {
+				if ft.Name() == "" && ft.Kind() == reflect.Pointer {
 					// Follow pointer.
 					ft = ft.Elem()
 				}

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal.go
@@ -179,7 +179,7 @@ func (e Equalities) deepValueEqual(v1, v2 reflect.Value, visited map[visit]bool,
 			return v1.IsNil() == v2.IsNil()
 		}
 		return e.deepValueEqual(v1.Elem(), v2.Elem(), visited, depth+1)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return e.deepValueEqual(v1.Elem(), v2.Elem(), visited, depth+1)
 	case reflect.Struct:
 		for i, n := 0, v1.NumField(); i < n; i++ {
@@ -327,7 +327,7 @@ func (e Equalities) deepValueDerive(v1, v2 reflect.Value, visited map[visit]bool
 			return true
 		}
 		return e.deepValueDerive(v1.Elem(), v2.Elem(), visited, depth+1)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if v1.IsNil() {
 			return true
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -1050,7 +1050,7 @@ func AddObjectParams(ws *restful.WebService, route *restful.RouteBuilder, obj in
 			}
 			switch sf.Type.Kind() {
 			case reflect.Interface, reflect.Struct:
-			case reflect.Ptr:
+			case reflect.Pointer:
 				// TODO: This is a hack to let metav1.Time through. This needs to be fixed in a more generic way eventually. bug #36191
 				if (sf.Type.Elem().Kind() == reflect.Interface || sf.Type.Elem().Kind() == reflect.Struct) && strings.TrimPrefix(sf.Type.String(), "*") != "metav1.Time" {
 					continue

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/jsonpath.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/jsonpath.go
@@ -85,7 +85,7 @@ func exists(item interface{}, indices ...interface{}) bool {
 // We indirect through pointers and empty interfaces (only) because
 // non-empty interfaces have methods we might need.
 func indirect(v reflect.Value) (rv reflect.Value, isNil bool) {
-	for ; v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface; v = v.Elem() {
+	for ; v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface; v = v.Elem() {
 		if v.IsNil() {
 			return v, true
 		}

--- a/staging/src/k8s.io/client-go/third_party/forked/golang/template/exec.go
+++ b/staging/src/k8s.io/client-go/third_party/forked/golang/template/exec.go
@@ -17,7 +17,7 @@ var (
 // We indirect through pointers and empty interfaces (only) because
 // non-empty interfaces have methods we might need.
 func Indirect(v reflect.Value) (rv reflect.Value, isNil bool) {
-	for ; v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface; v = v.Elem() {
+	for ; v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface; v = v.Elem() {
 		if v.IsNil() {
 			return v, true
 		}
@@ -31,7 +31,7 @@ func Indirect(v reflect.Value) (rv reflect.Value, isNil bool) {
 // PrintableValue returns the, possibly indirected, interface value inside v that
 // is best for a call to formatted printer.
 func PrintableValue(v reflect.Value) (interface{}, bool) {
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v, _ = Indirect(v) // fmt.Fprint handles nil.
 	}
 	if !v.IsValid() {
@@ -39,7 +39,7 @@ func PrintableValue(v reflect.Value) (interface{}, bool) {
 	}
 
 	if !v.Type().Implements(errorType) && !v.Type().Implements(fmtStringerType) {
-		if v.CanAddr() && (reflect.PtrTo(v.Type()).Implements(errorType) || reflect.PtrTo(v.Type()).Implements(fmtStringerType)) {
+		if v.CanAddr() && (reflect.PointerTo(v.Type()).Implements(errorType) || reflect.PointerTo(v.Type()).Implements(fmtStringerType)) {
 			v = v.Addr()
 		} else {
 			switch v.Kind() {

--- a/staging/src/k8s.io/component-base/logs/api/v1/types_test.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/types_test.go
@@ -228,7 +228,7 @@ func notZeroRecursive(t *testing.T, i interface{}, path string) bool {
 	kind := typeOfI.Kind()
 	value := reflect.ValueOf(i)
 	switch kind {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if !notZeroRecursive(t, value.Elem().Interface(), path) {
 			valid = false
 		}

--- a/staging/src/k8s.io/component-base/logs/datapol/datapol.go
+++ b/staging/src/k8s.io/component-base/logs/datapol/datapol.go
@@ -35,7 +35,7 @@ func Verify(value interface{}) []string {
 		}
 	}()
 	t := reflect.ValueOf(value)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return datatypes(t)
@@ -82,7 +82,7 @@ func datatypes(v reflect.Value) []string {
 
 		for i := 0; i < numField; i++ {
 			f := t.Field(i)
-			if f.Type.Kind() == reflect.Ptr {
+			if f.Type.Kind() == reflect.Pointer {
 				continue
 			}
 			if reason, ok := f.Tag.Lookup("datapolicy"); ok {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
@@ -921,7 +921,7 @@ func testClearLocationOfOrigin(config *clientcmdapi.Config) {
 }
 func testSetNilMapsToEmpties(curr reflect.Value) {
 	actualCurrValue := curr
-	if curr.Kind() == reflect.Ptr {
+	if curr.Kind() == reflect.Pointer {
 		actualCurrValue = curr.Elem()
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -115,7 +115,7 @@ func findNameStep(parts []string, typeOptions sets.String) string {
 
 // getPotentialTypeValues takes a type and looks up the tags used to represent its fields when serialized.
 func getPotentialTypeValues(typeValue reflect.Type) (map[string]reflect.Type, error) {
-	if typeValue.Kind() == reflect.Ptr {
+	if typeValue.Kind() == reflect.Pointer {
 		typeValue = typeValue.Elem()
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -145,7 +145,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 	currStep := steps.pop()
 
 	actualCurrValue := curr
-	if curr.Kind() == reflect.Ptr {
+	if curr.Kind() == reflect.Pointer {
 		actualCurrValue = curr.Elem()
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
@@ -182,7 +182,7 @@ func isLess(i, j reflect.Value) (bool, error) {
 		return i.Float() < j.Float(), nil
 	case reflect.String:
 		return sortorder.NaturalLess(i.String(), j.String()), nil
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return isLess(i.Elem(), j.Elem())
 	case reflect.Struct:
 		// sort metav1.Time

--- a/test/e2e/framework/config/config.go
+++ b/test/e2e/framework/config/config.go
@@ -135,7 +135,7 @@ func AddOptionsToSet(flags *flag.FlagSet, options interface{}, prefix string) bo
 	if optionsType == nil {
 		panic("options parameter without a type - nil?!")
 	}
-	if optionsType.Kind() != reflect.Ptr || optionsType.Elem().Kind() != reflect.Struct {
+	if optionsType.Kind() != reflect.Pointer || optionsType.Elem().Kind() != reflect.Struct {
 		panic(fmt.Sprintf("need a pointer to a struct, got instead: %T", options))
 	}
 	addStructFields(flags, optionsType.Elem(), reflect.Indirect(reflect.ValueOf(options)), prefix)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- `reflect.Ptr` is the old name for the `reflect.Pointer` kind.
- `reflect.PtrTo` is the old spelling of `reflect.PointerTo`.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
