### PR TITLE
kube-scheduler: Adjust the structure type to improve the efficiency

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -49,7 +49,7 @@ type NodeScore struct {
 }
 
 // PluginToNodeScores declares a map from plugin name to its NodeScoreList.
-type PluginToNodeScores map[string]NodeScoreList
+type PluginToNodeScores map[ScorePlugin]NodeScoreList
 
 // NodeToStatusMap declares map from node name to its status.
 type NodeToStatusMap map[string]*Status


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adjust the type of `PluginToNodeScores map[string]NodeScoreList` to `PluginToNodeScores map[ScorePlugin]NodeScoreList`, In this way, in the `RunScorePlugins` function,` plugintonodescores[pl.name()][index]` can be changed to `nl[index]`, which can improve the calculation efficiency as a whole.

After testing, according to the default number of scoring plug-ins, the time for each node to traverse all scoring plug-ins to get the total score is reduced by about 10us; When the number of cluster nodes is large, the overall optimization process time will be significantly reduced.

#### Which issue(s) this PR fixes:
Fixes #

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### SIG labels

- sig scheduling