### PR TITLE
Fix label output bug where dry run message was not printed

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -187,9 +187,10 @@ func (o *LabelOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	}
 	o.dryRunVerifier = resource.NewQueryParamVerifier(dynamicClient, f.OpenAPIGetter(), resource.QueryParamDryRun)
 
-	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.dryRunStrategy)
 	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
 		o.PrintFlags.NamePrintFlags.Operation = operation
+		// PrintFlagsWithDryRunStrategy must be done after NamePrintFlags.Operation is set
+		cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.dryRunStrategy)
 		return o.PrintFlags.ToPrinter()
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Ever since kubectl 1.18-ish, when you use the `--dry-run` flag with `kubectl label`, it does not print a message saying it was a dry run, making you think that it might have actually labeled the pod.  For example:
```
$ kubectl label pod foo bar=baz --dry-run=server
pod/foo labeled
```

This PR fixes this bug, so that the output is:
```
$ kubectl label pod foo bar=baz --dry-run=server
pod/foo labeled (server dry run)
```

Additional unit tests are added to test the output to make sure the proper dry run message is displayed.

#### Which issue(s) this PR fixes:
No issue created

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed bug where dry run message was not printed when running kubectl label with --dry-run flag.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
