### PR TITLE
kube-controller-manager: automatically add 'node.kubernetes.io/unschedulable=:PreferNoSchedule' taint for unschedulable node

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -632,21 +632,27 @@ func (nc *Controller) doNoScheduleTaintingPass(ctx context.Context, nodeName str
 	}
 	if node.Spec.Unschedulable {
 		// If unschedulable, append related taint.
-		taints = append(taints, v1.Taint{
-			Key:    v1.TaintNodeUnschedulable,
-			Effect: v1.TaintEffectNoSchedule,
-		})
+		taints = append(taints,
+			v1.Taint{
+				Key:    v1.TaintNodeUnschedulable,
+				Effect: v1.TaintEffectNoSchedule,
+			},
+			v1.Taint{
+				Key:    v1.TaintNodeUnschedulable,
+				Effect: v1.TaintEffectPreferNoSchedule,
+			},
+		)
 	}
 
 	// Get exist taints of node.
 	nodeTaints := taintutils.TaintSetFilter(node.Spec.Taints, func(t *v1.Taint) bool {
-		// only NoSchedule taints are candidates to be compared with "taints" later
-		if t.Effect != v1.TaintEffectNoSchedule {
-			return false
-		}
 		// Find unschedulable taint of node.
 		if t.Key == v1.TaintNodeUnschedulable {
 			return true
+		}
+		// only NoSchedule taints are candidates to be compared with "taints" later
+		if t.Effect != v1.TaintEffectNoSchedule {
+			return false
 		}
 		// Find node condition taints of node.
 		_, found := taintKeyToNodeConditionMap[t.Key]


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When a node is marked as unschedulable (after `kubectl cordon`), we prefer to avoid scheduling Pods to this node.
For now, we have only focused on the logic of the `filter` phase of scheduling, and the `node.kubernetes.io/unschedulable=:NoSchedule` will be added on the unschedulable node automatically.
However, when a Pod tolerates `node.kubernetes.io/unschedulable=:NoSchedule` taint, we does not do something on the `score` phase of scheduling, the Pod will likely still be scheduled to the unschedulable node.

With this patch, the kube-controller-manager will automatically add `node.kubernetes.io/unschedulable=:PreferNoSchedule` taint for unschedulable node,  and prevent Pods from being scheduled to unexpected unschedulable node.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-controller-manager will automatically add 'node.kubernetes.io/unschedulable=:PreferNoSchedule' taint for the unschedulable node
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
