### PR TITLE
Run kubectl api-resources to refresh cache

### DIFF
--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -478,8 +478,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		}
 	})
 
-	// Marked as flaky until https://github.com/kubernetes/kubernetes/issues/65517 is solved.
-	ginkgo.It("[Flaky] kubectl explain works for CR with the same resource name as built-in object.", func(ctx context.Context) {
+	ginkgo.It("kubectl explain works for CR with the same resource name as built-in object.", func(ctx context.Context) {
 		customServiceShortName := fmt.Sprintf("ksvc-%d", time.Now().Unix()) // make short name unique
 		opt := func(crd *apiextensionsv1.CustomResourceDefinition) {
 			crd.ObjectMeta = metav1.ObjectMeta{Name: "services." + crd.Spec.Group}
@@ -493,6 +492,11 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		}
 		crdSvc, err := setupCRDAndVerifySchemaWithOptions(f, schemaCustomService, schemaCustomService, "service", []string{"v1"}, opt)
 		if err != nil {
+			framework.Failf("%v", err)
+		}
+
+		// Run kubectl api-resources to invalidate kubectl's discovery cache
+		if _, err := e2ekubectl.RunKubectl("", "api-resources", "--cached=false"); err != nil {
 			framework.Failf("%v", err)
 		}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
The e2e test **[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin] [Flaky] kubectl explain works for CR with the same resource name as built-in object.** fails with message: 
```
the server doesn't have a resource type "ksvc-1650601303"
```

This PR fixes the test by invalidating kubectl's discovery cache (by executing kubectl api-resources) after the CRD is created, and unmarks the test as `[Flaky]` so that it will run in CI.  It appears to be working in CI according to this PR... I see it passed in pull-kubernetes-e2e-gce-ubuntu-containerd and pull-kubernetes-e2e-kind.

#### Which issue(s) this PR fixes:
Partially #109621 (There are two separate errors identified in that issue)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
