### PR TITLE
Append new pod conditions when deleting pods to indicate the reason for pod deletion

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2430,6 +2430,10 @@ const (
 	PodReasonUnschedulable = "Unschedulable"
 	// ContainersReady indicates whether all containers in the pod are ready.
 	ContainersReady PodConditionType = "ContainersReady"
+	// AlphaNoCompatGuaranteeDisruptionTarget indicates the pod is about to be deleted due to a
+	// disruption (such as preemption, eviction API or garbage-collection).
+	// The constant is to be renamed once the name is accepted within the KEP-3329.
+	AlphaNoCompatGuaranteeDisruptionTarget PodConditionType = "DisruptionTarget"
 )
 
 // PodCondition represents pod's condition

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -629,6 +629,14 @@ const (
 	// Enables controlling pod ranking on replicaset scale-down.
 	PodDeletionCost featuregate.Feature = "PodDeletionCost"
 
+	// owner: @mimowo
+	// kep: http://kep.k8s.io/3329
+	// alpha: v1.25
+	//
+	// Enables support for appending a dedicated pod condition indicating that
+	// the pod is being deleted due to a disruption.
+	PodDisruptionConditions featuregate.Feature = "PodDisruptionConditions"
+
 	// owner: @ddebroy
 	// alpha: v1.25
 	//
@@ -1004,6 +1012,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	PodAndContainerStatsFromCRI: {Default: false, PreRelease: featuregate.Alpha},
 
 	PodDeletionCost: {Default: true, PreRelease: featuregate.Beta},
+
+	PodDisruptionConditions: {Default: false, PreRelease: featuregate.Alpha},
 
 	PodHasNetworkCondition: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -684,7 +684,7 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 
 	mergedStatus := mergePodStatus(pod.Status, status.status, m.podDeletionSafety.PodCouldHaveRunningContainers(pod))
 
-	newPod, patchBytes, unchanged, err := statusutil.PatchPodStatus(m.kubeClient, pod.Namespace, pod.Name, pod.UID, pod.Status, mergedStatus)
+	newPod, patchBytes, unchanged, err := statusutil.PatchPodStatus(context.TODO(), m.kubeClient, pod.Namespace, pod.Name, pod.UID, pod.Status, mergedStatus)
 	klog.V(3).InfoS("Patch status for pod", "pod", klog.KObj(pod), "patch", string(patchBytes))
 
 	if err != nil {

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -105,7 +105,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, k client.ConnectionInfoGet
 		Pod:                 &REST{store, proxyTransport},
 		Binding:             &BindingREST{store: store},
 		LegacyBinding:       &LegacyBindingREST{bindingREST},
-		Eviction:            newEvictionStorage(store, podDisruptionBudgetClient),
+		Eviction:            newEvictionStorage(&statusStore, podDisruptionBudgetClient),
 		Status:              &StatusREST{store: &statusStore},
 		EphemeralContainers: &EphemeralContainersREST{store: &ephemeralContainersStore},
 		Log:                 &podrest.LogREST{Store: store, KubeletConn: k},

--- a/pkg/util/pod/pod.go
+++ b/pkg/util/pod/pod.go
@@ -30,7 +30,7 @@ import (
 )
 
 // PatchPodStatus patches pod status. It returns true and avoids an update if the patch contains no changes.
-func PatchPodStatus(c clientset.Interface, namespace, name string, uid types.UID, oldPodStatus, newPodStatus v1.PodStatus) (*v1.Pod, []byte, bool, error) {
+func PatchPodStatus(ctx context.Context, c clientset.Interface, namespace, name string, uid types.UID, oldPodStatus, newPodStatus v1.PodStatus) (*v1.Pod, []byte, bool, error) {
 	patchBytes, unchanged, err := preparePatchBytesForPodStatus(namespace, name, uid, oldPodStatus, newPodStatus)
 	if err != nil {
 		return nil, nil, false, err
@@ -39,7 +39,7 @@ func PatchPodStatus(c clientset.Interface, namespace, name string, uid types.UID
 		return nil, patchBytes, true, nil
 	}
 
-	updatedPod, err := c.CoreV1().Pods(namespace).Patch(context.TODO(), name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+	updatedPod, err := c.CoreV1().Pods(namespace).Patch(ctx, name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("failed to patch status %q for pod %q/%q: %v", patchBytes, namespace, name, err)
 	}

--- a/pkg/util/pod/pod_test.go
+++ b/pkg/util/pod/pod_test.go
@@ -88,7 +88,7 @@ func TestPatchPodStatus(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			_, patchBytes, unchanged, err := PatchPodStatus(client, ns, name, uid, getPodStatus(), tc.mutate(getPodStatus()))
+			_, patchBytes, unchanged, err := PatchPodStatus(context.TODO(), client, ns, name, uid, getPodStatus(), tc.mutate(getPodStatus()))
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -241,17 +241,23 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 			rbacv1helpers.NewRule("get", "list", "delete", "deletecollection").Groups("*").Resources("*").RuleOrDie(),
 		},
 	})
-	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "node-controller"},
-		Rules: []rbacv1.PolicyRule{
-			rbacv1helpers.NewRule("get", "list", "update", "delete", "patch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
-			rbacv1helpers.NewRule("patch", "update").Groups(legacyGroup).Resources("nodes/status").RuleOrDie(),
-			// used for pod eviction
-			rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("pods/status").RuleOrDie(),
-			rbacv1helpers.NewRule("list", "delete").Groups(legacyGroup).Resources("pods").RuleOrDie(),
-			eventsRule(),
-		},
-	})
+	addControllerRole(&controllerRoles, &controllerRoleBindings, func() rbacv1.ClusterRole {
+		role := rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "node-controller"},
+			Rules: []rbacv1.PolicyRule{
+				rbacv1helpers.NewRule("get", "list", "update", "delete", "patch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+				rbacv1helpers.NewRule("patch", "update").Groups(legacyGroup).Resources("nodes/status").RuleOrDie(),
+				// used for pod deletion
+				rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("pods/status").RuleOrDie(),
+				rbacv1helpers.NewRule("list", "delete").Groups(legacyGroup).Resources("pods").RuleOrDie(),
+				eventsRule(),
+			},
+		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.PodDisruptionConditions) {
+			role.Rules = append(role.Rules, rbacv1helpers.NewRule("patch").Groups(legacyGroup).Resources("pods/status").RuleOrDie())
+		}
+		return role
+	}())
 	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "persistent-volume-binder"},
 		Rules: []rbacv1.PolicyRule{
@@ -275,13 +281,19 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 			eventsRule(),
 		},
 	})
