### PR TITLE
Automated cherry pick of #110813: Ensure the dir of --audit-log-path exists

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -529,6 +530,9 @@ func (o *AuditLogOptions) getWriter() (io.Writer, error) {
 }
 
 func (o *AuditLogOptions) ensureLogFile() error {
+	if err := os.MkdirAll(filepath.Dir(o.Path), 0700); err != nil {
+		return err
+	}
 	mode := os.FileMode(0600)
 	f, err := os.OpenFile(o.Path, os.O_CREATE|os.O_APPEND|os.O_RDWR, mode)
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit_test.go
@@ -70,6 +70,15 @@ func TestAuditValidOptions(t *testing.T) {
 		},
 		expected: "ignoreErrors<log>",
 	}, {
+		name: "create audit log path dir",
+		options: func() *AuditOptions {
+			o := NewAuditOptions()
+			o.LogOptions.Path = filepath.Join(tmpDir, "non-existing-dir1", "non-existing-dir2", "audit")
+			o.PolicyFile = policy
+			return o
+		},
+		expected: "ignoreErrors<log>",
+	}, {
 		name: "default log no policy",
 		options: func() *AuditOptions {
 			o := NewAuditOptions()


### PR DESCRIPTION
Cherry pick of #110813 on release-1.23.

#110813: Ensure the dir of --audit-log-path exists

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
If the parent directory of the file specified in the `--audit-log-path` argument does not exist, Kubernetes now creates it.
```