### PR TITLE
WIP: Add AddMetaToScheme function into generator_for_scheme

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/fake/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/fake/register.go
@@ -52,5 +52,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(scheme)
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/scheme/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/scheme/register.go
@@ -52,5 +52,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(Scheme)
 	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/register.go
@@ -54,5 +54,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(scheme)
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme/register.go
@@ -54,5 +54,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(Scheme)
 	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/staging/src/k8s.io/client-go/kubernetes/fake/register.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/register.go
@@ -140,5 +140,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(scheme)
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/client-go/kubernetes/scheme/register.go
+++ b/staging/src/k8s.io/client-go/kubernetes/scheme/register.go
@@ -140,5 +140,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(Scheme)
 	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/scheme/generator_for_scheme.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/scheme/generator_for_scheme.go
@@ -99,6 +99,7 @@ func (g *GenScheme) GenerateType(c *generator.Context, t *types.Type, w io.Write
 		"runtimeUtilMust":           c.Universe.Function(types.Name{Package: "k8s.io/apimachinery/pkg/util/runtime", Name: "Must"}),
 		"schemaGroupVersion":        c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/runtime/schema", Name: "GroupVersion"}),
 		"metav1AddToGroupVersion":   c.Universe.Function(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "AddToGroupVersion"}),
+		"metav1AddMetaToScheme":     c.Universe.Function(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "AddMetaToScheme"}),
 	}
 	globals := map[string]string{
 		"Scheme":         "Scheme",
@@ -140,6 +141,7 @@ var registryRegistration = `
 
 func init() {
 	$.metav1AddToGroupVersion|raw$($.Scheme$, $.schemaGroupVersion|raw${Version: "v1"})
+	$.metav1AddMetaToScheme|raw$($.Scheme$)
 	Install($.Scheme$)
 }
 
@@ -182,6 +184,7 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	$.metav1AddToGroupVersion|raw$($.Scheme$, $.schemaGroupVersion|raw${Version: "v1"})
+	$.metav1AddMetaToScheme|raw$($.Scheme$)
 	$.runtimeUtilMust|raw$(AddToScheme($.Scheme$))
 }
 `

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/fake/register.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/fake/register.go
@@ -52,5 +52,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(scheme)
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/scheme/register.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/scheme/register.go
@@ -52,5 +52,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(Scheme)
 	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/fake/register.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/fake/register.go
@@ -52,5 +52,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(scheme)
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/scheme/register.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/scheme/register.go
@@ -52,5 +52,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(Scheme)
 	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/fake/register.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/fake/register.go
@@ -56,5 +56,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(scheme)
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/scheme/register.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/scheme/register.go
@@ -34,6 +34,7 @@ var ParameterCodec = runtime.NewParameterCodec(Scheme)
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(Scheme)
 	Install(Scheme)
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/fake/register.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/fake/register.go
@@ -56,5 +56,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(scheme)
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/scheme/register.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/scheme/register.go
@@ -56,5 +56,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(Scheme)
 	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/fake/register.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/fake/register.go
@@ -54,5 +54,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(scheme)
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/scheme/register.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/scheme/register.go
@@ -54,5 +54,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(Scheme)
 	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/register.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/register.go
@@ -54,5 +54,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(scheme)
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme/register.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme/register.go
@@ -54,5 +54,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(Scheme)
 	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake/register.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake/register.go
@@ -54,5 +54,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(scheme)
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/scheme/register.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/scheme/register.go
@@ -54,5 +54,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(Scheme)
 	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/fake/register.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/fake/register.go
@@ -54,5 +54,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(scheme)
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme/register.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme/register.go
@@ -54,5 +54,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(Scheme)
 	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/fake/register.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/fake/register.go
@@ -52,5 +52,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(scheme)
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/scheme/register.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/scheme/register.go
@@ -52,5 +52,6 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	v1.AddMetaToScheme(Scheme)
 	utilruntime.Must(AddToScheme(Scheme))
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`kubectl get events --watch` command supports server side printing by using `builder`(adding required headers in `transformRequests` function);

```go
r := f.NewBuilder().
		Unstructured().
		NamespaceParam(o.Namespace).DefaultNamespace().AllNamespaces(o.AllNamespaces).
		FilenameParam(o.ExplicitNamespace, &o.FilenameOptions).
		LabelSelectorParam(o.LabelSelector).
		FieldSelectorParam(o.FieldSelector).
		RequestChunksOf(o.ChunkSize).
		ResourceTypeOrNameArgs(true, args...).
		SingleResourceType().
		Latest().
		TransformRequests(o.transformRequests).
		Do()
```

As seen above, `builder` basically uses unstructured and does decoding operations in [here](https://github.com/kubernetes/kubernetes/blob/442a69c3bdf6fe8e525b05887e57d89db1e2f3a5/staging/src/k8s.io/kubectl/pkg/cmd/get/table_printer.go#L58). 
However, using `rest.Interface` instead `builder`;

```go
o.client.CoreV1().RESTClient().Get().
		Namespace(namespace).Resource("events").VersionedParams(&listOptions, metav1.ParameterCodec).
		SetHeader("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io,application/json;as=Table;v=v1beta1;g=meta.k8s.io,application/json").
		Watch(ctx)
```

results in an error;

```
Failure   InternalError   an error on the server ("unable to decode an event from the watch stream: unable to decode watch event: no kind \"Table\" is registered for version \"meta.k8s.io/v1\" in scheme \"vendor/k8s.io/client-go/kubernetes/scheme/register.go:74\"") has prevented the request from succeeding
```

The other possible way is using `dynamicClient` to get table objects in unstructured format and decoding it like the way of `get`
does. However, `dynamicClient` does not have any option to set headers;

```go
eventWatch, err := o.dynamicClient.Resource(schema.GroupVersionResource{
		Version:  "v1",
		Resource: "events",
	}).Namespace(namespace).Watch(ctx, listOptions)
```

This PR adds `AddMetaToScheme` function into generator_for_scheme code generator
to support server side printing via client-go rest.Interface.

After this PR, types can also be printed from server side, if request headers are
explicitly set for TablePrinting.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

This PR fixes problem choosing one way. But maybe  rather than that we should extend dynamic client to support setting headers, etc.

#### Does this PR introduce a user-facing change?
```release-note
None
```
