### PR TITLE
test: Only Check NPD logs in standalone mode

### DIFF
--- a/test/e2e/node/node_problem_detector.go
+++ b/test/e2e/node/node_problem_detector.go
@@ -113,77 +113,73 @@ var _ = SIGDescribe("NodeProblemDetector", func() {
 			result, err := e2essh.SSH(cmd, host, framework.TestContext.Provider)
 			isStandaloneMode[host] = (err == nil && result.Code == 0)
 
-			ginkgo.By(fmt.Sprintf("Check node %q has node-problem-detector process", host))
-			// Using brackets "[n]" is a trick to prevent grep command itself from
-			// showing up, because string text "[n]ode-problem-detector" does not
-			// match regular expression "[n]ode-problem-detector".
-			psCmd := "ps aux | grep [n]ode-problem-detector"
-			result, err = e2essh.SSH(psCmd, host, framework.TestContext.Provider)
-			framework.ExpectNoError(err)
-			framework.ExpectEqual(result.Code, 0)
-			gomega.Expect(result.Stdout).To(gomega.ContainSubstring("node-problem-detector"))
-
-			ginkgo.By(fmt.Sprintf("Check node-problem-detector is running fine on node %q", host))
-			journalctlCmd := "sudo journalctl -r -u node-problem-detector"
-			result, err = e2essh.SSH(journalctlCmd, host, framework.TestContext.Provider)
-			framework.ExpectNoError(err)
-			framework.ExpectEqual(result.Code, 0)
-			gomega.Expect(result.Stdout).NotTo(gomega.ContainSubstring("node-problem-detector.service: Failed"))
-
-			// Let's assume that node problem detector has started the same time as kubelet
-			// We only will check for the KubeletStart if parsing of date here succeed
-			// This is an optimization to not ssh one more time to get kubelet's start time.
-			// Also we assume specific datetime format to simplify the logic
-			output := result.Stdout
-
-			// searching for the line "Apr 14 04:47:42 gke-cluster-1-default-pool-b1565719-eqht systemd[1]: Started Kubernetes node problem detector." and fallback to
-			idx := strings.Index(output, "Started Kubernetes node problem detector")
-			if idx != -1 {
-				output = output[:idx]
-				idx = strings.LastIndex(output, "\n")
-
-				if idx != -1 {
-					output = output[0:15]
-				}
-
-				st, err := time.Parse("Jan 02 15:04:05", output)
-				st = st.AddDate(time.Now().Year(), 0, 0)
-
-				if err == nil {
-					checkForKubeletStart = time.Since(st) < time.Hour
-				}
-			} else {
-				// fallback to searching the line:
-				// -- Logs begin at Thu 2022-04-28 17:32:39 UTC, end at Thu 2022-04-28 17:40:05 UTC. --
-				idx := strings.Index(output, ", end at ")
-
-				output = output[:idx]
-				idx = strings.LastIndex(output, "-- Logs begin at ")
-				if idx != -1 {
-					output = output[17:]
-				}
-
-				st, err := time.Parse("Mon 2006-01-02 15:04:05 MST", output)
-
-				if err == nil {
-					checkForKubeletStart = time.Since(st) < time.Hour
-				}
-			}
-
-			if !checkForKubeletStart {
-				ginkgo.By("KubeletStart event will NOT be checked")
-			}
-
 			if isStandaloneMode[host] {
+				ginkgo.By(fmt.Sprintf("Check node %q has node-problem-detector process", host))
+				// Using brackets "[n]" is a trick to prevent grep command itself from
+				// showing up, because string text "[n]ode-problem-detector" does not
+				// match regular expression "[n]ode-problem-detector".
+				psCmd := "ps aux | grep [n]ode-problem-detector"
+				result, err = e2essh.SSH(psCmd, host, framework.TestContext.Provider)
+				framework.ExpectNoError(err)
+				framework.ExpectEqual(result.Code, 0)
+				gomega.Expect(result.Stdout).To(gomega.ContainSubstring("node-problem-detector"))
+
+				ginkgo.By(fmt.Sprintf("Check node-problem-detector is running fine on node %q", host))
+				journalctlCmd := "sudo journalctl -r -u node-problem-detector"
+				result, err = e2essh.SSH(journalctlCmd, host, framework.TestContext.Provider)
+				framework.ExpectNoError(err)
+				framework.ExpectEqual(result.Code, 0)
+				gomega.Expect(result.Stdout).NotTo(gomega.ContainSubstring("node-problem-detector.service: Failed"))
+
+				// Let's assume that node problem detector has started the same time as kubelet
+				// We only will check for the KubeletStart if parsing of date here succeed
+				// This is an optimization to not ssh one more time to get kubelet's start time.
+				// Also we assume specific datetime format to simplify the logic
+				output := result.Stdout
+
+				// searching for the line "Apr 14 04:47:42 gke-cluster-1-default-pool-b1565719-eqht systemd[1]: Started Kubernetes node problem detector." and fallback to
+				idx := strings.Index(output, "Started Kubernetes node problem detector")
+				if idx != -1 {
+					output = output[:idx]
+					idx = strings.LastIndex(output, "\n")
+
+					if idx != -1 {
+						output = output[0:15]
+					}
+
+					st, err := time.Parse("Jan 02 15:04:05", output)
+					st = st.AddDate(time.Now().Year(), 0, 0)
+
+					if err == nil {
+						checkForKubeletStart = time.Since(st) < time.Hour
+					}
+				} else {
+					// fallback to searching the line:
+					// -- Logs begin at Thu 2022-04-28 17:32:39 UTC, end at Thu 2022-04-28 17:40:05 UTC. --
+					idx := strings.Index(output, ", end at ")
+
+					output = output[:idx]
+					idx = strings.LastIndex(output, "-- Logs begin at ")
+					if idx != -1 {
+						output = output[17:]
+					}
+
+					st, err := time.Parse("Mon 2006-01-02 15:04:05 MST", output)
+
+					if err == nil {
+						checkForKubeletStart = time.Since(st) < time.Hour
+					}
+				}
+
 				cpuUsage, uptime := getCPUStat(f, host)
 				cpuUsageStats[host] = append(cpuUsageStats[host], cpuUsage)
 				uptimeStats[host] = append(uptimeStats[host], uptime)
-			}
 
+			}
 			ginkgo.By(fmt.Sprintf("Inject log to trigger DockerHung on node %q", host))
 			log := "INFO: task docker:12345 blocked for more than 120 seconds."
 			injectLogCmd := "sudo sh -c \"echo 'kernel: " + log + "' >> /dev/kmsg\""
-			_, err = e2essh.SSH(injectLogCmd, host, framework.TestContext.Provider)
+			result, err = e2essh.SSH(injectLogCmd, host, framework.TestContext.Provider)
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(result.Code, 0)
 		}
