### PR TITLE
[CCM - service controller] Clean up node sync and fix re-sync of failed services. 

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -86,16 +86,13 @@ type Controller struct {
 	eventRecorder       record.EventRecorder
 	nodeLister          corelisters.NodeLister
 	nodeListerSynced    cache.InformerSynced
-	// services that need to be synced
-	queue workqueue.RateLimitingInterface
-
-	// nodeSyncLock ensures there is only one instance of triggerNodeSync getting executed at one time
-	// and protects internal states (needFullSync) of nodeSync
-	nodeSyncLock sync.Mutex
-	// nodeSyncCh triggers nodeSyncLoop to run
-	nodeSyncCh chan interface{}
-	// lastSyncedNodes is used when reconciling node state and keeps track of the last synced set of
-	// nodes. Access to this attribute by multiple go-routines is protected by nodeSyncLock
+	// services and nodes that need to be synced
+	serviceQueue workqueue.RateLimitingInterface
+	nodeQueue    workqueue.RateLimitingInterface
+	// lastSyncedNodes is used when reconciling node state and keeps track of
+	// the last synced set of nodes. This field is concurrently safe because the
+	// nodeQueue is serviced by only one go-routine, so node events are not
+	// processed concurrently.
 	lastSyncedNodes []*v1.Node
 }
 
@@ -128,10 +125,9 @@ func New(
 		eventRecorder:    recorder,
 		nodeLister:       nodeInformer.Lister(),
 		nodeListerSynced: nodeInformer.Informer().HasSynced,
-		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "service"),
-		// nodeSyncCh has a size 1 buffer. Only one pending sync signal would be cached.
-		nodeSyncCh:      make(chan interface{}, 1),
-		lastSyncedNodes: []*v1.Node{},
+		serviceQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "service"),
+		nodeQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "node"),
+		lastSyncedNodes:  []*v1.Node{},
 	}
 
 	serviceInformer.Informer().AddEventHandlerWithResyncPeriod(
@@ -162,7 +158,7 @@ func New(
 	nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(cur interface{}) {
-				s.triggerNodeSync()
+				s.enqueueNode(cur)
 			},
 			UpdateFunc: func(old, cur interface{}) {
 				oldNode, ok := old.(*v1.Node)
@@ -179,13 +175,13 @@ func New(
 					return
 				}
 
-				s.triggerNodeSync()
+				s.enqueueNode(curNode)
 			},
 			DeleteFunc: func(old interface{}) {
-				s.triggerNodeSync()
+				s.enqueueNode(old)
 			},
 		},
-		time.Duration(0),
+		nodeSyncPeriod,
 	)
 
 	if err := s.init(); err != nil {
@@ -202,7 +198,17 @@ func (c *Controller) enqueueService(obj interface{}) {
 		runtime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", obj, err))
 		return
 	}
-	c.queue.Add(key)
+	c.serviceQueue.Add(key)
+}
+
+// obj could be an *v1.Service, or a DeletionFinalStateUnknown marker item.
+func (c *Controller) enqueueNode(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", obj, err))
+		return
+	}
+	c.nodeQueue.Add(key)
 }
 
 // Run starts a background goroutine that watches for changes to services that
