### PR TITLE
Update publishing-bot rules for go1.17.12 and go1.18.4

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -16,11 +16,12 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/code-generator
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/code-generator
   - name: release-1.24
+    go: 1.18.4
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
@@ -41,11 +42,12 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.24
+    go: 1.18.4
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
@@ -76,7 +78,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/api
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -84,6 +86,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/api
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -135,7 +138,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -149,6 +152,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -200,7 +204,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-base
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -212,6 +216,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-base
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -261,7 +266,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -273,6 +278,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -328,7 +334,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apiserver
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -342,6 +348,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apiserver
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -411,7 +418,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -429,6 +436,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -516,7 +524,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -539,6 +547,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -619,7 +628,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -638,6 +647,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -717,7 +727,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -737,6 +747,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -799,7 +810,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/metrics
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -813,6 +824,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/metrics
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -864,7 +876,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: api
       branch: release-1.23
@@ -876,6 +888,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: api
       branch: release-1.24
@@ -931,7 +944,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: api
       branch: release-1.23
@@ -945,6 +958,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1001,7 +1015,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1015,6 +1029,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1072,7 +1087,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubelet
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1086,6 +1101,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubelet
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1143,7 +1159,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1157,6 +1173,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1220,7 +1237,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1236,6 +1253,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1313,7 +1331,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1333,6 +1351,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1420,7 +1439,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1442,6 +1461,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1495,7 +1515,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1505,6 +1525,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1546,7 +1567,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1556,6 +1577,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1582,11 +1604,12 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.24
+    go: 1.18.4
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
@@ -1669,7 +1692,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1695,6 +1718,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1737,11 +1761,12 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cri-api
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/cri-api
   - name: release-1.24
+    go: 1.18.4
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
@@ -1814,7 +1839,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubectl
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1836,6 +1861,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubectl
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1891,7 +1917,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.23
-    go: 1.17.11
+    go: 1.17.12
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1907,6 +1933,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.24
+    go: 1.18.4
     dependencies:
     - repository: api
       branch: release-1.24

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -5,11 +5,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/code-generator
-  - name: release-1.21
-    go: 1.16.15
-    source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/code-generator
   - name: release-1.22
     go: 1.16.15
     source:
@@ -30,11 +25,6 @@ rules:
   - name: master
     source:
       branch: master
-      dir: staging/src/k8s.io/apimachinery
-  - name: release-1.21
-    go: 1.16.15
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.22
     go: 1.16.15
@@ -60,14 +50,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/api
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/api
   - name: release-1.22
     go: 1.16.15
@@ -104,20 +86,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/client-go
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod ./...
-      go test -mod=mod ./...
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/client-go
     smoke-test: |
       # assumes GO111MODULE=on
@@ -179,18 +147,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/component-base
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/component-base
   - name: release-1.22
     go: 1.16.15
     dependencies:
@@ -240,18 +196,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/component-helpers
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.22
     go: 1.16.15
@@ -304,20 +248,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/apiserver
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    - repository: component-base
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/apiserver
   - name: release-1.22
     go: 1.16.15
@@ -380,24 +310,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-aggregator
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    - repository: apiserver
-      branch: release-1.21
-    - repository: component-base
-      branch: release-1.21
-    - repository: code-generator
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.22
     go: 1.16.15
@@ -471,29 +383,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/sample-apiserver
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    - repository: apiserver
-      branch: release-1.21
-    - repository: code-generator
-      branch: release-1.21
-    - repository: component-base
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
@@ -589,25 +478,6 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    - repository: code-generator
-      branch: release-1.21
-    source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/sample-controller
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
   - name: release-1.22
     go: 1.16.15
     dependencies:
@@ -686,26 +556,6 @@ rules:
       dir: staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    - repository: apiserver
-      branch: release-1.21
-    - repository: code-generator
-      branch: release-1.21
-    - repository: component-base
-      branch: release-1.21
-    source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    required-packages:
-    - k8s.io/code-generator
   - name: release-1.22
     go: 1.16.15
     dependencies:
