### PR TITLE
Sandbox creation error suppression when pod is deleted

### DIFF
--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -68,7 +68,7 @@ func newFakePodStateProvider() *fakePodStateProvider {
 }
 
 func (f *fakePodStateProvider) IsPodTerminationRequested(uid types.UID) bool {
-	_, found := f.removed[uid]
+	_, found := f.terminated[uid]
 	return found
 }
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -806,7 +806,7 @@ func (m *kubeGenericRuntimeManager) SyncPod(pod *v1.Pod, podStatus *kubecontaine
 			//
 			// SyncPod can still be running when we get here, which
 			// means the PodWorker has not acked the deletion.
-			if m.podStateProvider.IsPodTerminationRequested(pod.UID) {
+			if m.podStateProvider.IsPodTerminationRequested(pod.UID) || m.podStateProvider.ShouldPodContentBeRemoved(pod.UID) {
 				klog.V(4).InfoS("Pod was deleted and sandbox failed to be created", "pod", klog.KObj(pod), "podUID", pod.UID)
 				return
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig node

#### What this PR does / why we need it:
If pods are created and then quickly force deleted there might be a CNI error because the pod does not exist anymore. This was addressed in https://github.com/kubernetes/kubernetes/pull/104268, but the pod can be completely deleted from the worker, rendering the same error again. With this change we add a check to see if the pod has already been deleted, not just scheduled for termination.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
