### PR TITLE
add unit test for pkg/kubelet/types/ func GetPodStartTime()

### DIFF
--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -61,27 +60,59 @@ func newPriorityPodWithStartTime(name string, priority int32, startTime time.Tim
 }
 
 func TestGetEarliestPodStartTime(t *testing.T) {
+	var priority int32 = 1
 	currentTime := time.Now()
-	pod1 := newPriorityPodWithStartTime("pod1", 1, currentTime.Add(time.Second))
-	pod2 := newPriorityPodWithStartTime("pod2", 2, currentTime.Add(time.Second))
-	pod3 := newPriorityPodWithStartTime("pod3", 2, currentTime)
-	victims := &extenderv1.Victims{
-		Pods: []*v1.Pod{pod1, pod2, pod3},
+	tests := []struct {
+		name              string
+		pods              []*v1.Pod
+		expectedStartTime *metav1.Time
+	}{
+		{
+			name:              "Pods length is 0",
+			pods:              []*v1.Pod{},
+			expectedStartTime: nil,
+		},
+		{
+			name: "generate new startTime",
+			pods: []*v1.Pod{
+				newPriorityPodWithStartTime("pod1", 1, currentTime.Add(-time.Second)),
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod2",
+					},
+					Spec: v1.PodSpec{
+						Priority: &priority,
+					},
+				},
+			},
+			expectedStartTime: &metav1.Time{Time: currentTime.Add(-time.Second)},
+		},
+		{
+			name: "Pod with earliest start time last in the list",
+			pods: []*v1.Pod{
+				newPriorityPodWithStartTime("pod1", 1, currentTime.Add(time.Second)),
+				newPriorityPodWithStartTime("pod2", 2, currentTime.Add(time.Second)),
+				newPriorityPodWithStartTime("pod3", 2, currentTime),
+			},
+			expectedStartTime: &metav1.Time{Time: currentTime},
+		},
+		{
+			name: "Pod with earliest start time first in the list",
+			pods: []*v1.Pod{
+				newPriorityPodWithStartTime("pod1", 2, currentTime),
+				newPriorityPodWithStartTime("pod2", 2, currentTime.Add(time.Second)),
+				newPriorityPodWithStartTime("pod3", 2, currentTime.Add(2*time.Second)),
+			},
+			expectedStartTime: &metav1.Time{Time: currentTime},
+		},
 	}
-	startTime := GetEarliestPodStartTime(victims)
-	if !startTime.Equal(pod3.Status.StartTime) {
-		t.Errorf("Got wrong earliest pod start time")
-	}
-
-	pod1 = newPriorityPodWithStartTime("pod1", 2, currentTime)
-	pod2 = newPriorityPodWithStartTime("pod2", 2, currentTime.Add(time.Second))
-	pod3 = newPriorityPodWithStartTime("pod3", 2, currentTime.Add(2*time.Second))
-	victims = &extenderv1.Victims{
-		Pods: []*v1.Pod{pod1, pod2, pod3},
-	}
-	startTime = GetEarliestPodStartTime(victims)
-	if !startTime.Equal(pod1.Status.StartTime) {
-		t.Errorf("Got wrong earliest pod start time, got %v, expected %v", startTime, pod1.Status.StartTime)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			startTime := GetEarliestPodStartTime(&extenderv1.Victims{Pods: test.pods})
+			if !startTime.Equal(test.expectedStartTime) {
+				t.Errorf("startTime is not the expected result,got %v, expected %v", startTime, test.expectedStartTime)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: zhoumingcheng <zhoumingcheng@beyondcent.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Improve test coverage

Add unit tests  for pkg/kubelet/types/ func GetPodStartTime()

Run test coverage command:
```
go test -cover ./pkg/scheduler/util/
```
Befor:
```
ok      k8s.io/kubernetes/pkg/scheduler/util    0.024s  coverage: 80.9% of statements
```
After:
```
ok      k8s.io/kubernetes/pkg/scheduler/util    0.061s  coverage: 85.3% of statements
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Thank you！

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
