### PR TITLE
Switch initial/final seats type to uint64

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/fifo_list_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/fifo_list_test.go
@@ -195,7 +195,7 @@ func TestFIFOQueueWorkEstimate(t *testing.T) {
 		}
 	}
 
-	newRequest := func(initialSeats, finalSeats uint, additionalLatency time.Duration) *request {
+	newRequest := func(initialSeats, finalSeats uint64, additionalLatency time.Duration) *request {
 		return &request{workEstimate: qs.completeWorkEstimate(&fcrequest.WorkEstimate{
 			InitialSeats:      initialSeats,
 			FinalSeats:        finalSeats,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -811,8 +811,8 @@ func (qs *queueSet) findDispatchQueueLocked() (*queue, *request) {
 	// If the requested final seats exceed capacity of that queue,
 	// we reduce them to current capacity and adjust additional latency
 	// to preserve the total amount of work.
-	if oldestReqFromMinQueue.workEstimate.FinalSeats > uint(qs.dCfg.ConcurrencyLimit) {
-		finalSeats := uint(qs.dCfg.ConcurrencyLimit)
+	if oldestReqFromMinQueue.workEstimate.FinalSeats > uint64(qs.dCfg.ConcurrencyLimit) {
+		finalSeats := uint64(qs.dCfg.ConcurrencyLimit)
 		additionalLatency := oldestReqFromMinQueue.workEstimate.finalWork.DurationPerSeat(float64(finalSeats))
 		oldestReqFromMinQueue.workEstimate.FinalSeats = finalSeats
 		oldestReqFromMinQueue.workEstimate.AdditionalLatency = additionalLatency

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -120,9 +120,9 @@ type uniformClient struct {
 	// period
 	split bool
 	// initialSeats is the number of seats this request occupies in the first phase of execution
-	initialSeats uint
+	initialSeats uint64
 	// finalSeats is the number occupied during the second phase of execution
-	finalSeats uint
+	finalSeats uint64
 }
 
 func newUniformClient(hash uint64, nThreads, nCalls int, execDuration, thinkDuration time.Duration) uniformClient {
@@ -142,13 +142,13 @@ func (uc uniformClient) setSplit() uniformClient {
 	return uc
 }
 
-func (uc uniformClient) setInitWidth(seats uint) uniformClient {
+func (uc uniformClient) setInitWidth(seats uint64) uniformClient {
 	uc.initialSeats = seats
 	return uc
 }
 
 func (uc uniformClient) pad(finalSeats int, duration time.Duration) uniformClient {
-	uc.finalSeats = uint(finalSeats)
+	uc.finalSeats = uint64(finalSeats)
 	uc.padDuration = duration
 	return uc
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/config.go
@@ -38,13 +38,13 @@ type WorkEstimatorConfig struct {
 	*MutatingWorkEstimatorConfig `json:"mutatingWorkEstimatorConfig,omitempty"`
 
 	// MinimumSeats is the minimum number of seats a request must occupy.
-	MinimumSeats uint `json:"minimumSeats,omitempty"`
+	MinimumSeats uint64 `json:"minimumSeats,omitempty"`
 	// MaximumSeats is the maximum number of seats a request can occupy
 	//
 	// NOTE: work_estimate_seats_samples metric uses the value of maximumSeats
 	// as the upper bound, so when we change maximumSeats we should also
 	// update the buckets of the metric.
-	MaximumSeats uint `json:"maximumSeats,omitempty"`
+	MaximumSeats uint64 `json:"maximumSeats,omitempty"`
 }
 
 // ListWorkEstimatorConfig holds work estimator parameters related to list requests.

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
@@ -113,7 +113,7 @@ func (e *listWorkEstimator) estimate(r *http.Request, flowSchemaName, priorityLe
 	// will be processed by the list request.
 	// we will come up with a different formula for the transformation function and/or
 	// fine tune this number in future iteratons.
-	seats := uint(math.Ceil(float64(estimatedObjectsToBeProcessed) / e.config.ObjectsPerSeat))
+	seats := uint64(math.Ceil(float64(estimatedObjectsToBeProcessed) / e.config.ObjectsPerSeat))
 
 	// make sure we never return a seat of zero
 	if seats < e.config.MinimumSeats {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/mutating_work_estimator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/mutating_work_estimator.go
@@ -74,7 +74,7 @@ func (e *mutatingWorkEstimator) estimate(r *http.Request, flowSchemaName, priori
 	// is taking 1/Nth of a seat for M milliseconds.
 	// We allow the accounting of that work in P&F to be reshaped into another
 	// rectangle of equal area for practical reasons.
-	var finalSeats uint
+	var finalSeats uint64
 	var additionalLatency time.Duration
 
 	// TODO: Make this unconditional after we tune the algorithm better.
@@ -86,7 +86,7 @@ func (e *mutatingWorkEstimator) estimate(r *http.Request, flowSchemaName, priori
 		// TODO: As described in the KEP, we should take into account that not all
 		//   events are equal and try to estimate the cost of a single event based on
 		//   some historical data about size of events.
-		finalSeats = uint(math.Ceil(float64(watchCount) / e.config.WatchesPerSeat))
+		finalSeats = uint64(math.Ceil(float64(watchCount) / e.config.WatchesPerSeat))
 		finalWork := SeatsTimesDuration(float64(finalSeats), e.config.eventAdditionalDuration())
 
 		// While processing individual events is highly parallel,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
@@ -30,11 +30,11 @@ import (
 type WorkEstimate struct {
 	// InitialSeats is the number of seats occupied while the server is
 	// executing this request.
-	InitialSeats uint
+	InitialSeats uint64
 
 	// FinalSeats is the number of seats occupied at the end,
 	// during the AdditionalLatency.
-	FinalSeats uint
+	FinalSeats uint64
 
 	// AdditionalLatency specifies the additional duration the seats allocated
 	// to this request must be reserved after the given request had finished.
@@ -85,9 +85,9 @@ func (e WorkEstimatorFunc) EstimateWork(r *http.Request, flowSchemaName, priorit
 
 type workEstimator struct {
 	// the minimum number of seats a request must occupy
-	minimumSeats uint
+	minimumSeats uint64
 	// the maximum number of seats a request can occupy
-	maximumSeats uint
+	maximumSeats uint64
 	// listWorkEstimator estimates work for list request(s)
 	listWorkEstimator WorkEstimatorFunc
 	// mutatingWorkEstimator calculates the width of mutating request(s)

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
@@ -37,8 +37,8 @@ func TestWorkEstimator(t *testing.T) {
 		counts                    map[string]int64
 		countErr                  error
 		watchCount                int
-		initialSeatsExpected      uint
-		finalSeatsExpected        uint
+		initialSeatsExpected      uint64
+		finalSeatsExpected        uint64
 		additionalLatencyExpected time.Duration
 	}{
 		{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is a followup to https://github.com/kubernetes/kubernetes/pull/111222#discussion_r928161660.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:
/assign @wojtek-t 
/cc @MikeSpreitzer 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
