### PR TITLE
Remove estimateMinSizeJSON calls for CEL

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
@@ -141,7 +141,7 @@ func Compile(s *schema.Structural, declType *celmodel.DeclType, perCallLimit uin
 	estimator := newCostEstimator(root)
 	// compResults is the return value which saves a list of compilation results in the same order as x-kubernetes-validations rules.
 	compResults := make([]CompilationResult, len(celRules))
-	maxCardinality := celmodel.MaxCardinality(s)
+	maxCardinality := celmodel.MaxCardinality(root.MinSerializedSize)
 	for i, rule := range celRules {
 		compResults[i] = compileRule(rule, env, perCallLimit, estimator, maxCardinality)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/value.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/value.go
@@ -766,4 +766,4 @@ func celBool(pred bool) ref.Val {
 	return types.False
 }
 
-var unknownType = &DeclType{name: "unknown"}
+var unknownType = &DeclType{name: "unknown", MinSerializedSize: 1}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

`estimateMinSizeJSON` is a function that is used to estimate the minimum valid size for a given schema node when serialized into JSON (this is used in turn to calculate how many values things like maps and arrays can have). The function works by walking through everything below the schema node it was given, though since `SchemaDeclType` (which is what calls `estimateMinSizeJSON`) is already walking the entire schema and calls `estimateMinSizeJSON` for all arrays/maps, this results in a lot of redundant `estimateMinSizeJSON` calls. This PR removes the need entirely for `estimateMinSizeJSON` by adding a `MinSerializedSize` attribute to `DeclTypes` instead.

The below two tables show the performance gained from this change; the tables were generated with the benchmark included in this branch (the `estimateMinSizeJSON` table used the benchmark patched onto master), with the depth parameter passed to `genNestedSchema` adjusted as per the values in the `n` column. All runs were performed on a 16-core Intel Xeon clocked at 2.3Ghz with 66GB of RAM.

**with estimateMinSizeJSON**

| n (schema depth) | ns/op |
| --- | --- |
| 1 | 538 |
| 5 | 10275 |
| 10 | 385079 |
| 15 | 22950231 |

**with MinSerializedSize**

| n (schema depth) | ns/op |
| --- | --- |
| 1 | 482 |
| 5 | 2274 |
| 10 | 4863 |
| 15 | 6750 |

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
