### PR TITLE
max-in-flight watermarks insist on efficient RatioedGaugeVec indexing

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/interface.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/interface.go
@@ -46,6 +46,14 @@ type RatioedGaugeVec interface {
 	// The "Safe" part is saying that the returned object will function properly after metric registration
 	// even if this method is called before registration.
 	NewForLabelValuesSafe(initialNumerator, initialDenominator float64, labelValues []string) RatioedGauge
+	// NewForLabelValuesEfficient makes a new vector member for the given tuple of label values,
+	// initialized with the given numerator and denominator.
+	// Unlike the usual Vec WithLabelValues method, this is intended to be called only
+	// once per vector member (at the start of its lifecycle).
+	// The "Efficient" part is saying that either (a) this was called after metric registration and
+	// the returned object does not repeatedly index into the underlying object, or
+	// (b) this was called before metric registration and panics.
+	NewForLabelValuesEfficient(initialNumerator, initialDenominator float64, labelValues []string) RatioedGauge
 }
 
 //////////////////////////////// Pairs ////////////////////////////////

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
@@ -350,7 +350,7 @@ type indexOnce struct {
 
 func (io *indexOnce) getGauge() RatioedGauge {
 	io.once.Do(func() {
-		io.gauge = readWriteConcurrencyGaugeVec.NewForLabelValuesSafe(0, 1, io.labelValues)
+		io.gauge = readWriteConcurrencyGaugeVec.NewForLabelValuesEfficient(0, 1, io.labelValues)
 	})
 	return io.gauge
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/timing_ratio_histogram.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/timing_ratio_histogram.go
@@ -210,6 +210,20 @@ func (v *TimingRatioHistogramVec) NewForLabelValuesSafe(initialNumerator, initia
 	}
 }
 
+func (v *TimingRatioHistogramVec) NewForLabelValuesEfficient(initialNumerator, initialDenominator float64, labelValues []string) RatioedGauge {
+	tro, err := v.NewForLabelValuesChecked(initialNumerator, initialDenominator, labelValues)
+	if err == nil {
+		klog.V(3).InfoS("TimingRatioHistogramVec.NewForLabelValuesEfficient hit the efficient case", "fqName", v.FQName(), "labelValues", labelValues)
+		return tro
+	}
+	if !compbasemetrics.ErrIsNotRegistered(err) {
+		klog.ErrorS(err, "Failed to extract TimingRatioHistogramVec member, using noop instead", "vectorname", v.FQName(), "labelValues", labelValues)
+		return tro
+	}
+	klog.ErrorS(nil, "TimingRatioHistogramVec.NewForLabelValuesEfficient hit the inefficient case", "fqName", v.FQName(), "labelValues", labelValues)
+	panic(v.FQName())
+}
+
 type noopRatioed struct{}
 
 func (noopRatioed) Set(float64)            {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR tests the accuracy of the assertion in https://github.com/kubernetes/kubernetes/pull/110164#discussion_r928516519 that the metrics are registered by the time the max-in-flight and APF filters are constructed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig api-machinery
/cc @wojtek-t 
