### PR TITLE
Remove TTL for scheduler cache to resolve the race condition when Cac…

### DIFF
--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -750,7 +750,7 @@ func (cache *cacheImpl) cleanupAssumedPods(now time.Time) {
 				"pod", klog.KObj(ps.pod))
 			continue
 		}
-		if now.After(*ps.deadline) {
+		if cache.ttl != 0 && now.After(*ps.deadline) {
 			klog.InfoS("Pod expired", "pod", klog.KObj(ps.pod))
 			if err := cache.removePod(ps.pod); err != nil {
 				klog.ErrorS(err, "ExpirePod failed", "pod", klog.KObj(ps.pod))

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -53,7 +53,7 @@ import (
 const (
 	// Duration the scheduler will wait before expiring an assumed pod.
 	// See issue #106361 for more details about this parameter and its value.
-	durationToExpireAssumedPod = 15 * time.Minute
+	durationToExpireAssumedPod = 0 * time.Minute
 )
 
 // ErrNoNodesAvailable is used to describe the error that no nodes available to schedule pods.


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
In this PR we are removing cache timeout because of below race condition

A race condition will happen in the follow case:

pod1 is assigned to a node, scheduler cache is updated with the assignment, bind operation issued to apiserver.

if the apiserver is under huge pressure, bind takes more than 30s, scheduler expires the cached pod-to-node assignment.

bind eventually succeeds, but because the apiserver is under huge pressure, the pod update with the node name takes a long time to propagate to the scheduler.

because the pod update took a long time to propagate and the cache entry expired, the scheduler is not aware that the assignment actually happened, and so it had no problem assigning a second pod to the same node that would otherwise not fit if the scheduler was aware that the first pod was eventually assigned to the node.

#### Which issue(s) this PR fixes:
Fixes #106361

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
