### PR TITLE
Automated cherry pick of #111721: Fix deleting UIDs tracking expectations

### DIFF
--- a/pkg/controller/job/tracking_utils.go
+++ b/pkg/controller/job/tracking_utils.go
@@ -105,8 +105,11 @@ func (u *uidTrackingExpectations) finalizerRemovalObserved(jobKey, deleteKey str
 
 // DeleteExpectations deletes the UID set.
 func (u *uidTrackingExpectations) deleteExpectations(jobKey string) {
-	if err := u.store.Delete(jobKey); err != nil {
-		klog.ErrorS(err, "deleting tracking annotation UID expectations", "job", jobKey)
+	set := u.getSet(jobKey)
+	if set != nil {
+		if err := u.store.Delete(set); err != nil {
+			klog.ErrorS(err, "Could not delete tracking annotation UID expectations", "job", jobKey)
+		}
 	}
 }
 

--- a/pkg/controller/job/tracking_utils_test.go
+++ b/pkg/controller/job/tracking_utils_test.go
@@ -108,4 +108,11 @@ func TestUIDTrackingExpectations(t *testing.T) {
 			t.Errorf("Unexpected keys for job %s (-want,+got):\n%s", track.job, diff)
 		}
 	}
+	for _, track := range tracks {
+		expectations.deleteExpectations(track.job)
+		uids := expectations.getSet(track.job)
+		if uids != nil {
+			t.Errorf("Wanted expectations for job %s to be cleared, but they were not", track.job)
+		}
+	}
 }


### PR DESCRIPTION
Cherry pick of #111721 on release-1.24.

#111721: Fix deleting UIDs tracking expectations

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix memory leak in the job controller related to JobTrackingWithFinalizers
```