### PR TITLE
Fix deleting UIDs tracking expectations

### DIFF
--- a/pkg/controller/job/tracking_utils.go
+++ b/pkg/controller/job/tracking_utils.go
@@ -105,8 +105,11 @@ func (u *uidTrackingExpectations) finalizerRemovalObserved(jobKey, deleteKey str
 
 // DeleteExpectations deletes the UID set.
 func (u *uidTrackingExpectations) deleteExpectations(jobKey string) {
-	if err := u.store.Delete(jobKey); err != nil {
-		klog.ErrorS(err, "deleting tracking annotation UID expectations", "job", jobKey)
+	set := u.getSet(jobKey)
+	if set != nil {
+		if err := u.store.Delete(set); err != nil {
+			klog.ErrorS(err, "Could not delete tracking annotation UID expectations", "job", jobKey)
+		}
 	}
 }
 

--- a/pkg/controller/job/tracking_utils_test.go
+++ b/pkg/controller/job/tracking_utils_test.go
@@ -108,4 +108,11 @@ func TestUIDTrackingExpectations(t *testing.T) {
 			t.Errorf("Unexpected keys for job %s (-want,+got):\n%s", track.job, diff)
 		}
 	}
+	for _, track := range tracks {
+		expectations.deleteExpectations(track.job)
+		uids := expectations.getSet(track.job)
+		if uids != nil {
+			t.Errorf("Wanted expectations for job %s to be cleared, but they were not", track.job)
+		}
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Fix the deletion of expectations that we no longer need. Without this fix, the job controller memory leaks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix memory leak in the job controller related to JobTrackingWithFinalizers
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