-	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "pod-garbage-collector"},
-		Rules: []rbacv1.PolicyRule{
-			rbacv1helpers.NewRule("list", "watch", "delete").Groups(legacyGroup).Resources("pods").RuleOrDie(),
-			rbacv1helpers.NewRule("get", "list").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
-		},
-	})
+	addControllerRole(&controllerRoles, &controllerRoleBindings, func() rbacv1.ClusterRole {
+		role := rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "pod-garbage-collector"},
+			Rules: []rbacv1.PolicyRule{
+				rbacv1helpers.NewRule("list", "watch", "delete").Groups(legacyGroup).Resources("pods").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "list").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+			},
+		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.PodDisruptionConditions) {
+			role.Rules = append(role.Rules, rbacv1helpers.NewRule("patch").Groups(legacyGroup).Resources("pods/status").RuleOrDie())
+		}
+		return role
+	}())
 	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "replicaset-controller"},
 		Rules: []rbacv1.PolicyRule{

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2653,6 +2653,10 @@ const (
 	PodReady PodConditionType = "Ready"
 	// PodScheduled represents status of the scheduling process for this pod.
 	PodScheduled PodConditionType = "PodScheduled"
+	// AlphaNoCompatGuaranteeDisruptionTarget indicates the pod is about to be deleted due to a
+	// disruption (such as preemption, eviction API or garbage-collection).
+	// The constant is to be renamed once the name is accepted within the KEP-3329.
+	AlphaNoCompatGuaranteeDisruptionTarget PodConditionType = "DisruptionTarget"
 )
 
 // These are reasons for a pod's transition to a condition.

--- a/test/integration/node/lifecycle_test.go
+++ b/test/integration/node/lifecycle_test.go
@@ -26,12 +26,17 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller/nodelifecycle"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/plugin/pkg/admission/defaulttolerationseconds"
 	"k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction"
 	pluginapi "k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction"
@@ -43,6 +48,140 @@ import (
 const poll = 2 * time.Second
 
 type podCondition func(pod *v1.Pod) (bool, error)
+
+// TestEvictionForNoExecuteTaintAddedByUser tests taint-based eviction for a node tainted NoExecute
+func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
+	tests := map[string]struct {
+		enablePodDisruptionConditions bool
+	}{
+		"Test eviciton for NoExecute taint added by user; pod condition added when PodDisruptionConditions enabled": {
+			enablePodDisruptionConditions: true,
+		},
+		"Test eviciton for NoExecute taint added by user; no pod condition added when PodDisruptionConditions disabled": {
+			enablePodDisruptionConditions: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			nodeIndex := 1
+			nodeCount := 3
+			var nodes []*v1.Node
+			for i := 0; i < nodeCount; i++ {
+				node := &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   fmt.Sprintf("testnode-%d", i),
+						Labels: map[string]string{"node.kubernetes.io/exclude-disruption": "true"},
+					},
+					Spec: v1.NodeSpec{},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				nodes = append(nodes, node)
+			}
+			testPod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testpod",
+				},
+				Spec: v1.PodSpec{
+					NodeName: nodes[nodeIndex].Name,
+					Containers: []v1.Container{
+						{Name: "container", Image: imageutils.GetPauseImageName()},
+					},
+				},
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.PodReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+				},
+			}
+
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodDisruptionConditions, test.enablePodDisruptionConditions)()
+			testCtx := testutils.InitTestAPIServer(t, "taint-no-execute", nil)
+
+			// Build clientset and informers for controllers.
+			defer testutils.CleanupTest(t, testCtx)
+			cs := testCtx.ClientSet
+
+			// Build clientset and informers for controllers.
+			externalClientConfig := restclient.CopyConfig(testCtx.KubeConfig)
+			externalClientConfig.QPS = -1
+			externalClientset := clientset.NewForConfigOrDie(externalClientConfig)
+			externalInformers := informers.NewSharedInformerFactory(externalClientset, time.Second)
+
+			// Start NodeLifecycleController for taint.
+			nc, err := nodelifecycle.NewNodeLifecycleController(
+				testCtx.Ctx,
+				externalInformers.Coordination().V1().Leases(),
+				externalInformers.Core().V1().Pods(),
+				externalInformers.Core().V1().Nodes(),
+				externalInformers.Apps().V1().DaemonSets(),
+				cs,
+				1*time.Second,    // Node monitor grace period
+				time.Minute,      // Node startup grace period
+				time.Millisecond, // Node monitor period
+				1,                // Pod eviction timeout
+				100,              // Eviction limiter QPS
+				100,              // Secondary eviction limiter QPS
+				50,               // Large cluster threshold
+				0.55,             // Unhealthy zone threshold
+				true,             // Run taint manager
+			)
+			if err != nil {
+				t.Errorf("Failed to create node controller: %v", err)
+				return
+			}
+
+			// Waiting for all controllers to sync
+			externalInformers.Start(testCtx.Ctx.Done())
+			externalInformers.WaitForCacheSync(testCtx.Ctx.Done())
+
+			// Run all controllers
+			go nc.Run(testCtx.Ctx)
+
+			for index := range nodes {
+				nodes[index], err = cs.CoreV1().Nodes().Create(testCtx.Ctx, nodes[index], metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("Failed to create node, err: %v", err)
+				}
+			}
+
+			testPod, err = cs.CoreV1().Pods(testCtx.NS.Name).Create(testCtx.Ctx, testPod, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Test Failed: error: %v, while creating pod", err)
+			}
+
+			if err := testutils.AddTaintToNode(cs, nodes[nodeIndex].Name, v1.Taint{Key: "CustomTaintByUser", Effect: v1.TaintEffectNoExecute}); err != nil {
+				t.Errorf("Failed to taint node in test %s <%s>, err: %v", name, nodes[nodeIndex].Name, err)
+			}
+
+			err = wait.PollImmediate(time.Second, time.Second*20, testutils.PodIsGettingEvicted(cs, testPod.Namespace, testPod.Name))
+			if err != nil {
+				t.Fatalf("Error %q in test %q when waiting for terminating pod: %q", err, name, klog.KObj(testPod))
+			}
+			testPod, err = cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, testPod.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Test Failed: error: %q, while getting updated pod", err)
+			}
+			_, cond := podutil.GetPodCondition(&testPod.Status, v1.AlphaNoCompatGuaranteeDisruptionTarget)
+			if test.enablePodDisruptionConditions == true && cond == nil {
+				t.Errorf("Pod %q does not have the expected condition: %q", klog.KObj(testPod), v1.AlphaNoCompatGuaranteeDisruptionTarget)
+			} else if test.enablePodDisruptionConditions == false && cond != nil {
+				t.Errorf("Pod %q has an unexpected condition: %q", klog.KObj(testPod), v1.AlphaNoCompatGuaranteeDisruptionTarget)
+			}
+		})
+	}
+}
 
 // TestTaintBasedEvictions tests related cases for the TaintBasedEvictions feature
 func TestTaintBasedEvictions(t *testing.T) {

--- a/test/integration/podgc/podgc_test.go
+++ b/test/integration/podgc/podgc_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/informers"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller/podgc"
 	"k8s.io/kubernetes/pkg/features"
 	testutils "k8s.io/kubernetes/test/integration/util"
@@ -36,144 +37,224 @@ import (
 
 // TestPodGcOrphanedPodsWithFinalizer tests deletion of orphaned pods
 func TestPodGcOrphanedPodsWithFinalizer(t *testing.T) {
-	testCtx := setup(t, "podgc-orphaned")
-	defer testutils.CleanupTest(t, testCtx)
-	cs := testCtx.ClientSet
-
-	node := &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "node",
+	tests := map[string]struct {
+		enablePodDisruptionConditions bool
+		wantPhase                     v1.PodPhase
+	}{
+		"PodDisruptionConditions enabled": {
+			enablePodDisruptionConditions: true,
+			wantPhase:                     v1.PodFailed,
 		},
-		Spec: v1.NodeSpec{},
-		Status: v1.NodeStatus{
-			Conditions: []v1.NodeCondition{
-				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionTrue,
+		"PodDisruptionConditions disabled": {
+			enablePodDisruptionConditions: false,
+			wantPhase:                     v1.PodPending,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodDisruptionConditions, test.enablePodDisruptionConditions)()
+			testCtx := setup(t, "podgc-orphaned")
+			defer testutils.CleanupTest(t, testCtx)
+			cs := testCtx.ClientSet
+
+			node := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node",
 				},
-			},
-		},
-	}
-	node, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Failed to create node '%v', err: %v", node.Name, err)
-	}
+				Spec: v1.NodeSpec{},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:   v1.NodeReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+				},
+			}
+			node, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create node '%v', err: %v", node.Name, err)
+			}
 
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "testpod",
-			Namespace:  testCtx.NS.Name,
-			Finalizers: []string{"test.k8s.io/finalizer"},
-		},
-		Spec: v1.PodSpec{
-			NodeName: node.Name,
-			Containers: []v1.Container{
-				{Name: "foo", Image: "bar"},
-			},
-		},
-	}
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "testpod",
+					Namespace:  testCtx.NS.Name,
+					Finalizers: []string{"test.k8s.io/finalizer"},
+				},
+				Spec: v1.PodSpec{
+					NodeName: node.Name,
+					Containers: []v1.Container{
+						{Name: "foo", Image: "bar"},
+					},
+				},
+			}
 
