### PR TITLE
ipvs ops mode changes

### DIFF
--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -100,6 +100,8 @@ type ServicePort interface {
 	// UsesLocalEndpoints returns true if the service port ever sends traffic to
 	// endpoints based on "Local" traffic policy
 	UsesLocalEndpoints() bool
+        // GetAnnotations returns annotations in the service. Only "kube-proxy.kubernetes.io/" annotations are returned.
+	GetAnnotations() map[string]string
 }
 
 // Endpoint in an interface which abstracts information about an endpoint.

--- a/pkg/util/ipvs/ipvs.go
+++ b/pkg/util/ipvs/ipvs.go
@@ -69,6 +69,8 @@ const (
 	FlagPersistent = 0x1
 	// FlagHashed specify IPVS service hash flag
 	FlagHashed = 0x2
+        // FlagOnePacket specify IPVS one-packet-scheduling flag
+        FlagOnePacket = 0x4
 )
 
 // IPVS required kernel modules.


### PR DESCRIPTION
#### What type of PR is this?
This is a pull request which provides One packet scheduling mode in IPVS. This enables ops mode for a service based on the Annotation and It is applicable for the services with UDP protocol only.   

/kind feature

#### What this PR does / why we need it:
One packet scheduling mode for IPVS does not work for NAT and works only for UDP.  It enables round-robin scheduling per packet for internal UDP traffic where we don't care about return packets. The feature would also be available only for proxy-mode=ipvs.

We need this because Kubernetes is mainly focused on helping with distributing the TCP traffic data. There are multiple examples where a user would want its UDP to be load balanced automatically. Please consider the following test cases - 
1- All UDP packet is recieved through a firewall which will send the UDP packet to the Service. From the service's point of view, it appears that Source IP: Source Port of the UDP packet is always the same even if its actual IP is different (Since incoming is through the Firewall). Hence, the traffic always gets redirected to only one real server despite running of multiple real servers. Normally the handling of responses is done at the application level and forwarding of requests to different real servers at the Network level is the main aim here.

2- SIP Proxy where the SIP Proxy while sending the SIP request to the SIP server is binded to an IP: Port and hence, its traffic keeps getting on the same destination SIP server, despite running the multiple copies of those servers. 

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/110814

#### Special notes for your reviewer:
The PR is 2 parts;

- Store all annotations with prefix; "kube-proxy.kubernetes.io/". This is on "proxy" level, i.e. all proxies are affected by this change.
- In the ipvs proxier the feature above is used to set the scheduler

The first is tested with an added unit-test the last is tested only on cluster. With manifest;

```
apiVersion: v1
kind: Service
metadata:
  name: proxy
  annotations:
    kube-proxy.kubernetes.io/ipvs-ops: "true"
...
```
The scheduler can be investigated with;
```
UDP  10.98.148.249:5060 rr ops 
  -> 10.244.2.27:5060             Masq    1      0          0         
  -> 10.244.2.28:5060             Masq    1      0          0         
  -> 10.244.2.29:5060             Masq    1      0          0
TCP  10.98.148.250:5060 rr
  -> 10.244.2.24:5060             Masq    1      0          0         
  -> 10.244.2.25:5060             Masq    1      0          0         
  -> 10.244.2.26:5060             Masq    1      0          0         
--
UDP  10.98.148.250:5060 rr
  -> 10.244.2.24:5060             Masq    1      0          0         
  -> 10.244.2.25:5060             Masq    1      0          0         
  -> 10.244.2.26:5060             Masq    1      0          0           
```

For the service with IP 10.98.148.249 (proxy), the UDP traffic distributes in rr fashion for every request. For the remaining services, the behavior is default as it should be

#### Does this PR introduce a user-facing change?
```
In proxy-mode=ipvs the scheduler can be controlled with an annotation in the service manifest. Example; 'kube-proxy.kubernetes.io/ipvs-ops: "true"  '
```
