### PR TITLE
code-generator: fix panic when running outside of ${GOPATH}/k8s.io/code-generator/

### DIFF
--- a/staging/src/k8s.io/code-generator/pkg/util/build.go
+++ b/staging/src/k8s.io/code-generator/pkg/util/build.go
@@ -23,6 +23,8 @@ import (
 	"reflect"
 	"strings"
 
+	"k8s.io/gengo/args"
+
 	"golang.org/x/tools/go/packages"
 )
 
@@ -63,7 +65,7 @@ func BoilerplatePath() string {
 	// set up paths to check
 	paths := []string{
 		// works when run from root of $GOPATH containing k8s.io/code-generator
-		filepath.Join(reflect.TypeOf(empty{}).PkgPath(), "/../../hack/boilerplate.go.txt"),
+		filepath.Join(args.DefaultSourceTree(), reflect.TypeOf(empty{}).PkgPath(), "/../../hack/boilerplate.go.txt"),
 		// works when run from root of module vendoring k8s.io/code-generator
 		"vendor/k8s.io/code-generator/hack/boilerplate.go.txt",
 		// works when run from root of $GOPATH containing k8s.io/kubernetes

--- a/staging/src/k8s.io/code-generator/pkg/util/build.go
+++ b/staging/src/k8s.io/code-generator/pkg/util/build.go
@@ -65,6 +65,8 @@ func BoilerplatePath() string {
 	// set up paths to check
 	paths := []string{
 		// works when run from root of $GOPATH containing k8s.io/code-generator
+		filepath.Join(reflect.TypeOf(empty{}).PkgPath(), "/../../hack/boilerplate.go.txt"),
+		// works when run outside of $GOPATH
 		filepath.Join(args.DefaultSourceTree(), reflect.TypeOf(empty{}).PkgPath(), "/../../hack/boilerplate.go.txt"),
 		// works when run from root of module vendoring k8s.io/code-generator
 		"vendor/k8s.io/code-generator/hack/boilerplate.go.txt",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes the following bug described in [Issue 131 of code-generator](https://github.com/kubernetes/code-generator/issues/131). 
The bug is described in detail in the issue, but in summary, a previous change to `util.BoilerplatePath()` removed the use of the `args.DefaultSourceTree()` function. As a result, when executing the code outside of `${GOPATH}/k8s.io/code-generator/` and `--go-header-file-path` is not defined, the default header file located [here](https://github.com/kubernetes/code-generator/blob/master/hack/boilerplate.go.txt) won't be found and this will cause a panic. 

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/code-generator/issues/131

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
Fixes a bug that caused a panic when running executing code-generator outside of the `${GOPATH}/k8s.io/code-generator/` directory. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None
