### PR TITLE
kubeadm: Don't ask for input if it's dry run mode

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/reset/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/preflight.go
@@ -51,7 +51,7 @@ func runPreflight(c workflow.RunData) error {
 		return errors.New("preflight phase invoked with an invalid data struct")
 	}
 
-	if !r.ForceReset() {
+	if !r.ForceReset() && !r.DryRun() {
 		klog.Warning("[reset] WARNING: Changes made to this host by 'kubeadm init' or 'kubeadm join' will be reverted.")
 		fmt.Print("[reset] Are you sure you want to proceed? [y/N]: ")
 		s := bufio.NewScanner(r.InputReader())


### PR DESCRIPTION
Signed-off-by: Dave Chen <dave.chen@arm.com>


This is consistent with `kubeadm upgrade apply`,  pls see the [code here](https://github.com/kubernetes/kubernetes/blob/bd2776e0c930ab149d8c0656e83f979fb017ce0a/cmd/kubeadm/app/cmd/upgrade/apply.go#L56-L58)

Background is I am working on the `nonInteractiveMode` for the `kubeadm reset`, the purpose is that when user add the flag `-yes` then there is no need to wait user's input.  Compared with other cmd like `upgrade apply`, seems like there is no need to wait for input when it's in `dry-run` mode as well.


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


/sig cluster-lifecycle