### PR TITLE
use new distroless kube-proxy image

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -90,7 +90,7 @@ readonly KUBE_RSYNC_PORT="${KUBE_RSYNC_PORT:-}"
 readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_debian_iptables_version=bullseye-v1.4.0
+readonly __default_distroless_iptables_version=v0.1.1
 readonly __default_go_runner_version=v2.3.1-go1.18.3-bullseye.0
 readonly __default_setcap_version=bullseye-v1.3.0
 
@@ -99,7 +99,7 @@ readonly KUBE_GORUNNER_IMAGE="${KUBE_GORUNNER_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/g
 readonly KUBE_APISERVER_BASE_IMAGE="${KUBE_APISERVER_BASE_IMAGE:-$KUBE_GORUNNER_IMAGE}"
 readonly KUBE_CONTROLLER_MANAGER_BASE_IMAGE="${KUBE_CONTROLLER_MANAGER_BASE_IMAGE:-$KUBE_GORUNNER_IMAGE}"
 readonly KUBE_SCHEDULER_BASE_IMAGE="${KUBE_SCHEDULER_BASE_IMAGE:-$KUBE_GORUNNER_IMAGE}"
-readonly KUBE_PROXY_BASE_IMAGE="${KUBE_PROXY_BASE_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/debian-iptables:$__default_debian_iptables_version}"
+readonly KUBE_PROXY_BASE_IMAGE="${KUBE_PROXY_BASE_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/distroless-iptables:$__default_distroless_iptables_version}"
 
 # This is the image used in a multi-stage build to apply capabilities to Docker-wrapped binaries.
 readonly KUBE_BUILD_SETCAP_IMAGE="${KUBE_BUILD_SETCAP_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/setcap:$__default_setcap_version}"

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -131,13 +131,13 @@ dependencies:
     - path: test/conformance/image/Makefile
       match: BASE_IMAGE_VERSION\?=
 
-  - name: "registry.k8s.io/debian-iptables: dependents"
-    version: bullseye-v1.4.0
+  - name: "registry.k8s.io/distroless-iptables: dependents"
+    version: v0.1.1
     refPaths:
     - path: build/common.sh
-      match: __default_debian_iptables_version=
+      match: __default_distroless_iptables_version=
     - path: test/utils/image/manifest.go
-      match: configs\[DebianIptables\] = Config{list\.BuildImageRegistry, "debian-iptables", "[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"}
+      match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
 
   - name: "registry.k8s.io/go-runner: dependents"
     version: v2.3.1-go1.18.3-bullseye.0

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -106,7 +106,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 				Containers: []v1.Container{
 					{
 						Name:            "e2e-net-exec",
-						Image:           imageutils.GetE2EImage(imageutils.DebianIptables),
+						Image:           imageutils.GetE2EImage(imageutils.DistrolessIptables),
 						ImagePullPolicy: v1.PullIfNotPresent,
 						Command:         []string{"sleep", "600"},
 						SecurityContext: &v1.SecurityContext{

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -164,8 +164,8 @@ const (
 	CudaVectorAdd
 	// CudaVectorAdd2 image
 	CudaVectorAdd2
-	// DebianIptables Image
-	DebianIptables
+	// DistrolessIptables Image
+	DistrolessIptables
 	// Etcd image
 	Etcd
 	// GlusterDynamicProvisioner image
@@ -240,7 +240,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.29-2"}
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.2"}
-	configs[DebianIptables] = Config{list.BuildImageRegistry, "debian-iptables", "bullseye-v1.4.0"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.1.1"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.4-0"}
 	configs[GlusterDynamicProvisioner] = Config{list.PromoterE2eRegistry, "glusterdynamic-provisioner", "v1.3"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-2"}


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

Debian based images require a lot of maintainance patching CVE, kube-proxy just need a few binaries to work only,

```release-note
For Linux, `kube-proxy` uses a new “distroless” container image, instead of an image based on Debian.
```

Fixes: https://github.com/kubernetes/kubernetes/issues/109406