### PR TITLE
kubelet: remove superfluous function

### DIFF
--- a/pkg/kubelet/util/store/filestore.go
+++ b/pkg/kubelet/util/store/filestore.go
@@ -41,7 +41,7 @@ type FileStore struct {
 
 // NewFileStore returns an instance of FileStore.
 func NewFileStore(path string, fs utilfs.Filesystem) (Store, error) {
-	if err := ensureDirectory(fs, path); err != nil {
+	if err := fs.MkdirAll(path, 0755); err != nil {
 		return nil, err
 	}
 	return &FileStore{directoryPath: path, filesystem: fs}, nil
@@ -52,7 +52,7 @@ func (f *FileStore) Write(key string, data []byte) error {
 	if err := ValidateKey(key); err != nil {
 		return err
 	}
-	if err := ensureDirectory(f.filesystem, f.directoryPath); err != nil {
+	if err := f.filesystem.MkdirAll(f.directoryPath, 0755); err != nil {
 		return err
 	}
 
@@ -97,15 +97,6 @@ func (f *FileStore) List() ([]string, error) {
 // getPathByKey returns the full path of the file for the key.
 func (f *FileStore) getPathByKey(key string) string {
 	return filepath.Join(f.directoryPath, key)
-}
-
-// ensureDirectory creates the directory if it does not exist.
-func ensureDirectory(fs utilfs.Filesystem, path string) error {
-	if _, err := fs.Stat(path); err != nil {
-		// MkdirAll returns nil if directory already exists.
-		return fs.MkdirAll(path, 0755)
-	}
-	return nil
 }
 
 // writeFile writes data to path in a single transaction.


### PR DESCRIPTION
the ensureDirectory seems to be just a wrapper around MkdirAll.

Since MkdirAll doesn't treat an existing directory as an error, there is no need of the extra stat() syscall that was previously performed.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

just create the directory without checking if it exists before

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
