### PR TITLE
Add flag to disable compression for local traffic

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/disable_compression.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/disable_compression.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"fmt"
+	"net/http"
+
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// CompressionDisabledFunc checks if a given request should disable compression.
+type CompressionDisabledFunc func(*http.Request) (bool, error)
+
+// WithCompressionDisabled stores result of CompressionDisabledFunc in context.
+func WithCompressionDisabled(handler http.Handler, predicate CompressionDisabledFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		decision, err := predicate(req)
+		if err != nil {
+			responsewriters.InternalError(w, req, fmt.Errorf("failed to determine if request should disable compression: %v", err))
+			return
+		}
+
+		req = req.WithContext(request.WithCompressionDisabled(ctx, decision))
+		handler.ServeHTTP(w, req)
+	})
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/disable_compression_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/disable_compression_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+func TestWithCompressionDisabled(t *testing.T) {
+	tests := []struct {
+		name              string
+		checkDecision     bool
+		checkErr          error
+		want              bool
+		wantHandlerCalled bool
+	}{
+		{
+			name:              "decision=true",
+			checkDecision:     true,
+			want:              true,
+			wantHandlerCalled: true,
+		},
+		{
+			name:              "decision=false",
+			checkDecision:     false,
+			want:              false,
+			wantHandlerCalled: true,
+		},
+		{
+			name:              "check error",
+			checkErr:          errors.New("check failed"),
+			want:              false,
+			wantHandlerCalled: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlerCalled := false
+			handler := http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+				handlerCalled = true
+				if got, want := request.CompressionDisabledFrom(req.Context()), tt.checkDecision; got != want {
+					t.Errorf("request.CompressionDisabledFrom(req.Context())=%v; want=%v", got, want)
+				}
+			})
+			fake := func(*http.Request) (bool, error) {
+				return tt.checkDecision, tt.checkErr
+			}
+			wrapped := WithCompressionDisabled(handler, fake)
+			testRequest, err := http.NewRequest(http.MethodGet, "/path", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			w := httptest.NewRecorder()
+			wrapped.ServeHTTP(w, testRequest)
+			if handlerCalled != tt.wantHandlerCalled {
+				t.Errorf("expected handlerCalled=%v, got=%v", handlerCalled, tt.wantHandlerCalled)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -87,19 +87,21 @@ func StreamObject(statusCode int, gv schema.GroupVersion, s runtime.NegotiatedSe
 // The context is optional and can be nil. This method will perform optional content compression if requested by
 // a client and the feature gate for APIResponseCompression is enabled.
 func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.ResponseWriter, req *http.Request, statusCode int, object runtime.Object) {
+	disableCompression := request.CompressionDisabledFrom(req.Context())
 	trace := utiltrace.New("SerializeObject",
 		utiltrace.Field{"audit-id", request.GetAuditIDTruncated(req.Context())},
 		utiltrace.Field{"method", req.Method},
 		utiltrace.Field{"url", req.URL.Path},
 		utiltrace.Field{"protocol", req.Proto},
 		utiltrace.Field{"mediaType", mediaType},
-		utiltrace.Field{"encoder", encoder.Identifier()})
+		utiltrace.Field{"encoder", encoder.Identifier()},
+		utiltrace.Field{"disableCompression", disableCompression})
 	defer trace.LogIfLong(5 * time.Second)
 
 	w := &deferredResponseWriter{
 		mediaType:       mediaType,
 		statusCode:      statusCode,
-		contentEncoding: negotiateContentEncoding(req),
+		contentEncoding: negotiateContentEncoding(req, disableCompression),
 		hw:              hw,
 		trace:           trace,
 	}
@@ -155,12 +157,12 @@ const (
 // negotiateContentEncoding returns a supported client-requested content encoding for the
 // provided request. It will return the empty string if no supported content encoding was
 // found or if response compression is disabled.
-func negotiateContentEncoding(req *http.Request) string {
+func negotiateContentEncoding(req *http.Request, disableCompression bool) string {
 	encoding := req.Header.Get("Accept-Encoding")
 	if len(encoding) == 0 {
 		return ""
 	}
-	if !utilfeature.DefaultFeatureGate.Enabled(features.APIResponseCompression) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.APIResponseCompression) || disableCompression {
 		return ""
 	}
 	for len(encoding) > 0 {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/disable_compression.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/disable_compression.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"context"
+)
+
+type disableCompressionIDKeyType int
+
+const disableCompressionIDKey disableCompressionIDKeyType = iota
+
+// WithCompressionDisabled stores bool in context.
+func WithCompressionDisabled(parent context.Context, disableCompression bool) context.Context {
+	return WithValue(parent, disableCompressionIDKey, disableCompression)
+}
+
+// CompressionDisabledFrom retrieves bool from context.
+// Defaults to false if not set.
+func CompressionDisabledFrom(ctx context.Context) bool {
+	decision, _ := ctx.Value(disableCompressionIDKey).(bool)
+	return decision
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/disable_compression_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/disable_compression_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCompressionDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	// Default value is false.
+	if got, want := CompressionDisabledFrom(ctx), false; got != want {
+		t.Errorf("CompressionDisabledFrom(ctx) = %v; want = %v", got, want)
+	}
+
+	// We retrieve stored true.
+	ctx = WithCompressionDisabled(ctx, true)
+	if got, want := CompressionDisabledFrom(ctx), true; got != want {
+		t.Errorf("CompressionDisabledFrom(ctx) = %v; want = %v", got, want)
+	}
+
+	// We retrieve stored false.
+	ctx = WithCompressionDisabled(ctx, false)
+	if got, want := CompressionDisabledFrom(ctx), false; got != want {
+		t.Errorf("CompressionDisabledFrom(ctx) = %v; want = %v", got, want)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -257,6 +257,9 @@ type Config struct {
 
 	// StorageVersionManager holds the storage versions of the API resources installed by this server.
 	StorageVersionManager storageversion.Manager
+
+	// CompressionDisabledFunc returns whether compression should be disabled for a given request.
+	CompressionDisabledFunc genericapifilters.CompressionDisabledFunc
 }
 
 type RecommendedConfig struct {
@@ -854,6 +857,9 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericfilters.WithHSTS(handler, c.HSTSDirectives)
 	if c.ShutdownSendRetryAfter {
 		handler = genericfilters.WithRetryAfter(handler, c.lifecycleSignals.NotAcceptingNewRequest.Signaled())
+	}
+	if c.CompressionDisabledFunc != nil {
+		handler = genericapifilters.WithCompressionDisabled(handler, c.CompressionDisabledFunc)
 	}
 	handler = genericfilters.WithHTTPLogging(handler)
 	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerTracing) {

--- a/staging/src/k8s.io/apiserver/pkg/util/disablecompression/disablecompression.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/disablecompression/disablecompression.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disablecompression
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	netutils "k8s.io/utils/net"
+)
+
+// ClientIPPredicate.Predicate implements CompressionDisabledFunc interface that decides
+// based on client IP.
+type ClientIPPredicate struct {
+	cidrs []*net.IPNet
+}
+
+// NewClientIPPredicate creates a new ClientIPPredicate instance.
+func NewClientIPPredicate(cidrStrings []string) (*ClientIPPredicate, error) {
+	cidrs, err := netutils.ParseCIDRs(cidrStrings)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cidrs: %v", err)
+	}
+	return &ClientIPPredicate{cidrs: cidrs}, nil
+}
+
+// Predicate checks if ClientIP matches any cidr.
+func (c *ClientIPPredicate) Predicate(req *http.Request) (bool, error) {
+	ip := utilnet.GetClientIP(req)
+	if ip == nil {
+		return false, fmt.Errorf("unable to determine source IP for %v", req)
+	}
+
+	for _, cidr := range c.cidrs {
+		if cidr.Contains(ip) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/disablecompression/disablecompression_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/disablecompression/disablecompression_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disablecompression
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewClientIPPredicate(t *testing.T) {
+	tests := []struct {
+		name        string
+		cidrStrings []string
+		wantErr     bool
+	}{
+		{
+			name:        "rfc1918",
+			cidrStrings: []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"},
+		},
+		{
+			name:        "rfc4193 (ipv6)",
+			cidrStrings: []string{"fc00::/7"},
+		},
+		{
+			name:        "ipv6 loopback",
+			cidrStrings: []string{"::1/128"},
+		},
+		{
+			name:        "bad cidr",
+			cidrStrings: []string{"not a cidr string"},
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewClientIPPredicate(tt.cidrStrings)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewClientIPPredicate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got, want := len(got.cidrs), len(tt.cidrStrings); got != want {
+				t.Errorf("len(NewClientIPPredicate.cidrs()) = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestClientIPPredicate_Predicate(t *testing.T) {
+	check, err := NewClientIPPredicate([]string{"::1/128", "10.0.0.0/8"})
+	if err != nil {
+		t.Fatalf("failed to construct NewClientIPPredicate: %v", err)
+	}
+	tests := []struct {
+		name    string
+		req     *http.Request
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "ipv4, in range",
+			req:  &http.Request{RemoteAddr: "10.0.0.1:123"},
+			want: true,
+		},
+		{
+			name: "ipv4, out of range",
+			req:  &http.Request{RemoteAddr: "11.0.0.1:123"},
+			want: false,
+		},
+		{
+			name: "ipv6, in range",
+			req:  &http.Request{RemoteAddr: "[::1]:123"},
+			want: true,
+		},
+		{
+			name: "ipv6, out of range",
+			req:  &http.Request{RemoteAddr: "[::2]:123"},
+			want: false,
+		},
+		{
+			name:    "no IP",
+			req:     &http.Request{},
+			wantErr: true,
+		},
+		{
+			name:    "RemoteAddr doesn't parse",
+			req:     &http.Request{RemoteAddr: "this is definitely not an IP address and port"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := check.Predicate(tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ClientIPPredicate.Predicate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ClientIPPredicate.Predicate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1658,6 +1658,7 @@ k8s.io/apiserver/pkg/storage/value/encrypt/secretbox
 k8s.io/apiserver/pkg/storageversion
 k8s.io/apiserver/pkg/tracing
 k8s.io/apiserver/pkg/util/apihelpers
+k8s.io/apiserver/pkg/util/disablecompression
 k8s.io/apiserver/pkg/util/dryrun
 k8s.io/apiserver/pkg/util/feature
 k8s.io/apiserver/pkg/util/flowcontrol


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
We have found that gzip compression significantly limits achievable throughput to ~20-30 MiB per seconds which is way below throughput achievable by modern local networks (16Gbps+).

In benchmark I prepared, the latency of listing 1G of configmaps from VM in the same VPC network differs a lot:
* With compression enabled (default) it takes ~33s
* With compression disabled it takes ~3.5s.

The motivation mentioned in the KEP was to help clients that are not on fast networks (https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/2338-graduate-API-gzip-compression-support-to-GA/README.md#motivation) which is reasonable, but there is a cost of this feature in all cases:
* increased CPU usage (cost of gzip compression/decompression)
* reduced throughput (in effect reduced limit of objects that can be returned within --request-timeout (limit for calls without pagination) and --etcd-compaction-interval (limit for paginated calls)).

In the case of fast networks, the cost doesn't overcome gain (which is saving network bandwidth which from our tests/experience is much more available resource than CPU on master).

This PR adds an option to take requestor's IP address into account during content encoding negotiation: if source IP is either in private (local network) or in loopback (same machine)) ranges, we disable compression.

The expected memory impact on client is expected to be none to little, as client-go is caching entire object in memory before deserialization anyway: https://github.com/kubernetes/kubernetes/blob/e30d15595f367bae54143ef3fc5f61527b2558a6/staging/src/k8s.io/client-go/rest/request.go#L959-L959

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

cleared release note since this is reverted in https://github.com/kubernetes/kubernetes/pull/111896
```release-note
NONE
```

original release note:
```
New flag `--disable-compression-for-client-ips` can be used to control client address ranges for which traffic shouldn't be compressed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @wojtek-t  @ilackarms  @sttts
