### PR TITLE
Revert "Cleanup: remove validation of removedPlugins"

### DIFF
--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -33,6 +33,8 @@ import (
 	componentbasevalidation "k8s.io/component-base/config/validation"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config/v1beta2"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config/v1beta3"
 )
 
 // ValidateKubeSchedulerConfiguration ensures validation of the KubeSchedulerConfiguration struct
@@ -115,6 +117,51 @@ func splitHostIntPort(s string) (string, int, error) {
 	return host, portInt, err
 }
 
+type removedPlugins struct {
+	schemeGroupVersion string
+	plugins            []string
+}
+
+// removedPluginsByVersion maintains a list of removed plugins in each version.
+// Remember to add an entry to that list when creating a new component config
+// version (even if the list of removed plugins is empty).
+var removedPluginsByVersion = []removedPlugins{
+	{
+		schemeGroupVersion: v1beta2.SchemeGroupVersion.String(),
+		plugins:            []string{},
+	},
+	{
+		schemeGroupVersion: v1beta3.SchemeGroupVersion.String(),
+		plugins:            []string{},
+	},
+}
+
+// isPluginRemoved checks if a given plugin was removed in the given component
+// config version or earlier.
+func isPluginRemoved(apiVersion string, name string) (bool, string) {
+	for _, dp := range removedPluginsByVersion {
+		for _, plugin := range dp.plugins {
+			if name == plugin {
+				return true, dp.schemeGroupVersion
+			}
+		}
+		if apiVersion == dp.schemeGroupVersion {
+			break
+		}
+	}
+	return false, ""
+}
+
+func validatePluginSetForRemovedPlugins(path *field.Path, apiVersion string, ps config.PluginSet) []error {
+	var errs []error
+	for i, plugin := range ps.Enabled {
+		if removed, removedVersion := isPluginRemoved(apiVersion, plugin.Name); removed {
+			errs = append(errs, field.Invalid(path.Child("enabled").Index(i), plugin.Name, fmt.Sprintf("was removed in version %q (KubeSchedulerConfiguration is version %q)", removedVersion, apiVersion)))
+		}
+	}
+	return errs
+}
+
 func validateKubeSchedulerProfile(path *field.Path, apiVersion string, profile *config.KubeSchedulerProfile) []error {
 	var errs []error
 	if len(profile.SchedulerName) == 0 {
@@ -136,6 +183,28 @@ func validatePluginConfig(path *field.Path, apiVersion string, profile *config.K
 		"VolumeBinding":                   ValidateVolumeBindingArgs,
 	}
 
+	if profile.Plugins != nil {
+		stagesToPluginSet := map[string]config.PluginSet{
+			"queueSort":  profile.Plugins.QueueSort,
+			"preFilter":  profile.Plugins.PreFilter,
+			"filter":     profile.Plugins.Filter,
+			"postFilter": profile.Plugins.PostFilter,
+			"preScore":   profile.Plugins.PreScore,
+			"score":      profile.Plugins.Score,
+			"reserve":    profile.Plugins.Reserve,
+			"permit":     profile.Plugins.Permit,
+			"preBind":    profile.Plugins.PreBind,
+			"bind":       profile.Plugins.Bind,
+			"postBind":   profile.Plugins.PostBind,
+		}
+
+		pluginsPath := path.Child("plugins")
+		for s, p := range stagesToPluginSet {
+			errs = append(errs, validatePluginSetForRemovedPlugins(
+				pluginsPath.Child(s), apiVersion, p)...)
+		}
+	}
+
 	seenPluginConfig := make(sets.String)
 
 	for i := range profile.PluginConfig {
@@ -147,7 +216,9 @@ func validatePluginConfig(path *field.Path, apiVersion string, profile *config.K
 		} else {
 			seenPluginConfig.Insert(name)
 		}
-		if validateFunc, ok := m[name]; ok {
+		if removed, removedVersion := isPluginRemoved(apiVersion, name); removed {
+			errs = append(errs, field.Invalid(pluginConfigPath, name, fmt.Sprintf("was removed in version %q (KubeSchedulerConfiguration is version %q)", removedVersion, apiVersion)))
+		} else if validateFunc, ok := m[name]; ok {
 			// type mismatch, no need to validate the `args`.
 			if reflect.TypeOf(args) != reflect.ValueOf(validateFunc).Type().In(1) {
 				errs = append(errs, field.Invalid(pluginConfigPath.Child("args"), args, "has to match plugin args"))

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -117,15 +117,15 @@ func splitHostIntPort(s string) (string, int, error) {
 	return host, portInt, err
 }
 
-type removedPlugins struct {
+type invalidPlugins struct {
 	schemeGroupVersion string
 	plugins            []string
 }
 
-// removedPluginsByVersion maintains a list of removed plugins in each version.
+// invalidPluginsByVersion maintains a list of removed/deprecated plugins in each version.
 // Remember to add an entry to that list when creating a new component config
-// version (even if the list of removed plugins is empty).
-var removedPluginsByVersion = []removedPlugins{
+// version (even if the list of invalid plugins is empty).
+var invalidPluginsByVersion = []invalidPlugins{
 	{
 		schemeGroupVersion: v1beta2.SchemeGroupVersion.String(),
 		plugins:            []string{},
@@ -136,10 +136,10 @@ var removedPluginsByVersion = []removedPlugins{
 	},
 }
 
-// isPluginRemoved checks if a given plugin was removed in the given component
+// isPluginInvalid checks if a given plugin was removed/deprecated in the given component
 // config version or earlier.
-func isPluginRemoved(apiVersion string, name string) (bool, string) {
-	for _, dp := range removedPluginsByVersion {
+func isPluginInvalid(apiVersion string, name string) (bool, string) {
+	for _, dp := range invalidPluginsByVersion {
 		for _, plugin := range dp.plugins {
 			if name == plugin {
 				return true, dp.schemeGroupVersion
@@ -152,11 +152,11 @@ func isPluginRemoved(apiVersion string, name string) (bool, string) {
 	return false, ""
 }
 
-func validatePluginSetForRemovedPlugins(path *field.Path, apiVersion string, ps config.PluginSet) []error {
+func validatePluginSetForInvalidPlugins(path *field.Path, apiVersion string, ps config.PluginSet) []error {
 	var errs []error
 	for i, plugin := range ps.Enabled {
-		if removed, removedVersion := isPluginRemoved(apiVersion, plugin.Name); removed {
-			errs = append(errs, field.Invalid(path.Child("enabled").Index(i), plugin.Name, fmt.Sprintf("was removed in version %q (KubeSchedulerConfiguration is version %q)", removedVersion, apiVersion)))
+		if invalid, invalidVersion := isPluginInvalid(apiVersion, plugin.Name); invalid {
+			errs = append(errs, field.Invalid(path.Child("enabled").Index(i), plugin.Name, fmt.Sprintf("was invalid in version %q (KubeSchedulerConfiguration is version %q)", invalidVersion, apiVersion)))
 		}
 	}
 	return errs
@@ -200,7 +200,7 @@ func validatePluginConfig(path *field.Path, apiVersion string, profile *config.K
 
 		pluginsPath := path.Child("plugins")
 		for s, p := range stagesToPluginSet {
-			errs = append(errs, validatePluginSetForRemovedPlugins(
+			errs = append(errs, validatePluginSetForInvalidPlugins(
 				pluginsPath.Child(s), apiVersion, p)...)
 		}
 	}
@@ -216,8 +216,8 @@ func validatePluginConfig(path *field.Path, apiVersion string, profile *config.K
 		} else {
 			seenPluginConfig.Insert(name)
 		}
-		if removed, removedVersion := isPluginRemoved(apiVersion, name); removed {
-			errs = append(errs, field.Invalid(pluginConfigPath, name, fmt.Sprintf("was removed in version %q (KubeSchedulerConfiguration is version %q)", removedVersion, apiVersion)))
+		if invalid, invalidVersion := isPluginInvalid(apiVersion, name); invalid {
+			errs = append(errs, field.Invalid(pluginConfigPath, name, fmt.Sprintf("was invalid in version %q (KubeSchedulerConfiguration is version %q)", invalidVersion, apiVersion)))
 		} else if validateFunc, ok := m[name]; ok {
 			// type mismatch, no need to validate the `args`.
 			if reflect.TypeOf(args) != reflect.ValueOf(validateFunc).Type().In(1) {

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -198,6 +198,9 @@ func TestValidateKubeSchedulerConfigurationV1beta2(t *testing.T) {
 		BindVerb:       "bar",
 	})
 
+	goodRemovedPlugins2 := validConfig.DeepCopy()
+	goodRemovedPlugins2.Profiles[0].Plugins.Score.Enabled = append(goodRemovedPlugins2.Profiles[0].Plugins.Score.Enabled, config.Plugin{Name: "PodTopologySpread", Weight: 2})
+
 	scenarios := map[string]struct {
 		expectedToFail bool
 		config         *config.KubeSchedulerConfiguration
@@ -274,6 +277,10 @@ func TestValidateKubeSchedulerConfigurationV1beta2(t *testing.T) {
 		"mismatch-queue-sort": {
 			expectedToFail: true,
 			config:         mismatchQueueSort,
+		},
+		"good-removed-plugins-2": {
+			expectedToFail: false,
+			config:         goodRemovedPlugins2,
 		},
 	}
 
@@ -465,6 +472,9 @@ func TestValidateKubeSchedulerConfigurationV1beta3(t *testing.T) {
 		BindVerb:       "bar",
 	})
 
+	goodRemovedPlugins2 := validConfig.DeepCopy()
+	goodRemovedPlugins2.Profiles[0].Plugins.Score.Enabled = append(goodRemovedPlugins2.Profiles[0].Plugins.Score.Enabled, config.Plugin{Name: "PodTopologySpread", Weight: 2})
+
 	scenarios := map[string]struct {
 		expectedToFail bool
 		config         *config.KubeSchedulerConfiguration
@@ -541,6 +551,10 @@ func TestValidateKubeSchedulerConfigurationV1beta3(t *testing.T) {
 		"mismatch-queue-sort": {
 			expectedToFail: true,
 			config:         mismatchQueueSort,
+		},
+		"good-removed-plugins-2": {
+			expectedToFail: false,
+			config:         goodRemovedPlugins2,
 		},
 	}
 

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -198,8 +198,8 @@ func TestValidateKubeSchedulerConfigurationV1beta2(t *testing.T) {
 		BindVerb:       "bar",
 	})
 
-	goodRemovedPlugins2 := validConfig.DeepCopy()
-	goodRemovedPlugins2.Profiles[0].Plugins.Score.Enabled = append(goodRemovedPlugins2.Profiles[0].Plugins.Score.Enabled, config.Plugin{Name: "PodTopologySpread", Weight: 2})
+	goodInvalidPlugins := validConfig.DeepCopy()
+	goodInvalidPlugins.Profiles[0].Plugins.Score.Enabled = append(goodInvalidPlugins.Profiles[0].Plugins.Score.Enabled, config.Plugin{Name: "PodTopologySpread", Weight: 2})
 
 	scenarios := map[string]struct {
 		expectedToFail bool
@@ -278,9 +278,9 @@ func TestValidateKubeSchedulerConfigurationV1beta2(t *testing.T) {
 			expectedToFail: true,
 			config:         mismatchQueueSort,
 		},
-		"good-removed-plugins-2": {
+		"good-invalid-plugins": {
 			expectedToFail: false,
-			config:         goodRemovedPlugins2,
+			config:         goodInvalidPlugins,
 		},
 	}
 
@@ -472,8 +472,8 @@ func TestValidateKubeSchedulerConfigurationV1beta3(t *testing.T) {
 		BindVerb:       "bar",
 	})
 
-	goodRemovedPlugins2 := validConfig.DeepCopy()
-	goodRemovedPlugins2.Profiles[0].Plugins.Score.Enabled = append(goodRemovedPlugins2.Profiles[0].Plugins.Score.Enabled, config.Plugin{Name: "PodTopologySpread", Weight: 2})
+	goodInvalidPlugins := validConfig.DeepCopy()
+	goodInvalidPlugins.Profiles[0].Plugins.Score.Enabled = append(goodInvalidPlugins.Profiles[0].Plugins.Score.Enabled, config.Plugin{Name: "PodTopologySpread", Weight: 2})
 
 	scenarios := map[string]struct {
 		expectedToFail bool
@@ -552,9 +552,9 @@ func TestValidateKubeSchedulerConfigurationV1beta3(t *testing.T) {
 			expectedToFail: true,
 			config:         mismatchQueueSort,
 		},
-		"good-removed-plugins-2": {
+		"good-invalid-plugins": {
 			expectedToFail: false,
-			config:         goodRemovedPlugins2,
+			config:         goodInvalidPlugins,
 		},
 	}
 


### PR DESCRIPTION
This reverts commit 0971577c3e6f7710a548630d5a42b4f11dae346f.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig scheduling
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
We removed `plugin removal validation` in https://github.com/kubernetes/kubernetes/pull/111032, but we still have one plugin to remove in the future, it's `selectorSpread` maybe in v1.27, so we should mark it as deprecated in CC v1 https://github.com/kubernetes/kubernetes/pull/110534.  

In this PR:

1. Revert the commit in https://github.com/kubernetes/kubernetes/pull/111032
2. Refactor removedPlugin to invalidPlugin which indicates not only removed plugins but also deprecated plugins. Then in  CC graduaation https://github.com/kubernetes/kubernetes/pull/110534, we'll add it to the invalid plugins list.

 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
