### PR TITLE
remove kube-proxy mode fallback

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -86,13 +86,6 @@ import (
 	utilpointer "k8s.io/utils/pointer"
 )
 
-const (
-	proxyModeUserspace   = "userspace"
-	proxyModeIPTables    = "iptables"
-	proxyModeIPVS        = "ipvs"
-	proxyModeKernelspace = "kernelspace" //nolint:deadcode,varcheck
-)
-
 // proxyRun defines the interface to run a specified ProxyServer
 type proxyRun interface {
 	Run() error
@@ -540,7 +533,7 @@ type ProxyServer struct {
 	Recorder               events.EventRecorder
 	ConntrackConfiguration kubeproxyconfig.KubeProxyConntrackConfiguration
 	Conntracker            Conntracker // if nil, ignored
-	ProxyMode              string
+	ProxyMode              kubeproxyconfig.ProxyMode
 	NodeRef                *v1.ObjectReference
 	MetricsBindAddress     string
 	BindAddressHardFail    bool
@@ -611,7 +604,7 @@ func serveHealthz(hz healthcheck.ProxierHealthUpdater, errCh chan error) {
 	go wait.Until(fn, 5*time.Second, wait.NeverStop)
 }
 
-func serveMetrics(bindAddress, proxyMode string, enableProfiling bool, errCh chan error) {
+func serveMetrics(bindAddress string, proxyMode kubeproxyconfig.ProxyMode, enableProfiling bool, errCh chan error) {
 	if len(bindAddress) == 0 {
 		return
 	}

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -52,10 +52,10 @@ import (
 
 // NewProxyServer returns a new ProxyServer.
 func NewProxyServer(o *Options) (*ProxyServer, error) {
-	return newProxyServer(o.config, o.CleanupAndExit, o.master)
+	return newProxyServer(o.config, o.master)
 }
 
-func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExit bool, master string) (*ProxyServer, error) {
+func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string) (*ProxyServer, error) {
 	if config == nil {
 		return nil, errors.New("config is required")
 	}
@@ -64,11 +64,6 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 		c.Set(config)
 	} else {
 		return nil, fmt.Errorf("unable to register configz: %s", err)
-	}
-
-	// We omit creation of pretty much everything if we run in cleanup mode
-	if cleanupAndExit {
-		return &ProxyServer{}, nil
 	}
 
 	if len(config.ShowHiddenMetricsForVersion) > 0 {
@@ -224,4 +219,9 @@ func tryWinKernelSpaceProxy(kcompat winkernel.KernelCompatTester) string {
 	// Fallback.
 	klog.V(1).InfoS("Can't use winkernel proxy, using userspace proxier")
 	return proxyModeUserspace
+}
+
+// cleanupAndExit cleans up after a previous proxy run
+func cleanupAndExit() error {
+	return errors.New("--cleanup-and-exit is not implemented on Windows")
 }

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -85,34 +85,6 @@ const (
 	largeClusterEndpointsThreshold = 1000
 )
 
-// KernelCompatTester tests whether the required kernel capabilities are
-// present to run the iptables proxier.
-type KernelCompatTester interface {
-	IsCompatible() error
-}
-
-// CanUseIPTablesProxier returns true if we should use the iptables Proxier
-// instead of the "classic" userspace Proxier.
-func CanUseIPTablesProxier(kcompat KernelCompatTester) (bool, error) {
-	if err := kcompat.IsCompatible(); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-var _ KernelCompatTester = LinuxKernelCompatTester{}
-
-// LinuxKernelCompatTester is the Linux implementation of KernelCompatTester
-type LinuxKernelCompatTester struct{}
-
-// IsCompatible checks for the required sysctls.  We don't care about the value, just
-// that it exists.  If this Proxier is chosen, we'll initialize it as we
-// need.
-func (lkct LinuxKernelCompatTester) IsCompatible() error {
-	_, err := utilsysctl.New().GetSysctl(sysctlRouteLocalnet)
-	return err
-}
-
 const sysctlRouteLocalnet = "net/ipv4/conf/all/route_localnet"
 const sysctlBridgeCallIPTables = "net/bridge/bridge-nf-call-iptables"
 

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -706,25 +706,25 @@ func (handle *LinuxKernelHandler) GetKernelVersion() (string, error) {
 	return strings.TrimSpace(string(fileContent)), nil
 }
 
-// CanUseIPVSProxier returns true if we can use the ipvs Proxier.
+// CanUseIPVSProxier checks if we can use the ipvs Proxier.
 // This is determined by checking if all the required kernel modules can be loaded. It may
 // return an error if it fails to get the kernel modules information without error, in which
 // case it will also return false.
-func CanUseIPVSProxier(handle KernelHandler, ipsetver IPSetVersioner, scheduler string) (bool, error) {
+func CanUseIPVSProxier(handle KernelHandler, ipsetver IPSetVersioner, scheduler string) error {
 	mods, err := handle.GetModules()
 	if err != nil {
-		return false, fmt.Errorf("error getting installed ipvs required kernel modules: %v", err)
+		return fmt.Errorf("error getting installed ipvs required kernel modules: %v", err)
 	}
 	loadModules := sets.NewString()
 	loadModules.Insert(mods...)
 
 	kernelVersionStr, err := handle.GetKernelVersion()
 	if err != nil {
-		return false, fmt.Errorf("error determining kernel version to find required kernel modules for ipvs support: %v", err)
+		return fmt.Errorf("error determining kernel version to find required kernel modules for ipvs support: %v", err)
 	}
 	kernelVersion, err := version.ParseGeneric(kernelVersionStr)
 	if err != nil {
-		return false, fmt.Errorf("error parsing kernel version %q: %v", kernelVersionStr, err)
+		return fmt.Errorf("error parsing kernel version %q: %v", kernelVersionStr, err)
 	}
 	mods = utilipvs.GetRequiredIPVSModules(kernelVersion)
 	wantModules := sets.NewString()
@@ -751,18 +751,18 @@ func CanUseIPVSProxier(handle KernelHandler, ipsetver IPSetVersioner, scheduler 
 	}
 
 	if len(missingMods) != 0 {
-		return false, fmt.Errorf("IPVS proxier will not be used because the following required kernel modules are not loaded: %v", missingMods)
+		return fmt.Errorf("IPVS proxier will not be used because the following required kernel modules are not loaded: %v", missingMods)
 	}
 
 	// Check ipset version
 	versionString, err := ipsetver.GetVersion()
 	if err != nil {
-		return false, fmt.Errorf("error getting ipset version, error: %v", err)
+		return fmt.Errorf("error getting ipset version, error: %v", err)
 	}
 	if !checkMinVersion(versionString) {
-		return false, fmt.Errorf("ipset version: %s is less than min required version: %s", versionString, MinIPSetCheckVersion)
+		return fmt.Errorf("ipset version: %s is less than min required version: %s", versionString, MinIPSetCheckVersion)
 	}
-	return true, nil
+	return nil
 }
 
 // CleanupIptablesLeftovers removes all iptables rules and chains created by the Proxier

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -364,9 +364,9 @@ func TestCanUseIPVSProxier(t *testing.T) {
 	for i := range testCases {
 		handle := &fakeKernelHandler{modules: testCases[i].mods, kernelVersion: testCases[i].kernelVersion}
 		versioner := &fakeIPSetVersioner{version: testCases[i].ipsetVersion, err: testCases[i].ipsetErr}
-		ok, err := CanUseIPVSProxier(handle, versioner, testCases[i].scheduler)
-		if ok != testCases[i].ok {
-			t.Errorf("Case [%d], expect %v, got %v: err: %v", i, testCases[i].ok, ok, err)
+		err := CanUseIPVSProxier(handle, versioner, testCases[i].scheduler)
+		if (err == nil) != testCases[i].ok {
+			t.Errorf("Case [%d], expect %v, got err: %v", i, testCases[i].ok, err)
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
`kube-proxy --proxy-mode ipvs` will fall back to iptables mode if IPVS mode is not usable, but this is not actually a reasonable behavior, at all, and was presumably only added by mistaken analogy to the iptables-to-userspace fallback, which was there because we wanted to make iptables the default but there used to be some systems that couldn't support it.

On that topic, there are no longer systems that can run kubernetes but can't run the iptables proxy (but _can_ run the userspace proxy), so remove the iptables-to-userspace fallback too.

#### Which issue(s) this PR fixes:
Fixes #111709

#### Does this PR introduce a user-facing change?
```release-note
kube-proxy no longer falls back from ipvs mode to iptables mode if you ask it to do ipvs but the system is not correctly configured. Instead, it will just exit with an error.
```

/sig network
/area ipvs
/priority important-soon