### PR TITLE
Revert "enforce strict alpha handling for API serving"

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds.go
@@ -54,10 +54,7 @@ type ResourceExpirationEvaluator interface {
 }
 
 func NewResourceExpirationEvaluator(currentVersion apimachineryversion.Info) (ResourceExpirationEvaluator, error) {
-	ret := &resourceExpirationEvaluator{
-		// TODO https://github.com/kubernetes/kubernetes/issues/109799 set this back to false after beta is tagged.
-		strictRemovedHandlingInAlpha: true,
-	}
+	ret := &resourceExpirationEvaluator{}
 	if len(currentVersion.Major) > 0 {
 		currentMajor64, err := strconv.ParseInt(currentVersion.Major, 10, 32)
 		if err != nil {


### PR DESCRIPTION
This reverts commit 233e0cb8c3a723f57d578be2179284e4eb9d017d.

fixes https://github.com/kubernetes/kubernetes/issues/109799

The auto-shutoff code has to be reset to make alpha handling do what we need in 1.26.  This happens as we prepare for removing APIs each release, but will get easier since beta APIs are no longer served by default.

/kind bug
/priority important-soon
/sig api-machinery

```release-note
NONE
```
