### PR TITLE
Promote patchCoreV1NamespacedPodStatus test - +1 endpoint

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2021,6 +2021,13 @@
     IP address.
   release: v1.9
   file: test/e2e/common/node/pods.go
+- testname: Pods, patching status
+  codename: '[sig-node] Pods should patch a pod status [Conformance]'
+  description: A pod is created which MUST succeed and be found running. The pod status
+    when patched MUST succeed. Given the patching of the pod status, the fields MUST
+    equal the new values.
+  release: v1.25
+  file: test/e2e/common/node/pods.go
 - testname: Pods, completes the lifecycle of a Pod and the PodStatus
   codename: '[sig-node] Pods should run through the lifecycle of Pods and PodStatus
     [Conformance]'

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -1071,7 +1071,15 @@ var _ = SIGDescribe("Pods", func() {
 		}
 	})
 
-	ginkgo.It("should patch a pod status", func() {
+	/*
+		Release: v1.25
+		Testname: Pods, patching status
+		Description: A pod is created which MUST succeed
+		and be found running. The pod status when patched
+		MUST succeed. Given the patching of the pod status,
+		the fields MUST equal the new values.
+	*/
+	framework.ConformanceIt("should patch a pod status", func() {
 		ns := f.Namespace.Name
 		podClient := f.ClientSet.CoreV1().Pods(ns)
 		podName := "pod-" + utilrand.String(5)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- patchCoreV1NamespacedPodStatus

**Which issue(s) this PR fixes:**
Fixes #108499

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.patch.a.pod.status)


**Special notes for your reviewer:**
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance