### PR TITLE
Make the validation logic about LeaderElectionConfiguration consistent between component-base and client-go

### DIFF
--- a/staging/src/k8s.io/component-base/config/options/leaderelectionconfig.go
+++ b/staging/src/k8s.io/component-base/config/options/leaderelectionconfig.go
@@ -35,7 +35,7 @@ func BindLeaderElectionFlags(l *config.LeaderElectionConfiguration, fs *pflag.Fl
 		"election is enabled.")
 	fs.DurationVar(&l.RenewDeadline.Duration, "leader-elect-renew-deadline", l.RenewDeadline.Duration, ""+
 		"The interval between attempts by the acting master to renew a leadership slot "+
-		"before it stops leading. This must be less than or equal to the lease duration. "+
+		"before it stops leading. This must be less than the lease duration. "+
 		"This is only applicable if leader election is enabled.")
 	fs.DurationVar(&l.RetryPeriod.Duration, "leader-elect-retry-period", l.RetryPeriod.Duration, ""+
 		"The duration the clients should wait between attempting acquisition and renewal "+

--- a/staging/src/k8s.io/component-base/config/validation/validation.go
+++ b/staging/src/k8s.io/component-base/config/validation/validation.go
@@ -45,7 +45,7 @@ func ValidateLeaderElectionConfiguration(cc *config.LeaderElectionConfiguration,
 	if cc.RetryPeriod.Duration <= 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("retryPeriod"), cc.RetryPeriod, "must be greater than zero"))
 	}
-	if cc.LeaseDuration.Duration < cc.RenewDeadline.Duration {
+	if cc.LeaseDuration.Duration <= cc.RenewDeadline.Duration {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("leaseDuration"), cc.RenewDeadline, "LeaseDuration must be greater than RenewDeadline"))
 	}
 	if len(cc.ResourceLock) == 0 {

--- a/staging/src/k8s.io/component-base/config/validation/validation_test.go
+++ b/staging/src/k8s.io/component-base/config/validation/validation_test.go
@@ -79,6 +79,9 @@ func TestValidateLeaderElectionConfiguration(t *testing.T) {
 		ResourceName:      "name",
 	}
 
+	renewDeadlineEqualToLeaseDuration := validConfig.DeepCopy()
+	renewDeadlineEqualToLeaseDuration.RenewDeadline = metav1.Duration{Duration: 30 * time.Second}
+
 	renewDeadlineExceedsLeaseDuration := validConfig.DeepCopy()
 	renewDeadlineExceedsLeaseDuration.RenewDeadline = metav1.Duration{Duration: 45 * time.Second}
 
@@ -121,6 +124,10 @@ func TestValidateLeaderElectionConfiguration(t *testing.T) {
 		"good-dont-check-leader-config-if-not-enabled": {
 			expectedToFail: false,
 			config:         LeaderElectButLeaderElectNotEnabled,
+		},
+		"bad-renew-deadline-equal-to-lease-duration": {
+			expectedToFail: true,
+			config:         renewDeadlineEqualToLeaseDuration,
 		},
 		"bad-renew-deadline-exceeds-lease-duration": {
 			expectedToFail: true,


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As the description `LeaseDuration must be greater than RenewDeadline`, we should use `cc.LeaseDuration.Duration <= cc.RenewDeadline.Duration` rather than `cc.LeaseDuration.Duration < cc.RenewDeadline.Duration`.
https://github.com/kubernetes/kubernetes/blob/a837be03ffea65115a90b4bc4a8092d9b842971e/staging/src/k8s.io/component-base/config/validation/validation.go#L48-L50

We already use `<=` in client-go similar code:
https://github.com/kubernetes/kubernetes/blob/a837be03ffea65115a90b4bc4a8092d9b842971e/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go#L78-L80

And the validation logic should be consistent between `component-base` and `client-go`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
component-base: make the validation logic about LeaderElectionConfiguration consistent between component-base and client-go
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
