### PR TITLE
fix pass []any as any in variadic function

### DIFF
--- a/test/e2e/framework/flake_reporting_util.go
+++ b/test/e2e/framework/flake_reporting_util.go
@@ -53,7 +53,7 @@ func (f *FlakeReport) RecordFlakeIfError(err error, optionalDescription ...inter
 		return
 	}
 	msg := fmt.Sprintf("Unexpected error occurred: %v", err)
-	desc := buildDescription(optionalDescription)
+	desc := buildDescription(optionalDescription...)
 	if desc != "" {
 		msg = fmt.Sprintf("%v (Description: %v)", msg, desc)
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -550,7 +550,7 @@ func (f *Framework) CreateNamespace(baseName string, labels map[string]string) (
 // RecordFlakeIfError records flakeness info if error happens.
 // NOTE: This function is not used at any places yet, but we are in progress for https://github.com/kubernetes/kubernetes/issues/66239 which requires this. Please don't remove this.
 func (f *Framework) RecordFlakeIfError(err error, optionalDescription ...interface{}) {
-	f.flakeReport.RecordFlakeIfError(err, optionalDescription)
+	f.flakeReport.RecordFlakeIfError(err, optionalDescription...)
 }
 
 // AddNamespacesToDelete adds one or more namespaces to be deleted when the test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

I'm write a [linter](https://github.com/alingse/asasalint) to lint the func call about pass []any as any in variadic function, and found this one.
see github action result [here](https://github.com/alingse/asasalint/runs/7262743689?check_suite_focus=true)

the bug code is here.

```golang
func buildDescription(optionalDescription ...interface{}) string {
	switch len(optionalDescription) {
	case 0:
		return ""
	default:
		return fmt.Sprintf(optionalDescription[0].(string), optionalDescription[1:]...)
	}
}

func (f *FlakeReport) RecordFlakeIfError(err error, optionalDescription ...interface{}) {
	if err == nil {
		return
	}
	msg := fmt.Sprintf("Unexpected error occurred: %v", err)
	desc := buildDescription(optionalDescription)
        ......
}
```

if someone call func like `RecordFlakeIfError(err, "args is %v", arg)`,  

it will actually call `buildDescription([]any{[]any{"arg is %v", arg}}),

and will be failed with `optionalDescription[0].(string)` assertion

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

these two function was never called in this repo, or it will be bugfixed already.

maybe we can just delete them for useless.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
bug fix in test/e2e/framework  Framework.RecordFlakeIfError
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
