### PR TITLE
Remove SIG Scheduling approvers from reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -168,10 +168,6 @@ aliases:
   # - ravisantoshgudimetla
   # - wojtek-t
   sig-scheduling:
-    - Huang-Wei
-    - ahg-g
-    - alculquicondor
-    - damemi
     - chendave
     - denkensk
     - sanposhiho


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

/sig scheduling

We currently have 4 approvers and 8 reviewers (including the 4 approvers)

I propose:
- To remove the approvers from the reviewers list (this PR)
- Any PR should be reviewed by a reviewer before being assigned to the approver. Reviewers are assigned automatically.
- If it's a hotfix, the PR can be assigned to an approver directly.

I hope this accomplishes the following:
- Lower review burden from approvers
- Encourage our reviewers to take more responsibility and build their reputation.
- Encourage new contributors to seek the reviewer status.

Original proposal https://groups.google.com/g/kubernetes-sig-scheduling/c/1JD2w1w48uo/

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
