### PR TITLE
cleanup: fix some error log capitalization

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/naming/naming.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/naming/naming.go
@@ -39,7 +39,7 @@ func VerifyGroupNames(scheme *runtime.Scheme, legacyUnsuffixedGroups sets.String
 	errs := []error{}
 	for _, gv := range scheme.PrioritizedVersionsAllGroups() {
 		if !strings.HasSuffix(gv.Group, ".k8s.io") && !legacyUnsuffixedGroups.Has(gv.Group) {
-			errs = append(errs, fmt.Errorf("Group %s does not have the standard kubernetes API group suffix of .k8s.io", gv.Group))
+			errs = append(errs, fmt.Errorf("group %s does not have the standard kubernetes API group suffix of .k8s.io", gv.Group))
 		}
 	}
 	return errors.NewAggregate(errs)
@@ -91,14 +91,14 @@ func ensureNoTags(gvk schema.GroupVersionKind, tp reflect.Type, parents []reflec
 			jsonTag := f.Tag.Get("json")
 			protoTag := f.Tag.Get("protobuf")
 			if len(jsonTag) > 0 || len(protoTag) > 0 {
-				errs = append(errs, fmt.Errorf("Internal types should not have json or protobuf tags. %#v has tag on field %v: %v.\n%s", gvk, f.Name, f.Tag, fmtParentString(parents)))
+				errs = append(errs, fmt.Errorf("internal types should not have json or protobuf tags. %#v has tag on field %v: %v.\n%s", gvk, f.Name, f.Tag, fmtParentString(parents)))
 			}
 
 			errs = append(errs, ensureNoTags(gvk, f.Type, parents, typesAllowedTags)...)
 		}
 
 	default:
-		errs = append(errs, fmt.Errorf("Unexpected type %v in %#v.\n%s", tp.Kind(), gvk, fmtParentString(parents)))
+		errs = append(errs, fmt.Errorf("unexpected type %v in %#v.\n%s", tp.Kind(), gvk, fmtParentString(parents)))
 	}
 	return errs
 }
@@ -140,7 +140,7 @@ func ensureTags(gvk schema.GroupVersionKind, tp reflect.Type, parents []reflect.
 		}
 
 	default:
-		errs = append(errs, fmt.Errorf("Unexpected type %v in %#v.\n%s", tp.Kind(), gvk, fmtParentString(parents)))
+		errs = append(errs, fmt.Errorf("unexpected type %v in %#v.\n%s", tp.Kind(), gvk, fmtParentString(parents)))
 	}
 	return errs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/codec_check.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/codec_check.go
@@ -30,7 +30,7 @@ import (
 // TODO: verify that the correct external version is chosen on encode...
 func CheckCodec(c Codec, internalType Object, externalTypes ...schema.GroupVersionKind) error {
 	if _, err := Encode(c, internalType); err != nil {
-		return fmt.Errorf("Internal type not encodable: %v", err)
+		return fmt.Errorf("internal type not encodable: %v", err)
 	}
 	for _, et := range externalTypes {
 		typeMeta := TypeMeta{

--- a/staging/src/k8s.io/apimachinery/pkg/util/jsonmergepatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/jsonmergepatch/patch.go
@@ -74,7 +74,7 @@ func CreateThreeWayJSONMergePatch(original, modified, current []byte, fns ...mer
 	var patchMap map[string]interface{}
 	err = json.Unmarshal(patch, &patchMap)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to unmarshal patch for precondition check: %s", patch)
+		return nil, fmt.Errorf("failed to unmarshal patch for precondition check: %s", patch)
 	}
 	meetPreconditions, err := meetPreconditions(patchMap, fns...)
 	if err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
@@ -339,7 +339,7 @@ func chooseIPFromHostInterfaces(nw networkInterfacer, addressFamilies AddressFam
 			for _, addr := range addrs {
 				ip, _, err := netutils.ParseCIDRSloppy(addr.String())
 				if err != nil {
-					return nil, fmt.Errorf("Unable to parse CIDR for interface %q: %s", intf.Name, err)
+					return nil, fmt.Errorf("unable to parse CIDR for interface %q: %s", intf.Name, err)
 				}
 				if !memberOf(ip, family) {
 					klog.V(4).Infof("Skipping: no address family match for %q on interface %q.", ip, intf.Name)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context. That is, use fmt.Errorf("something bad") not fmt.Errorf("Something bad").

```release-note
NONE
```