### PR TITLE
using Lister replace visit apiserver get persistentvolume in pv_controller

### DIFF
--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -752,6 +752,12 @@ func runSyncTests(t *testing.T, tests []controllerTest, storageClasses []*storag
 		}
 		ctrl.classLister = storagelisters.NewStorageClassLister(indexer)
 
+		pvIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		for _, pv := range test.initialVolumes {
+			pvIndexer.Add(pv)
+		}
+		ctrl.volumeLister = corelisters.NewPersistentVolumeLister(pvIndexer)
+
 		podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 		for _, pod := range pods {
 			podIndexer.Add(pod)
@@ -813,6 +819,12 @@ func runMultisyncTests(t *testing.T, tests []controllerTest, storageClasses []*s
 			indexer.Add(class)
 		}
 		ctrl.classLister = storagelisters.NewStorageClassLister(indexer)
+
+		pvIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		for _, pv := range test.initialVolumes {
+			pvIndexer.Add(pv)
+		}
+		ctrl.volumeLister = corelisters.NewPersistentVolumeLister(pvIndexer)
 
 		reactor := newVolumeReactor(client, ctrl, nil, nil, test.errors)
 		for _, claim := range test.initialClaims {

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -1149,7 +1149,7 @@ func (ctrl *PersistentVolumeController) recycleVolumeOperation(volume *v1.Persis
 	// This method may have been waiting for a volume lock for some time.
 	// Previous recycleVolumeOperation might just have saved an updated version,
 	// so read current volume state now.
-	newVolume, err := ctrl.kubeClient.CoreV1().PersistentVolumes().Get(context.TODO(), volume.Name, metav1.GetOptions{})
+	newVolume, err := ctrl.volumeLister.Get(volume.Name)
 	if err != nil {
 		klog.V(3).Infof("error reading persistent volume %q: %v", volume.Name, err)
 		return
@@ -1244,7 +1244,7 @@ func (ctrl *PersistentVolumeController) deleteVolumeOperation(volume *v1.Persist
 	// This method may have been waiting for a volume lock for some time.
 	// Previous deleteVolumeOperation might just have saved an updated version, so
 	// read current volume state now.
-	newVolume, err := ctrl.kubeClient.CoreV1().PersistentVolumes().Get(context.TODO(), volume.Name, metav1.GetOptions{})
+	newVolume, err := ctrl.volumeLister.Get(volume.Name)
 	if err != nil {
 		klog.V(3).Infof("error reading persistent volume %q: %v", volume.Name, err)
 		return "", nil


### PR DESCRIPTION
/kind bug
/sig storage 

#### What this PR does / why we need it:
When exist lots of "Released" status PVC  on our clusters, the pv_controller will visit apiserver frequently then trigger throttling and impact pvc bound. This pr replace with Lister get pv from local cache. Reduce the visit to apiserver.
