### PR TITLE
staging/publishing: add release-1.25 branch

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -20,6 +20,11 @@ rules:
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
+  - name: release-1.25
+    go: 1.19
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/code-generator
 - destination: apimachinery
   branches:
   - name: master

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -41,6 +41,11 @@ rules:
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
+  - name: release-1.25
+    go: 1.19
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/apimachinery
   library: true
 - destination: api
   branches:
@@ -74,6 +79,14 @@ rules:
       branch: release-1.24
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/api
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/api
   library: true
 - destination: client-go
@@ -133,6 +146,20 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod ./...
       go test -mod=mod ./...
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/client-go
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod ./...
+      go test -mod=mod ./...
   library: true
 - destination: component-base
   branches:
@@ -183,6 +210,18 @@ rules:
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/component-base
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/component-base
   library: true
 - destination: component-helpers
   branches:
@@ -232,6 +271,18 @@ rules:
       branch: release-1.24
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/component-helpers
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/component-helpers
   library: true
 - destination: apiserver
@@ -290,6 +341,20 @@ rules:
       branch: release-1.24
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/apiserver
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/apiserver
   library: true
 - destination: kube-aggregator
@@ -364,6 +429,24 @@ rules:
       branch: release-1.24
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/kube-aggregator
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: apiserver
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    - repository: code-generator
+      branch: release-1.25
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/kube-aggregator
 - destination: sample-apiserver
   branches:
@@ -458,6 +541,29 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: apiserver
+      branch: release-1.25
+    - repository: code-generator
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/sample-apiserver
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
 - destination: sample-controller
   branches:
   - name: master
@@ -529,6 +635,25 @@ rules:
       branch: release-1.24
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/sample-controller
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: code-generator
+      branch: release-1.25
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/sample-controller
     required-packages:
     - k8s.io/code-generator
@@ -616,6 +741,26 @@ rules:
       dir: staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: apiserver
+      branch: release-1.25
+    - repository: code-generator
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    required-packages:
+    - k8s.io/code-generator
 - destination: metrics
   branches:
   - name: master
@@ -673,6 +818,20 @@ rules:
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/metrics
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: code-generator
+      branch: release-1.25
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/metrics
   library: true
 - destination: cli-runtime
   branches:
@@ -722,6 +881,18 @@ rules:
       branch: release-1.24
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/cli-runtime
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: api
+      branch: release-1.25
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/cli-runtime
   library: true
 - destination: sample-cli-plugin
@@ -781,6 +952,20 @@ rules:
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/sample-cli-plugin
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: api
+      branch: release-1.25
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: cli-runtime
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/sample-cli-plugin
 - destination: kube-proxy
   branches:
   - name: master
@@ -837,6 +1022,20 @@ rules:
       branch: release-1.24
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/kube-proxy
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/kube-proxy
   library: true
 - destination: kubelet
@@ -896,6 +1095,20 @@ rules:
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/kubelet
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/kubelet
   library: true
 - destination: kube-scheduler
   branches:
@@ -953,6 +1166,20 @@ rules:
       branch: release-1.24
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/kube-scheduler
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/kube-scheduler
   library: true
 - destination: controller-manager
@@ -1019,6 +1246,22 @@ rules:
       branch: release-1.24
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/controller-manager
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: api
+      branch: release-1.25
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    - repository: apiserver
+      branch: release-1.25
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/controller-manager
   library: true
 - destination: cloud-provider
@@ -1101,6 +1344,26 @@ rules:
       branch: release-1.24
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/cloud-provider
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: api
+      branch: release-1.25
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: apiserver
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    - repository: controller-manager
+      branch: release-1.25
+    - repository: component-helpers
+      branch: release-1.25
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/cloud-provider
   library: true
 - destination: kube-controller-manager
@@ -1192,6 +1455,28 @@ rules:
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-controller-manager
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: apiserver
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: controller-manager
+      branch: release-1.25
+    - repository: cloud-provider
+      branch: release-1.25
+    - repository: component-helpers
+      branch: release-1.25
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/kube-controller-manager
   library: true
 - destination: cluster-bootstrap
   branches:
@@ -1233,6 +1518,16 @@ rules:
       branch: release-1.24
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/cluster-bootstrap
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: api
+      branch: release-1.25
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/cluster-bootstrap
   library: true
 - destination: csi-translation-lib
@@ -1276,6 +1571,16 @@ rules:
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/csi-translation-lib
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: api
+      branch: release-1.25
+    - repository: apimachinery
+      branch: release-1.25
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/csi-translation-lib
   library: true
 - destination: mount-utils
   branches:
@@ -1297,6 +1602,11 @@ rules:
     go: 1.18.5
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/mount-utils
+  - name: release-1.25
+    go: 1.19
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/mount-utils
   library: true
 - destination: legacy-cloud-providers
@@ -1404,6 +1714,32 @@ rules:
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/legacy-cloud-providers
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: api
+      branch: release-1.25
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: cloud-provider
+      branch: release-1.25
+    - repository: csi-translation-lib
+      branch: release-1.25
+    - repository: apiserver
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    - repository: controller-manager
+      branch: release-1.25
+    - repository: mount-utils
+      branch: release-1.25
+    - repository: component-helpers
+      branch: release-1.25
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/legacy-cloud-providers
   library: true
 - destination: cri-api
   branches:
@@ -1425,6 +1761,11 @@ rules:
     go: 1.18.5
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/cri-api
+  - name: release-1.25
+    go: 1.19
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/cri-api
   library: true
 - destination: kubectl
@@ -1516,6 +1857,28 @@ rules:
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/kubectl
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: api
+      branch: release-1.25
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: cli-runtime
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: code-generator
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    - repository: component-helpers
+      branch: release-1.25
+    - repository: metrics
+      branch: release-1.25
+    source:
+      branch: release-1.25
+      dir: staging/src/k8s.io/kubectl
   library: true
 - destination: pod-security-admission
   branches:
@@ -1581,6 +1944,22 @@ rules:
       branch: release-1.24
     source:
       branch: release-1.24
+      dir: staging/src/k8s.io/pod-security-admission
+  - name: release-1.25
+    go: 1.19
+    dependencies:
+    - repository: api
+      branch: release-1.25
+    - repository: apimachinery
+      branch: release-1.25
+    - repository: apiserver
+      branch: release-1.25
+    - repository: client-go
+      branch: release-1.25
+    - repository: component-base
+      branch: release-1.25
+    source:
+      branch: release-1.25
       dir: staging/src/k8s.io/pod-security-admission
   library: true
 recursive-delete-patterns:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds publishing config for new 1.25 release branch after RC.0 cut yesterday

#### Special notes for your reviewer:

See this [slack thread](https://kubernetes.slack.com/archives/CJH2GBF7Y/p1660057694134999) for more context

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

cc: @soltysh @dims @Verolop @puerco 
