### PR TITLE
[WIP] Stateful set available condition api

### DIFF
--- a/pkg/apis/apps/types.go
+++ b/pkg/apis/apps/types.go
@@ -262,7 +262,12 @@ type StatefulSetStatus struct {
 // StatefulSetConditionType describes the condition types of StatefulSets.
 type StatefulSetConditionType string
 
-// TODO: Add valid condition types for Statefulsets.
+// These are valid conditions of a stateful set.
+const (
+	// StatefulSetAvailable means the stateful set is available, ie. at least the minimum available
+	// replicas required are up and running for at least minReadySeconds.
+	StatefulSetAvailable StatefulSetConditionType = "Available"
+)
 
 // StatefulSetCondition describes the state of a statefulset at a certain point.
 type StatefulSetCondition struct {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -330,6 +330,13 @@ const (
 	// SYS_TIME). This should only be enabled if user namespace remapping is enabled in the docker daemon.
 	ExperimentalHostUserNamespaceDefaultingGate featuregate.Feature = "ExperimentalHostUserNamespaceDefaulting"
 
+	// owner: @atiratree
+	// kep: http://kep.k8s.io/2804
+	// alpha: v1.25
+	//
+	// Enable new Conditions in StatefulSet.
+	ExtendedWorkloadConditions featuregate.Feature = "ExtendedWorkloadConditions"
+
 	// owner: @yuzhiquan, @bowei, @PxyUp, @SergeyKanzhelev
 	// kep: http://kep.k8s.io/2727
 	// alpha: v1.23
@@ -895,6 +902,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ExpandedDNSConfig: {Default: false, PreRelease: featuregate.Alpha},
 
 	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: featuregate.Beta},
+
+	ExtendedWorkloadConditions: {Default: false, PreRelease: featuregate.Alpha},
 
 	GRPCContainerProbe: {Default: true, PreRelease: featuregate.Beta},
 

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -284,7 +284,15 @@ type StatefulSetStatus struct {
 	AvailableReplicas int32 `json:"availableReplicas" protobuf:"varint,11,opt,name=availableReplicas"`
 }
 
+// StatefulSetConditionType describes the condition types of StatefulSets.
 type StatefulSetConditionType string
+
+// These are valid conditions of a stateful set.
+const (
+	// StatefulSetAvailable means the stateful set is available, ie. at least the minimum available
+	// replicas required are up and running for at least minReadySeconds.
+	StatefulSetAvailable StatefulSetConditionType = "Available"
+)
 
 // StatefulSetCondition describes the state of a statefulset at a certain point.
 type StatefulSetCondition struct {

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -323,7 +323,15 @@ type StatefulSetStatus struct {
 	AvailableReplicas int32 `json:"availableReplicas" protobuf:"varint,11,opt,name=availableReplicas"`
 }
 
+// StatefulSetConditionType describes the condition types of StatefulSets.
 type StatefulSetConditionType string
+
+// These are valid conditions of a stateful set.
+const (
+	// StatefulSetAvailable means the stateful set is available, ie. at least the minimum available
+	// replicas required are up and running for at least minReadySeconds.
+	StatefulSetAvailable StatefulSetConditionType = "Available"
+)
 
 // StatefulSetCondition describes the state of a statefulset at a certain point.
 type StatefulSetCondition struct {

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -332,7 +332,15 @@ type StatefulSetStatus struct {
 	AvailableReplicas int32 `json:"availableReplicas" protobuf:"varint,11,opt,name=availableReplicas"`
 }
 
+// StatefulSetConditionType describes the condition types of StatefulSets.
 type StatefulSetConditionType string
+
+// These are valid conditions of a stateful set.
+const (
+	// StatefulSetAvailable means the stateful set is available, ie. at least the minimum available
+	// replicas required are up and running for at least minReadySeconds.
+	StatefulSetAvailable StatefulSetConditionType = "Available"
+)
 
 // StatefulSetCondition describes the state of a statefulset at a certain point.
 type StatefulSetCondition struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change


#### What this PR does / why we need it:
This PR introduces Available type for StatefulSetCondition. It also introduces ExtendedWorkloadConditions feature gate.

Useful for workloads' conditions to have a unified and simple way of checking the stateful set status.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially Fixes # https://github.com/kubernetes/enhancements/issues/2804

#### Special notes for your reviewer:
there are two other similar PRs:
- https://github.com/kubernetes/kubernetes/pull/108863
- https://github.com/kubernetes/kubernetes/pull/111349

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduce Available condition type in StatefulSet conditions
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/pull/2833
```