-	pod, err = cs.CoreV1().Pods(testCtx.NS.Name).Create(testCtx.Ctx, pod, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Error %v, while creating pod: %v", err, klog.KObj(pod))
-	}
-	defer testutils.RemovePodFinalizers(testCtx.ClientSet, t, []*v1.Pod{pod})
-	pod, err = cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, pod.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Error: '%v' while updating pod info: '%v'", err, klog.KObj(pod))
-	}
+			pod, err = cs.CoreV1().Pods(testCtx.NS.Name).Create(testCtx.Ctx, pod, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Error %v, while creating pod: %v", err, klog.KObj(pod))
+			}
+			defer testutils.RemovePodFinalizers(testCtx.ClientSet, t, []*v1.Pod{pod})
 
-	// we delete the node to orphan the pod
-	err = cs.CoreV1().Nodes().Delete(testCtx.Ctx, pod.Spec.NodeName, metav1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("Failed to delete node: %v, err: %v", pod.Spec.NodeName, err)
-	}
-
-	err = wait.PollImmediate(time.Second, time.Second*15, func() (bool, error) {
-		updatedPod, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, pod.Name, metav1.GetOptions{})
-		if err != nil {
-			return true, err
-		}
-		if updatedPod.ObjectMeta.DeletionTimestamp != nil {
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		t.Fatalf("Error '%v' while waiting for the pod '%v' to be deleted", err, klog.KObj(pod))
+			// we delete the node to orphan the pod
+			err = cs.CoreV1().Nodes().Delete(testCtx.Ctx, pod.Spec.NodeName, metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("Failed to delete node: %v, err: %v", pod.Spec.NodeName, err)
+			}
+			err = wait.PollImmediate(time.Second, time.Second*15, testutils.PodIsGettingEvicted(cs, pod.Namespace, pod.Name))
+			if err != nil {
+				t.Fatalf("Error '%v' while waiting for the pod '%v' to be terminating", err, klog.KObj(pod))
+			}
+			pod, err = cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, pod.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Error: '%v' while updating pod info: '%v'", err, klog.KObj(pod))
+			}
+			_, cond := podutil.GetPodCondition(&pod.Status, v1.AlphaNoCompatGuaranteeDisruptionTarget)
+			if test.enablePodDisruptionConditions == true && cond == nil {
+				t.Errorf("Pod %q does not have the expected condition: %q", klog.KObj(pod), v1.AlphaNoCompatGuaranteeDisruptionTarget)
+			} else if test.enablePodDisruptionConditions == false && cond != nil {
+				t.Errorf("Pod %q has an unexpected condition: %q", klog.KObj(pod), v1.AlphaNoCompatGuaranteeDisruptionTarget)
+			}
+			if pod.Status.Phase != test.wantPhase {
+				t.Errorf("Unexpected phase for pod %q. Got: %q, want: %q", klog.KObj(pod), pod.Status.Phase, test.wantPhase)
+			}
+		})
 	}
 }
 
 // TestTerminatingOnOutOfServiceNode tests deletion pods terminating on out-of-service nodes
 func TestTerminatingOnOutOfServiceNode(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeOutOfServiceVolumeDetach, true)()
