### PR TITLE
Avoid calling `f.Sync()` for every cached discovery endpoint

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/disk/diskv_cache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/diskv_cache.go
@@ -1,14 +1,32 @@
-// Package diskcache provides an implementation of httpcache.Cache that uses the diskv package
-// to supplement an in-memory map with persistent storage
-//
-package diskcache
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+// NOTE(negz): This file is copied from the upstream httpcache implementation,
+// which is no longer maintained.
+// https://github.com/gregjones/httpcache/blob/901d90/diskcache/diskcache.go
 
 import (
 	"bytes"
 	"crypto/md5"
 	"encoding/hex"
-	"github.com/peterbourgon/diskv"
 	"io"
+
+	"github.com/peterbourgon/diskv"
 )
 
 // Cache is an implementation of httpcache.Cache that supplements the in-memory map with persistent storage

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/round_tripper.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/round_tripper.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 
 	"github.com/gregjones/httpcache"
-	"github.com/gregjones/httpcache/diskcache"
 	"github.com/peterbourgon/diskv"
 	"k8s.io/klog/v2"
 )
@@ -41,7 +40,7 @@ func newCacheRoundTripper(cacheDir string, rt http.RoundTripper) http.RoundTripp
 		BasePath: cacheDir,
 		TempDir:  filepath.Join(cacheDir, ".diskv-temp"),
 	})
-	t := httpcache.NewTransport(diskcache.NewWithDiskv(d))
+	t := httpcache.NewTransport(NewWithDiskv(d))
 	t.Transport = rt
 
 	return &cacheRoundTripper{rt: t}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -501,7 +501,6 @@ github.com/gorilla/websocket
 # github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
 ## explicit
 github.com/gregjones/httpcache
-github.com/gregjones/httpcache/diskcache
 # github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 => github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 ## explicit; go 1.14
 github.com/grpc-ecosystem/go-grpc-middleware


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

(Kind of - if you consider poor performance to be a bug.)

#### What this PR does / why we need it:

client-go's discovery cache creates a cache entry for each HTTP response body that it caches, and each cache entry corresponds to an individual file. Calling the file's `Sync()` method after each value is written ensures data is always flushed to disk, but doing so is very slow on MacOS.  We bias for speed at the expense of potentially losing (easily recreatable) cache data by not calling `Sync()`. Refer to https://github.com/kubernetes/kubernetes/issues/110753 for the full details.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/110753

#### Special notes for your reviewer:

Before this change discovery of ~350 API groups takes over 10 seconds on MacOS (it takes about 1 on Linux). Profiling indicates that almost all of this time is spent writing to disk:

```console
$ kubectl --kubeconfig=$HOME/.kube/config.eks get crd|wc -l
1577

$ kubectl --kubeconfig=$HOME/.kube/config.eks api-versions|wc -l
343

$ rm -rf ~/.kube/cache

$ time kubectl get nodes
NAME                                            STATUS   ROLES    AGE   VERSION
ip-192-168-103-188.us-west-2.compute.internal   Ready    <none>   47h   v1.22.9-eks-810597c
ip-192-168-63-15.us-west-2.compute.internal     Ready    <none>   47h   v1.22.9-eks-810597c
ip-192-168-93-0.us-west-2.compute.internal      Ready    <none>   47h   v1.22.9-eks-810597c
kubectl get nodes  0.28s user 0.42s system 5% cpu 12.459 total
```

After this change discovery takes about one second (the same as a Linux machine):

```console
$ rm -rf ~/.kube/cache

$ time bin/kubectl get nodes
NAME                                            STATUS   ROLES    AGE    VERSION
ip-192-168-103-188.us-west-2.compute.internal   Ready    <none>   6d7h   v1.22.9-eks-810597c
ip-192-168-63-15.us-west-2.compute.internal     Ready    <none>   6d7h   v1.22.9-eks-810597c
ip-192-168-93-0.us-west-2.compute.internal      Ready    <none>   6d7h   v1.22.9-eks-810597c
bin/kubectl get nodes  0.21s user 0.29s system 48% cpu 1.036 total

$ du -hd1 ~/.kube/cache
1.7M    /Users/negz/.kube/cache/discovery
1.7M    /Users/negz/.kube/cache/http
3.4M    /Users/negz/.kube/cache
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

