### PR TITLE
correct OpenAPI extension in error message

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -1681,7 +1681,7 @@ func validatePreserveUnknownFields(crd, oldCRD *apiextensions.CustomResourceDefi
 	var errs field.ErrorList
 	if crd != nil && crd.Spec.PreserveUnknownFields != nil && *crd.Spec.PreserveUnknownFields {
 		// disallow changing spec.preserveUnknownFields=false to spec.preserveUnknownFields=true
-		errs = append(errs, field.Invalid(field.NewPath("spec").Child("preserveUnknownFields"), crd.Spec.PreserveUnknownFields, "cannot set to true, set x-preserve-unknown-fields to true in spec.versions[*].schema instead"))
+		errs = append(errs, field.Invalid(field.NewPath("spec").Child("preserveUnknownFields"), crd.Spec.PreserveUnknownFields, "cannot set to true, set x-kubernetes-preserve-unknown-fields to true in spec.versions[*].schema instead"))
 	}
 	return errs
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/celcoststability_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/celcoststability_test.go
@@ -608,7 +608,7 @@ func TestCelCostStability(t *testing.T) {
 			}),
 			expectCost: map[string]int64{
 				// 'kind', 'apiVersion', 'metadata.name' and 'metadata.generateName' are always accessible
-				// even if not specified in the schema, regardless of if x-preserve-unknown-fields is set.
+				// even if not specified in the schema, regardless of if x-kubernetes-preserve-unknown-fields is set.
 				"self.embedded.kind == 'Pod'":                          4,
 				"self.embedded.apiVersion == 'v1'":                     4,
 				"self.embedded.metadata.name == 'foo'":                 5,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -772,7 +772,7 @@ func TestValidationExpressions(t *testing.T) {
 			}),
 			valid: []string{
 				// 'kind', 'apiVersion', 'metadata.name' and 'metadata.generateName' are always accessible
-				// even if not specified in the schema, regardless of if x-preserve-unknown-fields is set.
+				// even if not specified in the schema, regardless of if x-kubernetes-preserve-unknown-fields is set.
 				"self.embedded.kind == 'Pod'",
 				"self.embedded.apiVersion == 'v1'",
 				"self.embedded.metadata.name == 'foo'",
@@ -782,7 +782,7 @@ func TestValidationExpressions(t *testing.T) {
 				"has(self.embedded)",
 			},
 			// only field declared in the schema can be field selected in CEL expressions, regardless of if
-			// x-preserve-unknown-fields is set.
+			// x-kubernetes-preserve-unknown-fields is set.
 			errors: map[string]string{
 				"has(self.embedded.spec)": "undefined field 'spec'",
 			},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/values.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/values.go
@@ -84,7 +84,7 @@ func UnstructuredToVal(unstructured interface{}, schema *structuralschema.Struct
 				},
 			}
 		}
