### PR TITLE
Apimachinery meta errors: Support errors.Is and error wrapping

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/errors.go
@@ -17,6 +17,7 @@ limitations under the License.
 package meta
 
 import (
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -43,6 +44,11 @@ func (e *AmbiguousResourceError) Error() string {
 	return fmt.Sprintf("%v matches multiple resources or kinds", e.PartialResource)
 }
 
+func (*AmbiguousResourceError) Is(target error) bool {
+	_, ok := target.(*AmbiguousResourceError)
+	return ok
+}
+
 // AmbiguousKindError is returned if the RESTMapper finds multiple matches for a kind
 type AmbiguousKindError struct {
 	PartialKind schema.GroupVersionKind
@@ -63,16 +69,16 @@ func (e *AmbiguousKindError) Error() string {
 	return fmt.Sprintf("%v matches multiple resources or kinds", e.PartialKind)
 }
 
+func (*AmbiguousKindError) Is(target error) bool {
+	_, ok := target.(*AmbiguousKindError)
+	return ok
+}
+
 func IsAmbiguousError(err error) bool {
 	if err == nil {
 		return false
 	}
-	switch err.(type) {
-	case *AmbiguousResourceError, *AmbiguousKindError:
-		return true
-	default:
-		return false
-	}
+	return errors.Is(err, &AmbiguousResourceError{}) || errors.Is(err, &AmbiguousKindError{})
 }
 
 // NoResourceMatchError is returned if the RESTMapper can't find any match for a resource
@@ -82,6 +88,11 @@ type NoResourceMatchError struct {
 
 func (e *NoResourceMatchError) Error() string {
 	return fmt.Sprintf("no matches for %v", e.PartialResource)
+}
+
+func (*NoResourceMatchError) Is(target error) bool {
+	_, ok := target.(*NoResourceMatchError)
+	return ok
 }
 
 // NoKindMatchError is returned if the RESTMapper can't find any match for a kind
@@ -108,14 +119,14 @@ func (e *NoKindMatchError) Error() string {
 	}
 }
 
+func (*NoKindMatchError) Is(target error) bool {
+	_, ok := target.(*NoKindMatchError)
+	return ok
+}
+
 func IsNoMatchError(err error) bool {
 	if err == nil {
 		return false
 	}
-	switch err.(type) {
-	case *NoResourceMatchError, *NoKindMatchError:
-		return true
-	default:
-		return false
-	}
+	return errors.Is(err, &NoResourceMatchError{}) || errors.Is(err, &NoKindMatchError{})
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/errors_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestErrorMatching(t *testing.T) {
+	testCases := []struct {
+		name string
+		// input should contain an error that is _not_ empty, otherwise the naive reflectlite.DeepEqual matching of
+		// the errors lib will always succeed, but for all of these we want to verify that the matching is based on
+		// type.
+		input       error
+		new         func() error
+		matcherFunc func(error) bool
+	}{
+		{
+			name:        "AmbiguousResourceError",
+			input:       &AmbiguousResourceError{MatchingResources: []schema.GroupVersionResource{{}}},
+			new:         func() error { return &AmbiguousResourceError{} },
+			matcherFunc: IsAmbiguousError,
+		},
+		{
+			name:        "AmbiguousKindError",
+			input:       &AmbiguousKindError{MatchingResources: []schema.GroupVersionResource{{}}},
+			new:         func() error { return &AmbiguousKindError{} },
+			matcherFunc: IsAmbiguousError,
+		},
+		{
+			name:        "NoResourceMatchError",
+			input:       &NoResourceMatchError{PartialResource: schema.GroupVersionResource{Group: "foo"}},
+			new:         func() error { return &NoResourceMatchError{} },
+			matcherFunc: IsNoMatchError,
+		},
+		{
+			name:        "NoKindMatchError",
+			input:       &NoKindMatchError{SearchedVersions: []string{"foo"}},
+			new:         func() error { return &NoKindMatchError{} },
+			matcherFunc: IsNoMatchError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !errors.Is(tc.input, tc.new()) {
+				t.Error("error doesn't match itself directly")
+			}
+			if !errors.Is(fmt.Errorf("wrapepd: %w", tc.input), tc.new()) {
+				t.Error("error doesn't match itself when wrapped")
+			}
+			if !tc.matcherFunc(tc.input) {
+				t.Errorf("error doesn't get matched by matcherfunc")
+			}
+			if errors.Is(tc.input, errors.New("foo")) {
+				t.Error("error incorrectly matches other error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently, the errors in the pkg/api/meta package don't work correctly
with the stdlibs `errors.Is` because they do not implement an `Is`
method, which makes the matching fall through to use reflect to check
for equality. This change fixes that and as a side-effect also adds
support to match on wrapped errors.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig api-machinery\
/cc @lavalamp @apelisse @alexzielenski  
<!--
Add one of the following kinds:



Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The errors in k8s.io/apimachinery/pkg/api/meta gained support for the stdlibs errors.Is matching, including when wrapped
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
