### PR TITLE
kubectl apply: warning that kubectl will ignores no-namespaced resource in future release with namespace specified and with default pruneAllowlist

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -70,7 +70,7 @@ func newPruner(o *ApplyOptions) pruner {
 
 func (p *pruner) pruneAll(o *ApplyOptions) error {
 
-	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(o.Mapper, o.PruneResources)
+	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(o.Mapper, o.PruneResources, o.Namespace != "")
 	if err != nil {
 		return fmt.Errorf("error retrieving RESTMappings to prune: %v", err)
 	}
@@ -82,6 +82,7 @@ func (p *pruner) pruneAll(o *ApplyOptions) error {
 			}
 		}
 	}
+
 	for _, m := range nonNamespacedRESTMappings {
 		if err := p.prune(metav1.NamespaceNone, m); err != nil {
 			return fmt.Errorf("error pruning nonNamespaced object %v: %v", m.GroupVersionKind, err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -747,7 +747,7 @@ func (o *DiffOptions) Run() error {
 	})
 
 	if o.pruner != nil {
-		prunedObjs, err := o.pruner.pruneAll()
+		prunedObjs, err := o.pruner.pruneAll(o.CmdNamespace != "")
 		if err != nil {
 			klog.Warningf("pruning failed and could not be evaluated err: %v", err)
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune.go
@@ -50,9 +50,9 @@ func newPruner(dc dynamic.Interface, m meta.RESTMapper, r []prune.Resource) *pru
 	}
 }
 
-func (p *pruner) pruneAll() ([]runtime.Object, error) {
+func (p *pruner) pruneAll(namespaceSpecified bool) ([]runtime.Object, error) {
 	var allPruned []runtime.Object
-	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(p.mapper, p.resources)
+	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(p.mapper, p.resources, namespaceSpecified)
 	if err != nil {
 		return allPruned, fmt.Errorf("error retrieving RESTMappings to prune: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
@@ -67,7 +67,7 @@ func TestGetRESTMappings(t *testing.T) {
 			mapper:             &testRESTMapper{},
 			pr:                 []Resource{},
 			namespaceSpecified: true,
-			expectedns:  14,
+			expectedns:         14,
 			// it will be 0 non-namespaced resources after the deprecation period has passed.
 			// for details, refer to https://github.com/kubernetes/kubernetes/pull/110907/.
 			expectednns: 2,

--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
@@ -48,23 +48,48 @@ func (m *testRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*
 
 func TestGetRESTMappings(t *testing.T) {
 	tests := []struct {
-		mapper      *testRESTMapper
-		pr          []Resource
-		expectedns  int
-		expectednns int
-		expectederr error
+		mapper             *testRESTMapper
+		pr                 []Resource
+		namespaceSpecified bool
+		expectedns         int
+		expectednns        int
+		expectederr        error
 	}{
 		{
-			mapper:      &testRESTMapper{},
-			pr:          []Resource{},
+			mapper:             &testRESTMapper{},
+			pr:                 []Resource{},
+			namespaceSpecified: false,
+			expectedns:         14,
+			expectednns:        2,
+			expectederr:        nil,
+		},
+		{
+			mapper:             &testRESTMapper{},
+			pr:                 []Resource{},
+			namespaceSpecified: true,
 			expectedns:  14,
+			// it will be 0 non-namespaced resources after the deprecation period has passed.
+			// for details, refer to https://github.com/kubernetes/kubernetes/pull/110907/.
 			expectednns: 2,
 			expectederr: nil,
+		},
+		{
+			mapper: &testRESTMapper{},
+			pr: []Resource{
+				{"apps", "v1", "DaemonSet", true},
+				{"core", "v1", "Pod", true},
+				{"", "v1", "Foo2", false},
+				{"foo", "v1", "Foo3", false},
+			},
+			namespaceSpecified: false,
+			expectedns:         2,
+			expectednns:        2,
+			expectederr:        nil,
 		},
 	}
 
 	for _, tc := range tests {
-		actualns, actualnns, actualerr := GetRESTMappings(tc.mapper, tc.pr)
+		actualns, actualnns, actualerr := GetRESTMappings(tc.mapper, tc.pr, tc.namespaceSpecified)
 		if tc.expectederr != nil {
 			assert.NotEmptyf(t, actualerr, "getRESTMappings error expected but not fired")
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
It is weird that a non-namespaced resource is pruned when I run `kubectl apply` on a specified namespace.
After discussions in sig-cli meeting, we only decided to add a warning in the current kubectl.
In a future release, we will change the behavior. (at least 1.28 or later)

#### Which issue(s) this PR fixes:
ref #110905

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/blob/fa16bf8e121e9a9ce0a8b92d96a39c986152c484/staging/src/k8s.io/kubectl/pkg/util/prune/prune.go#L41-L58

#### Does this PR introduce a user-facing change?

```release-note
kubectl apply: warning that kubectl will ignore no-namespaced resource `pv & namespace` in a future release if the namespace is specified and allowlist is not specified
```

- [ ] TODO: change the behavior as the comments in a future release: maybe v1.28.
