### PR TITLE
Stop using the deprecated `Measure` method

### DIFF
--- a/test/e2e/autoscaling/autoscaling_timer.go
+++ b/test/e2e/autoscaling/autoscaling_timer.go
@@ -30,11 +30,13 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega/gmeasure"
 )
 
 var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling", func() {
 	f := framework.NewDefaultFramework("autoscaling")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var experiment *gmeasure.Experiment
 
 	ginkgo.Describe("Autoscaling a service", func() {
 		ginkgo.BeforeEach(func() {
@@ -43,6 +45,8 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 			if err != nil {
 				e2eskipper.Skipf("test expects Cluster Autoscaler to be enabled")
 			}
+			experiment = gmeasure.NewExperiment("Autoscaling a service")
+			ginkgo.AddReportEntry(experiment.Name, experiment)
 		})
 
 		ginkgo.Context("from 1 pod and 3 nodes to 8 pods and >=4 nodes", func() {
@@ -82,7 +86,7 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 				}
 			})
 
-			ginkgo.Measure("takes less than 15 minutes", func(b ginkgo.Benchmarker) {
+			ginkgo.It("takes less than 15 minutes", func() {
 				// Measured over multiple samples, scaling takes 10 +/- 2 minutes, so 15 minutes should be fully sufficient.
 				const timeToWait = 15 * time.Minute
 
@@ -111,10 +115,10 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 				resourceConsumer.ConsumeCPU(int(cpuLoad))
 
 				// Measure the time it takes for the service to scale to 8 pods with 50% CPU utilization each.
-				b.Time("total scale-up time", func() {
+				experiment.SampleDuration("total scale-up time", func(idx int) {
 					resourceConsumer.WaitForReplicas(8, timeToWait)
-				})
-			}, 1) // Increase to run the test more than once.
+				}, gmeasure.SamplingConfig{N: 1})
+			}) // Increase to run the test more than once.
 		})
 	})
 })

