### PR TITLE
More useful audit error logs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"time"
 
 	authnv1 "k8s.io/api/authentication/v1"
@@ -154,7 +153,7 @@ func LogRequestObject(ctx context.Context, obj runtime.Object, objGV schema.Grou
 	if shouldOmitManagedFields(ctx) {
 		copy, ok, err := copyWithoutManagedFields(obj)
 		if err != nil {
-			klog.Warningf("error while dropping managed fields from the request for %q error: %v", reflect.TypeOf(obj).Name(), err)
+			klog.ErrorS(err, "Error while dropping managed fields from the request", "auditID", ae.AuditID)
 		}
 		if ok {
 			obj = copy
@@ -166,7 +165,7 @@ func LogRequestObject(ctx context.Context, obj runtime.Object, objGV schema.Grou
 	ae.RequestObject, err = encodeObject(obj, objGV, s)
 	if err != nil {
 		// TODO(audit): add error slice to audit event struct
-		klog.Warningf("Auditing failed of %v request: %v", reflect.TypeOf(obj).Name(), err)
+		klog.ErrorS(err, "Encoding failed of request object", "auditID", ae.AuditID, "gvr", gvr.String(), "obj", obj)
 		return
 	}
 }
@@ -209,7 +208,7 @@ func LogResponseObject(ctx context.Context, obj runtime.Object, gv schema.GroupV
 	if shouldOmitManagedFields(ctx) {
 		copy, ok, err := copyWithoutManagedFields(obj)
 		if err != nil {
-			klog.Warningf("error while dropping managed fields from the response for %q error: %v", reflect.TypeOf(obj).Name(), err)
+			klog.ErrorS(err, "Error while dropping managed fields from the response", "auditID", ae.AuditID)
 		}
 		if ok {
 			obj = copy
@@ -220,7 +219,7 @@ func LogResponseObject(ctx context.Context, obj runtime.Object, gv schema.GroupV
 	var err error
 	ae.ResponseObject, err = encodeObject(obj, gv, s)
 	if err != nil {
-		klog.Warningf("Audit failed for %q response: %v", reflect.TypeOf(obj).Name(), err)
+		klog.ErrorS(err, "Encoding failed of response object", "auditID", ae.AuditID, "obj", obj)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

1. Include the `auditID` with audit error logs in the kube-apiserver logs, so errors can be correlated with the request. (As an asside, I think we should do this for all apiserver log lines in the request serving path, but that's outside the scope of this PR)
2. Attempt to log the actual request / response object rather than it's reflected type when encoding fails.

---

While debugging a kube-apiserver, I came across a lot of log lines like this:
```
Auditing failed of  request: encoding failed: request to convert CR to an invalid group/version: v1
```

Note the double space after the first `of`. This is logged from
https://github.com/kubernetes/kubernetes/blob/eefcf6aa801c5db48b564d0464470d623b8bfb79/staging/src/k8s.io/apiserver/pkg/audit/request.go#L169

But `reflect.TypeOf(obj).Name()` is returning the empty string (from the docs: "Name returns the type's name within its package for a defined type. For other (non-defined) types it returns the empty string.")

#### Note to reviewers:

The underlying issue generating these log lines was fixed by https://github.com/kubernetes/kubernetes/pull/110110

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig api-machinery