### PR TITLE
Re-Generate k8s.io/apimachinery/pkg/util/sets

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/byte.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/byte.go
@@ -28,7 +28,7 @@ type Byte map[byte]Empty
 
 // NewByte creates a Byte from a list of values.
 func NewByte(items ...byte) Byte {
-	ss := Byte{}
+	ss := make(Byte, len(items))
 	ss.Insert(items...)
 	return ss
 }
@@ -87,6 +87,15 @@ func (s Byte) HasAny(items ...byte) bool {
 	return false
 }
 
+// Clone returns a new set which is a copy of the current set.
+func (s Byte) Clone() Byte {
+	result := make(Byte, len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s1 = {a1, a2, a3}
@@ -110,10 +119,7 @@ func (s Byte) Difference(s2 Byte) Byte {
 // s1.Union(s2) = {a1, a2, a3, a4}
 // s2.Union(s1) = {a1, a2, a3, a4}
 func (s1 Byte) Union(s2 Byte) Byte {
-	result := NewByte()
-	for key := range s1 {
-		result.Insert(key)
-	}
+	result := s1.Clone()
 	for key := range s2 {
 		result.Insert(key)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/int.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/int.go
@@ -28,7 +28,7 @@ type Int map[int]Empty
 
 // NewInt creates a Int from a list of values.
 func NewInt(items ...int) Int {
-	ss := Int{}
+	ss := make(Int, len(items))
 	ss.Insert(items...)
 	return ss
 }
@@ -87,6 +87,15 @@ func (s Int) HasAny(items ...int) bool {
 	return false
 }
 
+// Clone returns a new set which is a copy of the current set.
+func (s Int) Clone() Int {
+	result := make(Int, len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s1 = {a1, a2, a3}
@@ -110,10 +119,7 @@ func (s Int) Difference(s2 Int) Int {
 // s1.Union(s2) = {a1, a2, a3, a4}
 // s2.Union(s1) = {a1, a2, a3, a4}
 func (s1 Int) Union(s2 Int) Int {
-	result := NewInt()
-	for key := range s1 {
-		result.Insert(key)
-	}
+	result := s1.Clone()
 	for key := range s2 {
 		result.Insert(key)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/int32.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/int32.go
@@ -28,7 +28,7 @@ type Int32 map[int32]Empty
 
 // NewInt32 creates a Int32 from a list of values.
 func NewInt32(items ...int32) Int32 {
-	ss := Int32{}
+	ss := make(Int32, len(items))
 	ss.Insert(items...)
 	return ss
 }
@@ -87,6 +87,15 @@ func (s Int32) HasAny(items ...int32) bool {
 	return false
 }
 
+// Clone returns a new set which is a copy of the current set.
+func (s Int32) Clone() Int32 {
+	result := make(Int32, len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s1 = {a1, a2, a3}
@@ -110,10 +119,7 @@ func (s Int32) Difference(s2 Int32) Int32 {
 // s1.Union(s2) = {a1, a2, a3, a4}
 // s2.Union(s1) = {a1, a2, a3, a4}
 func (s1 Int32) Union(s2 Int32) Int32 {
-	result := NewInt32()
-	for key := range s1 {
-		result.Insert(key)
-	}
+	result := s1.Clone()
 	for key := range s2 {
 		result.Insert(key)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/int64.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/int64.go
@@ -28,7 +28,7 @@ type Int64 map[int64]Empty
 
 // NewInt64 creates a Int64 from a list of values.
 func NewInt64(items ...int64) Int64 {
-	ss := Int64{}
+	ss := make(Int64, len(items))
 	ss.Insert(items...)
 	return ss
 }
@@ -87,6 +87,15 @@ func (s Int64) HasAny(items ...int64) bool {
 	return false
 }
 
+// Clone returns a new set which is a copy of the current set.
+func (s Int64) Clone() Int64 {
+	result := make(Int64, len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s1 = {a1, a2, a3}
@@ -110,10 +119,7 @@ func (s Int64) Difference(s2 Int64) Int64 {
 // s1.Union(s2) = {a1, a2, a3, a4}
 // s2.Union(s1) = {a1, a2, a3, a4}
 func (s1 Int64) Union(s2 Int64) Int64 {
-	result := NewInt64()
-	for key := range s1 {
-		result.Insert(key)
-	}
+	result := s1.Clone()
 	for key := range s2 {
 		result.Insert(key)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/string.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/string.go
@@ -28,7 +28,7 @@ type String map[string]Empty
 
 // NewString creates a String from a list of values.
 func NewString(items ...string) String {
-	ss := String{}
+	ss := make(String, len(items))
 	ss.Insert(items...)
 	return ss
 }
@@ -87,6 +87,15 @@ func (s String) HasAny(items ...string) bool {
 	return false
 }
 
+// Clone returns a new set which is a copy of the current set.
+func (s String) Clone() String {
+	result := make(String, len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s1 = {a1, a2, a3}
@@ -110,10 +119,7 @@ func (s String) Difference(s2 String) String {
 // s1.Union(s2) = {a1, a2, a3, a4}
 // s2.Union(s1) = {a1, a2, a3, a4}
 func (s1 String) Union(s2 String) String {
-	result := NewString()
-	for key := range s1 {
-		result.Insert(key)
-	}
+	result := s1.Clone()
 	for key := range s2 {
 		result.Insert(key)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Re-generates k8s.io/apimachinery/pkg/util/sets in order to pick up https://github.com/kubernetes/gengo/pull/213

Instead of using `NewString(s.UnsortedList()...)` (which will make interim slice), we can just copy a set directly.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
