### PR TITLE
Automated cherry pick of #111235: fix a possible panic because of taking the address of nil

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/auth_loaders.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/auth_loaders.go
@@ -51,10 +51,10 @@ func (a *PromptingAuthLoader) LoadAuth(path string) (*clientauth.Info, error) {
 	// Prompt for user/pass and write a file if none exists.
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		authPtr, err := a.Prompt()
-		auth := *authPtr
 		if err != nil {
 			return nil, err
 		}
+		auth := *authPtr
 		data, err := json.Marshal(auth)
 		if err != nil {
 			return &auth, err


### PR DESCRIPTION
Cherry pick of #111235 on release-1.22.

#111235: fix a possible panic because of taking the address of nil

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```