-	testCtx := setup(t, "podgc-out-of-service")
-	defer testutils.CleanupTest(t, testCtx)
-	cs := testCtx.ClientSet
-
-	node := &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "node",
+	tests := map[string]struct {
+		enablePodDisruptionConditions bool
+		withFinalizer                 bool
+		wantPhase                     v1.PodPhase
+	}{
+		"pod has phase changed to Failed when PodDisruptionConditions enabled": {
+			enablePodDisruptionConditions: true,
+			withFinalizer:                 true,
+			wantPhase:                     v1.PodFailed,
 		},
-		Spec: v1.NodeSpec{},
-		Status: v1.NodeStatus{
-			Conditions: []v1.NodeCondition{
-				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionFalse,
+		"pod has phase when PodDisruptionConditions disabled": {
+			enablePodDisruptionConditions: true,
+			withFinalizer:                 true,
+			wantPhase:                     v1.PodPending,
+		},
+		"pod is getting deleted when no finalizer and PodDisruptionConditions enabled": {
+			enablePodDisruptionConditions: true,
+			withFinalizer:                 false,
+		},
+		"pod is getting deleted when no finalizer and PodDisruptionConditions disabled": {
+			enablePodDisruptionConditions: false,
+			withFinalizer:                 false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodDisruptionConditions, test.enablePodDisruptionConditions)()
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeOutOfServiceVolumeDetach, true)()
+			testCtx := setup(t, "podgc-out-of-service")
+			defer testutils.CleanupTest(t, testCtx)
+			cs := testCtx.ClientSet
+
+			node := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node",
 				},
-			},
-		},
-	}
-	node, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Failed to create node '%v', err: %v", node.Name, err)
-	}
+				Spec: v1.NodeSpec{},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:   v1.NodeReady,
+							Status: v1.ConditionFalse,
+						},
+					},
+				},
+			}
+			node, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create node '%v', err: %v", node.Name, err)
+			}
 
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testpod",
-			Namespace: testCtx.NS.Name,
-		},
-		Spec: v1.PodSpec{
-			NodeName: node.Name,
-			Containers: []v1.Container{
-				{Name: "foo", Image: "bar"},
-			},
-		},
-	}
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testpod",
+					Namespace: testCtx.NS.Name,
+				},
+				Spec: v1.PodSpec{
+					NodeName: node.Name,
+					Containers: []v1.Container{
+						{Name: "foo", Image: "bar"},
+					},
+				},
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+				},
+			}
+			if test.withFinalizer {
+				pod.ObjectMeta.Finalizers = []string{"test.k8s.io/finalizer"}
+			}
 
