### PR TITLE
scheduler: improve the comment and add more unit test cases for DefaultNormalizeScore

### DIFF
--- a/pkg/scheduler/framework/plugins/helper/normalize_score.go
+++ b/pkg/scheduler/framework/plugins/helper/normalize_score.go
@@ -21,8 +21,9 @@ import (
 )
 
 // DefaultNormalizeScore generates a Normalize Score function that can normalize the
-// scores to [0, maxPriority]. If reverse is set to true, it reverses the scores by
-// subtracting it from maxPriority.
+// scores from [0, max(scores)] to [0, maxPriority]. If reverse is set to true, it
+// reverses the scores by subtracting it from maxPriority.
+// Note: The input scores are always assumed to be non-negative integers.
 func DefaultNormalizeScore(maxPriority int64, reverse bool, scores framework.NodeScoreList) *framework.Status {
 	var maxCount int64
 	for i := range scores {

--- a/pkg/scheduler/framework/plugins/helper/normalize_score_test.go
+++ b/pkg/scheduler/framework/plugins/helper/normalize_score_test.go
@@ -61,6 +61,15 @@ func TestDefaultNormalizeScore(t *testing.T) {
 			scores:         []int64{0, 1, 1, 1},
 			expectedScores: []int64{100, 0, 0, 0},
 		},
+		{
+			scores:         []int64{0, 0, 0, 0},
+			expectedScores: []int64{0, 0, 0, 0},
+		},
+		{
+			reverse:        true,
+			scores:         []int64{0, 0, 0, 0},
+			expectedScores: []int64{100, 100, 100, 100},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
~~scheduler: enhance `DefaultNormalizeScore` function to tolerate negative scores
The comment of `DefaultNormalizeScore` function does not declare that the input scores must be non-negative, which may lead to the normalized score not in `[0, maxPriority]`.
This PR attempts to increase the tolerance of the function to accommodate more scenarios.~~

scheduler: improve the comment and add more unit test cases for DefaultNormalizeScore

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
