### PR TITLE
declare unsupported vSphere versions for in-tree plugin

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
@@ -218,16 +218,12 @@ func (connection *VSphereConnection) NewClient(ctx context.Context) (*vim25.Clie
 		connection.RoundTripperCount = RoundTripperDefaultCount
 	}
 	client.RoundTripper = vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(int(connection.RoundTripperCount)))
-	vcdeprecated, err := isvCenterDeprecated(client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion)
+	vcNotSupported, err := isvCenterNotSupported(client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion)
 	if err != nil {
-		klog.Errorf("failed to check if vCenter version:%v and api version: %s is deprecated. Error: %v", client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion, err)
+		klog.Errorf("failed to check if vCenter version:%v and api version: %s is supported. Error: %v", client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion, err)
 	}
-	if vcdeprecated {
-		// After this deprecation, vSphere 6.5 support period is extended to October 15, 2022 as
-		// https://blogs.vmware.com/vsphere/2021/03/announcing-limited-extension-of-vmware-vsphere-6-5-general-support-period.html
-		// In addition, the external vSphere cloud provider does not support vSphere 6.5.
-		// Please keep vSphere 6.5 support til the period.
-		klog.Warningf("vCenter is deprecated. version: %s, api verson: %s Please consider upgrading vCenter and ESXi servers to 6.7u3 or higher", client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion)
+	if vcNotSupported {
+		klog.Warningf("vCenter version is not supported. version: %s, api verson: %s Please consider upgrading vCenter and ESXi servers to 7.0u2 or higher", client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion)
 	}
 	return client, nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
@@ -29,9 +29,8 @@ import (
 	"github.com/vmware/govmomi/sts"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
-	"k8s.io/klog/v2"
-
 	"k8s.io/client-go/pkg/version"
+	"k8s.io/klog/v2"
 )
 
 // VSphereConnection contains information for connecting to vCenter
@@ -220,10 +219,10 @@ func (connection *VSphereConnection) NewClient(ctx context.Context) (*vim25.Clie
 	client.RoundTripper = vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(int(connection.RoundTripperCount)))
 	vcNotSupported, err := isvCenterNotSupported(client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion)
 	if err != nil {
-		klog.Errorf("failed to check if vCenter version:%v and api version: %s is supported. Error: %v", client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion, err)
+		klog.Errorf("failed to check if vCenter version:%v and api version: %s is supported or not. Error: %v", client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion, err)
 	}
 	if vcNotSupported {
-		klog.Warningf("vCenter version is not supported. version: %s, api verson: %s Please consider upgrading vCenter and ESXi servers to 7.0u2 or higher", client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion)
+		klog.Warningf("vCenter version (version: %q, api verson: %q) is not supported for CSI Migration. Please consider upgrading vCenter and ESXi servers to 7.0u2 or higher for migrating vSphere volumes to CSI.", client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion)
 	}
 	return client, nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils.go
@@ -201,8 +201,9 @@ func VerifyVolumePathsForVMDevices(vmDevices object.VirtualDeviceList, volPaths 
 
 }
 
-// isvCenterDeprecated takes vCenter version and vCenter API version as input and return true if vCenter is deprecated
-func isvCenterDeprecated(vCenterVersion string, vCenterAPIVersion string) (bool, error) {
+// isvCenterNotSupported takes vCenter version and vCenter API version as input and return true if vCenter is no longer
+// supported by VMware for in-tree vSphere volume plugin
+func isvCenterNotSupported(vCenterVersion string, vCenterAPIVersion string) (bool, error) {
 	var vcversion, vcapiversion, minvcversion vcVersion
 	var err error
 	err = vcversion.parse(vCenterVersion)

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils_test.go
@@ -70,11 +70,11 @@ func TestUtils(t *testing.T) {
 	}
 }
 
-func TestIsvCenterDeprecated(t *testing.T) {
+func TestIsvCenterNotSupported(t *testing.T) {
 	type testsData struct {
-		vcVersion    string
-		vcAPIVersion string
-		isDeprecated bool
+		vcVersion      string
+		vcAPIVersion   string
+		isNotSupported bool
 	}
 	testdataArray := []testsData{
 		{"8.0.0", "8.0.0.0", false},
@@ -90,16 +90,16 @@ func TestIsvCenterDeprecated(t *testing.T) {
 	}
 
 	for _, test := range testdataArray {
-		deprecated, err := isvCenterDeprecated(test.vcVersion, test.vcAPIVersion)
+		notsupported, err := isvCenterNotSupported(test.vcVersion, test.vcAPIVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if deprecated != test.isDeprecated {
-			t.Fatalf("deprecation test failed for vc version: %q and vc API version: %q",
+		if notsupported != test.isNotSupported {
+			t.Fatalf("test failed for vc version: %q and vc API version: %q",
 				test.vcVersion, test.vcAPIVersion)
 		} else {
-			t.Logf("deprecation test for vc version: %q and vc API version: %q passed. Is Deprecated : %v",
-				test.vcAPIVersion, test.vcAPIVersion, deprecated)
+			t.Logf("test for vc version: %q and vc API version: %q passed. Is Not Supported : %v",
+				test.vcAPIVersion, test.vcAPIVersion, notsupported)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind documentation
/kind deprecation

#### What this PR does / why we need it:
Declare unsupported vSphere versions for the in-tree plugin.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ACTION REQUIRED: 

vSphere releases less than 7.0u2 are not supported for in-tree vSphere volume as of Kubernetes v1.25. Please consider upgrading vSphere (both ESXi and vCenter)  to 7.0u2 or above.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

cc: @xing-yang 
