### PR TITLE
cleanup kubectl describe cronjob v1beta1 in 1.26

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -2326,22 +2326,14 @@ func (d *CronJobDescriber) Describe(namespace, name string, describerSettings De
 	var events *corev1.EventList
 
 	cronJob, err := d.client.BatchV1().CronJobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err == nil {
-		if describerSettings.ShowEvents {
-			events, _ = searchEvents(d.client.CoreV1(), cronJob, describerSettings.ChunkSize)
-		}
-		return describeCronJob(cronJob, events)
-	}
-
-	// TODO: drop this condition when beta disappears in 1.25
-	cronJobBeta, err := d.client.BatchV1beta1().CronJobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
+
 	if describerSettings.ShowEvents {
-		events, _ = searchEvents(d.client.CoreV1(), cronJobBeta, describerSettings.ChunkSize)
+		events, _ = searchEvents(d.client.CoreV1(), cronJob, describerSettings.ChunkSize)
 	}
-	return describeCronJobBeta(cronJobBeta, events)
+	return describeCronJob(cronJob, events)
 }
 
 func describeCronJob(cronJob *batchv1.CronJob, events *corev1.EventList) (string, error) {
@@ -2384,71 +2376,6 @@ func describeCronJob(cronJob *batchv1.CronJob, events *corev1.EventList) (string
 }
 
 func describeJobTemplate(jobTemplate batchv1.JobTemplateSpec, w PrefixWriter) {
-	if jobTemplate.Spec.Selector != nil {
-		if selector, err := metav1.LabelSelectorAsSelector(jobTemplate.Spec.Selector); err == nil {
-			w.Write(LEVEL_0, "Selector:\t%s\n", selector)
-		} else {
-			w.Write(LEVEL_0, "Selector:\tFailed to get selector: %s\n", err)
-		}
-	} else {
-		w.Write(LEVEL_0, "Selector:\t<unset>\n")
-	}
-	if jobTemplate.Spec.Parallelism != nil {
-		w.Write(LEVEL_0, "Parallelism:\t%d\n", *jobTemplate.Spec.Parallelism)
-	} else {
-		w.Write(LEVEL_0, "Parallelism:\t<unset>\n")
-	}
-	if jobTemplate.Spec.Completions != nil {
-		w.Write(LEVEL_0, "Completions:\t%d\n", *jobTemplate.Spec.Completions)
-	} else {
-		w.Write(LEVEL_0, "Completions:\t<unset>\n")
-	}
-	if jobTemplate.Spec.ActiveDeadlineSeconds != nil {
-		w.Write(LEVEL_0, "Active Deadline Seconds:\t%ds\n", *jobTemplate.Spec.ActiveDeadlineSeconds)
-	}
-	DescribePodTemplate(&jobTemplate.Spec.Template, w)
-}
-
-func describeCronJobBeta(cronJob *batchv1beta1.CronJob, events *corev1.EventList) (string, error) {
-	return tabbedString(func(out io.Writer) error {
-		w := NewPrefixWriter(out)
-		w.Write(LEVEL_0, "Name:\t%s\n", cronJob.Name)
-		w.Write(LEVEL_0, "Namespace:\t%s\n", cronJob.Namespace)
-		printLabelsMultiline(w, "Labels", cronJob.Labels)
-		printAnnotationsMultiline(w, "Annotations", cronJob.Annotations)
-		w.Write(LEVEL_0, "Schedule:\t%s\n", cronJob.Spec.Schedule)
-		w.Write(LEVEL_0, "Concurrency Policy:\t%s\n", cronJob.Spec.ConcurrencyPolicy)
-		w.Write(LEVEL_0, "Suspend:\t%s\n", printBoolPtr(cronJob.Spec.Suspend))
-		if cronJob.Spec.SuccessfulJobsHistoryLimit != nil {
-			w.Write(LEVEL_0, "Successful Job History Limit:\t%d\n", *cronJob.Spec.SuccessfulJobsHistoryLimit)
-		} else {
-			w.Write(LEVEL_0, "Successful Job History Limit:\t<unset>\n")
-		}
-		if cronJob.Spec.FailedJobsHistoryLimit != nil {
-			w.Write(LEVEL_0, "Failed Job History Limit:\t%d\n", *cronJob.Spec.FailedJobsHistoryLimit)
-		} else {
-			w.Write(LEVEL_0, "Failed Job History Limit:\t<unset>\n")
-		}
-		if cronJob.Spec.StartingDeadlineSeconds != nil {
-			w.Write(LEVEL_0, "Starting Deadline Seconds:\t%ds\n", *cronJob.Spec.StartingDeadlineSeconds)
-		} else {
-			w.Write(LEVEL_0, "Starting Deadline Seconds:\t<unset>\n")
-		}
-		describeJobTemplateBeta(cronJob.Spec.JobTemplate, w)
-		if cronJob.Status.LastScheduleTime != nil {
-			w.Write(LEVEL_0, "Last Schedule Time:\t%s\n", cronJob.Status.LastScheduleTime.Time.Format(time.RFC1123Z))
-		} else {
-			w.Write(LEVEL_0, "Last Schedule Time:\t<unset>\n")
-		}
-		printActiveJobs(w, "Active Jobs", cronJob.Status.Active)
-		if events != nil {
-			DescribeEvents(events, w)
-		}
-		return nil
-	})
-}
-
-func describeJobTemplateBeta(jobTemplate batchv1beta1.JobTemplateSpec, w PrefixWriter) {
 	if jobTemplate.Spec.Selector != nil {
 		if selector, err := metav1.LabelSelectorAsSelector(jobTemplate.Spec.Selector); err == nil {
 			w.Write(LEVEL_0, "Selector:\t%s\n", selector)


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25 
> The batch/v1beta1 API version of CronJob will no longer be served in v1.25.

But [kubectl needs to support +/- 1 minor version skew](https://kubernetes.io/releases/version-skew-policy/#kubectl). So 1.26 is minimal.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
