### PR TITLE
Promote List, Patch & DeleteCollection ResourceQuota test - +3 endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -492,6 +492,17 @@
     MUST match to expected used and total allowed resource quota count within namespace.
   release: v1.16
   file: test/e2e/apimachinery/resource_quota.go
+- testname: ResourceQuota, manage lifecycle of a ResourceQuota
+  codename: '[sig-api-machinery] ResourceQuota should manage the lifecycle of a ResourceQuota
+    [Conformance]'
+  description: Attempt to create a ResourceQuota for CPU and Memory quota limits.
+    Creation MUST be successful. Attempt to list all namespaces with a label selector
+    which MUST succeed. One list MUST be found. The ResourceQuota when patched MUST
+    succeed. Given the patching of the ResourceQuota, the fields MUST equal the new
+    values. It MUST succeed at deleting a collection of ResourceQuota via a label
+    selector.
+  release: v1.25
+  file: test/e2e/apimachinery/resource_quota.go
 - testname: ResourceQuota, quota scope, BestEffort and NotBestEffort scope
   codename: '[sig-api-machinery] ResourceQuota should verify ResourceQuota with best
     effort scope. [Conformance]'

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -919,7 +919,18 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		}
 	})
 
-	ginkgo.It("should manage the lifecycle of a ResourceQuota", func() {
+	/*
+		Release: v1.25
+		Testname: ResourceQuota, manage lifecycle of a ResourceQuota
+		Description: Attempt to create a ResourceQuota for CPU and Memory
+		quota limits. Creation MUST be successful. Attempt to list all
+		namespaces with a label selector which MUST succeed. One list
+		MUST be found. The ResourceQuota when patched MUST succeed.
+		Given the patching of the ResourceQuota, the fields MUST equal
+		the new values. It MUST succeed at deleting a collection of
+		ResourceQuota via a label selector.
+	*/
+	framework.ConformanceIt("should manage the lifecycle of a ResourceQuota", func() {
 		client := f.ClientSet
 		ns := f.Namespace.Name
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoint:
- listCoreV1ResourceQuotaForAllNamespaces
- patchCoreV1NamespacedResourceQuota
- deleteCoreV1CollectionNamespacedResourceQuota

**Which issue(s) this PR fixes:**
Fixes #109682
**Testgrid Link:**
[Testgid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should%20manage%20the%20lifecycle%20of%20a%20ResourceQuota)

**Special notes for your reviewer:**
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance