### PR TITLE
Revert "e2e: should manage the lifecycle of an APIService"

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -32,15 +32,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/util/retry"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	rbacv1helpers "k8s.io/kubernetes/pkg/apis/rbac/v1"
@@ -57,9 +54,6 @@ import (
 
 const (
 	aggregatorServicePort = 7443
-
-	apiServiceRetryPeriod  = 1 * time.Second
-	apiServiceRetryTimeout = 1 * time.Minute
 )
 
 var _ = SIGDescribe("Aggregator", func() {
@@ -106,122 +100,6 @@ var _ = SIGDescribe("Aggregator", func() {
 	framework.ConformanceIt("Should be able to support the 1.17 Sample API Server using the current Aggregator", func() {
 		// Testing a 1.17 version of the sample-apiserver
 		TestSampleAPIServer(f, aggrclient, imageutils.GetE2EImage(imageutils.APIServer))
-	})
-
-	ginkgo.It("should manage the lifecycle of an APIService [Serial][Disruptive]", func() {
-
-		ns := f.Namespace.Name
-		framework.Logf("ns: %v", ns)
-
-		subDomain := "e2e-" + utilrand.String(5)
-		apiServiceGroup := subDomain + ".example.com"
-		label := map[string]string{"e2e": subDomain}
-		labelSelector := labels.SelectorFromSet(label).String()
-
-		apiServiceName := "v1alpha1." + apiServiceGroup
-		apiServiceClient := aggrclient.ApiregistrationV1().APIServices()
-		certCtx := setupServerCert(ns, "e2e-api")
-
-		ginkgo.By(fmt.Sprintf("Create APIService %s", apiServiceName))
-		_, err := apiServiceClient.Create(context.TODO(), &apiregistrationv1.APIService{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   apiServiceName,
-				Labels: label,
-			},
-			Spec: apiregistrationv1.APIServiceSpec{
-				Service: &apiregistrationv1.ServiceReference{
-					Namespace: ns,
-					Name:      "e2e-api",
-					Port:      pointer.Int32Ptr(aggregatorServicePort),
-				},
-				Group:                apiServiceGroup,
-				Version:              "v1alpha1",
-				CABundle:             certCtx.signingCert,
-				GroupPriorityMinimum: 2000,
-				VersionPriority:      200,
-			},
-		}, metav1.CreateOptions{})
-		framework.ExpectNoError(err, "creating apiService %s, namespace %s", apiServiceName, ns)
-
-		_, err = apiServiceClient.List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
-		framework.ExpectNoError(err, "failed to list API Services")
-
-		ginkgo.By("Confirm that the generated APIService has been created")
-		err = wait.PollImmediate(apiServiceRetryPeriod, apiServiceRetryTimeout, checkApiServiceListQuantity(aggrclient, labelSelector, 1))
-		framework.ExpectNoError(err, "failed to count the required APIServices")
-
-		ginkgo.By(fmt.Sprintf("Update status for APIService %s", apiServiceName))
-		var statusToUpdate, updatedStatus *apiregistrationv1.APIService
-
-		updatedStatusConditions := apiregistrationv1.APIServiceCondition{
-			Type:    "StatusUpdate",
-			Status:  "True",
-			Reason:  "E2E",
-			Message: "Set from e2e test",
-		}
-
-		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			statusToUpdate, err = apiServiceClient.Get(context.TODO(), apiServiceName, metav1.GetOptions{})
-			framework.ExpectNoError(err, "Unable to retrieve api service %s", apiServiceName)
-
-			statusToUpdate.Status.Conditions = append(statusToUpdate.Status.Conditions, updatedStatusConditions)
-
-			updatedStatus, err = apiServiceClient.UpdateStatus(context.TODO(), statusToUpdate, metav1.UpdateOptions{})
-			return err
-		})
-		framework.ExpectNoError(err, "Failed to update status. %v", err)
-		framework.Logf("updatedStatus.Conditions: %#v", updatedStatus.Status.Conditions)
-
-		ginkgo.By("Confirm that the generated APIService has an updated status")
-		err = wait.PollImmediate(apiServiceRetryPeriod, apiServiceRetryTimeout, checkApiServiceStatus(aggrclient, apiServiceName, updatedStatusConditions))
-		framework.ExpectNoError(err, "failed to locate the required APIService status")
-
-		ginkgo.By(fmt.Sprintf("Patching status for APIService %s", apiServiceName))
-
-		patchedStatusConditions := apiregistrationv1.APIServiceCondition{
-			Type:    "StatusPatched",
-			Status:  "True",
-			Reason:  "E2E",
-			Message: "Set from e2e test",
-		}
-
-		payload := []byte(`{"status":{"conditions":[{"type":"StatusPatched","status":"True","reason":"E2E","message":"Set from e2e test"}]}}`)
-
-		patchedApiService, err := apiServiceClient.Patch(context.TODO(), apiServiceName, types.MergePatchType, payload, metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err, "Failed to patch status. %v", err)
-		framework.Logf("Patched status conditions: %#v", patchedApiService.Status.Conditions)
-
-		ginkgo.By("Confirm that the generated APIService has a patched status")
-		err = wait.PollImmediate(apiServiceRetryPeriod, apiServiceRetryTimeout, checkApiServiceStatus(aggrclient, apiServiceName, patchedStatusConditions))
-		framework.ExpectNoError(err, "failed to locate the required APIService status")
-
-		ginkgo.By(fmt.Sprintf("Replace APIService %s", apiServiceName))
-		var updatedApiService *apiregistrationv1.APIService
-
-		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			patchedApiService, err = apiServiceClient.Get(context.TODO(), apiServiceName, metav1.GetOptions{})
-			framework.ExpectNoError(err, "Unable to get APIService %s", apiServiceName)
-			patchedApiService.Labels = map[string]string{
-				apiServiceGroup: "updated",
-			}
-			updatedApiService, err = apiServiceClient.Update(context.TODO(), patchedApiService, metav1.UpdateOptions{})
-			return err
-		})
-		framework.ExpectNoError(err)
-		framework.ExpectEqual(updatedApiService.Labels[apiServiceGroup], "updated", "updated object should have the applied label")
-		framework.Logf("Found updated apiService label for %q", apiServiceName)
-
-		ginkgo.By(fmt.Sprintf("DeleteCollection APIService %s via labelSelector: %s", apiServiceName, labelSelector))
-
-		err = aggrclient.ApiregistrationV1().APIServices().DeleteCollection(context.TODO(),
-			metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(1)},
-			metav1.ListOptions{LabelSelector: labelSelector})
-		framework.ExpectNoError(err, "Unable to delete apiservice %s", apiServiceName)
-
-		ginkgo.By("Confirm that the generated APIService has been deleted")
-		err = wait.PollImmediate(apiServiceRetryPeriod, apiServiceRetryTimeout, checkApiServiceListQuantity(aggrclient, labelSelector, 0))
-		framework.ExpectNoError(err, "failed to count the required APIServices")
-		framework.Logf("APIService %s has been deleted.", apiServiceName)
 	})
 })
 
