### PR TITLE
Write CoreV1NamespaceReplace Test +1 Endpoint

### DIFF
--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -355,6 +355,26 @@ var _ = SIGDescribe("Namespaces [Serial]", func() {
 		framework.ExpectEqual(statusUpdated.Status.Conditions[len(statusUpdated.Status.Conditions)-1].Message, "Updated by an e2e test", "The Message returned was %v", statusUpdated.Status.Conditions[0].Message)
 		framework.Logf("Status.Condition: %#v", statusUpdated.Status.Conditions[len(statusUpdated.Status.Conditions)-1])
 	})
+
+	ginkgo.It("should apply an update to a Namespace", func() {
+		var err error
+		var updatedNamespace *v1.Namespace
+		ns := f.Namespace.Name
+		cs := f.ClientSet
+
+		ginkgo.By(fmt.Sprintf("Updating Namespace %q", ns))
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			updatedNamespace, err = cs.CoreV1().Namespaces().Get(context.TODO(), ns, metav1.GetOptions{})
+			framework.ExpectNoError(err, "Unable to get Namespace %q", ns)
+
+			updatedNamespace.Labels[ns] = "updated"
+			updatedNamespace, err = cs.CoreV1().Namespaces().Update(context.TODO(), updatedNamespace, metav1.UpdateOptions{})
+			return err
+		})
+		framework.ExpectNoError(err, "failed to update Namespace: %q", ns)
+		framework.ExpectEqual(updatedNamespace.ObjectMeta.Labels[ns], "updated", "Failed to update namespace %q. Current Labels: %#v", ns, updatedNamespace.Labels)
+		framework.Logf("Namespace %q now has labels, %#v", ns, updatedNamespace.Labels)
+	})
 })
 
 func unstructuredToNamespace(obj *unstructured.Unstructured) (*v1.Namespace, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceCoreV1Namespace

**Which issue(s) this PR fixes:**
Fixes #111847

**Testgrid Link:** 
[testgrid-link](https://testgrid.k8s.io/sig-api-machinery-gce-gke#gce-serial&graph-metrics=test-duration-minutes&include-filter-by-regex=should.apply.an.update.to.a.Namespace&width=20)

**Special notes for your reviewer:**
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance