### PR TITLE
Fix ControllerRevision e2e test flake

### DIFF
--- a/test/e2e/apps/controller_revision.go
+++ b/test/e2e/apps/controller_revision.go
@@ -39,6 +39,7 @@ import (
 	e2edaemonset "k8s.io/kubernetes/test/e2e/framework/daemonset"
 	e2eresource "k8s.io/kubernetes/test/e2e/framework/resource"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -153,6 +154,7 @@ var _ = SIGDescribe("ControllerRevision [Serial]", func() {
 		framework.Logf("%s has been patched", patchedControllerRevision.Name)
 
 		ginkgo.By("Create a new ControllerRevision")
+		ds.Spec.Template.Spec.TerminationGracePeriodSeconds = pointer.Int64(1)
 		newHash, newName := hashAndNameForDaemonSet(ds)
 		newRevision := &appsv1.ControllerRevision{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What type of PR is this?**
/bug

**What this PR does / why we need it:**
The #110122  test is currently flaking badly and this PR will fix the issue.

**Testgrid Link:** [Link](https://testgrid.k8s.io/sig-apps#gce-serial&width=20&include-filter-by-regex=should.manage.the.lifecycle.of.a.ControllerRevision)

**Special notes for your reviewer:**
This is needed ASAP to address the flake

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance