### PR TITLE
Promote feature CustomResourceValidationExpressions to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1039,7 +1039,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.AdvancedAuditing: {Default: true, PreRelease: featuregate.GA},
 
-	genericfeatures.CustomResourceValidationExpressions: {Default: false, PreRelease: featuregate.Alpha},
+	genericfeatures.CustomResourceValidationExpressions: {Default: true, PreRelease: featuregate.Beta},
 
 	genericfeatures.DryRun: {Default: true, PreRelease: featuregate.GA},
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -84,6 +84,7 @@ const (
 	// owner: @cici37
 	// kep: http://kep.k8s.io/2876
 	// alpha: v1.23
+	// beta: v1.25
 	//
 	// Enables expression validation for Custom Resource
 	CustomResourceValidationExpressions featuregate.Feature = "CustomResourceValidationExpressions"
@@ -198,7 +199,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	AdvancedAuditing: {Default: true, PreRelease: featuregate.GA},
 
-	CustomResourceValidationExpressions: {Default: false, PreRelease: featuregate.Alpha},
+	CustomResourceValidationExpressions: {Default: true, PreRelease: featuregate.Beta},
 
 	DryRun: {Default: true, PreRelease: featuregate.GA},
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is to promote feature CustomResourceValidationExpressions to beta as it's proposed in [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

The feature is in alpha since v1.23. For v1.25 cycle, we focus on performance optimization, test coverage, bug fix, metrics adding, dependency bumping, etc. The related PR FYI:
- https://github.com/kubernetes/kubernetes/pull/110135
- https://github.com/kubernetes/kubernetes/pull/111071
- https://github.com/kubernetes/kubernetes/pull/111035
- https://github.com/kubernetes/kubernetes/pull/109804
- https://github.com/kubernetes/kubernetes/pull/111005
- https://github.com/kubernetes/kubernetes/pull/110576
- https://github.com/kubernetes/kubernetes/pull/110549
- https://github.com/kubernetes/kubernetes/pull/110548
- https://github.com/kubernetes/kubernetes/pull/110330
- https://github.com/kubernetes/kubernetes/pull/109835
- https://github.com/kubernetes/kubernetes/pull/111008
- https://github.com/kubernetes/kubernetes/pull/108011

Graduation to beta criteria from the [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md#beta)
 - [x] Resolve topic of what support we should provide for access to the previous versions of object (ie. 'oldSelf' feature) -- resolved in https://github.com/kubernetes/kubernetes/blob/631a5a849ab09216da42c10858e962d71071ea65/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go#L1701-L1753
 - [x] x-kubernetes-int-or-string is upgraded to use a union type of just int or string, not a dynamic type (CEL go support is planned in lates 2021) -- resolved in https://github.com/kubernetes/kubernetes/blob/631a5a849ab09216da42c10858e962d71071ea65/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go#L793-L842
 - [x] Understanding of upper bounds of CPU/memory usage and appropriate limits set to prevent abuse.(Done in https://github.com/kubernetes/kubernetes/pull/108482; https://github.com/kubernetes/kubernetes/pull/108595; https://github.com/kubernetes/kubernetes/pull/108612; https://github.com/kubernetes/kubernetes/pull/109122)
 - [x] Build-in macro/function library is comprehensive and stable (any changes to this will be a breaking change) - **The later addition of quantity appears to complicate this.  See [CEL Validation Use Cases](https://docs.google.com/document/d/1KatwZJ3O0lTThs1Lg8YqY-PipbNM8aaUDDdPCLd3lic/edit?resourcekey=0-YeuQhCZlstVjL61WVqrz_w#) where it is postponed as a use-case** (https://github.com/kubernetes/kubernetes/pull/108312)
 - [x] CEL numeric comparison issue is resolved (e.g. ability to compare ints to doubles) (Added test [here](https://github.com/kubernetes/kubernetes/blob/3ffdfbe286ebcea5d75617da6accaf67f815e0cf/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go#L105))
 - [x] https://github.com/kubernetes/kubernetes/issues/106440 **Asking for clarification of the fix**
 - [x] https://github.com/kubernetes/kubernetes/issues/106438
 - [x] Demonstrate adoption and successful feature usage in the community -- confirmed against the list in [CEL Validation Use Cases](https://docs.google.com/document/d/1KatwZJ3O0lTThs1Lg8YqY-PipbNM8aaUDDdPCLd3lic/edit?resourcekey=0-YeuQhCZlstVjL61WVqrz_w#).  quantity to be rejected by supported releases when it is added.
 - [x] Optimization on super-linear complexity growth (https://github.com/kubernetes/kubernetes/pull/110135)
 - [x] Adding metric of the latency of CEL evaluation for CRD evaluation


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Graduated `CustomResourceValidationExpressions` to `beta`. The `CustomResourceValidationExpressions` feature gate is now enabled by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
```
