### PR TITLE
CSI Inline Volumes: promote API tests to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2450,6 +2450,20 @@
     pod.
   release: v1.19
   file: test/e2e/scheduling/preemption.go
+- testname: CSIInlineVolumes should support Pods with inline volumes
+  codename: '[sig-storage] CSIInlineVolumes should support CSIVolumeSource in Pod
+    API [Conformance]'
+  description: Pod resources with CSIVolumeSource should support create, get, list,
+    patch, and delete operations.
+  release: v1.26
+  file: test/e2e/storage/csi_inline.go
+- testname: CSIInlineVolumes should support ephemeral CSIDrivers
+  codename: '[sig-storage] CSIInlineVolumes should support ephemeral VolumeLifecycleMode
+    in CSIDriver API [Conformance]'
+  description: CSIDriver resources with ephemeral VolumeLifecycleMode should support
+    create, get, list, and delete operations.
+  release: v1.26
+  file: test/e2e/storage/csi_inline.go
 - testname: CSIStorageCapacity API
   codename: '[sig-storage] CSIStorageCapacity  should support CSIStorageCapacities
     API operations [Conformance]'

--- a/test/e2e/storage/csi_inline.go
+++ b/test/e2e/storage/csi_inline.go
@@ -37,8 +37,13 @@ var _ = utils.SIGDescribe("CSIInlineVolumes", func() {
 	f := framework.NewDefaultFramework("csiinlinevolumes")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	// TODO: promote to framework.ConformanceIt
-	ginkgo.It("should support ephemeral VolumeLifecycleMode in CSIDriver API", func() {
+	/*
+		Release: v1.26
+		Testname: CSIInlineVolumes should support ephemeral CSIDrivers
+		Description: CSIDriver resources with ephemeral VolumeLifecycleMode
+		  should support create, get, list, and delete operations.
+	*/
+	framework.ConformanceIt("should support ephemeral VolumeLifecycleMode in CSIDriver API", func() {
 		// Create client
 		client := f.ClientSet.StorageV1().CSIDrivers()
 		defaultFSGroupPolicy := storagev1.ReadWriteOnceWithFSTypeFSGroupPolicy
@@ -117,8 +122,13 @@ var _ = utils.SIGDescribe("CSIInlineVolumes", func() {
 		}
 	})
 
-	// TODO: promote to framework.ConformanceIt
-	ginkgo.It("should support CSIVolumeSource in Pod API", func() {
+	/*
+		Release: v1.26
+		Testname: CSIInlineVolumes should support Pods with inline volumes
+		Description: Pod resources with CSIVolumeSource should support
+		  create, get, list, patch, and delete operations.
+	*/
+	framework.ConformanceIt("should support CSIVolumeSource in Pod API", func() {
 		// Create client
 		client := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Promotes the API tests from https://github.com/kubernetes/kubernetes/pull/111258 to conformance.

#### Which issue(s) this PR fixes:

Originally suggested in [this comment](https://github.com/kubernetes/enhancements/pull/3445#discussion_r932772337)

#### Special notes for your reviewer:

/hold
for 2 weeks of flake-free tests before promoting to conformance

Testgrid:
https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-cos-master-default

Related PR's:
https://github.com/kubernetes/kubernetes/pull/111258
https://github.com/kubernetes/kubernetes/pull/111751
https://github.com/kubernetes/kubernetes/pull/113141

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

