### PR TITLE
Change cluster/gce/util to wait for firewall rule creation and fail on error

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2429,6 +2429,12 @@ function create-network() {
         --allow "tcp:3389" &
     fi
   fi
+
+  kube::util::wait-for-jobs || {
+    code=$?
+    echo -e "${color_red}Failed to create firewall rules.${color_norm}" >&2
+    exit $code
+  }
 }
 
 function expand-default-subnetwork() {
@@ -3099,7 +3105,9 @@ function create-nodes-firewall() {
 
   # Wait for last batch of jobs
   kube::util::wait-for-jobs || {
-    echo -e "${color_red}Some commands failed.${color_norm}" >&2
+    code=$?
+    echo -e "${color_red}Failed to create firewall rule.${color_norm}" >&2
+    exit $code
   }
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
I suspect that some e2e flakes are actually cluster setup failures that go unnoticed.  

This PR attempts to improve e2e test flakiness by waiting for firewall rule creation background commands to complete and report any errors that occur, immediately, instead of waiting for an e2e test to fail later on.

#### Which issue(s) this PR fixes:
Fixes #111580

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
