### PR TITLE
Capture the Container Logs for a Flaky Test

### DIFF
--- a/test/e2e_node/node_perf_test.go
+++ b/test/e2e_node/node_perf_test.go
@@ -126,12 +126,30 @@ var _ = SIGDescribe("Node Performance Testing [Serial] [Slow]", func() {
 		// Create the pod.
 		pod = f.PodClient().CreateSync(pod)
 		// Wait for pod success.
-		f.PodClient().WaitForSuccess(pod.Name, wl.Timeout())
+		// but avoid using WaitForSuccess because we want the container logs upon failure #109295
+		podErr := e2epod.WaitForPodCondition(f.ClientSet, f.Namespace.Name, pod.Name, fmt.Sprintf("%s or %s", v1.PodSucceeded, v1.PodFailed), wl.Timeout(),
+			func(pod *v1.Pod) (bool, error) {
+				switch pod.Status.Phase {
+				case v1.PodFailed:
+					return true, fmt.Errorf("pod %q failed with reason: %q, message: %q", pod.Name, pod.Status.Reason, pod.Status.Message)
+				case v1.PodSucceeded:
+					return true, nil
+				default:
+					return false, nil
+				}
+			},
+		)
 		podLogs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
 		framework.ExpectNoError(err)
+		if podErr != nil {
+			framework.Logf("dumping pod logs due to pod error detected: \n%s", podLogs)
+			framework.Failf("pod error: %v", podErr)
+		}
 		perf, err := wl.ExtractPerformanceFromLogs(podLogs)
 		framework.ExpectNoError(err)
 		framework.Logf("Time to complete workload %s: %v", wl.Name(), perf)
+		// using framework.ExpectNoError for consistency would cause changes the output format
+		gomega.Expect(podErr).To(gomega.Succeed(), "wait for pod %q to succeed", pod.Name)
 	}
 
 	ginkgo.BeforeEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test
/kind flake
/sig node

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR is to try to get some debugging info regarding a flaking test #109295.  The test driver was changed to capture the container logs on pod failure.

The flaking test is a long-running perf test for sig-node-containerd. 

There's some discussion in the associated ticket.  In short, the test does not fail when run locally and there are not enough clues in the test-related artifacts to allow for debugging. When the test fails, there are no container logs.  It discards them, since it only gets them to gather perf-related data.  Local testing indicates that it is likely some kind of problem with the job that is causing the problem.

- [testgrid](https://testgrid.k8s.io/sig-node-containerd#node-kubelet-containerd-performance-test)
- [prow](https://prow.k8s.io/?job=ci-kubernetes-node-kubelet-containerd-performance-test)

#### Which issue(s) this PR fixes:

#109295

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
