### PR TITLE
Promote Ephemeral Containers e2e test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1842,6 +1842,13 @@
     visible at runtime in the container.
   release: v1.9
   file: test/e2e/common/node/downwardapi.go
+- testname: Ephemeral Container Creation
+  codename: '[sig-node] Ephemeral Containers [NodeConformance] will start an ephemeral
+    container in an existing pod [Conformance]'
+  description: Adding an ephemeral container to pod.spec MUST result in the container
+    running.
+  release: "1.25"
+  file: test/e2e/common/node/ephemeral_containers.go
 - testname: init-container-starts-app-restartalways-pod
   codename: '[sig-node] InitContainer [NodeConformance] should invoke init containers
     on a RestartAlways pod [Conformance]'

--- a/test/e2e/common/node/ephemeral_containers.go
+++ b/test/e2e/common/node/ephemeral_containers.go
@@ -41,7 +41,10 @@ var _ = SIGDescribe("Ephemeral Containers [NodeConformance]", func() {
 		podClient = f.PodClient()
 	})
 
-	ginkgo.It("will start an ephemeral container in an existing pod", func() {
+	// Release: 1.25
+	// Testname: Ephemeral Container Creation
+	// Description: Adding an ephemeral container to pod.spec MUST result in the container running.
+	framework.ConformanceIt("will start an ephemeral container in an existing pod", func() {
 		ginkgo.By("creating a target pod")
 		pod := podClient.CreateSync(&v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "ephemeral-containers-target-pod"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/area conformance

#### What this PR does / why we need it:

The EphemeralContainers feature is ready for GA. This adds creation of ephemeral  containers to conformance testing.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #111025

#### Special notes for your reviewer:

@kubernetes/sig-architecture-pr-reviews @kubernetes/sig-node-pr-reviews @kubernetes/cncf-conformance-wg

The Ephemeral Containers creation test has existed for 2 releases and has a low incidence of flakes (all of the CI failures I spot checked seem to be infrastructure failures or timeouts). This was added to Node conformance tests in #111404.

- [Failure Dashboard](https://storage.googleapis.com/k8s-triage/index.html?sig=node&test=Ephemeral%20Containers)
- [Node Conformance testgrid](https://testgrid.k8s.io/presubmits-kubernetes-blocking#pull-kubernetes-node-e2e-containerd&include-filter-by-regex=Ephemeral%20Containers)
- [Node feature testgrid](https://testgrid.k8s.io/sig-node-containerd#node-e2e-features&include-filter-by-regex=Ephemeral%20Containers&show-stale-tests=) (stale since #111404)
- [sig-windows-signal testgrid](https://testgrid.k8s.io/sig-windows-signal#capz-windows-containerd-master&include-filter-by-regex=Ephemeral%20Containers&show-stale-tests=)

Other notes on conformance test requirements:

- Ephemeral Containers is promoting to GA in #111402 
- The test creates a container and checks its logs to verify its running. It doesn't require any special privilege, network or kubelet API access.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
