### PR TITLE
ginkgo: disable color escape sequences by default when not connected to a terminal

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -34,9 +34,12 @@ e2e_test=$(kube::util::find-binary "e2e.test")
 GINKGO_PARALLEL=${GINKGO_PARALLEL:-n} # set to 'y' to run tests in parallel
 CLOUD_CONFIG=${CLOUD_CONFIG:-""}
 
-# If 'y', Ginkgo's reporter will not print out in color when tests are run
-# in parallel
-GINKGO_NO_COLOR=${GINKGO_NO_COLOR:-n}
+# If 'y', Ginkgo's reporter will not use escape sequence to color output.
+#
+# Since Kubernetes 1.25, the default is to use colors only when connected to
+# a terminal. That is the right choice for all Prow jobs (Spyglass doesn't
+# render them properly).
+GINKGO_NO_COLOR=${GINKGO_NO_COLOR:-$(if [ -t 2 ]; then echo n; else echo y; fi)}
 
 # If 'y', will rerun failed tests once to give them a second chance.
 GINKGO_TOLERATE_FLAKES=${GINKGO_TOLERATE_FLAKES:-n}
@@ -148,7 +151,7 @@ if [[ "${GINKGO_TOLERATE_FLAKES}" == "y" ]]; then
 fi
 
 if [[ "${GINKGO_NO_COLOR}" == "y" ]]; then
-  ginkgo_args+=("--noColor")
+  ginkgo_args+=("--no-color")
 fi
 
 # The --host setting is used only when providing --auth_config


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This applies to all jobs using hack/ginkgo-e2e.sh. This is done because
Spyglass does not render the escape sequences, making test output harder to
read:
```
[BeforeEach] [sig-node] Probing container
  test/e2e/framework/framework.go:186
ï¿½[1mSTEP:ï¿½[0m Creating a kubernetes client ï¿½[38;5;243m08/02/22 07:59:02.423ï¿½[0m
Aug  2 07:59:02.423: INFO: >>> kubeConfig: /root/.kube/kind-test-config
```

It is done here because then we don't need to set GINKGO_NO_COLOR in all the
different Prow job configs.

#### Special notes for your reviewer:

Discussed in https://github.com/kubernetes/kubernetes/pull/111627#issuecomment-1202262794

#### Does this PR introduce a user-facing change?
```release-note
ginkgo: when e2e tests are invoked through ginkgo-e2e.sh, the default now is to use color escape sequences only when connected to a terminal. `GINKGO_NO_COLOR=y/n` can be used to override that default.
```

/cc @aojea 