### PR TITLE
Conformance test "manage the lifecycle of an APIService" is Disruptive and should run in Serial

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -160,18 +160,6 @@
     1.17 will work on the current Aggregator/API-Server.
   release: v1.17, v1.21
   file: test/e2e/apimachinery/aggregator.go
-- testname: Aggregator, manage lifecycle of an APIService
-  codename: '[sig-api-machinery] Aggregator should manage the lifecycle of an APIService
-    [Conformance]'
-  description: An APIService is created which MUST succeed. The APIService status
-    when replaced MUST succeed. Given the updating of the APIService status, the fields
-    MUST equal the new values. The APIService status when patched MUST succeed. Given
-    the patching of the APIService status, the fields MUST equal the new values. The
-    APIService when replaced MUST succeed. Given the updating of the APIService, the
-    fields MUST equal the new values. It MUST succeed at deleting a collection of
-    APIServices via a label selector.
-  release: v1.25
-  file: test/e2e/apimachinery/aggregator.go
 - testname: Custom Resource Definition Conversion Webhook, convert mixed version list
   codename: '[sig-api-machinery] CustomResourceConversionWebhook [Privileged:ClusterAdmin]
     should be able to convert a non homogeneous list of CRs [Conformance]'

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -108,19 +108,7 @@ var _ = SIGDescribe("Aggregator", func() {
 		TestSampleAPIServer(f, aggrclient, imageutils.GetE2EImage(imageutils.APIServer))
 	})
 
-	/*
-		Release: v1.25
-		Testname: Aggregator, manage lifecycle of an APIService
-		Description: An APIService is created which MUST succeed. The
-		APIService status when replaced MUST succeed. Given the updating
-		of the APIService status, the fields MUST equal the new values.
-		The APIService status when patched MUST succeed. Given the patching
-		of the APIService status, the fields MUST equal the new values. The
-		APIService when replaced MUST succeed. Given the updating of the
-		APIService, the fields MUST equal the new values. It MUST succeed at
-		deleting a collection of APIServices via a label selector.
-	*/
-	framework.ConformanceIt("should manage the lifecycle of an APIService", func() {
+	ginkgo.It("should manage the lifecycle of an APIService", func() {
 
 		ns := f.Namespace.Name
 		framework.Logf("ns: %v", ns)

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -108,7 +108,7 @@ var _ = SIGDescribe("Aggregator", func() {
 		TestSampleAPIServer(f, aggrclient, imageutils.GetE2EImage(imageutils.APIServer))
 	})
 
-	ginkgo.It("should manage the lifecycle of an APIService", func() {
+	ginkgo.It("should manage the lifecycle of an APIService [Serial][Disruptive]", func() {
 
 		ns := f.Namespace.Name
 		framework.Logf("ns: %v", ns)


### PR DESCRIPTION
/kind bug
/kind failing-test
/kind flake
/kind regression

```release-note
none
```

The test breaks the controllers that depend on api services to be resolvable, per example, the namespace controller, that is heavily used by the e2e framework to clean the environment, impacting all the other test that are running on the environment.

This can be verified by checking the logs in the controller-manager in any of the current jobs:

```
2022-07-22T07:56:34.495444693Z stderr F E0722 07:56:34.495346       1 namespace_controller.go:162] deletion of namespace kubectl-4138 failed: unable to retrieve the complete list of server APIs: e2e-prmvh.example.com/v1alpha1: the server is currently unable to handle the request
2022-07-22T07:56:35.361838874Z stderr F E0722 07:56:35.361677       1 namespace_controller.go:162] deletion of namespace events-7733 failed: unable to retrieve the complete list of server APIs: e2e-prmvh.example.com/v1alpha1: the server is currently unable to handle the request
2022-07-22T07:56:35.390257453Z stderr F E0722 07:56:35.390170       1 namespace_controller.go:162] deletion of namespace nettest-6099 failed: unable to retrieve the complete list of server APIs: e2e-prmvh.example.com/v1alpha1: the server is currently unable to handle the request
2022-07-22T07:56:35.451344876Z stderr F E0722 07:56:35.451217       1 namespace_controller.go:162] deletion of namespace nettest-2475 failed: unable to retrieve the complete list of server APIs: e2e-prmvh.example.com/v1alpha1: the server is currently unable to handle the request
2022-07-22T07:56:35.459872098Z stderr F E0722 07:56:35.459730       1 namespa
```

```
wget https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/111172/pull-kubernetes-e2e-kind/1550377010985963520/artifacts/kind-control-plane/pods/kube-system_kube-controller-manager-kind-control-plane_e9ec38736496c717a237032e25dc47c8/kube-controller-manager/0.log -O- | grep namespace_controller | grep "failed: unable to retrieve the complete list" | wc
   3411  105741 1087294
```


This is especially critical for the CSI sig-storage tests, that need to delete the namespace as part of the test, causing that test that use to run on the order of ~ 1 min, take more than 10 minutes



Fixes: #111086, #111247