### PR TITLE
HandleError of updateStatusIfNeeded in func reconcileAutoscaler

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -581,7 +581,9 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 	if err != nil {
 		a.eventRecorder.Event(hpa, v1.EventTypeWarning, "FailedGetScale", err.Error())
 		setCondition(hpa, autoscalingv2.AbleToScale, v1.ConditionFalse, "FailedGetScale", "the HPA controller was unable to get the target's current scale: %v", err)
-		a.updateStatusIfNeeded(ctx, hpaStatusOriginal, hpa)
+		if err := a.updateStatusIfNeeded(ctx, hpaStatusOriginal, hpa); err != nil {
+			utilruntime.HandleError(err)
+		}
 		return fmt.Errorf("invalid API version in scale target reference: %v", err)
 	}
 
@@ -594,7 +596,9 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 	if err != nil {
 		a.eventRecorder.Event(hpa, v1.EventTypeWarning, "FailedGetScale", err.Error())
 		setCondition(hpa, autoscalingv2.AbleToScale, v1.ConditionFalse, "FailedGetScale", "the HPA controller was unable to get the target's current scale: %v", err)
-		a.updateStatusIfNeeded(ctx, hpaStatusOriginal, hpa)
+		if err := a.updateStatusIfNeeded(ctx, hpaStatusOriginal, hpa); err != nil {
+			utilruntime.HandleError(err)
+		}
 		return fmt.Errorf("unable to determine resource for scale target reference: %v", err)
 	}
 
@@ -602,7 +606,9 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 	if err != nil {
 		a.eventRecorder.Event(hpa, v1.EventTypeWarning, "FailedGetScale", err.Error())
 		setCondition(hpa, autoscalingv2.AbleToScale, v1.ConditionFalse, "FailedGetScale", "the HPA controller was unable to get the target's current scale: %v", err)
-		a.updateStatusIfNeeded(ctx, hpaStatusOriginal, hpa)
+		if err := a.updateStatusIfNeeded(ctx, hpaStatusOriginal, hpa); err != nil {
+			utilruntime.HandleError(err)
+		}
 		return fmt.Errorf("failed to query scale subresource for %s: %v", reference, err)
 	}
 	setCondition(hpa, autoscalingv2.AbleToScale, v1.ConditionTrue, "SucceededGetScale", "the HPA controller was able to get the target's current scale")


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
“updateStatusIfNeeded” may fail in func (a *HorizontalController) reconcileAutoscaler. We should HandleError.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

/release-note-none
/priority backlog
/triage accepted
