### PR TITLE
Improve 'kubectl attach' usage and help information

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
@@ -101,7 +101,7 @@ func NewAttachOptions(streams genericclioptions.IOStreams) *AttachOptions {
 func NewCmdAttach(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewAttachOptions(streams)
 	cmd := &cobra.Command{
-		Use:                   "attach (POD | TYPE/NAME) -c CONTAINER",
+		Use:                   "attach (POD | TYPE/NAME) [--container=NAME]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Attach to a running container"),
 		Long:                  i18n.T("Attach to a process that is already running inside an existing container."),
@@ -203,7 +203,7 @@ func (o *AttachOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 // Validate checks that the provided attach options are specified.
 func (o *AttachOptions) Validate() error {
 	if len(o.Resources) == 0 {
-		return fmt.Errorf("at least 1 argument is required for attach")
+		return fmt.Errorf("at least 1 argument is required for attach. Expected POD, TYPE/NAME, or TYPE NAME")
 	}
 	if len(o.Resources) > 2 {
 		return fmt.Errorf("expected POD, TYPE/NAME, or TYPE NAME, (at most 2 arguments) saw %d: %v", len(o.Resources), o.Resources)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Two minor aesthetic changes for `kubectl attach` output. 

It improves the help output from `kubectl attach` when it's not provided with any arguments:

Now:
```
./_output/bin/kubectl attach
error: at least 1 argument is required for attach. Expected POD, TYPE/NAME, or TYPE NAME
```
Before:
```
kubectl attach
error: at least 1 argument is required for attach
```

Also updates the usage:
* Use long format `--container` instead of `-c` 
* Adds `[]` to indicate that it's not a strictly required argument (if the pod only has a single container).
* Changes `CONTAINER` to `NAME`

Now: `kubectl attach (POD | TYPE/NAME) [--container=NAME] [options]`
Before: `kubectl attach (POD | TYPE/NAME) -c CONTAINER [options]`


#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: