### PR TITLE
Correct event validation messages using the core/v1 field name `reportingComponent`

### DIFF
--- a/pkg/apis/core/validation/events.go
+++ b/pkg/apis/core/validation/events.go
@@ -40,7 +40,7 @@ const (
 
 func ValidateEventCreate(event *core.Event, requestVersion schema.GroupVersion) field.ErrorList {
 	// Make sure events always pass legacy validation.
-	allErrs := legacyValidateEvent(event)
+	allErrs := legacyValidateEvent(event, requestVersion)
 	if requestVersion == v1.SchemeGroupVersion || requestVersion == eventsv1beta1.SchemeGroupVersion {
 		// No further validation for backwards compatibility.
 		return allErrs
@@ -73,7 +73,7 @@ func ValidateEventCreate(event *core.Event, requestVersion schema.GroupVersion) 
 
 func ValidateEventUpdate(newEvent, oldEvent *core.Event, requestVersion schema.GroupVersion) field.ErrorList {
 	// Make sure the new event always passes legacy validation.
-	allErrs := legacyValidateEvent(newEvent)
+	allErrs := legacyValidateEvent(newEvent, requestVersion)
 	if requestVersion == v1.SchemeGroupVersion || requestVersion == eventsv1beta1.SchemeGroupVersion {
 		// No further validation for backwards compatibility.
 		return allErrs
@@ -119,10 +119,15 @@ func validateV1EventSeries(event *core.Event) field.ErrorList {
 }
 
 // legacyValidateEvent makes sure that the event makes sense.
-func legacyValidateEvent(event *core.Event) field.ErrorList {
+func legacyValidateEvent(event *core.Event, requestVersion schema.GroupVersion) field.ErrorList {
 	allErrs := field.ErrorList{}
 	// Because go
 	zeroTime := time.Time{}
+
+	reportingControllerFieldName := "reportingController"
+	if requestVersion == v1.SchemeGroupVersion {
+		reportingControllerFieldName = "reportingComponent"
+	}
 
 	// "New" Events need to have EventTime set, so it's validating old object.
 	if event.EventTime.Time == zeroTime {
@@ -144,9 +149,9 @@ func legacyValidateEvent(event *core.Event) field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("involvedObject", "namespace"), event.InvolvedObject.Namespace, "does not match event.namespace"))
 		}
 		if len(event.ReportingController) == 0 {
-			allErrs = append(allErrs, field.Required(field.NewPath("reportingController"), ""))
+			allErrs = append(allErrs, field.Required(field.NewPath(reportingControllerFieldName), ""))
 		}
-		allErrs = append(allErrs, ValidateQualifiedName(event.ReportingController, field.NewPath("reportingController"))...)
+		allErrs = append(allErrs, ValidateQualifiedName(event.ReportingController, field.NewPath(reportingControllerFieldName))...)
 		if len(event.ReportingInstance) == 0 {
 			allErrs = append(allErrs, field.Required(field.NewPath("reportingInstance"), ""))
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

when creating a events without `reportingComponent` field, the error message shows that `reportingController` is missing
```
The Event "xxx" is invalid:
* reportingController: Required value
* reportingController: Invalid value: "": name part must be non-empty
* reportingController: Invalid value: "": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
