### PR TITLE
kube-scheduler: Adjust the structure type to improve the efficiency

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -49,7 +49,7 @@ type NodeScore struct {
 }
 
 // PluginToNodeScores declares a map from plugin name to its NodeScoreList.
-type PluginToNodeScores map[string]NodeScoreList
+type PluginToNodeScores map[ScorePlugin]NodeScoreList
 
 // NodeToStatusMap declares map from node name to its status.
 type NodeToStatusMap map[string]*Status

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -902,16 +902,16 @@ func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state *framework.Cy
 	defer func() {
 		metrics.FrameworkExtensionPointDuration.WithLabelValues(score, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
-	pluginToNodeScores := make(framework.PluginToNodeScores, len(f.scorePlugins))
+	pluginToNodeScores := make(map[framework.ScorePlugin]framework.NodeScoreList, len(f.scorePlugins))
 	for _, pl := range f.scorePlugins {
-		pluginToNodeScores[pl.Name()] = make(framework.NodeScoreList, len(nodes))
+		pluginToNodeScores[pl] = make(framework.NodeScoreList, len(nodes))
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	errCh := parallelize.NewErrorChannel()
 
 	// Run Score method for each node in parallel.
 	f.Parallelizer().Until(ctx, len(nodes), func(index int) {
-		for _, pl := range f.scorePlugins {
+		for pl, nl := range pluginToNodeScores {
 			nodeName := nodes[index].Name
 			s, status := f.runScorePlugin(ctx, pl, state, pod, nodeName)
 			if !status.IsSuccess() {
@@ -919,7 +919,7 @@ func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state *framework.Cy
 				errCh.SendErrorWithCancel(err, cancel)
 				return
 			}
-			pluginToNodeScores[pl.Name()][index] = framework.NodeScore{
+			nl[index] = framework.NodeScore{
 				Name:  nodeName,
 				Score: s,
 			}
@@ -932,7 +932,7 @@ func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state *framework.Cy
 	// Run NormalizeScore method for each ScorePlugin in parallel.
 	f.Parallelizer().Until(ctx, len(f.scorePlugins), func(index int) {
 		pl := f.scorePlugins[index]
-		nodeScoreList := pluginToNodeScores[pl.Name()]
+		nodeScoreList := pluginToNodeScores[pl]
 		if pl.ScoreExtensions() == nil {
 			return
 		}
@@ -952,7 +952,7 @@ func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state *framework.Cy
 		pl := f.scorePlugins[index]
 		// Score plugins' weight has been checked when they are initialized.
 		weight := f.scorePluginWeight[pl.Name()]
-		nodeScoreList := pluginToNodeScores[pl.Name()]
+		nodeScoreList := pluginToNodeScores[pl]
 
 		for i, nodeScore := range nodeScoreList {
 			// return error if score plugin returns invalid score.

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -60,6 +60,7 @@ const (
 // TestScorePlugin only implements ScorePlugin interface.
 var _ framework.ScorePlugin = &TestScoreWithNormalizePlugin{}
 var _ framework.ScorePlugin = &TestScorePlugin{}
+var fscorePlugin1, fscoreNormalizePlugin1, fscoreNormalizePlugin2 framework.ScorePlugin
 
 func newScoreWithNormalizePlugin1(injArgs runtime.Object, f framework.Handle) (framework.Plugin, error) {
 	var inj injectedResult
@@ -1001,7 +1002,7 @@ func TestRunScorePlugins(t *testing.T) {
 			},
 			// scorePlugin1 Score returns 1, weight=1, so want=1.
 			want: framework.PluginToNodeScores{
-				scorePlugin1: {{Name: "node1", Score: 1}, {Name: "node2", Score: 1}},
+				fscorePlugin1: {{Name: "node1", Score: 1}, {Name: "node2", Score: 1}},
 			},
 		},
 		{
@@ -1018,7 +1019,7 @@ func TestRunScorePlugins(t *testing.T) {
 			},
 			// scoreWithNormalizePlugin1 Score returns 10, but NormalizeScore overrides to 5, weight=1, so want=5
 			want: framework.PluginToNodeScores{
-				scoreWithNormalizePlugin1: {{Name: "node1", Score: 5}, {Name: "node2", Score: 5}},
+				fscoreNormalizePlugin1: {{Name: "node1", Score: 5}, {Name: "node2", Score: 5}},
 			},
 		},
 		{
@@ -1048,9 +1049,9 @@ func TestRunScorePlugins(t *testing.T) {
 			// scoreWithNormalizePlugin1 Score returns 3, but NormalizeScore overrides to 4, weight=1, so want=4.
 			// scoreWithNormalizePlugin2 Score returns 4, but NormalizeScore overrides to 5, weight=2, so want=10.
 			want: framework.PluginToNodeScores{
-				scorePlugin1:              {{Name: "node1", Score: 1}, {Name: "node2", Score: 1}},
-				scoreWithNormalizePlugin1: {{Name: "node1", Score: 4}, {Name: "node2", Score: 4}},
-				scoreWithNormalizePlugin2: {{Name: "node1", Score: 10}, {Name: "node2", Score: 10}},
+				fscorePlugin1:          {{Name: "node1", Score: 1}, {Name: "node2", Score: 1}},
+				fscoreNormalizePlugin1: {{Name: "node1", Score: 4}, {Name: "node2", Score: 4}},
+				fscoreNormalizePlugin2: {{Name: "node1", Score: 10}, {Name: "node2", Score: 10}},
 			},
 		},
 		{
@@ -1155,7 +1156,7 @@ func TestRunScorePlugins(t *testing.T) {
 			},
 			// scorePlugin1 Score returns 1, weight=3, so want=3.
 			want: framework.PluginToNodeScores{
-				scorePlugin1: {{Name: "node1", Score: 3}, {Name: "node2", Score: 3}},
+				fscorePlugin1: {{Name: "node1", Score: 3}, {Name: "node2", Score: 3}},
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adjust the type of `PluginToNodeScores map[string]NodeScoreList` to `PluginToNodeScores map[ScorePlugin]NodeScoreList`, In this way, in the `RunScorePlugins` function,` plugintonodescores[pl.name()][index]` can be changed to `nl[index]`, which can improve the calculation efficiency as a whole.

After testing, according to the default number of scoring plug-ins, the time for each node to traverse all scoring plug-ins to get the total score is reduced by about 10us; When the number of cluster nodes is large, the overall optimization process time will be significantly reduced.

#### Which issue(s) this PR fixes:
Fixes #

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### SIG labels

- sig scheduling