### PR TITLE
deprecate GlusterFS plugin from available in-tree drivers.

### DIFF
--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -182,6 +182,9 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 		if v.Quobyte != nil {
 			warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.22, support removal is planned in v1.26", fieldPath.Child("spec", "volumes").Index(i).Child("quobyte")))
 		}
+		if v.Glusterfs != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.25, this feature will be removed soon after in a subsequent release", fieldPath.Child("spec", "volumes").Index(i).Child("glusterfs")))
+		}
 	}
 
 	// duplicate hostAliases (#91670, #58477)

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -206,6 +206,15 @@ func TestWarnings(t *testing.T) {
 			expected: []string{`spec.volumes[0].quobyte: deprecated in v1.22, support removal is planned in v1.26`},
 		},
 		{
+			name: "glusterfs",
+			template: &api.PodTemplateSpec{Spec: api.PodSpec{
+				Volumes: []api.Volume{
+					{Name: "s", VolumeSource: api.VolumeSource{Glusterfs: &api.GlusterfsVolumeSource{}}},
+				}},
+			},
+			expected: []string{`spec.volumes[0].glusterfs: deprecated in v1.25, this feature will be removed soon after in a subsequent release`},
+		},
+		{
 			name: "duplicate hostAlias",
 			template: &api.PodTemplateSpec{Spec: api.PodSpec{
 				HostAliases: []api.HostAlias{

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -70,6 +70,7 @@ var (
 		"kubernetes.io/storageos": "The StorageOS volume provider is deprecated and will be removed in a future release",
 		"kubernetes.io/quobyte":   "The Quobyte volume provider is deprecated and will be removed in a future release",
 		"kubernetes.io/flocker":   "The Flocker volume provider is deprecated and will be removed in a future release",
+		"kubernetes.io/glusterfs": "The GlusterFS volume provider is deprecated and will be removed soon after in a subsequent release",
 	}
 )
 


### PR DESCRIPTION
GlusterFS is one of the first dynamic provisioner which made into
Kubernetes release v1.4.

https://github.com/kubernetes/kubernetes/pull/30888

When CSI plugins/drivers to start appear, glusterfs' CSI driver
came into existence, however this project is not maintianed at
present and the last release happened few years back.

https://github.com/gluster/gluster-csi-driver/releases/tag/v0.0.9

The possibilities of migration to compatible CSI driver was also
discussed https://github.com/kubernetes/kubernetes/issues/100897
and consensus was to start the deprecation in v1.25.

This commit start the deprecation proces of glusterfs plugin from
in-tree drivers.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


/kind cleanup

-->
```release-note
GlusterFS provisioner (`kubernetes.io/glusterfs`) has been deprecated in this release. 
```

