### PR TITLE
Add kubectl help options output

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/options/options.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/options/options.go
@@ -36,7 +36,7 @@ func NewCmdOptions(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "options",
 		Short:   i18n.T("Print the list of flags inherited by all commands"),
-		Long:    i18n.T("Print the list of flags inherited by all commands"),
+		Long:    i18n.T("Print the list of flags inherited by all commands."),
 		Example: optionsExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Usage()

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
@@ -54,10 +54,9 @@ func ActsAsRootCommand(cmd *cobra.Command, filters []string, groups ...CommandGr
 func UseOptionsTemplates(cmd *cobra.Command) {
 	templater := &templater{
 		UsageTemplate: OptionsUsageTemplate(),
-		HelpTemplate:  OptionsHelpTemplate(),
 	}
 	cmd.SetUsageFunc(templater.UsageFunc())
-	cmd.SetHelpFunc(templater.HelpFunc())
+	cmd.SetHelpFunc(cmd.Run)
 }
 
 type templater struct {

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/templates.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/templates.go
@@ -90,14 +90,9 @@ func MainUsageTemplate() string {
 	return strings.TrimRightFunc(strings.Join(sections, ""), unicode.IsSpace)
 }
 
-// OptionsHelpTemplate if the template for 'help' used by the 'options' command.
-func OptionsHelpTemplate() string {
-	return ""
-}
-
 // OptionsUsageTemplate if the template for 'usage' used by the 'options' command.
 func OptionsUsageTemplate() string {
-	return `{{ if .HasInheritedFlags}}The following options can be passed to any command:
+	return `{{ if .HasInheritedFlags}}The following options can be passed to any command.
 
 {{flagsUsages .InheritedFlags}}{{end}}`
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Currently there is no output when running 'kubectl help options'. This
commit adds the same output as when running 'kubectl options'. It also
fixes the descriptions to be consistent with other commands.

```shell
./_output/local/go/bin/kubectl help options
The following options can be passed to any command.

    --as='':
	Username to impersonate for the operation. User could be a regular user or a service account in a namespace.

    --as-group=[]:
	Group to impersonate for the operation, this flag can be repeated to specify multiple groups.

    --as-uid='':
	UID to impersonate for the operation.

    --cache-dir='/home/oscaru/.kube/cache':
	Default cache directory

    --certificate-authority='':
	Path to a cert file for the certificate authority

    --client-certificate='':
	Path to a client certificate file for TLS

    --client-key='':
	Path to a client key file for TLS

    --cluster='':
	The name of the kubeconfig cluster to use

    --context='':
	The name of the kubeconfig context to use

    --disable-compression=false:
	If true, opt-out of response compression for all requests to the server

    --insecure-skip-tls-verify=false:
	If true, the server's certificate will not be checked for validity. This will make your HTTPS connections
	insecure

    --kubeconfig='':
	Path to the kubeconfig file to use for CLI requests.

    --log-flush-frequency=5s:
	Maximum number of seconds between log flushes

    --match-server-version=false:
	Require server version to match client version

    -n, --namespace='':
	If present, the namespace scope for this CLI request

    --password='':
	Password for basic authentication to the API server

    --profile='none':
	Name of profile to capture. One of (none|cpu|heap|goroutine|threadcreate|block|mutex)

    --profile-output='profile.pprof':
	Name of the file to write the profile to

    --request-timeout='0':
	The length of time to wait before giving up on a single server request. Non-zero values should contain a
	corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests.

    -s, --server='':
	The address and port of the Kubernetes API server

    --tls-server-name='':
	Server name to use for server certificate validation. If it is not provided, the hostname used to contact the
	server is used

    --token='':
	Bearer token for authentication to the API server

    --user='':
	The name of the kubeconfig user to use

    --username='':
	Username for basic authentication to the API server

    -v, --v=0:
	number for the log level verbosity

    --vmodule=:
	comma-separated list of pattern=N settings for file-filtered logging (only works for the default text log
	format)

    --warnings-as-errors=false:
	Treat warnings received from the server as errors and exit with a non-zero exit code

```

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