@@ -781,20 +631,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/metrics
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    - repository: code-generator
-      branch: release-1.21
-    source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/metrics
   - name: release-1.22
     go: 1.16.15
     dependencies:
@@ -851,18 +687,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/cli-runtime
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.21
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/cli-runtime
   - name: release-1.22
     go: 1.16.15
     dependencies:
@@ -914,20 +738,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/sample-cli-plugin
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.21
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: cli-runtime
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.22
     go: 1.16.15
@@ -985,20 +795,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-proxy
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: component-base
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.22
     go: 1.16.15
@@ -1058,20 +854,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/kubelet
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    - repository: component-base
-      branch: release-1.21
-    source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/kubelet
   - name: release-1.22
     go: 1.16.15
     dependencies:
@@ -1129,20 +911,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-scheduler
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: component-base
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.22
     go: 1.16.15
@@ -1203,22 +971,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/controller-manager
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.21
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    - repository: component-base
-      branch: release-1.21
-    - repository: apiserver
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.22
     go: 1.16.15
@@ -1289,26 +1041,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/cloud-provider
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.21
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: apiserver
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    - repository: component-base
-      branch: release-1.21
-    - repository: controller-manager
-      branch: release-1.21
-    - repository: component-helpers
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.22
     go: 1.16.15
@@ -1394,28 +1126,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/kube-controller-manager
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: apiserver
-      branch: release-1.21
-    - repository: component-base
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    - repository: controller-manager
-      branch: release-1.21
-    - repository: cloud-provider
-      branch: release-1.21
-    - repository: component-helpers
-      branch: release-1.21
-    source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.22
     go: 1.16.15
     dependencies:
@@ -1494,16 +1204,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/cluster-bootstrap
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: api
-      branch: release-1.21
-    source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.22
     go: 1.16.15
     dependencies:
@@ -1546,16 +1246,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/csi-translation-lib
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.21
-    - repository: apimachinery
-      branch: release-1.21
-    source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.22
     go: 1.16.15
     dependencies:
@@ -1592,11 +1282,6 @@ rules:
   - name: master
     source:
       branch: master
-      dir: staging/src/k8s.io/mount-utils
-  - name: release-1.21
-    go: 1.16.15
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.22
     go: 1.16.15
@@ -1640,30 +1325,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/legacy-cloud-providers
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.21
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    - repository: cloud-provider
-      branch: release-1.21
-    - repository: csi-translation-lib
-      branch: release-1.21
-    - repository: apiserver
-      branch: release-1.21
-    - repository: component-base
-      branch: release-1.21
-    - repository: controller-manager
-      branch: release-1.21
-    - repository: component-helpers
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.22
     go: 1.16.15
@@ -1750,11 +1411,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/cri-api
-  - name: release-1.21
-    go: 1.16.15
-    source:
-      branch: release-1.21
-      dir: staging/src/k8s.io/cri-api
   - name: release-1.22
     go: 1.16.15
     source:
@@ -1793,28 +1449,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kubectl
-  - name: release-1.21
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.21
-    - repository: apimachinery
-      branch: release-1.21
-    - repository: cli-runtime
-      branch: release-1.21
-    - repository: client-go
-      branch: release-1.21
-    - repository: code-generator
-      branch: release-1.21
-    - repository: component-base
-      branch: release-1.21
-    - repository: component-helpers
-      branch: release-1.21
-    - repository: metrics
-      branch: release-1.21
-    source:
-      branch: release-1.21
       dir: staging/src/k8s.io/kubectl
   - name: release-1.22
     go: 1.16.15


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- Update publishing-bot rules for go1.17.12 and go1.18.4
- drop configs for v1.21 due to EOL

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2620

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assign @xmudrii  @saschagrunert @palnabarun @Verolop @dims @nikhita 
cc @kubernetes/release-engineering 