### PR TITLE
Improve and simplify maintenance of APF bootstrap objects without type assertions

### DIFF
--- a/pkg/registry/flowcontrol/ensurer/flowschema.go
+++ b/pkg/registry/flowcontrol/ensurer/flowschema.go
@@ -18,194 +18,152 @@ package ensurer
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	flowcontrolv1beta3 "k8s.io/api/flowcontrol/v1beta3"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	flowcontrolclient "k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3"
 	flowcontrollisters "k8s.io/client-go/listers/flowcontrol/v1beta3"
 	flowcontrolapisv1beta3 "k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta3"
 )
 
-var (
-	errObjectNotFlowSchema = errors.New("object is not a FlowSchema type")
-)
-
-// FlowSchemaEnsurer ensures the specified bootstrap configuration objects
-type FlowSchemaEnsurer interface {
-	Ensure([]*flowcontrolv1beta3.FlowSchema) error
-}
-
-// FlowSchemaRemover is the interface that wraps the
-// RemoveAutoUpdateEnabledObjects method.
-//
-// RemoveAutoUpdateEnabledObjects removes a set of bootstrap FlowSchema
-// objects specified via their names. The function removes an object
-// only if automatic update of the spec is enabled for it.
-type FlowSchemaRemover interface {
-	RemoveAutoUpdateEnabledObjects([]string) error
-}
-
-// NewSuggestedFlowSchemaEnsurer returns a FlowSchemaEnsurer instance that
-// can be used to ensure a set of suggested FlowSchema configuration objects.
-func NewSuggestedFlowSchemaEnsurer(client flowcontrolclient.FlowSchemaInterface, lister flowcontrollisters.FlowSchemaLister) FlowSchemaEnsurer {
-	wrapper := &flowSchemaWrapper{
-		client: client,
-		lister: lister,
-	}
-	return &fsEnsurer{
-		strategy: newSuggestedEnsureStrategy(wrapper),
-		wrapper:  wrapper,
-	}
-}
-
-// NewMandatoryFlowSchemaEnsurer returns a FlowSchemaEnsurer instance that
-// can be used to ensure a set of mandatory FlowSchema configuration objects.
-func NewMandatoryFlowSchemaEnsurer(client flowcontrolclient.FlowSchemaInterface, lister flowcontrollisters.FlowSchemaLister) FlowSchemaEnsurer {
-	wrapper := &flowSchemaWrapper{
-		client: client,
-		lister: lister,
-	}
-	return &fsEnsurer{
-		strategy: newMandatoryEnsureStrategy(wrapper),
-		wrapper:  wrapper,
-	}
-}
-
-// NewFlowSchemaRemover returns a FlowSchemaRemover instance that
-// can be used to remove a set of FlowSchema configuration objects.
-func NewFlowSchemaRemover(client flowcontrolclient.FlowSchemaInterface, lister flowcontrollisters.FlowSchemaLister) FlowSchemaRemover {
-	return &fsEnsurer{
-		wrapper: &flowSchemaWrapper{
+// WrapBootstrapFlowSchemas creates a generic representation of the given bootstrap objects bound with their operations
+// Every object in `boots` is immutable.
+func WrapBootstrapFlowSchemas(client flowcontrolclient.FlowSchemaInterface, lister flowcontrollisters.FlowSchemaLister, boots []*flowcontrolv1beta3.FlowSchema) BootstrapObjects {
+	return &bootstrapFlowSchemas{
+		flowSchemaClient: flowSchemaClient{
 			client: client,
-			lister: lister,
-		},
+			lister: lister},
+		boots: boots,
 	}
 }
 
-// GetFlowSchemaRemoveCandidates returns a list of FlowSchema object
-// names that are candidates for deletion from the cluster.
-// bootstrap: a set of hard coded FlowSchema configuration objects
-// kube-apiserver maintains in-memory.
-func GetFlowSchemaRemoveCandidates(lister flowcontrollisters.FlowSchemaLister, bootstrap []*flowcontrolv1beta3.FlowSchema) ([]string, error) {
-	fsList, err := lister.List(labels.Everything())
-	if err != nil {
-		return nil, fmt.Errorf("failed to list FlowSchema - %w", err)
-	}
-
-	bootstrapNames := sets.String{}
-	for i := range bootstrap {
-		bootstrapNames.Insert(bootstrap[i].GetName())
-	}
-
-	currentObjects := make([]metav1.Object, len(fsList))
-	for i := range fsList {
-		currentObjects[i] = fsList[i]
-	}
-
-	return getDanglingBootstrapObjectNames(bootstrapNames, currentObjects), nil
-}
-
-type fsEnsurer struct {
-	strategy ensureStrategy
-	wrapper  configurationWrapper
-}
-
-func (e *fsEnsurer) Ensure(flowSchemas []*flowcontrolv1beta3.FlowSchema) error {
-	for _, flowSchema := range flowSchemas {
-		// This code gets called by different goroutines. To avoid race conditions when
-		// https://github.com/kubernetes/kubernetes/blob/330b5a2b8dbd681811cb8235947557c99dd8e593/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go#L221-L243
-		// temporarily modifies the TypeMeta, we have to make a copy here.
-		if err := ensureConfiguration(e.wrapper, e.strategy, flowSchema.DeepCopy()); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (e *fsEnsurer) RemoveAutoUpdateEnabledObjects(flowSchemas []string) error {
-	for _, flowSchema := range flowSchemas {
-		if err := removeAutoUpdateEnabledConfiguration(e.wrapper, flowSchema); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// flowSchemaWrapper abstracts all FlowSchema specific logic, with this
-// we can manage all boiler plate code in one place.
-type flowSchemaWrapper struct {
+type flowSchemaClient struct {
 	client flowcontrolclient.FlowSchemaInterface
 	lister flowcontrollisters.FlowSchemaLister
 }
 
-func (fs *flowSchemaWrapper) TypeName() string {
+type bootstrapFlowSchemas struct {
+	flowSchemaClient
+
+	// Every member is a pointer to immutable content
+	boots []*flowcontrolv1beta3.FlowSchema
+}
+
+func (*flowSchemaClient) typeName() string {
 	return "FlowSchema"
 }
 
-func (fs *flowSchemaWrapper) Create(object runtime.Object) (runtime.Object, error) {
-	fsObject, ok := object.(*flowcontrolv1beta3.FlowSchema)
-	if !ok {
-		return nil, errObjectNotFlowSchema
-	}
-
-	return fs.client.Create(context.TODO(), fsObject, metav1.CreateOptions{FieldManager: fieldManager})
+func (boots *bootstrapFlowSchemas) len() int {
+	return len(boots.boots)
 }
 
-func (fs *flowSchemaWrapper) Update(object runtime.Object) (runtime.Object, error) {
-	fsObject, ok := object.(*flowcontrolv1beta3.FlowSchema)
-	if !ok {
-		return nil, errObjectNotFlowSchema
+func (boots *bootstrapFlowSchemas) get(i int) bootstrapObject {
+	return &bootstrapFlowSchema{
+		flowSchemaClient: &boots.flowSchemaClient,
+		bootstrap:        boots.boots[i],
 	}
-
-	return fs.client.Update(context.TODO(), fsObject, metav1.UpdateOptions{FieldManager: fieldManager})
 }
 
-func (fs *flowSchemaWrapper) Get(name string) (configurationObject, error) {
-	return fs.lister.Get(name)
+func (boots *bootstrapFlowSchemas) getExistingObjects() ([]deletable, error) {
+	objs, err := boots.lister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list FlowSchema objects - %w", err)
+	}
+	dels := make([]deletable, len(objs))
+	for i, obj := range objs {
+		dels[i] = &deletableFlowSchema{
+			FlowSchema: obj,
+			client:     boots.client,
+		}
+	}
+	return dels, nil
 }
 
-func (fs *flowSchemaWrapper) Delete(name string) error {
-	return fs.client.Delete(context.TODO(), name, metav1.DeleteOptions{})
+type bootstrapFlowSchema struct {
+	*flowSchemaClient
+
+	// points to immutable contnet
+	bootstrap *flowcontrolv1beta3.FlowSchema
 }
 
-func (fs *flowSchemaWrapper) CopySpec(bootstrap, current runtime.Object) error {
-	bootstrapFS, ok := bootstrap.(*flowcontrolv1beta3.FlowSchema)
-	if !ok {
-		return errObjectNotFlowSchema
-	}
-	currentFS, ok := current.(*flowcontrolv1beta3.FlowSchema)
-	if !ok {
-		return errObjectNotFlowSchema
-	}
-
-	specCopy := bootstrapFS.Spec.DeepCopy()
-	currentFS.Spec = *specCopy
-	return nil
+func (boot *bootstrapFlowSchema) getName() string {
+	return boot.bootstrap.Name
 }
 
-func (fs *flowSchemaWrapper) HasSpecChanged(bootstrap, current runtime.Object) (bool, error) {
-	bootstrapFS, ok := bootstrap.(*flowcontrolv1beta3.FlowSchema)
-	if !ok {
-		return false, errObjectNotFlowSchema
-	}
-	currentFS, ok := current.(*flowcontrolv1beta3.FlowSchema)
-	if !ok {
-		return false, errObjectNotFlowSchema
-	}
+func (boot *bootstrapFlowSchema) create(ctx context.Context) error {
+	// Copy the object here because the Encoder in the client code may modify the object; see
+	// https://github.com/kubernetes/kubernetes/pull/117107
+	// and WithVersionEncoder in apimachinery/pkg/runtime/helper.go.
+	_, err := boot.client.Create(ctx, boot.bootstrap.DeepCopy(), metav1.CreateOptions{FieldManager: fieldManager})
+	return err
+}
 
-	return flowSchemaSpecChanged(bootstrapFS, currentFS), nil
+func (boot *bootstrapFlowSchema) getCurrent() (wantAndHave, error) {
+	current, err := boot.lister.Get(boot.bootstrap.Name)
+	if err != nil {
+		return nil, err
+	}
+	return &wantAndHaveFlowSchema{
+		client: boot.client,
+		want:   boot.bootstrap,
+		have:   current,
+	}, nil
+}
+
+type wantAndHaveFlowSchema struct {
+	client flowcontrolclient.FlowSchemaInterface
+	want   *flowcontrolv1beta3.FlowSchema
+	have   *flowcontrolv1beta3.FlowSchema
+}
+
+func (wah *wantAndHaveFlowSchema) getWant() configurationObject {
+	return wah.want
+}
+
+func (wah *wantAndHaveFlowSchema) getHave() configurationObject {
+	return wah.have
+}
+
+func (wah *wantAndHaveFlowSchema) copyHave(specFromWant bool) updatable {
+	copy := wah.have.DeepCopy()
+	if specFromWant {
+		copy.Spec = *wah.want.Spec.DeepCopy()
+	}
+	return &updatableFlowSchema{
+		FlowSchema: copy,
+		client:     wah.client,
+	}
+}
+
+func (wah *wantAndHaveFlowSchema) specsDiffer() bool {
+	return flowSchemaSpecChanged(wah.want, wah.have)
 }
 
 func flowSchemaSpecChanged(expected, actual *flowcontrolv1beta3.FlowSchema) bool {
 	copiedExpectedFlowSchema := expected.DeepCopy()
 	flowcontrolapisv1beta3.SetObjectDefaults_FlowSchema(copiedExpectedFlowSchema)
 	return !equality.Semantic.DeepEqual(copiedExpectedFlowSchema.Spec, actual.Spec)
+}
+
+type updatableFlowSchema struct {
+	*flowcontrolv1beta3.FlowSchema
+	client flowcontrolclient.FlowSchemaInterface
+}
+
+func (u *updatableFlowSchema) update(ctx context.Context) error {
+	_, err := u.client.Update(ctx, u.FlowSchema, metav1.UpdateOptions{FieldManager: fieldManager})
+	return err
+}
+
+type deletableFlowSchema struct {
+	*flowcontrolv1beta3.FlowSchema
+	client flowcontrolclient.FlowSchemaInterface
+}
+
+func (dbl *deletableFlowSchema) delete(ctx context.Context /* TODO: resourceVersion string */) error {
+	// return dbl.client.Delete(context.TODO(), dbl.Name, metav1.DeleteOptions{Preconditions: &metav1.Preconditions{ResourceVersion: &resourceVersion}})
+	return dbl.client.Delete(ctx, dbl.Name, metav1.DeleteOptions{})
 }

--- a/pkg/registry/flowcontrol/ensurer/flowschema_test.go
+++ b/pkg/registry/flowcontrol/ensurer/flowschema_test.go
@@ -26,20 +26,23 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
 	"k8s.io/client-go/kubernetes/fake"
-	flowcontrolclient "k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3"
 	flowcontrollisters "k8s.io/client-go/listers/flowcontrol/v1beta3"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 	flowcontrolapisv1beta3 "k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta3"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 )
+
+func init() {
+	klog.InitFlags(nil)
+}
 
 func TestEnsureFlowSchema(t *testing.T) {
 	tests := []struct {
 		name      string
-		strategy  func(flowcontrolclient.FlowSchemaInterface, flowcontrollisters.FlowSchemaLister) FlowSchemaEnsurer
+		strategy  func() EnsureStrategy
 		current   *flowcontrolv1beta3.FlowSchema
 		bootstrap *flowcontrolv1beta3.FlowSchema
 		expected  *flowcontrolv1beta3.FlowSchema
@@ -47,21 +50,21 @@ func TestEnsureFlowSchema(t *testing.T) {
 		// for suggested configurations
 		{
 			name:      "suggested flow schema does not exist - the object should always be re-created",
-			strategy:  NewSuggestedFlowSchemaEnsurer,
+			strategy:  NewSuggestedEnsureStrategy,
 			bootstrap: newFlowSchema("fs1", "pl1", 100).Object(),
 			current:   nil,
 			expected:  newFlowSchema("fs1", "pl1", 100).Object(),
 		},
 		{
 			name:      "suggested flow schema exists, auto update is enabled, spec does not match - current object should be updated",
-			strategy:  NewSuggestedFlowSchemaEnsurer,
+			strategy:  NewSuggestedEnsureStrategy,
 			bootstrap: newFlowSchema("fs1", "pl1", 100).Object(),
 			current:   newFlowSchema("fs1", "pl1", 200).WithAutoUpdateAnnotation("true").Object(),
 			expected:  newFlowSchema("fs1", "pl1", 100).WithAutoUpdateAnnotation("true").Object(),
 		},
 		{
 			name:      "suggested flow schema exists, auto update is disabled, spec does not match - current object should not be updated",
-			strategy:  NewSuggestedFlowSchemaEnsurer,
+			strategy:  NewSuggestedEnsureStrategy,
 			bootstrap: newFlowSchema("fs1", "pl1", 100).Object(),
 			current:   newFlowSchema("fs1", "pl1", 200).WithAutoUpdateAnnotation("false").Object(),
 			expected:  newFlowSchema("fs1", "pl1", 200).WithAutoUpdateAnnotation("false").Object(),
@@ -70,21 +73,21 @@ func TestEnsureFlowSchema(t *testing.T) {
 		// for mandatory configurations
 		{
 			name:      "mandatory flow schema does not exist - new object should be created",
-			strategy:  NewMandatoryFlowSchemaEnsurer,
+			strategy:  NewMandatoryEnsureStrategy,
 			bootstrap: newFlowSchema("fs1", "pl1", 100).WithAutoUpdateAnnotation("true").Object(),
 			current:   nil,
 			expected:  newFlowSchema("fs1", "pl1", 100).WithAutoUpdateAnnotation("true").Object(),
 		},
 		{
 			name:      "mandatory flow schema exists, annotation is missing - annotation should be added",
-			strategy:  NewMandatoryFlowSchemaEnsurer,
+			strategy:  NewMandatoryEnsureStrategy,
 			bootstrap: newFlowSchema("fs1", "pl1", 100).Object(),
 			current:   newFlowSchema("fs1", "pl1", 100).Object(),
 			expected:  newFlowSchema("fs1", "pl1", 100).WithAutoUpdateAnnotation("true").Object(),
 		},
 		{
 			name:      "mandatory flow schema exists, auto update is disabled, spec does not match - current object should be updated",
-			strategy:  NewMandatoryFlowSchemaEnsurer,
+			strategy:  NewMandatoryEnsureStrategy,
 			bootstrap: newFlowSchema("fs1", "pl1", 100).Object(),
 			current:   newFlowSchema("fs1", "pl1", 200).WithAutoUpdateAnnotation("false").Object(),
 			expected:  newFlowSchema("fs1", "pl1", 100).WithAutoUpdateAnnotation("true").Object(),
@@ -100,9 +103,9 @@ func TestEnsureFlowSchema(t *testing.T) {
 				indexer.Add(test.current)
 			}
 
-			ensurer := test.strategy(client, flowcontrollisters.NewFlowSchemaLister(indexer))
-
-			err := ensurer.Ensure([]*flowcontrolv1beta3.FlowSchema{test.bootstrap})
+			boots := WrapBootstrapFlowSchemas(client, flowcontrollisters.NewFlowSchemaLister(indexer), []*flowcontrolv1beta3.FlowSchema{test.bootstrap})
+			strategy := test.strategy()
+			err := EnsureConfigurations(context.Background(), boots, strategy)
 			if err != nil {
 				t.Fatalf("Expected no error, but got: %v", err)
 			}
@@ -207,12 +210,19 @@ func TestSuggestedFSEnsureStrategy_ShouldUpdate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			strategy := newSuggestedEnsureStrategy(&flowSchemaWrapper{})
-			newObjectGot, updateGot, err := strategy.ShouldUpdate(test.current, test.bootstrap)
+			wah := &wantAndHaveFlowSchema{
+				want: test.bootstrap,
+				have: test.current,
+			}
+			strategy := NewSuggestedEnsureStrategy()
+			updatableGot, updateGot, err := strategy.ShouldUpdate(wah)
 			if err != nil {
 				t.Errorf("Expected no error, but got: %v", err)
 			}
-
+			var newObjectGot *flowcontrolv1beta3.FlowSchema
+			if updatableGot != nil {
+				newObjectGot = updatableGot.(*updatableFlowSchema).FlowSchema
+			}
 			if test.newObjectExpected == nil {
 				if newObjectGot != nil {
 					t.Errorf("Expected a nil object, but got: %#v", newObjectGot)
@@ -288,24 +298,42 @@ func TestRemoveFlowSchema(t *testing.T) {
 		removeExpected bool
 	}{
 		{
-			name:          "flow schema does not exist",
+			name:          "no flow schema objects exist",
 			bootstrapName: "fs1",
 			current:       nil,
 		},
 		{
-			name:           "flow schema exists, auto update is enabled",
-			bootstrapName:  "fs1",
+			name:           "flow schema unwanted, auto update is enabled",
+			bootstrapName:  "fs0",
 			current:        newFlowSchema("fs1", "pl1", 200).WithAutoUpdateAnnotation("true").Object(),
 			removeExpected: true,
 		},
 		{
-			name:           "flow schema exists, auto update is disabled",
+			name:           "flow schema unwanted, auto update is disabled",
+			bootstrapName:  "fs0",
+			current:        newFlowSchema("fs1", "pl1", 200).WithAutoUpdateAnnotation("false").Object(),
+			removeExpected: false,
+		},
+		{
+			name:           "flow schema unwanted, the auto-update annotation is malformed",
+			bootstrapName:  "fs0",
+			current:        newFlowSchema("fs1", "pl1", 200).WithAutoUpdateAnnotation("invalid").Object(),
+			removeExpected: false,
+		},
+		{
+			name:           "flow schema wanted, auto update is enabled",
+			bootstrapName:  "fs1",
+			current:        newFlowSchema("fs1", "pl1", 200).WithAutoUpdateAnnotation("true").Object(),
+			removeExpected: false,
+		},
+		{
+			name:           "flow schema wanted, auto update is disabled",
 			bootstrapName:  "fs1",
 			current:        newFlowSchema("fs1", "pl1", 200).WithAutoUpdateAnnotation("false").Object(),
 			removeExpected: false,
 		},
 		{
-			name:           "flow schema exists, the auto-update annotation is malformed",
+			name:           "flow schema wanted, the auto-update annotation is malformed",
 			bootstrapName:  "fs1",
 			current:        newFlowSchema("fs1", "pl1", 200).WithAutoUpdateAnnotation("invalid").Object(),
 			removeExpected: false,
@@ -320,9 +348,10 @@ func TestRemoveFlowSchema(t *testing.T) {
 				client.Create(context.TODO(), test.current, metav1.CreateOptions{})
 				indexer.Add(test.current)
 			}
+			bootFS := newFlowSchema(test.bootstrapName, "pl", 100).Object()
+			boots := WrapBootstrapFlowSchemas(client, flowcontrollisters.NewFlowSchemaLister(indexer), []*flowcontrolv1beta3.FlowSchema{bootFS})
+			err := RemoveUnwantedObjects(context.Background(), boots)
 
-			remover := NewFlowSchemaRemover(client, flowcontrollisters.NewFlowSchemaLister(indexer))
-			err := remover.RemoveAutoUpdateEnabledObjects([]string{test.bootstrapName})
 			if err != nil {
 				t.Fatalf("Expected no error, but got: %v", err)
 			}
@@ -330,95 +359,16 @@ func TestRemoveFlowSchema(t *testing.T) {
 			if test.current == nil {
 				return
 			}
-			_, err = client.Get(context.TODO(), test.bootstrapName, metav1.GetOptions{})
+			_, err = client.Get(context.TODO(), test.current.Name, metav1.GetOptions{})
 			switch {
 			case test.removeExpected:
 				if !apierrors.IsNotFound(err) {
-					t.Errorf("Expected error: %q, but got: %v", metav1.StatusReasonNotFound, err)
+					t.Errorf("Expected error from Get after Delete: %q, but got: %v", metav1.StatusReasonNotFound, err)
 				}
 			default:
 				if err != nil {
-					t.Errorf("Expected no error, but got: %v", err)
+					t.Errorf("Expected no error from Get after Delete, but got: %v", err)
 				}
-			}
-		})
-	}
-}
-
-func TestGetFlowSchemaRemoveCandidate(t *testing.T) {
-	tests := []struct {
-		name      string
-		current   []*flowcontrolv1beta3.FlowSchema
-		bootstrap []*flowcontrolv1beta3.FlowSchema
-		expected  []string
-	}{
-		{
-			name: "no object has been removed from the bootstrap configuration",
-			bootstrap: []*flowcontrolv1beta3.FlowSchema{
-				newFlowSchema("fs1", "pl1", 100).WithAutoUpdateAnnotation("true").Object(),
-				newFlowSchema("fs2", "pl2", 200).WithAutoUpdateAnnotation("true").Object(),
-				newFlowSchema("fs3", "pl3", 300).WithAutoUpdateAnnotation("true").Object(),
-			},
-			current: []*flowcontrolv1beta3.FlowSchema{
-				newFlowSchema("fs1", "pl1", 100).WithAutoUpdateAnnotation("true").Object(),
-				newFlowSchema("fs2", "pl2", 200).WithAutoUpdateAnnotation("true").Object(),
-				newFlowSchema("fs3", "pl3", 300).WithAutoUpdateAnnotation("true").Object(),
-			},
-			expected: []string{},
-		},
-		{
-			name:      "bootstrap is empty, all current objects with the annotation should be candidates",
-			bootstrap: []*flowcontrolv1beta3.FlowSchema{},
-			current: []*flowcontrolv1beta3.FlowSchema{
-				newFlowSchema("fs1", "pl1", 100).WithAutoUpdateAnnotation("true").Object(),
-				newFlowSchema("fs2", "pl2", 200).WithAutoUpdateAnnotation("true").Object(),
-				newFlowSchema("fs3", "pl3", 300).Object(),
-			},
-			expected: []string{"fs1", "fs2"},
-		},
-		{
-			name: "object(s) have been removed from the bootstrap configuration",
-			bootstrap: []*flowcontrolv1beta3.FlowSchema{
-				newFlowSchema("fs1", "pl1", 100).WithAutoUpdateAnnotation("true").Object(),
-			},
-			current: []*flowcontrolv1beta3.FlowSchema{
-				newFlowSchema("fs1", "pl1", 100).WithAutoUpdateAnnotation("true").Object(),
-				newFlowSchema("fs2", "pl2", 200).WithAutoUpdateAnnotation("true").Object(),
-				newFlowSchema("fs3", "pl3", 300).WithAutoUpdateAnnotation("true").Object(),
-			},
-			expected: []string{"fs2", "fs3"},
-		},
-		{
-			name: "object(s) without the annotation key are ignored",
-			bootstrap: []*flowcontrolv1beta3.FlowSchema{
-				newFlowSchema("fs1", "pl1", 100).WithAutoUpdateAnnotation("true").Object(),
-			},
-			current: []*flowcontrolv1beta3.FlowSchema{
-				newFlowSchema("fs1", "pl1", 100).WithAutoUpdateAnnotation("true").Object(),
-				newFlowSchema("fs2", "pl2", 200).Object(),
-				newFlowSchema("fs3", "pl3", 300).Object(),
-			},
-			expected: []string{},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-			for i := range test.current {
-				indexer.Add(test.current[i])
-			}
-
-			lister := flowcontrollisters.NewFlowSchemaLister(indexer)
-			removeListGot, err := GetFlowSchemaRemoveCandidates(lister, test.bootstrap)
-			if err != nil {
-				t.Fatalf("Expected no error, but got: %v", err)
-			}
-
-			if !cmp.Equal(test.expected, removeListGot, cmpopts.SortSlices(func(a string, b string) bool {
-				return a < b
-			})) {
-				t.Errorf("Remove candidate list does not match - diff: %s", cmp.Diff(test.expected, removeListGot))
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Five things:

- Remove unnecessary layers of indirection to reach constant logic.
- Remove unnecessary split between finding unwanted objects and removing them.
- Use interfaces to remove need for type assertions.
- Consistently use a context.Context tied to the server shutdown.
- This PR does _not_ make deletion of unwanted objects conditional on ResourceVersion.  That would be a functional improvement, which I am reserving for a follow-on PR.  However, this PR includes some TODOs highlighting where that follow-on will make changes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This PR does not address point 4 of #107097 but _does_ include TODOs about how to fix that in a follow-on PR.

#### Special notes for your reviewer:
This is #107704 brought back to life.
This is an alternative to #107696 .
The version has the advantage of not using type assertions (outside the tests).
Accomplishing this required carefully wrapping up data and operations in interfaces,
arguably making more convoluted code.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
