### PR TITLE
Write Event Lifecycle Test +1 Endpoint

### DIFF
--- a/test/e2e/instrumentation/core_events.go
+++ b/test/e2e/instrumentation/core_events.go
@@ -22,7 +22,9 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/instrumentation/common"
@@ -106,6 +108,115 @@ var _ = common.SIGDescribe("Events", func() {
 		event, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Get(context.TODO(), eventCreatedName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to fetch the test event")
 		framework.ExpectEqual(event.Message, eventPatchMessage, "test event message does not match patch message")
+
+		ginkgo.By("deleting the test event")
+		// delete original event
+		err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Delete(context.TODO(), eventCreatedName, metav1.DeleteOptions{})
+		framework.ExpectNoError(err, "failed to delete the test event")
+
+		ginkgo.By("listing all events in all namespaces")
+		// get a list of Events list namespace
+		eventsList, err = f.ClientSet.CoreV1().Events("").List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "testevent-constant=true",
+		})
+		framework.ExpectNoError(err, "fail to list all events")
+		foundCreatedEvent = false
+		for _, val := range eventsList.Items {
+			if val.ObjectMeta.Name == eventTestName && val.ObjectMeta.Namespace == f.Namespace.Name {
+				foundCreatedEvent = true
+				break
+			}
+		}
+		if foundCreatedEvent {
+			framework.Failf("Should not have found test event %s in namespace %s, full list of events %+v", eventTestName, f.Namespace.Name, eventsList.Items)
+		}
+	})
+
+	ginkgo.It("should manage the lifecycle of an event", func() {
+		eventTestName := "event-test"
+
+		ginkgo.By("creating a test event")
+		// create a test event in test namespace
+		_, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Create(context.TODO(), &v1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: eventTestName,
+				Labels: map[string]string{
+					"testevent-constant": "true",
+				},
+			},
+			Message: "This is a test event",
+			Reason:  "Test",
+			Type:    "Normal",
+			Count:   1,
+			InvolvedObject: v1.ObjectReference{
+				Namespace: f.Namespace.Name,
+			},
+		}, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create test event")
+
+		ginkgo.By("listing all events in all namespaces")
+		// get a list of Events in all namespaces to ensure endpoint coverage
+		eventsList, err := f.ClientSet.CoreV1().Events("").List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "testevent-constant=true",
+		})
+		framework.ExpectNoError(err, "failed list all events")
+
+		foundCreatedEvent := false
+		var eventCreatedName string
+		for _, val := range eventsList.Items {
+			if val.ObjectMeta.Name == eventTestName && val.ObjectMeta.Namespace == f.Namespace.Name {
+				foundCreatedEvent = true
+				eventCreatedName = val.ObjectMeta.Name
+				break
+			}
+		}
+		if !foundCreatedEvent {
+			framework.Failf("unable to find test event %s in namespace %s, full list of events is %+v", eventTestName, f.Namespace.Name, eventsList.Items)
+		}
+
+		ginkgo.By("patching the test event")
+		// patch the event's message
+		eventPatchMessage := "This is a test event - patched"
+		eventPatch, err := json.Marshal(map[string]interface{}{
+			"message": eventPatchMessage,
+		})
+		framework.ExpectNoError(err, "failed to marshal the patch JSON payload")
+
+		_, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Patch(context.TODO(), eventTestName, types.StrategicMergePatchType, []byte(eventPatch), metav1.PatchOptions{})
+		framework.ExpectNoError(err, "failed to patch the test event")
+
+		ginkgo.By("fetching the test event")
+		// get event by name
+		event, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Get(context.TODO(), eventCreatedName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to fetch the test event")
+		framework.ExpectEqual(event.Message, eventPatchMessage, "test event message does not match patch message")
+
+		ginkgo.By("updating the test event")
+
+		testEvent, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Get(context.TODO(), event.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get test event")
+
+		testEvent.Series = &v1.EventSeries{
+			Count:            100,
+			LastObservedTime: metav1.MicroTime{Time: time.Unix(1505828956, 0)},
+		}
+
+		// clear ResourceVersion and ManagedFields which are set by control-plane
+		testEvent.ObjectMeta.ResourceVersion = ""
+		testEvent.ObjectMeta.ManagedFields = nil
+
+		_, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Update(context.TODO(), testEvent, metav1.UpdateOptions{})
+		framework.ExpectNoError(err, "failed to update the test event")
+
+		ginkgo.By("getting the test event")
+		event, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Get(context.TODO(), testEvent.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get test event")
+		// clear ResourceVersion and ManagedFields which are set by control-plane
+		event.ObjectMeta.ResourceVersion = ""
+		event.ObjectMeta.ManagedFields = nil
+		if !apiequality.Semantic.DeepEqual(testEvent, event) {
+			framework.Failf("test event wasn't properly updated: %v", diff.ObjectReflectDiff(testEvent, event))
+		}
 
 		ginkgo.By("deleting the test event")
 		// delete original event


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceCoreV1NamespacedEvent

**Which issue(s) this PR fixes:**
Fixes #110797

**Testgrid Link:** 
[testgrid-link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.manage.the.lifecycle.of.an.event)

**Special notes for your reviewer:**
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance