### PR TITLE
modify the signing/approving controller to tolerate either set of usages for kubelet client and serving certificates

### DIFF
--- a/pkg/apis/certificates/v1beta1/defaults.go
+++ b/pkg/apis/certificates/v1beta1/defaults.go
@@ -56,27 +56,27 @@ func DefaultSignerNameFromSpec(obj *certificatesv1beta1.CertificateSigningReques
 		// Set the signerName to 'legacy-unknown' as the CSR could not be
 		// recognised.
 		return certificatesv1beta1.LegacyUnknownSignerName
-	case IsKubeletClientCSR(csr, obj.Usages):
+	case IsKubeletClientCSR(csr, obj.Usages, false):
 		return certificatesv1beta1.KubeAPIServerClientKubeletSignerName
-	case IsKubeletServingCSR(csr, obj.Usages):
+	case IsKubeletServingCSR(csr, obj.Usages, false):
 		return certificatesv1beta1.KubeletServingSignerName
 	default:
 		return certificatesv1beta1.LegacyUnknownSignerName
 	}
 }
 
-func IsKubeletServingCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage) bool {
-	return certificates.IsKubeletServingCSR(req, usagesToSet(usages))
+func IsKubeletServingCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage, allowOmittingUsageKeyEncipherment bool) bool {
+	return certificates.IsKubeletServingCSR(req, usagesToSet(usages), allowOmittingUsageKeyEncipherment)
 }
-func ValidateKubeletServingCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage) error {
-	return certificates.ValidateKubeletServingCSR(req, usagesToSet(usages))
+func ValidateKubeletServingCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage, allowOmittingUsageKeyEncipherment bool) error {
+	return certificates.ValidateKubeletServingCSR(req, usagesToSet(usages), allowOmittingUsageKeyEncipherment)
 }
 
-func IsKubeletClientCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage) bool {
-	return certificates.IsKubeletClientCSR(req, usagesToSet(usages))
+func IsKubeletClientCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage, allowOmittingUsageKeyEncipherment bool) bool {
+	return certificates.IsKubeletClientCSR(req, usagesToSet(usages), allowOmittingUsageKeyEncipherment)
 }
