### PR TITLE
kubectl: correctly disambiguate configured/unchanged when server short circuits a patch

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
@@ -172,7 +172,7 @@ func (p *Patcher) patchSimple(obj runtime.Object, modified []byte, namespace, na
 	patchedObj, err := p.Helper.Patch(namespace, name, patchType, patch, nil)
 
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "patch request failed")
+		return nil, nil, err
 	}
 
 	patchedMeta, err := meta.Accessor(patchedObj)
@@ -186,7 +186,7 @@ func (p *Patcher) patchSimple(obj runtime.Object, modified []byte, namespace, na
 	// 	If the returned object has the same resource version then the server did
 	// 	not apply any new changes and effectively nothing has happened.
 	if patchedMeta.GetResourceVersion() == objMeta.GetResourceVersion() {
-		return []byte("{}"), obj, err
+		return []byte("{}"), patchedObj, err
 	}
 
 	return patch, patchedObj, err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

kubectl has logic to show whether the applied object was "unchanged" vs "configured". The logic it uses to determine this is all client side. If the cached object is unaffected by the patch, then the client will short circuit sending the request and say the object is "unchanged". 

Otherwise, the client sends the patch to the apiserver and reports it as "configured".

Unfortunately, the client-side does not have all information to determine if a change is a no-op or not. If the patch ends up being sent to the server because kubectl conservatively thinks there may be changes, then the patch is always reported as "configured". This presents as a UX bug when repeatedly applying the same configuration does not respond with "unchanged".

This PR adds a check to verify if the resource version of the returned patched object from the server is changed at all from the original object known to the client. 

More details in #66450

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #66450

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes bug where no-op patches sent to apiserver are reported by kubectl as `configured` rather than `unchanged` as expected
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
