### PR TITLE
enable stylecheck check in golangci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,7 @@ linters:
     - ineffassign
     - logcheck
     - staticcheck
+    - stylecheck
     - unused
 
 linters-settings: # please keep this alphabetized
@@ -41,6 +42,10 @@ linters-settings: # please keep this alphabetized
       "-SA5011", # TODO(fix) Possible nil pointer dereference
       "-SA1019", # TODO(fix) Using a deprecated function, variable, constant or field
       "-SA2002"  # TODO(fix) Called testing.T.FailNow or SkipNow in a goroutine, which isn’t allowed
+    ]
+  stylecheck:
+    checks: [
+      "ST1019",  # Importing the same package multiple times.
     ]
   unused:
     go: "1.18"


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
I noticed that there are some related pr to fix the duplicate import issue, and we can fix it earlier by adding detection to golangci-lint. 
https://github.com/kubernetes/kubernetes/pull/109639 should fix all old issue. Add detection to golangci to avoid later problems.


```bash
cmd/kubeadm/app/util/dryrun/dryrun.go:29:2: ST1019: package "k8s.io/kubernetes/cmd/kubeadm/app/constants" is being imported more than once (stylecheck)
        "k8s.io/kubernetes/cmd/kubeadm/app/constants"
        ^
cmd/kubeadm/app/util/dryrun/dryrun.go:30:2: ST1019(related information): other import of "k8s.io/kubernetes/cmd/kubeadm/app/constants" (stylecheck)
        kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
        ^
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:
[source](https://staticcheck.io/docs/checks#ST1019)

<blockquote>
Go allows importing the same package multiple times, as long as different import aliases are being used. That is, the following bit of code is valid:

````go
import (
    "fmt"
    fumpt "fmt"
    format "fmt"
    _ "fmt"
)
````

However, this is very rarely done on purpose. Usually, it is a sign of code that got refactored, accidentally adding duplicate import statements. It is also a rarely known feature, which may contribute to confusion.

Do note that sometimes, this feature may be used intentionally (see for example https://github.com/golang/go/commit/3409ce39bfd7584523b7a8c150a310cea92d879d) – if you want to allow this pattern in your code base, you’re advised to disable this check.
</blockquote>

As far as I know, k8s does not use this feature.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
