### PR TITLE
disallow --force and --prune in client-side apply

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -373,6 +373,12 @@ func (o *ApplyOptions) Validate() error {
 		return fmt.Errorf("all resources selected for prune without explicitly passing --all. To prune all resources, pass the --all flag. If you did not mean to prune all resources, specify a label selector")
 	}
 
+	// Do not force the recreation of an object(s) if we're pruning; this can cause
+	// undefined behavior since object UID's change.
+	if o.Prune && o.DeleteOptions.ForceDeletion {
+		return fmt.Errorf("--force cannot be used with --prune")
+	}
+
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -112,41 +112,41 @@ func TestApplyFlagValidation(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			args: [][]string {
+			args: [][]string{
 				{"force-conflicts", "true"},
 			},
 			expectedErr: "--force-conflicts only works with --server-side",
 		},
 		{
-			args: [][]string {
+			args: [][]string{
 				{"server-side", "true"},
 				{"dry-run", "client"},
 			},
 			expectedErr: "--dry-run=client doesn't work with --server-side (did you mean --dry-run=server instead?)",
 		},
 		{
-			args: [][]string {
+			args: [][]string{
 				{"force", "true"},
 				{"server-side", "true"},
 			},
 			expectedErr: "--force cannot be used with --server-side",
 		},
 		{
-			args: [][]string {
+			args: [][]string{
 				{"force", "true"},
 				{"dry-run", "server"},
 			},
 			expectedErr: "--dry-run=server cannot be used with --force",
 		},
 		{
-			args: [][]string {
+			args: [][]string{
 				{"all", "true"},
 				{"selector", "unused"},
 			},
 			expectedErr: "cannot set --all and --selector at the same time",
 		},
 		{
-			args: [][]string {
+			args: [][]string{
 				{"force", "true"},
 				{"prune", "true"},
 				{"all", "true"},


### PR DESCRIPTION
* Disallow `--force` and `--prune` flags in client-side apply.
* Adds unit tests for apply args.

Fixes https://github.com/kubernetes/kubectl/issues/1239 (part 1)

```release-note
NONE
```