### PR TITLE
Add e2e HPA Behavior tests: scale up/down limited by number of Pods / min, scale up/down limited by percentage / min

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -30,6 +30,12 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 	f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
+	hpaName := "consumer"
+
+	podCPURequest := 500
+	targetCPUUtilizationPercent := 25
+	usageForSingleReplica := 110
+
 	fullWindowOfNewUsage := 30 * time.Second
 	windowWithOldUsagePasses := 30 * time.Second
 	newPodMetricsDelay := 15 * time.Second
@@ -48,16 +54,13 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 	ginkgo.Describe("with short downscale stabilization window", func() {
 		ginkgo.It("should scale down soon after the stabilization period", func() {
 			ginkgo.By("setting up resource consumer and HPA")
-			podCPURequest := 500
-			targetCPUUtilizationPercent := 25
-			usageForSingleReplica := 110
 			initPods := 1
 			initCPUUsageTotal := initPods * usageForSingleReplica
 			upScaleStabilization := 0 * time.Minute
 			downScaleStabilization := 1 * time.Minute
 
 			rc := e2eautoscaling.NewDynamicResourceConsumer(
-				"consumer", f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
@@ -92,16 +95,13 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 	ginkgo.Describe("with long upscale stabilization window", func() {
 		ginkgo.It("should scale up only after the stabilization period", func() {
 			ginkgo.By("setting up resource consumer and HPA")
-			podCPURequest := 500
-			targetCPUUtilizationPercent := 25
-			usageForSingleReplica := 110
 			initPods := 2
 			initCPUUsageTotal := initPods * usageForSingleReplica
 			upScaleStabilization := 3 * time.Minute
 			downScaleStabilization := 0 * time.Minute
 
 			rc := e2eautoscaling.NewDynamicResourceConsumer(
-				"consumer", f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
@@ -133,24 +133,21 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 		})
 	})
 
-	ginkgo.Describe("with upscale autoscaling disabled", func() {
+	ginkgo.Describe("with autoscaling disabled", func() {
 		ginkgo.It("shouldn't scale up", func() {
 			ginkgo.By("setting up resource consumer and HPA")
-			podCPURequest := 500
-			targetCPUUtilizationPercent := 25
-			usageForSingleReplica := 110
 			initPods := 1
 			initCPUUsageTotal := initPods * usageForSingleReplica
 
 			rc := e2eautoscaling.NewDynamicResourceConsumer(
-				"consumer", f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
 			defer rc.CleanUp()
 
 			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
-				rc, int32(targetCPUUtilizationPercent), 1, 10, e2eautoscaling.HPABehaviorWithScaleUpDisabled(),
+				rc, int32(targetCPUUtilizationPercent), 1, 10, e2eautoscaling.HPABehaviorWithScaleDisabled(e2eautoscaling.ScaleUpDirection),
 			)
 			defer e2eautoscaling.DeleteHPAWithBehavior(rc, hpa.Name)
 
@@ -171,26 +168,21 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			replicas := rc.GetReplicas()
 			framework.ExpectEqual(replicas == initPods, true, "had %s replicas, still have %s replicas after time deadline", initPods, replicas)
 		})
-	})
 
-	ginkgo.Describe("with downscale autoscaling disabled", func() {
 		ginkgo.It("shouldn't scale down", func() {
 			ginkgo.By("setting up resource consumer and HPA")
-			podCPURequest := 500
-			targetCPUUtilizationPercent := 25
-			usageForSingleReplica := 110
 			initPods := 3
 			initCPUUsageTotal := initPods * usageForSingleReplica
 
 			rc := e2eautoscaling.NewDynamicResourceConsumer(
-				"consumer", f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
 			defer rc.CleanUp()
 
 			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
-				rc, int32(targetCPUUtilizationPercent), 1, 10, e2eautoscaling.HPABehaviorWithScaleDownDisabled(),
+				rc, int32(targetCPUUtilizationPercent), 1, 10, e2eautoscaling.HPABehaviorWithScaleDisabled(e2eautoscaling.ScaleDownDirection),
 			)
 			defer e2eautoscaling.DeleteHPAWithBehavior(rc, hpa.Name)
 
@@ -212,6 +204,178 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			replicas := rc.GetReplicas()
 			framework.ExpectEqual(replicas == initPods, true, "had %s replicas, still have %s replicas after time deadline", initPods, replicas)
 		})
+
 	})
 
+	ginkgo.Describe("with scale limited by number of Pods rate", func() {
+		ginkgo.It("should scale up no more than given number of Pods per minute", func() {
+			ginkgo.By("setting up resource consumer and HPA")
+			initPods := 1
+			initCPUUsageTotal := initPods * usageForSingleReplica
+			limitWindowLength := 1 * time.Minute
+			podsLimitPerMinute := 2
+
+			rc := e2eautoscaling.NewDynamicResourceConsumer(
+				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
+				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
+			)
+			defer rc.CleanUp()
+
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+				rc, int32(targetCPUUtilizationPercent), 1, 10,
+				e2eautoscaling.HPABehaviorWithScaleLimitedByNumberOfPods(e2eautoscaling.ScaleUpDirection, int32(podsLimitPerMinute), int32(limitWindowLength.Seconds())),
+			)
+			defer e2eautoscaling.DeleteHPAWithBehavior(rc, hpa.Name)
+
+			ginkgo.By("triggering scale up by increasing consumption")
+			rc.ConsumeCPU(5 * usageForSingleReplica)
+
+			waitStart := time.Now()
+			rc.WaitForReplicas(3, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			timeWaitedFor3 := time.Now().Sub(waitStart)
+
+			waitStart = time.Now()
+			rc.WaitForReplicas(5, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			timeWaitedFor5 := time.Now().Sub(waitStart)
+
+			ginkgo.By("verifying time waited for a scale up to 3 replicas")
+			deadline := limitWindowLength + maxHPAReactionTime + maxResourceConsumerDelay
+			// First scale event can happen right away, as there were no scale events in the past.
+			framework.ExpectEqual(timeWaitedFor3 < deadline, true, "waited %s, wanted less than %s", timeWaitedFor3, deadline)
+
+			ginkgo.By("verifying time waited for a scale up to 5 replicas")
+			// Second scale event needs to respect limit window.
+			framework.ExpectEqual(timeWaitedFor5 > limitWindowLength, true, "waited %s, wanted to wait more than %s", timeWaitedFor5, limitWindowLength)
+			framework.ExpectEqual(timeWaitedFor5 < deadline, true, "waited %s, wanted less than %s", timeWaitedFor5, deadline)
+		})
+
+		ginkgo.It("should scale down no more than given number of Pods per minute", func() {
+			ginkgo.By("setting up resource consumer and HPA")
+			initPods := 6
+			initCPUUsageTotal := initPods * usageForSingleReplica
+			limitWindowLength := 1 * time.Minute
+			podsLimitPerMinute := 2
+
+			rc := e2eautoscaling.NewDynamicResourceConsumer(
+				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
+				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
+			)
+			defer rc.CleanUp()
+
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+				rc, int32(targetCPUUtilizationPercent), 1, 10,
+				e2eautoscaling.HPABehaviorWithScaleLimitedByNumberOfPods(e2eautoscaling.ScaleDownDirection, int32(podsLimitPerMinute), int32(limitWindowLength.Seconds())),
+			)
+			defer e2eautoscaling.DeleteHPAWithBehavior(rc, hpa.Name)
+
+			ginkgo.By("triggering scale down by lowering consumption")
+			rc.ConsumeCPU(1 * usageForSingleReplica)
+
+			waitStart := time.Now()
+			rc.WaitForReplicas(4, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			timeWaitedFor4 := time.Now().Sub(waitStart)
+
+			waitStart = time.Now()
+			rc.WaitForReplicas(2, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			timeWaitedFor2 := time.Now().Sub(waitStart)
+
+			ginkgo.By("verifying time waited for a scale down to 4 replicas")
+			deadline := limitWindowLength + maxHPAReactionTime + maxResourceConsumerDelay
+			// First scale event can happen right away, as there were no scale events in the past.
+			framework.ExpectEqual(timeWaitedFor4 < deadline, true, "waited %s, wanted less than %s", timeWaitedFor4, deadline)
+
+			ginkgo.By("verifying time waited for a scale down to 2 replicas")
+			// Second scale event needs to respect limit window.
+			framework.ExpectEqual(timeWaitedFor2 > limitWindowLength, true, "waited %s, wanted more than %s", timeWaitedFor2, limitWindowLength)
+			framework.ExpectEqual(timeWaitedFor2 < deadline, true, "waited %s, wanted less than %s", timeWaitedFor2, deadline)
+		})
+	})
+
+	ginkgo.Describe("with scale limited by percentage", func() {
+		ginkgo.It("should scale up no more than given percentage of current Pods per minute", func() {
+			ginkgo.By("setting up resource consumer and HPA")
+			initPods := 4
+			initCPUUsageTotal := initPods * usageForSingleReplica
+			limitWindowLength := 1 * time.Minute
+			percentageLimitPerMinute := 50
+
+			rc := e2eautoscaling.NewDynamicResourceConsumer(
+				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
+				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
+			)
+			defer rc.CleanUp()
+
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+				rc, int32(targetCPUUtilizationPercent), 1, 10,
+				e2eautoscaling.HPABehaviorWithScaleLimitedByPercentage(e2eautoscaling.ScaleUpDirection, int32(percentageLimitPerMinute), int32(limitWindowLength.Seconds())),
+			)
+			defer e2eautoscaling.DeleteHPAWithBehavior(rc, hpa.Name)
+
+			ginkgo.By("triggering scale up by increasing consumption")
+			rc.ConsumeCPU(10 * usageForSingleReplica)
+
+			waitStart := time.Now()
+			rc.WaitForReplicas(6, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			timeWaitedFor6 := time.Now().Sub(waitStart)
+
+			waitStart = time.Now()
+			rc.WaitForReplicas(9, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			timeWaitedFor9 := time.Now().Sub(waitStart)
+
+			ginkgo.By("verifying time waited for a scale up to 6 replicas")
+			deadline := limitWindowLength + maxHPAReactionTime + maxResourceConsumerDelay
+			// First scale event can happen right away, as there were no scale events in the past.
+			framework.ExpectEqual(timeWaitedFor6 < deadline, true, "waited %s, wanted less than %s", timeWaitedFor6, deadline)
+
+			ginkgo.By("verifying time waited for a scale up to 9 replicas")
+			// Second scale event needs to respect limit window.
+			framework.ExpectEqual(timeWaitedFor9 > limitWindowLength, true, "waited %s, wanted to wait more than %s", timeWaitedFor9, limitWindowLength)
+			framework.ExpectEqual(timeWaitedFor9 < deadline, true, "waited %s, wanted less than %s", timeWaitedFor9, deadline)
+		})
+
+		ginkgo.It("should scale down no more than given percentage of current Pods per minute", func() {
+			ginkgo.By("setting up resource consumer and HPA")
+			initPods := 8
+			initCPUUsageTotal := initPods * usageForSingleReplica
+			limitWindowLength := 1 * time.Minute
+			percentageLimitPerMinute := 50
+
+			rc := e2eautoscaling.NewDynamicResourceConsumer(
+				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
+				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
+			)
+			defer rc.CleanUp()
+
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+				rc, int32(targetCPUUtilizationPercent), 1, 10,
+				e2eautoscaling.HPABehaviorWithScaleLimitedByPercentage(e2eautoscaling.ScaleDownDirection, int32(percentageLimitPerMinute), int32(limitWindowLength.Seconds())),
+			)
+			defer e2eautoscaling.DeleteHPAWithBehavior(rc, hpa.Name)
+
+			ginkgo.By("triggering scale down by lowering consumption")
+			rc.ConsumeCPU(1 * usageForSingleReplica)
+
+			waitStart := time.Now()
+			rc.WaitForReplicas(4, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			timeWaitedFor4 := time.Now().Sub(waitStart)
+
+			waitStart = time.Now()
+			rc.WaitForReplicas(2, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			timeWaitedFor2 := time.Now().Sub(waitStart)
+
+			ginkgo.By("verifying time waited for a scale down to 4 replicas")
+			deadline := limitWindowLength + maxHPAReactionTime + maxResourceConsumerDelay
+			// First scale event can happen right away, as there were no scale events in the past.
+			framework.ExpectEqual(timeWaitedFor4 < deadline, true, "waited %s, wanted less than %s", timeWaitedFor4, deadline)
+
+			ginkgo.By("verifying time waited for a scale down to 2 replicas")
+			// Second scale event needs to respect limit window.
+			framework.ExpectEqual(timeWaitedFor2 > limitWindowLength, true, "waited %s, wanted more than %s", timeWaitedFor2, limitWindowLength)
+			framework.ExpectEqual(timeWaitedFor2 < deadline, true, "waited %s, wanted less than %s", timeWaitedFor2, deadline)
+		})
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
e2e test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Implementing e2e tests for HPA behavior, requested by https://github.com/kubernetes/kubernetes/issues/102369.

Specifically, this PR tests following behavior features:
- scale up limited by number of Pods / minute, 
- scale down limited by number of Pods / minute, 
- scale up limited by percentage of Pods / minute,
- scale down limited by percentage of Pods / minute.

It also refactors some common autoscaling utils.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #102369

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
    NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
