### PR TITLE
add requirement for apiversion of unstructured when decoding

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -340,7 +340,9 @@ func (s unstructuredJSONScheme) Decode(data []byte, _ *schema.GroupVersionKind, 
 	if len(gvk.Kind) == 0 {
 		return nil, &gvk, runtime.NewMissingKindErr(string(data))
 	}
-	// TODO(109023): require apiVersion here as well
+	if gvk.GroupVersion().Empty() {
+		return nil, &gvk, runtime.NewMissingVersionErr(string(data))
+	}
 
 	return obj, &gvk, nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -176,7 +176,9 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 				if len(actual.Kind) == 0 {
 					return nil, actual, runtime.NewMissingKindErr(string(originalData))
 				}
-				// TODO(109023): require apiVersion here as well once unstructuredJSONScheme#Decode does
+				if actual.GroupVersion().Empty() {
+					return nil, actual, runtime.NewMissingVersionErr(string(originalData))
+				}
 			}
 
 			if len(strictErrs) > 0 {


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
add requirement for apiversion of unstructured when decoding

Which issue(s) this PR fixes:
#109023

/cc @apelisse @kevindelgado @liggitt
/sig api-machinery