### PR TITLE
Fix typo in attacher_test.go

### DIFF
--- a/pkg/volume/gcepd/attacher_test.go
+++ b/pkg/volume/gcepd/attacher_test.go
@@ -248,7 +248,7 @@ func TestVerifyVolumesAttached(t *testing.T) {
 	verifyDiskAttachedInResult := func(results map[*volume.Spec]bool, spec *volume.Spec, expected bool) error {
 		found, ok := results[spec]
 		if !ok {
-			return fmt.Errorf("expected to find volume %s in verifcation result, but didn't", spec.Name())
+			return fmt.Errorf("expected to find volume %s in verification result, but didn't", spec.Name())
 		}
 		if found != expected {
 			return fmt.Errorf("expected to find volume %s to be have attached value %v but got %v", spec.Name(), expected, found)


### PR DESCRIPTION
#### What type of PR is this?

Typo fixed.

```
verifcation -> verification
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

