### PR TITLE
Always emit the stopped leading event

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -64,9 +64,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
-	"k8s.io/utils/clock"
-
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 )
 
 const (
@@ -199,9 +198,7 @@ type LeaderElector struct {
 // stopped holding the leader lease
 func (le *LeaderElector) Run(ctx context.Context) {
 	defer runtime.HandleCrash()
-	defer func() {
-		le.config.Callbacks.OnStoppedLeading()
-	}()
+	defer le.config.Callbacks.OnStoppedLeading()
 
 	if !le.acquire(ctx) {
 		return // ctx signalled done
@@ -263,6 +260,7 @@ func (le *LeaderElector) acquire(ctx context.Context) bool {
 
 // renew loops calling tryAcquireOrRenew and returns immediately when tryAcquireOrRenew fails or ctx signals done.
 func (le *LeaderElector) renew(ctx context.Context) {
+	defer le.config.Lock.RecordEvent("stopped leading")
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	wait.Until(func() {
@@ -278,7 +276,6 @@ func (le *LeaderElector) renew(ctx context.Context) {
 			klog.V(5).Infof("successfully renewed lease %v", desc)
 			return
 		}
-		le.config.Lock.RecordEvent("stopped leading")
 		le.metrics.leaderOff(le.config.Name)
 		klog.Infof("failed to renew lease %v: %v", desc, err)
 		cancel()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

Currently my program emits only the `became leader` events and never `stopped leading`:

```
24m         Normal    LeaderElection            lease/agent-4-lock          pod-name became leader
19m         Normal    LeaderElection            lease/agent-4-lock          pod-name became leader
18m         Normal    LeaderElection            lease/agent-4-lock          pod-name became leader
17m         Normal    LeaderElection            lease/agent-4-lock          pod-name became leader
2m49s       Normal    LeaderElection            lease/agent-4-lock          pod-name became leader
```

I think it'd be good to also always emit the `stopped leading` event when program cleanly stops and aborts the leader elector (via context).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```