### PR TITLE
add uint test for SubtractWithNonNegativeResult，Improve test coverage

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/quota/v1/resources_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/quota/v1/resources_test.go
@@ -493,3 +493,81 @@ func TestDifference(t *testing.T) {
 		}
 	}
 }
+
+func TestSubtractWithNonNegativeResult(t *testing.T) {
+	type args struct {
+		a corev1.ResourceList
+		b corev1.ResourceList
+	}
+	tests := []struct {
+		name string
+		args args
+		want corev1.ResourceList
+	}{
+		{
+			name: "all resource a > b ",
+			args: args{
+				a: corev1.ResourceList{
+					corev1.ResourceCPU:     resource.MustParse("200m"),
+					corev1.ResourceMemory:  resource.MustParse("10Gi"),
+					corev1.ResourceStorage: resource.MustParse("100Gi"),
+				},
+				b: corev1.ResourceList{
+					corev1.ResourceCPU:     resource.MustParse("100m"),
+					corev1.ResourceMemory:  resource.MustParse("5Gi"),
+					corev1.ResourceStorage: resource.MustParse("50Gi"),
+				},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:     resource.MustParse("100m"),
+				corev1.ResourceMemory:  resource.MustParse("5Gi"),
+				corev1.ResourceStorage: resource.MustParse("50Gi"),
+			},
+		}, {
+			name: "all resource a < b ",
+			args: args{
+				a: corev1.ResourceList{
+					corev1.ResourceCPU:     resource.MustParse("20m"),
+					corev1.ResourceMemory:  resource.MustParse("1Gi"),
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+				b: corev1.ResourceList{
+					corev1.ResourceCPU:     resource.MustParse("100m"),
+					corev1.ResourceMemory:  resource.MustParse("5Gi"),
+					corev1.ResourceStorage: resource.MustParse("50Gi"),
+				},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:     resource.MustParse("0m"),
+				corev1.ResourceMemory:  resource.MustParse("0Gi"),
+				corev1.ResourceStorage: resource.MustParse("0Gi"),
+			},
+		},
+		{
+			name: "some resource a < b ",
+			args: args{
+				a: corev1.ResourceList{
+					corev1.ResourceCPU:     resource.MustParse("200m"),
+					corev1.ResourceMemory:  resource.MustParse("1Gi"),
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+				b: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("5Gi"),
+				},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:     resource.MustParse("100m"),
+				corev1.ResourceMemory:  resource.MustParse("0Gi"),
+				corev1.ResourceStorage: resource.MustParse("10Gi"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SubtractWithNonNegativeResult(tt.args.a, tt.args.b); !Equals(got, tt.want) {
+				t.Errorf("SubtractWithNonNegativeResult() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Improve test coverage

Run test coverage command:

go test -cover ./pkg/quota/v1/
Befor:
`ok      k8s.io/apiserver/pkg/quota/v1   0.034s  coverage: 69.3% of statements`

After:
`ok      k8s.io/apiserver/pkg/quota/v1   0.035s  coverage: 77.9% of statements`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
