### PR TITLE
Add failure handling of the desiredStateOfWorldPopulator start

### DIFF
--- a/pkg/kubelet/pluginmanager/plugin_manager.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager.go
@@ -108,7 +108,11 @@ var _ PluginManager = &pluginManager{}
 func (pm *pluginManager) Run(sourcesReady config.SourcesReady, stopCh <-chan struct{}) {
 	defer runtime.HandleCrash()
 
-	pm.desiredStateOfWorldPopulator.Start(stopCh)
+	if err := pm.desiredStateOfWorldPopulator.Start(stopCh); err != nil {
+		klog.ErrorS(err, "The desired_state_of_world populator (plugin watcher) starts failed!")
+		return
+	}
+
 	klog.V(2).InfoS("The desired_state_of_world populator (plugin watcher) starts")
 
 	klog.InfoS("Starting Kubelet Plugin Manager")


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
“pm.desiredStateOfWorldPopulator.Start” may fail. We should deal with the error.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

/release-note-none
/priority backlog
/triage accepted