-	pod, err = cs.CoreV1().Pods(testCtx.NS.Name).Create(testCtx.Ctx, pod, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Error %v, while creating pod: %v", err, klog.KObj(pod))
-	}
+			pod, err = cs.CoreV1().Pods(testCtx.NS.Name).Create(testCtx.Ctx, pod, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Error %v, while creating pod: %v", err, klog.KObj(pod))
+			}
+			if test.withFinalizer {
+				defer testutils.RemovePodFinalizers(testCtx.ClientSet, t, []*v1.Pod{pod})
+			}
 
-	// trigger termination of the pod, but with long grace period so that it is not removed immediately
-	err = cs.CoreV1().Pods(testCtx.NS.Name).Delete(testCtx.Ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(300)})
-	if err != nil {
-		t.Fatalf("Error: '%v' while deleting pod: '%v'", err, klog.KObj(pod))
-	}
-
-	// taint the node with the out-of-service taint
-	err = testutils.AddTaintToNode(cs, pod.Spec.NodeName, v1.Taint{Key: v1.TaintNodeOutOfService, Value: "", Effect: v1.TaintEffectNoExecute})
-	if err != nil {
-		t.Fatalf("Failed to taint node: %v, err: %v", pod.Spec.NodeName, err)
-	}
-
-	// wait until the pod is deleted
-	err = wait.PollImmediate(time.Second, time.Second*15, func() (bool, error) {
-		updatedPod, err := cs.CoreV1().Pods(pod.Namespace).Get(testCtx.Ctx, pod.Name, metav1.GetOptions{})
-		if err == nil {
-			return updatedPod == nil, nil
-		}
-		// there was an error
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, err
-	})
-	if err != nil {
-		t.Fatalf("Error '%v' while waiting for the pod '%v' to be deleted", err, klog.KObj(pod))
+			// trigger termination of the pod, but with long grace period so that it is not removed immediately
+			err = cs.CoreV1().Pods(testCtx.NS.Name).Delete(testCtx.Ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(300)})
+			if err != nil {
+				t.Fatalf("Error: '%v' while deleting pod: '%v'", err, klog.KObj(pod))
+			}
+			// wait until the pod is terminating
+			err = wait.PollImmediate(time.Second, time.Second*15, testutils.PodIsGettingEvicted(cs, pod.Namespace, pod.Name))
+			if err != nil {
+				t.Fatalf("Error '%v' while waiting for the pod '%v' to be terminating", err, klog.KObj(pod))
+			}
+			// taint the node with the out-of-service taint
+			err = testutils.AddTaintToNode(cs, pod.Spec.NodeName, v1.Taint{Key: v1.TaintNodeOutOfService, Value: "", Effect: v1.TaintEffectNoExecute})
+			if err != nil {
+				t.Fatalf("Failed to taint node: %v, err: %v", pod.Spec.NodeName, err)
+			}
+			if test.withFinalizer {
+				// wait until the pod phase is set as expected
+				err = wait.PollImmediate(time.Second, time.Second*15, func() (bool, error) {
+					var e error
+					pod, e = cs.CoreV1().Pods(pod.Namespace).Get(testCtx.Ctx, pod.Name, metav1.GetOptions{})
+					if e != nil {
+						return true, e
+					}
+					return test.wantPhase == pod.Status.Phase, nil
+				})
+				if err != nil {
+					t.Errorf("Error %q while waiting for the pod %q to be in expected phase", err, klog.KObj(pod))
+				}
+				_, cond := podutil.GetPodCondition(&pod.Status, v1.AlphaNoCompatGuaranteeDisruptionTarget)
+				if cond != nil {
+					t.Errorf("Pod %q has an unexpected condition: %q", klog.KObj(pod), v1.AlphaNoCompatGuaranteeDisruptionTarget)
+				}
+			} else {
+				// wait until the pod is deleted
+				err = wait.PollImmediate(time.Second, time.Second*15, func() (bool, error) {
+					var e error
+					pod, e = cs.CoreV1().Pods(pod.Namespace).Get(testCtx.Ctx, pod.Name, metav1.GetOptions{})
+					if e == nil {
+						return pod == nil, nil
+					}
+					// there was an error
+					if apierrors.IsNotFound(e) {
+						return true, nil
+					}
+					return false, e
+				})
+				if err != nil {
+					t.Errorf("Error %q while waiting for the pod %q to be deleted", err, klog.KObj(pod))
+				}
+			}
+		})
 	}
 }
 

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -33,13 +33,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
 	configv1 "k8s.io/kube-scheduler/config/v1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 	configtesting "k8s.io/kubernetes/pkg/scheduler/apis/config/testing"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -186,13 +189,40 @@ func TestPreemption(t *testing.T) {
 
 	maxTokens := 1000
 	tests := []struct {
-		name                string
-		existingPods        []*v1.Pod
-		pod                 *v1.Pod
-		initTokens          int
-		unresolvable        bool
-		preemptedPodIndexes map[int]struct{}
+		name                          string
+		existingPods                  []*v1.Pod
+		pod                           *v1.Pod
+		initTokens                    int
+		unresolvable                  bool
+		preemptedPodIndexes           map[int]struct{}
+		enablePodDisruptionConditions bool
 	}{
+		{
+			name:       "basic pod preemption with PodDisruptionConditions enabled",
+			initTokens: maxTokens,
+			existingPods: []*v1.Pod{
+				initPausePod(&testutils.PausePodConfig{
+					Name:      "victim-pod",
+					Namespace: testCtx.NS.Name,
+					Priority:  &lowPriority,
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(400, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+					},
+				}),
+			},
+			pod: initPausePod(&testutils.PausePodConfig{
+				Name:      "preemptor-pod",
+				Namespace: testCtx.NS.Name,
+				Priority:  &highPriority,
+				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewMilliQuantity(300, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+				},
+			}),
+			preemptedPodIndexes:           map[int]struct{}{0: {}},
+			enablePodDisruptionConditions: true,
+		},
 		{
 			name:       "basic pod preemption",
 			initTokens: maxTokens,
@@ -412,6 +442,7 @@ func TestPreemption(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodDisruptionConditions, test.enablePodDisruptionConditions)()
 			filter.Tokens = test.initTokens
 			filter.Unresolvable = test.unresolvable
 			pods := make([]*v1.Pod, len(test.existingPods))
@@ -432,6 +463,16 @@ func TestPreemption(t *testing.T) {
 				if _, found := test.preemptedPodIndexes[i]; found {
 					if err = wait.Poll(time.Second, wait.ForeverTestTimeout, podIsGettingEvicted(cs, p.Namespace, p.Name)); err != nil {
 						t.Errorf("Pod %v/%v is not getting evicted.", p.Namespace, p.Name)
+					}
+					pod, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx.Ctx, p.Name, metav1.GetOptions{})
+					if err != nil {
+						t.Errorf("Error %v when getting the updated status for pod %v/%v ", err, p.Namespace, p.Name)
+					}
+					_, cond := podutil.GetPodCondition(&pod.Status, v1.AlphaNoCompatGuaranteeDisruptionTarget)
+					if test.enablePodDisruptionConditions == true && cond == nil {
+						t.Errorf("Pod %q does not have the expected condition: %q", klog.KObj(pod), v1.AlphaNoCompatGuaranteeDisruptionTarget)
+					} else if test.enablePodDisruptionConditions == false && cond != nil {
+						t.Errorf("Pod %q has an unexpected condition: %q", klog.KObj(pod), v1.AlphaNoCompatGuaranteeDisruptionTarget)
 					}
 				} else {
 					if p.DeletionTimestamp != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR appends pod conditions with a dedicated pod condition type `DisruptionTarget`.
Its `reason` field indicates the reason for pod termination:
- PreemptionByKubeScheduler (Pod preempted by kube-scheduler)
- DeletionByTaintManager (Pod deleted by taint manager due to NoExecute taint)
- EvictionByEvictionAPI (Pod evicted by Eviction API)
- DeletionByPodGC (an orphaned Pod deleted by PodGC)

<!--
#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*

Fixes #
-->
#### Which issue(s) this PR fixes:

- Tracking issue: https://github.com/kubernetes/enhancements/issues/3329

#### Special notes for your reviewer:

- This PR is accompanied by other PRs within KEP:
  - to use the conditions in order to determine the handling of pod failures: https://github.com/kubernetes/kubernetes/pull/111113
  - to clean up stale `DisruptionTarget` condition: https://github.com/kubernetes/kubernetes/pull/111475
- There is a new PR prepared to update the KEP according to design changes done during implementation:
https://github.com/kubernetes/enhancements/pull/3438.

#### Does this PR introduce a user-facing change?

Yes, it appends new pod conditions when deleting a pod.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduction of the `DisruptionTarget` pod condition type. Its `reason` field indicates the reason for pod termination:
- PreemptionByKubeScheduler (Pod preempted by kube-scheduler)
- DeletionByTaintManager (Pod deleted by taint manager due to NoExecute taint)
- EvictionByEvictionAPI (Pod evicted by Eviction API)
- DeletionByPodGC (an orphaned Pod deleted by PodGC)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: 
- [Usage]: <link>
- [Other doc]: <link>
-
-->
 ```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures
```


