### PR TITLE
tests: Ports volume unit tests to Windows

### DIFF
--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
 	fakecsi "k8s.io/kubernetes/pkg/volume/csi/fake"
+	"k8s.io/kubernetes/pkg/volume/util"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
 )
 
@@ -1327,7 +1328,7 @@ func TestAttacherMountDevice(t *testing.T) {
 				if err != nil {
 					t.Errorf("error attempting to populate file on parent path: %v", err)
 				}
-				err = os.Chmod(parent, 0555)
+				err = util.Chmod(parent, 0555)
 				if err != nil {
 					t.Errorf("error attempting to modify directory permissions: %v", err)
 				}
@@ -1356,7 +1357,7 @@ func TestAttacherMountDevice(t *testing.T) {
 					if os.IsNotExist(err) {
 						t.Errorf("expecting file to exist after err received: %v", err)
 					}
-					err = os.Chmod(parent, 0777)
+					err = util.Chmod(parent, 0777)
 					if err != nil {
 						t.Errorf("failed to modify permissions after test: %v", err)
 					}

--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -439,31 +439,31 @@ func (ed *emptyDir) setupDir(dir string) error {
 		return err
 	}
 
-	// stat the directory to read permission bits
-	fileinfo, err := os.Lstat(dir)
+	// read the permission bits
+	mode, err := volumeutil.GetFileMode(dir)
 	if err != nil {
 		return err
 	}
 
-	if fileinfo.Mode().Perm() != perm.Perm() {
+	if mode != perm.Perm() {
 		// If the permissions on the created directory are wrong, the
 		// kubelet is probably running with a umask set.  In order to
 		// avoid clearing the umask for the entire process or locking
 		// the thread, clearing the umask, creating the dir, restoring
 		// the umask, and unlocking the thread, we do a chmod to set
 		// the specific bits we need.
-		err := os.Chmod(dir, perm)
+		err := volumeutil.Chmod(dir, perm)
 		if err != nil {
 			return err
 		}
 
-		fileinfo, err = os.Lstat(dir)
+		mode, err = volumeutil.GetFileMode(dir)
 		if err != nil {
 			return err
 		}
 
-		if fileinfo.Mode().Perm() != perm.Perm() {
-			klog.Errorf("Expected directory %q permissions to be: %s; got: %s", dir, perm.Perm(), fileinfo.Mode().Perm())
+		if mode != perm.Perm() {
+			klog.Errorf("Expected directory %q permissions to be: %s; got: %s", dir, perm.Perm(), mode)
 		}
 	}
 

--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -264,7 +264,8 @@ func validatePath(targetPath string) error {
 		return fmt.Errorf("invalid path: must be less than or equal to %d characters", maxPathLength)
 	}
 
-	items := strings.Split(targetPath, string(os.PathSeparator))
+	p := filepath.FromSlash(targetPath)
+	items := strings.Split(p, string(os.PathSeparator))
 	for _, item := range items {
 		if item == ".." {
 			return fmt.Errorf("invalid path: must not contain '..': %s", targetPath)
@@ -339,6 +340,7 @@ func (w *AtomicWriter) pathsToRemove(payload map[string]FileProjection, oldTsDir
 	for file := range payload {
 		// add all subpaths for the payload to the set of new paths
 		// to avoid attempting to remove non-empty dirs
+		file = filepath.FromSlash(file)
 		for subPath := file; subPath != ""; {
 			newPaths.Insert(subPath)
 			subPath, _ = filepath.Split(subPath)
@@ -364,7 +366,7 @@ func (w *AtomicWriter) newTimestampDir() (string, error) {
 	// 0755 permissions are needed to allow 'group' and 'other' to recurse the
 	// directory tree.  do a chmod here to ensure that permissions are set correctly
 	// regardless of the process' umask.
-	err = os.Chmod(tsDir, 0755)
+	err = Chmod(tsDir, 0755)
 	if err != nil {
 		klog.Errorf("%s: unable to set mode on new temp directory: %v", w.logContext, err)
 		return "", err
@@ -395,7 +397,7 @@ func (w *AtomicWriter) writePayloadToDir(payload map[string]FileProjection, dir 
 		// open(2) to create the file, so the final mode used is "mode &
 		// ~umask". But we want to make sure the specified mode is used
 		// in the file no matter what the umask is.
-		if err := os.Chmod(fullPath, mode); err != nil {
+		if err := Chmod(fullPath, mode); err != nil {
 			klog.Errorf("%s: unable to change file %s with mode %v: %v", w.logContext, fullPath, mode, err)
 			return err
 		}

--- a/pkg/volume/util/atomic_writer_test.go
+++ b/pkg/volume/util/atomic_writer_test.go
@@ -1,6 +1,3 @@
-//go:build linux
-// +build linux
-
 /*
 Copyright 2016 The Kubernetes Authors.
 
@@ -251,7 +248,13 @@ func TestPathsToRemove(t *testing.T) {
 			continue
 		}
 
-		if e, a := tc.expected, actual; !e.Equal(a) {
+		// Clean paths. For Windows, this will replace / with \.
+		expected := tc.expected.List()
+		for i := 0; i < len(expected); i++ {
+			expected[i] = filepath.Clean(expected[i])
+		}
+		expectedSet := sets.NewString(expected...)
+		if e, a := expectedSet, actual; !e.Equal(a) {
 			t.Errorf("%v: unexpected paths to remove:\nexpected: %v\n     got: %v", tc.name, e, a)
 		}
 	}
@@ -760,7 +763,7 @@ func checkVolumeContents(targetDir, tcName string, payload map[string]FileProjec
 		}
 
 		relativePath := strings.TrimPrefix(path, dataDirPath)
-		relativePath = strings.TrimPrefix(relativePath, "/")
+		relativePath = strings.TrimPrefix(relativePath, string(os.PathSeparator))
 		if strings.HasPrefix(relativePath, "..") {
 			return nil
 		}
@@ -769,13 +772,12 @@ func checkVolumeContents(targetDir, tcName string, payload map[string]FileProjec
 		if err != nil {
 			return err
 		}
-		fileInfo, err := os.Stat(path)
+		mode, err := GetFileMode(path)
 		if err != nil {
 			return err
 		}
-		mode := int32(fileInfo.Mode())
 
-		observedPayload[relativePath] = FileProjection{Data: content, Mode: mode}
+		observedPayload[relativePath] = FileProjection{Data: content, Mode: int32(mode)}
 
 		return nil
 	}
@@ -895,7 +897,14 @@ func TestValidatePayload(t *testing.T) {
 			}
 
 			realPaths := getPayloadPaths(real)
-			if !realPaths.Equal(tc.expected) {
+
+			// Clean paths. For Windows, this will replace / with \.
+			expected := tc.expected.List()
+			for i := 0; i < len(expected); i++ {
+				expected[i] = filepath.Clean(expected[i])
+			}
+			expectedSet := sets.NewString(expected...)
+			if !realPaths.Equal(expectedSet) {
 				t.Errorf("%v: unexpected payload paths: %v is not equal to %v", tc.name, realPaths, tc.expected)
 			}
 		}
@@ -978,6 +987,7 @@ func TestCreateUserVisibleFiles(t *testing.T) {
 				t.Fatalf("%v: unable to read symlink %v: %v", tc.name, dataDirPath, err)
 			}
 
+			expectedDest = filepath.FromSlash(expectedDest)
 			if expectedDest != destination {
 				t.Fatalf("%v: symlink destination %q not same with expected data dir %q", tc.name, destination, expectedDest)
 			}

--- a/pkg/volume/util/util_others.go
+++ b/pkg/volume/util/util_others.go
@@ -1,0 +1,36 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"os"
+)
+
+// Chmod is os.Chmod.
+var Chmod = os.Chmod
+
+// GetFileMode will return the given file's mode.
+func GetFileMode(path string) (os.FileMode, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	return fileInfo.Mode(), nil
+}

--- a/pkg/volume/util/util_windows.go
+++ b/pkg/volume/util/util_windows.go
@@ -1,0 +1,303 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// https://docs.microsoft.com/en-us/windows/win32/fileio/file-access-rights-constants
+	// read = read data | read attributes
+	READ_PERMISSIONS = 0x0001 | 0x0080
+
+	// write = write data | append data | write attributes | write EA
+	WRITE_PERMISSIONS = 0x0002 | 0x0004 | 0x0100 | 0x0010
+
+	// execute = read data | file execute
+	EXECUTE_PERMISSIONS = 0x0001 | 0x0020
+
+	// Accounts
+	EVERYONE = "Everyone"
+	NONE     = "None"
+
+	// Well-known SID Strings
+	// https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems
+	CREATOR_SID_STR  = "S-1-3-0"
+	GROUP_SID_STR    = "S-1-3-1"
+	EVERYONE_SID_STR = "S-1-1-0"
+
+	// Constants for AceType
+	// https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-ace_header
+	ACCESS_ALLOWED_ACE_TYPE = 0
+	ACCESS_DENIED_ACE_TYPE  = 1
+)
+
+var (
+	advapi32                  = windows.MustLoadDLL("advapi32.dll")
+	procSetEntriesInAclW      = advapi32.MustFindProc("SetEntriesInAclW")
+	procGetAce                = advapi32.MustFindProc("GetAce")
+	procGetNamedSecurityInfoW = advapi32.MustFindProc("GetNamedSecurityInfoW")
+)
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-acl
+type ACL struct {
+	aclRevision byte
+	sbz1        byte
+	aclSize     uint16
+	aceCount    uint16
+	sbz2        uint16
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-access_allowed_ace
+type accessAllowedAce struct {
+	aceType  byte
+	aceFlags byte
+	aceSize  uint16
+	mask     windows.ACCESS_MASK
+	sid      windows.SID
+}
+
+// Change the permissions of the specified file. Only the nine
+// least-significant bytes are used, allowing access by the file's owner, the
+// file's group, and everyone else to be explicitly controlled.
+func Chmod(name string, fileMode os.FileMode) error {
+	creatorOwnerSID, err := windows.StringToSid(CREATOR_SID_STR)
+	if err != nil {
+		return err
+	}
+	creatorGroupSID, err := windows.StringToSid(GROUP_SID_STR)
+	if err != nil {
+		return err
+	}
+	everyoneSID, err := windows.StringToSid(EVERYONE_SID_STR)
+	if err != nil {
+		return err
+	}
+
+	mode := windows.ACCESS_MASK(fileMode)
+	return apply(
+		name,
+		true,
+		false,
+		grantSid(((mode&0700)<<23)|((mode&0200)<<9), creatorOwnerSID),
+		grantSid(((mode&0070)<<26)|((mode&0020)<<12), creatorGroupSID),
+		grantSid(((mode&0007)<<29)|((mode&0002)<<15), everyoneSID),
+	)
+}
+
+// apply the provided access control entries to a file. If the replace
+// parameter is true, existing entries will be overwritten. If the inherit
+// parameter is true, the file will inherit ACEs from its parent.
+func apply(name string, replace, inherit bool, entries ...windows.EXPLICIT_ACCESS) error {
+	var oldAcl windows.Handle
+	if !replace {
+		var secDesc windows.Handle
+		getNamedSecurityInfo(
+			name,
+			windows.SE_FILE_OBJECT,
+			windows.DACL_SECURITY_INFORMATION,
+			nil,
+			nil,
+			&oldAcl,
+			nil,
+			&secDesc,
+		)
+		defer windows.LocalFree(secDesc)
+	}
+	var acl *windows.ACL
+	if err := setEntriesInAcl(
+		entries,
+		oldAcl,
+		&acl,
+	); err != nil {
+		return err
+	}
+	defer windows.LocalFree((windows.Handle)(unsafe.Pointer(acl)))
+	var secInfo windows.SECURITY_INFORMATION
+	if !inherit {
+		secInfo = windows.PROTECTED_DACL_SECURITY_INFORMATION
+	} else {
+		secInfo = windows.UNPROTECTED_DACL_SECURITY_INFORMATION
+	}
+	return windows.SetNamedSecurityInfo(
+		name,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|secInfo,
+		nil,
+		nil,
+		acl,
+		nil,
+	)
+}
+
+// GetFileMode returns the mode of the given file.
+func GetFileMode(file string) (os.FileMode, error) {
+	var (
+		daclHandle, secDesc windows.Handle
+		owner, group        *windows.SID
+	)
+	err := getNamedSecurityInfo(
+		file,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.GROUP_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.UNPROTECTED_DACL_SECURITY_INFORMATION,
+		&owner,
+		&group,
+		&daclHandle,
+		nil,
+		&secDesc,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	defer windows.LocalFree(secDesc)
+
+	dacl := (*ACL)(unsafe.Pointer(daclHandle))
+	aces, err := getACEs(dacl)
+	if err != nil {
+		return 0, err
+	}
+
+	allowMode := 0
+	denyMode := 0
+	for _, ace := range aces {
+		accountName, _, _, err := ace.sid.LookupAccount("")
+		if err != nil {
+			return 0, err
+		}
+
+		// LookupAccount may return an empty string.
+		if accountName == "" {
+			accountName = NONE
+		}
+
+		perms := 0
+		if (ace.mask & READ_PERMISSIONS) == READ_PERMISSIONS {
+			perms = 0x4
+		}
+		if (ace.mask & WRITE_PERMISSIONS) == WRITE_PERMISSIONS {
+			perms |= 0x2
+		}
+		if (ace.mask & EXECUTE_PERMISSIONS) == EXECUTE_PERMISSIONS {
+			perms |= 0x1
+		}
+
+		mode := 0
+		if owner.Equals(&ace.sid) {
+			mode = perms << 6
+		}
+		if group.Equals(&ace.sid) {
+			mode |= perms << 3
+		}
+		if accountName == EVERYONE {
+			mode |= perms
+		}
+
+		if ace.aceType == ACCESS_ALLOWED_ACE_TYPE {
+			allowMode |= mode
+		} else if ace.aceType == ACCESS_DENIED_ACE_TYPE {
+			denyMode |= mode
+		}
+	}
+
+	// Exclude the denied permissions.
+	return os.FileMode(allowMode & ^denyMode), nil
+}
+
+// https://docs.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-setentriesinaclw
+func setEntriesInAcl(entries []windows.EXPLICIT_ACCESS, oldAcl windows.Handle, newAcl **windows.ACL) error {
+	ret, _, _ := procSetEntriesInAclW.Call(
+		uintptr(len(entries)),
+		uintptr(unsafe.Pointer(&entries[0])),
+		uintptr(oldAcl),
+		uintptr(unsafe.Pointer(newAcl)),
+	)
+	if ret != 0 {
+		return windows.Errno(ret)
+	}
+	return nil
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-getace
+func getACEs(acl *ACL) ([]*accessAllowedAce, error) {
+	aces := make([]*accessAllowedAce, acl.aceCount)
+	var ace *accessAllowedAce
+
+	for i := uint16(0); i < acl.aceCount; i++ {
+		ret, _, _ := procGetAce.Call(
+			uintptr(unsafe.Pointer(acl)),
+			uintptr(i),
+			uintptr(unsafe.Pointer(&ace)),
+		)
+		if ret == 0 {
+			return []*accessAllowedAce{}, windows.GetLastError()
+		}
+
+		aceBytes := make([]byte, ace.aceSize)
+		copy(aceBytes, (*[(1 << 31) - 1]byte)(unsafe.Pointer(ace))[:len(aceBytes)])
+		aces[i] = (*accessAllowedAce)(unsafe.Pointer(&aceBytes[0]))
+	}
+
+	return aces, nil
+}
+
+// https://docs.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-getnamedsecurityinfow
+func getNamedSecurityInfo(objectName string, objectType windows.SE_OBJECT_TYPE, secInfo windows.SECURITY_INFORMATION, owner, group **windows.SID, dacl, sacl, secDesc *windows.Handle) error {
+	ret, _, _ := procGetNamedSecurityInfoW.Call(
+		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(objectName))),
+		uintptr(objectType),
+		uintptr(secInfo),
+		uintptr(unsafe.Pointer(owner)),
+		uintptr(unsafe.Pointer(group)),
+		uintptr(unsafe.Pointer(dacl)),
+		uintptr(unsafe.Pointer(sacl)),
+		uintptr(unsafe.Pointer(secDesc)),
+	)
+	if ret != 0 {
+		return windows.Errno(ret)
+	}
+	return nil
+}
+
+// Create an EXPLICIT_ACCESS instance granting permissions to the provided SID.
+func grantSid(accessPermissions windows.ACCESS_MASK, sid *windows.SID) windows.EXPLICIT_ACCESS {
+	return accessSid(accessPermissions, windows.GRANT_ACCESS, sid)
+}
+
+// Create an EXPLICIT_ACCESS instance denying permissions to the provided SID.
+func denySid(accessPermissions windows.ACCESS_MASK, sid *windows.SID) windows.EXPLICIT_ACCESS {
+	return accessSid(accessPermissions, windows.DENY_ACCESS, sid)
+}
+
+func accessSid(accessPermissions windows.ACCESS_MASK, accessMode windows.ACCESS_MODE, sid *windows.SID) windows.EXPLICIT_ACCESS {
+	return windows.EXPLICIT_ACCESS{
+		AccessPermissions: accessPermissions,
+		AccessMode:        accessMode,
+		Inheritance:       windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeValue: windows.TrusteeValueFromSID(sid),
+		},
+	}
+}

--- a/pkg/volume/util/util_windows_test.go
+++ b/pkg/volume/util/util_windows_test.go
@@ -1,0 +1,95 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWindowsFileMode(t *testing.T) {
+	// Create a temp file and set read only permissions on it.
+	f, err := os.CreateTemp("", "permissions_test")
+	require.NoError(t, err)
+
+	// Write a sample string into the file, and then expect to be able to read it later.
+	_, err = f.WriteString("hello!")
+	require.NoError(t, err)
+
+	f.Close()
+	defer os.Remove(f.Name())
+
+	err = Chmod(f.Name(), 0000)
+	require.NoError(t, err)
+
+	// Assert that the File Mode changed.
+	mode, err := GetFileMode(f.Name())
+	require.NoError(t, err)
+	assert.Equal(t, 0000, int(mode))
+
+	// Assert that we cannot read the file, as we don't have read permissions.
+	_, err = os.Open(f.Name())
+	expectedErrMsg := "Access is denied."
+	if err == nil || !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Fatalf("Unexpected error message while opening the file for reading. Got: %v, expected: %v", err, expectedErrMsg)
+	}
+
+	// Assert that we cannot write in the file, as we do not have write permissions.
+	_, err = os.Create(f.Name())
+	if err == nil || !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Fatalf("Unexpected error message while opening the file for writing. Got: %v, expected: %v", err, expectedErrMsg)
+	}
+
+	// Change the File Mode again.
+	err = Chmod(f.Name(), 0644)
+	require.NoError(t, err)
+
+	mode, err = GetFileMode(f.Name())
+	require.NoError(t, err)
+	assert.Equal(t, 0644, int(mode))
+
+	// Open the file in write mode, it should not fail.
+	f, err = os.Create(f.Name())
+	require.NoError(t, err)
+
+	expectedContent := "another hello!"
+	_, err = f.WriteString(expectedContent)
+	require.NoError(t, err)
+
+	f.Close()
+
+	// Open the file in read mode, we should be able to read the expected content.
+	f, err = os.Open(f.Name())
+	require.NoError(t, err)
+
+	bytes := make([]byte, len(expectedContent))
+	_, err = f.Read(bytes)
+	require.NoError(t, err)
+	assert.Equal(t, expectedContent, string(bytes))
+
+	f.Close()
+
+	err = os.Remove(f.Name())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

/sig testing
/sig windows
/priority important-soon
/milestone v1.25

#### What this PR does / why we need it:

Adds Windows file permissions.

The Windows file permissions / ACLs are a bit more complex and fine-grained than the Linux file permissions. However, the Linux file permissions could be translated to some extent to Windows ACLs.

We could translate the Linux user / group / other to the Windows SIDs: Creator Owner ID / Creator Group ID / World, or more precisely, ``S-1-3-0`` / ``S-1-3-1`` / ``S-1-1-0``.

As for the permissions, we can use the Generic Access Rights: ``GENERIC_READ`` / ``GENERIC_WRITE`` / ``GENERIC_EXECUTE``.

Adds ``GetFileMode``, which will return the mode of the given file. For Windows, the mode is retrieved using the Windows API, and returns a Linux-like ``FileMode``, based on the file's owner, owner group, and ``Everyone``.

Ports the ``atomic_writer`` unit tests to Windows.
Fixes a few other unit tests for Windows.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related: #51540

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
File permissions will now be set on files and volumes on Windows pods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
