### PR TITLE
make ParseWatchCacheSizes() initializing only once

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -609,7 +609,7 @@ func Complete(s *options.ServerRunOptions) (completedServerRunOptions, error) {
 	if s.Etcd.EnableWatchCache {
 		sizes := kubeapiserver.DefaultWatchCacheSizes()
 		// Ensure that overrides parse correctly.
-		userSpecified, err := serveroptions.ParseWatchCacheSizes(s.Etcd.WatchCacheSizes)
+		userSpecified, err := serveroptions.ParseWatchCacheSizesWithOnce(s.Etcd.WatchCacheSizes)
 		if err != nil {
 			return options, err
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -179,7 +179,7 @@ func TestParseWatchCacheSizes(t *testing.T) {
 
 	for _, testcase := range testCases {
 		t.Run(testcase.name, func(t *testing.T) {
-			result, err := ParseWatchCacheSizes(testcase.cacheSizes)
+			result, err := parseWatchCacheSizes(testcase.cacheSizes)
 			if len(testcase.expectErr) != 0 && !strings.Contains(err.Error(), testcase.expectErr) {
 				t.Errorf("got err: %v, expected err: %s", err, testcase.expectErr)
 			}
@@ -193,6 +193,35 @@ func TestParseWatchCacheSizes(t *testing.T) {
 						}
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestParseWatchCacheSizesWithOnce(t *testing.T) {
+	testCases := []struct {
+		name       string
+		cacheSizes []string
+		expectErr  string
+	}{
+		{
+			name:       "test when invalid value of watch cache size",
+			cacheSizes: []string{"deployments.apps#65536", "replicasets.extensions"},
+			expectErr:  "invalid value of watch cache size",
+		},
+		{
+			name:       "test output should be consistent with last case when using sync.once",
+			cacheSizes: []string{"deployments.apps#65536", "replicasets.extensions#65536"},
+			expectErr:  "invalid value of watch cache size",
+		},
+	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.name, func(t *testing.T) {
+			_, err := ParseWatchCacheSizesWithOnce(testcase.cacheSizes)
+			// We just concern err output here.
+			if !strings.Contains(err.Error(), testcase.expectErr) {
+				t.Errorf("got err: %v, expected err: %s", err, testcase.expectErr)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The param of `ParseWatchCacheSizes()` is specified by --watch-cache-sizes, it's call is the `GetRESTOptions` of `RESTOptionsGetter` interface, and then every resource store will call generic store's `CompleteWithOptions` to complete their own store, which then exists duplicate method calling and computing, --watch-cache-sizes is only specified once, hence `ParseWatchCacheSizes()` only need to be initialized once to parse watch cache size.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
