### PR TITLE
migrate deprecate flags from ginkgo v1 to v2

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -170,7 +170,7 @@ fi
 # for backward compatibility purpose.
 "${program[@]}" "${ginkgo_args[@]:+${ginkgo_args[@]}}" "${e2e_test}" -- \
   "${auth_config[@]:+${auth_config[@]}}" \
-  --ginkgo.flakeAttempts="${FLAKE_ATTEMPTS}" \
+  --ginkgo.flake-attempts="${FLAKE_ATTEMPTS}" \
   --ginkgo.timeout="24h" \
   --host="${KUBE_MASTER_URL}" \
   --provider="${KUBERNETES_PROVIDER}" \
@@ -191,7 +191,7 @@ fi
   --docker-config-file="${DOCKER_CONFIG_FILE:-}" \
   --dns-domain="${KUBE_DNS_DOMAIN:-cluster.local}" \
   --prepull-images="${PREPULL_IMAGES:-false}" \
-  --ginkgo.slowSpecThreshold="${GINKGO_SLOW_SPEC_THRESHOLD:-300}" \
+  --ginkgo.slow-spec-threshold="${GINKGO_SLOW_SPEC_THRESHOLD:-300s}" \
   ${MASTER_OS_DISTRIBUTION:+"--master-os-distro=${MASTER_OS_DISTRIBUTION}"} \
   ${NODE_OS_DISTRIBUTION:+"--node-os-distro=${NODE_OS_DISTRIBUTION}"} \
   ${NUM_NODES:+"--num-nodes=${NUM_NODES}"} \


### PR DESCRIPTION

/kind cleanup
/kind deprecation
```release-note
NONE
```


reported in https://github.com/kubernetes/kubernetes/issues/109744#issuecomment-1179336102

> 
  �[38;5;11m--ginkgo.flakeAttempts is deprecated, use --ginkgo.flake-attempts instead�[0m
  �[1mLearn more at:�[0m �[38;5;14m�[4mhttps://onsi.github.io/ginkgo/MIGRATING_TO_V2#changed-command-line-flags�[0m
  �[38;5;11m--ginkgo.slowSpecThreshold is deprecated use --slow-spec-threshold instead and pass in a duration string (e.g. '5s', not '5.0')�[0m
  �[1mLearn more at:�[0m �[38;5;14m�[4mhttps://onsi.github.io/ginkgo/MIGRATING_TO_V2#changed--slowspecthreshold�[0m