### PR TITLE
Automated cherry pick of #111773: fix a memory leak problem when calling DryRunPreemption

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -329,6 +329,7 @@ func dryRunPreemption(ctx context.Context, fh framework.Handle,
 	nonViolatingCandidates := newCandidateList(numCandidates)
 	violatingCandidates := newCandidateList(numCandidates)
 	parallelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	nodeStatuses := make(framework.NodeToStatusMap)
 	var statusesLock sync.Mutex
 	checkNode := func(i int) {


### PR DESCRIPTION
Cherry pick of #111773 on release-1.22.

#111773: fix a memory leak problem when calling DryRunPreemption

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix memory leak on kube-scheduler preemption
```