### PR TITLE
fix:e2e test flake: Probing container should mark readiness on pods to false...

### DIFF
--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -25,12 +25,16 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/apimachinery/pkg/util/wait"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -609,13 +613,12 @@ done
 
 		// Shutdown pod. Readiness should change to false
 		podClient.Delete(context.Background(), podName, metav1.DeleteOptions{})
-		err = wait.PollImmediate(framework.Poll, f.Timeouts.PodDelete, func() (bool, error) {
-			pod, err := podClient.Get(context.Background(), podName, metav1.GetOptions{})
-			if err != nil {
-				return false, err
+		err = waitForPodStatusByInformer(f.ClientSet, f.Namespace.Name, podName, f.Timeouts.PodDelete, func(pod *v1.Pod) (bool, error) {
+			if !podutil.IsPodReady(pod) {
+				return true, nil
 			}
-			// verify the pod ready status has reported not ready
-			return !podutil.IsPodReady(pod), nil
+			framework.Logf("pod %s/%s is still ready, waiting until is not ready", pod.Namespace, pod.Name)
+			return false, nil
 		})
 		framework.ExpectNoError(err)
 	})
@@ -692,13 +695,12 @@ done
 		podClient.Delete(context.Background(), podName, metav1.DeleteOptions{})
 
 		// Wait for pod to go unready
-		err = wait.PollImmediate(framework.Poll, f.Timeouts.PodDelete, func() (bool, error) {
-			pod, err := podClient.Get(context.Background(), podName, metav1.GetOptions{})
-			if err != nil {
-				return false, err
+		err = waitForPodStatusByInformer(f.ClientSet, f.Namespace.Name, podName, f.Timeouts.PodDelete, func(pod *v1.Pod) (bool, error) {
+			if !podutil.IsPodReady(pod) {
+				return true, nil
 			}
-			// verify the pod ready status has reported not ready
-			return !podutil.IsPodReady(pod), nil
+			framework.Logf("pod %s/%s is still ready, waiting until is not ready", pod.Namespace, pod.Name)
+			return false, nil
 		})
 		framework.ExpectNoError(err)
 
@@ -720,6 +722,66 @@ done
 		}, 1*time.Minute, framework.Poll).ShouldNot(gomega.BeTrue(), "should not see liveness probes")
 	})
 })
