### PR TITLE
Graduate SeccompDefault feature to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -981,7 +981,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	RotateKubeletServerCertificate: {Default: true, PreRelease: featuregate.Beta},
 
-	SeccompDefault: {Default: false, PreRelease: featuregate.Alpha},
+	SeccompDefault: {Default: true, PreRelease: featuregate.Beta},
 
 	ServiceIPStaticSubrange: {Default: false, PreRelease: featuregate.Beta},
 

--- a/test/e2e_node/seccompdefault_test.go
+++ b/test/e2e_node/seccompdefault_test.go
@@ -1,0 +1,71 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"github.com/onsi/ginkgo"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+// Serial because the test updates kubelet configuration.
+var _ = SIGDescribe("SeccompDefault [Serial] [Feature:SeccompDefault] [LinuxOnly]", func() {
+	f := framework.NewDefaultFramework("seccompdefault-test")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	ginkgo.Context("with SeccompDefault enabled", func() {
+		tempSetCurrentKubeletConfig(f, func(cfg *kubeletconfig.KubeletConfiguration) {
+			cfg.SeccompDefault = true
+		})
+
+		newPod := func(securityContext *v1.SecurityContext) *v1.Pod {
+			name := "seccompdefault-test-" + string(uuid.NewUUID())
+			return &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyNever,
+					Containers: []v1.Container{
+						{
+							Name:            name,
+							Image:           busyboxImage,
+							Command:         []string{"grep", "Seccomp:", "/proc/self/status"},
+							SecurityContext: securityContext,
+						},
+					},
+				},
+			}
+		}
+
+		ginkgo.It("should use the default seccomp profile when unspecified", func() {
+			pod := newPod(nil)
+			f.TestContainerOutput("SeccompDefault", pod, 0, []string{"2"})
+		})
+
+		ginkgo.It("should use unconfined when specified", func() {
+			pod := newPod(&v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}})
+			f.TestContainerOutput("SeccompDefault-unconfined", pod, 0, []string{"0"})
+		})
+	})
+})


### PR DESCRIPTION
#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
As outlined in the KEP, we now graduate the Kubelet feature to beta which means that it is enabled by default. The corresponding Kubelet flag still defaults to `false`, but we now have the chance to e2e test the feature by using a new serial test case.

#### Which issue(s) this PR fixes:

Refers to: https://github.com/kubernetes/enhancements/issues/2413
Docs PR: https://github.com/kubernetes/website/pull/34640

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Graduated SeccompDefault to `beta`. The Kubelet feature gate is now enabled by default and the configuration/CLI flag still defaults to `false`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- KEP: https://github.com/kubernetes/enhancements/issues/2413
- Docs: https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads
```
