### PR TITLE
Add prune flag support for server side apply

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -646,7 +646,7 @@ func (o *DiffOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 		if err != nil {
 			return err
 		}
-		o.pruner = newPruner(o.DynamicClient, mapper, resources)
+		o.pruner = newPruner(o.DynamicClient, mapper, o.ServerSideApply, o.FieldManager, resources)
 	}
 
 	o.Builder = f.NewBuilder()


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently, pruning is [skipped](https://github.com/kubernetes/kubernetes/blob/fa16bf8e121e9a9ce0a8b92d96a39c986152c484/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go#L116) for the resources created by using
server side apply. Because these resources do not contain
`last-applied-configuration` annotation.

This PR enables pruning functionality for server side apply.
This PR checks resource has `managedFields` annotation and if
this annotation exists and it's fieldmanager equals to the
kubectl active fieldmanager, prune flag works.

#### Which issue(s) this PR fixes:
Fixes #110893

#### Does this PR introduce a user-facing change?
```release-note
None
```