### PR TITLE
Simplify the integration test for node lifecycle manager

### DIFF
--- a/test/integration/node/lifecycle_test.go
+++ b/test/integration/node/lifecycle_test.go
@@ -45,6 +45,10 @@ import (
 
 // TestEvictionForNoExecuteTaintAddedByUser tests taint-based eviction for a node tainted NoExecute
 func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
+	// we need at least 2 nodes to prevent lifecycle manager from entering "fully-disrupted" mode
+	nodeCount := 3
+	nodeIndex := 1 // the exact node doesn't matter, pick one
+
 	tests := map[string]struct {
 		enablePodDisruptionConditions bool
 	}{
@@ -58,8 +62,6 @@ func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			nodeIndex := 1
-			nodeCount := 3
 			var nodes []*v1.Node
 			for i := 0; i < nodeCount; i++ {
 				node := &v1.Node{
@@ -132,8 +134,7 @@ func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
 				true,             // Run taint manager
 			)
 			if err != nil {
-				t.Errorf("Failed to create node controller: %v", err)
-				return
+				t.Fatalf("Failed to create node controller: %v", err)
 			}
 
 			// Waiting for all controllers to sync
@@ -146,7 +147,7 @@ func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
 			for index := range nodes {
 				nodes[index], err = cs.CoreV1().Nodes().Create(testCtx.Ctx, nodes[index], metav1.CreateOptions{})
 				if err != nil {
-					t.Errorf("Failed to create node, err: %v", err)
+					t.Fatalf("Failed to create node, err: %v", err)
 				}
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Simplifies the setup in the integration test for node lifecycle manager. In particular:
- uses "NodeDisruptionExclusion" feature instead of  periodic heartbeat events to simplify the logic, it was also requested in this comment:
```
			// Regularly send heartbeat event to APIServer so that the cluster doesn't enter fullyDisruption mode.
			// TODO(Huang-Wei): use "NodeDisruptionExclusion" feature to simply the below logic when it's beta.
```
- eliminates scheduler from this test
- replaces the custom code for awaiting for a condition with built-in wait.PollImmediate()

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #111183

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

