### PR TITLE
Add wait option to kubectl logs

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
@@ -663,6 +663,24 @@ func TestValidateLogOptions(t *testing.T) {
 			args:     []string{"my-pod", "my-container"},
 			expected: "only one of -c or an inline",
 		},
+		{
+			name: "waiting for container to start is only allowed in streaming mode",
+			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+				o := NewLogsOptions(streams, false)
+				o.Follow = false
+				o.WaitForContainerStart = true
+
+				var err error
+				o.Options, err = o.ToLogOptions()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				return o
+			},
+			args:     []string{"my-pod"},
+			expected: "--wait can only be set together with --follow",
+		},
 	}
 	for _, test := range tests {
 		streams := genericclioptions.NewTestIOStreamsDiscard()

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/interface.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/interface.go
@@ -31,7 +31,10 @@ import (
 type LogsForObjectFunc func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool) (map[v1.ObjectReference]rest.ResponseWrapper, error)
 
 // LogsForObjectFn gives a way to easily override the function for unit testing if needed.
-var LogsForObjectFn LogsForObjectFunc = logsForObject
+var LogsForObjectFn LogsForObjectFunc = logsForObjectImmediate
+
+// LogsForObjectWithWaitFn gives a way to easily override the function for unit testing if needed.
+var LogsForObjectWithWaitFn LogsForObjectFunc = logsForObjectWithWait
 
 // AttachablePodForObjectFunc is a function type that can tell you how to get the pod for which to attach a given object
 type AttachablePodForObjectFunc func(restClientGetter genericclioptions.RESTClientGetter, object runtime.Object, timeout time.Duration) (*v1.Pod, error)

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
@@ -385,7 +385,7 @@ func TestLogsForObject(t *testing.T) {
 
 	for _, test := range tests {
 		fakeClientset := fakeexternal.NewSimpleClientset(test.clientsetPods...)
-		responses, err := logsForObjectWithClient(fakeClientset.CoreV1(), test.obj, test.opts, 20*time.Second, test.allContainers)
+		responses, err := logsForObjectWithClient(fakeClientset.CoreV1(), test.obj, test.opts, 20*time.Second, test.allContainers, false)
 		if test.expectedErr == "" && err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 			continue
@@ -561,7 +561,7 @@ func TestLogsForObjectWithClient(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pod := tc.podFn()
 			fakeClientset := fakeexternal.NewSimpleClientset(pod)
-			responses, err := logsForObjectWithClient(fakeClientset.CoreV1(), pod, tc.podLogOptions, 20*time.Second, tc.allContainers)
+			responses, err := logsForObjectWithClient(fakeClientset.CoreV1(), pod, tc.podLogOptions, 20*time.Second, tc.allContainers, false)
 			if err != nil {
 				if len(tc.expectedError) > 0 {
 					if err.Error() == tc.expectedError {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/sig cli
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

`kubectl logs` failing when container is waiting to start is a common annoyance (https://github.com/kubernetes/kubernetes/issues/79547)

```console
$ kubectl logs -f test -c nginx
Error from server (BadRequest): container "nginx" in pod "test" is waiting to start: CreateContainerConfigError
```

This patch adds a new backwards compatible `--wait` option to `kubectl logs`, which waits for queried container (containers) to start before invoking logs endpoint.

`--wait` is only allowed in combination with `--follow`, because otherwise it would return empty result as soon as the container started, which wouldn't be very useful. Wait is ignored when combined with `--previous`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/79547
Fixes https://github.com/kubernetes/kubectl/issues/1227

#### Special notes for your reviewer:

The changes were made in a backwards compatible way, both on the CLI frontend, and the backend implementation. Specifically I was mindful of not modifying any `polymorphichelpers` exports.

<details>

<summary>e2e results</summary>

```console
$ go test -v ./test/e2e -ginkgo.focus 'Kubectl logs \(wait\)'
[sig-cli] Kubectl client Kubectl logs (wait)
  should be able to wait for containers to start
  /Users/mdite/Projects/kubernetes/test/e2e/kubectl/kubectl.go:1646
[BeforeEach] [sig-cli] Kubectl client
  /Users/mdite/Projects/kubernetes/test/e2e/framework/framework.go:186
STEP: Creating a kubernetes client
Jul  7 14:17:29.693: INFO: >>> kubeConfig: /Users/mdite/.kube/config
STEP: Building a namespace api object, basename kubectl
STEP: Waiting for a default service account to be provisioned in namespace
STEP: Waiting for kube-root-ca.crt to be provisioned in namespace
[BeforeEach] [sig-cli] Kubectl client
  /Users/mdite/Projects/kubernetes/test/e2e/kubectl/kubectl.go:272
[It] should be able to wait for containers to start
  /Users/mdite/Projects/kubernetes/test/e2e/kubectl/kubectl.go:1646
STEP: creating pod with multiple container waiting to start
STEP: streaming logs in wait mode
Jul  7 14:17:29.720: INFO: Running '/Users/mdite/Projects/kubernetes/kubectl --server=https://127.0.0.1:52594 --kubeconfig=/Users/mdite/.kube/config --namespace=kubectl-1804 logs logs-generator-with-cm logs-generator --follow --wait'
STEP: creating configmap to unblock one container and allow it to start
STEP: waiting for kubectl logs to terminate
Jul  7 14:17:36.602: INFO: stderr: ""
Jul  7 14:17:36.602: INFO: stdout: "I0707 13:17:31.077837       1 logs_generator.go:76] 0 PUT /api/v1/namespaces/kube-system/pods/tr5x 575\nI0707 13:17:31.579534       1 logs_generator.go:76] 1 POST /api/v1/namespaces/kube-system/pods/6th 572\nI0707 13:17:32.078027       1 logs_generator.go:76] 2 POST /api/v1/namespaces/kube-system/pods/4kt 526\nI0707 13:17:32.579945       1 logs_generator.go:76] 3 GET /api/v1/namespaces/default/pods/twjp 293\nI0707 13:17:33.078464       1 logs_generator.go:76] 4 PUT /api/v1/namespaces/default/pods/6dk7 455\nI0707 13:17:33.582788       1 logs_generator.go:76] 5 PUT /api/v1/namespaces/kube-system/pods/dgv 438\nI0707 13:17:34.092890       1 logs_generator.go:76] 6 GET /api/v1/namespaces/ns/pods/dwn 248\nI0707 13:17:34.579656       1 logs_generator.go:76] 7 GET /api/v1/namespaces/kube-system/pods/pn95 368\nI0707 13:17:35.083150       1 logs_generator.go:76] 8 GET /api/v1/namespaces/ns/pods/fmb 215\nI0707 13:17:35.578041       1 logs_generator.go:76] 9 GET /api/v1/namespaces/ns/pods/t9pw 252\n"
[AfterEach] Kubectl logs (wait)
  /Users/mdite/Projects/kubernetes/test/e2e/kubectl/kubectl.go:1641
Jul  7 14:17:36.602: INFO: Running '/Users/mdite/Projects/kubernetes/kubectl --server=https://127.0.0.1:52594 --kubeconfig=/Users/mdite/.kube/config --namespace=kubectl-1804 delete pod logs-generator-with-cm'
Jul  7 14:17:37.056: INFO: stderr: ""
Jul  7 14:17:37.056: INFO: stdout: "pod \"logs-generator-with-cm\" deleted\n"
Jul  7 14:17:37.057: INFO: Running '/Users/mdite/Projects/kubernetes/kubectl --server=https://127.0.0.1:52594 --kubeconfig=/Users/mdite/.kube/config --namespace=kubectl-1804 delete configmap log-container-blocker'
Jul  7 14:17:37.106: INFO: stderr: ""
Jul  7 14:17:37.106: INFO: stdout: "configmap \"log-container-blocker\" deleted\n"
[AfterEach] [sig-cli] Kubectl client
  /Users/mdite/Projects/kubernetes/test/e2e/framework/framework.go:187
Jul  7 14:17:37.106: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "kubectl-1804" for this suite.

• [SLOW TEST:7.420 seconds]
[sig-cli] Kubectl client
/Users/mdite/Projects/kubernetes/test/e2e/kubectl/framework.go:23
  Kubectl logs (wait)
  /Users/mdite/Projects/kubernetes/test/e2e/kubectl/kubectl.go:1635
    should be able to wait for containers to start
    /Users/mdite/Projects/kubernetes/test/e2e/kubectl/kubectl.go:1646

Ran 1 of 7048 Specs in 7.499 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 7047 Skipped
--- PASS: TestE2E (8.32s)
```

</details>

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl logs: add --wait option which waits for containers to start before streaming logs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
