### PR TITLE
Promote Event Lifecycle Test +1 Endpoint

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1208,13 +1208,15 @@
     its label selector.
   release: v1.20
   file: test/e2e/instrumentation/core_events.go
-- testname: Event resource lifecycle
-  codename: '[sig-instrumentation] Events should ensure that an event can be fetched,
-    patched, deleted, and listed [Conformance]'
-  description: Create an event, the event MUST exist. The event is patched with a
-    new message, the check MUST have the update message. The event is deleted and
-    MUST NOT show up when listing all events.
-  release: v1.20
+- testname: Event, manage lifecycle of an Event
+  codename: '[sig-instrumentation] Events should manage the lifecycle of an event
+    [Conformance]'
+  description: Attempt to create an event which MUST succeed. Attempt to list all
+    namespaces with a label selector which MUST succeed. One list MUST be found. The
+    event is patched with a new message, the check MUST have the update message. The
+    event is updated with a new series of events, the check MUST confirm this update.
+    The event is deleted and MUST NOT show up when listing all events.
+  release: v1.25
   file: test/e2e/instrumentation/core_events.go
 - testname: DNS, cluster
   codename: '[sig-network] DNS should provide /etc/hosts entries for the cluster [Conformance]'

--- a/test/e2e/instrumentation/core_events.go
+++ b/test/e2e/instrumentation/core_events.go
@@ -44,95 +44,20 @@ var _ = common.SIGDescribe("Events", func() {
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	/*
-			   Release: v1.20
-			   Testname: Event resource lifecycle
-			   Description: Create an event, the event MUST exist.
-		           The event is patched with a new message, the check MUST have the update message.
-		           The event is deleted and MUST NOT show up when listing all events.
+		Release: v1.25
+		Testname: Event, manage lifecycle of an Event
+		Description: Attempt to create an event which MUST succeed.
+		Attempt to list all namespaces with a label selector which MUST
+		succeed. One list MUST be found. The event is patched with a
+		new message, the check MUST have the update message. The event
+		is updated with a new series of events, the check MUST confirm
+		this update. The event is deleted and MUST NOT show up when
+		listing all events.
 	*/
-	framework.ConformanceIt("should ensure that an event can be fetched, patched, deleted, and listed", func() {
-		eventTestName := "event-test"
+	framework.ConformanceIt("should manage the lifecycle of an event", func() {
+		// As per SIG-Arch meeting 14 July 2022 this e2e test now supersede
+		// e2e test "Event resource lifecycle", which has been removed.
 
-		ginkgo.By("creating a test event")
-		// create a test event in test namespace
-		_, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Create(context.TODO(), &v1.Event{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: eventTestName,
-				Labels: map[string]string{
-					"testevent-constant": "true",
-				},
-			},
-			Message: "This is a test event",
-			Reason:  "Test",
-			Type:    "Normal",
-			Count:   1,
-			InvolvedObject: v1.ObjectReference{
-				Namespace: f.Namespace.Name,
-			},
-		}, metav1.CreateOptions{})
-		framework.ExpectNoError(err, "failed to create test event")
-
-		ginkgo.By("listing all events in all namespaces")
-		// get a list of Events in all namespaces to ensure endpoint coverage
-		eventsList, err := f.ClientSet.CoreV1().Events("").List(context.TODO(), metav1.ListOptions{
-			LabelSelector: "testevent-constant=true",
-		})
-		framework.ExpectNoError(err, "failed list all events")
-
-		foundCreatedEvent := false
-		var eventCreatedName string
-		for _, val := range eventsList.Items {
-			if val.ObjectMeta.Name == eventTestName && val.ObjectMeta.Namespace == f.Namespace.Name {
-				foundCreatedEvent = true
-				eventCreatedName = val.ObjectMeta.Name
-				break
-			}
-		}
-		if !foundCreatedEvent {
-			framework.Failf("unable to find test event %s in namespace %s, full list of events is %+v", eventTestName, f.Namespace.Name, eventsList.Items)
-		}
-
-		ginkgo.By("patching the test event")
-		// patch the event's message
-		eventPatchMessage := "This is a test event - patched"
-		eventPatch, err := json.Marshal(map[string]interface{}{
-			"message": eventPatchMessage,
-		})
-		framework.ExpectNoError(err, "failed to marshal the patch JSON payload")
-
-		_, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Patch(context.TODO(), eventTestName, types.StrategicMergePatchType, []byte(eventPatch), metav1.PatchOptions{})
-		framework.ExpectNoError(err, "failed to patch the test event")
-
-		ginkgo.By("fetching the test event")
-		// get event by name
-		event, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Get(context.TODO(), eventCreatedName, metav1.GetOptions{})
-		framework.ExpectNoError(err, "failed to fetch the test event")
-		framework.ExpectEqual(event.Message, eventPatchMessage, "test event message does not match patch message")
-
-		ginkgo.By("deleting the test event")
-		// delete original event
-		err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Delete(context.TODO(), eventCreatedName, metav1.DeleteOptions{})
-		framework.ExpectNoError(err, "failed to delete the test event")
-
-		ginkgo.By("listing all events in all namespaces")
-		// get a list of Events list namespace
-		eventsList, err = f.ClientSet.CoreV1().Events("").List(context.TODO(), metav1.ListOptions{
-			LabelSelector: "testevent-constant=true",
-		})
-		framework.ExpectNoError(err, "fail to list all events")
-		foundCreatedEvent = false
-		for _, val := range eventsList.Items {
-			if val.ObjectMeta.Name == eventTestName && val.ObjectMeta.Namespace == f.Namespace.Name {
-				foundCreatedEvent = true
-				break
-			}
-		}
-		if foundCreatedEvent {
-			framework.Failf("Should not have found test event %s in namespace %s, full list of events %+v", eventTestName, f.Namespace.Name, eventsList.Items)
-		}
-	})
-
-	ginkgo.It("should manage the lifecycle of an event", func() {
 		eventTestName := "event-test"
 
 		ginkgo.By("creating a test event")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceCoreV1NamespacedEvent

**Which issue(s) this PR fixes:**
Fixes #110797

**Testgrid Link:** 
[testgrid-link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.manage.the.lifecycle.of.an.event)

**Special notes for your reviewer:**
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance