### PR TITLE
Makefile: sort debug output by time

### DIFF
--- a/build/root/Makefile.generated_files
+++ b/build/root/Makefile.generated_files
@@ -202,9 +202,10 @@ $(foreach dir, $(PRERELEASE_LIFECYCLE_DIRS), $(eval                            \
 $(META_DIR)/$(PRERELEASE_LIFECYCLE_GEN).todo: $(PRERELEASE_LIFECYCLE_FILES)
 
 $(PRERELEASE_LIFECYCLE_FILES): $(PRERELEASE_LIFECYCLE_GEN)
-	if [[ "$(DBG_CODEGEN)" == 1 ]]; then                 \
-	    echo "DBG: prerelease-lifecycle needed $(@D):";  \
-	    ls -lf --full-time $@ $? || true;                \
+	if [[ "$(DBG_CODEGEN)" == 1 ]]; then                    \
+	    echo "DBG: prerelease-lifecycle needed in $(@D):";  \
+	    ls -lft --full-time $@ || true;                     \
+	    ls -lft --full-time $? || true;                     \
 	fi
 	echo $(PRJ_SRC_PATH)/$(@D) >> $(META_DIR)/$(PRERELEASE_LIFECYCLE_GEN).todo
 
@@ -297,9 +298,10 @@ $(foreach dir, $(DEEPCOPY_DIRS), $(eval                            \
 $(META_DIR)/$(DEEPCOPY_GEN).todo: $(DEEPCOPY_FILES)
 
 $(DEEPCOPY_FILES): $(DEEPCOPY_GEN)
-	if [[ "$(DBG_CODEGEN)" == 1 ]]; then     \
-	    echo "DBG: deepcopy needed $(@D):";  \
-	    ls -lf --full-time $@ $? || true;    \
+	if [[ "$(DBG_CODEGEN)" == 1 ]]; then        \
+	    echo "DBG: deepcopy needed in $(@D):";  \
+	    ls -lft --full-time $@ || true;         \
+	    ls -lft --full-time $? || true;         \
 	fi
 	echo $(PRJ_SRC_PATH)/$(@D) >> $(META_DIR)/$(DEEPCOPY_GEN).todo
 
@@ -398,9 +400,10 @@ $(foreach dir, $(DEFAULTER_DIRS), $(eval                            \
 $(META_DIR)/$(DEFAULTER_GEN).todo: $(DEFAULTER_FILES)
 
 $(DEFAULTER_FILES): $(DEFAULTER_GEN)
-	if [[ "$(DBG_CODEGEN)" == 1 ]]; then      \
-	    echo "DBG: defaulter needed $(@D):";  \
-	    ls -lf --full-time $@ $? || true;     \
+	if [[ "$(DBG_CODEGEN)" == 1 ]]; then         \
+	    echo "DBG: defaulter needed in $(@D):";  \
+	    ls -lft --full-time $@ || true;          \
+	    ls -lft --full-time $? || true;          \
 	fi
 	echo $(PRJ_SRC_PATH)/$(@D) >> $(META_DIR)/$(DEFAULTER_GEN).todo
 
@@ -512,9 +515,10 @@ $(foreach dir, $(CONVERSION_DIRS), $(eval                            \
 $(META_DIR)/$(CONVERSION_GEN).todo: $(CONVERSION_FILES)
 
 $(CONVERSION_FILES): $(CONVERSION_GEN)
-	if [[ "$(DBG_CODEGEN)" == 1 ]]; then       \
-	    echo "DBG: conversion needed $(@D):";  \
-	    ls -lf --full-time $@ $? || true;      \
+	if [[ "$(DBG_CODEGEN)" == 1 ]]; then          \
+	    echo "DBG: conversion needed in $(@D):";  \
+	    ls -lft --full-time $@ || true;           \
+	    ls -lft --full-time $? || true;           \
 	fi
 	echo $(PRJ_SRC_PATH)/$(@D) >> $(META_DIR)/$(CONVERSION_GEN).todo
 


### PR DESCRIPTION
Makes makefile debugging easier (which is useful to approximately 2 people, I know)

/kind cleanup

```release-note
NONE
```

/sig architecture