### PR TITLE
Replaces path.Operation with filepath.Operation (part 2)

### DIFF
--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -159,7 +158,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 		if err != nil {
 			return result, err
 		}
-		proxyCACertFile := path.Join(s.SecureServing.ServerCert.CertDirectory, "proxy-ca.crt")
+		proxyCACertFile := filepath.Join(s.SecureServing.ServerCert.CertDirectory, "proxy-ca.crt")
 		if err := os.WriteFile(proxyCACertFile, testutil.EncodeCertPEM(proxySigningCert), 0644); err != nil {
 			return result, err
 		}
@@ -186,8 +185,8 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 		if err := pkiutil.WriteCertAndKey(s.SecureServing.ServerCert.CertDirectory, "misty-crt", clientCrtOfAPIServer, signer); err != nil {
 			return result, err
 		}
-		s.ProxyClientKeyFile = path.Join(s.SecureServing.ServerCert.CertDirectory, "misty-crt.key")
-		s.ProxyClientCertFile = path.Join(s.SecureServing.ServerCert.CertDirectory, "misty-crt.crt")
+		s.ProxyClientKeyFile = filepath.Join(s.SecureServing.ServerCert.CertDirectory, "misty-crt.key")
+		s.ProxyClientCertFile = filepath.Join(s.SecureServing.ServerCert.CertDirectory, "misty-crt.crt")
 
 		clientSigningKey, err := testutil.NewPrivateKey()
 		if err != nil {
@@ -197,7 +196,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 		if err != nil {
 			return result, err
 		}
-		clientCACertFile := path.Join(s.SecureServing.ServerCert.CertDirectory, "client-ca.crt")
+		clientCACertFile := filepath.Join(s.SecureServing.ServerCert.CertDirectory, "client-ca.crt")
 		if err := os.WriteFile(clientCACertFile, testutil.EncodeCertPEM(clientSigningCert), 0644); err != nil {
 			return result, err
 		}

--- a/cmd/kubeadm/app/componentconfigs/kubelet_windows.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_windows.go
@@ -32,7 +32,7 @@ func (kc *kubeletConfig) Mutate() error {
 	// When "kubeadm join" downloads the KubeletConfiguration from the cluster on Windows
 	// nodes, it would contain absolute paths that may lack drive letters, since the config
 	// could have been generated on a Linux control-plane node. On Windows the
-	// Golang path.IsAbs() function returns false unless the path contains a drive letter.
+	// Golang filepath.IsAbs() function returns false unless the path contains a drive letter.
 	// This trips client-go and the kubelet, creating problems on Windows nodes.
 	// Fixing it in client-go or the kubelet is a breaking change to existing Windows
 	// users that rely on relative paths:
@@ -57,7 +57,7 @@ func (kc *kubeletConfig) Mutate() error {
 
 func mutatePaths(cfg *kubeletconfig.KubeletConfiguration, drive string) {
 	mutateStringField := func(name string, field *string) {
-		// path.IsAbs() is not reliable here in the Windows runtime, so check if the
+		// filepath.IsAbs() is not reliable here in the Windows runtime, so check if the
 		// path starts with "/" instead. This means the path originated from a Unix node and
 		// is an absolute path.
 		if !strings.HasPrefix(*field, "/") {

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -595,9 +594,9 @@ func GetKubeletKubeConfigPath() string {
 
 // CreateTempDirForKubeadm is a function that creates a temporary directory under /etc/kubernetes/tmp (not using /tmp as that would potentially be dangerous)
 func CreateTempDirForKubeadm(kubernetesDir, dirName string) (string, error) {
-	tempDir := path.Join(KubernetesDir, TempDirForKubeadm)
+	tempDir := filepath.Join(KubernetesDir, TempDirForKubeadm)
 	if len(kubernetesDir) != 0 {
-		tempDir = path.Join(kubernetesDir, TempDirForKubeadm)
+		tempDir = filepath.Join(kubernetesDir, TempDirForKubeadm)
 	}
 
 	// creates target folder if not already exists
@@ -614,9 +613,9 @@ func CreateTempDirForKubeadm(kubernetesDir, dirName string) (string, error) {
 
 // CreateTimestampDirForKubeadm is a function that creates a temporary directory under /etc/kubernetes/tmp formatted with the current date
 func CreateTimestampDirForKubeadm(kubernetesDir, dirName string) (string, error) {
-	tempDir := path.Join(KubernetesDir, TempDirForKubeadm)
+	tempDir := filepath.Join(KubernetesDir, TempDirForKubeadm)
 	if len(kubernetesDir) != 0 {
-		tempDir = path.Join(kubernetesDir, TempDirForKubeadm)
+		tempDir = filepath.Join(kubernetesDir, TempDirForKubeadm)
 	}
 
 	// creates target folder if not already exists
@@ -625,7 +624,7 @@ func CreateTimestampDirForKubeadm(kubernetesDir, dirName string) (string, error)
 	}
 
 	timestampDirName := fmt.Sprintf("%s-%s", dirName, time.Now().Format("2006-01-02-15-04-05"))
-	timestampDir := path.Join(tempDir, timestampDirName)
+	timestampDir := filepath.Join(tempDir, timestampDirName)
 	if err := os.Mkdir(timestampDir, 0700); err != nil {
 		return "", errors.Wrap(err, "could not create timestamp directory")
 	}

--- a/cmd/kubeadm/app/phases/certs/certlist_test.go
+++ b/cmd/kubeadm/app/phases/certs/certlist_test.go
@@ -21,7 +21,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	certutil "k8s.io/client-go/util/cert"
@@ -192,8 +192,8 @@ func TestCreateCertificateChain(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	caCert, _ := parseCertAndKey(path.Join(dir, "test-ca"), t)
-	daughterCert, _ := parseCertAndKey(path.Join(dir, "test-daughter"), t)
+	caCert, _ := parseCertAndKey(filepath.Join(dir, "test-ca"), t)
+	daughterCert, _ := parseCertAndKey(filepath.Join(dir, "test-daughter"), t)
 
 	pool := x509.NewCertPool()
 	pool.AddCert(caCert)

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -263,7 +262,7 @@ func TestWriteCSRFilesIfNotExist(t *testing.T) {
 		{
 			name: "existing CSR is garbage",
 			setupFunc: func(csrPath string) error {
-				return os.WriteFile(path.Join(csrPath, "dummy.csr"), []byte("a--bunch--of-garbage"), os.ModePerm)
+				return os.WriteFile(filepath.Join(csrPath, "dummy.csr"), []byte("a--bunch--of-garbage"), os.ModePerm)
 			},
 			expectedError: true,
 		},

--- a/cmd/kubeadm/app/phases/copycerts/copycerts.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts.go
@@ -21,7 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -182,17 +182,17 @@ func loadAndEncryptCert(certPath string, key []byte) ([]byte, error) {
 func certsToTransfer(cfg *kubeadmapi.InitConfiguration) map[string]string {
 	certsDir := cfg.CertificatesDir
 	certs := map[string]string{
-		kubeadmconstants.CACertName:                   path.Join(certsDir, kubeadmconstants.CACertName),
-		kubeadmconstants.CAKeyName:                    path.Join(certsDir, kubeadmconstants.CAKeyName),
-		kubeadmconstants.FrontProxyCACertName:         path.Join(certsDir, kubeadmconstants.FrontProxyCACertName),
-		kubeadmconstants.FrontProxyCAKeyName:          path.Join(certsDir, kubeadmconstants.FrontProxyCAKeyName),
-		kubeadmconstants.ServiceAccountPublicKeyName:  path.Join(certsDir, kubeadmconstants.ServiceAccountPublicKeyName),
-		kubeadmconstants.ServiceAccountPrivateKeyName: path.Join(certsDir, kubeadmconstants.ServiceAccountPrivateKeyName),
+		kubeadmconstants.CACertName:                   filepath.Join(certsDir, kubeadmconstants.CACertName),
+		kubeadmconstants.CAKeyName:                    filepath.Join(certsDir, kubeadmconstants.CAKeyName),
+		kubeadmconstants.FrontProxyCACertName:         filepath.Join(certsDir, kubeadmconstants.FrontProxyCACertName),
+		kubeadmconstants.FrontProxyCAKeyName:          filepath.Join(certsDir, kubeadmconstants.FrontProxyCAKeyName),
+		kubeadmconstants.ServiceAccountPublicKeyName:  filepath.Join(certsDir, kubeadmconstants.ServiceAccountPublicKeyName),
+		kubeadmconstants.ServiceAccountPrivateKeyName: filepath.Join(certsDir, kubeadmconstants.ServiceAccountPrivateKeyName),
 	}
 
 	if cfg.Etcd.External == nil {
-		certs[kubeadmconstants.EtcdCACertName] = path.Join(certsDir, kubeadmconstants.EtcdCACertName)
-		certs[kubeadmconstants.EtcdCAKeyName] = path.Join(certsDir, kubeadmconstants.EtcdCAKeyName)
+		certs[kubeadmconstants.EtcdCACertName] = filepath.Join(certsDir, kubeadmconstants.EtcdCACertName)
+		certs[kubeadmconstants.EtcdCAKeyName] = filepath.Join(certsDir, kubeadmconstants.EtcdCAKeyName)
 	} else {
 		certs[externalEtcdCA] = cfg.Etcd.External.CAFile
 		certs[externalEtcdCert] = cfg.Etcd.External.CertFile

--- a/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/hex"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	goruntime "runtime"
 	"testing"
@@ -55,7 +55,7 @@ func TestGetDataFromInitConfig(t *testing.T) {
 		t.Fatalf(dedent.Dedent("failed to decode key.\nfatal error: %v"), err)
 	}
 
-	if err := os.Mkdir(path.Join(tmpdir, "etcd"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(tmpdir, "etcd"), 0755); err != nil {
 		t.Fatalf(dedent.Dedent("failed to create etcd cert dir.\nfatal error: %v"), err)
 	}
 

--- a/cmd/kubeadm/app/util/certs/util.go
+++ b/cmd/kubeadm/app/util/certs/util.go
@@ -21,7 +21,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"net"
-	"path"
+	"path/filepath"
 	"testing"
 
 	certutil "k8s.io/client-go/util/cert"
@@ -230,7 +230,7 @@ func WritePKIFiles(t *testing.T, dir string, files PKIFiles) {
 	for filename, body := range files {
 		switch body := body.(type) {
 		case *x509.Certificate:
-			if err := certutil.WriteCert(path.Join(dir, filename), pkiutil.EncodeCertPEM(body)); err != nil {
+			if err := certutil.WriteCert(filepath.Join(dir, filename), pkiutil.EncodeCertPEM(body)); err != nil {
 				t.Errorf("unable to write certificate to file %q: [%v]", dir, err)
 			}
 		case *rsa.PublicKey:
@@ -238,7 +238,7 @@ func WritePKIFiles(t *testing.T, dir string, files PKIFiles) {
 			if err != nil {
 				t.Errorf("unable to write public key to file %q: [%v]", filename, err)
 			}
-			if err := keyutil.WriteKey(path.Join(dir, filename), publicKeyBytes); err != nil {
+			if err := keyutil.WriteKey(filepath.Join(dir, filename), publicKeyBytes); err != nil {
 				t.Errorf("unable to write public key to file %q: [%v]", filename, err)
 			}
 		case *rsa.PrivateKey:
@@ -246,7 +246,7 @@ func WritePKIFiles(t *testing.T, dir string, files PKIFiles) {
 			if err != nil {
 				t.Errorf("unable to write private key to file %q: [%v]", filename, err)
 			}
-			if err := keyutil.WriteKey(path.Join(dir, filename), privateKey); err != nil {
+			if err := keyutil.WriteKey(filepath.Join(dir, filename), privateKey); err != nil {
 				t.Errorf("unable to write private key to file %q: [%v]", filename, err)
 			}
 		}

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -26,7 +26,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -1010,8 +1009,8 @@ func getNodeName(cloud cloudprovider.Interface, hostname string) (types.NodeName
 // certificate and key file are generated. Returns a configured server.TLSOptions object.
 func InitializeTLS(kf *options.KubeletFlags, kc *kubeletconfiginternal.KubeletConfiguration) (*server.TLSOptions, error) {
 	if !kc.ServerTLSBootstrap && kc.TLSCertFile == "" && kc.TLSPrivateKeyFile == "" {
-		kc.TLSCertFile = path.Join(kf.CertDirectory, "kubelet.crt")
-		kc.TLSPrivateKeyFile = path.Join(kf.CertDirectory, "kubelet.key")
+		kc.TLSCertFile = filepath.Join(kf.CertDirectory, "kubelet.crt")
+		kc.TLSPrivateKeyFile = filepath.Join(kf.CertDirectory, "kubelet.key")
 
 		canReadCertAndKey, err := certutil.CanReadCertAndKey(kc.TLSCertFile, kc.TLSPrivateKeyFile)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

/sig windows
/priority important-soon
/milestone v1.25

#### What this PR does / why we need it:

The path module has a few different functions: Clean, Split, Join, Ext, Dir, Base, IsAbs. These functions do not take into account the OS-specific path separator, meaning that they won't behave as intended on Windows.

For example, Dir is supposed to return all but the last element of the path. For the path ``C:\some\dir\somewhere``, it is supposed to return ``C:\some\dir\``, however, it returns ``.``.

Instead of these functions, the ones in filepath should be used instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #110600

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```