### PR TITLE
Promote ControllerRevisionLifecycleTest +7 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -594,6 +594,22 @@
     and minor versions MUST only be an integer.
   release: v1.19
   file: test/e2e/apimachinery/server_version.go
+- testname: ControllerRevision, resource lifecycle
+  codename: '[sig-apps] ControllerRevision [Serial] should manage the lifecycle of
+    a ControllerRevision [Conformance]'
+  description: Creating a DaemonSet MUST succeed. Listing all ControllerRevisions
+    with a label selector MUST find only one. After patching the ControllerRevision
+    with a new label, the label MUST be found. Creating a new ControllerRevision for
+    the DaemonSet MUST succeed. Listing the ControllerRevisions by label selector
+    MUST find only two. Deleting a ControllerRevision MUST succeed. Listing the ControllerRevisions
+    by label selector MUST find only one. After updating the ControllerRevision with
+    a new label, the label MUST be found. Patching the DaemonSet MUST succeed. Listing
+    the ControllerRevisions by label selector MUST find only two. Deleting a collection
+    of ControllerRevision via a label selector MUST succeed. Listing the ControllerRevisions
+    by label selector MUST find only one. The current ControllerRevision revision
+    MUST be 3.
+  release: v1.25
+  file: test/e2e/apps/controller_revision.go
 - testname: CronJob Suspend
   codename: '[sig-apps] CronJob should not schedule jobs when suspended [Slow] [Conformance]'
   description: CronJob MUST support suspension, which suppresses creation of new jobs.

--- a/test/e2e/apps/controller_revision.go
+++ b/test/e2e/apps/controller_revision.go
@@ -104,7 +104,24 @@ var _ = SIGDescribe("ControllerRevision [Serial]", func() {
 		framework.ExpectNoError(err)
 	})
 
-	ginkgo.It("should manage the lifecycle of a ControllerRevision", func() {
+	/*
+		Release: v1.25
+		Testname: ControllerRevision, resource lifecycle
+		Description: Creating a DaemonSet MUST succeed. Listing all
+		ControllerRevisions with a label selector MUST find only one.
+		After patching the ControllerRevision with a new label, the label
+		MUST be found. Creating a new ControllerRevision for the DaemonSet
+		MUST succeed. Listing the ControllerRevisions by label selector
+		MUST find only two. Deleting a ControllerRevision MUST succeed.
+		Listing the ControllerRevisions by label selector MUST find only
+		one. After updating the ControllerRevision with a new label, the
+		label MUST be found. Patching the DaemonSet MUST succeed. Listing the
+		ControllerRevisions by label selector MUST find only two. Deleting
+		a collection of ControllerRevision via a label selector MUST succeed.
+		Listing the ControllerRevisions by label selector MUST find only one.
+		The current ControllerRevision revision MUST be 3.
+	*/
+	framework.ConformanceIt("should manage the lifecycle of a ControllerRevision", func() {
 		csAppsV1 := f.ClientSet.AppsV1()
 
 		dsLabel := map[string]string{"daemonset-name": dsName}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceAppsV1NamespacedControllerRevision
- readAppsV1NamespacedControllerRevision
- patchAppsV1NamespacedControllerRevision
- listAppsV1ControllerRevisionForAllNamespaces
- deleteAppsV1NamespacedControllerRevision 
- deleteAppsV1CollectionNamespacedControllerRevision 
- createAppsV1NamespacedControllerRevision 

**Which issue(s) this PR fixes:**
Fixes #110121

**Testgrid Link:** [Link](https://testgrid.k8s.io/sig-apps#gce-serial&width=20&graph-metrics=test-duration-minutes&include-filter-by-regex=should.manage.the.lifecycle.of.a.ControllerRevision)

**Special notes for your reviewer:**
Adds +7 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance