### PR TITLE
Add StatefulSet controller metrics

### DIFF
--- a/pkg/controller/statefulset/metrics.go
+++ b/pkg/controller/statefulset/metrics.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statefulset
+
+import (
+	"sync"
+
+	apps "k8s.io/api/apps/v1"
+	"k8s.io/component-base/metrics"
+)
+
+// StatefulSet is the subsystem name used by this package.
+const StatefulSet = "statefulset"
+
+var (
+	policyCounter = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      StatefulSet,
+			Name:           "statefulset_reconcile_policy_total",
+			Help:           "Count of PVC retention policies seen during reconcile of StatefulSets.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"deleted_policy", "scaled_policy"},
+	)
+	reconcileSeconds = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem:      StatefulSet,
+			Name:           "statefulset_reconcile_seconds",
+			Help:           "StatefulSet reconcile duration in seconds.",
+			Buckets:        metrics.ExponentialBuckets(1, 1.5, 10),
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{},
+	)
+	unhealthyPodsCounter = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      StatefulSet,
+			Name:           "statefulset_unhealthy_pods_total",
+			Help:           "Count of StatefulSets reconciles that saw an unhealthy pod.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{},
+	)
+)
+
+func recordRetentionPolicyMetrics(set *apps.StatefulSet) {
+	if set == nil {
+		return
+	}
+	policy := set.Spec.PersistentVolumeClaimRetentionPolicy
+	if policy == nil {
+		policy = &apps.StatefulSetPersistentVolumeClaimRetentionPolicy{}
+	}
+	deletedPolicy := policy.WhenDeleted
+	if deletedPolicy == "" {
+		deletedPolicy = apps.RetainPersistentVolumeClaimRetentionPolicyType
+	}
+	scaledPolicy := policy.WhenScaled
+	if scaledPolicy == "" {
+		scaledPolicy = apps.RetainPersistentVolumeClaimRetentionPolicyType
+	}
+	policyCounter.WithLabelValues(string(deletedPolicy), string(scaledPolicy)).Inc()
+}
+
+var once sync.Once
+
+func registerMetrics() {
+	once.Do(func() {
+		r := metrics.NewKubeRegistry()
+		r.MustRegister(policyCounter)
+		r.MustRegister(reconcileSeconds)
+		r.MustRegister(unhealthyPodsCounter)
+	})
+}

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -46,6 +46,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
+func init() {
+	registerMetrics()
+}
+
 // controllerKind contains the schema.GroupVersionKind for this controller type.
 var controllerKind = apps.SchemeGroupVersion.WithKind("StatefulSet")
 
@@ -437,7 +441,9 @@ func (ssc *StatefulSetController) worker(ctx context.Context) {
 func (ssc *StatefulSetController) sync(ctx context.Context, key string) error {
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing statefulset %q (%v)", key, time.Since(startTime))
+		duration := time.Since(startTime)
+		klog.V(4).Infof("Finished syncing statefulset %q (%v)", key, duration)
+		reconcileSeconds.WithLabelValues().Observe(duration.Seconds())
 	}()
 
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -290,6 +290,8 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 	unhealthy := 0
 	var firstUnhealthyPod *v1.Pod
 
+	recordRetentionPolicyMetrics(set)
+
 	// First we partition pods into two lists valid replicas and condemned Pods
 	for i := range pods {
 		status.Replicas++
@@ -359,6 +361,7 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 	// find the first unhealthy Pod
 	for i := range replicas {
 		if !isHealthy(replicas[i]) {
+			unhealthyPodsCounter.WithLabelValues().Inc()
 			unhealthy++
 			if firstUnhealthyPod == nil {
 				firstUnhealthyPod = replicas[i]


### PR DESCRIPTION
See new metrics described in the [statefulset autodelete KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/1847-autoremove-statefulset-pvcs#monitoring-requirements).


#### What type of PR is this?

/kind feature


```release-note
StatefulSet controller metrics added: statefulset_non_retain_when_deleted_policy, statefulset_non_retain_when_scaled_policy, statefulset_reconcile_seconds, statefulset_unhealthy_pods_count
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/1847-autoremove-statefulset-pvcs)
