### PR TITLE
Revert "e2e: Trim junit reporter to adapt with testgrid"

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path"
 	"sort"
 	"strings"
 	"time"
@@ -355,6 +356,14 @@ func CreateGinkgoConfig() (types.SuiteConfig, types.ReporterConfig) {
 	suiteConfig.RandomizeAllSpecs = true
 	// Turn on verbose by default to get spec names
 	reporterConfig.Verbose = true
+	// Enable JUnit output to the result directory, but only if not already specified
+	// via -junit-report.
+	if reporterConfig.JUnitReport == "" && TestContext.ReportDir != "" {
+		// With Ginkgo v1, we used to write one file per parallel node. Now Ginkgo v2 automatically
+		// merges all results into a single file for us. The 01 suffix is kept in case that users
+		// expect files to be called "junit_<prefix><number>.xml".
+		reporterConfig.JUnitReport = path.Join(TestContext.ReportDir, "junit_"+TestContext.ReportPrefix+"01.xml")
+	}
 	// Disable skipped tests unless they are explicitly requested.
 	if len(suiteConfig.FocusStrings) == 0 && len(suiteConfig.SkipStrings) == 0 {
 		suiteConfig.SkipStrings = []string{`\[Flaky\]|\[Feature:.+\]`}


### PR DESCRIPTION
Reverts kubernetes/kubernetes#111627

/hold

looks like this broke test results for all node e2e jobs (https://testgrid.k8s.io/sig-node-containerd#cos-cgroupv2-containerd-node-features) we need those while triaging failures ahead of a release.

```release-note
NONE
```