--- a/vendor/github.com/onsi/gomega/gmeasure/cache.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/cache.go
@@ -1,0 +1,202 @@
+package gmeasure
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/onsi/gomega/internal/gutil"
+)
+
+const CACHE_EXT = ".gmeasure-cache"
+
+/*
+ExperimentCache provides a director-and-file based cache of experiments
+*/
+type ExperimentCache struct {
+	Path string
+}
+
+/*
+NewExperimentCache creates and initializes a new cache.  Path must point to a directory (if path does not exist, NewExperimentCache will create a directory at path).
+
+Cached Experiments are stored as separate files in the cache directory - the filename is a hash of the Experiment name.  Each file contains two JSON-encoded objects - a CachedExperimentHeader that includes the experiment's name and cache version number, and then the Experiment itself.
+*/
+func NewExperimentCache(path string) (ExperimentCache, error) {
+	stat, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		err := os.MkdirAll(path, 0777)
+		if err != nil {
+			return ExperimentCache{}, err
+		}
+	} else if !stat.IsDir() {
+		return ExperimentCache{}, fmt.Errorf("%s is not a directory", path)
+	}
+
+	return ExperimentCache{
+		Path: path,
+	}, nil
+}
+
+/*
+CachedExperimentHeader captures the name of the Cached Experiment and its Version
+*/
+type CachedExperimentHeader struct {
+	Name    string
+	Version int
+}
+
+func (cache ExperimentCache) hashOf(name string) string {
+	return fmt.Sprintf("%x", md5.Sum([]byte(name)))
+}
+
+func (cache ExperimentCache) readHeader(filename string) (CachedExperimentHeader, error) {
+	out := CachedExperimentHeader{}
+	f, err := os.Open(filepath.Join(cache.Path, filename))
+	if err != nil {
+		return out, err
+	}
+	defer f.Close()
+	err = json.NewDecoder(f).Decode(&out)
+	return out, err
+}
+
+/*
+List returns a list of all Cached Experiments found in the cache.
+*/
+func (cache ExperimentCache) List() ([]CachedExperimentHeader, error) {
+	var out []CachedExperimentHeader
+	names, err := gutil.ReadDir(cache.Path)
+	if err != nil {
+		return out, err
+	}
+	for _, name := range names {
+		if filepath.Ext(name) != CACHE_EXT {
+			continue
+		}
+		header, err := cache.readHeader(name)
+		if err != nil {
+			return out, err
+		}
+		out = append(out, header)
+	}
+	return out, nil
+}
+
+/*
+Clear empties out the cache - this will delete any and all detected cache files in the cache directory.  Use with caution!
+*/
+func (cache ExperimentCache) Clear() error {
+	names, err := gutil.ReadDir(cache.Path)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		if filepath.Ext(name) != CACHE_EXT {
+			continue
+		}
+		err := os.Remove(filepath.Join(cache.Path, name))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+/*
+Load fetches an experiment from the cache.  Lookup occurs by name.  Load requires that the version numer in the cache is equal to or greater than the passed-in version.
+
+If an experiment with corresponding name and version >= the passed-in version is found, it is unmarshaled and returned.
+
+If no experiment is found, or the cached version is smaller than the passed-in version, Load will return nil.
+
+When paired with Ginkgo you can cache experiments and prevent potentially expensive recomputation with this pattern:
+
+	const EXPERIMENT_VERSION = 1 //bump this to bust the cache and recompute _all_ experiments
+
+    Describe("some experiments", func() {
+    	var cache gmeasure.ExperimentCache
+    	var experiment *gmeasure.Experiment
+
+    	BeforeEach(func() {
+    		cache = gmeasure.NewExperimentCache("./gmeasure-cache")
+    		name := CurrentSpecReport().LeafNodeText
+    		experiment = cache.Load(name, EXPERIMENT_VERSION)
+    		if experiment != nil {
+    			AddReportEntry(experiment)
+    			Skip("cached")
+    		}
+    		experiment = gmeasure.NewExperiment(name)
+			AddReportEntry(experiment)
+    	})
+
+    	It("foo runtime", func() {
+    		experiment.SampleDuration("runtime", func() {
+    			//do stuff
+    		}, gmeasure.SamplingConfig{N:100})
+    	})
+
+    	It("bar runtime", func() {
+    		experiment.SampleDuration("runtime", func() {
+    			//do stuff
+    		}, gmeasure.SamplingConfig{N:100})
+    	})
+
+    	AfterEach(func() {
+    		if !CurrentSpecReport().State.Is(types.SpecStateSkipped) {
+	    		cache.Save(experiment.Name, EXPERIMENT_VERSION, experiment)
+	    	}
+    	})
+    })
+*/
+func (cache ExperimentCache) Load(name string, version int) *Experiment {
+	path := filepath.Join(cache.Path, cache.hashOf(name)+CACHE_EXT)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	header := CachedExperimentHeader{}
+	dec.Decode(&header)
+	if header.Version < version {
+		return nil
+	}
+	out := NewExperiment("")
+	err = dec.Decode(out)
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+/*
+Save stores the passed-in experiment to the cache with the passed-in name and version.
+*/
+func (cache ExperimentCache) Save(name string, version int, experiment *Experiment) error {
+	path := filepath.Join(cache.Path, cache.hashOf(name)+CACHE_EXT)
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	err = enc.Encode(CachedExperimentHeader{
+		Name:    name,
+		Version: version,
+	})
+	if err != nil {
+		return err
+	}
+	return enc.Encode(experiment)
+}
+
+/*
+Delete removes the experiment with the passed-in name from the cache
+*/
+func (cache ExperimentCache) Delete(name string) error {
+	path := filepath.Join(cache.Path, cache.hashOf(name)+CACHE_EXT)
+	return os.Remove(path)
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/enum_support.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/enum_support.go
@@ -1,0 +1,43 @@
+package gmeasure
+
+import "encoding/json"
+
+type enumSupport struct {
+	toString map[uint]string
+	toEnum   map[string]uint
+	maxEnum  uint
+}
+
+func newEnumSupport(toString map[uint]string) enumSupport {
+	toEnum, maxEnum := map[string]uint{}, uint(0)
+	for k, v := range toString {
+		toEnum[v] = k
+		if maxEnum < k {
+			maxEnum = k
+		}
+	}
+	return enumSupport{toString: toString, toEnum: toEnum, maxEnum: maxEnum}
+}
+
+func (es enumSupport) String(e uint) string {
+	if e > es.maxEnum {
+		return es.toString[0]
+	}
+	return es.toString[e]
+}
+
+func (es enumSupport) UnmarshJSON(b []byte) (uint, error) {
+	var dec string
+	if err := json.Unmarshal(b, &dec); err != nil {
+		return 0, err
+	}
+	out := es.toEnum[dec] // if we miss we get 0 which is what we want anyway
+	return out, nil
+}
+
+func (es enumSupport) MarshJSON(e uint) ([]byte, error) {
+	if e == 0 || e > es.maxEnum {
+		return json.Marshal(nil)
+	}
+	return json.Marshal(es.toString[e])
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/experiment.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/experiment.go
@@ -1,0 +1,526 @@
+/*
+Package gomega/gmeasure provides support for benchmarking and measuring code.  It is intended as a more robust replacement for Ginkgo V1's Measure nodes.
+
+gmeasure is organized around the metaphor of an Experiment that can record multiple Measurements.  A Measurement is a named collection of data points and gmeasure supports
+measuring Values (of type float64) and Durations (of type time.Duration).
+
+Experiments allows the user to record Measurements directly by passing in Values (i.e. float64) or Durations (i.e. time.Duration)
+or to measure measurements by passing in functions to measure.  When measuring functions Experiments take care of timing the duration of functions (for Duration measurements)
+and/or recording returned values (for Value measurements).  Experiments also support sampling functions - when told to sample Experiments will run functions repeatedly
+and measure and record results.  The sampling behavior is configured by passing in a SamplingConfig that can control the maximum number of samples, the maximum duration for sampling (or both)
+and the number of concurrent samples to take.
+
+Measurements can be decorated with additional information.  This is supported by passing in special typed decorators when recording measurements.  These include:
+
+- Units("any string") - to attach units to a Value Measurement (Duration Measurements always have units of "duration")
+- Style("any Ginkgo color style string") - to attach styling to a Measurement.  This styling is used when rendering console information about the measurement in reports.  Color style strings are documented at TODO.
+- Precision(integer or time.Duration) - to attach precision to a Measurement.  This controls how many decimal places to show for Value Measurements and how to round Duration Measurements when rendering them to screen.
+
+In addition, individual data points in a Measurement can be annotated with an Annotation("any string").  The annotation is associated with the individual data point and is intended to convey additional context about the data point.
+
+Once measurements are complete, an Experiment can generate a comprehensive report by calling its String() or ColorableString() method.
+
+Users can also access and analyze the resulting Measurements directly.  Use Experiment.Get(NAME) to fetch the Measurement named NAME.  This returned struct will have fields containing
+all the data points and annotations recorded by the experiment.  You can subsequently fetch the Measurement.Stats() to get a Stats struct that contains basic statistical information about the
+Measurement (min, max, median, mean, standard deviation).  You can order these Stats objects using RankStats() to identify best/worst performers across multpile experiments or measurements.
+
+gmeasure also supports caching Experiments via an ExperimentCache.  The cache supports storing and retreiving experiments by name and version.  This allows you to rerun code without
+repeating expensive experiments that may not have changed (which can be controlled by the cache version number).  It also enables you to compare new experiment runs with older runs to detect
+variations in performance/behavior.
+
+When used with Ginkgo, you can emit experiment reports and encode them in test reports easily using Ginkgo V2's support for Report Entries.
+Simply pass your experiment to AddReportEntry to get a report every time the tests run.  You can also use AddReportEntry with Measurements to emit all the captured data
+and Rankings to emit measurement summaries in rank order.
+
+Finally, Experiments provide an additional mechanism to measure durations called a Stopwatch.  The Stopwatch makes it easy to pepper code with statements that measure elapsed time across
+different sections of code and can be useful when debugging or evaluating bottlenecks in a given codepath.
+*/
+package gmeasure
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/onsi/gomega/gmeasure/table"
+)
+
+/*
+SamplingConfig configures the Sample family of experiment methods.
+These methods invoke passed-in functions repeatedly to sample and record a given measurement.
+SamplingConfig is used to control the maximum number of samples or time spent sampling (or both).  When both are specified sampling ends as soon as one of the conditions is met.
+SamplingConfig can also ensure a minimum interval between samples and can enable concurrent sampling.
+*/
+type SamplingConfig struct {
+	// N - the maximum number of samples to record
+	N int
+	// Duration - the maximum amount of time to spend recording samples
+	Duration time.Duration
+	// MinSamplingInterval - the minimum time that must elapse between samplings.  It is an error to specify both MinSamplingInterval and NumParallel.
+	MinSamplingInterval time.Duration
+	// NumParallel - the number of parallel workers to spin up to record samples.  It is an error to specify both MinSamplingInterval and NumParallel.
+	NumParallel int
+}
+
+// The Units decorator allows you to specify units (an arbitrary string) when recording values.  It is ignored when recording durations.
+//
+//     e := gmeasure.NewExperiment("My Experiment")
+//     e.RecordValue("length", 3.141, gmeasure.Units("inches"))
+//
+// Units are only set the first time a value of a given name is recorded.  In the example above any subsequent calls to e.RecordValue("length", X) will maintain the "inches" units even if a new set of Units("UNIT") are passed in later.
+type Units string
+
+// The Annotation decorator allows you to attach an annotation to a given recorded data-point:
+//
+// For example:
+//
+//     e := gmeasure.NewExperiment("My Experiment")
+//     e.RecordValue("length", 3.141, gmeasure.Annotation("bob"))
+//     e.RecordValue("length", 2.71, gmeasure.Annotation("jane"))
+//
+// ...will result in a Measurement named "length" that records two values )[3.141, 2.71]) annotation with (["bob", "jane"])
+type Annotation string
+
+// The Style decorator allows you to associate a style with a measurement.  This is used to generate colorful console reports using Ginkgo V2's
+// console formatter.  Styles are strings in curly brackets that correspond to a color or style.
+//
+// For example:
+//
+//     e := gmeasure.NewExperiment("My Experiment")
+//     e.RecordValue("length", 3.141, gmeasure.Style("{{blue}}{{bold}}"))
+//     e.RecordValue("length", 2.71)
+//     e.RecordDuration("cooking time", 3 * time.Second, gmeasure.Style("{{red}}{{underline}}"))
+//     e.RecordDuration("cooking time", 2 * time.Second)
+//
+// will emit a report with blue bold entries for the length measurement and red underlined entries for the cooking time measurement.
+//
+// Units are only set the first time a value or duration of a given name is recorded.  In the example above any subsequent calls to e.RecordValue("length", X) will maintain the "{{blue}}{{bold}}" style even if a new Style is passed in later.
+type Style string
+
+// The PrecisionBundle decorator controls the rounding of value and duration measurements.  See Precision().
+type PrecisionBundle struct {
+	Duration    time.Duration
+	ValueFormat string
+}
+
+// Precision() allows you to specify the precision of a value or duration measurement - this precision is used when rendering the measurement to screen.
+//
+// To control the precision of Value measurements, pass Precision an integer.  This will denote the number of decimal places to render (equivalen to the format string "%.Nf")
+// To control the precision of Duration measurements, pass Precision a time.Duration.  Duration measurements will be rounded oo the nearest time.Duration when rendered.
+//
+// For example:
+//
+//     e := gmeasure.NewExperiment("My Experiment")
+//     e.RecordValue("length", 3.141, gmeasure.Precision(2))
+//     e.RecordValue("length", 2.71)
+//     e.RecordDuration("cooking time", 3214 * time.Millisecond, gmeasure.Precision(100*time.Millisecond))
+//     e.RecordDuration("cooking time", 2623 * time.Millisecond)
+func Precision(p interface{}) PrecisionBundle {
+	out := DefaultPrecisionBundle
+	switch reflect.TypeOf(p) {
+	case reflect.TypeOf(time.Duration(0)):
+		out.Duration = p.(time.Duration)
+	case reflect.TypeOf(int(0)):
+		out.ValueFormat = fmt.Sprintf("%%.%df", p.(int))
+	default:
+		panic("invalid precision type, must be time.Duration or int")
+	}
+	return out
+}
+
+// DefaultPrecisionBundle captures the default precisions for Vale and Duration measurements.
+var DefaultPrecisionBundle = PrecisionBundle{
+	Duration:    100 * time.Microsecond,
+	ValueFormat: "%.3f",
+}
+
+type extractedDecorations struct {
+	annotation      Annotation
+	units           Units
+	precisionBundle PrecisionBundle
+	style           Style
+}
+
+func extractDecorations(args []interface{}) extractedDecorations {
+	var out extractedDecorations
+	out.precisionBundle = DefaultPrecisionBundle
+
+	for _, arg := range args {
+		switch reflect.TypeOf(arg) {
+		case reflect.TypeOf(out.annotation):
+			out.annotation = arg.(Annotation)
+		case reflect.TypeOf(out.units):
+			out.units = arg.(Units)
+		case reflect.TypeOf(out.precisionBundle):
+			out.precisionBundle = arg.(PrecisionBundle)
+		case reflect.TypeOf(out.style):
+			out.style = arg.(Style)
+		default:
+			panic(fmt.Sprintf("unrecognized argument %#v", arg))
+		}
+	}
+
+	return out
+}
+
+/*
+Experiment is gmeasure's core data type.  You use experiments to record Measurements and generate reports.
+Experiments are thread-safe and all methods can be called from multiple goroutines.
+*/
+type Experiment struct {
+	Name string
+
+	// Measurements includes all Measurements recorded by this experiment.  You should access them by name via Get() and GetStats()
+	Measurements Measurements
+	lock         *sync.Mutex
+}
+
+/*
+NexExperiment creates a new experiment with the passed-in name.
+
+When using Ginkgo we recommend immediately registering the experiment as a ReportEntry:
+
+	experiment = NewExperiment("My Experiment")
+	AddReportEntry(experiment.Name, experiment)
+
+this will ensure an experiment report is emitted as part of the test output and exported with any test reports.
+*/
+func NewExperiment(name string) *Experiment {
+	experiment := &Experiment{
+		Name: name,
+		lock: &sync.Mutex{},
+	}
+	return experiment
+}
+
+func (e *Experiment) report(enableStyling bool) string {
+	t := table.NewTable()
+	t.TableStyle.EnableTextStyling = enableStyling
+	t.AppendRow(table.R(
+		table.C("Name"), table.C("N"), table.C("Min"), table.C("Median"), table.C("Mean"), table.C("StdDev"), table.C("Max"),
+		table.Divider("="),
+		"{{bold}}",
+	))
+
+	for _, measurement := range e.Measurements {
+		r := table.R(measurement.Style)
+		t.AppendRow(r)
+		switch measurement.Type {
+		case MeasurementTypeNote:
+			r.AppendCell(table.C(measurement.Note))
+		case MeasurementTypeValue, MeasurementTypeDuration:
+			name := measurement.Name
+			if measurement.Units != "" {
+				name += " [" + measurement.Units + "]"
+			}
+			r.AppendCell(table.C(name))
+			r.AppendCell(measurement.Stats().cells()...)
+		}
+	}
+
+	out := e.Name + "\n"
+	if enableStyling {
+		out = "{{bold}}" + out + "{{/}}"
+	}
+	out += t.Render()
+	return out
+}
+
+/*
+ColorableString returns a Ginkgo formatted summary of the experiment and all its Measurements.
+It is called automatically by Ginkgo's reporting infrastructure when the Experiment is registered as a ReportEntry via AddReportEntry.
+*/
+func (e *Experiment) ColorableString() string {
+	return e.report(true)
+}
+
+/*
+ColorableString returns an unformatted summary of the experiment and all its Measurements.
+*/
+func (e *Experiment) String() string {
+	return e.report(false)
+}
+
+/*
+RecordNote records a Measurement of type MeasurementTypeNote - this is simply a textual note to annotate the experiment.  It will be emitted in any experiment reports.
+
+RecordNote supports the Style() decoration.
+*/
+func (e *Experiment) RecordNote(note string, args ...interface{}) {
+	decorations := extractDecorations(args)
+
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.Measurements = append(e.Measurements, Measurement{
+		ExperimentName: e.Name,
+		Type:           MeasurementTypeNote,
+		Note:           note,
+		Style:          string(decorations.style),
+	})
+}
+
+/*
+RecordDuration records the passed-in duration on a Duration Measurement with the passed-in name.  If the Measurement does not exist it is created.
+
+RecordDuration supports the Style(), Precision(), and Annotation() decorations.
+*/
+func (e *Experiment) RecordDuration(name string, duration time.Duration, args ...interface{}) {
+	decorations := extractDecorations(args)
+	e.recordDuration(name, duration, decorations)
+}
+
+/*
+MeasureDuration runs the passed-in callback and times how long it takes to complete.  The resulting duration is recorded on a Duration Measurement with the passed-in name.  If the Measurement does not exist it is created.
+
+MeasureDuration supports the Style(), Precision(), and Annotation() decorations.
+*/
+func (e *Experiment) MeasureDuration(name string, callback func(), args ...interface{}) time.Duration {
+	t := time.Now()
+	callback()
+	duration := time.Since(t)
+	e.RecordDuration(name, duration, args...)
+	return duration
+}
+
+/*
+SampleDuration samples the passed-in callback and times how long it takes to complete each sample.
+The resulting durations are recorded on a Duration Measurement with the passed-in name.  If the Measurement does not exist it is created.
+
+The callback is given a zero-based index that increments by one between samples.  The Sampling is configured via the passed-in SamplingConfig
+
+SampleDuration supports the Style(), Precision(), and Annotation() decorations.  When passed an Annotation() the same annotation is applied to all sample measurements.
+*/
+func (e *Experiment) SampleDuration(name string, callback func(idx int), samplingConfig SamplingConfig, args ...interface{}) {
+	decorations := extractDecorations(args)
+	e.Sample(func(idx int) {
+		t := time.Now()
+		callback(idx)
+		duration := time.Since(t)
+		e.recordDuration(name, duration, decorations)
+	}, samplingConfig)
+}
+
+/*
+SampleDuration samples the passed-in callback and times how long it takes to complete each sample.
+The resulting durations are recorded on a Duration Measurement with the passed-in name.  If the Measurement does not exist it is created.
+
+The callback is given a zero-based index that increments by one between samples.  The callback must return an Annotation - this annotation is attached to the measured duration.
+
+The Sampling is configured via the passed-in SamplingConfig
+
+SampleAnnotatedDuration supports the Style() and Precision() decorations.
+*/
+func (e *Experiment) SampleAnnotatedDuration(name string, callback func(idx int) Annotation, samplingConfig SamplingConfig, args ...interface{}) {
+	decorations := extractDecorations(args)
+	e.Sample(func(idx int) {
+		t := time.Now()
+		decorations.annotation = callback(idx)
+		duration := time.Since(t)
+		e.recordDuration(name, duration, decorations)
+	}, samplingConfig)
+}
+
+func (e *Experiment) recordDuration(name string, duration time.Duration, decorations extractedDecorations) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	idx := e.Measurements.IdxWithName(name)
+	if idx == -1 {
+		measurement := Measurement{
+			ExperimentName:  e.Name,
+			Type:            MeasurementTypeDuration,
+			Name:            name,
+			Units:           "duration",
+			Durations:       []time.Duration{duration},
+			PrecisionBundle: decorations.precisionBundle,
+			Style:           string(decorations.style),
+			Annotations:     []string{string(decorations.annotation)},
+		}
+		e.Measurements = append(e.Measurements, measurement)
+	} else {
+		if e.Measurements[idx].Type != MeasurementTypeDuration {
+			panic(fmt.Sprintf("attempting to record duration with name '%s'.  That name is already in-use for recording values.", name))
+		}
+		e.Measurements[idx].Durations = append(e.Measurements[idx].Durations, duration)
+		e.Measurements[idx].Annotations = append(e.Measurements[idx].Annotations, string(decorations.annotation))
+	}
+}
+
+/*
+NewStopwatch() returns a stopwatch configured to record duration measurements with this experiment.
+*/
+func (e *Experiment) NewStopwatch() *Stopwatch {
+	return newStopwatch(e)
+}
+
+/*
+RecordValue records the passed-in value on a Value Measurement with the passed-in name.  If the Measurement does not exist it is created.
+
+RecordValue supports the Style(), Units(), Precision(), and Annotation() decorations.
+*/
+func (e *Experiment) RecordValue(name string, value float64, args ...interface{}) {
+	decorations := extractDecorations(args)
+	e.recordValue(name, value, decorations)
+}
+
+/*
+MeasureValue runs the passed-in callback and records the return value on a Value Measurement with the passed-in name.  If the Measurement does not exist it is created.
+
+MeasureValue supports the Style(), Units(), Precision(), and Annotation() decorations.
+*/
+func (e *Experiment) MeasureValue(name string, callback func() float64, args ...interface{}) float64 {
+	value := callback()
+	e.RecordValue(name, value, args...)
+	return value
+}
+
+/*
+SampleValue samples the passed-in callback and records the return value on a Value Measurement with the passed-in name. If the Measurement does not exist it is created.
+
+The callback is given a zero-based index that increments by one between samples.  The callback must return a float64.  The Sampling is configured via the passed-in SamplingConfig
+
+SampleValue supports the Style(), Units(), Precision(), and Annotation() decorations.  When passed an Annotation() the same annotation is applied to all sample measurements.
+*/
+func (e *Experiment) SampleValue(name string, callback func(idx int) float64, samplingConfig SamplingConfig, args ...interface{}) {
+	decorations := extractDecorations(args)
+	e.Sample(func(idx int) {
+		value := callback(idx)
+		e.recordValue(name, value, decorations)
+	}, samplingConfig)
+}
+
+/*
+SampleAnnotatedValue samples the passed-in callback and records the return value on a Value Measurement with the passed-in name. If the Measurement does not exist it is created.
+
+The callback is given a zero-based index that increments by one between samples.  The callback must return a float64 and an Annotation - the annotation is attached to the recorded value.
+
+The Sampling is configured via the passed-in SamplingConfig
+
+SampleValue supports the Style(), Units(), and Precision() decorations.
+*/
+func (e *Experiment) SampleAnnotatedValue(name string, callback func(idx int) (float64, Annotation), samplingConfig SamplingConfig, args ...interface{}) {
+	decorations := extractDecorations(args)
+	e.Sample(func(idx int) {
+		var value float64
+		value, decorations.annotation = callback(idx)
+		e.recordValue(name, value, decorations)
+	}, samplingConfig)
+}
+
+func (e *Experiment) recordValue(name string, value float64, decorations extractedDecorations) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	idx := e.Measurements.IdxWithName(name)
+	if idx == -1 {
+		measurement := Measurement{
+			ExperimentName:  e.Name,
+			Type:            MeasurementTypeValue,
+			Name:            name,
+			Style:           string(decorations.style),
+			Units:           string(decorations.units),
+			PrecisionBundle: decorations.precisionBundle,
+			Values:          []float64{value},
+			Annotations:     []string{string(decorations.annotation)},
+		}
+		e.Measurements = append(e.Measurements, measurement)
+	} else {
+		if e.Measurements[idx].Type != MeasurementTypeValue {
+			panic(fmt.Sprintf("attempting to record value with name '%s'.  That name is already in-use for recording durations.", name))
+		}
+		e.Measurements[idx].Values = append(e.Measurements[idx].Values, value)
+		e.Measurements[idx].Annotations = append(e.Measurements[idx].Annotations, string(decorations.annotation))
+	}
+}
+
+/*
+Sample samples the passed-in callback repeatedly.  The sampling is governed by the passed in SamplingConfig.
+
+The SamplingConfig can limit the total number of samples and/or the total time spent sampling the callback.
+The SamplingConfig can also instruct Sample to run with multiple concurrent workers.
+
+The callback is called with a zero-based index that incerements by one between samples.
+*/
+func (e *Experiment) Sample(callback func(idx int), samplingConfig SamplingConfig) {
+	if samplingConfig.N == 0 && samplingConfig.Duration == 0 {
+		panic("you must specify at least one of SamplingConfig.N and SamplingConfig.Duration")
+	}
+	if samplingConfig.MinSamplingInterval > 0 && samplingConfig.NumParallel > 1 {
+		panic("you cannot specify both SamplingConfig.MinSamplingInterval and SamplingConfig.NumParallel")
+	}
+	maxTime := time.Now().Add(100000 * time.Hour)
+	if samplingConfig.Duration > 0 {
+		maxTime = time.Now().Add(samplingConfig.Duration)
+	}
+	maxN := math.MaxInt32
+	if samplingConfig.N > 0 {
+		maxN = samplingConfig.N
+	}
+	numParallel := 1
+	if samplingConfig.NumParallel > numParallel {
+		numParallel = samplingConfig.NumParallel
+	}
+	minSamplingInterval := samplingConfig.MinSamplingInterval
+
+	work := make(chan int)
+	if numParallel > 1 {
+		for worker := 0; worker < numParallel; worker++ {
+			go func() {
+				for idx := range work {
+					callback(idx)
+				}
+			}()
+		}
+	}
+
+	idx := 0
+	var avgDt time.Duration
+	for {
+		t := time.Now()
+		if numParallel > 1 {
+			work <- idx
+		} else {
+			callback(idx)
+		}
+		dt := time.Since(t)
+		if numParallel == 1 && dt < minSamplingInterval {
+			time.Sleep(minSamplingInterval - dt)
+			dt = time.Since(t)
+		}
+		if idx >= numParallel {
+			avgDt = (avgDt*time.Duration(idx-numParallel) + dt) / time.Duration(idx-numParallel+1)
+		}
+		idx += 1
+		if idx >= maxN {
+			return
+		}
+		if time.Now().Add(avgDt).After(maxTime) {
+			return
+		}
+	}
+}
+
+/*
+Get returns the Measurement with the associated name.  If no Measurement is found a zero Measurement{} is returned.
+*/
+func (e *Experiment) Get(name string) Measurement {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	idx := e.Measurements.IdxWithName(name)
+	if idx == -1 {
+		return Measurement{}
+	}
+	return e.Measurements[idx]
+}
+
+/*
+GetStats returns the Stats for the Measurement with the associated name.  If no Measurement is found a zero Stats{} is returned.
+
+experiment.GetStats(name) is equivalent to experiment.Get(name).Stats()
+*/
+func (e *Experiment) GetStats(name string) Stats {
+	measurement := e.Get(name)
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	return measurement.Stats()
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/measurement.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/measurement.go
@@ -1,0 +1,235 @@
+package gmeasure
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/onsi/gomega/gmeasure/table"
+)
+
+type MeasurementType uint
+
+const (
+	MeasurementTypeInvalid MeasurementType = iota
+	MeasurementTypeNote
+	MeasurementTypeDuration
+	MeasurementTypeValue
+)
+
+var letEnumSupport = newEnumSupport(map[uint]string{uint(MeasurementTypeInvalid): "INVALID LOG ENTRY TYPE", uint(MeasurementTypeNote): "Note", uint(MeasurementTypeDuration): "Duration", uint(MeasurementTypeValue): "Value"})
+
+func (s MeasurementType) String() string { return letEnumSupport.String(uint(s)) }
+func (s *MeasurementType) UnmarshalJSON(b []byte) error {
+	out, err := letEnumSupport.UnmarshJSON(b)
+	*s = MeasurementType(out)
+	return err
+}
+func (s MeasurementType) MarshalJSON() ([]byte, error) { return letEnumSupport.MarshJSON(uint(s)) }
+
+/*
+Measurement records all captured data for a given measurement.  You generally don't make Measurements directly - but you can fetch them from Experiments using Get().
+
+When using Ginkgo, you can register Measurements as Report Entries via AddReportEntry.  This will emit all the captured data points when Ginkgo generates the report.
+*/
+type Measurement struct {
+	// Type is the MeasurementType - one of MeasurementTypeNote, MeasurementTypeDuration, or MeasurementTypeValue
+	Type MeasurementType
+
+	// ExperimentName is the name of the experiment that this Measurement is associated with
+	ExperimentName string
+
+	// If Type is MeasurementTypeNote, Note is populated with the note text.
+	Note string
+
+	// If Type is MeasurementTypeDuration or MeasurementTypeValue, Name is the name of the recorded measurement
+	Name string
+
+	// Style captures the styling information (if any) for this Measurement
+	Style string
+
+	// Units capture the units (if any) for this Measurement.  Units is set to "duration" if the Type is MeasurementTypeDuration
+	Units string
+
+	// PrecisionBundle captures the precision to use when rendering data for this Measurement.
+	// If Type is MeasurementTypeDuration then PrecisionBundle.Duration is used to round any durations before presentation.
+	// If Type is MeasurementTypeValue then PrecisionBundle.ValueFormat is used to format any values before presentation
+	PrecisionBundle PrecisionBundle
+
+	// If Type is MeasurementTypeDuration, Durations will contain all durations recorded for this measurement
+	Durations []time.Duration
+
+	// If Type is MeasurementTypeValue, Values will contain all float64s recorded for this measurement
+	Values []float64
+
+	// If Type is MeasurementTypeDuration or MeasurementTypeValue then Annotations will include string annotations for all recorded Durations or Values.
+	// If the user does not pass-in an Annotation() decoration for a particular value or duration, the corresponding entry in the Annotations slice will be the empty string ""
+	Annotations []string
+}
+
+type Measurements []Measurement
+
+func (m Measurements) IdxWithName(name string) int {
+	for idx, measurement := range m {
+		if measurement.Name == name {
+			return idx
+		}
+	}
+
+	return -1
+}
+
+func (m Measurement) report(enableStyling bool) string {
+	out := ""
+	style := m.Style
+	if !enableStyling {
+		style = ""
+	}
+	switch m.Type {
+	case MeasurementTypeNote:
+		out += fmt.Sprintf("%s - Note\n%s\n", m.ExperimentName, m.Note)
+		if style != "" {
+			out = style + out + "{{/}}"
+		}
+		return out
+	case MeasurementTypeValue, MeasurementTypeDuration:
+		out += fmt.Sprintf("%s - %s", m.ExperimentName, m.Name)
+		if m.Units != "" {
+			out += " [" + m.Units + "]"
+		}
+		if style != "" {
+			out = style + out + "{{/}}"
+		}
+		out += "\n"
+		out += m.Stats().String() + "\n"
+	}
+	t := table.NewTable()
+	t.TableStyle.EnableTextStyling = enableStyling
+	switch m.Type {
+	case MeasurementTypeValue:
+		t.AppendRow(table.R(table.C("Value", table.AlignTypeCenter), table.C("Annotation", table.AlignTypeCenter), table.Divider("="), style))
+		for idx := range m.Values {
+			t.AppendRow(table.R(
+				table.C(fmt.Sprintf(m.PrecisionBundle.ValueFormat, m.Values[idx]), table.AlignTypeRight),
+				table.C(m.Annotations[idx], "{{gray}}", table.AlignTypeLeft),
+			))
+		}
+	case MeasurementTypeDuration:
+		t.AppendRow(table.R(table.C("Duration", table.AlignTypeCenter), table.C("Annotation", table.AlignTypeCenter), table.Divider("="), style))
+		for idx := range m.Durations {
+			t.AppendRow(table.R(
+				table.C(m.Durations[idx].Round(m.PrecisionBundle.Duration).String(), style, table.AlignTypeRight),
+				table.C(m.Annotations[idx], "{{gray}}", table.AlignTypeLeft),
+			))
+		}
+	}
+	out += t.Render()
+	return out
+}
+
+/*
+ColorableString generates a styled report that includes all the data points for this Measurement.
+It is called automatically by Ginkgo's reporting infrastructure when the Measurement is registered as a ReportEntry via AddReportEntry.
+*/
+func (m Measurement) ColorableString() string {
+	return m.report(true)
+}
+
+/*
+String generates an unstyled report that includes all the data points for this Measurement.
+*/
+func (m Measurement) String() string {
+	return m.report(false)
+}
+
+/*
+Stats returns a Stats struct summarizing the statistic of this measurement
+*/
+func (m Measurement) Stats() Stats {
+	if m.Type == MeasurementTypeInvalid || m.Type == MeasurementTypeNote {
+		return Stats{}
+	}
+
+	out := Stats{
+		ExperimentName:  m.ExperimentName,
+		MeasurementName: m.Name,
+		Style:           m.Style,
+		Units:           m.Units,
+		PrecisionBundle: m.PrecisionBundle,
+	}
+
+	switch m.Type {
+	case MeasurementTypeValue:
+		out.Type = StatsTypeValue
+		out.N = len(m.Values)
+		if out.N == 0 {
+			return out
+		}
+		indices, sum := make([]int, len(m.Values)), 0.0
+		for idx, v := range m.Values {
+			indices[idx] = idx
+			sum += v
+		}
+		sort.Slice(indices, func(i, j int) bool {
+			return m.Values[indices[i]] < m.Values[indices[j]]
+		})
+		out.ValueBundle = map[Stat]float64{
+			StatMin:    m.Values[indices[0]],
+			StatMax:    m.Values[indices[out.N-1]],
+			StatMean:   sum / float64(out.N),
+			StatStdDev: 0.0,
+		}
+		out.AnnotationBundle = map[Stat]string{
+			StatMin: m.Annotations[indices[0]],
+			StatMax: m.Annotations[indices[out.N-1]],
+		}
+
+		if out.N%2 == 0 {
+			out.ValueBundle[StatMedian] = (m.Values[indices[out.N/2]] + m.Values[indices[out.N/2-1]]) / 2.0
+		} else {
+			out.ValueBundle[StatMedian] = m.Values[indices[(out.N-1)/2]]
+		}
+
+		for _, v := range m.Values {
+			out.ValueBundle[StatStdDev] += (v - out.ValueBundle[StatMean]) * (v - out.ValueBundle[StatMean])
+		}
+		out.ValueBundle[StatStdDev] = math.Sqrt(out.ValueBundle[StatStdDev] / float64(out.N))
+	case MeasurementTypeDuration:
+		out.Type = StatsTypeDuration
+		out.N = len(m.Durations)
+		if out.N == 0 {
+			return out
+		}
+		indices, sum := make([]int, len(m.Durations)), time.Duration(0)
+		for idx, v := range m.Durations {
+			indices[idx] = idx
+			sum += v
+		}
+		sort.Slice(indices, func(i, j int) bool {
+			return m.Durations[indices[i]] < m.Durations[indices[j]]
+		})
+		out.DurationBundle = map[Stat]time.Duration{
+			StatMin:  m.Durations[indices[0]],
+			StatMax:  m.Durations[indices[out.N-1]],
+			StatMean: sum / time.Duration(out.N),
+		}
+		out.AnnotationBundle = map[Stat]string{
+			StatMin: m.Annotations[indices[0]],
+			StatMax: m.Annotations[indices[out.N-1]],
+		}
+
+		if out.N%2 == 0 {
+			out.DurationBundle[StatMedian] = (m.Durations[indices[out.N/2]] + m.Durations[indices[out.N/2-1]]) / 2
+		} else {
+			out.DurationBundle[StatMedian] = m.Durations[indices[(out.N-1)/2]]
+		}
+		stdDev := 0.0
+		for _, v := range m.Durations {
+			stdDev += float64(v-out.DurationBundle[StatMean]) * float64(v-out.DurationBundle[StatMean])
+		}
+		out.DurationBundle[StatStdDev] = time.Duration(math.Sqrt(stdDev / float64(out.N)))
+	}
+
+	return out
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/rank.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/rank.go
@@ -1,0 +1,141 @@
+package gmeasure
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/onsi/gomega/gmeasure/table"
+)
+
+/*
+RankingCriteria is an enum representing the criteria by which Stats should be ranked.  The enum names should be self explanatory.  e.g. LowerMeanIsBetter means that Stats with lower mean values are considered more beneficial, with the lowest mean being declared the "winner" .
+*/
+type RankingCriteria uint
+
+const (
+	LowerMeanIsBetter RankingCriteria = iota
+	HigherMeanIsBetter
+	LowerMedianIsBetter
+	HigherMedianIsBetter
+	LowerMinIsBetter
+	HigherMinIsBetter
+	LowerMaxIsBetter
+	HigherMaxIsBetter
+)
+
+var rcEnumSupport = newEnumSupport(map[uint]string{uint(LowerMeanIsBetter): "Lower Mean is Better", uint(HigherMeanIsBetter): "Higher Mean is Better", uint(LowerMedianIsBetter): "Lower Median is Better", uint(HigherMedianIsBetter): "Higher Median is Better", uint(LowerMinIsBetter): "Lower Mins is Better", uint(HigherMinIsBetter): "Higher Min is Better", uint(LowerMaxIsBetter): "Lower Max is Better", uint(HigherMaxIsBetter): "Higher Max is Better"})
+
+func (s RankingCriteria) String() string { return rcEnumSupport.String(uint(s)) }
+func (s *RankingCriteria) UnmarshalJSON(b []byte) error {
+	out, err := rcEnumSupport.UnmarshJSON(b)
+	*s = RankingCriteria(out)
+	return err
+}
+func (s RankingCriteria) MarshalJSON() ([]byte, error) { return rcEnumSupport.MarshJSON(uint(s)) }
+
+/*
+Ranking ranks a set of Stats by a specified RankingCritera.  Use RankStats to create a Ranking.
+
+When using Ginkgo, you can register Rankings as Report Entries via AddReportEntry.  This will emit a formatted table representing the Stats in rank-order when Ginkgo generates the report.
+*/
+type Ranking struct {
+	Criteria RankingCriteria
+	Stats    []Stats
+}
+
+/*
+RankStats creates a new ranking of the passed-in stats according to the passed-in criteria.
+*/
+func RankStats(criteria RankingCriteria, stats ...Stats) Ranking {
+	sort.Slice(stats, func(i int, j int) bool {
+		switch criteria {
+		case LowerMeanIsBetter:
+			return stats[i].FloatFor(StatMean) < stats[j].FloatFor(StatMean)
+		case HigherMeanIsBetter:
+			return stats[i].FloatFor(StatMean) > stats[j].FloatFor(StatMean)
+		case LowerMedianIsBetter:
+			return stats[i].FloatFor(StatMedian) < stats[j].FloatFor(StatMedian)
+		case HigherMedianIsBetter:
+			return stats[i].FloatFor(StatMedian) > stats[j].FloatFor(StatMedian)
+		case LowerMinIsBetter:
+			return stats[i].FloatFor(StatMin) < stats[j].FloatFor(StatMin)
+		case HigherMinIsBetter:
+			return stats[i].FloatFor(StatMin) > stats[j].FloatFor(StatMin)
+		case LowerMaxIsBetter:
+			return stats[i].FloatFor(StatMax) < stats[j].FloatFor(StatMax)
+		case HigherMaxIsBetter:
+			return stats[i].FloatFor(StatMax) > stats[j].FloatFor(StatMax)
+		}
+		return false
+	})
+
+	out := Ranking{
+		Criteria: criteria,
+		Stats:    stats,
+	}
+
+	return out
+}
+
+/*
+Winner returns the Stats with the most optimal rank based on the specified ranking criteria.  For example, if the RankingCriteria is LowerMaxIsBetter then the Stats with the lowest value or duration for StatMax will be returned as the "winner"
+*/
+func (c Ranking) Winner() Stats {
+	if len(c.Stats) == 0 {
+		return Stats{}
+	}
+	return c.Stats[0]
+}
+
+func (c Ranking) report(enableStyling bool) string {
+	if len(c.Stats) == 0 {
+		return "Empty Ranking"
+	}
+	t := table.NewTable()
+	t.TableStyle.EnableTextStyling = enableStyling
+	t.AppendRow(table.R(
+		table.C("Experiment"), table.C("Name"), table.C("N"), table.C("Min"), table.C("Median"), table.C("Mean"), table.C("StdDev"), table.C("Max"),
+		table.Divider("="),
+		"{{bold}}",
+	))
+
+	for idx, stats := range c.Stats {
+		name := stats.MeasurementName
+		if stats.Units != "" {
+			name = name + " [" + stats.Units + "]"
+		}
+		experimentName := stats.ExperimentName
+		style := stats.Style
+		if idx == 0 {
+			style = "{{bold}}" + style
+			name += "\n*Winner*"
+			experimentName += "\n*Winner*"
+		}
+		r := table.R(style)
+		t.AppendRow(r)
+		r.AppendCell(table.C(experimentName), table.C(name))
+		r.AppendCell(stats.cells()...)
+
+	}
+	out := fmt.Sprintf("Ranking Criteria: %s\n", c.Criteria)
+	if enableStyling {
+		out = "{{bold}}" + out + "{{/}}"
+	}
+	out += t.Render()
+	return out
+}
+
+/*
+ColorableString generates a styled report that includes a table of the rank-ordered Stats
+It is called automatically by Ginkgo's reporting infrastructure when the Ranking is registered as a ReportEntry via AddReportEntry.
+*/
+func (c Ranking) ColorableString() string {
+	return c.report(true)
+}
+
+/*
+String generates an unstyled report that includes a table of the rank-ordered Stats
+*/
+func (c Ranking) String() string {
+	return c.report(false)
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/stats.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/stats.go
@@ -1,0 +1,153 @@
+package gmeasure
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/gomega/gmeasure/table"
+)
+
+/*
+Stat is an enum representing the statistics you can request of a Stats struct
+*/
+type Stat uint
+
+const (
+	StatInvalid Stat = iota
+	StatMin
+	StatMax
+	StatMean
+	StatMedian
+	StatStdDev
+)
+
+var statEnumSupport = newEnumSupport(map[uint]string{uint(StatInvalid): "INVALID STAT", uint(StatMin): "Min", uint(StatMax): "Max", uint(StatMean): "Mean", uint(StatMedian): "Median", uint(StatStdDev): "StdDev"})
+
+func (s Stat) String() string { return statEnumSupport.String(uint(s)) }
+func (s *Stat) UnmarshalJSON(b []byte) error {
+	out, err := statEnumSupport.UnmarshJSON(b)
+	*s = Stat(out)
+	return err
+}
+func (s Stat) MarshalJSON() ([]byte, error) { return statEnumSupport.MarshJSON(uint(s)) }
+
+type StatsType uint
+
+const (
+	StatsTypeInvalid StatsType = iota
+	StatsTypeValue
+	StatsTypeDuration
+)
+
+var statsTypeEnumSupport = newEnumSupport(map[uint]string{uint(StatsTypeInvalid): "INVALID STATS TYPE", uint(StatsTypeValue): "StatsTypeValue", uint(StatsTypeDuration): "StatsTypeDuration"})
+
+func (s StatsType) String() string { return statsTypeEnumSupport.String(uint(s)) }
+func (s *StatsType) UnmarshalJSON(b []byte) error {
+	out, err := statsTypeEnumSupport.UnmarshJSON(b)
+	*s = StatsType(out)
+	return err
+}
+func (s StatsType) MarshalJSON() ([]byte, error) { return statsTypeEnumSupport.MarshJSON(uint(s)) }
+
+/*
+Stats records the key statistics for a given measurement.  You generally don't make Stats directly - but you can fetch them from Experiments using GetStats() and from Measurements using Stats().
+
+When using Ginkgo, you can register Measurements as Report Entries via AddReportEntry.  This will emit all the captured data points when Ginkgo generates the report.
+*/
+type Stats struct {
+	// Type is the StatType - one of StatTypeDuration or StatTypeValue
+	Type StatsType
+
+	// ExperimentName is the name of the Experiment that recorded the Measurement from which this Stat is derived
+	ExperimentName string
+
+	// MeasurementName is the name of the Measurement from which this Stat is derived
+	MeasurementName string
+
+	// Units captures the Units of the Measurement from which this Stat is derived
+	Units string
+
+	// Style captures the Style of the Measurement from which this Stat is derived
+	Style string
+
+	// PrecisionBundle captures the precision to use when rendering data for this Measurement.
+	// If Type is StatTypeDuration then PrecisionBundle.Duration is used to round any durations before presentation.
+	// If Type is StatTypeValue then PrecisionBundle.ValueFormat is used to format any values before presentation
+	PrecisionBundle PrecisionBundle
+
+	// N represents the total number of data points in the Meassurement from which this Stat is derived
+	N int
+
+	// If Type is StatTypeValue, ValueBundle will be populated with float64s representing this Stat's statistics
+	ValueBundle map[Stat]float64
+
+	// If Type is StatTypeDuration, DurationBundle will be populated with float64s representing this Stat's statistics
+	DurationBundle map[Stat]time.Duration
+
+	// AnnotationBundle is populated with Annotations corresponding to the data points that can be associated with a Stat.
+	// For example AnnotationBundle[StatMin] will return the Annotation for the data point that has the minimum value/duration.
+	AnnotationBundle map[Stat]string
+}
+
+// String returns a minimal summary of the stats of the form "MIN < [MEDIAN] | <MEAN> ±STDDEV < MAX"
+func (s Stats) String() string {
+	return fmt.Sprintf("%s < [%s] | <%s> ±%s < %s", s.StringFor(StatMin), s.StringFor(StatMedian), s.StringFor(StatMean), s.StringFor(StatStdDev), s.StringFor(StatMax))
+}
+
+// ValueFor returns the float64 value for a particular Stat.  You should only use this if the Stats has Type StatsTypeValue
+// For example:
+//
+//    median := experiment.GetStats("length").ValueFor(gmeasure.StatMedian)
+//
+// will return the median data point for the "length" Measurement.
+func (s Stats) ValueFor(stat Stat) float64 {
+	return s.ValueBundle[stat]
+}
+
+// DurationFor returns the time.Duration for a particular Stat.  You should only use this if the Stats has Type StatsTypeDuration
+// For example:
+//
+//    mean := experiment.GetStats("runtime").ValueFor(gmeasure.StatMean)
+//
+// will return the mean duration for the "runtime" Measurement.
+func (s Stats) DurationFor(stat Stat) time.Duration {
+	return s.DurationBundle[stat]
+}
+
+// FloatFor returns a float64 representation of the passed-in Stat.
+// When Type is StatsTypeValue this is equivalent to s.ValueFor(stat).
+// When Type is StatsTypeDuration this is equivalent to float64(s.DurationFor(stat))
+func (s Stats) FloatFor(stat Stat) float64 {
+	switch s.Type {
+	case StatsTypeValue:
+		return s.ValueFor(stat)
+	case StatsTypeDuration:
+		return float64(s.DurationFor(stat))
+	}
+	return 0
+}
+
+// StringFor returns a formatted string representation of the passed-in Stat.
+// The formatting honors the precision directives provided in stats.PrecisionBundle
+func (s Stats) StringFor(stat Stat) string {
+	switch s.Type {
+	case StatsTypeValue:
+		return fmt.Sprintf(s.PrecisionBundle.ValueFormat, s.ValueFor(stat))
+	case StatsTypeDuration:
+		return s.DurationFor(stat).Round(s.PrecisionBundle.Duration).String()
+	}
+	return ""
+}
+
+func (s Stats) cells() []table.Cell {
+	out := []table.Cell{}
+	out = append(out, table.C(fmt.Sprintf("%d", s.N)))
+	for _, stat := range []Stat{StatMin, StatMedian, StatMean, StatStdDev, StatMax} {
+		content := s.StringFor(stat)
+		if s.AnnotationBundle[stat] != "" {
+			content += "\n" + s.AnnotationBundle[stat]
+		}
+		out = append(out, table.C(content))
+	}
+	return out
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/stopwatch.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/stopwatch.go
@@ -1,0 +1,117 @@
+package gmeasure
+
+import "time"
+
+/*
+Stopwatch provides a convenient abstraction for recording durations.  There are two ways to make a Stopwatch:
+
+You can make a Stopwatch from an Experiment via experiment.NewStopwatch().  This is how you first get a hold of a Stopwatch.
+
+You can subsequently call stopwatch.NewStopwatch() to get a fresh Stopwatch.
+This is only necessary if you need to record durations on a different goroutine as a single Stopwatch is not considered thread-safe.
+
+The Stopwatch starts as soon as it is created.  You can Pause() the stopwatch and Reset() it as needed.
+
+Stopwatches refer back to their parent Experiment.  They use this reference to record any measured durations back with the Experiment.
+*/
+type Stopwatch struct {
+	Experiment    *Experiment
+	t             time.Time
+	pauseT        time.Time
+	pauseDuration time.Duration
+	running       bool
+}
+
+func newStopwatch(experiment *Experiment) *Stopwatch {
+	return &Stopwatch{
+		Experiment: experiment,
+		t:          time.Now(),
+		running:    true,
+	}
+}
+
+/*
+NewStopwatch returns a new Stopwatch pointing to the same Experiment as this Stopwatch
+*/
+func (s *Stopwatch) NewStopwatch() *Stopwatch {
+	return newStopwatch(s.Experiment)
+}
+
+/*
+Record captures the amount of time that has passed since the Stopwatch was created or most recently Reset().  It records the duration on it's associated Experiment in a Measurement with the passed-in name.
+
+Record takes all the decorators that experiment.RecordDuration takes (e.g. Annotation("...") can be used to annotate this duration)
+
+Note that Record does not Reset the Stopwatch.  It does, however, return the Stopwatch so the following pattern is common:
+
+    stopwatch := experiment.NewStopwatch()
+    // first expensive operation
+    stopwatch.Record("first operation").Reset() //records the duration of the first operation and resets the stopwatch.
+    // second expensive operation
+    stopwatch.Record("second operation").Reset() //records the duration of the second operation and resets the stopwatch.
+
+omitting the Reset() after the first operation would cause the duration recorded for the second operation to include the time elapsed by both the first _and_ second operations.
+
+The Stopwatch must be running (i.e. not paused) when Record is called.
+*/
+func (s *Stopwatch) Record(name string, args ...interface{}) *Stopwatch {
+	if !s.running {
+		panic("stopwatch is not running - call Resume or Reset before calling Record")
+	}
+	duration := time.Since(s.t) - s.pauseDuration
+	s.Experiment.RecordDuration(name, duration, args...)
+	return s
+}
+
+/*
+Reset resets the Stopwatch.  Subsequent recorded durations will measure the time elapsed from the moment Reset was called.
+If the Stopwatch was Paused it is unpaused after calling Reset.
+*/
+func (s *Stopwatch) Reset() *Stopwatch {
+	s.running = true
+	s.t = time.Now()
+	s.pauseDuration = 0
+	return s
+}
+
+/*
+Pause pauses the Stopwatch.  While pasued the Stopwatch does not accumulate elapsed time.  This is useful for ignoring expensive operations that are incidental to the behavior you are attempting to characterize.
+Note: You must call Resume() before you can Record() subsequent measurements.
+
+For example:
+
+    stopwatch := experiment.NewStopwatch()
+    // first expensive operation
+    stopwatch.Record("first operation").Reset()
+    // second expensive operation - part 1
+    stopwatch.Pause()
+    // something expensive that we don't care about
+    stopwatch.Resume()
+    // second expensive operation - part 2
+    stopwatch.Record("second operation").Reset() // the recorded duration captures the time elapsed during parts 1 and 2 of the second expensive operation, but not the bit in between
+
+
+The Stopwatch must be running when Pause is called.
+*/
+func (s *Stopwatch) Pause() *Stopwatch {
+	if !s.running {
+		panic("stopwatch is not running - call Resume or Reset before calling Pause")
+	}
+	s.running = false
+	s.pauseT = time.Now()
+	return s
+}
+
+/*
+Resume resumes a paused Stopwatch.  Any time that elapses after Resume is called will be accumulated as elapsed time when a subsequent duration is Recorded.
+
+The Stopwatch must be Paused when Resume is called
+*/
+func (s *Stopwatch) Resume() *Stopwatch {
+	if s.running {
+		panic("stopwatch is running - call Pause before calling Resume")
+	}
+	s.running = true
+	s.pauseDuration = s.pauseDuration + time.Since(s.pauseT)
+	return s
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/table/table.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/table/table.go
@@ -1,0 +1,370 @@
+package table
+
+// This is a temporary package - Table will move to github.com/onsi/consolable once some more dust settles
+
+import (
+	"reflect"
+	"strings"
+	"unicode/utf8"
+)
+
+type AlignType uint
+
+const (
+	AlignTypeLeft AlignType = iota
+	AlignTypeCenter
+	AlignTypeRight
+)
+
+type Divider string
+
+type Row struct {
+	Cells   []Cell
+	Divider string
+	Style   string
+}
+
+func R(args ...interface{}) *Row {
+	r := &Row{
+		Divider: "-",
+	}
+	for _, arg := range args {
+		switch reflect.TypeOf(arg) {
+		case reflect.TypeOf(Divider("")):
+			r.Divider = string(arg.(Divider))
+		case reflect.TypeOf(r.Style):
+			r.Style = arg.(string)
+		case reflect.TypeOf(Cell{}):
+			r.Cells = append(r.Cells, arg.(Cell))
+		}
+	}
+	return r
+}
+
+func (r *Row) AppendCell(cells ...Cell) *Row {
+	r.Cells = append(r.Cells, cells...)
+	return r
+}
+
+func (r *Row) Render(widths []int, totalWidth int, tableStyle TableStyle, isLastRow bool) string {
+	out := ""
+	if len(r.Cells) == 1 {
+		out += strings.Join(r.Cells[0].render(totalWidth, r.Style, tableStyle), "\n") + "\n"
+	} else {
+		if len(r.Cells) != len(widths) {
+			panic("row vs width mismatch")
+		}
+		renderedCells := make([][]string, len(r.Cells))
+		maxHeight := 0
+		for colIdx, cell := range r.Cells {
+			renderedCells[colIdx] = cell.render(widths[colIdx], r.Style, tableStyle)
+			if len(renderedCells[colIdx]) > maxHeight {
+				maxHeight = len(renderedCells[colIdx])
+			}
+		}
+		for colIdx := range r.Cells {
+			for len(renderedCells[colIdx]) < maxHeight {
+				renderedCells[colIdx] = append(renderedCells[colIdx], strings.Repeat(" ", widths[colIdx]))
+			}
+		}
+		border := strings.Repeat(" ", tableStyle.Padding)
+		if tableStyle.VerticalBorders {
+			border += "|" + border
+		}
+		for lineIdx := 0; lineIdx < maxHeight; lineIdx++ {
+			for colIdx := range r.Cells {
+				out += renderedCells[colIdx][lineIdx]
+				if colIdx < len(r.Cells)-1 {
+					out += border
+				}
+			}
+			out += "\n"
+		}
+	}
+	if tableStyle.HorizontalBorders && !isLastRow && r.Divider != "" {
+		out += strings.Repeat(string(r.Divider), totalWidth) + "\n"
+	}
+
+	return out
+}
+
+type Cell struct {
+	Contents []string
+	Style    string
+	Align    AlignType
+}
+
+func C(contents string, args ...interface{}) Cell {
+	c := Cell{
+		Contents: strings.Split(contents, "\n"),
+	}
+	for _, arg := range args {
+		switch reflect.TypeOf(arg) {
+		case reflect.TypeOf(c.Style):
+			c.Style = arg.(string)
+		case reflect.TypeOf(c.Align):
+			c.Align = arg.(AlignType)
+		}
+	}
+	return c
+}
+
+func (c Cell) Width() (int, int) {
+	w, minW := 0, 0
+	for _, line := range c.Contents {
+		lineWidth := utf8.RuneCountInString(line)
+		if lineWidth > w {
+			w = lineWidth
+		}
+		for _, word := range strings.Split(line, " ") {
+			wordWidth := utf8.RuneCountInString(word)
+			if wordWidth > minW {
+				minW = wordWidth
+			}
+		}
+	}
+	return w, minW
+}
+
+func (c Cell) alignLine(line string, width int) string {
+	lineWidth := utf8.RuneCountInString(line)
+	if lineWidth == width {
+		return line
+	}
+	if lineWidth < width {
+		gap := width - lineWidth
+		switch c.Align {
+		case AlignTypeLeft:
+			return line + strings.Repeat(" ", gap)
+		case AlignTypeRight:
+			return strings.Repeat(" ", gap) + line
+		case AlignTypeCenter:
+			leftGap := gap / 2
+			rightGap := gap - leftGap
+			return strings.Repeat(" ", leftGap) + line + strings.Repeat(" ", rightGap)
+		}
+	}
+	return line
+}
+
+func (c Cell) splitWordToWidth(word string, width int) []string {
+	out := []string{}
+	n, subWord := 0, ""
+	for _, c := range word {
+		subWord += string(c)
+		n += 1
+		if n == width-1 {
+			out = append(out, subWord+"-")
+			n, subWord = 0, ""
+		}
+	}
+	return out
+}
+
+func (c Cell) splitToWidth(line string, width int) []string {
+	lineWidth := utf8.RuneCountInString(line)
+	if lineWidth <= width {
+		return []string{line}
+	}
+
+	outLines := []string{}
+	words := strings.Split(line, " ")
+	outWords := []string{words[0]}
+	length := utf8.RuneCountInString(words[0])
+	if length > width {
+		splitWord := c.splitWordToWidth(words[0], width)
+		lastIdx := len(splitWord) - 1
+		outLines = append(outLines, splitWord[:lastIdx]...)
+		outWords = []string{splitWord[lastIdx]}
+		length = utf8.RuneCountInString(splitWord[lastIdx])
+	}
+
+	for _, word := range words[1:] {
+		wordLength := utf8.RuneCountInString(word)
+		if length+wordLength+1 <= width {
+			length += wordLength + 1
+			outWords = append(outWords, word)
+			continue
+		}
+		outLines = append(outLines, strings.Join(outWords, " "))
+
+		outWords = []string{word}
+		length = wordLength
+		if length > width {
+			splitWord := c.splitWordToWidth(word, width)
+			lastIdx := len(splitWord) - 1
+			outLines = append(outLines, splitWord[:lastIdx]...)
+			outWords = []string{splitWord[lastIdx]}
+			length = utf8.RuneCountInString(splitWord[lastIdx])
+		}
+	}
+	if len(outWords) > 0 {
+		outLines = append(outLines, strings.Join(outWords, " "))
+	}
+
+	return outLines
+}
+
+func (c Cell) render(width int, style string, tableStyle TableStyle) []string {
+	out := []string{}
+	for _, line := range c.Contents {
+		out = append(out, c.splitToWidth(line, width)...)
+	}
+	for idx := range out {
+		out[idx] = c.alignLine(out[idx], width)
+	}
+
+	if tableStyle.EnableTextStyling {
+		style = style + c.Style
+		if style != "" {
+			for idx := range out {
+				out[idx] = style + out[idx] + "{{/}}"
+			}
+		}
+	}
+
+	return out
+}
+
+type TableStyle struct {
+	Padding           int
+	VerticalBorders   bool
+	HorizontalBorders bool
+	MaxTableWidth     int
+	MaxColWidth       int
+	EnableTextStyling bool
+}
+
+var DefaultTableStyle = TableStyle{
+	Padding:           1,
+	VerticalBorders:   true,
+	HorizontalBorders: true,
+	MaxTableWidth:     120,
+	MaxColWidth:       40,
+	EnableTextStyling: true,
+}
+
+type Table struct {
+	Rows []*Row
+
+	TableStyle TableStyle
+}
+
+func NewTable() *Table {
+	return &Table{
+		TableStyle: DefaultTableStyle,
+	}
+}
+
+func (t *Table) AppendRow(row *Row) *Table {
+	t.Rows = append(t.Rows, row)
+	return t
+}
+
+func (t *Table) Render() string {
+	out := ""
+	totalWidth, widths := t.computeWidths()
+	for rowIdx, row := range t.Rows {
+		out += row.Render(widths, totalWidth, t.TableStyle, rowIdx == len(t.Rows)-1)
+	}
+	return out
+}
+
+func (t *Table) computeWidths() (int, []int) {
+	nCol := 0
+	for _, row := range t.Rows {
+		if len(row.Cells) > nCol {
+			nCol = len(row.Cells)
+		}
+	}
+
+	// lets compute the contribution to width from the borders + padding
+	borderWidth := t.TableStyle.Padding
+	if t.TableStyle.VerticalBorders {
+		borderWidth += 1 + t.TableStyle.Padding
+	}
+	totalBorderWidth := borderWidth * (nCol - 1)
+
+	// lets compute the width of each column
+	widths := make([]int, nCol)
+	minWidths := make([]int, nCol)
+	for colIdx := range widths {
+		for _, row := range t.Rows {
+			if colIdx >= len(row.Cells) {
+				// ignore rows with fewer columns
+				continue
+			}
+			w, minWid := row.Cells[colIdx].Width()
+			if w > widths[colIdx] {
+				widths[colIdx] = w
+			}
+			if minWid > minWidths[colIdx] {
+				minWidths[colIdx] = minWid
+			}
+		}
+	}
+
+	// do we already fit?
+	if sum(widths)+totalBorderWidth <= t.TableStyle.MaxTableWidth {
+		// yes! we're done
+		return sum(widths) + totalBorderWidth, widths
+	}
+
+	// clamp the widths and minWidths to MaxColWidth
+	for colIdx := range widths {
+		widths[colIdx] = min(widths[colIdx], t.TableStyle.MaxColWidth)
+		minWidths[colIdx] = min(minWidths[colIdx], t.TableStyle.MaxColWidth)
+	}
+
+	// do we fit now?
+	if sum(widths)+totalBorderWidth <= t.TableStyle.MaxTableWidth {
+		// yes! we're done
+		return sum(widths) + totalBorderWidth, widths
+	}
+
+	// hmm... still no... can we possibly squeeze the table in without violating minWidths?
+	if sum(minWidths)+totalBorderWidth >= t.TableStyle.MaxTableWidth {
+		// nope - we're just going to have to exceed MaxTableWidth
+		return sum(minWidths) + totalBorderWidth, minWidths
+	}
+
+	// looks like we don't fit yet, but we should be able to fit without violating minWidths
+	// lets start scaling down
+	n := 0
+	for sum(widths)+totalBorderWidth > t.TableStyle.MaxTableWidth {
+		budget := t.TableStyle.MaxTableWidth - totalBorderWidth
+		baseline := sum(widths)
+
+		for colIdx := range widths {
+			widths[colIdx] = max((widths[colIdx]*budget)/baseline, minWidths[colIdx])
+		}
+		n += 1
+		if n > 100 {
+			break // in case we somehow fail to converge
+		}
+	}
+
+	return sum(widths) + totalBorderWidth, widths
+}
+
+func sum(s []int) int {
+	out := 0
+	for _, v := range s {
+		out += v
+	}
+	return out
+}
+
+func min(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a int, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -651,6 +651,8 @@ github.com/onsi/ginkgo/v2/types
 ## explicit; go 1.18
 github.com/onsi/gomega
 github.com/onsi/gomega/format
+github.com/onsi/gomega/gmeasure
+github.com/onsi/gomega/gmeasure/table
 github.com/onsi/gomega/gstruct
 github.com/onsi/gomega/gstruct/errors
 github.com/onsi/gomega/internal


### PR DESCRIPTION
As what suggested by Ginkgo migration guide, `Measure` node was
deprecated and replaced with `It` node which creates `gmeasure.Experiment`.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind deprecation


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/109744

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ginkgo.Measure has been deprecated in Ginkgo V2, switch to use gomega/gmeasure instead
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig testing