### PR TITLE
Fix formatting of Until comment

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/until.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until.go
@@ -101,9 +101,7 @@ func UntilWithoutRetry(ctx context.Context, watcher watch.Interface, conditions 
 // It guarantees you to see all events and in the order they happened.
 // Due to this guarantee there is no way it can deal with 'Resource version too old error'. It will fail in this case.
 // (See `UntilWithSync` if you'd prefer to recover from all the errors including RV too old by re-listing
-//
-//	those items. In normal code you should care about being level driven so you'd not care about not seeing all the edges.)
-//
+// those items. In normal code you should care about being level driven so you'd not care about not seeing all the edges.)
 // The most frequent usage for Until would be a test where you want to verify exact order of events ("edges").
 func Until(ctx context.Context, initialResourceVersion string, watcherClient cache.Watcher, conditions ...ConditionFunc) (*watch.Event, error) {
 	w, err := NewRetryWatcher(initialResourceVersion, watcherClient)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

There's currently [a formatting issue in the `client-go` docs](https://pkg.go.dev/k8s.io/client-go/tools/watch#Until) due to extra spacing in the comment for Until (see screenshot below).

<img width="863" alt="image" src="https://user-images.githubusercontent.com/24868312/183926817-2c9c74ad-57f7-4343-8404-6fb6900489c3.png">


#### Which issue(s) this PR fixes:

There's no open issue for this, as far as I know

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
