### PR TITLE
Refactor gc_controller to do not use the deletePod stub

### DIFF
--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -52,7 +52,6 @@ const (
 
 type PodGCController struct {
 	kubeClient clientset.Interface
-	ctx        context.Context
 
 	podLister        corelisters.PodLister
 	podListerSynced  cache.InformerSynced
@@ -80,11 +79,6 @@ func NewPodGC(ctx context.Context, kubeClient clientset.Interface, podInformer c
 	}
 
 	return gcc
-}
-
-func (gcc *PodGCController) deletePod(ctx context.Context, namespace, name string) error {
-	klog.InfoS("PodGC is force deleting Pod", "pod", klog.KRef(namespace, name))
-	return gcc.kubeClient.CoreV1().Pods(namespace).Delete(ctx, name, *metav1.NewDeleteOptions(0))
 }
 
 func (gcc *PodGCController) Run(ctx context.Context) {
@@ -302,4 +296,9 @@ func (o byCreationTimestamp) Less(i, j int) bool {
 		return o[i].Name < o[j].Name
 	}
 	return o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
+}
+
+func (gcc *PodGCController) deletePod(ctx context.Context, namespace, name string) error {
+	klog.InfoS("PodGC is force deleting Pod", "pod", klog.KRef(namespace, name))
+	return gcc.kubeClient.CoreV1().Pods(namespace).Delete(ctx, name, *metav1.NewDeleteOptions(0))
 }

--- a/pkg/controller/podgc/gc_controller_test.go
+++ b/pkg/controller/podgc/gc_controller_test.go
@@ -433,7 +433,7 @@ func TestGCUnscheduledTerminating(t *testing.T) {
 				t.Errorf("Error while listing all Pods: %v", err)
 				return
 			}
-			gcc.gcUnscheduledTerminating(pods)
+			gcc.gcUnscheduledTerminating(context.TODO(), pods)
 			deletedPodNames := getDeletedPodNames(client)
 
 			if pass := compareStringSetToList(test.deletedPodNames, deletedPodNames); !pass {

--- a/pkg/controller/podgc/gc_controller_test.go
+++ b/pkg/controller/podgc/gc_controller_test.go
@@ -18,7 +18,6 @@ package podgc
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/util/workqueue"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/controller"
@@ -61,6 +61,17 @@ func compareStringSetToList(set sets.String, list []string) bool {
 		return false
 	}
 	return true
+}
+
+func getDeletedPodNames(client *fake.Clientset) []string {
+	deletedPodNames := make([]string, 0)
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "delete" && action.GetResource().Resource == "pods" {
+			deleteAction := action.(clienttesting.DeleteAction)
+			deletedPodNames = append(deletedPodNames, deleteAction.GetName())
+		}
+	}
+	return deletedPodNames
 }
 
 func TestGCTerminated(t *testing.T) {
@@ -129,14 +140,6 @@ func TestGCTerminated(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{*testutil.NewNode("node")}})
 			gcc, podInformer, _ := NewFromClient(client, test.threshold)
-			deletedPodNames := make([]string, 0)
-			var lock sync.Mutex
-			gcc.deletePod = func(_, name string) error {
-				lock.Lock()
-				defer lock.Unlock()
-				deletedPodNames = append(deletedPodNames, name)
-				return nil
-			}
 
 			creationTime := time.Unix(0, 0)
 			for _, pod := range test.pods {
@@ -149,6 +152,8 @@ func TestGCTerminated(t *testing.T) {
 			}
 
 			gcc.gc(context.TODO())
+
+			deletedPodNames := getDeletedPodNames(client)
 
 			if pass := compareStringSetToList(test.deletedPodNames, deletedPodNames); !pass {
 				t.Errorf("[%v]pod's deleted expected and actual did not match.\n\texpected: %v\n\tactual: %v",
@@ -329,17 +334,10 @@ func TestGCOrphaned(t *testing.T) {
 			gcc.nodeQueue.ShutDown()
 			gcc.nodeQueue = workqueue.NewDelayingQueueWithCustomClock(fakeClock, "podgc_test_queue")
 
-			deletedPodNames := make([]string, 0)
-			var lock sync.Mutex
-			gcc.deletePod = func(_, name string) error {
-				lock.Lock()
-				defer lock.Unlock()
-				deletedPodNames = append(deletedPodNames, name)
-				return nil
-			}
-
 			// First GC of orphaned pods
 			gcc.gc(context.TODO())
+			deletedPodNames := getDeletedPodNames(client)
+
 			if len(deletedPodNames) > 0 {
 				t.Errorf("no pods should be deleted at this point.\n\tactual: %v", deletedPodNames)
 			}
@@ -371,6 +369,7 @@ func TestGCOrphaned(t *testing.T) {
 
 			// Actual pod deletion
 			gcc.gc(context.TODO())
+			deletedPodNames = getDeletedPodNames(client)
 
 			if pass := compareStringSetToList(test.deletedPodNames, deletedPodNames); !pass {
 				t.Errorf("pod's deleted expected and actual did not match.\n\texpected: %v\n\tactual: %v",
@@ -417,14 +416,6 @@ func TestGCUnscheduledTerminating(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset()
 			gcc, podInformer, _ := NewFromClient(client, -1)
-			deletedPodNames := make([]string, 0)
-			var lock sync.Mutex
-			gcc.deletePod = func(_, name string) error {
-				lock.Lock()
-				defer lock.Unlock()
-				deletedPodNames = append(deletedPodNames, name)
-				return nil
-			}
 
 			creationTime := time.Unix(0, 0)
 			for _, pod := range test.pods {
@@ -443,6 +434,7 @@ func TestGCUnscheduledTerminating(t *testing.T) {
 				return
 			}
 			gcc.gcUnscheduledTerminating(pods)
+			deletedPodNames := getDeletedPodNames(client)
 
 			if pass := compareStringSetToList(test.deletedPodNames, deletedPodNames); !pass {
 				t.Errorf("[%v]pod's deleted expected and actual did not match.\n\texpected: %v\n\tactual: %v, test: %v",
@@ -557,14 +549,7 @@ func TestGCTerminating(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{*testutil.NewNode("node-a")}})
 			gcc, podInformer, nodeInformer := NewFromClient(client, -1)
-			deletedPodNames := make([]string, 0)
-			var lock sync.Mutex
-			gcc.deletePod = func(_, name string) error {
-				lock.Lock()
-				defer lock.Unlock()
-				deletedPodNames = append(deletedPodNames, name)
-				return nil
-			}
+
 			creationTime := time.Unix(0, 0)
 			for _, node := range test.nodes {
 				creationTime = creationTime.Add(2 * time.Hour)
@@ -595,6 +580,8 @@ func TestGCTerminating(t *testing.T) {
 			}
 
 			gcc.gc(context.TODO())
+			deletedPodNames := getDeletedPodNames(client)
+
 			if pass := compareStringSetToList(test.deletedPodNames, deletedPodNames); !pass {
 				t.Errorf("[%v]pod's deleted expected and actual did not match.\n\texpected: %v\n\tactual: %v",
 					i, test.deletedPodNames.List(), deletedPodNames)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR refactors gc_controller to eliminate the deletePod stub. It will allow easier adding or unit tests. 
It is a preparatory code change before 
[Append new pod conditions when deleting pods to indicate the reason for pod deletion #110959](https://github.com/kubernetes/kubernetes/pull/110959).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*

Fixes #
-->
None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?


<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->
- [KEP-3329: Retriable and non-retriable Pod failures for Jobs](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures)
