### PR TITLE
KEP-3327: Add CPUManager policy option to align CPUs by Socket instead of by NUMA node

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_options.go
+++ b/pkg/kubelet/cm/cpumanager/policy_options.go
@@ -28,11 +28,13 @@ import (
 const (
 	FullPCPUsOnlyOption            string = "full-pcpus-only"
 	DistributeCPUsAcrossNUMAOption string = "distribute-cpus-across-numa"
+	AlignBySocketOption            string = "align-by-socket"
 )
 
 var (
 	alphaOptions = sets.NewString(
 		DistributeCPUsAcrossNUMAOption,
+		AlignBySocketOption,
 	)
 	betaOptions = sets.NewString(
 		FullPCPUsOnlyOption,
@@ -69,6 +71,9 @@ type StaticPolicyOptions struct {
 	// Flag to evenly distribute CPUs across NUMA nodes in cases where more
 	// than one NUMA node is required to satisfy the allocation.
 	DistributeCPUsAcrossNUMA bool
+	// Flag to ensure CPU's are considered aligned at socket boundary rather than
+	// NUMA boundary
+	AlignBySocket bool
 }
 
 func NewStaticPolicyOptions(policyOptions map[string]string) (StaticPolicyOptions, error) {
@@ -91,6 +96,12 @@ func NewStaticPolicyOptions(policyOptions map[string]string) (StaticPolicyOption
 				return opts, fmt.Errorf("bad value for option %q: %w", name, err)
 			}
 			opts.DistributeCPUsAcrossNUMA = optValue
+		case AlignBySocketOption:
+			optValue, err := strconv.ParseBool(value)
+			if err != nil {
+				return opts, fmt.Errorf("bad value for option %q: %w", name, err)
+			}
+			opts.AlignBySocket = optValue
 		default:
 			// this should never be reached, we already detect unknown options,
 			// but we keep it as further safety.

--- a/pkg/kubelet/cm/cpumanager/policy_options.go
+++ b/pkg/kubelet/cm/cpumanager/policy_options.go
@@ -73,7 +73,7 @@ type StaticPolicyOptions struct {
 	// Flag to evenly distribute CPUs across NUMA nodes in cases where more
 	// than one NUMA node is required to satisfy the allocation.
 	DistributeCPUsAcrossNUMA bool
-	// Flag to ensure CPU's are considered aligned at socket boundary rather than
+	// Flag to ensure CPUs are considered aligned at socket boundary rather than
 	// NUMA boundary
 	AlignBySocket bool
 }
@@ -114,12 +114,12 @@ func NewStaticPolicyOptions(policyOptions map[string]string) (StaticPolicyOption
 }
 
 func ValidateStaticPolicyOptions(opts StaticPolicyOptions, topology *topology.CPUTopology, topologyManager topologymanager.Store) error {
-	if opts.AlignBySocket == true {
-		//1. not compatible with topology manager single numa policy option
+	if opts.AlignBySocket {
+		// Not compatible with topology manager single-numa-node policy option.
 		if topologyManager.GetPolicy().Name() == topologymanager.PolicySingleNumaNode {
-			return fmt.Errorf("Topolgy manager Single numa policy is incompatible with CPUManager Align  by socket policy option")
+			return fmt.Errorf("Topolgy manager %s policy is incompatible with CPUManager %s policy option", topologymanager.PolicySingleNumaNode, AlignBySocketOption)
 		}
-		//2. not comptuble with topology when num_socets > num_numa
+		// Not compatible with topology when number of sockets are more than number of NUMA nodes.
 		if topology.NumSockets > topology.NumNUMANodes {
 			return fmt.Errorf("Align by socket is not compatible with hardware where number of sockets are more than number of NUMA")
 		}

--- a/pkg/kubelet/cm/cpumanager/policy_options_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_options_test.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	pkgfeatures "k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 )
 
 type optionAvailTest struct {
@@ -54,7 +56,7 @@ func TestPolicyDefaultsAvailable(t *testing.T) {
 	}
 }
 
-func TestPolicyBetaOptionsAvailable(t *testing.T) {
+func TestPolicyOptionsAvailable(t *testing.T) {
 	testCases := []optionAvailTest{
 		{
 			option:            "this-option-does-not-exist",
@@ -80,6 +82,18 @@ func TestPolicyBetaOptionsAvailable(t *testing.T) {
 			featureGateEnable: false,
 			expectedAvailable: false,
 		},
+		{
+			option:            AlignBySocketOption,
+			featureGate:       pkgfeatures.CPUManagerPolicyAlphaOptions,
+			featureGateEnable: true,
+			expectedAvailable: true,
+		},
+		{
+			option:            AlignBySocketOption,
+			featureGate:       pkgfeatures.CPUManagerPolicyBetaOptions,
+			featureGateEnable: true,
+			expectedAvailable: false,
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.option, func(t *testing.T) {
@@ -88,6 +102,77 @@ func TestPolicyBetaOptionsAvailable(t *testing.T) {
 			isEnabled := (err == nil)
 			if isEnabled != testCase.expectedAvailable {
 				t.Errorf("option %q available got=%v expected=%v", testCase.option, isEnabled, testCase.expectedAvailable)
+			}
+		})
+	}
+}
+
+func TestValidateStaticPolicyOptions(t *testing.T) {
+	testCases := []struct {
+		description   string
+		policyOption  map[string]string
+		topology      *topology.CPUTopology
+		topoMgrPolicy string
+		expectedErr   bool
+	}{
+		{
+			description:   "Align by socket not enabled",
+			policyOption:  map[string]string{FullPCPUsOnlyOption: "true"},
+			topology:      topoDualSocketMultiNumaPerSocketHT,
+			topoMgrPolicy: topologymanager.PolicySingleNumaNode,
+			expectedErr:   false,
+		},
+		{
+			description:   "Align by socket enabled with topology manager single numa node",
+			policyOption:  map[string]string{AlignBySocketOption: "true"},
+			topology:      topoDualSocketMultiNumaPerSocketHT,
+			topoMgrPolicy: topologymanager.PolicySingleNumaNode,
+			expectedErr:   true,
+		},
+		{
+			description:   "Align by socket enabled with num_sockets > num_numa",
+			policyOption:  map[string]string{AlignBySocketOption: "true"},
+			topology:      fakeTopoMultiSocketDualSocketPerNumaHT,
+			topoMgrPolicy: topologymanager.PolicyNone,
+			expectedErr:   true,
+		},
+		{
+			description:   "Align by socket enabled: with topology manager None policy",
+			policyOption:  map[string]string{AlignBySocketOption: "true"},
+			topology:      topoDualSocketMultiNumaPerSocketHT,
+			topoMgrPolicy: topologymanager.PolicyNone,
+			expectedErr:   false,
+		},
+		{
+			description:   "Align by socket enabled: with topology manager best-effort policy",
+			policyOption:  map[string]string{AlignBySocketOption: "true"},
+			topology:      topoDualSocketMultiNumaPerSocketHT,
+			topoMgrPolicy: topologymanager.PolicyBestEffort,
+			expectedErr:   false,
+		},
+		{
+			description:   "Align by socket enabled: with topology manager restricted policy",
+			policyOption:  map[string]string{AlignBySocketOption: "true"},
+			topology:      topoDualSocketMultiNumaPerSocketHT,
+			topoMgrPolicy: topologymanager.PolicyRestricted,
+			expectedErr:   false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			topoMgrPolicy := topologymanager.NewNonePolicy()
+			if testCase.topoMgrPolicy == topologymanager.PolicySingleNumaNode {
+				topoMgrPolicy = topologymanager.NewSingleNumaNodePolicy(nil)
+
+			}
+			topoMgrStore := topologymanager.NewFakeManagerWithPolicy(topoMgrPolicy)
+
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)()
+			policyOpt, _ := NewStaticPolicyOptions(testCase.policyOption)
+			err := ValidateStaticPolicyOptions(policyOpt, testCase.topology, topoMgrStore)
+			gotError := (err != nil)
+			if gotError != testCase.expectedErr {
+				t.Errorf("testCase %q failed, got %v expected %v", testCase.description, gotError, testCase.expectedErr)
 			}
 		})
 	}

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -115,6 +115,10 @@ func NewStaticPolicy(topology *topology.CPUTopology, numReservedCPUs int, reserv
 	if err != nil {
 		return nil, err
 	}
+	err = ValidateStaticPolicyOptions(opts, topology, affinity)
+	if err != nil {
+		return nil, err
+	}
 
 	klog.InfoS("Static policy created with configuration", "options", opts)
 

--- a/pkg/kubelet/cm/devicemanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints_test.go
@@ -39,6 +39,10 @@ func (m *mockAffinityStore) GetAffinity(podUID string, containerName string) top
 	return m.hint
 }
 
+func (m *mockAffinityStore) GetPolicy() topologymanager.Policy {
+	return nil
+}
+
 func makeNUMADevice(id string, numa int) pluginapi.Device {
 	return pluginapi.Device{
 		ID:       id,

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -50,6 +50,10 @@ func (m *fakeManager) GetAffinity(podUID string, containerName string) TopologyH
 	return *m.hint
 }
 
+func (m *fakeManager) GetPolicy() Policy {
+	return NewNonePolicy()
+}
+
 func (m *fakeManager) AddHintProvider(h HintProvider) {
 	klog.InfoS("AddHintProvider", "hintProvider", h)
 }

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -24,7 +24,8 @@ import (
 )
 
 type fakeManager struct {
-	hint *TopologyHint
+	hint   *TopologyHint
+	policy Policy
 }
 
 // NewFakeManager returns an instance of FakeManager
@@ -37,7 +38,16 @@ func NewFakeManager() Manager {
 func NewFakeManagerWithHint(hint *TopologyHint) Manager {
 	klog.InfoS("NewFakeManagerWithHint")
 	return &fakeManager{
-		hint: hint,
+		hint:   hint,
+		policy: NewNonePolicy(),
+	}
+}
+
+// NewFakeManagerWithPolicy returns an instance of fake topology manager with specified policy
+func NewFakeManagerWithPolicy(policy Policy) Manager {
+	klog.InfoS("NewFakeManagerWithPolicy")
+	return &fakeManager{
+		policy: policy,
 	}
 }
 
@@ -51,7 +61,7 @@ func (m *fakeManager) GetAffinity(podUID string, containerName string) TopologyH
 }
 
 func (m *fakeManager) GetPolicy() Policy {
-	return NewNonePolicy()
+	return m.policy
 }
 
 func (m *fakeManager) AddHintProvider(h HintProvider) {

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -90,7 +90,7 @@ func (s *scope) GetAffinity(podUID string, containerName string) TopologyHint {
 }
 
 func (s *scope) GetPolicy() Policy {
-    return s.policy
+	return s.policy
 }
 
 func (s *scope) AddHintProvider(h HintProvider) {

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -38,6 +38,7 @@ type podTopologyHints map[string]map[string]TopologyHint
 // Scope interface for Topology Manager
 type Scope interface {
 	Name() string
+	GetPolicy() Policy
 	Admit(pod *v1.Pod) lifecycle.PodAdmitResult
 	// AddHintProvider adds a hint provider to manager to indicate the hint provider
 	// wants to be consoluted with when making topology hints
@@ -86,6 +87,10 @@ func (s *scope) setTopologyHints(podUID string, containerName string, th Topolog
 
 func (s *scope) GetAffinity(podUID string, containerName string) TopologyHint {
 	return s.getTopologyHints(podUID, containerName)
+}
+
+func (s *scope) GetPolicy() Policy {
+    return s.policy
 }
 
 func (s *scope) AddHintProvider(h HintProvider) {

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -95,6 +95,7 @@ type HintProvider interface {
 // Store interface is to allow Hint Providers to retrieve pod affinity
 type Store interface {
 	GetAffinity(podUID string, containerName string) TopologyHint
+	GetPolicy() Policy
 }
 
 // TopologyHint is a struct containing the NUMANodeAffinity for a Container
@@ -182,6 +183,10 @@ func NewManager(topology []cadvisorapi.Node, topologyPolicyName string, topology
 
 func (m *manager) GetAffinity(podUID string, containerName string) TopologyHint {
 	return m.scope.GetAffinity(podUID, containerName)
+}
+
+func (m *manager) GetPolicy() Policy {
+       return m.scope.GetPolicy()
 }
 
 func (m *manager) AddHintProvider(h HintProvider) {

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -186,7 +186,7 @@ func (m *manager) GetAffinity(podUID string, containerName string) TopologyHint 
 }
 
 func (m *manager) GetPolicy() Policy {
-       return m.scope.GetPolicy()
+	return m.scope.GetPolicy()
 }
 
 func (m *manager) AddHintProvider(h HintProvider) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/sig node

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR implements logic of [KEP-3327](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3327-align-by-socket)

#### Which issue(s) this PR fixes:
Enhancement [KEP-3327](https://github.com/kubernetes/enhancements/issues/3327)
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a new `align-by-socket` policy option to cpu manager `static` policy. When enabled CPU's to be aligned at socket boundary rather than NUMA boundary.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
--> 
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3327-align-by-socket
```
