### PR TITLE
(kubectl certificate): Move towards restClientGetter instead cmdutil.Factory

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates_test.go
@@ -293,6 +293,7 @@ func TestCertificates(t *testing.T) {
 				Client:               fakeClient,
 			}
 			streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
+			tf.ClientConfigVal.Transport = fakeClient.Transport
 
 			defer func() {
 				// Restore cmdutil behavior.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

To preserve loose coupling, it is needed to pass `RESTClientGetter`
instead `cmdutil.Factory` for all kubectl commands.

This PR removes `cmdutil.Factory` usage and instead
passes `RESTClientGetter` as well as required changes in unit tests.

#### Does this PR introduce a user-facing change?
```release-note
None
```