### PR TITLE
cleanup: omit redundant arguments in make call

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -654,7 +654,7 @@ func (q Quantity) MarshalJSON() ([]byte, error) {
 		copy(out[1:], q.s)
 		return out, nil
 	}
-	result := make([]byte, int64QuantityExpectedBytes, int64QuantityExpectedBytes)
+	result := make([]byte, int64QuantityExpectedBytes)
 	result[0] = '"'
 	number, suffix := q.CanonicalizeBytes(result[1:1])
 	// if the same slice was returned to us that we passed in, avoid another allocation by copying number into

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
@@ -165,7 +165,7 @@ func (sh *suffixHandler) constructBytes(base, exponent int32, format Format) (s 
 		if exponent == 0 {
 			return nil, true
 		}
-		result := make([]byte, 8, 8)
+		result := make([]byte, 8)
 		result[0] = 'e'
 		number := strconv.AppendInt(result[1:1], int64(exponent), 10)
 		if &result[1] == &number[0] {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/allocator.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/allocator.go
@@ -60,7 +60,7 @@ func (a *Allocator) Allocate(n uint64) []byte {
 	}
 	// grow the buffer
 	size := uint64(2*cap(a.buf)) + n
-	a.buf = make([]byte, size, size)
+	a.buf = make([]byte, size)
 	a.buf = a.buf[:n]
 	return a.buf
 }
@@ -72,5 +72,5 @@ type SimpleAllocator struct{}
 var _ MemoryAllocator = &SimpleAllocator{}
 
 func (sa *SimpleAllocator) Allocate(n uint64) []byte {
-	return make([]byte, n, n)
+	return make([]byte, n)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf_test.go
@@ -174,7 +174,7 @@ type testAllocator struct {
 }
 
 func (ta *testAllocator) Allocate(n uint64) []byte {
-	ta.buf = make([]byte, n, n)
+	ta.buf = make([]byte, n)
 	ta.allocateCount++
 	return ta.buf
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Simplify make call by omitting redundant arguments 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```