### PR TITLE
clientcmd: ConfirmUsable() should respect overrides.CurrentContext

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -401,6 +401,9 @@ func (config *DirectClientConfig) ConfirmUsable() error {
 	} else {
 		contextName = config.config.CurrentContext
 	}
+	if config.overrides != nil && len(config.overrides.CurrentContext) != 0 {
+		contextName = config.overrides.CurrentContext
+	}
 
 	if len(contextName) > 0 {
 		_, exists := config.config.Contexts[contextName]

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -157,6 +157,18 @@ func TestInsecureOverridesCA(t *testing.T) {
 	matchByteArg(nil, actualCfg.TLSClientConfig.CAData, t)
 }
 
+func TestCurrentContextOverrides(t *testing.T) {
+	config := createCAValidTestConfig()
+	clientBuilder := NewNonInteractiveClientConfig(*config, "not-present", &ConfigOverrides{
+		CurrentContext: "clean",
+	}, nil)
+
+	_, err := clientBuilder.ClientConfig()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
 func TestCAOverridesCAData(t *testing.T) {
 	file, err := ioutil.TempFile("", "my.ca")
 	if err != nil {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Previously if
- the `CurrentContext` is not present
- an `overrides.CurrentContext` is provided and exists

then `ConfirmUsable()` will fail, complaining about the not present context (ignoring the override)

I originally saw this when I had deleted a context, while it was still my "current" context in `.kube/config`. My Kubernetes client program was trying to operate on a specific cluster which did exist via an override, but the override was ignored.

For example this small test program (where `present` does exist but `not-present` does not exist)
```golang
package main

import (
	"fmt"

	"k8s.io/client-go/tools/clientcmd"
)

func main() {
	config, err := clientcmd.NewDefaultPathOptions().GetStartingConfig()
	if err != nil {
		panic(err)
	}
	// Simulate the current context being missing
	config.CurrentContext = "not-present"
	// But it shouldn't matter because we want to operate on a context that does exist
	if _, err := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{CurrentContext: "present"}).ClientConfig(); err != nil {
		panic(err)
	}
	fmt.Println("ok")
}
```

When I ran this locally I saw:
```
PS test> go build
PS test> .\test.exe
panic: invalid configuration: context was not found for specified context: not-present
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
