### PR TITLE
Fix typo in command_headers_test.go

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/command_headers_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/command_headers_test.go
@@ -105,7 +105,7 @@ func buildCommandChain(commands []*cobra.Command) *cobra.Command {
 	return currCmd
 }
 
-// Tests that the CancelRequest function is propogated to the wrapped Delegate
+// Tests that the CancelRequest function is propagated to the wrapped Delegate
 // RoundTripper; but only if the Delegate implements the CancelRequest function.
 func TestCancelRequest(t *testing.T) {
 	tests := map[string]struct {


### PR DESCRIPTION

#### What type of PR is this?

Typo fixed.

```
propogated -> propagated
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