+
+// waitForPodStatusByInformer waits pod status change by informer
+func waitForPodStatusByInformer(c clientset.Interface, podNamespace, podName string, timeout time.Duration, condition func(pod *v1.Pod) (bool, error)) error {
+	stopCh := make(chan struct{})
+	checkPodStatusFunc := func(pod *v1.Pod) {
+		if ok, _ := condition(pod); ok {
+			close(stopCh)
+		}
+	}
+	controller := newInformerWatchPod(c, podNamespace, podName, checkPodStatusFunc)
+	go controller.Run(stopCh)
+	after := time.After(timeout)
+	select {
+	case <-stopCh:
+		return nil
+	case <-after:
+		defer close(stopCh)
+		return fmt.Errorf("timeout to wait pod status ready")
+	}
+}
+
+// newInformerWatchPod creates a informer for given pod
+func newInformerWatchPod(c clientset.Interface, podNamespace, podName string, checkPodStatusFunc func(p *v1.Pod)) cache.Controller {
+	_, controller := cache.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				options.FieldSelector = fields.SelectorFromSet(fields.Set{"metadata.name": podName}).String()
+				obj, err := c.CoreV1().Pods(podNamespace).List(context.TODO(), options)
+				return runtime.Object(obj), err
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.FieldSelector = fields.SelectorFromSet(fields.Set{"metadata.name": podName}).String()
+				return c.CoreV1().Pods(podNamespace).Watch(context.TODO(), options)
+			},
+		},
+		&v1.Pod{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				p, ok := obj.(*v1.Pod)
+				if ok {
+					checkPodStatusFunc(p)
+				}
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				p, ok := newObj.(*v1.Pod)
+				if ok {
+					checkPodStatusFunc(p)
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				p, ok := obj.(*v1.Pod)
+				if ok {
+					checkPodStatusFunc(p)
+				}
+			},
+		},
+	)
+	return controller
+}
 
 // GetContainerStartedTime returns the time when the given container started and error if any
 func GetContainerStartedTime(p *v1.Pod, containerName string) (time.Time, error) {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
```
Jul 30 13:54:29.951: INFO: 1 / 1 pods in namespace 'container-probe-1329' are running and ready (20 seconds elapsed)
    Jul 30 13:54:29.951: INFO: expected 0 pod replicas in namespace 'container-probe-1329', 0 are Running and Ready.
    Jul 30 13:54:55.959: INFO: Unexpected error: 
        <*errors.StatusError | 0xc0020605a0>: {
            ErrStatus: {
                TypeMeta: {Kind: "", APIVersion: ""},
                ListMeta: {
                    SelfLink: "",
                    ResourceVersion: "",
                    Continue: "",
                    RemainingItemCount: nil,
                },
                Status: "Failure",
                Message: "pods \"probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51\" not found",
                Reason: "NotFound",
                Details: {
                    Name: "probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51",
                    Group: "",
                    Kind: "pods",
                    UID: "",
                    Causes: nil,
                    RetryAfterSeconds: 0,
                },
                Code: 404,
            },
        }
    Jul 30 13:54:55.959: FAIL: pods "probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51" not found
```

pod ready becomes false at this time
```
Jul 30 13:54:54 kind-worker kubelet[285]: I0730 13:54:54.551301     285 status_manager.go:685] "Patch status for pod" pod="container-probe-1329/probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51" patch="{\"metadata\":{\"uid\":\"59b3df81-bd8b-4860-aee5-3fd8c3e05cde\"},\"status\":{\"$setElementOrder/conditions\":[{\"type\":\"Initialized\"},{\"type\":\"Ready\"},{\"type\":\"ContainersReady\"},{\"type\":\"PodScheduled\"}],\"conditions\":[{\"lastTransitionTime\":\"2022-07-30T13:54:35Z\",\"message\":\"containers with unready status: [probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51]\",\"reason\":\"ContainersNotReady\",\"status\":\"False\",\"type\":\"Ready\"},{\"lastTransitionTime\":\"2022-07-30T13:54:35Z\",\"message\":\"containers with unready status: [probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51]\",\"reason\":\"ContainersNotReady\",\"status\":\"False\",\"type\":\"ContainersReady\"}],\"containerStatuses\":[{\"containerID\":\"containerd://f379ea23891146790e01a563034a59567494ff715eaf8bc8ab36d71c6032dba1\",\"image\":\"registry.k8s.io/e2e-test-images/agnhost:2.40\",\"imageID\":\"registry.k8s.io/e2e-test-images/agnhost@sha256:af7e3857d87770ddb40f5ea4f89b5a2709504ab1ee31f9ea4ab5823c045f2146\",\"lastState\":{},\"name\":\"probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51\",\"ready\":false,\"restartCount\":0,\"started\":false,\"state\":{\"terminated\":{\"containerID\":\"containerd://f379ea23891146790e01a563034a59567494ff715eaf8bc8ab36d71c6032dba1\",\"exitCode\":0,\"finishedAt\":\"2022-07-30T13:54:53Z\",\"reason\":\"Completed\",\"startedAt\":\"2022-07-30T13:54:13Z\"}}}]}}"
Jul 30 13:54:54 kind-worker kubelet[285]: I0730 13:54:54.551418     285 status_manager.go:694] "Status for pod updated successfully" pod="container-probe-1329/probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51" statusVersion=7 status={Phase:Running Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2022-07-30 13:54:09 +0000 UTC Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2022-07-30 13:54:35 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2022-07-30 13:54:35 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2022-07-30 13:54:09 +0000 UTC Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:fc00:f853:ccd:e793::3 PodIP:fd00:10:244:1::f0 PodIPs:[{IP:fd00:10:244:1::f0}] StartTime:2022-07-30 13:54:09 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[{Name:probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51 State:{Waiting:nil Running:nil Terminated:&ContainerStateTerminated{ExitCode:0,Signal:0,Reason:Completed,Message:,StartedAt:2022-07-30 13:54:13 +0000 UTC,FinishedAt:2022-07-30 13:54:53 +0000 UTC,ContainerID:containerd://f379ea23891146790e01a563034a59567494ff715eaf8bc8ab36d71c6032dba1,}} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:registry.k8s.io/e2e-test-images/agnhost:2.40 ImageID:registry.k8s.io/e2e-test-images/agnhost@sha256:af7e3857d87770ddb40f5ea4f89b5a2709504ab1ee31f9ea4ab5823c045f2146 ContainerID:containerd://f379ea23891146790e01a563034a59567494ff715eaf8bc8ab36d71c6032dba1 Started:0xc001b9f230}] QOSClass:BestEffort EphemeralContainerStatuses:[]}
Jul 30 13:54:54 kind-worker kubelet[285]: I0730 13:54:54.551728     285 kubelet_pods.go:955] "Pod is terminated and all resources are reclaimed" pod="container-probe-1329/probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51"
```
pod was removed
```

Jul 30 13:54:54 kind-worker kubelet[285]: I0730 13:54:54.747015     285 config.go:281] "Setting pods for source" source="api"
Jul 30 13:54:54 kind-worker kubelet[285]: I0730 13:54:54.748206     285 kubelet.go:2101] "SyncLoop DELETE" source="api" pods=[container-probe-1329/probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51]
Jul 30 13:54:54 kind-worker kubelet[285]: I0730 13:54:54.748261     285 pod_workers.go:625] "Pod is finished processing, no further updates" pod="container-probe-1329/probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51" podUID=59b3df81-bd8b-4860-aee5-3fd8c3e05cde
Jul 30 13:54:54 kind-worker kubelet[285]: I0730 13:54:54.750172     285 config.go:281] "Setting pods for source" source="api"
Jul 30 13:54:54 kind-worker kubelet[285]: I0730 13:54:54.750522     285 status_manager.go:713] "Pod fully terminated and removed from etcd" pod="container-probe-1329/probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51"
Jul 30 13:54:54 kind-worker kubelet[285]: I0730 13:54:54.751333     285 kubelet.go:2095] "SyncLoop REMOVE" source="api" pods=[container-probe-1329/probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51]
Jul 30 13:54:54 kind-worker kubelet[285]: I0730 13:54:54.751375     285 kubelet.go:1940] "Pod has been deleted and must be killed" pod="container-probe-1329/probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51" podUID=59b3df81-bd8b-4860-aee5-3fd8c3e05cde
Jul 30 13:54:54 kind-worker kubelet[285]: I0730 13:54:54.751398     285 pod_workers.go:625] "Pod is finished processing, no further updates" pod="container-probe-1329/probe-test-bc498ae5-344e-47fb-a710-a18fa8647b51" podUID=59b3df81-bd8b-4860-aee5-3fd8c3e05cde
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #111578

#### Special notes for your reviewer:
/cc @aojea @endocrimes 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
