### PR TITLE
Clear ephemeral container resources field when creating one in volume test

### DIFF
--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -606,6 +606,7 @@ func testVolumeClient(f *framework.Framework, config TestConfig, fsGroup *int64,
 	ec := &v1.EphemeralContainer{
 		EphemeralContainerCommon: v1.EphemeralContainerCommon(clientPod.Spec.Containers[0]),
 	}
+	ec.Resources = v1.ResourceRequirements{}
 	ec.Name = "volume-ephemeral-container"
 	err = f.PodClient().AddEphemeralContainerSync(clientPod, ec, timeouts.PodStart)
 	// The API server will return NotFound for the subresource when the feature is disabled


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`testVolumeClient` uses `clientPod.Spec.Containers[0]` as a starting point for an ephemeral container.  But in some clusters `clientPod.Spec.Containers[0]` might have a non-empty resources field. And setting non-empty resources field is disallowed on ephemeral containers: https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/. Trying to do so results in a `422` error. Therefore the ephemeral container resources field must be cleared first to avoid a `422` error during this test.

Specifically, on all EKS clusters there is this webhook that patches ALL Pod resources to include non-empty value https://github.com/aws/amazon-vpc-resource-controller-k8s/blob/master/webhooks/core/pod_webhook.go#L176. This includes `clientPod`. So when `testVolumeClient` tries to create an ephemeral container based on `clientPod.Spec.Containers[0]` it gets:
```
    <*errors.StatusError | 0xc002b67040>: {
        ErrStatus: {
            TypeMeta: {Kind: "", APIVersion: ""},
            ListMeta: {
                SelfLink: "",
                ResourceVersion: "",
                Continue: "",
                RemainingItemCount: nil,
            },
            Status: "Failure",
            Message: "Pod \"aws-client\" is invalid: spec.ephemeralContainers[0].resources: Forbidden: cannot be set for an Ephemeral Container",
            Reason: "Invalid",
            Details: {
                Name: "aws-client",
                Group: "",
                Kind: "Pod",
                UID: "",
                Causes: [
                    {
                        Type: "FieldValueForbidden",
                        Message: "Forbidden: cannot be set for an Ephemeral Container",
                        Field: "spec.ephemeralContainers[0].resources",
                    },
                ],
                RetryAfterSeconds: 0,
            },
            Code: 422,
        },
    }
```

With this PR, `testVolumeClient` succeeds on EKS.
```
...
[1mSTEP:[0m Repeating the test on an ephemeral container (if enabled) [38;5;243m07/28/22 15:45:43.563[0m
Jul 28 15:45:43.596: INFO: Waiting up to 5m0s for pod "aws-client" in namespace "volume-8152" to be "container volume-ephemeral-container running"
...
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
