### PR TITLE
Automated cherry pick of #108146: Fixing logic for kubelet permissions check on windows

### DIFF
--- a/cmd/kubelet/app/server_windows.go
+++ b/cmd/kubelet/app/server_windows.go
@@ -19,66 +19,27 @@ limitations under the License.
 package app
 
 import (
-	"fmt"
+	"errors"
 	"os/user"
 
 	"golang.org/x/sys/windows"
+	"k8s.io/klog/v2"
 )
 
-func isAdmin() (bool, error) {
-	// Get current user
+func checkPermissions() error {
+
 	u, err := user.Current()
 	if err != nil {
-		return false, fmt.Errorf("error retrieving current user: %s", err)
-	}
-	// Get IDs of group user is a member of
-	ids, err := u.GroupIds()
-	if err != nil {
-		return false, fmt.Errorf("error retrieving group ids: %s", err)
+		klog.ErrorS(err, "Unable to get current user")
+		return err
 	}
 
-	// Check for existence of BUILTIN\ADMINISTRATORS group id
-	for i := range ids {
-		// BUILTIN\ADMINISTRATORS
-		if "S-1-5-32-544" == ids[i] {
-			return true, nil
-		}
-	}
-	return false, nil
-}
+	// For Windows user.UserName contains the login name and user.Name contains
+	// the user's display name - https://pkg.go.dev/os/user#User
+	klog.InfoS("Kubelet is running as", "login name", u.Username, "dispaly name", u.Name)
 
-func checkPermissions() error {
-	//https://github.com/golang/go/issues/28804#issuecomment-505326268
-	var sid *windows.SID
-	var userIsAdmin bool
-
-	// https://docs.microsoft.com/en-us/windows/desktop/api/securitybaseapi/nf-securitybaseapi-checktokenmembership
-	err := windows.AllocateAndInitializeSid(
-		&windows.SECURITY_NT_AUTHORITY,
-		2,
-		windows.SECURITY_BUILTIN_DOMAIN_RID,
-		windows.DOMAIN_ALIAS_RID_ADMINS,
-		0, 0, 0, 0, 0, 0,
-		&sid)
-	if err != nil {
-		return fmt.Errorf("error while checking for elevated permissions: %s", err)
-	}
-
-	//We must free the sid to prevent security token leaks
-	defer windows.FreeSid(sid)
-	token := windows.Token(0)
-
-	userIsAdmin, err = isAdmin()
-	if err != nil {
-		return fmt.Errorf("error while checking admin group membership: %s", err)
-	}
-
-	member, err := token.IsMember(sid)
-	if err != nil {
-		return fmt.Errorf("error while checking for elevated permissions: %s", err)
-	}
-	if !member {
-		return fmt.Errorf("kubelet needs to run with administrator permissions. Run as admin is: %t, User in admin group: %t", member, userIsAdmin)
+	if !windows.GetCurrentProcessToken().IsElevated() {
+		return errors.New("kubelet needs to run with elevated permissions!")
 	}
 
 	return nil


### PR DESCRIPTION
Cherry pick of #108146 on release-1.22.

#108146: Fixing logic for kubelet permissions check on windows

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Updating kubelet permissions check for Windows nodes to see if process is elevated instead of checking if process owner is in Administrators group
```