### PR TITLE
Make yamlfmt tool print filenames

### DIFF
--- a/cmd/yamlfmt/yamlfmt.go
+++ b/cmd/yamlfmt/yamlfmt.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"os"
 
@@ -32,19 +33,23 @@ func main() {
 		for _, path := range flag.Args() {
 			sourceYaml, err := os.ReadFile(path)
 			if err != nil {
-				panic(err)
+				fmt.Fprintf(os.Stderr, "%s: %v\n", path, err)
+				continue
 			}
 			rootNode, err := fetchYaml(sourceYaml)
 			if err != nil {
-				panic(err)
+				fmt.Fprintf(os.Stderr, "%s: %v\n", path, err)
+				continue
 			}
 			writer, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 			if err != nil {
-				panic(err)
+				fmt.Fprintf(os.Stderr, "%s: %v\n", path, err)
+				continue
 			}
 			err = streamYaml(writer, indent, rootNode)
 			if err != nil {
-				panic(err)
+				fmt.Fprintf(os.Stderr, "%s: %v\n", path, err)
+				continue
 			}
 		}
 	}


### PR DESCRIPTION
Otherwise fixing errors YAML is much harder.


/kind cleanup

```release-note
NONE
```

/sig architecture