### PR TITLE
Fix test order  pkg/volume/azuredd/azure_common_test.go

### DIFF
--- a/pkg/volume/azuredd/azure_common_test.go
+++ b/pkg/volume/azuredd/azure_common_test.go
@@ -179,8 +179,8 @@ func TestNormalizeStorageAccountType(t *testing.T) {
 
 	for _, test := range tests {
 		result, err := normalizeStorageAccountType(test.storageAccountType)
-		assert.Equal(t, result, test.expectedAccountType)
-		assert.Equal(t, err != nil, test.expectError, fmt.Sprintf("error msg: %v", err))
+		assert.Equal(t, test.expectedAccountType, result)
+		assert.Equal(t, test.expectError, err != nil, fmt.Sprintf("error msg: %v", err))
 	}
 }
 
@@ -219,7 +219,7 @@ func TestGetDiskNum(t *testing.T) {
 
 	for _, test := range tests {
 		result, err := getDiskNum(test.deviceInfo)
-		assert.Equal(t, result, test.expectedNum)
-		assert.Equal(t, err != nil, test.expectError, fmt.Sprintf("error msg: %v", err))
+		assert.Equal(t, test.expectedNum, result)
+		assert.Equal(t, test.expectError, err != nil, fmt.Sprintf("error msg: %v", err))
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Per https://pkg.go.dev/github.com/stretchr/testify/assert#Equal expected goes before actual:

func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Fixes tests asserting that the expected values were the actual ones, when they were not. just like https://github.com/kubernetes/kubernetes/pull/102611
https://github.com/kubernetes/kubernetes/pull/102615
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
"NONE"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
