### PR TITLE
Add integration test for podgc

### DIFF
--- a/test/integration/podgc/OWNERS
+++ b/test/integration/podgc/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-apps-approvers
+reviewers:
+  - sig-apps-reviewers
+labels:
+  - sig/apps

--- a/test/integration/podgc/main_test.go
+++ b/test/integration/podgc/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podgc
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}

--- a/test/integration/podgc/podgc_test.go
+++ b/test/integration/podgc/podgc_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podgc
+
+import (
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/controller/podgc"
+	"k8s.io/kubernetes/pkg/features"
+	testutils "k8s.io/kubernetes/test/integration/util"
+	"k8s.io/utils/pointer"
+)
+
+// TestPodGcOrphanedPodsWithFinalizer tests deletion of orphaned pods
+func TestPodGcOrphanedPodsWithFinalizer(t *testing.T) {
+	testCtx := setup(t, "podgc-orphaned")
+	defer testutils.CleanupTest(t, testCtx)
+	cs := testCtx.ClientSet
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node",
+		},
+		Spec: v1.NodeSpec{},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				{
+					Type:   v1.NodeReady,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+	node, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create node '%v', err: %v", node.Name, err)
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "testpod",
+			Namespace:  testCtx.NS.Name,
+			Finalizers: []string{"test.k8s.io/finalizer"},
+		},
+		Spec: v1.PodSpec{
+			NodeName: node.Name,
+			Containers: []v1.Container{
+				{Name: "foo", Image: "bar"},
+			},
+		},
+	}
+
+	pod, err = cs.CoreV1().Pods(testCtx.NS.Name).Create(testCtx.Ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error %v, while creating pod: %v", err, klog.KObj(pod))
+	}
+	defer testutils.RemovePodFinalizers(testCtx.ClientSet, t, []*v1.Pod{pod})
+	pod, err = cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error: '%v' while updating pod info: '%v'", err, klog.KObj(pod))
+	}
+
+	// we delete the node to orphan the pod
+	err = cs.CoreV1().Nodes().Delete(testCtx.Ctx, pod.Spec.NodeName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Failed to delete node: %v, err: %v", pod.Spec.NodeName, err)
+	}
+
+	err = wait.PollImmediate(time.Second, time.Second*15, func() (bool, error) {
+		updatedPod, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+		if updatedPod.ObjectMeta.DeletionTimestamp != nil {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Error '%v' while waiting for the pod '%v' to be deleted", err, klog.KObj(pod))
+	}
+}
+
+// TestTerminatingOnOutOfServiceNode tests deletion pods terminating on out-of-service nodes
+func TestTerminatingOnOutOfServiceNode(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeOutOfServiceVolumeDetach, true)()
+	testCtx := setup(t, "podgc-out-of-service")
+	defer testutils.CleanupTest(t, testCtx)
+	cs := testCtx.ClientSet
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node",
+		},
+		Spec: v1.NodeSpec{},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				{
+					Type:   v1.NodeReady,
+					Status: v1.ConditionFalse,
+				},
+			},
+		},
+	}
+	node, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create node '%v', err: %v", node.Name, err)
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testpod",
+			Namespace: testCtx.NS.Name,
+		},
+		Spec: v1.PodSpec{
+			NodeName: node.Name,
+			Containers: []v1.Container{
+				{Name: "foo", Image: "bar"},
+			},
+		},
+	}
+
+	pod, err = cs.CoreV1().Pods(testCtx.NS.Name).Create(testCtx.Ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error %v, while creating pod: %v", err, klog.KObj(pod))
+	}
+
+	// trigger termination of the pod, but with long grace period so that it is not removed immediately
+	err = cs.CoreV1().Pods(testCtx.NS.Name).Delete(testCtx.Ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(300)})
+	if err != nil {
+		t.Fatalf("Error: '%v' while deleting pod: '%v'", err, klog.KObj(pod))
+	}
+
+	// taint the node with the out-of-service taint
+	err = testutils.AddTaintToNode(cs, pod.Spec.NodeName, v1.Taint{Key: v1.TaintNodeOutOfService, Value: "", Effect: v1.TaintEffectNoExecute})
+	if err != nil {
+		t.Fatalf("Failed to taint node: %v, err: %v", pod.Spec.NodeName, err)
+	}
+
+	// wait until the pod is deleted
+	err = wait.PollImmediate(time.Second, time.Second*15, func() (bool, error) {
+		updatedPod, err := cs.CoreV1().Pods(pod.Namespace).Get(testCtx.Ctx, pod.Name, metav1.GetOptions{})
+		if err == nil {
+			return updatedPod == nil, nil
+		}
+		// there was an error
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		t.Fatalf("Error '%v' while waiting for the pod '%v' to be deleted", err, klog.KObj(pod))
+	}
+}
+
+func setup(t *testing.T, name string) *testutils.TestContext {
+	testCtx := testutils.InitTestAPIServer(t, name, nil)
+	externalInformers := informers.NewSharedInformerFactory(testCtx.ClientSet, time.Second)
+
+	podgc := podgc.NewPodGCInternal(testCtx.Ctx,
+		testCtx.ClientSet,
+		externalInformers.Core().V1().Pods(),
+		externalInformers.Core().V1().Nodes(),
+		0,
+		500*time.Millisecond,
+		time.Second)
+
+	// Waiting for all controllers to sync
+	externalInformers.Start(testCtx.Ctx.Done())
+	externalInformers.WaitForCacheSync(testCtx.Ctx.Done())
+
+	go podgc.Run(testCtx.Ctx)
+	return testCtx
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR introduces integration tests for the podgc component. It covers these execution paths which will be modified
during implementation of [Append new pod conditions when deleting pods to indicate the reason for pod deletion #110959](https://github.com/kubernetes/kubernetes/pull/110959).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->
- [KEP-3329: Retriable and non-retriable Pod failures for Jobs](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures)

