### PR TITLE
set ginkgo intercept mode to none to avoid hangs

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -168,10 +168,13 @@ fi
 
 # NOTE: Ginkgo's default timeout has been reduced from 24h to 1h in V2, set it manually here as "24h"
 # for backward compatibility purpose.
+# Set --output-interceptor-mode= none to circumvent cases where the code grabbing the stdout/stderr pipe
+# is not under the framework control and may cause hangs (https://github.com/onsi/ginkgo/issues/851)
 "${program[@]}" "${ginkgo_args[@]:+${ginkgo_args[@]}}" "${e2e_test}" -- \
   "${auth_config[@]:+${auth_config[@]}}" \
   --ginkgo.flake-attempts="${FLAKE_ATTEMPTS}" \
   --ginkgo.timeout="24h" \
+  --ginkgo.output-interceptor-mode=none \
   --host="${KUBE_MASTER_URL}" \
   --provider="${KUBERNETES_PROVIDER}" \
   --gce-project="${PROJECT:-}" \


### PR DESCRIPTION
/kind bug
/kind failing-test
/kind flake
/kind regression

```release-note
NONE
```


> GINKGO_INTERCEPTOR_MODE=NONE will turn off stdout/stderr capture completely. Your specs will still run in parallel however any output to stdout/stderr will be lost. Anything written to GinkgoWriter will work just fine though.

https://github.com/onsi/ginkgo/issues/851#issuecomment-954070168

Let's run with --interceptor-mode-output to none as recommened by the ginkgo author, if is not the solution at least will help us to debug it , see https://github.com/kubernetes/kubernetes/issues/111086#issuecomment-1182341802