### PR TITLE
Always log APF WorkEstimate params in kube-apiserver http logs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
@@ -125,14 +125,10 @@ func WithPriorityAndFairness(
 			workEstimate := workEstimator(r, classification.FlowSchemaName, classification.PriorityLevelName)
 
 			fcmetrics.ObserveWorkEstimatedSeats(classification.PriorityLevelName, classification.FlowSchemaName, workEstimate.MaxSeats())
-			// nolint:logcheck // Not using the result of klog.V
-			// inside the if branch is okay, we just use it to
-			// determine whether the additional information should
-			// be added.
-			if klog.V(4).Enabled() {
-				httplog.AddKeyValue(ctx, "apf_iseats", workEstimate.InitialSeats)
-				httplog.AddKeyValue(ctx, "apf_fseats", workEstimate.FinalSeats)
-			}
+			httplog.AddKeyValue(ctx, "apf_iseats", workEstimate.InitialSeats)
+			httplog.AddKeyValue(ctx, "apf_fseats", workEstimate.FinalSeats)
+			httplog.AddKeyValue(ctx, "apf_additionalLatency", workEstimate.AdditionalLatency)
+
 			return workEstimate
 		}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

It's very hard to debug latency issues without `apf_iseats` and `apf_fseats` fields. Also, there was WorkEstimate.AdditionalLatency field, which was missing. After this change, there would be added to HTTP kube-apiserver logs despite the verbosity level

#### Special notes for your reviewer:

No tests modified, as they currently don't verify httplogs
I checked, that `httplog.AddKeyValue` can accept `time.Duration` as value, see [example](https://github.com/kubernetes/kubernetes/blob/2b14fd9fb133a28cf7295986b93d350af77695c5/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go#L190-L191)

#### Does this PR introduce a user-facing change?

```release-note
Improve debuggability of API Priority&Fairness feature
```

/assign mborsz