### PR TITLE
kubeadm: unify the way to cleanup the files for `kubeadm reset`

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -50,6 +50,7 @@ func NewCleanupNodePhase() workflow.Phase {
 }
 
 func runCleanupNode(c workflow.RunData) error {
+	dirsToClean := []string{filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.ManifestsSubDirName)}
 	r, ok := c.(resetData)
 	if !ok {
 		return errors.New("cleanup-node phase invoked with an invalid data struct")
@@ -81,7 +82,7 @@ func runCleanupNode(c workflow.RunData) error {
 		kubeletRunDir, err := absoluteKubeletRunDirectory()
 		if err == nil {
 			// Only clean absoluteKubeletRunDirectory if umountDirsCmd passed without error
-			r.AddDirsToClean(kubeletRunDir)
+			dirsToClean = append(dirsToClean, kubeletRunDir)
 		}
 	} else {
 		fmt.Printf("[reset] Would unmount mounted directories in %q\n", kubeadmconstants.KubeletRunDirectory)
@@ -100,7 +101,8 @@ func runCleanupNode(c workflow.RunData) error {
 	if certsDir != kubeadmapiv1.DefaultCertificatesDir {
 		klog.Warningf("[reset] WARNING: Cleaning a non-default certificates directory: %q\n", certsDir)
 	}
-	resetConfigDir(kubeadmconstants.KubernetesDir, certsDir, r.DryRun())
+	dirsToClean = append(dirsToClean, certsDir)
+	resetConfigDir(kubeadmconstants.KubernetesDir, dirsToClean, r.DryRun())
 
 	if r.Cfg() != nil && features.Enabled(r.Cfg().FeatureGates, features.RootlessControlPlane) {
 		if !r.DryRun() {
@@ -142,12 +144,8 @@ func removeContainers(execer utilsexec.Interface, criSocketPath string) error {
 	return containerRuntime.RemoveContainers(containers)
 }
 
-// resetConfigDir is used to cleanup the files kubeadm writes in /etc/kubernetes/.
-func resetConfigDir(configPathDir, pkiPathDir string, isDryRun bool) {
-	dirsToClean := []string{
-		filepath.Join(configPathDir, kubeadmconstants.ManifestsSubDirName),
-		pkiPathDir,
-	}
+// resetConfigDir is used to cleanup the files in the folder defined in dirsToClean.
+func resetConfigDir(configPathDir string, dirsToClean []string, isDryRun bool) {
 	if !isDryRun {
 		fmt.Printf("[reset] Deleting contents of directories: %v\n", dirsToClean)
 		for _, dir := range dirsToClean {

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -19,6 +19,7 @@ package phases
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -200,4 +201,17 @@ func CleanDir(filePath string) error {
 		}
 	}
 	return nil
+}
+
+func IsDirEmpty(dir string) (bool, error) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return false, err
+	}
+	defer d.Close()
+	_, err = d.Readdirnames(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, nil
 }

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
@@ -173,7 +173,11 @@ func TestConfigDirCleaner(t *testing.T) {
 			if test.resetDir == "" {
 				test.resetDir = "pki"
 			}
-			resetConfigDir(tmpDir, filepath.Join(tmpDir, test.resetDir), false)
+			dirsToClean := []string{
+				filepath.Join(tmpDir, test.resetDir),
+				filepath.Join(tmpDir, kubeadmconstants.ManifestsSubDirName),
+			}
+			resetConfigDir(tmpDir, dirsToClean, false)
 
 			// Verify the files we cleanup implicitly in every test:
 			assertExists(t, tmpDir)

--- a/cmd/kubeadm/app/cmd/phases/reset/data.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/data.go
@@ -34,7 +34,6 @@ type resetData interface {
 	Cfg() *kubeadmapi.InitConfiguration
 	DryRun() bool
 	Client() clientset.Interface
-	AddDirsToClean(dirs ...string)
 	CertificatesDir() string
 	CRISocketPath() string
 }

--- a/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember.go
@@ -19,11 +19,14 @@ package phases
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"k8s.io/klog/v2"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -63,12 +66,24 @@ func runRemoveETCDMemberPhase(c workflow.RunData) error {
 					klog.Warningf("[reset] Failed to remove etcd member: %v, please manually remove this etcd member using etcdctl", err)
 				} else {
 					if err := CleanDir(etcdDataDir); err != nil {
-						klog.Warningf("[reset] Failed to delete contents of %q directory: %v", etcdDataDir, err)
+						klog.Warningf("[reset] Failed to delete contents of the etcd directory: %q, error: %v", etcdDataDir, err)
+					} else {
+						fmt.Printf("[reset] Deleted contents of the etcd data directory: %v\n", etcdDataDir)
 					}
 				}
 			} else {
 				fmt.Println("[reset] Would remove the etcd member on this node from the etcd cluster")
 				fmt.Printf("[reset] Would delete contents of the etcd data directory: %v\n", etcdDataDir)
+			}
+		}
+		// This could happen if the phase `cleanup-node` is run before the `remove-etcd-member`.
+		// Cleanup the data in the etcd data dir to avoid some stale files which might cause the failure to build cluster in the next time.
+		empty, _ := IsDirEmpty(etcdDataDir)
+		if !empty && !r.DryRun() {
+			if err := CleanDir(etcdDataDir); err != nil {
+				klog.Warningf("[reset] Failed to delete contents of the etcd directory: %q, error: %v", etcdDataDir, err)
+			} else {
+				fmt.Printf("[reset] Deleted contents of the etcd data directory: %v\n", etcdDataDir)
 			}
 		}
 	} else {
@@ -88,11 +103,17 @@ func getEtcdDataDir(manifestPath string, cfg *kubeadmapi.InitConfiguration) (str
 	}
 	klog.Warningln("[reset] No kubeadm config, using etcd pod spec to get data directory")
 
+	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
+		// Fall back to use the default cluster config if etcd.yaml doesn't exist, this could happen that
+		// etcd.yaml is removed by other reset phases, e.g. cleanup-node.
+		cfg := &v1beta3.ClusterConfiguration{}
+		scheme.Scheme.Default(cfg)
+		return cfg.Etcd.Local.DataDir, nil
+	}
 	etcdPod, err := utilstaticpod.ReadStaticPodFromDisk(manifestPath)
 	if err != nil {
 		return "", err
 	}
-
 	for _, volumeMount := range etcdPod.Spec.Volumes {
 		if volumeMount.Name == etcdVolumeName {
 			dataDir = volumeMount.HostPath.Path

--- a/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember_test.go
@@ -63,10 +63,11 @@ func TestGetEtcdDataDir(t *testing.T) {
 		writeManifest bool
 		validConfig   bool
 	}{
-		"non-existent file returns error": {
-			expectErr:     true,
+		"non-existent file returns default data dir": {
+			expectErr:     false,
 			writeManifest: false,
 			validConfig:   true,
+			dataDir:       "/var/lib/etcd",
 		},
 		"return etcd data dir": {
 			dataDir:       "/path/to/etcd",


### PR DESCRIPTION
Split the PR into two commits with each one focus on one specific issue, 

- commit 1
Move the logic of file cleanup within each phase.
This address the issue that if end user resets cluster by the calling of the three phases instead of `kubeadm reset`, then the stale data, such as /var/lib/kubelet/ could be cleanup eventually.

- commit 2
Cleanup etcd data dir on best effort basis.
If end user call `reset phase remove-etcd-member` before `reset cleanup-node` then commit1 should be enough, otherwise,  there is no way to tell where is the etcd data dir is configured by user, kubeadm will check the default etcd data directory and make sure that directory will be cleanup, this would address most of the problem.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug



#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/2721

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubeadm will cleanup the stale data on best effort basis. Stale data will be removed when each reset phase are executed, default etcd data directory will be cleanup when the `remove-etcd-member` phase are executed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