@@ -217,7 +223,8 @@ func (c *Controller) enqueueService(obj interface{}) {
 // object.
 func (c *Controller) Run(ctx context.Context, workers int, controllerManagerMetrics *controllersmetrics.ControllerManagerMetrics) {
 	defer runtime.HandleCrash()
-	defer c.queue.ShutDown()
+	defer c.serviceQueue.ShutDown()
+	defer c.nodeQueue.ShutDown()
 
 	// Start event processing pipeline.
 	c.eventBroadcaster.StartStructuredLogging(0)
@@ -234,65 +241,60 @@ func (c *Controller) Run(ctx context.Context, workers int, controllerManagerMetr
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.UntilWithContext(ctx, c.worker, time.Second)
+		go wait.UntilWithContext(ctx, c.serviceWorker, time.Second)
 	}
 
-	go c.nodeSyncLoop(ctx, workers)
-	go wait.Until(c.triggerNodeSync, nodeSyncPeriod, ctx.Done())
+	// Initialize one go-routine servicing node events. This ensure we only
+	// process one node at any given moment in time
+	go wait.UntilWithContext(ctx, func(ctx context.Context) { c.nodeWorker(ctx, workers) }, time.Second)
 
 	<-ctx.Done()
 }
 
-// triggerNodeSync triggers a nodeSync asynchronously
-func (c *Controller) triggerNodeSync() {
-	c.nodeSyncLock.Lock()
-	defer c.nodeSyncLock.Unlock()
-	select {
-	case c.nodeSyncCh <- struct{}{}:
-		klog.V(4).Info("Triggering nodeSync")
-		return
-	default:
-		klog.V(4).Info("A pending nodeSync is already in queue")
-		return
+// worker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (c *Controller) serviceWorker(ctx context.Context) {
+	for c.processNextServiceItem(ctx) {
 	}
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 // It enforces that the syncHandler is never invoked concurrently with the same key.
-func (c *Controller) worker(ctx context.Context) {
-	for c.processNextWorkItem(ctx) {
+func (c *Controller) nodeWorker(ctx context.Context, workers int) {
+	for c.processNextNodeItem(ctx, workers) {
 	}
 }
 
-// nodeSyncLoop takes nodeSync signal and triggers nodeSync
-func (c *Controller) nodeSyncLoop(ctx context.Context, workers int) {
-	klog.V(4).Info("nodeSyncLoop Started")
-	for {
-		select {
-		case <-c.nodeSyncCh:
-			klog.V(4).Info("nodeSync has been triggered")
-			c.nodeSyncInternal(ctx, workers)
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-func (c *Controller) processNextWorkItem(ctx context.Context) bool {
-	key, quit := c.queue.Get()
+func (c *Controller) processNextNodeItem(ctx context.Context, workers int) bool {
+	key, quit := c.nodeQueue.Get()
 	if quit {
 		return false
 	}
-	defer c.queue.Done(key)
+	defer c.nodeQueue.Done(key)
+
+	for serviceToRetry := range c.syncNodes(ctx, workers) {
+		c.serviceQueue.Add(serviceToRetry)
+	}
+
+	c.nodeQueue.Forget(key)
+	return true
+}
+
+func (c *Controller) processNextServiceItem(ctx context.Context) bool {
+	key, quit := c.serviceQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.serviceQueue.Done(key)
 
 	err := c.syncService(ctx, key.(string))
 	if err == nil {
-		c.queue.Forget(key)
+		c.serviceQueue.Forget(key)
 		return true
 	}
 
 	runtime.HandleError(fmt.Errorf("error processing service %v (will retry): %v", key, err))
-	c.queue.AddRateLimited(key)
+	c.serviceQueue.AddRateLimited(key)
 	return true
 }
 
@@ -675,13 +677,13 @@ func shouldSyncUpdatedNode(oldNode, newNode *v1.Node) bool {
 	return respectsPredicates(oldNode, allNodePredicates...) != respectsPredicates(newNode, allNodePredicates...)
 }
 
-// nodeSyncInternal handles updating the hosts pointed to by all load
+// syncNodes handles updating the hosts pointed to by all load
 // balancers whenever the set of nodes in the cluster changes.
-func (c *Controller) nodeSyncInternal(ctx context.Context, workers int) {
+func (c *Controller) syncNodes(ctx context.Context, workers int) sets.String {
 	startTime := time.Now()
 	defer func() {
 		latency := time.Since(startTime).Seconds()
-		klog.V(4).Infof("It took %v seconds to finish nodeSyncInternal", latency)
+		klog.V(4).Infof("It took %v seconds to finish syncNodes", latency)
 		nodeSyncLatency.Observe(latency)
 	}()
 
@@ -691,6 +693,7 @@ func (c *Controller) nodeSyncInternal(ctx context.Context, workers int) {
 	servicesToRetry := c.updateLoadBalancerHosts(ctx, servicesToUpdate, workers)
 	klog.V(2).Infof("Successfully updated %d out of %d load balancers to direct traffic to the updated set of nodes",
 		numServices-len(servicesToRetry), numServices)
+	return servicesToRetry
 }
 
 // nodeSyncService syncs the nodes for one load balancer type service. The return value

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,8 +47,6 @@ import (
 	servicehelper "k8s.io/cloud-provider/service/helpers"
 
 	utilpointer "k8s.io/utils/pointer"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const region = "us-central"
@@ -101,7 +100,6 @@ func newController() (*Controller, *fakecloud.Cloud, *fake.Clientset) {
 
 	controller := &Controller{
 		cloud:            cloud,
-		knownHosts:       []*v1.Node{},
 		kubeClient:       kubeClient,
 		clusterName:      "test-cluster",
 		cache:            &serviceCache{serviceMap: make(map[string]*cachedService)},
@@ -566,7 +564,6 @@ func TestUpdateNodesInExternalLoadBalancer(t *testing.T) {
 			defer cancel()
 			controller, cloud, _ := newController()
 			controller.nodeLister = newFakeNodeLister(nil, nodes...)
-
 			if servicesToRetry := controller.updateLoadBalancerHosts(ctx, item.services, item.workers); len(servicesToRetry) != 0 {
 				t.Errorf("for case %q, unexpected servicesToRetry: %v", item.desc, servicesToRetry)
 			}
@@ -1513,28 +1510,6 @@ func TestServiceCache(t *testing.T) {
 		if err := tc.checkCacheFn(); err != nil {
 			t.Errorf("%v returned %v", tc.testName, err)
 		}
-	}
-}
-
-// Test a utility functions as it's not easy to unit test nodeSyncInternal directly
-func TestNodeSlicesEqualForLB(t *testing.T) {
-	numNodes := 10
-	nArray := make([]*v1.Node, numNodes)
-	mArray := make([]*v1.Node, numNodes)
-	for i := 0; i < numNodes; i++ {
-		nArray[i] = &v1.Node{}
-		nArray[i].Name = fmt.Sprintf("node%d", i)
-	}
-	for i := 0; i < numNodes; i++ {
-		mArray[i] = &v1.Node{}
-		mArray[i].Name = fmt.Sprintf("node%d", i+1)
-	}
-
-	if !nodeSlicesEqualForLB(nArray, nArray) {
-		t.Errorf("nodeSlicesEqualForLB() Expected=true Obtained=false")
-	}
-	if nodeSlicesEqualForLB(nArray, mArray) {
-		t.Errorf("nodeSlicesEqualForLB() Expected=false Obtained=true")
 	}
 }
 
@@ -3225,32 +3200,6 @@ func TestTriggerNodeSync(t *testing.T) {
 	tryReadFromChannel(t, controller.nodeSyncCh, false)
 	tryReadFromChannel(t, controller.nodeSyncCh, false)
 	tryReadFromChannel(t, controller.nodeSyncCh, false)
-}
-
-func TestMarkAndUnmarkFullSync(t *testing.T) {
-	controller, _, _ := newController()
-	if controller.needFullSync != false {
-		t.Errorf("expect controller.needFullSync to be false, but got true")
-	}
-
-	ret := controller.needFullSyncAndUnmark()
-	if ret != false {
-		t.Errorf("expect ret == false, but got true")
-	}
-
-	ret = controller.needFullSyncAndUnmark()
-	if ret != false {
-		t.Errorf("expect ret == false, but got true")
-	}
-	controller.needFullSync = true
-	ret = controller.needFullSyncAndUnmark()
-	if ret != true {
-		t.Errorf("expect ret == true, but got false")
-	}
-	ret = controller.needFullSyncAndUnmark()
-	if ret != false {
-		t.Errorf("expect ret == false, but got true")
-	}
 }
 
 func tryReadFromChannel(t *testing.T, ch chan interface{}, expectValue bool) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR cleans up the service sync and fixes a minor issue related to resyncing failed services which were tried due to a node related event. It builds on #109706, and hence depends on it. Because of that:

/hold 

until #109706 gets in 

I wouldn't say this PR is required, but it would be beneficial to consider it, simply because the current node sync loop implemented by the service controller is a bit odd and could use some up-to-dating. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig network
/sig cloud-provider
/assign @thockin

