### PR TITLE
Schedule: Fix status type error in logs

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -108,10 +108,10 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 				// Run PostFilter plugins to try to make the pod schedulable in a future scheduling cycle.
 				result, status := fwk.RunPostFilterPlugins(ctx, state, pod, fitError.Diagnosis.NodeToStatusMap)
 				if status.Code() == framework.Error {
-					klog.ErrorS(nil, "Status after running PostFilter plugins for pod", "pod", klog.KObj(pod), "status", status)
+					klog.ErrorS(nil, "Status after running PostFilter plugins for pod", "pod", klog.KObj(pod), "status", status.Message())
 				} else {
 					fitError.Diagnosis.PostFilterMsg = status.Message()
-					klog.V(5).InfoS("Status after running PostFilter plugins for pod", "pod", klog.KObj(pod), "status", status)
+					klog.V(5).InfoS("Status after running PostFilter plugins for pod", "pod", klog.KObj(pod), "status", status.Message())
 				}
 				if result != nil {
 					nominatingInfo = result.NominatingInfo


### PR DESCRIPTION
Signed-off-by: Zemtsov Vladimir <vl.zemtsov@gmail.com>

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fix Scheduler logs in `schedule_one.go`

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/111815

#### Special notes for your reviewer:

Before my changes field `status` in scheduler logs has differends types:
```
grep -nr '\"status\", status' ./pkg/scheduler
./pkg/scheduler/schedule_one.go:111:                                    klog.ErrorS(nil, "Status after running PostFilter plugins for pod", "pod", klog.KObj(pod), "status", status)
./pkg/scheduler/schedule_one.go:114:                                    klog.V(5).InfoS("Status after running PostFilter plugins for pod", "pod", klog.KObj(pod), "status", status)
./pkg/scheduler/framework/runtime/framework.go:1150:                            klog.V(4).InfoS("Pod rejected by permit plugin", "pod", klog.KObj(pod), "plugin", pl.Name(), "status", status.Message())
```
In `./pkg/scheduler/schedule_one.go string has type` - object
In `./pkg/scheduler/framework/runtime/framework.go` - string

In My PR i set in `./pkg/scheduler/schedule_one.go string has type` type string for field `status`.
Now in scheduler logs field `status` always have same type.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug than scheduler has wrong type of status in logs
```