### PR TITLE
Change snapshot-controller image to v4.2.1

### DIFF
--- a/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
+++ b/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccount: volume-snapshot-controller
       containers:
         - name: volume-snapshot-controller
-          image: registry.k8s.io/sig-storage/snapshot-controller:v6.0.1
+          image: registry.k8s.io/sig-storage/snapshot-controller:v4.2.1
           args:
             - "--v=5"
             - "--metrics-path=/metrics"


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR is a workaround for https://github.com/kubernetes-csi/external-snapshotter/issues/736.
The CI job pull-kubernetes-e2e-gce-storage-snapshot started to fail when the following PR changed snapshot-controller image from v4.0.0 to v6.0.1: https://github.com/kubernetes/kubernetes/pull/110204/
I tried with image v5.0.1, but it failed with same errors.
I tried with image v4.2.1 and it passed. 
So the failure started with v5.0.1.  I'm changing the image to v4.2.1 in this PR.

In the PR https://github.com/kubernetes/kubernetes/pull/110826, we'll try to fix the problem with image v6.0.1.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```