### PR TITLE
Cleanup no longer used Create/Delete TestingNamespace

### DIFF
--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -44,28 +44,6 @@ const (
 	singleCallTimeout = 5 * time.Minute
 )
 
-// CreateTestingNamespace creates a namespace for testing.
-func CreateTestingNamespace(baseName string, t *testing.T) *v1.Namespace {
-	// TODO: Create a namespace with a given basename.
-	// Currently we neither create the namespace nor delete all of its contents at the end.
-	// But as long as tests are not using the same namespaces, this should work fine.
-	// Note: As the integration tests do not run with admission turned on, it's not actually
-	// required to persist a Namespace object to create other objects inside of it.
-	return &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			// TODO: Once we start creating namespaces, switch to GenerateName.
-			Name: baseName,
-		},
-	}
-}
-
-// DeleteTestingNamespace is currently a no-op function.
-func DeleteTestingNamespace(ns *v1.Namespace, t *testing.T) {
-	// TODO: Remove all resources from a given namespace once we implement CreateTestingNamespace.
-	// Note: integration tests are not expected to run against persistent fixtures today, so not
-	// cleaning up data they create has no impact.
-}
-
 // CreateNamespaceOrDie creates a namespace.
 func CreateNamespaceOrDie(c clientset.Interface, baseName string, t *testing.T) *v1.Namespace {
 	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: baseName}}

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -213,7 +213,7 @@ func CleanupTest(t *testing.T, testCtx *TestContext) {
 	testCtx.CancelFn()
 	// Cleanup nodes.
 	testCtx.ClientSet.CoreV1().Nodes().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
-	framework.DeleteTestingNamespace(testCtx.NS, t)
+	framework.DeleteNamespaceOrDie(testCtx.ClientSet, testCtx.NS, t)
 	testCtx.CloseFn()
 }
 


### PR DESCRIPTION
```release-note
NONE
```

/kind cleanup
/sig testing
/priority important-longterm

