### PR TITLE
kcm: don't continue with partial server resources

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -472,7 +472,7 @@ func GetAvailableResources(clientBuilder clientbuilder.ControllerClientBuilder) 
 	discoveryClient := client.Discovery()
 	_, resourceMap, err := discoveryClient.ServerGroupsAndResources()
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to get all supported resources from server: %v", err))
+		return nil, fmt.Errorf("unable to get all supported resources from server: %v", err)
 	}
 	if len(resourceMap) == 0 {
 		return nil, fmt.Errorf("unable to get any supported resources from server")

--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -472,7 +471,7 @@ func GetAvailableResources(clientBuilder clientbuilder.ControllerClientBuilder) 
 	discoveryClient := client.Discovery()
 	_, resourceMap, err := discoveryClient.ServerGroupsAndResources()
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to get all supported resources from server: %v", err))
+		return nil, fmt.Errorf("unable to get all supported resources from server: %v", err)
 	}
 	if len(resourceMap) == 0 {
 		return nil, fmt.Errorf("unable to get any supported resources from server")


### PR DESCRIPTION
`discoverClient.ServerGroupsAndResources` may give a non-nil error but
with partial results, see its comment [here][1]. This is a problem since
all the controller initFuncs which rely on AvailableResources may make a
wrong decision without being known.

[1]: https://github.com/kubernetes/kubernetes/blob/1a916f278b97dcb5bbe439946c328865f5b98ea3/staging/src/k8s.io/client-go/discovery/discovery_client.go#L99-L102

/kind bug

```release-note
NONE
```