### PR TITLE
*: Move ShouldDelegateList into storage layer and make it exportable

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
@@ -57,14 +57,7 @@ func (e *listWorkEstimator) estimate(r *http.Request, flowSchemaName, priorityLe
 		// return maximumSeats for this request to be consistent.
 		return WorkEstimate{InitialSeats: maximumSeats}
 	}
-	isListFromCache := !storage.ShouldDelegateList(storage.ListOptions{
-		Predicate: storage.SelectionPredicate{
-			Limit:    listOptions.Limit,
-			Continue: listOptions.Continue,
-		},
-		ResourceVersion:      listOptions.ResourceVersion,
-		ResourceVersionMatch: listOptions.ResourceVersionMatch,
-	})
+	isListFromCache := !storage.ShouldDelegateList(storage.ConvertToListOptions(listOptions))
 
 	numStored, err := e.countGetterFn(key(requestInfo))
 	switch {

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -559,14 +559,7 @@ func testListOptionsCase(t *testing.T, rsClient appsv1.ReplicaSetInterface, watc
 
 	// Cacher.GetList uses this for logic to decide if the watch cache is skipped. We need to know it to know if
 	// the limit is respected when testing here.
-	skipWatchCache := storage.ShouldDelegateList(storage.ListOptions{
-		Predicate: storage.SelectionPredicate{
-			Limit:    opts.Limit,
-			Continue: opts.Continue,
-		},
-		ResourceVersion:      opts.ResourceVersion,
-		ResourceVersionMatch: opts.ResourceVersionMatch,
-	})
+	skipWatchCache := storage.ShouldDelegateList(storage.ConvertToListOptions(opts))
 	usingWatchCache := watchCacheEnabled && !skipWatchCache
 
 	if usingWatchCache { // watch cache does not respect limit and is not used for continue


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/priority backlog
#### What this PR does / why we need it:

storage: ShouldDelegateList is now a public function which tells if the LIST request will be served from the watch cache or etcd.

Commit 1:
Previously, shouldDelegateList was an unexported helper function
whose logic was used in list work estimation and integration tests.
This needed any change in its logic to be made individually to
areas which replicated it.

This commit makes the function exportable and makes it a utility
function defined by the storage package hence making it re-usable
by other areas of the codebase.

One of the reasons for moving it into the storage package was also to
avoid import cycles between the cacher package and the flowcontrol package.

Commit 2:
This commit re-uses the ShouldDelegateList utility function from the storage package.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @wojtek-t 