### PR TITLE
add bind-network option

### DIFF
--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -398,6 +398,7 @@ func TestAddFlags(t *testing.T) {
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
 			BindPort:    10001,
+			BindNetwork: "tcp",
 			BindAddress: netutils.ParseIPSloppy("192.168.4.21"),
 			ServerCert: apiserveroptions.GeneratableKeyCert{
 				CertDirectory: "/a/b/c",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -111,6 +111,7 @@ func NewSecureServingOptions() *SecureServingOptions {
 	return &SecureServingOptions{
 		BindAddress: netutils.ParseIPSloppy("0.0.0.0"),
 		BindPort:    443,
+		BindNetwork: "tcp",
 		ServerCert: GeneratableKeyCert{
 			PairName:      "apiserver",
 			CertDirectory: "apiserver.local.config/certificates",
@@ -154,6 +155,10 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 		"The IP address on which to listen for the --secure-port port. The "+
 		"associated interface(s) must be reachable by the rest of the cluster, and by CLI/web "+
 		"clients. If blank or an unspecified address (0.0.0.0 or ::), all interfaces will be used.")
+
+	fs.StringVar(&s.BindNetwork, "bind-network", s.BindNetwork, ""+
+		"The IP address bind to which type of network, defaults to \"tcp\", accepts \"tcp\","+
+		" \"tcp4\", and \"tcp6\".")
 
 	desc := "The port on which to serve HTTPS with authentication and authorization."
 	if s.Required {

--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -91,6 +91,7 @@ func TestDefaultFlags(t *testing.T) {
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
 			BindPort:    10258,
+			BindNetwork: "tcp",
 			BindAddress: netutils.ParseIPSloppy("0.0.0.0"),
 			ServerCert: apiserveroptions.GeneratableKeyCert{
 				CertDirectory: "",
@@ -229,6 +230,7 @@ func TestAddFlags(t *testing.T) {
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
 			BindPort:    10001,
+			BindNetwork: "tcp",
 			BindAddress: netutils.ParseIPSloppy("192.168.4.21"),
 			ServerCert: apiserveroptions.GeneratableKeyCert{
 				CertDirectory: "/a/b/c",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

if node disable ipv6, thus will make localhost connect failed, so maybe could `network type` as option

the audit log is below:
```
# use option  --bind-address 0.0.0.0
{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"RequestResponse","auditID":"7c00ec31-d63f-4985-96cc-85b92c0720b3","stage":"ResponseComplete","requestURI":"/api/v1/namespaces/kube-public","verb":"get","user":{"username":"system:apiserver","uid":"5e88a5f1-2bbc-4cbd-b399-32e344aed140","groups":["system:masters"]},"sourceIPs":["::1"],"userAgent":"kube-apiserver/v1.20.14 (linux/amd64) kubernetes/d687c6b"...

# use option  --bind-address 0.0.0.0 and --bind-network tcp4
{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"RequestResponse","auditID":"781f5225-6062-4314-83cd-51f6b0ff8620","stage":"ResponseComplete","requestURI":"/api/v1/namespaces/kube-system","verb":"get","user":{"username":"system:apiserver","uid":"1a4729c5-6f9a-4b8f-8a2c-9798b84d9246","groups":["system:masters"]},"sourceIPs":["127.0.0.1"],"userAgent":"kube-apiserver/v1.20.14 (linux/amd64) kubernetes/d687c6b"...
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82067

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
