### PR TITLE
[go] Bump images, dependencies and versions to go 1.19

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.25.0-go1.19rc2-bullseye.0
+v1.25.0-go1.19-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -91,7 +91,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
 readonly __default_distroless_iptables_version=v0.1.1
-readonly __default_go_runner_version=v2.3.1-go1.19rc2-bullseye.0
+readonly __default_go_runner_version=v2.3.1-go1.19-bullseye.0
 readonly __default_setcap_version=bullseye-v1.3.0
 
 # These are the base images for the Docker-wrapped binaries.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -88,7 +88,7 @@ dependencies:
 
   # Golang
   - name: "golang: upstream version"
-    version: 1.19rc2
+    version: 1.19
     refPaths:
     - path: build/build-image/cross/VERSION
     - path: staging/publishing/rules.yaml
@@ -102,7 +102,7 @@ dependencies:
   # This entry is a stub of the major version to allow dependency checks to
   # pass when building Kubernetes using a pre-release of Golang.
   - name: "golang: 1.<major>"
-    version: 1.19rc2
+    version: 1.19
     refPaths:
     - path: build/build-image/cross/VERSION
     # TODO(dims): Uncomment once images are updated to go1.19
@@ -110,7 +110,7 @@ dependencies:
     #  match: minimum_go_version=go([0-9]+\.[0-9]+)
 
   - name: "registry.k8s.io/kube-cross: dependents"
-    version: v1.25.0-go1.19rc2-bullseye.0
+    version: v1.25.0-go1.19-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -140,7 +140,7 @@ dependencies:
       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
 
   - name: "registry.k8s.io/go-runner: dependents"
-    version: v2.3.1-go1.19rc2-bullseye.0
+    version: v2.3.1-go1.19-bullseye.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1590,4 +1590,4 @@ recursive-delete-patterns:
 - '*/BUILD.bazel'
 - Gopkg.toml
 - '*/.gitattributes'
-default-go-version: 1.19rc2
+default-go-version: 1.19

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -16,7 +16,7 @@ REGISTRY ?= registry.k8s.io/e2e-test-images
 GOARM ?= 7
 DOCKER_CERT_BASE_PATH ?=
 QEMUVERSION=v5.1.0-2
-GOLANG_VERSION=1.19rc2
+GOLANG_VERSION=1.19
 export
 
 ifndef WHAT


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area dependency

#### What this PR does / why we need it:

This PR updates go to version 1.19

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2575

#### Special notes for your reviewer:

/cc @dims @cpanato @kubernetes/release-managers 

#### Does this PR introduce a user-facing change?

```release-note
Kubernetes is now built with go 1.19.0
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
