### PR TITLE
kubeadm: respect user specified image repository when using Kubernetes ci version

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -364,6 +364,9 @@ const (
 	// TODO: Find a better place for this constant
 	YAMLDocumentSeparator = "---\n"
 
+	// CIKubernetesVersionPrefix is the prefix for CI Kubernetes version
+	CIKubernetesVersionPrefix = "ci/"
+
 	// DefaultAPIServerBindAddress is the default bind address for the API Server
 	DefaultAPIServerBindAddress = "0.0.0.0"
 

--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -94,7 +94,7 @@ func NormalizeKubernetesVersion(cfg *kubeadmapi.ClusterConfiguration) error {
 	isCIVersion := kubeadmutil.KubernetesIsCIVersion(cfg.KubernetesVersion)
 
 	// Requested version is automatic CI build, thus use KubernetesCI Image Repository for core images
-	if isCIVersion {
+	if isCIVersion && cfg.ImageRepository == kubeadmapiv1.DefaultImageRepository {
 		cfg.CIImageRepository = constants.DefaultCIImageRepository
 	}
 
@@ -106,7 +106,7 @@ func NormalizeKubernetesVersion(cfg *kubeadmapi.ClusterConfiguration) error {
 
 	// Requested version is automatic CI build, thus mark CIKubernetesVersion as `ci/<resolved-version>`
 	if isCIVersion {
-		cfg.CIKubernetesVersion = fmt.Sprintf("ci/%s", ver)
+		cfg.CIKubernetesVersion = fmt.Sprintf("%s%s", constants.CIKubernetesVersionPrefix, ver)
 	}
 
 	cfg.KubernetesVersion = ver


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: respect user specified image repository when using Kubernetes ci version

Before this patch:
```bash
# kubeadm config images list --kubernetes-version=ci/latest-1.24
gcr.io/k8s-staging-ci-images/kube-apiserver:v1.24.3-rc.0.29_99b7713ba36e8f
gcr.io/k8s-staging-ci-images/kube-controller-manager:v1.24.3-rc.0.29_99b7713ba36e8f
gcr.io/k8s-staging-ci-images/kube-scheduler:v1.24.3-rc.0.29_99b7713ba36e8f
gcr.io/k8s-staging-ci-images/kube-proxy:v1.24.3-rc.0.29_99b7713ba36e8f
registry.k8s.io/pause:3.7
registry.k8s.io/etcd:3.5.4-0
registry.k8s.io/coredns/coredns:v1.9.3
# kubeadm config images list --kubernetes-version=ci/latest-1.24 --image-repository registry.cn-hangzhou.aliyuncs.com/google_containers
gcr.io/k8s-staging-ci-images/kube-apiserver:v1.24.3-rc.0.29_99b7713ba36e8f
gcr.io/k8s-staging-ci-images/kube-controller-manager:v1.24.3-rc.0.29_99b7713ba36e8f
gcr.io/k8s-staging-ci-images/kube-scheduler:v1.24.3-rc.0.29_99b7713ba36e8f
gcr.io/k8s-staging-ci-images/kube-proxy:v1.24.3-rc.0.29_99b7713ba36e8f
registry.cn-hangzhou.aliyuncs.com/google_containers/pause:3.7
registry.cn-hangzhou.aliyuncs.com/google_containers/etcd:3.5.4-0
registry.cn-hangzhou.aliyuncs.com/google_containers/coredns:v1.9.3
```

After this patch:
```bash
# kubeadm config images list --kubernetes-version=ci/latest-1.24
gcr.io/k8s-staging-ci-images/kube-apiserver:v1.24.3-rc.0.29_99b7713ba36e8f
gcr.io/k8s-staging-ci-images/kube-controller-manager:v1.24.3-rc.0.29_99b7713ba36e8f
gcr.io/k8s-staging-ci-images/kube-scheduler:v1.24.3-rc.0.29_99b7713ba36e8f
gcr.io/k8s-staging-ci-images/kube-proxy:v1.24.3-rc.0.29_99b7713ba36e8f
registry.k8s.io/pause:3.7
registry.k8s.io/etcd:3.5.4-0
registry.k8s.io/coredns/coredns:v1.9.3
# kubeadm config images list --kubernetes-version=ci/latest-1.24 --image-repository registry.cn-hangzhou.aliyuncs.com/google_containers
registry.cn-hangzhou.aliyuncs.com/google_containers/kube-apiserver:v1.24.3-rc.0.29_99b7713ba36e8f
registry.cn-hangzhou.aliyuncs.com/google_containers/kube-controller-manager:v1.24.3-rc.0.29_99b7713ba36e8f
registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler:v1.24.3-rc.0.29_99b7713ba36e8f
registry.cn-hangzhou.aliyuncs.com/google_containers/kube-proxy:v1.24.3-rc.0.29_99b7713ba36e8f
registry.cn-hangzhou.aliyuncs.com/google_containers/pause:3.7
registry.cn-hangzhou.aliyuncs.com/google_containers/etcd:3.5.4-0
registry.cn-hangzhou.aliyuncs.com/google_containers/coredns:v1.9.3
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: respect user specified image repository when using Kubernetes ci version
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
