### PR TITLE
use klog.InfoS instead of klog.V(0).InfoS

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -814,7 +814,7 @@ func detectNodeIP(client clientset.Interface, hostname, bindAddress string) net.
 		nodeIP = utilnode.GetNodeIP(client, hostname)
 	}
 	if nodeIP == nil {
-		klog.V(0).InfoS("Can't determine this node's IP, assuming 127.0.0.1; if this is incorrect, please set the --bind-address flag")
+		klog.InfoS("Can't determine this node's IP, assuming 127.0.0.1; if this is incorrect, please set the --bind-address flag")
 		nodeIP = netutils.ParseIPSloppy("127.0.0.1")
 	}
 	return nodeIP

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -170,22 +170,22 @@ func newProxyServer(
 
 		for _, perFamilyIpt := range ipt {
 			if !perFamilyIpt.Present() {
-				klog.V(0).InfoS("kube-proxy running in single-stack mode, this ipFamily is not supported", "ipFamily", perFamilyIpt.Protocol())
+				klog.InfoS("kube-proxy running in single-stack mode, this ipFamily is not supported", "ipFamily", perFamilyIpt.Protocol())
 				dualStack = false
 			}
 		}
 	}
 
 	if proxyMode == proxyconfigapi.ProxyModeIPTables {
-		klog.V(0).InfoS("Using iptables Proxier")
+		klog.InfoS("Using iptables Proxier")
 		if config.IPTables.MasqueradeBit == nil {
 			// MasqueradeBit must be specified or defaulted.
 			return nil, fmt.Errorf("unable to read IPTables MasqueradeBit from config")
 		}
 
 		if dualStack {
-			klog.V(0).InfoS("kube-proxy running in dual-stack mode", "ipFamily", iptInterface.Protocol())
-			klog.V(0).InfoS("Creating dualStackProxier for iptables")
+			klog.InfoS("kube-proxy running in dual-stack mode", "ipFamily", iptInterface.Protocol())
+			klog.InfoS("Creating dualStackProxier for iptables")
 			// Always ordered to match []ipt
 			var localDetectors [2]proxyutiliptables.LocalTrafficDetector
 			localDetectors, err = getDualStackLocalDetectorTuple(detectLocalMode, config, ipt, nodeInfo)
@@ -247,9 +247,9 @@ func newProxyServer(
 		}
 		ipvsInterface = utilipvs.New()
 
-		klog.V(0).InfoS("Using ipvs Proxier")
+		klog.InfoS("Using ipvs Proxier")
 		if dualStack {
-			klog.V(0).InfoS("Creating dualStackProxier for ipvs")
+			klog.InfoS("Creating dualStackProxier for ipvs")
 
 			nodeIPs := nodeIPTuple(config.BindAddress)
 
@@ -321,8 +321,8 @@ func newProxyServer(
 		}
 		proxymetrics.RegisterMetrics()
 	} else {
-		klog.V(0).InfoS("Using userspace Proxier")
-		klog.V(0).InfoS("The userspace proxier is now deprecated and will be removed in a future release, please use 'iptables' or 'ipvs' instead")
+		klog.InfoS("Using userspace Proxier")
+		klog.InfoS("The userspace proxier is now deprecated and will be removed in a future release, please use 'iptables' or 'ipvs' instead")
 
 		// TODO this has side effects that should only happen when Run() is invoked.
 		proxier, err = userspace.NewProxier(
@@ -453,7 +453,7 @@ func getLocalDetector(mode proxyconfigapi.LocalMode, config *proxyconfigapi.Kube
 		}
 		return proxyutiliptables.NewDetectLocalByInterfaceNamePrefix(config.DetectLocal.InterfaceNamePrefix)
 	}
-	klog.V(0).InfoS("Defaulting to no-op detect-local", "detect-local-mode", string(mode))
+	klog.InfoS("Defaulting to no-op detect-local", "detect-local-mode", string(mode))
 	return proxyutiliptables.NewNoOpLocalDetector(), nil
 }
 

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -105,9 +105,9 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string
 	proxyMode := getProxyMode(config.Mode, winkernel.WindowsKernelCompatTester{})
 	dualStackMode := getDualStackMode(config.Winkernel.NetworkName, winkernel.DualStackCompatTester{})
 	if proxyMode == proxyconfigapi.ProxyModeKernelspace {
-		klog.V(0).InfoS("Using Kernelspace Proxier.")
+		klog.InfoS("Using Kernelspace Proxier.")
 		if dualStackMode {
-			klog.V(0).InfoS("Creating dualStackProxier for Windows kernel.")
+			klog.InfoS("Creating dualStackProxier for Windows kernel.")
 
 			proxier, err = winkernel.NewDualStackProxier(
 				config.IPTables.SyncPeriod.Duration,
@@ -146,8 +146,8 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string
 
 		winkernel.RegisterMetrics()
 	} else {
-		klog.V(0).InfoS("Using userspace Proxier.")
-		klog.V(0).InfoS("The userspace proxier is now deprecated and will be removed in a future release, please use 'kernelspace' instead")
+		klog.InfoS("Using userspace Proxier.")
+		klog.InfoS("The userspace proxier is now deprecated and will be removed in a future release, please use 'kernelspace' instead")
 		execer := exec.New()
 		var netshInterface utilnetsh.Interface
 		netshInterface = utilnetsh.New(execer)

--- a/pkg/controller/nodeipam/ipam/controller_legacyprovider.go
+++ b/pkg/controller/nodeipam/ipam/controller_legacyprovider.go
@@ -113,7 +113,7 @@ func NewController(
 // registers the informers for node changes. This will start synchronization
 // of the node and cloud CIDR range allocations.
 func (c *Controller) Start(nodeInformer informers.NodeInformer) error {
-	klog.V(0).InfoS("Starting IPAM controller", "config", c.config)
+	klog.InfoS("Starting IPAM controller", "config", c.config)
 
 	nodes, err := listNodes(c.adapter.k8s)
 	if err != nil {

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -249,7 +249,7 @@ func (gcc *PodGCController) gcOrphaned(ctx context.Context, pods []*v1.Pod, node
 		if err := gcc.markFailedAndDeletePodWithCondition(ctx, pod, condition); err != nil {
 			utilruntime.HandleError(err)
 		} else {
-			klog.V(0).InfoS("Forced deletion of orphaned Pod succeeded", "pod", klog.KObj(pod))
+			klog.InfoS("Forced deletion of orphaned Pod succeeded", "pod", klog.KObj(pod))
 		}
 	}
 }
@@ -298,7 +298,7 @@ func (gcc *PodGCController) gcUnscheduledTerminating(ctx context.Context, pods [
 		if err := gcc.markFailedAndDeletePod(ctx, pod); err != nil {
 			utilruntime.HandleError(err)
 		} else {
-			klog.V(0).InfoS("Forced deletion of unscheduled terminating Pod succeeded", "pod", klog.KObj(pod))
+			klog.InfoS("Forced deletion of unscheduled terminating Pod succeeded", "pod", klog.KObj(pod))
 		}
 	}
 }

--- a/pkg/registry/core/service/storage/alloc.go
+++ b/pkg/registry/core/service/storage/alloc.go
@@ -324,7 +324,7 @@ func (al *Allocators) txnAllocClusterIPs(service *api.Service, dryRun bool) (tra
 		commit: func() {
 			if !dryRun {
 				if len(allocated) > 0 {
-					klog.V(0).InfoS("allocated clusterIPs",
+					klog.InfoS("allocated clusterIPs",
 						"service", klog.KObj(service),
 						"clusterIPs", allocated)
 				}
@@ -614,7 +614,7 @@ func (al *Allocators) txnUpdateClusterIPs(after After, before Before, dryRun boo
 				return
 			}
 			if len(allocated) > 0 {
-				klog.V(0).InfoS("allocated clusterIPs",
+				klog.InfoS("allocated clusterIPs",
 					"service", klog.KObj(service),
 					"clusterIPs", allocated)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
use klog.InfoS instead of klog.V(0).InfoS
As mentioned in the issue https://github.com/kubernetes-sigs/logtools/issues/2, Calling V with zero as parameter just causes additional overhead, so we need to avoid this scenario
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
release-note
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/cc @pohly 