### PR TITLE
kubeadm: move show-join-command as a separate phase

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/showjoincommand.go
+++ b/cmd/kubeadm/app/cmd/phases/init/showjoincommand.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"io"
+	"text/template"
+
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
+	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
+)
+
+var (
+	initDoneTempl = template.Must(template.New("init").Parse(dedent.Dedent(`
+		Your Kubernetes control-plane has initialized successfully!
+
+		To start using your cluster, you need to run the following as a regular user:
+
+		  mkdir -p $HOME/.kube
+		  sudo cp -i {{.KubeConfigPath}} $HOME/.kube/config
+		  sudo chown $(id -u):$(id -g) $HOME/.kube/config
+
+		Alternatively, if you are the root user, you can run:
+
+		  export KUBECONFIG=/etc/kubernetes/admin.conf
+
+		You should now deploy a pod network to the cluster.
+		Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
+		  https://kubernetes.io/docs/concepts/cluster-administration/addons/
+
+		{{if .ControlPlaneEndpoint -}}
+		{{if .UploadCerts -}}
+		You can now join any number of the control-plane node running the following command on each as root:
+
+		  {{.joinControlPlaneCommand}}
+
+		Please note that the certificate-key gives access to cluster sensitive data, keep it secret!
+		As a safeguard, uploaded-certs will be deleted in two hours; If necessary, you can use
+		"kubeadm init phase upload-certs --upload-certs" to reload certs afterward.
+
+		{{else -}}
+		You can now join any number of control-plane nodes by copying certificate authorities
+		and service account keys on each node and then running the following as root:
+
+		  {{.joinControlPlaneCommand}}
+
+		{{end}}{{end}}Then you can join any number of worker nodes by running the following on each as root:
+
+		{{.joinWorkerCommand}}
+		`)))
+)
+
+// NewShowJoinCommandPhase creates a kubeadm workflow phase that implements showing the join command.
+func NewShowJoinCommandPhase() workflow.Phase {
+	return workflow.Phase{
+		Name:         "show-join-command",
+		Short:        "Show the join command for control-plane and worker node",
+		Run:          showJoinCommand,
+		Dependencies: []string{"bootstrap-token", "upload-certs"},
+	}
+}
+
+// showJoinCommand prints the join command after all the phases in init have finished
+func showJoinCommand(c workflow.RunData) error {
+	data, ok := c.(InitData)
+	if !ok {
+		return errors.New("show-join-command phase invoked with an invalid data struct")
+	}
+
+	adminKubeConfigPath := data.KubeConfigPath()
+
+	// Prints the join command, multiple times in case the user has multiple tokens
+	for _, token := range data.Tokens() {
+		if err := printJoinCommand(data.OutputWriter(), adminKubeConfigPath, token, data); err != nil {
+			return errors.Wrap(err, "failed to print join command")
+		}
+	}
+
+	return nil
+}
+
+func printJoinCommand(out io.Writer, adminKubeConfigPath, token string, i InitData) error {
+	joinControlPlaneCommand, err := cmdutil.GetJoinControlPlaneCommand(adminKubeConfigPath, token, i.CertificateKey(), i.SkipTokenPrint(), i.SkipCertificateKeyPrint())
+	if err != nil {
+		return err
+	}
+
+	joinWorkerCommand, err := cmdutil.GetJoinWorkerCommand(adminKubeConfigPath, token, i.SkipTokenPrint())
+	if err != nil {
+		return err
+	}
+
+	ctx := map[string]interface{}{
+		"KubeConfigPath":          adminKubeConfigPath,
+		"ControlPlaneEndpoint":    i.Cfg().ControlPlaneEndpoint,
+		"UploadCerts":             i.UploadCerts(),
+		"joinControlPlaneCommand": joinControlPlaneCommand,
+		"joinWorkerCommand":       joinWorkerCommand,
+	}
+
+	return initDoneTempl.Execute(out, ctx)
+}

--- a/cmd/kubeadm/app/cmd/phases/workflow/phase.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/phase.go
@@ -78,6 +78,9 @@ type Phase struct {
 	// ArgsValidator defines the positional arg function to be used for validating args for this phase
 	// If not set a phase will adopt the args of the top level command.
 	ArgsValidator cobra.PositionalArgs
+
+	// Dependencies is a list of phases that the specific phase depends on.
+	Dependencies []string
 }
 
 // AppendPhase adds the given phase to the nested, ordered sequence of phases.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: move show-join-command as a separate phase

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#2734

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: "show-join-command" has been added as a new separate phase at the end of "kubeadm init". You can skip printing the join information by using "kubeadm init --skip-phases=show-join-command". Executing only this phase on demand will throw an error because the phase needs dependencies such as bootstrap tokens to be pre-populated.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
