### PR TITLE
Fix integration test case and bug in validator

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
@@ -66,7 +66,7 @@ type Validator struct {
 // only errors.
 // Adding perCallLimit as input arg for testing purpose only. Callers should always use const PerCallLimit as input
 func NewValidator(s *schema.Structural, isResourceRoot bool, perCallLimit uint64) *Validator {
-	return validator(s, true, model.SchemaDeclType(s, isResourceRoot), perCallLimit)
+	return validator(s, isResourceRoot, model.SchemaDeclType(s, isResourceRoot), perCallLimit)
 }
 
 // validator creates a Validator for all x-kubernetes-validations at the level of the provided schema and lower and

--- a/test/integration/apiserver/apply/apply_crd_test.go
+++ b/test/integration/apiserver/apply/apply_crd_test.go
@@ -487,6 +487,7 @@ func TestApplyCRDUnhandledSchema(t *testing.T) {
 	var c apiextensionsv1beta1.CustomResourceValidation
 	err = json.Unmarshal([]byte(`{
 		"openAPIV3Schema": {
+            "type": "object",
 			"properties": {
 				"TypeFooBar": {
 					"type": "array"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Structural schemas are considered valid even if the root object does not explicitly set Type: "Object". This wasn't noticed until the feature gate was enabled by default for CEL and k8s.io/kubernetes/test/integration/apiserver/apply: TestApplyCRDUnhandledSchema started failing consistently because it tests this specific case.
Since we have existing validation and test coverage for type required in root level:
https://github.com/kubernetes/kubernetes/blob/a4a22a25622bf426308995d99d4f708396bbde6c/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go#L121-L122
And root level type must be `object`: https://github.com/kubernetes/kubernetes/blob/a4a22a25622bf426308995d99d4f708396bbde6c/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go#L133-L135

The failing test is to test "type: array" without any items at all is completely valid: https://github.com/kubernetes/kubernetes/blob/a4a22a25622bf426308995d99d4f708396bbde6c/test/integration/apiserver/apply/apply_crd_test.go#L489-L492
Fixing the currently integration test sounds like an option. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
