### PR TITLE
Enable 'running_managed_controllers' for KCM nodeipam controller

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -166,7 +166,7 @@ func startNodeIpamController(ctx context.Context, controllerContext ControllerCo
 	if err != nil {
 		return nil, true, err
 	}
-	go nodeIpamController.Run(ctx.Done())
+	go nodeIpamController.RunWithMetrics(ctx.Done(), controllerContext.ControllerManagerMetrics)
 	return nil, true, nil
 }
 

--- a/pkg/controller/nodeipam/node_ipam_controller.go
+++ b/pkg/controller/nodeipam/node_ipam_controller.go
@@ -32,6 +32,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	cloudprovider "k8s.io/cloud-provider"
+	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	"k8s.io/kubernetes/pkg/controller/nodeipam/ipam"
 )
@@ -163,4 +164,11 @@ func (nc *Controller) Run(stopCh <-chan struct{}) {
 	}
 
 	<-stopCh
+}
+
+// RunWithMetrics is a wrapper for Run that also tracks starting and stopping of the nodeipam controller with additional metric
+func (nc *Controller) RunWithMetrics(stopCh <-chan struct{}, controllerManagerMetrics *controllersmetrics.ControllerManagerMetrics) {
+	controllerManagerMetrics.ControllerStarted("nodeipam")
+	defer controllerManagerMetrics.ControllerStopped("nodeipam")
+	nc.Run(stopCh)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR enables `running_managed_controllers` for nodeipam controller running inside KCM. 

This metric support HA migration described in [KEP-2436](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2436-controller-manager-leader-migration)

#### Which issue(s) this PR fixes:
It doesn't fix, but is a part of #111029

#### Special notes for your reviewer:
First PR is already merged. See #111033.
Second PR is in-flight. See #111462

#### Does this PR introduce a user-facing change?

```release-note
Metric `running_managed_controllers` is enabled for Node IPAM controller in KCM
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
- [KEP-2436](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2436-controller-manager-leader-migration) 
- [Mentioned during Cloud Provider Extraction/Migration (April 21st, 2022)](https://docs.google.com/document/d/1KLsGGzNXQbsPeELCeF_q-f0h0CEGSe20xiwvcR2NlYM/edit)
- First PR - #111033 
- Second PR - #11462
/sig cloud-provider
