### PR TITLE
Update publishing-bot rules for go1.17.13 and go1.18.5

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -11,12 +11,12 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/code-generator
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/code-generator
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
@@ -32,12 +32,12 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
@@ -60,7 +60,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/api
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -68,7 +68,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/api
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -106,7 +106,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -120,7 +120,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -160,7 +160,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-base
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -172,7 +172,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-base
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -210,7 +210,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -222,7 +222,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -264,7 +264,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apiserver
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -278,7 +278,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apiserver
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -330,7 +330,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -348,7 +348,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -413,7 +413,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -436,7 +436,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -498,7 +498,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -517,7 +517,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -577,7 +577,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -597,7 +597,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -646,7 +646,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/metrics
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -660,7 +660,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/metrics
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -700,7 +700,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: api
       branch: release-1.23
@@ -712,7 +712,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -754,7 +754,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: api
       branch: release-1.23
@@ -768,7 +768,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -811,7 +811,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -825,7 +825,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -869,7 +869,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubelet
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -883,7 +883,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubelet
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -927,7 +927,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -941,7 +941,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -989,7 +989,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1005,7 +1005,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1063,7 +1063,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1083,7 +1083,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1149,7 +1149,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1171,7 +1171,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1215,7 +1215,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1225,7 +1225,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1257,7 +1257,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1267,7 +1267,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1289,12 +1289,12 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
@@ -1353,7 +1353,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1379,7 +1379,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1417,12 +1417,12 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cri-api
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/cri-api
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
@@ -1473,7 +1473,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubectl
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1495,7 +1495,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubectl
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1551,7 +1551,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.23
-    go: 1.17.12
+    go: 1.17.13
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1567,7 +1567,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.24
-    go: 1.18.4
+    go: 1.18.5
     dependencies:
     - repository: api
       branch: release-1.24


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- Update publishing-bot rules for go1.17.13 and go1.18.5

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2625

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assign @xmudrii  @saschagrunert @palnabarun @ameukam @dims @nikhita 
cc @kubernetes/release-engineering 