### PR TITLE
e2e: Trim junit reporter to adapt with testgrid

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,11 +21,14 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/reporters"
+	"github.com/onsi/ginkgo/v2/types"
 	"gopkg.in/yaml.v2"
 
 	// Never, ever remove the line with "/ginkgo". Without it,
@@ -143,10 +146,9 @@ var _ = ginkgo.ReportAfterEach(func(report ginkgo.SpecReport) {
 	progressReporter.ProcessSpecReport(report)
 })
 
-var _ = ginkgo.ReportAfterSuite("Kubernetes e2e suite report", func(report ginkgo.Report) {
-	var err error
-	// The DetailsRepoerter will output details about every test (name, files, lines, etc) which helps
-	// when documenting our tests.
+// writeSpecSummaryOutput will output details about every test (name, files, lines, etc) which helps
+// when documenting our tests.
+func writeSpecSummaryOutput(report ginkgo.Report) {
 	if len(framework.TestContext.SpecSummaryOutput) <= 0 {
 		return
 	}
@@ -169,16 +171,58 @@ var _ = ginkgo.ReportAfterSuite("Kubernetes e2e suite report", func(report ginkg
 			klog.Errorf("Error in detail reporter: %v", err)
 			return
 		}
-		_, err = f.Write(b)
-		if err != nil {
+		if _, err = f.Write(b); err != nil {
 			klog.Errorf("Error saving test details in detail reporter: %v", err)
 			return
 		}
 		// Printing newline between records for easier viewing in various tools.
-		_, err = fmt.Fprintln(f, "")
-		if err != nil {
+		if _, err = fmt.Fprintln(f, ""); err != nil {
 			klog.Errorf("Error saving test details in detail reporter: %v", err)
 			return
 		}
 	}
+}
+
+// writeJUnitReport generates a JUnit file in the e2e report directory that is
+// shorter than the one normally written by `ginkgo --junit-report`. This is
+// needed because the full report can become too large for tools like Spyglass
+// (https://github.com/kubernetes/kubernetes/issues/111510).
+//
+// Users who want the full report can use `--junit-report`.
+func writeJUnitReport(report ginkgo.Report) {
+	if framework.TestContext.ReportDir == "" {
+		return
+	}
+
+	trimmedReport := report
+	trimmedReport.SpecReports = nil
+	for _, specReport := range report.SpecReports {
+		// Remove details for any spec that hasn't failed. In Prow,
+		// the test output captured in build-log.txt has all of this
+		// information, so we don't need it in the XML.
+		if specReport.State != types.SpecStateFailed {
+			// strip the "system-error" if the testcase is not failed.
+			specReport.CapturedGinkgoWriterOutput = ""
+			// strip the "system-out" if the testcase is not failed.
+			specReport.CapturedStdOutErr = ""
+			// strip some details for tracing each steps executed by Ginkgo, this is used to build the "system-out"
+			// while "system-out" is not shown by Spyglass if the testcase is not failed.
+			specReport.ReportEntries = nil
+
+		}
+
+		trimmedReport.SpecReports = append(trimmedReport.SpecReports, specReport)
+	}
+
+	// With Ginkgo v1, we used to write one file per parallel node. Now
+	// Ginkgo v2 automatically merges all results into a report for us. The
+	// 01 suffix is kept in case that users expect files to be called
+	// "junit_<prefix><number>.xml".
+	junitReport := path.Join(framework.TestContext.ReportDir, "junit_"+framework.TestContext.ReportPrefix+"01.xml")
+	reporters.GenerateJUnitReport(trimmedReport, junitReport)
+}
+
+var _ = ginkgo.ReportAfterSuite("Kubernetes e2e suite report", func(report ginkgo.Report) {
+	writeSpecSummaryOutput(report)
+	writeJUnitReport(report)
 })

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"path"
 	"sort"
 	"strings"
 	"time"
@@ -330,14 +329,6 @@ func CreateGinkgoConfig() (types.SuiteConfig, types.ReporterConfig) {
 	suiteConfig.RandomizeAllSpecs = true
 	// Turn on verbose by default to get spec names
 	reporterConfig.Verbose = true
-	// Enable JUnit output to the result directory, but only if not already specified
-	// via -junit-report.
-	if reporterConfig.JUnitReport == "" && TestContext.ReportDir != "" {
-		// With Ginkgo v1, we used to write one file per parallel node. Now Ginkgo v2 automatically
-		// merges all results into a single file for us. The 01 suffix is kept in case that users
-		// expect files to be called "junit_<prefix><number>.xml".
-		reporterConfig.JUnitReport = path.Join(TestContext.ReportDir, "junit_"+TestContext.ReportPrefix+"01.xml")
-	}
 	// Disable skipped tests unless they are explicitly requested.
 	if len(suiteConfig.FocusStrings) == 0 && len(suiteConfig.SkipStrings) == 0 {
 		suiteConfig.SkipStrings = []string{`\[Flaky\]|\[Feature:.+\]`}


### PR DESCRIPTION
The PR trimmed the system out and system err from the junit xml file, besides that, the concrete steps executed will be dropped as well if the testcase is not failed.  This makes the final report mostly like a V1, no system error and only show system out when the test failed, and no concrete steps printed in the file.

The trimmed version could be used for the tool like testgrid, ~the original one will still available under the same directory.~

/kind bug

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/111510

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


/sig testing