### PR TITLE
PodTolerationRestriction: ignore duplicates when changing pod toleration 

### DIFF
--- a/plugin/pkg/admission/podtolerationrestriction/admission_test.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission_test.go
@@ -224,6 +224,33 @@ func TestPodAdmission(t *testing.T) {
 			admit:    true,
 			testName: "added memoryPressure/DiskPressure for Guaranteed pod",
 		},
+		{
+			pod:                       guaranteedPod,
+			defaultClusterTolerations: []api.Toleration{},
+			namespaceTolerations:      []api.Toleration{},
+			whitelist:                 []api.Toleration{},
+			podTolerations:            []api.Toleration{{Operator: api.TolerationOpExists, Effect: "NoExecute", TolerationSeconds: nil}, {Key: "testKey", Operator: "Equal", Value: "testValue", Effect: "NoExecute", TolerationSeconds: nil}},
+			mergedTolerations: []api.Toleration{
+				{Operator: api.TolerationOpExists, Effect: "NoExecute", TolerationSeconds: nil},
+				{Key: "testKey", Operator: "Equal", Value: "testValue", Effect: "NoExecute", TolerationSeconds: nil},
+				{Key: corev1.TaintNodeMemoryPressure, Operator: api.TolerationOpExists, Effect: api.TaintEffectNoSchedule, TolerationSeconds: nil},
+			},
+			admit:    true,
+			testName: "added memoryPressure/DiskPressure for Guaranteed pod with dup tolerations",
+		},
+		{
+			pod:                       guaranteedPod,
+			defaultClusterTolerations: []api.Toleration{},
+			namespaceTolerations:      []api.Toleration{},
+			whitelist:                 []api.Toleration{},
+			podTolerations:            []api.Toleration{{Operator: api.TolerationOpExists, Effect: "NoSchedule", TolerationSeconds: nil}, {Key: "testKey", Operator: "Equal", Value: "testValue", Effect: "NoSchedule", TolerationSeconds: nil}},
+			mergedTolerations: []api.Toleration{
+				{Operator: api.TolerationOpExists, Effect: "NoSchedule", TolerationSeconds: nil},
+				{Key: "testKey", Operator: "Equal", Value: "testValue", Effect: "NoSchedule", TolerationSeconds: nil},
+			},
+			admit:    true,
+			testName: "added memoryPressure/DiskPressure for Guaranteed pod with dup tolerations and existing toleration",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Reproduce steps
1. make sure podtolerationrestriction is not enable at first.
2. create a daemonset A with toleration `{"operator":"Exists","effect":"NoSchedule"},`, and pod A-1 was created
3. enable podtolerationrestriction in all apiserver
4. try to update the pod annotation
> "reason": "FieldvalueForbidden", "message" :"Forbidden: existing toleration can not be modified except tolerationSeconds",

Workarounds
1. just remove the pod to trigger a recreation


#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/111745

#### Special notes for your reviewer:

See more in the issue reproduce steps and logics.

#### Does this PR introduce a user-facing change?

```release-note
Changed `PodTolerationRestriction` admission controller to ignore duplicates of existing tolerations
```
