### PR TITLE
Update PodIP after sandbox creation

### DIFF
--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -222,11 +222,15 @@ func (f *FakeRuntime) GetPods(all bool) ([]*kubecontainer.Pod, error) {
 	return pods, f.Err
 }
 
-func (f *FakeRuntime) SyncPod(pod *v1.Pod, _ *kubecontainer.PodStatus, _ []v1.Secret, backOff *flowcontrol.Backoff) (result kubecontainer.PodSyncResult) {
+func (f *FakeRuntime) SyncPodSandbox(pod *v1.Pod, _ *kubecontainer.PodStatus) (result kubecontainer.PodSyncResult, podIPs []string, podSandboxID string) {
+	return
+}
+
+func (f *FakeRuntime) SyncPodContainers(pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, backOff *flowcontrol.Backoff, podIPs []string, podSandboxID string) (result kubecontainer.PodSyncResult) {
 	f.Lock()
 	defer f.Unlock()
 
-	f.CalledFunctions = append(f.CalledFunctions, "SyncPod")
+	f.CalledFunctions = append(f.CalledFunctions, "SyncPodContainers")
 	f.StartedPods = append(f.StartedPods, string(pod.UID))
 	for _, c := range pod.Spec.Containers {
 		f.StartedContainers = append(f.StartedContainers, c.Name)

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -315,18 +315,34 @@ func (mr *MockRuntimeMockRecorder) Status() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockRuntime)(nil).Status))
 }
 
-// SyncPod mocks base method.
-func (m *MockRuntime) SyncPod(pod *v1.Pod, podStatus *container.PodStatus, pullSecrets []v1.Secret, backOff *flowcontrol.Backoff) container.PodSyncResult {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncPod", pod, podStatus, pullSecrets, backOff)
+// SyncPodSandbox mocks base method.
+func (r *MockRuntime) SyncPodSandbox(pod *v1.Pod, status *container.PodStatus) (result container.PodSyncResult, podIPs []string, podSandboxID string) {
+	r.ctrl.T.Helper()
+	ret := r.ctrl.Call(r, "SyncPodSandbox", pod, status)
+	ret0, _ := ret[0].(container.PodSyncResult)
+	ret1, _ := ret[1].([]string)
+	ret2, _ := ret[2].(string)
+	return ret0, ret1, ret2
+}
+
+// SyncPod indicates an expected call of SyncPodSandbox.
+func (mr *MockRuntimeMockRecorder) SyncPodSandbox(pod *v1.Pod, podStatus *container.PodStatus) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncPodSandbox", reflect.TypeOf((*MockRuntime)(nil).SyncPodSandbox), pod, podStatus)
+}
+
+// SyncPodContainers mocks base method.
+func (r *MockRuntime) SyncPodContainers(pod *v1.Pod, status *container.PodStatus, secrets []v1.Secret, backOff *flowcontrol.Backoff, podIPs []string, podSandboxID string) container.PodSyncResult {
+	r.ctrl.T.Helper()
+	ret := r.ctrl.Call(r, "SyncPodContainers", pod, status, secrets, backOff, podIPs, podSandboxID)
 	ret0, _ := ret[0].(container.PodSyncResult)
 	return ret0
 }
 
-// SyncPod indicates an expected call of SyncPod.
-func (mr *MockRuntimeMockRecorder) SyncPod(pod, podStatus, pullSecrets, backOff interface{}) *gomock.Call {
+// SyncPodContainers indicates an expected call of SyncPodContainers.
+func (mr *MockRuntimeMockRecorder) SyncPodContainers(pod *v1.Pod, podStatus *container.PodStatus, pullSecrets, backOff interface{}, podIPs []string, podSandboxID string) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncPod", reflect.TypeOf((*MockRuntime)(nil).SyncPod), pod, podStatus, pullSecrets, backOff)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncPodContainers", reflect.TypeOf((*MockRuntime)(nil).SyncPodContainers), pod, podStatus, pullSecrets, backOff, podIPs, podSandboxID)
 }
 
 // Type mocks base method.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1727,8 +1727,39 @@ func (kl *Kubelet) syncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	// Ensure the pod is being probed
 	kl.probeManager.AddPod(pod)
 
-	// Call the container runtime's SyncPod callback
-	result := kl.containerRuntime.SyncPod(pod, podStatus, pullSecrets, kl.backOff)
+	// Call the container runtime's SyncPodSandbox callback
+	result, podIPs, sandboxID := kl.containerRuntime.SyncPodSandbox(pod, podStatus)
+	kl.reasonCache.Update(pod.UID, result)
+	if err := result.Error(); err != nil {
+		// Do not return error if the only failures were pods in backoff
+		for _, r := range result.SyncResults {
+			if r.Error != kubecontainer.ErrCrashLoopBackOff && r.Error != images.ErrImagePullBackOff {
+				// Do not record an event here, as we keep all event logging for sync pod failures
+				// local to container runtime so we get better errors
+				return false, err
+			}
+		}
+
+		return false, nil
+	}
+
+	podStatus2, err := kl.containerRuntime.GetPodStatus(pod.UID, pod.Name, pod.Namespace)
+	if err != nil {
+		klog.Warningf("unable to get pod status for %s : %v", pod.Name, err)
+	} else {
+		if len(podIPs) != 0 {
+			klog.Infof("podIP is %s, IPs from current podStatus %v", podIPs[0], podStatus2.IPs)
+			podStatus.IPs = podIPs
+		} else {
+			klog.Infof("IPs from current podStatus %v, from prior %v", podStatus2.IPs, podStatus.IPs)
+			podStatus.IPs = podStatus2.IPs
+		}
+		apiPodStatus := kl.generateAPIPodStatus(pod, podStatus)
+		// Update status in the status manager
+		kl.statusManager.SetPodStatus(pod, apiPodStatus)
+	}
+
+	result = kl.containerRuntime.SyncPodContainers(pod, podStatus, pullSecrets, kl.backOff, podIPs, sandboxID)
 	kl.reasonCache.Update(pod.UID, result)
 	if err := result.Error(); err != nil {
 		// Do not return error if the only failures were pods in backoff


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR splits SyncPod into two phases (SyncPod and SyncPodContainers): the first phase (SyncPod) creates sandbox, if needed.
PodStatus is updated after the first step.
The second step (SyncPodContainers) is to create various containers.

It introduces a map within kubeGenericRuntimeManager to handle the pod UID and podActions mapping so that podActions struct is not leaked to other classes.

#### Which issue(s) this PR fixes:
Fixes #85966

#### Special notes for your reviewer:
This is a rebase of #88169 just in the hope that the issue can move on any direction (towards resolution or withdrawal with an official note as danwinship mentions on https://github.com/kubernetes/kubernetes/issues/85966#issuecomment-1163340134). 

I'm not taking further assumptions, just rebase and making original PR tests work again.
It's also my first PR, so I could be missing things (hopefully not) or the original design idea does not fit on the current project status.

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
