### PR TITLE
Update kube aggregator readme

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/README.md
+++ b/staging/src/k8s.io/kube-aggregator/README.md
@@ -1,12 +1,12 @@
 # kube-aggregator
-## Coming Soon!
 
 Implements https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/aggregated-api-servers.md.
 
-It provides
-* Provide an API for registering API servers.
-* Summarize discovery information from all the servers.
-* Proxy client requests to individual servers.
+It provides:
+
+* an API for registering API servers.
+* Summaries of discovery information from all the aggregated APIs
+* HTTP proxying of requests from clients on to specific API backends
 
 
 ## Purpose

--- a/staging/src/k8s.io/kube-aggregator/README.md
+++ b/staging/src/k8s.io/kube-aggregator/README.md
@@ -1,6 +1,6 @@
 # kube-aggregator
 
-Implements https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/aggregated-api-servers.md.
+Implements the [Aggregated API Servers](https://github.com/kubernetes/design-proposals-archive/blob/main/api-machinery/aggregated-api-servers.md) design proposal.
 
 It provides:
 


### PR DESCRIPTION
Update the [README](https://github.com/kubernetes/kube-aggregator#readme) for `kube-aggregator`:

- omit “Coming soon!” text
- revise deliverables list
- fix link to design proposal ([new link](https://github.com/kubernetes/design-proposals-archive/blob/main/api-machinery/aggregated-api-servers.md)) following archival of those docs

```release-note
NONE
```

/sig api-machinery
/kind documentation
/kind cleanup