### PR TITLE
Automated cherry pick of #110791: kubeadm: fix the bug that configurable KubernetesVersion not

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -77,10 +77,11 @@ func fuzzClusterConfiguration(obj *kubeadm.ClusterConfiguration, c fuzz.Continue
 
 	// Pinning values for fields that get defaults if fuzz value is empty string or nil (thus making the round trip test fail)
 	obj.CertificatesDir = "foo"
-	obj.CIImageRepository = "" //This fields doesn't exists in public API >> using default to get the roundtrip test pass
 	obj.ClusterName = "bar"
 	obj.ImageRepository = "baz"
+	obj.CIImageRepository = "" // This fields doesn't exists in public API >> using default to get the roundtrip test pass
 	obj.KubernetesVersion = "qux"
+	obj.CIKubernetesVersion = "" // This fields doesn't exists in public API >> using default to get the roundtrip test pass
 	obj.APIServer.TimeoutForControlPlane = &metav1.Duration{
 		Duration: constants.DefaultControlPlaneTimeout,
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -84,8 +84,14 @@ type ClusterConfiguration struct {
 
 	// Networking holds configuration for the networking topology of the cluster.
 	Networking Networking
+
 	// KubernetesVersion is the target version of the control plane.
 	KubernetesVersion string
+
+	// CIKubernetesVersion is the target CI version of the control plane.
+	// Useful for running kubeadm with CI Kubernetes version.
+	// +k8s:conversion-gen=false
+	CIKubernetesVersion string
 
 	// ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
 	// can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/zz_generated.conversion.go
@@ -346,6 +346,7 @@ func autoConvert_kubeadm_ClusterConfiguration_To_v1beta2_ClusterConfiguration(in
 		return err
 	}
 	out.KubernetesVersion = in.KubernetesVersion
+	// INFO: in.CIKubernetesVersion opted out of conversion generation
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if err := Convert_kubeadm_APIServer_To_v1beta2_APIServer(&in.APIServer, &out.APIServer, s); err != nil {
 		return err

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/zz_generated.conversion.go
@@ -345,6 +345,7 @@ func autoConvert_kubeadm_ClusterConfiguration_To_v1beta3_ClusterConfiguration(in
 		return err
 	}
 	out.KubernetesVersion = in.KubernetesVersion
+	// INFO: in.CIKubernetesVersion opted out of conversion generation
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if err := Convert_kubeadm_APIServer_To_v1beta3_APIServer(&in.APIServer, &out.APIServer, s); err != nil {
 		return err

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
@@ -47,6 +47,11 @@ func UploadConfiguration(cfg *kubeadmapi.InitConfiguration, client clientset.Int
 	clusterConfigurationToUpload := cfg.ClusterConfiguration.DeepCopy()
 	clusterConfigurationToUpload.ComponentConfigs = kubeadmapi.ComponentConfigMap{}
 
+	// restore the resolved Kubernetes version as CI Kubernetes version if needed
+	if len(clusterConfigurationToUpload.CIKubernetesVersion) > 0 {
+		clusterConfigurationToUpload.KubernetesVersion = clusterConfigurationToUpload.CIKubernetesVersion
+	}
+
 	// Marshal the ClusterConfiguration into YAML
 	clusterConfigurationYaml, err := configutil.MarshalKubeadmConfigObject(clusterConfigurationToUpload)
 	if err != nil {

--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"net"
 	"reflect"
 	"strings"
@@ -90,8 +91,10 @@ func validateSupportedVersion(gv schema.GroupVersion, allowDeprecated bool) erro
 // image registry if requested for CI builds, and validates minimal
 // version that kubeadm SetInitDynamicDefaultssupports.
 func NormalizeKubernetesVersion(cfg *kubeadmapi.ClusterConfiguration) error {
+	isCIVersion := kubeadmutil.KubernetesIsCIVersion(cfg.KubernetesVersion)
+
 	// Requested version is automatic CI build, thus use KubernetesCI Image Repository for core images
-	if kubeadmutil.KubernetesIsCIVersion(cfg.KubernetesVersion) {
+	if isCIVersion {
 		cfg.CIImageRepository = constants.DefaultCIImageRepository
 	}
 
@@ -100,6 +103,12 @@ func NormalizeKubernetesVersion(cfg *kubeadmapi.ClusterConfiguration) error {
 	if err != nil {
 		return err
 	}
+
+	// Requested version is automatic CI build, thus mark CIKubernetesVersion as `ci/<resolved-version>`
+	if isCIVersion {
+		cfg.CIKubernetesVersion = fmt.Sprintf("ci/%s", ver)
+	}
+
 	cfg.KubernetesVersion = ver
 
 	// Parse the given kubernetes version and make sure it's higher than the lowest supported


### PR DESCRIPTION
Cherry pick of #110791 on release-1.24.

#110791: kubeadm: fix the bug that configurable KubernetesVersion not

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```