-		// A object with x-preserve-unknown-fields but no properties or additionalProperties is treated
+		// A object with x-kubernetes-preserve-unknown-fields but no properties or additionalProperties is treated
 		// as an empty object.
 		if schema.XPreserveUnknownFields {
 			return &unstructuredMap{

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -246,20 +246,21 @@
     update to reflect the rename.
   release: v1.16
   file: test/e2e/apimachinery/crd_publish_openapi.go
-- testname: Custom Resource OpenAPI Publish, with x-preserve-unknown-fields at root
+- testname: Custom Resource OpenAPI Publish, with x-kubernetes-preserve-unknown-fields
+    at root
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
     works for CRD preserving unknown fields at the schema root [Conformance]'
-  description: Register a custom resource definition with x-preserve-unknown-fields
+  description: Register a custom resource definition with x-kubernetes-preserve-unknown-fields
     in the schema root. Attempt to create and apply a change a custom resource, via
     kubectl; kubectl validation MUST accept unknown properties. Attempt kubectl explain;
     the output MUST show the custom resource KIND.
   release: v1.16
   file: test/e2e/apimachinery/crd_publish_openapi.go
-- testname: Custom Resource OpenAPI Publish, with x-preserve-unknown-fields in embedded
-    object
+- testname: Custom Resource OpenAPI Publish, with x-kubernetes-preserve-unknown-fields
+    in embedded object
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
     works for CRD preserving unknown fields in an embedded object [Conformance]'
-  description: Register a custom resource definition with x-preserve-unknown-fields
+  description: Register a custom resource definition with x-kubernetes-preserve-unknown-fields
     in an embedded object. Attempt to create and apply a change a custom resource,
     via kubectl; kubectl validation MUST accept unknown properties. Attempt kubectl
     explain; the output MUST show that x-preserve-unknown-properties is used on the
@@ -279,10 +280,11 @@
     validation should be the same.
   release: v1.16
   file: test/e2e/apimachinery/crd_publish_openapi.go
-- testname: Custom Resource OpenAPI Publish, with x-preserve-unknown-fields in object
+- testname: Custom Resource OpenAPI Publish, with x-kubernetes-preserve-unknown-fields
+    in object
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
     works for CRD without validation schema [Conformance]'
-  description: Register a custom resource definition with x-preserve-unknown-fields
+  description: Register a custom resource definition with x-kubernetes-preserve-unknown-fields
     in the top level object. Attempt to create and apply a change a custom resource,
     via kubectl; kubectl validation MUST accept unknown properties. Attempt kubectl
     explain; the output MUST contain a valid DESCRIPTION stanza.

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -145,8 +145,8 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 
 	/*
 		Release: v1.16
-		Testname: Custom Resource OpenAPI Publish, with x-preserve-unknown-fields in object
-		Description: Register a custom resource definition with x-preserve-unknown-fields in the top level object.
+		Testname: Custom Resource OpenAPI Publish, with x-kubernetes-preserve-unknown-fields in object
+		Description: Register a custom resource definition with x-kubernetes-preserve-unknown-fields in the top level object.
 		Attempt to create and apply a change a custom resource, via kubectl; kubectl validation MUST accept unknown
 		properties. Attempt kubectl explain; the output MUST contain a valid DESCRIPTION stanza.
 	*/
@@ -186,8 +186,8 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 
 	/*
 		Release: v1.16
-		Testname: Custom Resource OpenAPI Publish, with x-preserve-unknown-fields at root
-		Description: Register a custom resource definition with x-preserve-unknown-fields in the schema root.
+		Testname: Custom Resource OpenAPI Publish, with x-kubernetes-preserve-unknown-fields at root
+		Description: Register a custom resource definition with x-kubernetes-preserve-unknown-fields in the schema root.
 		Attempt to create and apply a change a custom resource, via kubectl; kubectl validation MUST accept unknown
 		properties. Attempt kubectl explain; the output MUST show the custom resource KIND.
 	*/
@@ -227,8 +227,8 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 
 	/*
 		Release: v1.16
-		Testname: Custom Resource OpenAPI Publish, with x-preserve-unknown-fields in embedded object
-		Description: Register a custom resource definition with x-preserve-unknown-fields in an embedded object.
+		Testname: Custom Resource OpenAPI Publish, with x-kubernetes-preserve-unknown-fields in embedded object
+		Description: Register a custom resource definition with x-kubernetes-preserve-unknown-fields in an embedded object.
 		Attempt to create and apply a change a custom resource, via kubectl; kubectl validation MUST accept unknown
 		properties. Attempt kubectl explain; the output MUST show that x-preserve-unknown-properties is used on the
 		nested field.


### PR DESCRIPTION
when attemping to use preserveUnknownFields the error message leads you astray

#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

I tried to apply the following CRD:

```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    helm.sh/resource-policy: keep
  labels:
    svcat: "true"
  name: clusterserviceplans.servicecatalog.stable.com
spec:
  group: servicecatalog.stable.com
  names:
    categories:
    - all
    - svcat
    kind: ClusterServicePlan
    listKind: ClusterServicePlanList
    plural: clusterserviceplans
    singular: clusterserviceplan
  preserveUnknownFields: true
  scope: Cluster
  versions:
  - name: v1beta1
    served: true
    storage: true
```

I got the following error:

```
The CustomResourceDefinition "clusterserviceplans.servicecatalog.stable.com" is invalid:
* spec.versions[0].schema.openAPIV3Schema: Required value: schemas are required
* spec.preserveUnknownFields: Invalid value: true: cannot set to true, set x-preserve-unknown-fields to true in spec.versions[*].schema instead
*
```

I then did as instructed and added an openAPIV3Schema with x-preserve-unknown-fields:

```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    helm.sh/resource-policy: keep
  labels:
    svcat: "true"
  name: clusterserviceplans.servicecatalog.stable.com
spec:
  group: servicecatalog.stable.com
  names:
    categories:
    - all
    - svcat
    kind: ClusterServicePlan
    listKind: ClusterServicePlanList
    plural: clusterserviceplans
    singular: clusterserviceplan
  scope: Cluster
  versions:
  - name: v1beta1
    served: true
    storage: true
    schema:
      openAPIV3Schema:
        x-preserve-unknown-fields: true
```

But I still got an error:

```
error validating data: ValidationError(CustomResourceDefinition.spec.versions[0].schema.openAPIV3Schema): unknown field "x-preserve-unkn0wn-fields" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps; if you choose to ignore these errors, turn validation off with --validate=false
```

It is fixed when I change `x-preserve-unknown-fields` to be `x-kubernetes-perserve-unknown-fields`:

```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    helm.sh/resource-policy: keep
  labels:
    svcat: "true"
  name: clusterserviceplans.servicecatalog.stable.com
spec:
  group: servicecatalog.stable.com
  names:
    categories:
    - all
    - svcat
    kind: ClusterServicePlan
    listKind: ClusterServicePlanList
    plural: clusterserviceplans
    singular: clusterserviceplan
  scope: Cluster
  versions:
  - name: v1beta1
    served: true
    storage: true
    schema:
      openAPIV3Schema:
        x-kubernetes-preserve-unknown-fields: true
```

This finally succeeds.

```
customresourcedefinition.apiextensions.k8s.io/clusterserviceplans.servicecatalog.stable.com created
```

Documentation in source: 

https://github.com/kubernetes/kubernetes/blob/d66477d5124c54f5cba225c7eb473c66aaba6686/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types.go#L287

https://github.com/kubernetes/kubernetes/blob/66af4ecfd5c4152542a95710edd9db9a4166464f/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go#L90-L96

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
