### PR TITLE
Execute kubectl top node and kubectl pod to display the appropriate units

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -45,6 +45,7 @@ type TopNodeOptions struct {
 	NoHeaders          bool
 	UseProtocolBuffers bool
 	ShowCapacity       bool
+	Unit               bool
 
 	NodeClient      corev1client.CoreV1Interface
 	Printer         *metricsutil.TopCmdPrinter
@@ -95,6 +96,7 @@ func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericclioptio
 	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "If present, print output without headers")
 	cmd.Flags().BoolVar(&o.UseProtocolBuffers, "use-protocol-buffers", o.UseProtocolBuffers, "Enables using protocol-buffers to access Metrics API.")
 	cmd.Flags().BoolVar(&o.ShowCapacity, "show-capacity", o.ShowCapacity, "Print node resources based on Capacity instead of Allocatable(default) of the nodes.")
+	cmd.Flags().BoolVar(&o.Unit, "format-unit", o.Unit, "Print the suitable unit of the resource usage")
 
 	return cmd
 }
@@ -200,7 +202,7 @@ func (o TopNodeOptions) RunTopNode() error {
 		}
 	}
 
-	return o.Printer.PrintNodeMetrics(metrics.Items, availableResources, o.NoHeaders, o.SortBy)
+	return o.Printer.PrintNodeMetrics(metrics.Items, availableResources, o.NoHeaders, o.SortBy, o.Unit)
 }
 
 func getNodeMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, resourceName string, selector labels.Selector) (*metricsapi.NodeMetricsList, error) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -53,6 +53,7 @@ type TopPodOptions struct {
 	NoHeaders          bool
 	UseProtocolBuffers bool
 	Sum                bool
+	Unit               bool
 
 	PodClient       corev1client.PodsGetter
 	Printer         *metricsutil.TopCmdPrinter
@@ -117,6 +118,7 @@ func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericclioptions
 	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "If present, print output without headers.")
 	cmd.Flags().BoolVar(&o.UseProtocolBuffers, "use-protocol-buffers", o.UseProtocolBuffers, "Enables using protocol-buffers to access Metrics API.")
 	cmd.Flags().BoolVar(&o.Sum, "sum", o.Sum, "Print the sum of the resource usage")
+	cmd.Flags().BoolVar(&o.Unit, "format-unit", o.Unit, "Print the suitable unit of the resource usage")
 	return cmd
 }
 
@@ -217,7 +219,7 @@ func (o TopPodOptions) RunTopPod() error {
 		}
 	}
 
