### PR TITLE
Add cli.RunContext to allow running with a caller-provided Context.

### DIFF
--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	_ "time/tzdata" // for timeZone support in CronJob
 
+	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/cli"
 	_ "k8s.io/component-base/logs/json/register"          // for JSON log format registration
 	_ "k8s.io/component-base/metrics/prometheus/clientgo" // load all the prometheus client-go plugins
@@ -31,6 +32,6 @@ import (
 
 func main() {
 	command := app.NewAPIServerCommand()
-	code := cli.Run(command)
+	code := cli.RunContext(genericapiserver.SetupSignalContext(), command)
 	os.Exit(code)
 }

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -126,7 +126,7 @@ cluster's shared state through which all other components interact.`,
 				return utilerrors.NewAggregate(errs)
 			}
 
-			return Run(completedOptions, genericapiserver.SetupSignalHandler())
+			return Run(completedOptions, cmd.Context().Done())
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			for _, arg := range args {

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/apiserver/pkg/server"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/server/mux"
@@ -126,20 +125,12 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
 	}
 	cliflag.PrintFlags(cmd.Flags())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		stopCh := server.SetupSignalHandler()
-		<-stopCh
-		cancel()
-	}()
-
-	cc, sched, err := Setup(ctx, opts, registryOptions...)
+	cc, sched, err := Setup(cmd.Context(), opts, registryOptions...)
 	if err != nil {
 		return err
 	}
 
-	return Run(ctx, cc, sched)
+	return Run(cmd.Context(), cc, sched)
 }
 
 // Run executes the scheduler based on the given configuration. It only returns on error or when context is done.

--- a/cmd/kube-scheduler/scheduler.go
+++ b/cmd/kube-scheduler/scheduler.go
@@ -19,6 +19,7 @@ package main
 import (
 	"os"
 
+	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/cli"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
@@ -28,6 +29,6 @@ import (
 
 func main() {
 	command := app.NewSchedulerCommand()
-	code := cli.Run(command)
+	code := cli.RunContext(genericapiserver.SetupSignalContext(), command)
 	os.Exit(code)
 }

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -49,7 +49,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/wait"
-	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/healthz"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
@@ -262,11 +261,8 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 			// log the kubelet's config for inspection
 			klog.V(5).InfoS("KubeletConfiguration", "configuration", config)
 
-			// set up signal context for kubelet shutdown
-			ctx := genericapiserver.SetupSignalContext()
-
 			// run the kubelet
-			return Run(ctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate)
+			return Run(cmd.Context(), kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate)
 		},
 	}
 

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -24,6 +24,7 @@ package main
 import (
 	"os"
 
+	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/cli"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	_ "k8s.io/component-base/metrics/prometheus/restclient"
@@ -33,6 +34,6 @@ import (
 
 func main() {
 	command := app.NewKubeletCommand()
-	code := cli.Run(command)
+	code := cli.RunContext(genericapiserver.SetupSignalContext(), command)
 	os.Exit(code)
 }

--- a/staging/src/k8s.io/component-base/cli/run.go
+++ b/staging/src/k8s.io/component-base/cli/run.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -43,7 +44,11 @@ import (
 // Commands like kubectl where logging is not normally part of the runtime output
 // should use RunNoErrOutput instead and deal with the returned error themselves.
 func Run(cmd *cobra.Command) int {
-	if logsInitialized, err := run(cmd); err != nil {
+	return RunContext(context.Background(), cmd)
+}
+
+func RunContext(ctx context.Context, cmd *cobra.Command) int {
+	if logsInitialized, err := run(ctx, cmd); err != nil {
 		// If the error is about flag parsing, then printing that error
 		// with the decoration that klog would add ("E0923
 		// 23:02:03.219216 4168816 run.go:61] unknown shorthand flag")
@@ -81,11 +86,11 @@ func Run(cmd *cobra.Command) int {
 // RunNoErrOutput is a version of Run which returns the cobra command error
 // instead of printing it.
 func RunNoErrOutput(cmd *cobra.Command) error {
-	_, err := run(cmd)
+	_, err := run(context.Background(), cmd)
 	return err
 }
 
-func run(cmd *cobra.Command) (logsInitialized bool, err error) {
+func run(ctx context.Context, cmd *cobra.Command) (logsInitialized bool, err error) {
 	rand.Seed(time.Now().UnixNano())
 	defer logs.FlushLogs()
 
@@ -143,6 +148,6 @@ func run(cmd *cobra.Command) (logsInitialized bool, err error) {
 		}
 	}
 
-	err = cmd.Execute()
+	err = cmd.ExecuteContext(ctx)
 	return
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds an alternate signature for `cli.Run` to let callers specify a context for the command to be used instead of `context.Background()`.

The commands for kube-apiserver, kube-scheduler, and kubelet get stop channels from k8s.io/apiserver/pkg/server.SetupSignalContext -- which can be called at most once in a process -- during command execution. This is inconvenient for testing these commands, and for distros that embed multiple core components within a single process.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
