### PR TITLE
Removing trailing slash from OpenID related routes in the openapi doc

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -18113,7 +18113,7 @@
     }
   },
   "paths": {
-    "/.well-known/openid-configuration/": {
+    "/.well-known/openid-configuration": {
       "get": {
         "description": "get service account issuer OpenID configuration, also known as the 'OIDC discovery doc'",
         "operationId": "getServiceAccountIssuerOpenIDConfiguration",
@@ -76042,7 +76042,7 @@
         }
       ]
     },
-    "/openid/v1/jwks/": {
+    "/openid/v1/jwks": {
       "get": {
         "description": "get service account issuer OpenID JSON Web Key Set (contains public token verification keys)",
         "operationId": "getServiceAccountIssuerOpenIDKeyset",

--- a/api/openapi-spec/v3/.well-known_openapi.json
+++ b/api/openapi-spec/v3/.well-known_openapi.json
@@ -15,14 +15,14 @@
   },
   "openapi": "3.0.0",
   "paths": {
-    "/openid/v1/jwks/": {
+    "/.well-known/openid-configuration": {
       "get": {
-        "description": "get service account issuer OpenID JSON Web Key Set (contains public token verification keys)",
-        "operationId": "getServiceAccountIssuerOpenIDKeyset",
+        "description": "get service account issuer OpenID configuration, also known as the 'OIDC discovery doc'",
+        "operationId": "getServiceAccountIssuerOpenIDConfiguration",
         "responses": {
           "200": {
             "content": {
-              "application/jwk-set+json": {
+              "application/json": {
                 "schema": {
                   "type": "string"
                 }
@@ -35,7 +35,7 @@
           }
         },
         "tags": [
-          "openid"
+          "WellKnown"
         ]
       }
     }

--- a/api/openapi-spec/v3/openid__v1_openapi.json
+++ b/api/openapi-spec/v3/openid__v1_openapi.json
@@ -15,14 +15,14 @@
   },
   "openapi": "3.0.0",
   "paths": {
-    "/.well-known/openid-configuration/": {
+    "/openid/v1/jwks": {
       "get": {
-        "description": "get service account issuer OpenID configuration, also known as the 'OIDC discovery doc'",
-        "operationId": "getServiceAccountIssuerOpenIDConfiguration",
+        "description": "get service account issuer OpenID JSON Web Key Set (contains public token verification keys)",
+        "operationId": "getServiceAccountIssuerOpenIDKeyset",
         "responses": {
           "200": {
             "content": {
-              "application/json": {
+              "application/jwk-set+json": {
                 "schema": {
                   "type": "string"
                 }
@@ -35,7 +35,7 @@
           }
         },
         "tags": [
-          "WellKnown"
+          "openid"
         ]
       }
     }

--- a/pkg/routes/openidmetadata.go
+++ b/pkg/routes/openidmetadata.go
@@ -64,8 +64,8 @@ func (s *OpenIDMetadataServer) Install(c *restful.Container) {
 	cfg := new(restful.WebService).
 		Produces(restful.MIME_JSON)
 
-	cfg.Path(serviceaccount.OpenIDConfigPath).Route(
-		cfg.GET("").
+	cfg.Path(serviceaccount.OpenIDConfigPathPrefix).Route(
+		cfg.GET(serviceaccount.OpenIDConfigPath).
 			To(fromStandard(s.serveConfiguration)).
 			Doc("get service account issuer OpenID configuration, also known as the 'OIDC discovery doc'").
 			Operation("getServiceAccountIssuerOpenIDConfiguration").
@@ -77,8 +77,8 @@ func (s *OpenIDMetadataServer) Install(c *restful.Container) {
 	jwks := new(restful.WebService).
 		Produces(mimeJWKS)
 
-	jwks.Path(serviceaccount.JWKSPath).Route(
-		jwks.GET("").
+	jwks.Path(serviceaccount.JWKSPathPrefix).Route(
+		jwks.GET(serviceaccount.JWKSPath).
 			To(fromStandard(s.serveKeys)).
 			Doc("get service account issuer OpenID JSON Web Key Set (contains public token verification keys)").
 			Operation("getServiceAccountIssuerOpenIDKeyset").

--- a/pkg/serviceaccount/openidmetadata.go
+++ b/pkg/serviceaccount/openidmetadata.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"net/url"
 
-	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2"
 
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -36,12 +36,14 @@ const (
 	// an OIDC Provider Configuration Information document, corresponding
 	// to the Kubernetes Service Account key issuer.
 	// https://openid.net/specs/openid-connect-discovery-1_0.html
-	OpenIDConfigPath = "/.well-known/openid-configuration"
+	OpenIDConfigPath       = "/openid-configuration"
+	OpenIDConfigPathPrefix = "/.well-known"
 
 	// JWKSPath is the URL path at which the API server serves a JWKS
 	// containing the public keys that may be used to sign Kubernetes
 	// Service Account keys.
-	JWKSPath = "/openid/v1/jwks"
+	JWKSPath       = "/jwks"
+	JWKSPathPrefix = "/openid/v1"
 )
 
 // OpenIDMetadata contains the pre-rendered responses for OIDC discovery endpoints.

--- a/pkg/serviceaccount/openidmetadata_test.go
+++ b/pkg/serviceaccount/openidmetadata_test.go
@@ -234,7 +234,9 @@ func TestURLBoundaries(t *testing.T) {
 		WantOK bool
 	}{
 		{"OIDC config path", "/.well-known/openid-configuration", true},
+		{"OIDC config path with trailing slash", "/.well-known/openid-configuration/", true},
 		{"JWKS path", "/openid/v1/jwks", true},
+		{"JWKS path with trailing slash", "/openid/v1/jwks/", true},
 		{"well-known", "/.well-known", false},
 		{"subpath", "/openid/v1/jwks/foo", false},
 		{"query", "/openid/v1/jwks?format=yaml", true},


### PR DESCRIPTION
/sig api-machienry
/kind bugfix

ref: https://github.com/kubernetes-client/java/issues/2295

currently in the published openapi/swagger doc, it has two paths for openid related api with trailing slashes:

```
"/.well-known/openid-configuration/": ..
"/openid/v1/jwks": ...
```

however in the bootstrap rbac polies, we're only granting permission for the non-slash-trailing paths:

https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go#L503-L504

this results in those non-golang clients generated from openapi spec to access the slash-trailing api paths, which will get 403 rejected due to insufficient permission. this pull removes the trailing slashes for the openid related routes.

```release-note
NONE
```
