### PR TITLE
Promote APIService lifecycle test + 4 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -160,6 +160,18 @@
     1.17 will work on the current Aggregator/API-Server.
   release: v1.17, v1.21
   file: test/e2e/apimachinery/aggregator.go
+- testname: Aggregator, manage lifecycle of an APIService
+  codename: '[sig-api-machinery] Aggregator should manage the lifecycle of an APIService
+    [Conformance]'
+  description: An APIService is created which MUST succeed. The APIService status
+    when replaced MUST succeed. Given the updating of the APIService status, the fields
+    MUST equal the new values. The APIService status when patched MUST succeed. Given
+    the patching of the APIService status, the fields MUST equal the new values. The
+    APIService when replaced MUST succeed. Given the updating of the APIService, the
+    fields MUST equal the new values. It MUST succeed at deleting a collection of
+    APIServices via a label selector.
+  release: v1.25
+  file: test/e2e/apimachinery/aggregator.go
 - testname: Custom Resource Definition Conversion Webhook, convert mixed version list
   codename: '[sig-api-machinery] CustomResourceConversionWebhook [Privileged:ClusterAdmin]
     should be able to convert a non homogeneous list of CRs [Conformance]'

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -108,7 +108,19 @@ var _ = SIGDescribe("Aggregator", func() {
 		TestSampleAPIServer(f, aggrclient, imageutils.GetE2EImage(imageutils.APIServer))
 	})
 
-	ginkgo.It("should manage the lifecycle of an APIService", func() {
+	/*
+		Release: v1.25
+		Testname: Aggregator, manage lifecycle of an APIService
+		Description: An APIService is created which MUST succeed. The
+		APIService status when replaced MUST succeed. Given the updating
+		of the APIService status, the fields MUST equal the new values.
+		The APIService status when patched MUST succeed. Given the patching
+		of the APIService status, the fields MUST equal the new values. The
+		APIService when replaced MUST succeed. Given the updating of the
+		APIService, the fields MUST equal the new values. It MUST succeed at
+		deleting a collection of APIServices via a label selector.
+	*/
+	framework.ConformanceIt("should manage the lifecycle of an APIService", func() {
 
 		ns := f.Namespace.Name
 		framework.Logf("ns: %v", ns)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceApiregistrationV1APIServiceStatus
- replaceApiregistrationV1APIService
-  patchApiregistrationV1APIServiceStatus
- deleteApiregistrationV1CollectionAPIService

**Which issue(s) this PR fixes:**
Fixes #110236

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should%20manage%20the%20lifecycle%20of%20an%20APIService)


**Special notes for your reviewer:**
Adds +4 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance