### PR TITLE
Promote CSIMigrationAWS to GA

### DIFF
--- a/pkg/controller/volume/expand/expand_controller_test.go
+++ b/pkg/controller/volume/expand/expand_controller_test.go
@@ -33,12 +33,10 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	coretesting "k8s.io/client-go/testing"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	csitrans "k8s.io/csi-translation-lib"
 	csitranslationplugins "k8s.io/csi-translation-lib/plugins"
 	"k8s.io/kubernetes/pkg/controller"
 	controllervolumetesting "k8s.io/kubernetes/pkg/controller/volume/attachdetach/testing"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/awsebs"
 	"k8s.io/kubernetes/pkg/volume/csimigration"
@@ -49,14 +47,13 @@ import (
 
 func TestSyncHandler(t *testing.T) {
 	tests := []struct {
-		name                string
-		csiMigrationEnabled bool
-		pvcKey              string
-		pv                  *v1.PersistentVolume
-		pvc                 *v1.PersistentVolumeClaim
-		expansionCalled     bool
-		hasError            bool
-		expectedAnnotation  map[string]string
+		name               string
+		pvcKey             string
+		pv                 *v1.PersistentVolume
+		pvc                *v1.PersistentVolumeClaim
+		expansionCalled    bool
+		hasError           bool
+		expectedAnnotation map[string]string
 	}{
 		{
 			name:     "when pvc has no PV binding",
@@ -69,8 +66,8 @@ func TestSyncHandler(t *testing.T) {
 			pv:                 getFakePersistentVolume("vol-3", csitranslationplugins.AWSEBSInTreePluginName, "1Gi", "good-pvc-vol-3"),
 			pvc:                getFakePersistentVolumeClaim("good-pvc", "vol-3", "1Gi", "2Gi", "good-pvc-vol-3"),
 			pvcKey:             "default/good-pvc",
-			expansionCalled:    true,
-			expectedAnnotation: map[string]string{volumetypes.VolumeResizerKey: csitranslationplugins.AWSEBSInTreePluginName},
+			expansionCalled:    false,
+			expectedAnnotation: map[string]string{volumetypes.VolumeResizerKey: csitranslationplugins.AWSEBSDriverName},
 		},
 		{
 			name: "if pv has pre-resize capacity annotation, generate expand operation should not be called",
@@ -83,14 +80,6 @@ func TestSyncHandler(t *testing.T) {
 			pvc:             getFakePersistentVolumeClaim("good-pvc", "vol-4", "2Gi", "2Gi", "good-pvc-vol-4"),
 			pvcKey:          "default/good-pvc",
 			expansionCalled: false,
-		},
-		{
-			name:                "when csi migration is enabled for a in-tree plugin",
-			csiMigrationEnabled: true,
-			pv:                  getFakePersistentVolume("vol-4", csitranslationplugins.AWSEBSInTreePluginName, "1Gi", "csi-pvc-vol-5"),
-			pvc:                 getFakePersistentVolumeClaim("csi-pvc", "vol-4", "1Gi", "2Gi", "csi-pvc-vol-5"),
-			pvcKey:              "default/csi-pvc",
-			expectedAnnotation:  map[string]string{volumetypes.VolumeResizerKey: csitranslationplugins.AWSEBSDriverName},
 		},
 		{
 			name:            "for csi plugin without migration path",
@@ -123,12 +112,6 @@ func TestSyncHandler(t *testing.T) {
 		expc, err := NewExpandController(fakeKubeClient, pvcInformer, pvInformer, nil, allPlugins, translator, csimigration.NewPluginManager(translator, utilfeature.DefaultFeatureGate), nil)
 		if err != nil {
 			t.Fatalf("error creating expand controller : %v", err)
-		}
-
-		if test.csiMigrationEnabled {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIMigrationAWS, true)()
-		} else {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIMigrationAWS, false)()
 		}
 
 		var expController *expandController

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -111,6 +111,7 @@ const (
 	// owner: @leakingtapan
 	// alpha: v1.14
 	// beta: v1.17
+	// GA: v1.25
 	//
 	// Enables the AWS EBS in-tree driver to AWS EBS CSI Driver migration feature.
 	CSIMigrationAWS featuregate.Feature = "CSIMigrationAWS"
@@ -833,7 +834,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	CSIMigration: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.27
 
-	CSIMigrationAWS: {Default: true, PreRelease: featuregate.Beta},
+	CSIMigrationAWS: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 
 	CSIMigrationAzureDisk: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // On by default in 1.23 (requires Azure Disk CSI driver)
 

--- a/pkg/volume/csimigration/plugin_manager_test.go
+++ b/pkg/volume/csimigration/plugin_manager_test.go
@@ -101,27 +101,6 @@ func TestIsMigratable(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:                 "AWS EBS PV with CSIMigration and CSIMigrationAWS disabled",
-			pluginFeature:        features.CSIMigrationAWS,
-			pluginFeatureEnabled: false,
-			isMigratable:         false,
-			csiMigrationEnabled:  false,
-			spec: &volume.Spec{
-				PersistentVolume: &v1.PersistentVolume{
-					Spec: v1.PersistentVolumeSpec{
-						PersistentVolumeSource: v1.PersistentVolumeSource{
-							AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
-								VolumeID:  "vol01",
-								FSType:    "ext3",
-								Partition: 1,
-								ReadOnly:  true,
-							},
-						},
-					},
-				},
-			},
-		},
 	}
 	csiTranslator := csitrans.New()
 	for _, test := range testCases {
@@ -250,28 +229,6 @@ func TestMigrationFeatureFlagStatus(t *testing.T) {
 			inTreePluginUnregisterEnabled: true,
 			csiMigrationResult:            true,
 			csiMigrationCompleteResult:    true,
-		},
-		{
-			name:                          "aws-ebs migration flag disabled and migration-complete flag disabled with CSI migration flag disabled",
-			pluginName:                    "kubernetes.io/aws-ebs",
-			pluginFeature:                 features.CSIMigrationAWS,
-			pluginFeatureEnabled:          false,
-			csiMigrationEnabled:           false,
-			inTreePluginUnregister:        features.InTreePluginAWSUnregister,
-			inTreePluginUnregisterEnabled: false,
-			csiMigrationResult:            false,
-			csiMigrationCompleteResult:    false,
-		},
-		{
-			name:                          "aws-ebs migration flag disabled and migration-complete flag disabled with CSI migration flag enabled",
-			pluginName:                    "kubernetes.io/aws-ebs",
-			pluginFeature:                 features.CSIMigrationAWS,
-			pluginFeatureEnabled:          false,
-			csiMigrationEnabled:           true,
-			inTreePluginUnregister:        features.InTreePluginAWSUnregister,
-			inTreePluginUnregisterEnabled: false,
-			csiMigrationResult:            false,
-			csiMigrationCompleteResult:    false,
 		},
 		{
 			name:                          "aws-ebs migration flag enabled and migration-complete flag disabled with CSI migration flag enabled",


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

/sig storage

#### What this PR does / why we need it:
CSIMigrationAWS has been beta since 1.17, on by default since 1.23, this takes it to GA for 1.25.
https://github.com/kubernetes/enhancements/issues/1487

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

I am still working on Windows and upgrade tests, aim to complete this week but opening the PR now as placeholder.

Testing:
- [x] Automated existing in-tree plugin tests for the migrated driver have been running in driver CI since alpha/beta: https://testgrid.k8s.io/provider-aws-ebs-csi-driver#ci-migration-test. Implementation: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/tests/e2e-kubernetes/e2e_test.go#L85-L94 / https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/hack/e2e/ebs.sh#L8
- [x] Manual Windows Nodes test. (Resize was never supported by in-tree so I will skip `expand` tests. For promoting  off->on by default*, there was no official vendor-supported AWS+Windows Nodes setup to test so I had to hack my own VM/driver images. As of April this year now EKS has Windows Nodes with CSI support https://docs.aws.amazon.com/eks/latest/userguide/eks-ami-versions-windows.html so for GA I will be using that to test. However, there is no official EKS 1.23 Kubernetes Control Plane with migration enabled (yet) so I have to hack that together again, and since it is not public/reproducible you will have to take my word for it that the tests succeed!)
  - [x] Pre-upgrade EKS 1.22 control plane + EKS 1.22 Windows Nodes in-tree plugin test (sanity check that my cluster is configured properly). PASSED with caveat: I hit the 'volume stuck attaching' bug which affects Windows in-tree but is fixed in CSI by https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1193
  - [x] Post-upgrade EKS 1.23 control plane + EKS 1.22 Windows Nodes "partially" migrated plugin test. PASSED with caveat: ephemeral containers step of `should store data` test cases fail on EKS due to EKS specific issue, it's not related to CSI: https://github.com/kubernetes/kubernetes/pull/111521
  - [X] Post-upgrade EKS 1.23 control plane + EKS 1.23 Windows Nodes "fully" migrated plugin test `ip-192-168-71-159.us-west-2.compute.internal   Ready                      <none>   37m    v1.23.7-eks-4721010   192.168.71.159   34.222.140.157   Windows Server 2019 Datacenter   10.0.17763.3165                docker://20.10.9`. PASSED with caveat:  'should mount multiple PV pointing to the same storage on the same node' test case fails because it's not applicable to 1.23 Nodes, I am executing master e2e.test against 1.23 Nodes
- [ ] Manual upgrade/skew test. (For promoting off->on by default*, I wrote/ran a test to toggle the feature gate on which is effectively the same thing as upgrade: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/tests/e2e-upgrade/e2e_test.go#L70. For GA I will repeat this test.)
  - [ ] Pre-upgrade KOPS 1.25 control plane + KOPS 1.25 Nodes in-tree plugin test. Disable migration on kubelet/KCM and create a workload (Pod+PVC+PV), in-tree driver should do all operations here
  - [ ] Post-upgrade KOPS 1.25 control plane + KOPS 1.25 Nodes "fully" migrated plugin test. Enable migration on kubelet/KCM, the existing workload should continue to work (besides eviction/recreation of Pod during kubelet drain+update for enabling migration), csi driver should do all operations here

---

MISC NOTES FOR SELF (sorry, I am editing this PR frequently with notes/progress so to keep above checklist comprehensible dumping stuff here):

Disable migration means:
```
cloudProvider: aws
featureGates:
  CSIMigration: "false"
  CSIMigrationAWS: "false"
```


Windows test
`./_output/bin/e2e.test --ginkgo.focus="aws.*ntfs" \ --ginkgo.skip="LinuxOnly|expand" \ --kubeconfig=$HOME/.kube/config \ --node-os-distro=windows \ --gce-zone=us-west-2a \ --provider=aws`

`{"msg":"FAILED [sig-storage] In-tree Volumes [Driver: aws] [Testpattern: Dynamic PV (ntfs)][Feature:Windows] subPath should support creating multiple subpathfrom same volumes [Slow]","completed":19,"skipped":6573,"failed":1,"failures":["[sig-storage] In-tree Volumes [Driver: aws] [Testpattern: Dynamic PV (ntfs)][Feature:Windows] subPath should support creating multiple subpath from same volumes [Slow]"]}`~


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CSIMigrationAWS upgraded to GA and locked to true.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1487-csi-migration-aws

