### PR TITLE
Revert the workaround needed to cleanup for Ginkgo V1

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -98,11 +98,6 @@ type Framework struct {
 	// Flaky operation failures in an e2e test can be captured through this.
 	flakeReport *FlakeReport
 
-	// To make sure that this framework cleans up after itself, no matter what,
-	// we install a Cleanup action before each test and clear it after.  If we
-	// should abort, the AfterSuite hook should run all Cleanup actions.
-	cleanupHandle CleanupActionHandle
-
 	// afterEaches is a map of name to function to be called after each test.  These are not
 	// cleared.  The call order is randomized so that no dependencies can grow between
 	// the various afterEaches
@@ -193,9 +188,6 @@ func NewFramework(baseName string, options Options, client clientset.Interface) 
 func (f *Framework) BeforeEach() {
 	f.beforeEachStarted = true
 
-	// The fact that we need this feels like a bug in ginkgo.
-	// https://github.com/onsi/ginkgo/v2/issues/222
-	f.cleanupHandle = AddCleanupAction(f.AfterEach)
 	if f.ClientSet == nil {
 		ginkgo.By("Creating a kubernetes client")
 		config, err := LoadConfig()
@@ -374,8 +366,6 @@ func (f *Framework) AfterEach() {
 	if !f.beforeEachStarted {
 		return
 	}
-
-	RemoveCleanupAction(f.cleanupHandle)
 
 	// This should not happen. Given ClientSet is a public field a test must have updated it!
 	// Error out early before any API calls during cleanup.


### PR DESCRIPTION
Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially Fixes https://github.com/kubernetes/kubernetes/issues/109744

#### Special notes for your reviewer:
This partially revert the change: https://github.com/kubernetes/kubernetes/pull/20771, [the file](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/cleanup.go) is kept untouched, since the function defined in that file might be diverged for other purpose, e.g. [storage csi](https://github.com/kubernetes/kubernetes/blob/a3f777603be3655a17d75acf5ee4216879e08aeb/test/e2e/storage/drivers/csi.go#L986-L1016). I believe all of the cleanup can be moved to Ginkgo function e.g. `AfterEach` with some refactoring. And then remove the hook entirely.

Verified with @robdimsdale's [sample code](https://github.com/robdimsdale/ginkgotest), here is what I can see with Ginkgo V2.
```
Running Suite: Ginkgotest Suite - /home/davche02/test/ginkgo/ginkgotest_v2
==========================================================================
Random Seed: 1657515833

Will run 1 of 1 specs
BeforeSuite
BeforeEach
Inside It
sleeping
^CAfterEach
...
------------------------------
AfterSuite
```

`AfterEach` is called after Hitting ^C
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
