### PR TITLE
Provide metrics for images pulling observation

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -483,6 +483,16 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
+
+	// ImagePullingCount is a gauge that tracks the number of Images currently pulling
+	ImagePullingCount = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           "image_pulling_count",
+			Help:           "Number of images currently pulling.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
 )
 
 var registerMetrics sync.Once
@@ -531,6 +541,7 @@ func Register(collectors ...metrics.StableCollector) {
 			legacyregistry.MustRegister(GracefulShutdownStartTime)
 			legacyregistry.MustRegister(GracefulShutdownEndTime)
 		}
+		legacyregistry.MustRegister(ImagePullingCount)
 
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Provide following metrics for images pulling observation:
- number of currently pulling images
- pull duration of pulling an image
- image pulling total errors

It would be helpful to provide a basis for speeding up images pulling, for example:
- for users to move to use parallel image puller provided by kubelet
- for users to use image preheating ability, such as [ImagePullJob](https://openkruise.io/docs/user-manuals/imagepulljob/)

#### Which issue(s) this PR fixes:
Resolves https://github.com/kubernetes/kubernetes/issues/111259

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
Signed-off-by: DrAuYueng [ouyang1204@gmail.com](mailto:ouyang1204@gmail.com)
