### PR TITLE
fix slave-node cannot get lock immediately for leaderelection package

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -347,7 +347,7 @@ func (le *LeaderElector) tryAcquireOrRenew(ctx context.Context) bool {
 		le.observedRawRecord = oldLeaderElectionRawRecord
 	}
 	if len(oldLeaderElectionRecord.HolderIdentity) > 0 &&
-		le.observedTime.Add(le.config.LeaseDuration).After(now.Time) &&
+		le.observedTime.Add(time.Duration(oldLeaderElectionRecord.LeaseDurationSeconds)).After(now.Time) &&
 		!le.IsLeader() {
 		klog.V(4).Infof("lock is held by %v and has not yet expired", oldLeaderElectionRecord.HolderIdentity)
 		return false


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
make sure slave-node can get lock immediately rather than waiting for 15s when master node release the lock.

Which issue(s) this PR fixes:
Slaves node still need to wait lockreleaseduration(15s) after the master node already release the lock. Although master changed the leaseduration field into 1s in the k8s, the slaves still use the leaseduration in their config, which is 15s, not 1s in k8s changed by master node. In this situation, it is pointless for master node to release this lock. So we need to change the code to make sure the slave nodes use the lockreleaseduration in K8S. Only in this way, slaves will try to get lock immediately rather than still 15s once the master node release the lock.

Special notes for your reviewer:

Does this PR introduce a user-facing change?
No.