@@ -702,43 +580,4 @@ func generateFlunderName(base string) string {
 		return base
 	}
 	return fmt.Sprintf("%s-%d", base, id)
-}
-
-func checkApiServiceListQuantity(aggrclient *aggregatorclient.Clientset, label string, quantity int) func() (bool, error) {
-	return func() (bool, error) {
-		var err error
-
-		framework.Logf("Requesting list of APIServices to confirm quantity")
-
-		list, err := aggrclient.ApiregistrationV1().APIServices().List(context.TODO(), metav1.ListOptions{LabelSelector: label})
-		if err != nil {
-			return false, err
-		}
-
-		if len(list.Items) != quantity {
-			return false, err
-		}
-		framework.Logf("Found %d APIService with label %q", quantity, label)
-		return true, nil
-	}
-}
-
-func checkApiServiceStatus(aggrclient *aggregatorclient.Clientset, apiServiceName string, statusConditions apiregistrationv1.APIServiceCondition) func() (bool, error) {
-	return func() (bool, error) {
-
-		framework.Logf("Get APIService %q to confirm status", apiServiceName)
-		currentApiService, err := aggrclient.ApiregistrationV1().APIServices().Get(context.TODO(), apiServiceName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-
-		for _, cond := range currentApiService.Status.Conditions {
-			if cond.Type == statusConditions.Type && cond.Reason == statusConditions.Reason && cond.Message == statusConditions.Message {
-				framework.Logf("APIService %q has the required status conditions", apiServiceName)
-				return true, nil
-			}
-		}
-
-		return false, err
-	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it:**
The e2e test [Write APIService lifecycle test + 4 Endpoints #110237 
](https://github.com/kubernetes/kubernetes/pull/110237) was introduced and later promoted to [Conformance](https://github.com/kubernetes/kubernetes/pull/111263) after proving to run flake free for 2 weeks.

The test however seems to cause distruption and was therefore marked as Disruptive and demoted to e2e test. 
Conformance test "manage the lifecycle of an APIService" is Disruptive and should run in Serial #111347 
This did not resolve the issue, therefore the test would we reverted and re-worked in 1.26

Related Issues:
#111086, #111470, #111588,  #111247

**Special notes for your reviewer:**


**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/priority critical-urgent