### PR TITLE
Only create one etcd client per transport

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/latency_tracker.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/latency_tracker.go
@@ -37,7 +37,7 @@ func NewETCDLatencyTracker(delegate clientv3.KV) clientv3.KV {
 // complete response back)
 //
 // If an API request involves N (N>=1) round trips to etcd, then we will sum
-// up the latenciy incurred in each roundtrip.
+// up the latency incurred in each roundtrip.
 
 // It uses the context associated with the request in flight, so there
 // are no states shared among the requests in flight, and so there is no
@@ -45,10 +45,6 @@ func NewETCDLatencyTracker(delegate clientv3.KV) clientv3.KV {
 // If the goroutine executing the request handler makes concurrent calls
 // to the underlying storage layer, that is protected since the latency
 // tracking function TrackStorageLatency is thread safe.
-//
-// NOTE: Compact is an asynchronous process and is not associated with
-//
-//	any request, so we will not be tracking its latency.
 type clientV3KVLatencyTracker struct {
 	clientv3.KV
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/size_monitor.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/size_monitor.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd3
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/storage/etcd3/metrics"
+	"k8s.io/klog/v2"
+)
+
+const dbMetricsMonitorJitter = 0.5
+
+var (
+	// dbMetricsMonitorsMu guards access to dbMetricsMonitors map
+	dbMetricsMonitorsMu sync.Mutex
+	dbMetricsMonitors   map[string]struct{}
+)
+
+func init() {
+	dbMetricsMonitors = make(map[string]struct{})
+}
+
+// StartDBSizeMonitor starts a loop to monitor etcd database size and update the
+// corresponding metric etcd_db_total_size_in_bytes for each etcd server
+// endpoint. The monitors are stopped when the supplied context is done.
+func StartDBSizeMonitor(ctx context.Context, client *clientv3.Client, interval time.Duration) {
+	if interval == 0 {
+		return
+	}
+	dbMetricsMonitorsMu.Lock()
+	defer dbMetricsMonitorsMu.Unlock()
+
+	for _, ep := range client.Endpoints() {
+		if _, found := dbMetricsMonitors[ep]; found {
+			continue
+		}
+		dbMetricsMonitors[ep] = struct{}{}
+		endpoint := ep
+		klog.V(4).Infof("Start monitoring storage db size metric for endpoint %s with polling interval %v", endpoint, interval)
+		go wait.JitterUntilWithContext(ctx, func(context.Context) {
+			epStatus, err := client.Maintenance.Status(ctx, endpoint)
+			if err != nil {
+				klog.V(4).Infof("Failed to get storage db size for ep %s: %v", endpoint, err)
+				metrics.UpdateEtcdDbSize(endpoint, -1)
+			} else {
+				metrics.UpdateEtcdDbSize(endpoint, epStatus.DbSize)
+			}
+		}, interval, dbMetricsMonitorJitter, true)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
@@ -81,7 +81,7 @@ func TestTLSConnection(t *testing.T) {
 		},
 		Codec: codec,
 	}
-	storage, destroyFunc, err := newETCD3Storage(*cfg.ForResource(schema.GroupResource{Resource: "pods"}), nil)
+	storage, destroyFunc, err := newETCD3Storage(newETCD3ClientCache(), *cfg.ForResource(schema.GroupResource{Resource: "pods"}), nil)
 	defer destroyFunc()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Previously we would create one etcd client per type of custom resource, resulting in a TCP connection to the etcd cluster per type of resource, and excessive memory usage (mostly because we also created an expensive logger per client).

With [~1,900 CRDs](https://github.com/negz/crossplane-scale/tree/dc25bef873f0e6b1678547fad21e79fe423817b2/etoomanycrds/latest-crds) loaded on an otherwise idle `kind` cluster **I'm seeing a ~35% reduction in RSS memory** with this change. Garbage collection appears to be kicking in at ~5.2GiB RSS rather than ~8Gib RSS. Here's a profile:

![profile-with-one-client-per-transport](https://user-images.githubusercontent.com/1049349/181870984-9cd4b57f-54c8-44ee-bbf4-27245f3da4dd.png)

You can see that we're using dramatically fewer etcd connections:


```console
root@e092b6d27bf-clientpertransport-control-plane:/# ps -C kube-apiserver
    PID TTY          TIME CMD
    605 ?        00:16:41 kube-apiserver

# Column 3 is the remote host and port per https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt
# 0100007F:094B is hex for 127.0.0.1:2379 (the etcd client port)
root@e092b6d27bf-clientpertransport-control-plane:/# cat /proc/605/net/tcp|awk '{ print $3 }'|grep '0100007F:094B'|wc -l
5
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/111622

#### Special notes for your reviewer:

I'm opening this as a  draft to illustrate my thinking. Notably it's missing any new tests at the moment - I'd like to get some signal that this direction looks good before I spend time on that.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
