### PR TITLE
Adding value attribute to get the value of zone property as per the u…

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -111,9 +111,9 @@ if [ "${remote}" = true ] && [ "${remote_mode}" = gce ] ; then
   fi
 
   # Get the compute zone
-  zone=${ZONE:-"$(gcloud info --format='value(config.properties.compute.zone)')"}
+  zone=${ZONE:-"$(gcloud info --format='value(config.properties.compute.zone.value)')"}
   if [[ ${zone} == "" ]]; then
-    echo "Could not find gcloud compute/zone when running: \`gcloud info --format='value(config.properties.compute.zone)'\`"
+    echo "Could not find gcloud compute/zone when running: \`gcloud info --format='value(config.properties.compute.zone.value)'\`"
     exit 1
   fi
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node

#### What this PR does / why we need it:

As per https://cloud.google.com/sdk/docs/release-notes#miscellaneous, gcloud changed their output for 'gcloud info' command and requires value attribute i.e.".value" to get the value of a property. Hence, this PR is appending ".value" to get the value of zone being set in the property file.

Output of gcloud info command without using value attribute for zone property:
$ gcloud info --format='value(config.properties.compute.zone)'
source={'name': 'PROPERTY_FILE', 'value': 'property file'};value=us-central1-c

Output of gcloud info command with value attribute for zone property:
$ gcloud info --format='value(config.properties.compute.zone.value)'
us-central1-c

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```