### PR TITLE
Add categories to kubectl api-resources wide output and add --categories flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources_test.go
@@ -110,6 +110,7 @@ func TestAPIResourcesRun(t *testing.T) {
 					Kind:       "Foo",
 					Verbs:      []string{"get", "list"},
 					ShortNames: []string{"f", "fo"},
+					Categories: []string{"some-category"},
 				},
 				{
 					Name:       "bars",
@@ -117,6 +118,7 @@ func TestAPIResourcesRun(t *testing.T) {
 					Kind:       "Bar",
 					Verbs:      []string{"get", "list", "create"},
 					ShortNames: []string{},
+					Categories: []string{},
 				},
 			},
 		},
@@ -129,6 +131,7 @@ func TestAPIResourcesRun(t *testing.T) {
 					Kind:       "Baz",
 					Verbs:      []string{"get", "list", "create", "delete"},
 					ShortNames: []string{"b"},
+					Categories: []string{"some-category", "another-category"},
 				},
 				{
 					Name:       "NoVerbs",
@@ -136,6 +139,7 @@ func TestAPIResourcesRun(t *testing.T) {
 					Kind:       "NoVerbs",
 					Verbs:      []string{},
 					ShortNames: []string{"b"},
+					Categories: []string{},
 				},
 			},
 		},
@@ -189,10 +193,10 @@ bazzes   b            somegroup/v1   true         Baz
 			commandSetupFn: func(cmd *cobra.Command) {
 				cmd.Flags().Set("output", "wide")
 			},
-			expectedOutput: `NAME     SHORTNAMES   APIVERSION     NAMESPACED   KIND   VERBS
-bars                  v1             true         Bar    [get list create]
-foos     f,fo         v1             false        Foo    [get list]
-bazzes   b            somegroup/v1   true         Baz    [get list create delete]
+			expectedOutput: `NAME     SHORTNAMES   APIVERSION     NAMESPACED   KIND   VERBS                    CATEGORIES
+bars                  v1             true         Bar    get,list,create          
+foos     f,fo         v1             false        Foo    get,list                 some-category
+bazzes   b            somegroup/v1   true         Baz    get,list,create,delete   some-category,another-category
 `,
 			expectedInvalidations: 1,
 		},
@@ -233,6 +237,27 @@ bazzes   b            somegroup/v1   true         Baz
 			name: "multiple verbs",
 			commandSetupFn: func(cmd *cobra.Command) {
 				cmd.Flags().Set("verbs", "create,delete")
+			},
+			expectedOutput: `NAME     SHORTNAMES   APIVERSION     NAMESPACED   KIND
+bazzes   b            somegroup/v1   true         Baz
+`,
+			expectedInvalidations: 1,
+		},
+		{
+			name: "single category",
+			commandSetupFn: func(cmd *cobra.Command) {
+				cmd.Flags().Set("categories", "some-category")
+			},
+			expectedOutput: `NAME     SHORTNAMES   APIVERSION     NAMESPACED   KIND
+foos     f,fo         v1             false        Foo
+bazzes   b            somegroup/v1   true         Baz
+`,
+			expectedInvalidations: 1,
+		},
+		{
+			name: "multiple categories",
+			commandSetupFn: func(cmd *cobra.Command) {
+				cmd.Flags().Set("categories", "some-category,another-category")
 			},
 			expectedOutput: `NAME     SHORTNAMES   APIVERSION     NAMESPACED   KIND
 bazzes   b            somegroup/v1   true         Baz


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Some resources have one or more categories to which they belong (ie. all, api-extensions).  However, there is not a good way for people to discover those categories.

Additionally, this leads to confusion about commands like `kubectl get all` where it seems that the `all` is some kind of magic keyword, when in reality it is simply a category name that is being resolved.

This PR does the following:
* Adds a "Categories" column to the wide output (`kubectl api-resources -o wide`)
* Adds a `--categories` flag that lets you filter on category, just like you can filter on verb.
* Changes how the verbs column is displayed, so that it is comma-separated, which is how short names are displayed already and how categories will now be displayed, so every multi-value column will be displayed consistently.

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added categories column to the `kubectl api-resources` command's wide output (`-o wide`).
Added `--categories` flag to the `kubectl api-resources` command, which can be used to filter the output to show only resources belonging to one or more categories.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
