### PR TITLE
Modify timeout for etcd healthcheck

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -164,6 +164,7 @@ func TestAddFlags(t *testing.T) {
 				CountMetricPollPeriod: time.Minute,
 				DBMetricPollInterval:  storagebackend.DefaultDBMetricPollInterval,
 				HealthcheckTimeout:    storagebackend.DefaultHealthcheckTimeout,
+				ReadycheckTimeout:     storagebackend.DefaultReadinessTimeout,
 				LeaseManagerConfig: etcd3.LeaseManagerConfig{
 					ReuseDurationSeconds: 100,
 					MaxObjectCount:       1000,

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -455,6 +455,12 @@ func (c *Config) AddHealthChecks(healthChecks ...healthz.HealthChecker) {
 	c.ReadyzChecks = append(c.ReadyzChecks, healthChecks...)
 }
 
+// AddReadyzChecks adds a health check to our config to be exposed by the readyz endpoint
+// of our configured apiserver.
+func (c *Config) AddReadyzChecks(healthChecks ...healthz.HealthChecker) {
+	c.ReadyzChecks = append(c.ReadyzChecks, healthChecks...)
+}
+
 // AddPostStartHook allows you to add a PostStartHook that will later be added to the server itself in a New call.
 // Name conflicts will cause an error.
 func (c *Config) AddPostStartHook(name string, hook PostStartHookFunc) error {

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
@@ -36,6 +36,7 @@ const (
 	DefaultCompactInterval      = 5 * time.Minute
 	DefaultDBMetricPollInterval = 30 * time.Second
 	DefaultHealthcheckTimeout   = 2 * time.Second
+	DefaultReadinessTimeout     = 2 * time.Second
 )
 
 // TransportConfig holds all connection related info,  i.e. equal TransportConfig means equal servers we talk to.
@@ -84,6 +85,8 @@ type Config struct {
 	DBMetricPollInterval time.Duration
 	// HealthcheckTimeout specifies the timeout used when checking health
 	HealthcheckTimeout time.Duration
+	// ReadycheckTimeout specifies the timeout used when checking readiness
+	ReadycheckTimeout time.Duration
 
 	LeaseManagerConfig etcd3.LeaseManagerConfig
 
@@ -117,6 +120,7 @@ func NewDefaultConfig(prefix string, codec runtime.Codec) *Config {
 		CompactionInterval:   DefaultCompactInterval,
 		DBMetricPollInterval: DefaultDBMetricPollInterval,
 		HealthcheckTimeout:   DefaultHealthcheckTimeout,
+		ReadycheckTimeout:    DefaultReadinessTimeout,
 		LeaseManagerConfig:   etcd3.NewDefaultLeaseManagerConfig(),
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory.go
@@ -50,3 +50,14 @@ func CreateHealthCheck(c storagebackend.Config, stopCh <-chan struct{}) (func() 
 		return nil, fmt.Errorf("unknown storage type: %s", c.Type)
 	}
 }
+
+func CreateReadyCheck(c storagebackend.Config, stopCh <-chan struct{}) (func() error, error) {
+	switch c.Type {
+	case storagebackend.StorageTypeETCD2:
+		return nil, fmt.Errorf("%s is no longer a supported storage backend", c.Type)
+	case storagebackend.StorageTypeUnset, storagebackend.StorageTypeETCD3:
+		return newETCD3ReadyCheck(c, stopCh)
+	default:
+		return nil, fmt.Errorf("unknown storage type: %s", c.Type)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package factory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
+)
+
+type mockKV struct {
+	get func(ctx context.Context) (*clientv3.GetResponse, error)
+}
+
+func (mkv mockKV) Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error) {
+	return nil, nil
+}
+func (mkv mockKV) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	return mkv.get(ctx)
+}
+func (mockKV) Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
+	return nil, nil
+}
+func (mockKV) Compact(ctx context.Context, rev int64, opts ...clientv3.CompactOption) (*clientv3.CompactResponse, error) {
+	return nil, nil
+}
+func (mockKV) Do(ctx context.Context, op clientv3.Op) (clientv3.OpResponse, error) {
+	return clientv3.OpResponse{}, nil
+}
+func (mockKV) Txn(ctx context.Context) clientv3.Txn {
+	return nil
+}
+
+func TestCreateHealthcheck(t *testing.T) {
+	etcdConfig := testserver.NewTestConfig(t)
+	client := testserver.RunEtcd(t, etcdConfig)
+	newETCD3ClientFn := newETCD3Client
+	defer func() {
+		newETCD3Client = newETCD3ClientFn
+	}()
+	tests := []struct {
+		name         string
+		cfg          storagebackend.Config
+		want         error
+		responseTime time.Duration
+	}{
+		{
+			name: "ok if response time lower than default timeout",
+			cfg: storagebackend.Config{
+				Type:      storagebackend.StorageTypeETCD3,
+				Transport: storagebackend.TransportConfig{},
+			},
+			responseTime: 1 * time.Second,
+			want:         nil,
+		},
+		{
+			name: "ok if response time lower than custom timeout",
+			cfg: storagebackend.Config{
+				Type:               storagebackend.StorageTypeETCD3,
+				Transport:          storagebackend.TransportConfig{},
+				HealthcheckTimeout: 5 * time.Second,
+			},
+			responseTime: 3 * time.Second,
+			want:         nil,
+		},
+		{
+			name: "timeouts if response time higher than default timeout",
+			cfg: storagebackend.Config{
+				Type:      storagebackend.StorageTypeETCD3,
+				Transport: storagebackend.TransportConfig{},
+			},
+			responseTime: 3 * time.Second,
+			want:         context.DeadlineExceeded,
+		},
+		{
+			name: "timeouts if response time higher than custom timeout",
+			cfg: storagebackend.Config{
+				Type:               storagebackend.StorageTypeETCD3,
+				Transport:          storagebackend.TransportConfig{},
+				HealthcheckTimeout: 3 * time.Second,
+			},
+			responseTime: 5 * time.Second,
+			want:         context.DeadlineExceeded,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.cfg.Transport.ServerList = client.Endpoints()
+			newETCD3Client = func(c storagebackend.TransportConfig) (*clientv3.Client, error) {
+				dummyKV := mockKV{
+					get: func(ctx context.Context) (*clientv3.GetResponse, error) {
+						select {
+						case <-ctx.Done():
+							return nil, ctx.Err()
+						case <-time.After(tc.responseTime):
+							return nil, nil
+						}
+					},
+				}
+				client.KV = dummyKV
+				return client, nil
+			}
+			stop := make(chan struct{})
+			healthcheck, err := CreateHealthCheck(tc.cfg, stop)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Wait for healthcheck to establish connection
+			time.Sleep(2 * time.Second)
+
+			got := healthcheck()
+
+			if !errors.Is(got, tc.want) {
+				t.Errorf("healthcheck() missmatch want %v got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestCreateReadycheck(t *testing.T) {
+	etcdConfig := testserver.NewTestConfig(t)
+	client := testserver.RunEtcd(t, etcdConfig)
+	newETCD3ClientFn := newETCD3Client
+	defer func() {
+		newETCD3Client = newETCD3ClientFn
+	}()
+	tests := []struct {
+		name         string
+		cfg          storagebackend.Config
+		want         error
+		responseTime time.Duration
+	}{
+		{
+			name: "ok if response time lower than default timeout",
+			cfg: storagebackend.Config{
+				Type:      storagebackend.StorageTypeETCD3,
+				Transport: storagebackend.TransportConfig{},
+			},
+			responseTime: 1 * time.Second,
+			want:         nil,
+		},
+		{
+			name: "ok if response time lower than custom timeout",
+			cfg: storagebackend.Config{
+				Type:              storagebackend.StorageTypeETCD3,
+				Transport:         storagebackend.TransportConfig{},
+				ReadycheckTimeout: 5 * time.Second,
+			},
+			responseTime: 3 * time.Second,
+			want:         nil,
+		},
+		{
+			name: "timeouts if response time higher than default timeout",
+			cfg: storagebackend.Config{
+				Type:      storagebackend.StorageTypeETCD3,
+				Transport: storagebackend.TransportConfig{},
+			},
+			responseTime: 3 * time.Second,
+			want:         context.DeadlineExceeded,
+		},
+		{
+			name: "timeouts if response time higher than custom timeout",
+			cfg: storagebackend.Config{
+				Type:              storagebackend.StorageTypeETCD3,
+				Transport:         storagebackend.TransportConfig{},
+				ReadycheckTimeout: 3 * time.Second,
+			},
+			responseTime: 5 * time.Second,
+			want:         context.DeadlineExceeded,
+		},
+		{
+			name: "timeouts if response time higher than default timeout with custom healthcheck timeout",
+			cfg: storagebackend.Config{
+				Type:               storagebackend.StorageTypeETCD3,
+				Transport:          storagebackend.TransportConfig{},
+				HealthcheckTimeout: 10 * time.Second,
+			},
+			responseTime: 3 * time.Second,
+			want:         context.DeadlineExceeded,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.cfg.Transport.ServerList = client.Endpoints()
+			newETCD3Client = func(c storagebackend.TransportConfig) (*clientv3.Client, error) {
+				dummyKV := mockKV{
+					get: func(ctx context.Context) (*clientv3.GetResponse, error) {
+						select {
+						case <-ctx.Done():
+							return nil, ctx.Err()
+						case <-time.After(tc.responseTime):
+							return nil, nil
+						}
+					},
+				}
+				client.KV = dummyKV
+				return client, nil
+			}
+			stop := make(chan struct{})
+			healthcheck, err := CreateReadyCheck(tc.cfg, stop)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Wait for healthcheck to establish connection
+			time.Sleep(2 * time.Second)
+
+			got := healthcheck()
+
+			if !errors.Is(got, tc.want) {
+				t.Errorf("healthcheck() missmatch want %v got %v", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Increase default timeout for etcd healthcheck to 15 seconds.
Add additional etcd check to readyz with 2 seconds timeout.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR increases default timeout for etcd healthcheck to 15 seconds and adds new etcd check to readiness check with timeout of 2 seconds. Currently, when the control plane is overloaded, healthchecks to etcd can take more than 2 seconds marking kube apsierver unhealthy, even if it is only etcd performance degradation. Adding 2 seconds check to readyz should help with load distribution between apiservers in case of etcd performance degradation.

#### Which issue(s) this PR fixes:
Fixes #111290
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
a new flag `etcd-ready-timeout` has been added. It configures a timeout of an additional etcd check performed as part of readyz check. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