@@ -211,6 +207,8 @@ var _ = SIGDescribe("NodeProblemDetector", func() {
 				gomega.Eventually(func() error {
 					return verifyEventExists(f, eventListOptions, "KubeletStart", node.Name)
 				}, pollTimeout, pollInterval).Should(gomega.Succeed())
+			} else {
+				ginkgo.By("KubeletStart event will NOT be checked")
 			}
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

NPD can run in "standalone" or "daemonset" mode in cluster GCE tests.

For standalone mode, NPD runs as a systemd unit, daemonset mode it runs
as pod.

If NPD is running in standalone mode, as soon as we detect that the npd
service does not exist with `systemctl status`, we should skip the rest
of the checks such as looking at the journalctl logs or pid.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This was found as part of upgrading to new Ubuntu 22.04 image. The test was panicing:

```
I0719 00:33:15.748]   �[38;5;13mTest Panicked�[0m
I0719 00:33:15.748]   �[38;5;13mIn �[1m[It]�[0m�[38;5;13m at: �[1m/usr/local/go/src/runtime/panic.go:99�[0m
I0719 00:33:15.748] 
I0719 00:33:15.748]   �[38;5;13mruntime error: slice bounds out of range [:-1]�[0m
I0719 00:33:15.748] 
I0719 00:33:15.749]   �[38;5;13mFull Stack Trace�[0m
I0719 00:33:15.749]     k8s.io/kubernetes/test/e2e/node.glob..func8.2()
I0719 00:33:15.749]     	test/e2e/node/node_problem_detector.go:160 +0x29ae
```

This is because the journalctl log format changed in Ubuntu 20.04 and 22.04 when asking journalctl logs for a systemd service that does not exist, xref [here](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/node/node_problem_detector.go#L160).

We should skip these checks if we detect the systemd service doesn't exist in the first place.

```
root@e2e-test-porterdavid-minion-group-r3zr:~# cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
root@e2e-test-porterdavid-minion-group-r3zr:~# sudo journalctl -r -u node-problem-detector
-- Logs begin at Tue 2022-07-19 04:45:13 UTC, end at Tue 2022-07-19 05:44:50 UTC. --
-- No entries --
root@e2e-test-porterdavid-minion-group-r3zr:~#
```

```
root@ubuntu-jammy:~# cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
root@ubuntu-jammy:~# sudo journalctl -r -u node-problem-detector
-- No entries --
root@ubuntu-jammy:~#
```

Since on 22.04 the output is  `No entries` (without the `Logs begin at`... stanza) we end up panicing here: https://github.com/kubernetes/kubernetes/blob/122254fc01d3f5b5200bc68b77f0b0c49442b52f/test/e2e/node/node_problem_detector.go#L160

If we detect that NPD is not in standalone mode, let's skip these checks in the first place since they don't make sense if NPD is running as a daemonset.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
