### PR TITLE
kubelet: make the image pull time more accurate in event

### DIFF
--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -19,7 +19,6 @@ package images
 import (
 	"context"
 	"fmt"
-	"time"
 
 	dockerref "github.com/docker/distribution/reference"
 	v1 "k8s.io/api/core/v1"
@@ -150,7 +149,6 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, pod *v1.Pod, conta
 	}
 	m.podPullingTimeRecorder.RecordImageStartedPulling(pod.UID)
 	m.logIt(ref, v1.EventTypeNormal, events.PullingImage, logPrefix, fmt.Sprintf("Pulling image %q", container.Image), klog.Info)
-	startTime := time.Now()
 	pullChan := make(chan pullResult)
 	m.puller.pullImage(ctx, spec, pullSecrets, pullChan, podSandboxConfig)
 	imagePullResult := <-pullChan
@@ -164,8 +162,7 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, pod *v1.Pod, conta
 
 		return "", imagePullResult.err.Error(), ErrImagePull
 	}
-	m.podPullingTimeRecorder.RecordImageFinishedPulling(pod.UID)
-	m.logIt(ref, v1.EventTypeNormal, events.PulledImage, logPrefix, fmt.Sprintf("Successfully pulled image %q in %v", container.Image, time.Since(startTime)), klog.Info)
+	m.logIt(ref, v1.EventTypeNormal, events.PulledImage, logPrefix, fmt.Sprintf("Successfully pulled image %q in %v", container.Image, imagePullResult.pullDuration), klog.Info)
 	m.backOff.GC()
 	return imagePullResult.imageRef, "", nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
image pulling may hang for serial image pulling. The pull time is including waiting time for other images pulling. This is not accurate.

```
Successfully pulled image "docker.m.daocloud.io/library/ubuntu:22.10" in 49.18401355s
```
The time should be exactly how long it takes to pull this image. Or the event message should be something like 
```
Successfully pulled image "docker.m.daocloud.io/library/ubuntu:22.10" in 49.18401355s(72.871704s including waiting)
```

#### Which issue(s) this PR fixes:
Fixes #111704

#### Special notes for your reviewer:
- if a user needs to know the pending time, user can get the time between `Pulling` event and `Pulled` event.

**Before this change** the three pulling, the later one will include the time of the first pulling.
```
[root@paco ~]# kubectl create -f images/image.yaml
pod/pod-small-1 created
pod/pod-small-2 created
pod/pod-small-3 created
[root@paco ~]# kubectl get events -w| grep pulled
0s          Normal    Pulled                    pod/pod-small-3   Successfully pulled image "docker.m.daocloud.io/library/ubuntu:22.10" in 1m21.284220239s
0s          Normal    Pulled                    pod/pod-small-2   Successfully pulled image "docker.m.daocloud.io/library/ubuntu:20.04" in 2m7.876426944s
0s          Normal    Pulled                    pod/pod-small-1   Successfully pulled image "docker.m.daocloud.io/library/ubuntu:14.04" in 4m52.884660938s
```


**With this change** the later pulling will not take the first pulling time into account.
```
[root@paco ~]# kubectl create -f images/image.yaml
pod/pod-small-1 created
pod/pod-small-2 created
pod/pod-small-3 created
[root@paco ~]# kubectl get events -w| grep pulled
0s          Normal    Pulled             pod/pod-small-1                                 Successfully pulled image "docker.m.daocloud.io/library/ubuntu:14.04" in 1m10.319558171s
0s          Normal    Pulled             pod/pod-small-3                                 Successfully pulled image "docker.m.daocloud.io/library/ubuntu:22.10" in 27.63731662s
0s          Normal    Pulled             pod/pod-small-2                                 Successfully pulled image "docker.m.daocloud.io/library/ubuntu:20.04" in 31.496845543s
```

#### Does this PR introduce a user-facing change?
```release-note
None
```
