### PR TITLE
Cherry-pick of #110853:  filter out unsatisfied nodes when calling AddPod in PodTopologySpread

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -127,6 +127,13 @@ func (s *preFilterState) updateWithPod(updatedPod, preemptorPod *v1.Pod, node *v
 		return
 	}
 
+	// We only need to update the counters for the nodes that match the topology spreading policy,
+	// in other words, the node affinity.
+	requiredSchedulingTerm := nodeaffinity.GetRequiredNodeAffinity(preemptorPod)
+	if match, _ := requiredSchedulingTerm.Match(node); !match {
+		return
+	}
+
 	podLabelSet := labels.Set(updatedPod.Labels)
 	for _, constraint := range s.Constraints {
 		if !constraint.Selector.Matches(podLabelSet) {


### PR DESCRIPTION
Cherry pick of https://github.com/kubernetes/kubernetes/pull/110853 on release-1.22.

https://github.com/kubernetes/kubernetes/pull/110853: Fix: filter out unsatisfied nodes when calling AddPod in PodTopologySpread

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Fixed potential scheduler crash when scheduling with unsatisfied nodes in PodTopologySpread.
```