### PR TITLE
e2e: bump Azure Disk in-tree timeouts

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1537,6 +1537,7 @@ var _ storageframework.PreprovisionedVolumeTestDriver = &azureDiskDriver{}
 var _ storageframework.InlineVolumeTestDriver = &azureDiskDriver{}
 var _ storageframework.PreprovisionedPVTestDriver = &azureDiskDriver{}
 var _ storageframework.DynamicPVTestDriver = &azureDiskDriver{}
+var _ storageframework.CustomTimeoutsTestDriver = &azureDiskDriver{}
 
 // InitAzureDiskDriver returns azureDiskDriver that implements TestDriver interface
 func InitAzureDiskDriver() storageframework.TestDriver {
@@ -2154,4 +2155,12 @@ func (a *azureFileDriver) CreateVolume(config *storageframework.PerTestConfig, v
 func (v *azureFileVolume) DeleteVolume() {
 	err := e2epv.DeleteShare(v.accountName, v.shareName)
 	framework.ExpectNoError(err)
+}
+
+func (a *azureDiskDriver) GetTimeouts() *framework.TimeoutContext {
+	return &framework.TimeoutContext{
+		PodStart:  time.Minute * 15,
+		PodDelete: time.Minute * 15,
+		PVDelete:  time.Minute * 20,
+	}
 }


### PR DESCRIPTION
Some operations with Azure Disk volumes can be arbitrarily slow sometimes. This causes CI flakes that are hard to debug.

Bumping the timeouts has sown to improve or eliminate this issue.

/assign @andyzhangx 
/sig storage

#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

This PR bumps the timeout limits for Azure Disk in-tree plugin.


#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
