### PR TITLE
Add support for summary metrics for stablity checks

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/summary.go
+++ b/staging/src/k8s.io/component-base/metrics/summary.go
@@ -23,6 +23,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	DefAgeBuckets = prometheus.DefAgeBuckets
+	DefBufCap     = prometheus.DefBufCap
+	DefMaxAge     = prometheus.DefMaxAge
+)
+
 // Summary is our internal representation for our wrapping struct around prometheus
 // summaries. Summary implements both kubeCollector and ObserverMetric
 //

--- a/test/instrumentation/error.go
+++ b/test/instrumentation/error.go
@@ -33,9 +33,13 @@ const (
 	errBadImportedVariableAttribute = "Metric attribute was not correctly set. Please use only global consts in correctly impoprted same file"
 	errFieldNotSupported            = "Field %s is not supported"
 	errBuckets                      = "Buckets should be set to list of floats, result from function call of prometheus.LinearBuckets or prometheus.ExponentialBuckets"
-	errLabels                       = "Labels were not set to list of strings"
-	errImport                       = `Importing using "." is not supported`
-	errExprNotIdent                 = "expr selector does not refer to type ast.Ident, is type %s"
+	errObjectives                   = "Buckets should be set to map of floats to floats"
+	errDecodeUint32                 = "Should decode to uint32"
+	errDecodeInt64                  = "Should decode to int64"
+
+	errLabels       = "Labels were not set to list of strings"
+	errImport       = `Importing using "." is not supported`
+	errExprNotIdent = "expr selector does not refer to type ast.Ident, is type %s"
 )
 
 type decodeError struct {

--- a/test/instrumentation/error.go
+++ b/test/instrumentation/error.go
@@ -33,7 +33,7 @@ const (
 	errBadImportedVariableAttribute = "Metric attribute was not correctly set. Please use only global consts in correctly impoprted same file"
 	errFieldNotSupported            = "Field %s is not supported"
 	errBuckets                      = "Buckets should be set to list of floats, result from function call of prometheus.LinearBuckets or prometheus.ExponentialBuckets"
-	errObjectives                   = "Buckets should be set to map of floats to floats"
+	errObjectives                   = "Objectives should be set to map of floats to floats"
 	errDecodeUint32                 = "Should decode to uint32"
 	errDecodeInt64                  = "Should decode to int64"
 

--- a/test/instrumentation/main_test.go
+++ b/test/instrumentation/main_test.go
@@ -540,18 +540,6 @@ func TestIncorrectStableMetricDeclarations(t *testing.T) {
 		err      error
 	}{
 		{
-			testName: "Fail on stable summary metric (Summary is DEPRECATED)",
-			err:      fmt.Errorf("testdata/metric.go:4:9: Stable summary metric is not supported"),
-			src: `
-package test
-import "k8s.io/component-base/metrics"
-var _ = metrics.NewSummary(
-		&metrics.SummaryOpts{
-			StabilityLevel: metrics.STABLE,
-		},
-	)
-`},
-		{
 			testName: "Fail on stable metric with attribute set to unknown variable",
 			err:      fmt.Errorf("testdata/metric.go:6:4: Metric attribute was not correctly set. Please use only global consts in same file"),
 			src: `

--- a/test/instrumentation/main_test.go
+++ b/test/instrumentation/main_test.go
@@ -696,7 +696,7 @@ var _ = metrics.NewCounter(
 	)
 `},
 		{
-			testName: "error stable historgram with unknown prometheus bucket variable",
+			testName: "error stable histogram with unknown prometheus bucket variable",
 			err:      fmt.Errorf("testdata/metric.go:9:13: Buckets should be set to list of floats, result from function call of prometheus.LinearBuckets or prometheus.ExponentialBuckets"),
 			src: `
 package test
@@ -711,7 +711,22 @@ var _ = metrics.NewHistogram(
 	)
 `},
 		{
-			testName: "error stable historgram with unknown bucket variable",
+			testName: "error stable summary with unknown prometheus objective variable",
+			err:      fmt.Errorf("testdata/metric.go:9:16: Objectives should be set to map of floats to floats"),
+			src: `
+package test
+import "k8s.io/component-base/metrics"
+import "github.com/prometheus/client_golang/prometheus"
+var _ = metrics.NewSummary(
+		&metrics.SummaryOpts{
+			Name: "summary",
+			StabilityLevel: metrics.STABLE,
+			Objectives: prometheus.FakeObjectives,
+		},
+	)
+`},
+		{
+			testName: "error stable histogram with unknown bucket variable",
 			err:      fmt.Errorf("testdata/metric.go:9:13: Buckets should be set to list of floats, result from function call of prometheus.LinearBuckets or prometheus.ExponentialBuckets"),
 			src: `
 package test

--- a/test/instrumentation/metric.go
+++ b/test/instrumentation/metric.go
@@ -24,18 +24,23 @@ const (
 	counterMetricType   = "Counter"
 	gaugeMetricType     = "Gauge"
 	histogramMetricType = "Histogram"
+	summaryMetricType   = "Summary"
 )
 
 type metric struct {
-	Name              string    `yaml:"name"`
-	Subsystem         string    `yaml:"subsystem,omitempty"`
-	Namespace         string    `yaml:"namespace,omitempty"`
-	Help              string    `yaml:"help,omitempty"`
-	Type              string    `yaml:"type,omitempty"`
-	DeprecatedVersion string    `yaml:"deprecatedVersion,omitempty"`
-	StabilityLevel    string    `yaml:"stabilityLevel,omitempty"`
-	Labels            []string  `yaml:"labels,omitempty"`
-	Buckets           []float64 `yaml:"buckets,omitempty"`
+	Name              string              `yaml:"name"`
+	Subsystem         string              `yaml:"subsystem,omitempty"`
+	Namespace         string              `yaml:"namespace,omitempty"`
+	Help              string              `yaml:"help,omitempty"`
+	Type              string              `yaml:"type,omitempty"`
+	DeprecatedVersion string              `yaml:"deprecatedVersion,omitempty"`
+	StabilityLevel    string              `yaml:"stabilityLevel,omitempty"`
+	Labels            []string            `yaml:"labels,omitempty"`
+	Buckets           []float64           `yaml:"buckets,omitempty"`
+	Objectives        map[float64]float64 `yaml:"objectives,omitempty"`
+	AgeBuckets        uint32              `yaml:"ageBuckets,omitempty"`
+	BufCap            uint32              `yaml:"bufCap,omitempty"`
+	MaxAge            int64               `yaml:"maxAge,omitempty"`
 }
 
 func (m metric) buildFQName() string {

--- a/test/instrumentation/test-update.sh
+++ b/test/instrumentation/test-update.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs to ensure that we do not violate metric stability
+# policies.
+# Usage: `test/instrumentation/test-update.sh`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
+source "${KUBE_ROOT}/test/instrumentation/stability-utils.sh"
+
+kube::update::test::stablemetrics

--- a/test/instrumentation/test-verify.sh
+++ b/test/instrumentation/test-verify.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs to ensure that we do not violate metric stability
+# policies.
+# Usage: `test/instrumentation/test-verify.sh`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
+source "${KUBE_ROOT}/test/instrumentation/stability-utils.sh"
+
+kube::validate::test::stablemetrics

--- a/test/instrumentation/testdata/pkg/kubelet/metrics/metrics.go
+++ b/test/instrumentation/testdata/pkg/kubelet/metrics/metrics.go
@@ -28,28 +28,22 @@ import (
 
 // This const block defines the metric names for the kubelet metrics.
 const (
-	KubeletSubsystem             = "kubelet"
-	NodeNameKey                  = "node_name"
-	NodeLabelKey                 = "node"
-	PodWorkerDurationKey         = "pod_worker_duration_seconds"
-	PodStartDurationKey          = "pod_start_duration_seconds"
-	CgroupManagerOperationsKey   = "cgroup_manager_duration_seconds"
-	PodWorkerStartDurationKey    = "pod_worker_start_duration_seconds"
-	PLEGRelistDurationKey        = "pleg_relist_duration_seconds"
-	PLEGDiscardEventsKey         = "pleg_discard_events"
-	PLEGRelistIntervalKey        = "pleg_relist_interval_seconds"
-	PLEGLastSeenKey              = "pleg_last_seen_seconds"
-	EvictionsKey                 = "evictions"
-	EvictionStatsAgeKey          = "eviction_stats_age_seconds"
-	PreemptionsKey               = "preemptions"
-	VolumeStatsCapacityBytesKey  = "volume_stats_capacity_bytes"
-	VolumeStatsAvailableBytesKey = "volume_stats_available_bytes"
-	VolumeStatsUsedBytesKey      = "volume_stats_used_bytes"
-	VolumeStatsInodesKey         = "volume_stats_inodes"
-	VolumeStatsInodesFreeKey     = "volume_stats_inodes_free"
-	VolumeStatsInodesUsedKey     = "volume_stats_inodes_used"
-	RunningPodsKey               = "running_pods"
-	RunningContainersKey         = "running_containers"
+	KubeletSubsystem           = "kubelet"
+	NodeNameKey                = "node_name"
+	NodeLabelKey               = "node"
+	PodWorkerDurationKey       = "pod_worker_duration_seconds"
+	PodStartDurationKey        = "pod_start_duration_seconds"
+	CgroupManagerOperationsKey = "cgroup_manager_duration_seconds"
+	PodWorkerStartDurationKey  = "pod_worker_start_duration_seconds"
+	PLEGRelistDurationKey      = "pleg_relist_duration_seconds"
+	PLEGDiscardEventsKey       = "pleg_discard_events"
+	PLEGRelistIntervalKey      = "pleg_relist_interval_seconds"
+	PLEGLastSeenKey            = "pleg_last_seen_seconds"
+	EvictionsKey               = "evictions"
+	EvictionStatsAgeKey        = "eviction_stats_age_seconds"
+	PreemptionsKey             = "preemptions"
+	RunningPodsKey             = "running_pods"
+	RunningContainersKey       = "running_containers"
 	// Metrics keys of remote runtime operations
 	RuntimeOperationsKey         = "runtime_operations_total"
 	RuntimeOperationsDurationKey = "runtime_operations_duration_seconds"
@@ -70,6 +64,7 @@ const (
 )
 
 var (
+	defObjectives = map[float64]float64{0.5: 0.5, 0.75: 0.75}
 	// NodeName is a Gauge that tracks the ode's name. The count is always 1.
 	NodeName = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
@@ -160,10 +155,10 @@ var (
 	PLEGRelistInterval = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem:      KubeletSubsystem,
-			Name:           PLEGRelistIntervalKey,
+			Name:           "test_histogram_metric",
 			Help:           "Interval in seconds between relisting in PLEG.",
 			Buckets:        metrics.DefBuckets,
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.STABLE,
 		},
 	)
 	// PLEGLastSeen is a Gauge giving the Unix timestamp when the Kubelet's
@@ -265,6 +260,32 @@ var (
 			Help:           "Duration in seconds to serve a device plugin Allocation request. Broken down by resource name.",
 			Buckets:        metrics.DefBuckets,
 			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"resource_name"},
+	)
+
+	// TestSummary is a Summary that tracks the cumulative number of device plugin registrations.
+	// Broken down by resource name.
+	TestSummary = metrics.NewSummary(
+		&metrics.SummaryOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           "summary_metric_test",
+			Help:           "Cumulative number of device plugin registrations. Broken down by resource name.",
+			StabilityLevel: metrics.STABLE,
+		},
+	)
+	// TestSummaryVec is a NewSummaryVec that tracks the duration (in seconds) to serve a device plugin allocation request.
+	// Broken down by resource name.
+	TestSummaryVec = metrics.NewSummaryVec(
+		&metrics.SummaryOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           "summary_vec_metric_test",
+			Help:           "Duration in seconds to serve a device plugin Allocation request. Broken down by resource name.",
+			Objectives:     defObjectives,
+			MaxAge:         metrics.DefMaxAge,
+			AgeBuckets:     metrics.DefAgeBuckets,
+			BufCap:         metrics.DefBufCap,
+			StabilityLevel: metrics.STABLE,
 		},
 		[]string{"resource_name"},
 	)

--- a/test/instrumentation/testdata/test-stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/test-stable-metrics-list.yaml
@@ -1,0 +1,37 @@
+- name: summary_metric_test
+  subsystem: kubelet
+  help: Cumulative number of device plugin registrations. Broken down by resource
+    name.
+  type: Summary
+  stabilityLevel: STABLE
+- name: summary_vec_metric_test
+  subsystem: kubelet
+  help: Duration in seconds to serve a device plugin Allocation request. Broken down
+    by resource name.
+  type: Summary
+  stabilityLevel: STABLE
+  labels:
+  - resource_name
+  objectives:
+    0.5: 0.5
+    0.75: 0.75
+  ageBuckets: 5
+  bufCap: 500
+  maxAge: 600000000000
+- name: test_histogram_metric
+  subsystem: kubelet
+  help: Interval in seconds between relisting in PLEG.
+  type: Histogram
+  stabilityLevel: STABLE
+  buckets:
+  - 0.005
+  - 0.01
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  - 10


### PR DESCRIPTION
Also add entrypoints for verifying and updating a test file for easier
debugging. This is considerably faster than running the stablity checks
against the entire Kubernetes codebase.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We haven't been able to properly parse summary metrics using the stability framework, this fixes that. It also adds testing capabilities to the stability framework, for ease in development debuggability.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig instrumentation
/priority important-soon
/assign @dgrisonnet 
