### PR TITLE
Promote NamespaceStatus endpoints test +3 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -382,6 +382,15 @@
     MUST cause pods created by that RC to be orphaned.
   release: v1.9
   file: test/e2e/apimachinery/garbage_collector.go
+- testname: Namespace, apply changes to a namespace status
+  codename: '[sig-api-machinery] Namespaces [Serial] should apply changes to a namespace
+    status [Conformance]'
+  description: Getting the current namespace status MUST succeed. The reported status
+    phase MUST be active. Given the patching of the namespace status, the fields MUST
+    equal the new values. Given the updating of the namespace status, the fields MUST
+    equal the new values.
+  release: v1.25
+  file: test/e2e/apimachinery/namespace.go
 - testname: namespace-deletion-removes-pods
   codename: '[sig-api-machinery] Namespaces [Serial] should ensure that all pods are
     removed when a namespace is deleted [Conformance]'

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -287,7 +287,15 @@ var _ = SIGDescribe("Namespaces [Serial]", func() {
 		framework.ExpectEqual(namespace.ObjectMeta.Labels["testLabel"], "testValue", "namespace not patched")
 	})
 
-	ginkgo.It("should apply changes to a namespace status", func() {
+	/*
+		Release: v1.25
+		Testname: Namespace, apply changes to a namespace status
+		Description: Getting the current namespace status MUST succeed. The reported status
+		phase MUST be active. Given the patching of the namespace status, the fields MUST
+		equal the new values. Given the updating of the namespace status, the fields MUST
+		equal the new values.
+	*/
+	framework.ConformanceIt("should apply changes to a namespace status", func() {
 		ns := f.Namespace.Name
 		dc := f.DynamicClient
 		nsResource := v1.SchemeGroupVersion.WithResource("namespaces")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- readCoreV1NamespaceStatus
- patchCoreV1NamespaceStatus
- replaceCoreV1NamespaceStatus

**Which issue(s) this PR fixes:**
Fixes #109762

**Testgrid Link:** [testgrid](https://testgrid.k8s.io/sig-api-machinery-gce-gke#gce-serial&width=20&graph-metrics=test-duration-minutes&include-filter-by-regex=should.apply.changes.to.a.namespace.status)


**Special notes for your reviewer:**
Adds +2 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance