### PR TITLE
Support passing extra arguments into debug profiles

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -240,7 +240,7 @@ func TestGenerateDebugContainer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("fail to create %s profile", ProfileLegacy)
 			}
-			tc.opts.applier = applier
+			tc.opts.Applier = applier
 
 			_, debugContainer, err := tc.opts.generateDebugContainer(tc.pod)
 			if err != nil {
@@ -1017,7 +1017,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var err error
-			tc.opts.applier, err = NewProfileApplier(ProfileLegacy)
+			tc.opts.Applier, err = NewProfileApplier(ProfileLegacy)
 			if err != nil {
 				t.Fatalf("Fail to create legacy profile: %v", err)
 			}
@@ -1212,7 +1212,7 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var err error
-			tc.opts.applier, err = NewProfileApplier(ProfileLegacy)
+			tc.opts.Applier, err = NewProfileApplier(ProfileLegacy)
 			if err != nil {
 				t.Fatalf("Fail to create legacy profile: %v", err)
 			}
@@ -1236,7 +1236,7 @@ func TestCompleteAndValidate(t *testing.T) {
 	cmpFilter := cmp.FilterPath(func(p cmp.Path) bool {
 		switch p.String() {
 		// IOStreams contains unexported fields
-		case "IOStreams":
+		case "IOStreams", "Applier", "ExtraArgs":
 			return true
 		}
 		return false

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/profile_applier.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/profile_applier.go
@@ -28,7 +28,7 @@ const ProfileLegacy = "legacy"
 
 type ProfileApplier interface {
 	// Apply applies the profile to the given container in the pod.
-	Apply(pod *corev1.Pod, containerName string, target runtime.Object) error
+	Apply(pod *corev1.Pod, containerName string, target runtime.Object, extraArgs map[string]interface{}) error
 }
 
 // NewProfileApplier returns a new Options for the given profile name.
@@ -42,8 +42,8 @@ func NewProfileApplier(profile string) (ProfileApplier, error) {
 }
 
 // applierFunc is a function that applies a profile to a container in the pod.
-type applierFunc func(pod *corev1.Pod, containerName string, target runtime.Object) error
+type applierFunc func(pod *corev1.Pod, containerName string, target runtime.Object, extraArgs map[string]interface{}) error
 
-func (f applierFunc) Apply(pod *corev1.Pod, containerName string, target runtime.Object) error {
-	return f(pod, containerName, target)
+func (f applierFunc) Apply(pod *corev1.Pod, containerName string, target runtime.Object, extraArgs map[string]interface{}) error {
+	return f(pod, containerName, target, extraArgs)
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles.go
@@ -24,7 +24,7 @@ import (
 )
 
 // profileLegacy represents the legacy debugging profile which is backwards-compatible with 1.23 behavior.
-func profileLegacy(pod *corev1.Pod, containerName string, target runtime.Object) error {
+func profileLegacy(pod *corev1.Pod, containerName string, target runtime.Object, extraArgs map[string]interface{}) error {
 	switch target.(type) {
 	case *corev1.Pod:
 		// do nothing to the copied pod


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Currently debug profiles do not take any extra arguments. This PR provides a
way to pass arguments to debug profiles. This will be mostly used for the reasons
described in this issue https://github.com/kubernetes/kubectl/issues/1258.

#### Does this PR introduce a user-facing change?
```release-note
None
```