### PR TITLE
Automated cherry pick of #111026: Do not skip job requeue in conflict error

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -531,12 +531,7 @@ func (jm *Controller) processNextWorkItem(ctx context.Context) bool {
 	}
 
 	utilruntime.HandleError(fmt.Errorf("syncing job: %w", err))
-	if !apierrors.IsConflict(err) {
-		// If this was a conflict error, we expect a Job or Pod update event, which
-		// will add the job back to the queue. Avoiding the rate limited requeue
-		// saves an unnecessary sync.
-		jm.queue.AddRateLimited(key)
-	}
+	jm.queue.AddRateLimited(key)
 
 	return true
 }

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -1963,11 +1963,13 @@ func TestSyncJobUpdateRequeue(t *testing.T) {
 			wantRequeue: true,
 		},
 		"conflict error": {
-			updateErr: apierrors.NewConflict(schema.GroupResource{}, "", nil),
+			updateErr:   apierrors.NewConflict(schema.GroupResource{}, "", nil),
+			wantRequeue: true,
 		},
 		"conflict error, with finalizers": {
 			withFinalizers: true,
 			updateErr:      apierrors.NewConflict(schema.GroupResource{}, "", nil),
+			wantRequeue:    true,
 		},
 	}
 	for name, tc := range cases {


### PR DESCRIPTION
Cherry pick of #111026 on release-1.24.

#111026: Do not skip job requeue in conflict error

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```