### PR TITLE
Minor fixes to e2epod wait logic

### DIFF
--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -713,7 +713,7 @@ func shouldRetry(err error) (retry bool, retryAfter time.Duration) {
 	}
 
 	// these errors indicate a transient error that should be retried.
-	if apierrors.IsInternalError(err) || apierrors.IsTimeout(err) || apierrors.IsTooManyRequests(err) {
+	if apierrors.IsTimeout(err) || apierrors.IsTooManyRequests(err) {
 		return true, 0
 	}
 

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -276,14 +276,15 @@ func WaitForPodCondition(c clientset.Interface, ns, podName, conditionDesc strin
 	if err == nil {
 		return nil
 	}
-	if IsTimeout(err) && lastPod != nil {
-		return TimeoutError(fmt.Sprintf("timed out while waiting for pod %s to be %s", podIdentifier(ns, podName), conditionDesc),
-			lastPod,
-		)
-	}
-	if lastPodError != nil {
-		// If the last API call was an error.
-		err = lastPodError
+	if IsTimeout(err) {
+		if lastPod != nil {
+			return TimeoutError(fmt.Sprintf("timed out while waiting for pod %s to be %s", podIdentifier(ns, podName), conditionDesc),
+				lastPod,
+			)
+		} else if lastPodError != nil {
+			// If the last API call was an error, propagate that instead of the timeout error.
+			err = lastPodError
+		}
 	}
 	return maybeTimeoutError(err, "waiting for pod %s to be %s", podIdentifier(ns, podName), conditionDesc)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

1. Don't retry on 50X internal server errors. We don't want to mask these types of errors in e2e tests.
2. Only override the polling error with the API error if it was a timeout error, so as not to hide terminal condition errors.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig testing
/assign @pohly 