### PR TITLE
(kubectl apply): Remove returning patch diff

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -624,16 +624,14 @@ See https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts`
 		if err != nil {
 			return err
 		}
-		patchBytes, patchedObject, err := patcher.Patch(info.Object, modified, info.Source, info.Namespace, info.Name, o.ErrOut)
+		changed, err := patcher.Patch(info, modified, o.ErrOut)
 		if err != nil {
-			return cmdutil.AddSourceToErr(fmt.Sprintf("applying patch:\n%s\nto:\n%v\nfor:", patchBytes, info), info.Source, err)
+			return err
 		}
-
-		info.Refresh(patchedObject, true)
 
 		WarnIfDeleting(info.Object, o.ErrOut)
 
-		if string(patchBytes) == "{}" && !o.shouldPrintObject() {
+		if !changed && !o.shouldPrintObject() {
 			printer, err := o.ToPrinter("unchanged")
 			if err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -395,8 +395,8 @@ func (obj InfoObject) Merged() (runtime.Object, error) {
 		ResourceVersion: resourceVersion,
 	}
 
-	_, result, err := patcher.Patch(obj.Info.Object, modified, obj.Info.Source, obj.Info.Namespace, obj.Info.Name, obj.ErrOut)
-	return result, err
+	_, err = patcher.Patch(obj.Info, modified, obj.ErrOut)
+	return obj.Info.Object, err
 }
 
 func (obj InfoObject) Name() string {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
During patching, nearly all functions also return patch diff. The only
reason for that is to assure that there is any change or not.
Instead we can compare patchedObject and actual object to determine
is there any change.

#### Does this PR introduce a user-facing change?
```release-note
None
```