### PR TITLE
rbd driver support enable object-map feature to accelerate large volume map

### DIFF
--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -43,7 +43,7 @@ import (
 )
 
 var (
-	supportedFeatures = sets.NewString("layering")
+	supportedFeatures = sets.NewString("layering", "object-map", "exclusive-lock")
 )
 
 // ProbeVolumePlugins is the primary entrypoint for volume plugins.


### PR DESCRIPTION
/kind feature
/sig storage

When user use large size of rbd volume, like 50T or larger, the pv mount need take 40 minutes or more time. The rbd object map feature can accelerate the rbd map process. But this feature only support on os 5.3 kernel or later. See this: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d9b9c893048e9d308a833619f0866f1f52778cf5

```release-note
Support rbd enable object-map feature to accelerate large rbd volume mount
```

