### PR TITLE
Remove default annotations from copied storage class

### DIFF
--- a/test/e2e/storage/framework/driver_operations.go
+++ b/test/e2e/storage/framework/driver_operations.go
@@ -22,6 +22,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -57,6 +58,11 @@ func CopyStorageClass(sc *storagev1.StorageClass, ns string, suffix string) *sto
 	copy := sc.DeepCopy()
 	copy.ObjectMeta.Name = names.SimpleNameGenerator.GenerateName(ns + "-" + suffix)
 	copy.ResourceVersion = ""
+
+	// Remove the default annotation from the storage class if they exists.
+	// Multiple storage classes with this annotation will result in failure.
+	delete(copy.Annotations, util.BetaIsDefaultStorageClassAnnotation)
+	delete(copy.Annotations, util.IsDefaultStorageClassAnnotation)
 	return copy
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

kOps would like to test CSI drivers with the default StoreClass using `fromExistingStorageClass`. The storage class is copied with the is-default-storage-class annotation resulting in multiple default StorageClasses. This breaks other tests that use the default storage class should they run at the same time as the CSI driver tests.

This PR removes those annotations if they exist before copying.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
