### PR TITLE
cleanup termination log causes nodes to avoid run out of inodes

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -106,7 +106,7 @@ func TestRemoveContainer(t *testing.T) {
 	fakeOS.Create(expectedContainerLogPath)
 	fakeOS.Create(expectedContainerLogPathRotated)
 
-	err = m.removeContainer(ctx, containerID)
+	err = m.DeleteContainer(ctx, kubecontainer.ContainerID{ID: containerID})
 	assert.NoError(t, err)
 
 	// Verify container log is removed.

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -18,6 +18,7 @@ package kuberuntime
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -38,9 +39,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	"k8s.io/kubernetes/pkg/kubelet/logs"
 )
 
 // TestRemoveContainer tests removing the container and its corresponding container logs.
@@ -79,7 +82,27 @@ func TestRemoveContainer(t *testing.T) {
 	expectedContainerLogPath := filepath.Join(podLogsRootDirectory, "new_bar_12345678", "foo", "0.log")
 	expectedContainerLogPathRotated := filepath.Join(podLogsRootDirectory, "new_bar_12345678", "foo", "0.log.20060102-150405")
 	expectedContainerLogSymlink := legacyLogSymlink(containerID, "foo", "bar", "new")
+	resp, err := m.runtimeService.ContainerStatus(ctx, containerID, false)
+	require.NoError(t, err)
+	status := resp.Status
+	mounts := status.GetMounts()
+	var terminationLogName string
+	for _, mount := range mounts {
+		if mount.GetContainerPath() == v1.TerminationMessagePathDefault {
+			terminationLogName = filepath.Base(mount.GetHostPath())
+			break
+		}
+	}
 
+	const defaultRootDir = "/var/lib/kubelet"
+	expectedTerminationLogPath := filepath.Join(defaultRootDir,
+		config.DefaultKubeletPodsDirName,
+		"12345678",
+		config.DefaultKubeletContainersDirName,
+		"foo",
+		terminationLogName)
+
+	fakeOS.Create(expectedTerminationLogPath)
 	fakeOS.Create(expectedContainerLogPath)
 	fakeOS.Create(expectedContainerLogPathRotated)
 
@@ -89,7 +112,90 @@ func TestRemoveContainer(t *testing.T) {
 	// Verify container log is removed.
 	// We could not predict the order of `fakeOS.Removes`, so we use `assert.ElementsMatch` here.
 	assert.ElementsMatch(t,
-		[]string{expectedContainerLogSymlink, expectedContainerLogPath, expectedContainerLogPathRotated},
+		[]string{expectedContainerLogSymlink, expectedContainerLogPath, expectedContainerLogPathRotated, expectedTerminationLogPath},
+		fakeOS.Removes)
+	// Verify container is removed
+	assert.Contains(t, fakeRuntime.Called, "RemoveContainer")
+	containers, err := fakeRuntime.ListContainers(ctx, &runtimeapi.ContainerFilter{Id: containerID})
+	assert.NoError(t, err)
+	assert.Empty(t, containers)
+}
+
+// To make removeContainerLog fail deliberately
+type NewFakeOS struct {
+	containertest.FakeOS
+}
+
+func (f *NewFakeOS) Glob(pattern string) ([]string, error) {
+	return nil, errors.New("There is an error.")
+}
+
+// TestRemoveContainer tests removing the container and its corresponding container logs.
+func TestRemoveLogFail(t *testing.T) {
+	fakeRuntime, _, m, err := createTestRuntimeManager()
+	require.NoError(t, err)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "12345678",
+			Name:      "bar",
+			Namespace: "new",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:            "foo",
+					Image:           "busybox",
+					ImagePullPolicy: v1.PullIfNotPresent,
+				},
+			},
+		},
+	}
+
+	// Create fake sandbox and container
+	_, fakeContainers := makeAndSetFakePod(t, m, fakeRuntime, pod)
+	assert.Equal(t, len(fakeContainers), 1)
+
+	containerID := fakeContainers[0].Id
+	fakeOS := m.osInterface.(*containertest.FakeOS)
+	fakeOS.GlobFn = func(pattern, path string) bool {
+		pattern = strings.Replace(pattern, "*", ".*", -1)
+		return regexp.MustCompile(pattern).MatchString(path)
+	}
+
+	ctx := context.Background()
+	resp, err := m.runtimeService.ContainerStatus(ctx, containerID, false)
+	require.NoError(t, err)
+	status := resp.Status
+	mounts := status.GetMounts()
+	var terminationLogName string
+	for _, mount := range mounts {
+		if mount.GetContainerPath() == v1.TerminationMessagePathDefault {
+			terminationLogName = filepath.Base(mount.GetHostPath())
+			break
+		}
+	}
+
+	const defaultRootDir = "/var/lib/kubelet"
+	expectedTerminationLogPath := filepath.Join(defaultRootDir,
+		config.DefaultKubeletPodsDirName,
+		"12345678",
+		config.DefaultKubeletContainersDirName,
+		"foo",
+		terminationLogName)
+
+	fakeOS.Create(expectedTerminationLogPath)
+
+	// use NewFakeOS to make removeContainerLog fail deliberately
+	m.logManager, err = logs.NewContainerLogManager(fakeRuntime, &NewFakeOS{}, "1", 2)
+	assert.NoError(t, err)
+
+	err = m.DeleteContainer(ctx, kubecontainer.ContainerID{ID: containerID})
+	// DeleteContainer do report failure information
+	assert.Error(t, err)
+
+	// Verify termination log is removed.
+	assert.ElementsMatch(t,
+		[]string{expectedTerminationLogPath},
 		fakeOS.Removes)
 	// Verify container is removed
 	assert.Contains(t, fakeRuntime.Called, "RemoveContainer")


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig node

#### What this PR does / why we need it:
This pr is based on #104632

For each start of the pod, kubelet will mount a termination log to the container with path /dev/termination-log.
On k8s clusters where many pods are stuck in CrashLoopBackOff state, kubelet will create millions of these files, which can lead to nodes running out of inodes on a filesystem where /var/lib/kubelet is located.


#### Which issue(s) this PR fixes:

Fixes #104592

#### Special notes for your reviewer:

> When kubelet removes evictable containers, it will remove container logs ([code here](https://github.com/kubernetes/kubernetes/blob/587132131071a0342e81d6b023d65ca7191162a5/pkg/kubelet/kuberuntime/kuberuntime_container.go#L946)), but omitting the termination log.
> Is the previous termination log useful for pod failure analysis?
> The termination log is for message log right before the container exits. Its size is limited to 4096 bytes. The drop of containers also includes the removal of the log files, which I think are more helpful for troubleshooting.
> The last termination log message has been stored in the lastState of status.containerStatuses. We can send request to api-server and ask lastState's message for further analysis.
> After the removal of the container, the bound termination log is out of kubernetes's scope. Since the container it bound to has already been removed. It is left alone in the /var/lib/kubelet/pods/<pod-uid>/containers/<container-name> before the pod gets dropped, as well as the folder /var/lib/kubelet/pods/<pod-uid>.

#### Does this PR introduce a user-facing change?

```release-note
kubelet: delete termination message log files on container eviction to prevent running out of inodes
```

/cc @matthyx @akshaysharama
/assign @mrunalp