### PR TITLE
Fix IPSet weak on hiding #109034

### DIFF
--- a/pkg/proxy/ipvs/ipset.go
+++ b/pkg/proxy/ipvs/ipset.go
@@ -120,7 +120,7 @@ func NewIPSet(handle utilipset.Interface, name string, setType utilipset.Type, i
 	}
 	defaultHashSize, defaultMaxElem := 1024, 65536
 	set := &IPSet{
-		IPSet: *utilipset.NewIPSet(
+		IPSet: utilipset.NewIPSet(
 			name, setType, hashFamily,
 			defaultHashSize, defaultMaxElem, utilipset.DefaultPortRange,
 			comment,
@@ -132,7 +132,7 @@ func NewIPSet(handle utilipset.Interface, name string, setType utilipset.Type, i
 }
 
 func (set *IPSet) validateEntry(entry *utilipset.Entry) bool {
-	return entry.Validate(&set.IPSet)
+	return entry.Validate(set.IPSet)
 }
 
 func (set *IPSet) isEmpty() bool {
@@ -173,7 +173,7 @@ func (set *IPSet) syncIPSetEntries() {
 		}
 		// Create active entries
 		for _, entry := range set.activeEntries.Difference(currentIPSetEntries).List() {
-			if err := set.handle.AddEntry(entry, &set.IPSet, true); err != nil {
+			if err := set.handle.AddEntry(entry, set.IPSet, true); err != nil {
 				klog.ErrorS(err, "Failed to add ip set entry to ip set", "ipSetEntry", entry, "ipSet", set.Name)
 			} else {
 				klog.V(3).InfoS("Successfully added ip set entry to ip set", "ipSetEntry", entry, "ipSet", set.Name)
@@ -183,7 +183,7 @@ func (set *IPSet) syncIPSetEntries() {
 }
 
 func ensureIPSet(set *IPSet) error {
-	if err := set.handle.CreateSet(&set.IPSet, true); err != nil {
+	if err := set.handle.CreateSet(set.IPSet, true); err != nil {
 		klog.ErrorS(err, "Failed to make sure existence of ip set", "ipSet", set)
 		return err
 	}

--- a/pkg/proxy/ipvs/ipset.go
+++ b/pkg/proxy/ipvs/ipset.go
@@ -118,13 +118,13 @@ func NewIPSet(handle utilipset.Interface, name string, setType utilipset.Type, i
 			}
 		}
 	}
+	defaultHashSize, defaultMaxElem := 1024, 65536
 	set := &IPSet{
-		IPSet: utilipset.IPSet{
-			Name:       name,
-			SetType:    setType,
-			HashFamily: hashFamily,
-			Comment:    comment,
-		},
+		IPSet: *utilipset.NewIPSet(
+			name, setType, hashFamily,
+			defaultHashSize, defaultMaxElem, utilipset.DefaultPortRange,
+			comment,
+		),
 		activeEntries: sets.NewString(),
 		handle:        handle,
 	}

--- a/pkg/proxy/ipvs/ipset.go
+++ b/pkg/proxy/ipvs/ipset.go
@@ -140,7 +140,7 @@ func (set *IPSet) isEmpty() bool {
 }
 
 func (set *IPSet) getComment() string {
-	return fmt.Sprintf("\"%s\"", set.Comment)
+	return fmt.Sprintf("\"%s\"", set.Comment())
 }
 
 func (set *IPSet) resetEntries() {
@@ -148,7 +148,7 @@ func (set *IPSet) resetEntries() {
 }
 
 func (set *IPSet) syncIPSetEntries() {
-	appliedEntries, err := set.handle.ListEntries(set.Name)
+	appliedEntries, err := set.handle.ListEntries(set.Name())
 	if err != nil {
 		klog.ErrorS(err, "Failed to list ip set entries")
 		return
@@ -163,7 +163,7 @@ func (set *IPSet) syncIPSetEntries() {
 	if !set.activeEntries.Equal(currentIPSetEntries) {
 		// Clean legacy entries
 		for _, entry := range currentIPSetEntries.Difference(set.activeEntries).List() {
-			if err := set.handle.DelEntry(entry, set.Name); err != nil {
+			if err := set.handle.DelEntry(entry, set.Name()); err != nil {
 				if !utilipset.IsNotFoundError(err) {
 					klog.ErrorS(err, "Failed to delete ip set entry from ip set", "ipSetEntry", entry, "ipSet", set.Name)
 				}

--- a/pkg/proxy/ipvs/ipset_test.go
+++ b/pkg/proxy/ipvs/ipset_test.go
@@ -57,14 +57,14 @@ func TestCheckIPSetVersion(t *testing.T) {
 
 const testIPSetVersion = "v6.19"
 
-func newTestIPSet(name string) *utilipset.IPSet {
+func newTestIPSet(name string) utilipset.IPSet {
 	return utilipset.NewIPSet(name, utilipset.HashIPPort, "", 1024, 65536, utilipset.DefaultPortRange, "")
 }
 
 func TestSyncIPSetEntries(t *testing.T) {
 	testCases := []struct {
 		name            string
-		set             *utilipset.IPSet
+		set             utilipset.IPSet
 		setType         utilipset.Type
 		ipv6            bool
 		activeEntries   []string
@@ -200,7 +200,7 @@ func TestSyncIPSetEntries(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			set := NewIPSet(fakeipset.NewFake(testIPSetVersion), testCase.set.Name(), testCase.setType, testCase.ipv6, "comment-"+testCase.set.Name())
 
-			if err := set.handle.CreateSet(&set.IPSet, true); err != nil {
+			if err := set.handle.CreateSet(set.IPSet, true); err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}
 

--- a/pkg/proxy/ipvs/ipset_test.go
+++ b/pkg/proxy/ipvs/ipset_test.go
@@ -198,7 +198,7 @@ func TestSyncIPSetEntries(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			set := NewIPSet(fakeipset.NewFake(testIPSetVersion), testCase.set.Name, testCase.setType, testCase.ipv6, "comment-"+testCase.set.Name)
+			set := NewIPSet(fakeipset.NewFake(testIPSetVersion), testCase.set.Name(), testCase.setType, testCase.ipv6, "comment-"+testCase.set.Name())
 
 			if err := set.handle.CreateSet(&set.IPSet, true); err != nil {
 				t.Errorf("Unexpected error: %v", err)
@@ -211,7 +211,7 @@ func TestSyncIPSetEntries(t *testing.T) {
 			set.activeEntries.Insert(testCase.activeEntries...)
 			set.syncIPSetEntries()
 			for _, entry := range testCase.expectedEntries {
-				found, err := set.handle.TestEntry(entry, testCase.set.Name)
+				found, err := set.handle.TestEntry(entry, testCase.set.Name())
 				if err != nil {
 					t.Errorf("Unexpected error: %v", err)
 				}

--- a/pkg/proxy/ipvs/ipset_test.go
+++ b/pkg/proxy/ipvs/ipset_test.go
@@ -57,6 +57,10 @@ func TestCheckIPSetVersion(t *testing.T) {
 
 const testIPSetVersion = "v6.19"
 
+func newTestIPSet(name string) *utilipset.IPSet {
+	return utilipset.NewIPSet(name, utilipset.HashIPPort, "", 1024, 65536, utilipset.DefaultPortRange, "")
+}
+
 func TestSyncIPSetEntries(t *testing.T) {
 	testCases := []struct {
 		name            string
@@ -68,10 +72,8 @@ func TestSyncIPSetEntries(t *testing.T) {
 		expectedEntries []string
 	}{
 		{
-			name: "normal ipset sync",
-			set: &utilipset.IPSet{
-				Name: "foo",
-			},
+			name:            "normal ipset sync",
+			set:             newTestIPSet("foo"),
 			setType:         utilipset.HashIPPort,
 			ipv6:            false,
 			activeEntries:   []string{"172.17.0.4,tcp:80"},
@@ -79,10 +81,8 @@ func TestSyncIPSetEntries(t *testing.T) {
 			expectedEntries: []string{"172.17.0.4,tcp:80"},
 		},
 		{
-			name: "ipset IPv6 sync with no new entries",
-			set: &utilipset.IPSet{
-				Name: "abz",
-			},
+			name:            "ipset IPv6 sync with no new entries",
+			set:             newTestIPSet("abz"),
 			setType:         utilipset.HashIPPort,
 			ipv6:            true,
 			activeEntries:   []string{"FE80::0202:B3FF:FE1E:8329,tcp:80"},
@@ -90,10 +90,8 @@ func TestSyncIPSetEntries(t *testing.T) {
 			expectedEntries: []string{"FE80::0202:B3FF:FE1E:8329,tcp:80"},
 		},
 		{
-			name: "ipset sync with updated udp->tcp in hash",
-			set: &utilipset.IPSet{
-				Name: "bca",
-			},
+			name:            "ipset sync with updated udp->tcp in hash",
+			set:             newTestIPSet("bca"),
 			setType:         utilipset.HashIPPort,
 			ipv6:            false,
 			activeEntries:   []string{"172.17.0.4,tcp:80", "172.17.0.5,tcp:80"},
@@ -101,10 +99,8 @@ func TestSyncIPSetEntries(t *testing.T) {
 			expectedEntries: []string{"172.17.0.4,tcp:80", "172.17.0.5,tcp:80"},
 		},
 		{
-			name: "ipset sync no updates required",
-			set: &utilipset.IPSet{
-				Name: "bar",
-			},
+			name:            "ipset sync no updates required",
+			set:             newTestIPSet("bar"),
 			setType:         utilipset.HashIPPortIP,
 			ipv6:            false,
 			activeEntries:   []string{"172.17.0.4,tcp:80:172.17.0.4"},
@@ -112,10 +108,8 @@ func TestSyncIPSetEntries(t *testing.T) {
 			expectedEntries: []string{"172.17.0.4,tcp:80:172.17.0.4"},
 		},
 		{
-			name: "ipset IPv6 sync, delete and add new entry",
-			set: &utilipset.IPSet{
-				Name: "baz",
-			},
+			name:            "ipset IPv6 sync, delete and add new entry",
+			set:             newTestIPSet("baz"),
 			setType:         utilipset.HashIPPortIP,
 			ipv6:            true,
 			activeEntries:   []string{"FE80:0000:0000:0000:0202:B3FF:FE1E:8329,tcp:8080:FE80:0000:0000:0000:0202:B3FF:FE1E:8329"},
@@ -123,10 +117,8 @@ func TestSyncIPSetEntries(t *testing.T) {
 			expectedEntries: []string{"FE80:0000:0000:0000:0202:B3FF:FE1E:8329,tcp:8080:FE80:0000:0000:0000:0202:B3FF:FE1E:8329"},
 		},
 		{
-			name: "ipset sync, no current entries",
-			set: &utilipset.IPSet{
-				Name: "NOPE",
-			},
+			name:            "ipset sync, no current entries",
+			set:             newTestIPSet("NOPE"),
 			setType:         utilipset.HashIPPortIP,
 			ipv6:            false,
 			activeEntries:   []string{"172.17.0.4,tcp:80,172.17.0.9", "172.17.0.5,tcp:80,172.17.0.10"},
@@ -134,10 +126,8 @@ func TestSyncIPSetEntries(t *testing.T) {
 			expectedEntries: []string{"172.17.0.4,tcp:80,172.17.0.9", "172.17.0.5,tcp:80,172.17.0.10"},
 		},
 		{
-			name: "ipset sync, no current entries with /16 subnet",
-			set: &utilipset.IPSet{
-				Name: "ABC-DEF",
-			},
+			name:            "ipset sync, no current entries with /16 subnet",
+			set:             newTestIPSet("ABC-DEF"),
 			setType:         utilipset.HashIPPortNet,
 			ipv6:            false,
 			activeEntries:   []string{"172.17.0.4,tcp:80,172.17.0.0/16", "172.17.0.5,tcp:80,172.17.0.0/16"},
@@ -145,10 +135,8 @@ func TestSyncIPSetEntries(t *testing.T) {
 			expectedEntries: []string{"172.17.0.4,tcp:80,172.17.0.0/16", "172.17.0.5,tcp:80,172.17.0.0/16"},
 		},
 		{
-			name: "ipset IPv6 sync, no updates required with /32 subnet",
-			set: &utilipset.IPSet{
-				Name: "zar",
-			},
+			name:            "ipset IPv6 sync, no updates required with /32 subnet",
+			set:             newTestIPSet("zar"),
 			setType:         utilipset.HashIPPortNet,
 			ipv6:            true,
 			activeEntries:   []string{"FE80::8329,tcp:8800,2001:db8::/32"},
@@ -156,10 +144,8 @@ func TestSyncIPSetEntries(t *testing.T) {
 			expectedEntries: []string{"FE80::8329,tcp:8800,2001:db8::/32"},
 		},
 		{
-			name: "ipset IPv6 sync, current entries removed",
-			set: &utilipset.IPSet{
-				Name: "bbb",
-			},
+			name:            "ipset IPv6 sync, current entries removed",
+			set:             newTestIPSet("bbb"),
 			setType:         utilipset.HashIPPortNet,
 			ipv6:            true,
 			activeEntries:   nil,
@@ -167,40 +153,32 @@ func TestSyncIPSetEntries(t *testing.T) {
 			expectedEntries: nil,
 		},
 		{
-			name: "ipset sync, port entry removed",
-			set: &utilipset.IPSet{
-				Name: "AAA",
-			},
+			name:            "ipset sync, port entry removed",
+			set:             newTestIPSet("AAA"),
 			setType:         utilipset.BitmapPort,
 			activeEntries:   nil,
 			currentEntries:  []string{"80"},
 			expectedEntries: nil,
 		},
 		{
-			name: "ipset sync, remove old and add new",
-			set: &utilipset.IPSet{
-				Name: "c-c-c",
-			},
+			name:            "ipset sync, remove old and add new",
+			set:             newTestIPSet("c-c-c"),
 			setType:         utilipset.BitmapPort,
 			activeEntries:   []string{"8080", "9090"},
 			currentEntries:  []string{"80"},
 			expectedEntries: []string{"8080", "9090"},
 		},
 		{
-			name: "ipset sync, remove many stale ports",
-			set: &utilipset.IPSet{
-				Name: "NODE-PORT",
-			},
+			name:            "ipset sync, remove many stale ports",
+			set:             newTestIPSet("NODE-PORT"),
 			setType:         utilipset.BitmapPort,
 			activeEntries:   []string{"8080"},
 			currentEntries:  []string{"80", "9090", "8081", "8082"},
 			expectedEntries: []string{"8080"},
 		},
 		{
-			name: "ipset sync, add sctp entry",
-			set: &utilipset.IPSet{
-				Name: "sctp-1",
-			},
+			name:            "ipset sync, add sctp entry",
+			set:             newTestIPSet("sctp-1"),
 			setType:         utilipset.HashIPPort,
 			ipv6:            false,
 			activeEntries:   []string{"172.17.0.4,sctp:80"},
@@ -208,10 +186,8 @@ func TestSyncIPSetEntries(t *testing.T) {
 			expectedEntries: []string{"172.17.0.4,sctp:80"},
 		},
 		{
-			name: "ipset sync, add IPV6 sctp entry",
-			set: &utilipset.IPSet{
-				Name: "sctp-2",
-			},
+			name:            "ipset sync, add IPV6 sctp entry",
+			set:             newTestIPSet("sctp-2"),
 			setType:         utilipset.HashIPPort,
 			ipv6:            true,
 			activeEntries:   []string{"FE80::0202:B3FF:FE1E:8329,sctp:80"},

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1674,7 +1674,7 @@ func (proxier *Proxier) writeIptablesRules() {
 			}
 			args = append(args,
 				"-m", "comment", "--comment", proxier.ipsetList[set.name].getComment(),
-				"-m", "set", "--match-set", proxier.ipsetList[set.name].Name,
+				"-m", "set", "--match-set", proxier.ipsetList[set.name].Name(),
 				set.matchType,
 			)
 			if set.table == utiliptables.TableFilter {
@@ -1689,7 +1689,7 @@ func (proxier *Proxier) writeIptablesRules() {
 		args = append(args[:0],
 			"-A", string(kubeServicesChain),
 			"-m", "comment", "--comment", proxier.ipsetList[kubeClusterIPSet].getComment(),
-			"-m", "set", "--match-set", proxier.ipsetList[kubeClusterIPSet].Name,
+			"-m", "set", "--match-set", proxier.ipsetList[kubeClusterIPSet].Name(),
 		)
 		if proxier.masqueradeAll {
 			proxier.natRules.Write(
@@ -1740,7 +1740,7 @@ func (proxier *Proxier) writeIptablesRules() {
 		args = append(args[:0],
 			"-A", string(kubeServicesChain),
 			"-m", "comment", "--comment", proxier.ipsetList[kubeExternalIPSet].getComment(),
-			"-m", "set", "--match-set", proxier.ipsetList[kubeExternalIPSet].Name,
+			"-m", "set", "--match-set", proxier.ipsetList[kubeExternalIPSet].Name(),
 			"dst,dst",
 		)
 		proxier.natRules.Write(args, "-j", string(kubeMarkMasqChain))
@@ -1751,7 +1751,7 @@ func (proxier *Proxier) writeIptablesRules() {
 		args = append(args[:0],
 			"-A", string(kubeServicesChain),
 			"-m", "comment", "--comment", proxier.ipsetList[kubeExternalIPLocalSet].getComment(),
-			"-m", "set", "--match-set", proxier.ipsetList[kubeExternalIPLocalSet].Name,
+			"-m", "set", "--match-set", proxier.ipsetList[kubeExternalIPLocalSet].Name(),
 			"dst,dst",
 		)
 		externalIPRules(args)
@@ -1805,7 +1805,7 @@ func (proxier *Proxier) writeIptablesRules() {
 	proxier.filterRules.Write(
 		"-A", string(kubeNodePortChain),
 		"-m", "comment", "--comment", proxier.ipsetList[kubeHealthCheckNodePortSet].getComment(),
-		"-m", "set", "--match-set", proxier.ipsetList[kubeHealthCheckNodePortSet].Name, "dst",
+		"-m", "set", "--match-set", proxier.ipsetList[kubeHealthCheckNodePortSet].Name(), "dst",
 		"-j", "ACCEPT",
 	)
 
@@ -1813,17 +1813,17 @@ func (proxier *Proxier) writeIptablesRules() {
 	// https://github.com/kubernetes/kubernetes/issues/72236
 	proxier.filterRules.Write(
 		"-A", string(kubeIPVSFilterChain),
-		"-m", "set", "--match-set", proxier.ipsetList[kubeLoadBalancerSet].Name, "dst,dst", "-j", "RETURN")
+		"-m", "set", "--match-set", proxier.ipsetList[kubeLoadBalancerSet].Name(), "dst,dst", "-j", "RETURN")
 	proxier.filterRules.Write(
 		"-A", string(kubeIPVSFilterChain),
-		"-m", "set", "--match-set", proxier.ipsetList[kubeClusterIPSet].Name, "dst,dst", "-j", "RETURN")
+		"-m", "set", "--match-set", proxier.ipsetList[kubeClusterIPSet].Name(), "dst,dst", "-j", "RETURN")
 	proxier.filterRules.Write(
 		"-A", string(kubeIPVSFilterChain),
-		"-m", "set", "--match-set", proxier.ipsetList[kubeExternalIPSet].Name, "dst,dst", "-j", "RETURN")
+		"-m", "set", "--match-set", proxier.ipsetList[kubeExternalIPSet].Name(), "dst,dst", "-j", "RETURN")
 	proxier.filterRules.Write(
 		"-A", string(kubeIPVSFilterChain),
 		"-m", "conntrack", "--ctstate", "NEW",
-		"-m", "set", "--match-set", proxier.ipsetList[kubeIPVSSet].Name, "dst", "-j", "REJECT")
+		"-m", "set", "--match-set", proxier.ipsetList[kubeIPVSSet].Name(), "dst", "-j", "REJECT")
 
 	// Install the kubernetes-specific postrouting rules. We use a whole chain for
 	// this so that it is easier to flush and change, for example if the mark
@@ -1868,7 +1868,7 @@ func (proxier *Proxier) acceptIPVSTraffic() {
 	for _, set := range sets {
 		var matchType string
 		if !proxier.ipsetList[set].isEmpty() {
-			switch proxier.ipsetList[set].SetType {
+			switch proxier.ipsetList[set].SetType() {
 			case utilipset.BitmapPort:
 				matchType = "dst"
 			default:
@@ -1876,7 +1876,7 @@ func (proxier *Proxier) acceptIPVSTraffic() {
 			}
 			proxier.natRules.Write(
 				"-A", string(kubeServicesChain),
-				"-m", "set", "--match-set", proxier.ipsetList[set].Name, matchType,
+				"-m", "set", "--match-set", proxier.ipsetList[set].Name(), matchType,
 				"-j", "ACCEPT",
 			)
 		}

--- a/pkg/proxy/ipvs/safe_ipset.go
+++ b/pkg/proxy/ipvs/safe_ipset.go
@@ -55,14 +55,14 @@ func (s *safeIpset) DestroyAllSets() error {
 }
 
 // CreateSet creates a new set.  It will ignore error when the set already exists if ignoreExistErr=true.
-func (s *safeIpset) CreateSet(set *ipset.IPSet, ignoreExistErr bool) error {
+func (s *safeIpset) CreateSet(set ipset.IPSet, ignoreExistErr bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.ipset.CreateSet(set, ignoreExistErr)
 }
 
 // AddEntry adds a new entry to the named set.  It will ignore error when the entry already exists if ignoreExistErr=true.
-func (s *safeIpset) AddEntry(entry string, set *ipset.IPSet, ignoreExistErr bool) error {
+func (s *safeIpset) AddEntry(entry string, set ipset.IPSet, ignoreExistErr bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.ipset.AddEntry(entry, set, ignoreExistErr)

--- a/pkg/util/ipset/ipset.go
+++ b/pkg/util/ipset/ipset.go
@@ -91,6 +91,31 @@ type IPSet struct {
 	Comment string
 }
 
+// Option is variadic initializer for IPSet
+type Option func(set *IPSet)
+
+// NewIPSet returns a new IPSet struct
+func NewIPSet(
+	name string,
+	setType Type,
+	hashFamily string,
+	hashSize int,
+	maxElem int,
+	portRange string,
+	comment string,
+) *IPSet {
+	ret := IPSet{
+		Name:       name,
+		SetType:    setType,
+		HashFamily: hashFamily,
+		HashSize:   hashSize,
+		MaxElem:    maxElem,
+		PortRange:  portRange,
+		Comment:    comment,
+	}
+	return &ret
+}
+
 // Validate checks if a given ipset is valid or not.
 func (set *IPSet) Validate() error {
 	// Check if protocol is valid for `HashIPPort`, `HashIPPortIP` and `HashIPPortNet` type set.

--- a/pkg/util/ipset/ipset_test.go
+++ b/pkg/util/ipset/ipset_test.go
@@ -197,7 +197,7 @@ func TestCreateSet(t *testing.T) {
 	}
 	runner := New(&fexec)
 	// Create with ignoreExistErr = false, expect success
-	err := runner.CreateSet(&testSet, false)
+	err := runner.CreateSet(testSet, false)
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
 	}
@@ -208,7 +208,7 @@ func TestCreateSet(t *testing.T) {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[0])
 	}
 	// Create with ignoreExistErr = true, expect success
-	err = runner.CreateSet(&testSet, true)
+	err = runner.CreateSet(testSet, true)
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
 	}
@@ -219,7 +219,7 @@ func TestCreateSet(t *testing.T) {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
 	}
 	// Create with ignoreExistErr = false, expect failure
-	err = runner.CreateSet(&testSet, false)
+	err = runner.CreateSet(testSet, false)
 	if err == nil {
 		t.Errorf("expected failure, got nil")
 	}
@@ -227,7 +227,7 @@ func TestCreateSet(t *testing.T) {
 
 var testCases = []struct {
 	entry                *Entry
-	set                  *IPSet
+	set                  IPSet
 	addCombinedOutputLog [][]string
 	delCombinedOutputLog []string
 }{
@@ -238,7 +238,7 @@ var testCases = []struct {
 			Protocol: ProtocolUDP,
 			SetType:  HashIPPort,
 		},
-		set: &IPSet{
+		set: IPSet{
 			name: "ZERO",
 		},
 		addCombinedOutputLog: [][]string{
@@ -254,7 +254,7 @@ var testCases = []struct {
 			Protocol: ProtocolTCP,
 			SetType:  HashIPPort,
 		},
-		set: &IPSet{
+		set: IPSet{
 			name: "UN",
 		},
 		addCombinedOutputLog: [][]string{
@@ -271,7 +271,7 @@ var testCases = []struct {
 			SetType:  HashIPPortIP,
 			IP2:      "10.20.30.1",
 		},
-		set: &IPSet{
+		set: IPSet{
 			name: "DEUX",
 		},
 		addCombinedOutputLog: [][]string{
@@ -288,7 +288,7 @@ var testCases = []struct {
 			SetType:  HashIPPortIP,
 			IP2:      "10.20.30.2",
 		},
-		set: &IPSet{
+		set: IPSet{
 			name: "TROIS",
 		},
 		addCombinedOutputLog: [][]string{
@@ -305,7 +305,7 @@ var testCases = []struct {
 			SetType:  HashIPPortNet,
 			Net:      "10.20.30.0/24",
 		},
-		set: &IPSet{
+		set: IPSet{
 			name: "QUATRE",
 		},
 		addCombinedOutputLog: [][]string{
@@ -322,7 +322,7 @@ var testCases = []struct {
 			SetType:  HashIPPortNet,
 			Net:      "10.20.40.0/24",
 		},
-		set: &IPSet{
+		set: IPSet{
 			name: "CINQ",
 		},
 		addCombinedOutputLog: [][]string{
@@ -337,7 +337,7 @@ var testCases = []struct {
 			Protocol: ProtocolTCP,
 			SetType:  BitmapPort,
 		},
-		set: &IPSet{
+		set: IPSet{
 			name: "SIX",
 		},
 		addCombinedOutputLog: [][]string{
@@ -353,7 +353,7 @@ var testCases = []struct {
 			Protocol: ProtocolSCTP,
 			SetType:  HashIPPort,
 		},
-		set: &IPSet{
+		set: IPSet{
 			name: "SETTE",
 		},
 		addCombinedOutputLog: [][]string{
@@ -897,12 +897,12 @@ func Test_validateProtocol(t *testing.T) {
 
 func TestValidateIPSet(t *testing.T) {
 	testCases := []struct {
-		ipset     *IPSet
+		ipset     IPSet
 		expectErr bool
 		desc      string
 	}{
 		{ // case[0]
-			ipset: &IPSet{
+			ipset: IPSet{
 				name:       "test",
 				setType:    HashIPPort,
 				hashFamily: ProtocolFamilyIPV4,
@@ -913,7 +913,7 @@ func TestValidateIPSet(t *testing.T) {
 			desc:      "No Port range",
 		},
 		{ // case[1]
-			ipset: &IPSet{
+			ipset: IPSet{
 				name:       "SET",
 				setType:    BitmapPort,
 				hashFamily: ProtocolFamilyIPV6,
@@ -925,7 +925,7 @@ func TestValidateIPSet(t *testing.T) {
 			desc:      "control case",
 		},
 		{ // case[2]
-			ipset: &IPSet{
+			ipset: IPSet{
 				name:       "foo",
 				setType:    BitmapPort,
 				hashFamily: ProtocolFamilyIPV6,
@@ -936,7 +936,7 @@ func TestValidateIPSet(t *testing.T) {
 			desc:      "should specify right port range for bitmap type set",
 		},
 		{ // case[3]
-			ipset: &IPSet{
+			ipset: IPSet{
 				name:       "bar",
 				setType:    HashIPPort,
 				hashFamily: ProtocolFamilyIPV6,
@@ -947,7 +947,7 @@ func TestValidateIPSet(t *testing.T) {
 			desc:      "wrong hash size number",
 		},
 		{ // case[4]
-			ipset: &IPSet{
+			ipset: IPSet{
 				name:       "baz",
 				setType:    HashIPPort,
 				hashFamily: ProtocolFamilyIPV6,
@@ -958,7 +958,7 @@ func TestValidateIPSet(t *testing.T) {
 			desc:      "wrong hash max elem number",
 		},
 		{ // case[5]
-			ipset: &IPSet{
+			ipset: IPSet{
 				name:       "baz",
 				setType:    HashIPPortNet,
 				hashFamily: "ip",
@@ -969,7 +969,7 @@ func TestValidateIPSet(t *testing.T) {
 			desc:      "wrong protocol",
 		},
 		{ // case[6]
-			ipset: &IPSet{
+			ipset: IPSet{
 				name:       "foo-bar",
 				setType:    "xxx",
 				hashFamily: ProtocolFamilyIPV4,
@@ -994,15 +994,15 @@ func TestValidateIPSet(t *testing.T) {
 func Test_setIPSetDefaults(t *testing.T) {
 	testCases := []struct {
 		name   string
-		set    *IPSet
-		expect *IPSet
+		set    IPSet
+		expect IPSet
 	}{
 		{
 			name: "test all the IPSet fields not present",
-			set: &IPSet{
+			set: IPSet{
 				name: "test1",
 			},
-			expect: &IPSet{
+			expect: IPSet{
 				name:       "test1",
 				setType:    HashIPPort,
 				hashFamily: ProtocolFamilyIPV4,
@@ -1013,7 +1013,7 @@ func Test_setIPSetDefaults(t *testing.T) {
 		},
 		{
 			name: "test all the IPSet fields present",
-			set: &IPSet{
+			set: IPSet{
 				name:       "test2",
 				setType:    BitmapPort,
 				hashFamily: ProtocolFamilyIPV6,
@@ -1021,7 +1021,7 @@ func Test_setIPSetDefaults(t *testing.T) {
 				maxElem:    2048,
 				portRange:  DefaultPortRange,
 			},
-			expect: &IPSet{
+			expect: IPSet{
 				name:       "test2",
 				setType:    BitmapPort,
 				hashFamily: ProtocolFamilyIPV6,
@@ -1032,13 +1032,13 @@ func Test_setIPSetDefaults(t *testing.T) {
 		},
 		{
 			name: "test part of the IPSet fields present",
-			set: &IPSet{
+			set: IPSet{
 				name:       "test3",
 				setType:    BitmapPort,
 				hashFamily: ProtocolFamilyIPV6,
 				hashSize:   65535,
 			},
-			expect: &IPSet{
+			expect: IPSet{
 				name:       "test3",
 				setType:    BitmapPort,
 				hashFamily: ProtocolFamilyIPV6,
@@ -1051,7 +1051,6 @@ func Test_setIPSetDefaults(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			test.set.setIPSetDefaults()
 			if !reflect.DeepEqual(test.set, test.expect) {
 				t.Errorf("expected ipset struct: %v, got ipset struct: %v", test.expect, test.set)
 			}
@@ -1060,7 +1059,7 @@ func Test_setIPSetDefaults(t *testing.T) {
 }
 
 func Test_checkIPandProtocol(t *testing.T) {
-	testset := &IPSet{
+	testset := IPSet{
 		name:       "test1",
 		setType:    HashIPPort,
 		hashFamily: ProtocolFamilyIPV4,
@@ -1240,7 +1239,7 @@ func Test_parsePortRange(t *testing.T) {
 func TestValidateEntry(t *testing.T) {
 	testCases := []struct {
 		entry *Entry
-		set   *IPSet
+		set   IPSet
 		valid bool
 		desc  string
 	}{
@@ -1248,7 +1247,7 @@ func TestValidateEntry(t *testing.T) {
 			entry: &Entry{
 				SetType: BitmapPort,
 			},
-			set: &IPSet{
+			set: IPSet{
 				portRange: DefaultPortRange,
 			},
 			valid: true,
@@ -1259,7 +1258,7 @@ func TestValidateEntry(t *testing.T) {
 				SetType: BitmapPort,
 				Port:    0,
 			},
-			set: &IPSet{
+			set: IPSet{
 				portRange: DefaultPortRange,
 			},
 			valid: true,
@@ -1278,7 +1277,7 @@ func TestValidateEntry(t *testing.T) {
 				SetType: BitmapPort,
 				Port:    1080,
 			},
-			set: &IPSet{
+			set: IPSet{
 				name:      "baz",
 				portRange: DefaultPortRange,
 			},
@@ -1290,7 +1289,7 @@ func TestValidateEntry(t *testing.T) {
 				SetType: BitmapPort,
 				Port:    1080,
 			},
-			set: &IPSet{
+			set: IPSet{
 				name:      "foo",
 				portRange: "0-1079",
 			},
@@ -1304,7 +1303,7 @@ func TestValidateEntry(t *testing.T) {
 				Protocol: ProtocolTCP,
 				Port:     8080,
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "bar",
 			},
 			valid: true,
@@ -1316,7 +1315,7 @@ func TestValidateEntry(t *testing.T) {
 				Protocol: ProtocolUDP,
 				Port:     0,
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "bar",
 			},
 			valid: true,
@@ -1328,7 +1327,7 @@ func TestValidateEntry(t *testing.T) {
 				Protocol: ProtocolTCP,
 				Port:     1111,
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "ipv6",
 			},
 			valid: true,
@@ -1340,7 +1339,7 @@ func TestValidateEntry(t *testing.T) {
 				Protocol: ProtocolTCP,
 				Port:     1234,
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "empty-ip",
 			},
 			valid: false,
@@ -1352,7 +1351,7 @@ func TestValidateEntry(t *testing.T) {
 				Protocol: ProtocolTCP,
 				Port:     8900,
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "bad-ip",
 			},
 			valid: false,
@@ -1364,7 +1363,7 @@ func TestValidateEntry(t *testing.T) {
 				Protocol: "",
 				Port:     8090,
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "empty-protocol",
 			},
 			valid: true,
@@ -1376,7 +1375,7 @@ func TestValidateEntry(t *testing.T) {
 				Protocol: "ICMP",
 				Port:     8090,
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "unsupported-protocol",
 			},
 			valid: false,
@@ -1388,7 +1387,7 @@ func TestValidateEntry(t *testing.T) {
 				Protocol: "ICMP",
 				Port:     -1,
 			},
-			set: &IPSet{
+			set: IPSet{
 				// TODO: set name string with white space?
 				name: "negative-port-number",
 			},
@@ -1402,7 +1401,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     53,
 				IP2:      "10.20.30.40",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "LOOP-BACK",
 			},
 			valid: true,
@@ -1415,7 +1414,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     53,
 				IP2:      "",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "empty IP2",
 			},
 			valid: false,
@@ -1428,7 +1427,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     53,
 				IP2:      "foo",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "invalid IP2",
 			},
 			valid: false,
@@ -1441,7 +1440,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     0,
 				IP2:      "1.2.3.4",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "zero port",
 			},
 			valid: true,
@@ -1454,7 +1453,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     10000,
 				IP2:      "1::4",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "IPV6",
 				// TODO: check set's hash family
 			},
@@ -1468,7 +1467,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     1234,
 				IP2:      "1.2.3.4",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "empty-ip",
 			},
 			valid: false,
@@ -1481,7 +1480,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     8900,
 				IP2:      "10.20.30.41",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "bad-ip",
 			},
 			valid: false,
@@ -1494,7 +1493,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     8090,
 				IP2:      "10.20.30.41",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "sctp",
 			},
 			valid: true,
@@ -1507,7 +1506,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     -1,
 				IP2:      "100.200.30.41",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "negative-port-number",
 			},
 			valid: false,
@@ -1520,7 +1519,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     53,
 				Net:      "10.20.30.0/24",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "abc",
 			},
 			valid: true,
@@ -1533,7 +1532,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     1122,
 				Net:      "",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "empty Net",
 			},
 			valid: false,
@@ -1546,7 +1545,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     8080,
 				Net:      "x-y-z-w",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "invalid Net",
 			},
 			valid: false,
@@ -1559,7 +1558,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     0,
 				Net:      "10.1.0.0/16",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "zero port",
 			},
 			valid: true,
@@ -1572,7 +1571,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     80,
 				Net:      "2001:db8::/32",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "IPV6",
 				// TODO: check set's hash family
 			},
@@ -1586,7 +1585,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     1234,
 				Net:      "1.2.3.4/22",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "empty-ip",
 			},
 			valid: false,
@@ -1599,7 +1598,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     8900,
 				Net:      "10.20.30.41/31",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "bad-ip",
 			},
 			valid: false,
@@ -1612,7 +1611,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     8090,
 				IP2:      "10.20.30.0/10",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "unsupported-protocol",
 			},
 			valid: false,
@@ -1625,7 +1624,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     -1,
 				IP2:      "100.200.30.0/12",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "negative-port-number",
 			},
 			valid: false,
@@ -1638,7 +1637,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     53,
 				Net:      "192.168.3.0/0",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "net mask boundary 0",
 			},
 			valid: true,
@@ -1651,7 +1650,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     53,
 				Net:      "192.168.3.0/32",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "net mask boundary 32",
 			},
 			valid: true,
@@ -1664,7 +1663,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     53,
 				Net:      "192.168.3.1/33",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "invalid net mask",
 			},
 			valid: false,
@@ -1677,7 +1676,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     53,
 				Net:      "192.168.3.1/-1",
 			},
-			set: &IPSet{
+			set: IPSet{
 				name: "invalid net mask",
 			},
 			valid: false,

--- a/pkg/util/ipset/ipset_test.go
+++ b/pkg/util/ipset/ipset_test.go
@@ -171,9 +171,9 @@ func TestDestroyAllSets(t *testing.T) {
 
 func TestCreateSet(t *testing.T) {
 	testSet := IPSet{
-		Name:       "FOOBAR",
-		SetType:    HashIPPort,
-		HashFamily: ProtocolFamilyIPV4,
+		name:       "FOOBAR",
+		setType:    HashIPPort,
+		hashFamily: ProtocolFamilyIPV4,
 	}
 
 	fcmd := fakeexec.FakeCmd{
@@ -239,7 +239,7 @@ var testCases = []struct {
 			SetType:  HashIPPort,
 		},
 		set: &IPSet{
-			Name: "ZERO",
+			name: "ZERO",
 		},
 		addCombinedOutputLog: [][]string{
 			{"ipset", "add", "ZERO", "192.168.1.1,udp:53"},
@@ -255,7 +255,7 @@ var testCases = []struct {
 			SetType:  HashIPPort,
 		},
 		set: &IPSet{
-			Name: "UN",
+			name: "UN",
 		},
 		addCombinedOutputLog: [][]string{
 			{"ipset", "add", "UN", "192.168.1.2,tcp:80"},
@@ -272,7 +272,7 @@ var testCases = []struct {
 			IP2:      "10.20.30.1",
 		},
 		set: &IPSet{
-			Name: "DEUX",
+			name: "DEUX",
 		},
 		addCombinedOutputLog: [][]string{
 			{"ipset", "add", "DEUX", "192.168.1.3,udp:53,10.20.30.1"},
@@ -289,7 +289,7 @@ var testCases = []struct {
 			IP2:      "10.20.30.2",
 		},
 		set: &IPSet{
-			Name: "TROIS",
+			name: "TROIS",
 		},
 		addCombinedOutputLog: [][]string{
 			{"ipset", "add", "TROIS", "192.168.1.4,tcp:80,10.20.30.2"},
@@ -306,7 +306,7 @@ var testCases = []struct {
 			Net:      "10.20.30.0/24",
 		},
 		set: &IPSet{
-			Name: "QUATRE",
+			name: "QUATRE",
 		},
 		addCombinedOutputLog: [][]string{
 			{"ipset", "add", "QUATRE", "192.168.1.5,udp:53,10.20.30.0/24"},
@@ -323,7 +323,7 @@ var testCases = []struct {
 			Net:      "10.20.40.0/24",
 		},
 		set: &IPSet{
-			Name: "CINQ",
+			name: "CINQ",
 		},
 		addCombinedOutputLog: [][]string{
 			{"ipset", "add", "CINQ", "192.168.1.6,tcp:80,10.20.40.0/24"},
@@ -338,7 +338,7 @@ var testCases = []struct {
 			SetType:  BitmapPort,
 		},
 		set: &IPSet{
-			Name: "SIX",
+			name: "SIX",
 		},
 		addCombinedOutputLog: [][]string{
 			{"ipset", "add", "SIX", "80"},
@@ -354,7 +354,7 @@ var testCases = []struct {
 			SetType:  HashIPPort,
 		},
 		set: &IPSet{
-			Name: "SETTE",
+			name: "SETTE",
 		},
 		addCombinedOutputLog: [][]string{
 			{"ipset", "add", "SETTE", "192.168.1.2,sctp:80"},
@@ -436,7 +436,7 @@ func TestDelEntry(t *testing.T) {
 		}
 		runner := New(&fexec)
 
-		err := runner.DelEntry(testCases[i].entry.String(), testCases[i].set.Name)
+		err := runner.DelEntry(testCases[i].entry.String(), testCases[i].set.Name())
 		if err != nil {
 			t.Errorf("expected success, got %v", err)
 		}
@@ -446,7 +446,7 @@ func TestDelEntry(t *testing.T) {
 		if !sets.NewString(fcmd.CombinedOutputLog[0]...).HasAll(testCases[i].delCombinedOutputLog...) {
 			t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[0])
 		}
-		err = runner.DelEntry(testCases[i].entry.String(), testCases[i].set.Name)
+		err = runner.DelEntry(testCases[i].entry.String(), testCases[i].set.Name())
 		if err == nil {
 			t.Errorf("expected failure, got nil")
 		}
@@ -551,7 +551,7 @@ func TestTestEntryIPv6(t *testing.T) {
 
 func TestListEntries(t *testing.T) {
 
-	output := `Name: foobar
+	output := `name: foobar
 Type: hash:ip,port
 Revision: 2
 Header: family inet hashsize 1024 maxelem 65536
@@ -561,7 +561,7 @@ Members:
 192.168.1.2,tcp:8080
 192.168.1.1,udp:53`
 
-	emptyOutput := `Name: KUBE-NODE-PORT
+	emptyOutput := `name: KUBE-NODE-PORT
 Type: bitmap:port
 Revision: 1
 Header: range 0-65535
@@ -903,78 +903,78 @@ func TestValidateIPSet(t *testing.T) {
 	}{
 		{ // case[0]
 			ipset: &IPSet{
-				Name:       "test",
-				SetType:    HashIPPort,
-				HashFamily: ProtocolFamilyIPV4,
-				HashSize:   1024,
-				MaxElem:    1024,
+				name:       "test",
+				setType:    HashIPPort,
+				hashFamily: ProtocolFamilyIPV4,
+				hashSize:   1024,
+				maxElem:    1024,
 			},
 			expectErr: false,
 			desc:      "No Port range",
 		},
 		{ // case[1]
 			ipset: &IPSet{
-				Name:       "SET",
-				SetType:    BitmapPort,
-				HashFamily: ProtocolFamilyIPV6,
-				HashSize:   65535,
-				MaxElem:    2048,
-				PortRange:  DefaultPortRange,
+				name:       "SET",
+				setType:    BitmapPort,
+				hashFamily: ProtocolFamilyIPV6,
+				hashSize:   65535,
+				maxElem:    2048,
+				portRange:  DefaultPortRange,
 			},
 			expectErr: false,
 			desc:      "control case",
 		},
 		{ // case[2]
 			ipset: &IPSet{
-				Name:       "foo",
-				SetType:    BitmapPort,
-				HashFamily: ProtocolFamilyIPV6,
-				HashSize:   65535,
-				MaxElem:    2048,
+				name:       "foo",
+				setType:    BitmapPort,
+				hashFamily: ProtocolFamilyIPV6,
+				hashSize:   65535,
+				maxElem:    2048,
 			},
 			expectErr: true,
 			desc:      "should specify right port range for bitmap type set",
 		},
 		{ // case[3]
 			ipset: &IPSet{
-				Name:       "bar",
-				SetType:    HashIPPort,
-				HashFamily: ProtocolFamilyIPV6,
-				HashSize:   0,
-				MaxElem:    2048,
+				name:       "bar",
+				setType:    HashIPPort,
+				hashFamily: ProtocolFamilyIPV6,
+				hashSize:   0,
+				maxElem:    2048,
 			},
 			expectErr: true,
 			desc:      "wrong hash size number",
 		},
 		{ // case[4]
 			ipset: &IPSet{
-				Name:       "baz",
-				SetType:    HashIPPort,
-				HashFamily: ProtocolFamilyIPV6,
-				HashSize:   1024,
-				MaxElem:    -1,
+				name:       "baz",
+				setType:    HashIPPort,
+				hashFamily: ProtocolFamilyIPV6,
+				hashSize:   1024,
+				maxElem:    -1,
 			},
 			expectErr: true,
 			desc:      "wrong hash max elem number",
 		},
 		{ // case[5]
 			ipset: &IPSet{
-				Name:       "baz",
-				SetType:    HashIPPortNet,
-				HashFamily: "ip",
-				HashSize:   1024,
-				MaxElem:    1024,
+				name:       "baz",
+				setType:    HashIPPortNet,
+				hashFamily: "ip",
+				hashSize:   1024,
+				maxElem:    1024,
 			},
 			expectErr: true,
 			desc:      "wrong protocol",
 		},
 		{ // case[6]
 			ipset: &IPSet{
-				Name:       "foo-bar",
-				SetType:    "xxx",
-				HashFamily: ProtocolFamilyIPV4,
-				HashSize:   1024,
-				MaxElem:    1024,
+				name:       "foo-bar",
+				setType:    "xxx",
+				hashFamily: ProtocolFamilyIPV4,
+				hashSize:   1024,
+				maxElem:    1024,
 			},
 			expectErr: true,
 			desc:      "wrong set type",
@@ -1000,51 +1000,51 @@ func Test_setIPSetDefaults(t *testing.T) {
 		{
 			name: "test all the IPSet fields not present",
 			set: &IPSet{
-				Name: "test1",
+				name: "test1",
 			},
 			expect: &IPSet{
-				Name:       "test1",
-				SetType:    HashIPPort,
-				HashFamily: ProtocolFamilyIPV4,
-				HashSize:   1024,
-				MaxElem:    65536,
-				PortRange:  DefaultPortRange,
+				name:       "test1",
+				setType:    HashIPPort,
+				hashFamily: ProtocolFamilyIPV4,
+				hashSize:   1024,
+				maxElem:    65536,
+				portRange:  DefaultPortRange,
 			},
 		},
 		{
 			name: "test all the IPSet fields present",
 			set: &IPSet{
-				Name:       "test2",
-				SetType:    BitmapPort,
-				HashFamily: ProtocolFamilyIPV6,
-				HashSize:   65535,
-				MaxElem:    2048,
-				PortRange:  DefaultPortRange,
+				name:       "test2",
+				setType:    BitmapPort,
+				hashFamily: ProtocolFamilyIPV6,
+				hashSize:   65535,
+				maxElem:    2048,
+				portRange:  DefaultPortRange,
 			},
 			expect: &IPSet{
-				Name:       "test2",
-				SetType:    BitmapPort,
-				HashFamily: ProtocolFamilyIPV6,
-				HashSize:   65535,
-				MaxElem:    2048,
-				PortRange:  DefaultPortRange,
+				name:       "test2",
+				setType:    BitmapPort,
+				hashFamily: ProtocolFamilyIPV6,
+				hashSize:   65535,
+				maxElem:    2048,
+				portRange:  DefaultPortRange,
 			},
 		},
 		{
 			name: "test part of the IPSet fields present",
 			set: &IPSet{
-				Name:       "test3",
-				SetType:    BitmapPort,
-				HashFamily: ProtocolFamilyIPV6,
-				HashSize:   65535,
+				name:       "test3",
+				setType:    BitmapPort,
+				hashFamily: ProtocolFamilyIPV6,
+				hashSize:   65535,
 			},
 			expect: &IPSet{
-				Name:       "test3",
-				SetType:    BitmapPort,
-				HashFamily: ProtocolFamilyIPV6,
-				HashSize:   65535,
-				MaxElem:    65536,
-				PortRange:  DefaultPortRange,
+				name:       "test3",
+				setType:    BitmapPort,
+				hashFamily: ProtocolFamilyIPV6,
+				hashSize:   65535,
+				maxElem:    65536,
+				portRange:  DefaultPortRange,
 			},
 		},
 	}
@@ -1061,12 +1061,12 @@ func Test_setIPSetDefaults(t *testing.T) {
 
 func Test_checkIPandProtocol(t *testing.T) {
 	testset := &IPSet{
-		Name:       "test1",
-		SetType:    HashIPPort,
-		HashFamily: ProtocolFamilyIPV4,
-		HashSize:   1024,
-		MaxElem:    65536,
-		PortRange:  DefaultPortRange,
+		name:       "test1",
+		setType:    HashIPPort,
+		hashFamily: ProtocolFamilyIPV4,
+		hashSize:   1024,
+		maxElem:    65536,
+		portRange:  DefaultPortRange,
 	}
 
 	testCases := []struct {
@@ -1249,7 +1249,7 @@ func TestValidateEntry(t *testing.T) {
 				SetType: BitmapPort,
 			},
 			set: &IPSet{
-				PortRange: DefaultPortRange,
+				portRange: DefaultPortRange,
 			},
 			valid: true,
 			desc:  "port number can be empty, default is 0. And port number is in the range of its ipset's port range",
@@ -1260,7 +1260,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:    0,
 			},
 			set: &IPSet{
-				PortRange: DefaultPortRange,
+				portRange: DefaultPortRange,
 			},
 			valid: true,
 			desc:  "port number can be 0. And port number is in the range of its ipset's port range",
@@ -1279,8 +1279,8 @@ func TestValidateEntry(t *testing.T) {
 				Port:    1080,
 			},
 			set: &IPSet{
-				Name:      "baz",
-				PortRange: DefaultPortRange,
+				name:      "baz",
+				portRange: DefaultPortRange,
 			},
 			desc:  "port number is in the range of its ipset's port range",
 			valid: true,
@@ -1291,8 +1291,8 @@ func TestValidateEntry(t *testing.T) {
 				Port:    1080,
 			},
 			set: &IPSet{
-				Name:      "foo",
-				PortRange: "0-1079",
+				name:      "foo",
+				portRange: "0-1079",
 			},
 			desc:  "port number is NOT in the range of its ipset's port range",
 			valid: false,
@@ -1305,7 +1305,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     8080,
 			},
 			set: &IPSet{
-				Name: "bar",
+				name: "bar",
 			},
 			valid: true,
 		},
@@ -1317,7 +1317,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     0,
 			},
 			set: &IPSet{
-				Name: "bar",
+				name: "bar",
 			},
 			valid: true,
 		},
@@ -1329,7 +1329,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     1111,
 			},
 			set: &IPSet{
-				Name: "ipv6",
+				name: "ipv6",
 			},
 			valid: true,
 		},
@@ -1341,7 +1341,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     1234,
 			},
 			set: &IPSet{
-				Name: "empty-ip",
+				name: "empty-ip",
 			},
 			valid: false,
 		},
@@ -1353,7 +1353,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     8900,
 			},
 			set: &IPSet{
-				Name: "bad-ip",
+				name: "bad-ip",
 			},
 			valid: false,
 		},
@@ -1365,7 +1365,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     8090,
 			},
 			set: &IPSet{
-				Name: "empty-protocol",
+				name: "empty-protocol",
 			},
 			valid: true,
 		},
@@ -1377,7 +1377,7 @@ func TestValidateEntry(t *testing.T) {
 				Port:     8090,
 			},
 			set: &IPSet{
-				Name: "unsupported-protocol",
+				name: "unsupported-protocol",
 			},
 			valid: false,
 		},
@@ -1390,7 +1390,7 @@ func TestValidateEntry(t *testing.T) {
 			},
 			set: &IPSet{
 				// TODO: set name string with white space?
-				Name: "negative-port-number",
+				name: "negative-port-number",
 			},
 			valid: false,
 		},
@@ -1403,7 +1403,7 @@ func TestValidateEntry(t *testing.T) {
 				IP2:      "10.20.30.40",
 			},
 			set: &IPSet{
-				Name: "LOOP-BACK",
+				name: "LOOP-BACK",
 			},
 			valid: true,
 		},
@@ -1416,7 +1416,7 @@ func TestValidateEntry(t *testing.T) {
 				IP2:      "",
 			},
 			set: &IPSet{
-				Name: "empty IP2",
+				name: "empty IP2",
 			},
 			valid: false,
 		},
@@ -1429,7 +1429,7 @@ func TestValidateEntry(t *testing.T) {
 				IP2:      "foo",
 			},
 			set: &IPSet{
-				Name: "invalid IP2",
+				name: "invalid IP2",
 			},
 			valid: false,
 		},
@@ -1442,7 +1442,7 @@ func TestValidateEntry(t *testing.T) {
 				IP2:      "1.2.3.4",
 			},
 			set: &IPSet{
-				Name: "zero port",
+				name: "zero port",
 			},
 			valid: true,
 		},
@@ -1455,7 +1455,7 @@ func TestValidateEntry(t *testing.T) {
 				IP2:      "1::4",
 			},
 			set: &IPSet{
-				Name: "IPV6",
+				name: "IPV6",
 				// TODO: check set's hash family
 			},
 			valid: true,
@@ -1469,7 +1469,7 @@ func TestValidateEntry(t *testing.T) {
 				IP2:      "1.2.3.4",
 			},
 			set: &IPSet{
-				Name: "empty-ip",
+				name: "empty-ip",
 			},
 			valid: false,
 		},
@@ -1482,7 +1482,7 @@ func TestValidateEntry(t *testing.T) {
 				IP2:      "10.20.30.41",
 			},
 			set: &IPSet{
-				Name: "bad-ip",
+				name: "bad-ip",
 			},
 			valid: false,
 		},
@@ -1495,7 +1495,7 @@ func TestValidateEntry(t *testing.T) {
 				IP2:      "10.20.30.41",
 			},
 			set: &IPSet{
-				Name: "sctp",
+				name: "sctp",
 			},
 			valid: true,
 		},
@@ -1508,7 +1508,7 @@ func TestValidateEntry(t *testing.T) {
 				IP2:      "100.200.30.41",
 			},
 			set: &IPSet{
-				Name: "negative-port-number",
+				name: "negative-port-number",
 			},
 			valid: false,
 		},
@@ -1521,7 +1521,7 @@ func TestValidateEntry(t *testing.T) {
 				Net:      "10.20.30.0/24",
 			},
 			set: &IPSet{
-				Name: "abc",
+				name: "abc",
 			},
 			valid: true,
 		},
@@ -1534,7 +1534,7 @@ func TestValidateEntry(t *testing.T) {
 				Net:      "",
 			},
 			set: &IPSet{
-				Name: "empty Net",
+				name: "empty Net",
 			},
 			valid: false,
 		},
@@ -1547,7 +1547,7 @@ func TestValidateEntry(t *testing.T) {
 				Net:      "x-y-z-w",
 			},
 			set: &IPSet{
-				Name: "invalid Net",
+				name: "invalid Net",
 			},
 			valid: false,
 		},
@@ -1560,7 +1560,7 @@ func TestValidateEntry(t *testing.T) {
 				Net:      "10.1.0.0/16",
 			},
 			set: &IPSet{
-				Name: "zero port",
+				name: "zero port",
 			},
 			valid: true,
 		},
@@ -1573,7 +1573,7 @@ func TestValidateEntry(t *testing.T) {
 				Net:      "2001:db8::/32",
 			},
 			set: &IPSet{
-				Name: "IPV6",
+				name: "IPV6",
 				// TODO: check set's hash family
 			},
 			valid: true,
@@ -1587,7 +1587,7 @@ func TestValidateEntry(t *testing.T) {
 				Net:      "1.2.3.4/22",
 			},
 			set: &IPSet{
-				Name: "empty-ip",
+				name: "empty-ip",
 			},
 			valid: false,
 		},
@@ -1600,7 +1600,7 @@ func TestValidateEntry(t *testing.T) {
 				Net:      "10.20.30.41/31",
 			},
 			set: &IPSet{
-				Name: "bad-ip",
+				name: "bad-ip",
 			},
 			valid: false,
 		},
@@ -1613,7 +1613,7 @@ func TestValidateEntry(t *testing.T) {
 				IP2:      "10.20.30.0/10",
 			},
 			set: &IPSet{
-				Name: "unsupported-protocol",
+				name: "unsupported-protocol",
 			},
 			valid: false,
 		},
@@ -1626,7 +1626,7 @@ func TestValidateEntry(t *testing.T) {
 				IP2:      "100.200.30.0/12",
 			},
 			set: &IPSet{
-				Name: "negative-port-number",
+				name: "negative-port-number",
 			},
 			valid: false,
 		},
@@ -1639,7 +1639,7 @@ func TestValidateEntry(t *testing.T) {
 				Net:      "192.168.3.0/0",
 			},
 			set: &IPSet{
-				Name: "net mask boundary 0",
+				name: "net mask boundary 0",
 			},
 			valid: true,
 		},
@@ -1652,7 +1652,7 @@ func TestValidateEntry(t *testing.T) {
 				Net:      "192.168.3.0/32",
 			},
 			set: &IPSet{
-				Name: "net mask boundary 32",
+				name: "net mask boundary 32",
 			},
 			valid: true,
 		},
@@ -1665,7 +1665,7 @@ func TestValidateEntry(t *testing.T) {
 				Net:      "192.168.3.1/33",
 			},
 			set: &IPSet{
-				Name: "invalid net mask",
+				name: "invalid net mask",
 			},
 			valid: false,
 		},
@@ -1678,7 +1678,7 @@ func TestValidateEntry(t *testing.T) {
 				Net:      "192.168.3.1/-1",
 			},
 			set: &IPSet{
-				Name: "invalid net mask",
+				name: "invalid net mask",
 			},
 			valid: false,
 		},

--- a/pkg/util/ipset/testing/fake.go
+++ b/pkg/util/ipset/testing/fake.go
@@ -28,7 +28,7 @@ type FakeIPSet struct {
 	// version of ipset util
 	Version string
 	// The key of Sets map is the ip set name
-	Sets map[string]*ipset.IPSet
+	Sets map[string]ipset.IPSet
 	// The key of Entries map is the ip set name where the entries exists
 	Entries map[string]sets.String
 }
@@ -37,7 +37,7 @@ type FakeIPSet struct {
 func NewFake(version string) *FakeIPSet {
 	return &FakeIPSet{
 		Version: version,
-		Sets:    make(map[string]*ipset.IPSet),
+		Sets:    make(map[string]ipset.IPSet),
 		Entries: make(map[string]sets.String),
 	}
 }
@@ -78,8 +78,8 @@ func (f *FakeIPSet) DestroyAllSets() error {
 }
 
 // CreateSet is part of interface.
-func (f *FakeIPSet) CreateSet(set *ipset.IPSet, ignoreExistErr bool) error {
-	if f.Sets[set.Name()] != nil {
+func (f *FakeIPSet) CreateSet(set ipset.IPSet, ignoreExistErr bool) error {
+	if _, ok := f.Sets[set.Name()]; !ok {
 		if !ignoreExistErr {
 			// already exists
 			return fmt.Errorf("Set cannot be created: set with the same name already exists")
@@ -93,7 +93,7 @@ func (f *FakeIPSet) CreateSet(set *ipset.IPSet, ignoreExistErr bool) error {
 }
 
 // AddEntry is part of interface.
-func (f *FakeIPSet) AddEntry(entry string, set *ipset.IPSet, ignoreExistErr bool) error {
+func (f *FakeIPSet) AddEntry(entry string, set ipset.IPSet, ignoreExistErr bool) error {
 	if f.Entries[set.Name()].Has(entry) {
 		if !ignoreExistErr {
 			// already exists

--- a/pkg/util/ipset/testing/fake.go
+++ b/pkg/util/ipset/testing/fake.go
@@ -79,29 +79,29 @@ func (f *FakeIPSet) DestroyAllSets() error {
 
 // CreateSet is part of interface.
 func (f *FakeIPSet) CreateSet(set *ipset.IPSet, ignoreExistErr bool) error {
-	if f.Sets[set.Name] != nil {
+	if f.Sets[set.Name()] != nil {
 		if !ignoreExistErr {
 			// already exists
 			return fmt.Errorf("Set cannot be created: set with the same name already exists")
 		}
 		return nil
 	}
-	f.Sets[set.Name] = set
+	f.Sets[set.Name()] = set
 	// initialize entry map
-	f.Entries[set.Name] = sets.NewString()
+	f.Entries[set.Name()] = sets.NewString()
 	return nil
 }
 
 // AddEntry is part of interface.
 func (f *FakeIPSet) AddEntry(entry string, set *ipset.IPSet, ignoreExistErr bool) error {
-	if f.Entries[set.Name].Has(entry) {
+	if f.Entries[set.Name()].Has(entry) {
 		if !ignoreExistErr {
 			// already exists
 			return fmt.Errorf("Element cannot be added to the set: it's already added")
 		}
 		return nil
 	}
-	f.Entries[set.Name].Insert(entry)
+	f.Entries[set.Name()].Insert(entry)
 	return nil
 }
 

--- a/pkg/util/ipset/testing/fake_test.go
+++ b/pkg/util/ipset/testing/fake_test.go
@@ -128,7 +128,7 @@ func TestSetEntry(t *testing.T) {
 	if err := fake.DestroySet(set.Name()); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if fake.Sets[set.Name()] != nil {
+	if _, ok := fake.Sets[set.Name()]; ok {
 		t.Errorf("Unexpected set: %v", fake.Sets[set.Name()])
 	}
 	if fake.Entries[set.Name()] != nil {
@@ -147,7 +147,7 @@ func TestSetEntry(t *testing.T) {
 	}
 }
 
-func newTestIPSet(name string, setType ipset.Type, hashFamily string) *ipset.IPSet {
+func newTestIPSet(name string, setType ipset.Type, hashFamily string) ipset.IPSet {
 	return ipset.NewIPSet(name, setType, hashFamily, 1024, 65536, ipset.DefaultPortRange, "")
 }
 

--- a/pkg/util/ipset/testing/fake_test.go
+++ b/pkg/util/ipset/testing/fake_test.go
@@ -49,7 +49,7 @@ func TestSetEntry(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	entries, err := fake.ListEntries(set.Name)
+	entries, err := fake.ListEntries(set.Name())
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestSetEntry(t *testing.T) {
 	}
 
 	// test entries
-	found, err := fake.TestEntry("192.168.1.1,tcp:8080", set.Name)
+	found, err := fake.TestEntry("192.168.1.1,tcp:8080", set.Name())
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestSetEntry(t *testing.T) {
 		t.Errorf("Unexpected entry 192.168.1.1,tcp:8080 not found")
 	}
 
-	found, err = fake.TestEntry("192.168.1.2,tcp:8081", set.Name)
+	found, err = fake.TestEntry("192.168.1.2,tcp:8081", set.Name())
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -79,10 +79,10 @@ func TestSetEntry(t *testing.T) {
 	}
 
 	// delete entry from a given set
-	if err := fake.DelEntry("192.168.1.1,tcp:8080", set.Name); err != nil {
+	if err := fake.DelEntry("192.168.1.1,tcp:8080", set.Name()); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	entries, err = fake.ListEntries(set.Name)
+	entries, err = fake.ListEntries(set.Name())
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -95,10 +95,10 @@ func TestSetEntry(t *testing.T) {
 	}
 
 	// Flush set
-	if err := fake.FlushSet(set.Name); err != nil {
+	if err := fake.FlushSet(set.Name()); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	entries, err = fake.ListEntries(set.Name)
+	entries, err = fake.ListEntries(set.Name())
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -125,14 +125,14 @@ func TestSetEntry(t *testing.T) {
 	}
 
 	// Destroy a given set
-	if err := fake.DestroySet(set.Name); err != nil {
+	if err := fake.DestroySet(set.Name()); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if fake.Sets[set.Name] != nil {
-		t.Errorf("Unexpected set: %v", fake.Sets[set.Name])
+	if fake.Sets[set.Name()] != nil {
+		t.Errorf("Unexpected set: %v", fake.Sets[set.Name()])
 	}
-	if fake.Entries[set.Name] != nil {
-		t.Errorf("Unexpected entries: %v", fake.Entries[set.Name])
+	if fake.Entries[set.Name()] != nil {
+		t.Errorf("Unexpected entries: %v", fake.Entries[set.Name()])
 	}
 
 	// Destroy all sets

--- a/pkg/util/ipset/testing/fake_test.go
+++ b/pkg/util/ipset/testing/fake_test.go
@@ -35,11 +35,7 @@ func TestSetEntry(t *testing.T) {
 		t.Errorf("Unexpected version mismatch, expected: %s, got: %s", testVersion, version)
 	}
 	// create a set
-	set := &ipset.IPSet{
-		Name:       "foo",
-		SetType:    ipset.HashIPPort,
-		HashFamily: ipset.ProtocolFamilyIPV4,
-	}
+	set := newTestIPSet("foo", ipset.HashIPPort, ipset.ProtocolFamilyIPV4)
 	if err := fake.CreateSet(set, true); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -111,11 +107,7 @@ func TestSetEntry(t *testing.T) {
 	}
 
 	// create another set
-	set2 := &ipset.IPSet{
-		Name:       "bar",
-		SetType:    ipset.HashIPPortIP,
-		HashFamily: ipset.ProtocolFamilyIPV6,
-	}
+	set2 := newTestIPSet("bar", ipset.HashIPPort, ipset.ProtocolFamilyIPV6)
 	if err := fake.CreateSet(set2, true); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -153,6 +145,10 @@ func TestSetEntry(t *testing.T) {
 	if len(fake.Entries) != 0 {
 		t.Errorf("Expected 0 entries, got %d, entries: %v", len(fake.Entries), fake.Entries)
 	}
+}
+
+func newTestIPSet(name string, setType ipset.Type, hashFamily string) *ipset.IPSet {
+	return ipset.NewIPSet(name, setType, hashFamily, 1024, 65536, ipset.DefaultPortRange, "")
 }
 
 // TODO: Test ignoreExistErr=false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The pkg/util/ipset.IPSet API is very weak on "hiding"

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #109034
[Comment](https://github.com/kubernetes/kubernetes/pull/108946#discussion_r835426136)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/kubernetes/pull/108946#discussion_r835426136
```
