### PR TITLE
Move StatefulSetAutoDeletePVC feature gate to beta

### DIFF
--- a/pkg/apis/apps/fuzzer/fuzzer.go
+++ b/pkg/apis/apps/fuzzer/fuzzer.go
@@ -50,6 +50,15 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 					WhenDeleted: policies[choice&1],
 					WhenScaled:  policies[(choice>>1)&1],
 				}
+			} else {
+				// Defaulting will set empty policy fields, so they are
+				//proactively set here to avoid changes during conversion.
+				if len(s.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted) == 0 {
+					s.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted = apps.RetainPersistentVolumeClaimRetentionPolicyType
+				}
+				if len(s.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled) == 0 {
+					s.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled = apps.RetainPersistentVolumeClaimRetentionPolicyType
+				}
 			}
 			if s.Spec.RevisionHistoryLimit == nil {
 				s.Spec.RevisionHistoryLimit = new(int32)

--- a/pkg/apis/apps/types.go
+++ b/pkg/apis/apps/types.go
@@ -212,7 +212,7 @@ type StatefulSetSpec struct {
 
 	// PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from
 	// the StatefulSet VolumeClaimTemplates. This requires the
-	// StatefulSetAutoDeletePVC feature gate to be enabled, which is alpha.
+	// StatefulSetAutoDeletePVC feature gate to be enabled, which is beta.
 	// +optional
 	PersistentVolumeClaimRetentionPolicy *StatefulSetPersistentVolumeClaimRetentionPolicy
 }

--- a/pkg/apis/apps/v1beta2/defaults_test.go
+++ b/pkg/apis/apps/v1beta2/defaults_test.go
@@ -232,6 +232,10 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 							Partition: &defaultPartition,
 						},
 					},
+					PersistentVolumeClaimRetentionPolicy: &appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy{
+						WhenDeleted: appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
+						WhenScaled:  appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
+					},
 					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
@@ -257,6 +261,10 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 					PodManagementPolicy: appsv1beta2.OrderedReadyPodManagement,
 					UpdateStrategy: appsv1beta2.StatefulSetUpdateStrategy{
 						Type: appsv1beta2.OnDeleteStatefulSetStrategyType,
+					},
+					PersistentVolumeClaimRetentionPolicy: &appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy{
+						WhenDeleted: appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
+						WhenScaled:  appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
 					},
 					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
@@ -285,6 +293,10 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 							Partition: &defaultPartition,
 						},
 					},
+					PersistentVolumeClaimRetentionPolicy: &appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy{
+						WhenDeleted: appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
+						WhenScaled:  appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
+					},
 					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
@@ -309,6 +321,10 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 						RollingUpdate: &appsv1beta2.RollingUpdateStatefulSetStrategy{
 							Partition: getPartition(0),
 						},
+					},
+					PersistentVolumeClaimRetentionPolicy: &appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy{
+						WhenDeleted: appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
+						WhenScaled:  appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
 					},
 					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
@@ -343,6 +359,10 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 							MaxUnavailable: getMaxUnavailable(1),
 						},
 					},
+					PersistentVolumeClaimRetentionPolicy: &appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy{
+						WhenDeleted: appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
+						WhenScaled:  appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
+					},
 					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
@@ -376,6 +396,10 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 							MaxUnavailable: getMaxUnavailable(3),
 						},
 					},
+					PersistentVolumeClaimRetentionPolicy: &appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy{
+						WhenDeleted: appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
+						WhenScaled:  appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
+					},
 					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
@@ -402,6 +426,10 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 							Partition:      getPartition(0),
 							MaxUnavailable: getMaxUnavailable(1),
 						},
+					},
+					PersistentVolumeClaimRetentionPolicy: &appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy{
+						WhenDeleted: appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
+						WhenScaled:  appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
 					},
 					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
@@ -435,6 +463,10 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 							Partition:      getPartition(42),
 							MaxUnavailable: getMaxUnavailable(3),
 						},
+					},
+					PersistentVolumeClaimRetentionPolicy: &appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy{
+						WhenDeleted: appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
+						WhenScaled:  appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType,
 					},
 					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -754,6 +754,7 @@ const (
 
 	// owner: @mattcary
 	// alpha: v1.22
+	// beta: v1.26
 	//
 	// Enables policies controlling deletion of PVCs created by a StatefulSet.
 	StatefulSetAutoDeletePVC featuregate.Feature = "StatefulSetAutoDeletePVC"
@@ -1035,7 +1036,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	SizeMemoryBackedVolumes: {Default: true, PreRelease: featuregate.Beta},
 
-	StatefulSetAutoDeletePVC: {Default: false, PreRelease: featuregate.Alpha},
+	StatefulSetAutoDeletePVC: {Default: true, PreRelease: featuregate.Beta},
 
 	StatefulSetMinReadySeconds: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.27
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -1453,6 +1453,12 @@ items:
     - create
     - patch
     - update
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumeclaims
+    verbs:
+    - update
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

Move statefulset autodelete feature to beta.

```release-note
StatefulSetAutoDeletePVC feature gate promoted to beta.
```

- [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/1847-autoremove-statefulset-pvcs)

/sig apps