### PR TITLE
gitignore __* - leave them for local use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # OSX trash
 .DS_Store
 
+# Developers can store local stuff in dirs named __something
+__*
+
 # Eclipse files
 .classpath
 .project


### PR DESCRIPTION
I know it is useful to keep some local stuff and NOT see it in `git
status`, so let's agree that anything that starts with "__" will be
ignored.


/kind cleanup

```release-note
NONE
```

/sig architecture