### PR TITLE
Replace fallocate with dd in e2e tests

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2408,7 +2408,7 @@ var _ = common.SIGDescribe("Services", func() {
 		// Create a pod in one node to get evicted
 		ginkgo.By("creating a client pod that is going to be evicted for the service " + serviceName)
 		evictedPod := e2epod.NewAgnhostPod(namespace, "evicted-pod", nil, nil, nil)
-		evictedPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", "sleep 10; fallocate -l 10M file; sleep 10000"}
+		evictedPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", "sleep 10; dd if=/dev/zero of=file bs=1M count=10; sleep 10000"}
 		evictedPod.Spec.Containers[0].Name = "evicted-pod"
 		evictedPod.Spec.Containers[0].Resources = v1.ResourceRequirements{
 			Limits: v1.ResourceList{"ephemeral-storage": resource.MustParse("5Mi")},

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -315,7 +315,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 							Name:  "bar",
 							Image: image,
 							Command: []string{
-								"/bin/sh", "-c", "sleep 10; fallocate -l 10M file; sleep 10000",
+								"/bin/sh", "-c", "sleep 10; dd if=/dev/zero of=file bs=1M count=10; sleep 10000",
 							},
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

K8s does not require support for `fallocate` in container fs'es, so neither should e2e tests. This PR replaces `fallocate` with the more primitive, but always working, `dd` command.

#### Which issue(s) this PR fixes:

Fixes #111368

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