-	return o.Printer.PrintPodMetrics(metrics.Items, o.PrintContainers, o.AllNamespaces, o.NoHeaders, o.SortBy, o.Sum)
+	return o.Printer.PrintPodMetrics(metrics.Items, o.PrintContainers, o.AllNamespaces, o.NoHeaders, o.SortBy, o.Sum, o.Unit)
 }
 
 func getMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, namespace, resourceName string, allNamespaces bool, labelSelector labels.Selector, fieldSelector fields.Selector) (*metricsapi.PodMetricsList, error) {

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsutil
+
+import (
+	"bytes"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"testing"
+)
+
+func Test_printSingleResourceUsage(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType v1.ResourceName
+		quantity     resource.Quantity
+		unit         bool
+		wantOut      string
+	}{
+		// TODO: Add test cases.
+		{
+			name:         "print cpu usage of unit mcore when format-unit equal true",
+			resourceType: v1.ResourceCPU,
+			quantity:     *resource.NewScaledQuantity(500, -3),
+			unit:         true,
+			wantOut:      "500m",
+		},
+		{
+			name:         "print cpu usage of unit core when format-unit equal true",
+			resourceType: v1.ResourceCPU,
+			quantity:     *resource.NewScaledQuantity(500, 0),
+			unit:         true,
+			wantOut:      "500",
+		},
+		{
+			name:         "print memory usage of unit byte when format-unit equal true",
+			resourceType: v1.ResourceMemory,
+			quantity:     *resource.NewScaledQuantity(500, 0),
+			unit:         true,
+			wantOut:      "500",
+		},
+		{
+			name:         "print memory usage of unit Kbyte when format-unit equal true",
+			resourceType: v1.ResourceMemory,
+			quantity:     *resource.NewScaledQuantity(512, 3),
+			unit:         true,
+			wantOut:      "500Ki",
+		},
+		{
+			name:         "print memory usage of unit Mbyte when format-unit equal true",
+			resourceType: v1.ResourceMemory,
+			quantity:     *resource.NewScaledQuantity(500, 6),
+			unit:         true,
+			wantOut:      "477Mi",
+		},
+		{
+			name:         "print memory usage of unit Gbyte when format-unit equal true",
+			resourceType: v1.ResourceMemory,
+			quantity:     *resource.NewScaledQuantity(3984588800, 0),
+			unit:         true,
+			wantOut:      "4Gi",
+		},
+		{
+			name:         "print memory usage of unit Tbyte when format-unit equal true",
+			resourceType: v1.ResourceMemory,
+			quantity:     *resource.NewScaledQuantity(500, 12),
+			unit:         true,
+			wantOut:      "455Ti",
+		},
+		{
+			name:         "print storage usage of unit byte when format-unit equal true",
+			resourceType: v1.ResourceStorage,
+			quantity:     *resource.NewScaledQuantity(500, 3),
+			unit:         true,
+			wantOut:      "500000",
+		},
+		{
+			name:         "print cpu usage of unit mcore when format-unit equal false",
+			resourceType: v1.ResourceCPU,
+			quantity:     *resource.NewScaledQuantity(500, -3),
+			unit:         false,
+			wantOut:      "500m",
+		},
+		{
+			name:         "print cpu usage of unit core when format-unit equal false",
+			resourceType: v1.ResourceCPU,
+			quantity:     *resource.NewScaledQuantity(500, 0),
+			unit:         false,
+			wantOut:      "500000m",
+		},
+		{
+			name:         "print memory usage of unit byte when format-unit equal false",
+			resourceType: v1.ResourceMemory,
+			quantity:     *resource.NewScaledQuantity(500, 0),
+			unit:         false,
+			wantOut:      "0Mi",
+		},
+		{
+			name:         "print memory usage of unit Kbyte when format-unit equal false",
+			resourceType: v1.ResourceMemory,
+			quantity:     *resource.NewScaledQuantity(512, 3),
+			unit:         false,
+			wantOut:      "0Mi",
+		},
+		{
+			name:         "print memory usage of unit Mbyte when format-unit equal false",
+			resourceType: v1.ResourceMemory,
+			quantity:     *resource.NewScaledQuantity(500, 6),
+			unit:         false,
+			wantOut:      "476Mi",
+		},
+		{
+			name:         "print memory usage of unit Gbyte when format-unit equal false",
+			resourceType: v1.ResourceMemory,
+			quantity:     *resource.NewScaledQuantity(3984588800, 0),
+			unit:         false,
+			wantOut:      "3800Mi",
+		},
+		{
+			name:         "print memory usage of unit Tbyte when format-unit equal false",
+			resourceType: v1.ResourceMemory,
+			quantity:     *resource.NewScaledQuantity(500, 12),
+			unit:         false,
+			wantOut:      "476837158Mi",
+		},
+		{
+			name:         "print storage usage of unit byte when format-unit equal false",
+			resourceType: v1.ResourceStorage,
+			quantity:     *resource.NewScaledQuantity(500, 3),
+			unit:         false,
+			wantOut:      "500000",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			printSingleResourceUsage(out, tt.resourceType, tt.quantity, tt.unit)
+			if gotOut := out.String(); gotOut != tt.wantOut {
+				t.Errorf("printSingleResourceUsage() = %v, want %v", gotOut, tt.wantOut)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Execute kubectl top node and kubectl pod commands, the unit of cpu and memory will only be displayed in m/Mi, add flexible display

For Example

current
```
kubectl top  node

NAME           CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%   
node           194m         6%     3958Mi          58%   
```

Optimized
```
kubectl top  node --format-unit

NAME           CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%   
node           194m         6%     4Gi             58%  
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #110722

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added flag --format-unit to display reasonable units of cpu and memory usage
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
"NONE"
```