-func ValidateKubeletClientCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage) error {
-	return certificates.ValidateKubeletClientCSR(req, usagesToSet(usages))
+func ValidateKubeletClientCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage, allowOmittingUsageKeyEncipherment bool) error {
+	return certificates.ValidateKubeletClientCSR(req, usagesToSet(usages), allowOmittingUsageKeyEncipherment)
 }
 
 func usagesToSet(usages []certificatesv1beta1.KeyUsage) sets.String {

--- a/pkg/apis/certificates/v1beta1/defaults_test.go
+++ b/pkg/apis/certificates/v1beta1/defaults_test.go
@@ -40,14 +40,27 @@ func TestIsKubeletServingCSR(t *testing.T) {
 		return csr
 	}
 	tests := map[string]struct {
-		req    *x509.CertificateRequest
-		usages []capi.KeyUsage
-		exp    bool
+		req                               *x509.CertificateRequest
+		usages                            []capi.KeyUsage
+		allowOmittingUsageKeyEncipherment bool
+		exp                               bool
 	}{
 		"defaults for kubelet-serving": {
 			req:    newCSR(kubeletServerPEMOptions),
 			usages: kubeletServerUsages,
 			exp:    true,
+		},
+		"defaults without key encipherment for kubelet-serving if allow omitting key encipherment": {
+			req:                               newCSR(kubeletServerPEMOptions),
+			usages:                            kubeletServerUsagesNoRSA,
+			allowOmittingUsageKeyEncipherment: true,
+			exp:                               true,
+		},
+		"defaults for kubelet-serving if allow omitting key encipherment": {
+			req:                               newCSR(kubeletServerPEMOptions),
+			usages:                            kubeletServerUsages,
+			allowOmittingUsageKeyEncipherment: true,
+			exp:                               true,
 		},
 		"does not default to kube-apiserver-client-kubelet if org is not 'system:nodes'": {
 			req:    newCSR(kubeletServerPEMOptions, pemOptions{org: "not-system:nodes"}),
@@ -69,6 +82,17 @@ func TestIsKubeletServingCSR(t *testing.T) {
 			usages: kubeletServerUsages[1:],
 			exp:    false,
 		},
+		"does not default to kubelet-serving if it is missing an expected usage if allow omitting key encipherment": {
+			req:                               newCSR(kubeletServerPEMOptions),
+			usages:                            kubeletServerUsagesNoRSA[1:],
+			allowOmittingUsageKeyEncipherment: true,
+			exp:                               false,
+		},
+		"does not default to kubelet-serving if it is missing an expected usage withou key encipherment": {
+			req:    newCSR(kubeletServerPEMOptions),
+			usages: kubeletServerUsagesNoRSA,
+			exp:    false,
+		},
 		"does not default to kubelet-serving if it does not specify any dnsNames or ipAddresses": {
 			req:    newCSR(kubeletServerPEMOptions, pemOptions{ipAddresses: []net.IP{}, dnsNames: []string{}}),
 			usages: kubeletServerUsages[1:],
@@ -87,7 +111,7 @@ func TestIsKubeletServingCSR(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := IsKubeletServingCSR(test.req, test.usages)
+			got := IsKubeletServingCSR(test.req, test.usages, test.allowOmittingUsageKeyEncipherment)
 			if test.exp != got {
 				t.Errorf("unexpected IsKubeletClientCSR output: exp=%v, got=%v", test.exp, got)
 			}
@@ -105,9 +129,10 @@ func TestIsKubeletClientCSR(t *testing.T) {
 		return csr
 	}
 	tests := map[string]struct {
-		req    *x509.CertificateRequest
-		usages []capi.KeyUsage
-		exp    bool
+		req                               *x509.CertificateRequest
+		usages                            []capi.KeyUsage
+		allowOmittingUsageKeyEncipherment bool
+		exp                               bool
 	}{
 		"defaults for kube-apiserver-client-kubelet": {
 			req:    newCSR(kubeletClientPEMOptions),
@@ -154,10 +179,28 @@ func TestIsKubeletClientCSR(t *testing.T) {
 			usages: kubeletClientUsages[1:],
 			exp:    false,
 		},
+		"does not default to kube-apiserver-client-kubelet if it is missing an expected usage without key encipherment": {
+			req:                               newCSR(kubeletClientPEMOptions),
+			usages:                            kubeletClientUsagesNoRSA[1:],
+			allowOmittingUsageKeyEncipherment: true,
+			exp:                               false,
+		},
+		"default to kube-apiserver-client-kubelet with key encipherment": {
+			req:                               newCSR(kubeletClientPEMOptions),
+			usages:                            kubeletClientUsages,
+			allowOmittingUsageKeyEncipherment: true,
+			exp:                               true,
+		},
+		"default to kube-apiserver-client-kubelet without key encipherment": {
+			req:                               newCSR(kubeletClientPEMOptions),
+			usages:                            kubeletClientUsagesNoRSA,
+			allowOmittingUsageKeyEncipherment: true,
+			exp:                               true,
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := IsKubeletClientCSR(test.req, test.usages)
+			got := IsKubeletClientCSR(test.req, test.usages, test.allowOmittingUsageKeyEncipherment)
 			if test.exp != got {
 				t.Errorf("unexpected IsKubeletClientCSR output: exp=%v, got=%v", test.exp, got)
 			}
@@ -171,6 +214,10 @@ var (
 		capi.UsageKeyEncipherment,
 		capi.UsageClientAuth,
 	}
+	kubeletClientUsagesNoRSA = []capi.KeyUsage{
+		capi.UsageDigitalSignature,
+		capi.UsageClientAuth,
+	}
 	kubeletClientPEMOptions = pemOptions{
 		cn:  "system:node:nodename",
 		org: "system:nodes",
@@ -179,6 +226,10 @@ var (
 	kubeletServerUsages = []capi.KeyUsage{
 		capi.UsageDigitalSignature,
 		capi.UsageKeyEncipherment,
+		capi.UsageServerAuth,
+	}
+	kubeletServerUsagesNoRSA = []capi.KeyUsage{
+		capi.UsageDigitalSignature,
 		capi.UsageServerAuth,
 	}
 	kubeletServerPEMOptions = pemOptions{

--- a/pkg/controller/certificates/approver/sarapprove.go
+++ b/pkg/controller/certificates/approver/sarapprove.go
@@ -152,7 +152,7 @@ func isNodeClientCert(csr *capi.CertificateSigningRequest, x509cr *x509.Certific
 	if csr.Spec.SignerName != capi.KubeAPIServerClientKubeletSignerName {
 		return false
 	}
-	return capihelper.IsKubeletClientCSR(x509cr, usagesToSet(csr.Spec.Usages))
+	return capihelper.IsKubeletClientCSR(x509cr, usagesToSet(csr.Spec.Usages), true)
 }
 
 func isSelfNodeClientCert(csr *capi.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {

--- a/pkg/controller/certificates/signer/signer.go
+++ b/pkg/controller/certificates/signer/signer.go
@@ -248,14 +248,14 @@ func isKubeletServing(req *x509.CertificateRequest, usages []capi.KeyUsage, sign
 	if signerName != capi.KubeletServingSignerName {
 		return false, nil
 	}
-	return true, capihelper.ValidateKubeletServingCSR(req, usagesToSet(usages))
+	return true, capihelper.ValidateKubeletServingCSR(req, usagesToSet(usages), true)
 }
 
 func isKubeletClient(req *x509.CertificateRequest, usages []capi.KeyUsage, signerName string) (bool, error) {
 	if signerName != capi.KubeAPIServerClientKubeletSignerName {
 		return false, nil
 	}
-	return true, capihelper.ValidateKubeletClientCSR(req, usagesToSet(usages))
+	return true, capihelper.ValidateKubeletClientCSR(req, usagesToSet(usages), true)
 }
 
 func isKubeAPIServerClient(req *x509.CertificateRequest, usages []capi.KeyUsage, signerName string) (bool, error) {

--- a/pkg/controller/certificates/signer/signer_test.go
+++ b/pkg/controller/certificates/signer/signer_test.go
@@ -144,6 +144,24 @@ func TestHandle(t *testing.T) {
 			},
 		},
 		{
+			name:       "should sign without key encipherment if signerName is kubernetes.io/kube-apiserver-client",
+			signerName: "kubernetes.io/kube-apiserver-client",
+			commonName: "hello-world",
+			org:        []string{"some-org"},
+			usages:     []capi.KeyUsage{capi.UsageClientAuth, capi.UsageDigitalSignature},
+			approved:   true,
+			verify: func(t *testing.T, as []testclient.Action) {
+				if len(as) != 1 {
+					t.Errorf("expected one Update action but got %d", len(as))
+					return
+				}
+				csr := as[0].(testclient.UpdateAction).GetObject().(*capi.CertificateSigningRequest)
+				if len(csr.Status.Certificate) == 0 {
+					t.Errorf("expected certificate to be issued but it was not")
+				}
+			},
+		},
+		{
 			name:       "should refuse to sign if signerName is kubernetes.io/kube-apiserver-client and contains an unexpected usage",
 			signerName: "kubernetes.io/kube-apiserver-client",
 			commonName: "hello-world",
@@ -183,6 +201,24 @@ func TestHandle(t *testing.T) {
 			},
 		},
 		{
+			name:       "should sign without usage key encipherment if signerName is kubernetes.io/kube-apiserver-client-kubelet",
+			signerName: "kubernetes.io/kube-apiserver-client-kubelet",
+			commonName: "system:node:hello-world",
+			org:        []string{"system:nodes"},
+			usages:     []capi.KeyUsage{capi.UsageClientAuth, capi.UsageDigitalSignature},
+			approved:   true,
+			verify: func(t *testing.T, as []testclient.Action) {
+				if len(as) != 1 {
+					t.Errorf("expected one Update action but got %d", len(as))
+					return
+				}
+				csr := as[0].(testclient.UpdateAction).GetObject().(*capi.CertificateSigningRequest)
+				if len(csr.Status.Certificate) == 0 {
+					t.Errorf("expected certificate to be issued but it was not")
+				}
+			},
+		},
+		{
 			name:       "should sign if signerName is kubernetes.io/legacy-unknown",
 			signerName: "kubernetes.io/legacy-unknown",
 			approved:   true,
@@ -203,6 +239,25 @@ func TestHandle(t *testing.T) {
 			commonName: "system:node:testnode",
 			org:        []string{"system:nodes"},
 			usages:     []capi.KeyUsage{capi.UsageServerAuth, capi.UsageDigitalSignature, capi.UsageKeyEncipherment},
+			dnsNames:   []string{"example.com"},
+			approved:   true,
+			verify: func(t *testing.T, as []testclient.Action) {
+				if len(as) != 1 {
+					t.Errorf("expected one Update action but got %d", len(as))
+					return
+				}
+				csr := as[0].(testclient.UpdateAction).GetObject().(*capi.CertificateSigningRequest)
+				if len(csr.Status.Certificate) == 0 {
+					t.Errorf("expected certificate to be issued but it was not")
+				}
+			},
+		},
+		{
+			name:       "should sign without usage key encipherment if signerName is kubernetes.io/kubelet-serving",
+			signerName: "kubernetes.io/kubelet-serving",
+			commonName: "system:node:testnode",
+			org:        []string{"system:nodes"},
+			usages:     []capi.KeyUsage{capi.UsageServerAuth, capi.UsageDigitalSignature},
 			dnsNames:   []string{"example.com"},
 			approved:   true,
 			verify: func(t *testing.T, as []testclient.Action) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/kubernetes/issues/109077

- set it to optional in this release, but the default will use it
- in the next release, we can set the default not to include it.

#### Special notes for your reviewer:

1. API validation of CSR create and update requests
2. Controller tolerating CSR objects with/without that usage
3. Kubelets requesting CSRs properly without that usage if given a non-RSA key

https://github.com/kubernetes/kubernetes/blob/14e8db067e93154b2561129724fccabe676876d8/pkg/controller/certificates/signer/signer.go#L277-L293
The controller already tolerates it.

#### Does this PR introduce a user-facing change?
```release-note
Modify the signing/approving controller to tolerate either set of usages for kubelet client and serving certificates without key encipherment
```
