### PR TITLE
Add error return for InitData of Runner

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/workflow/runner.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/runner.go
@@ -178,11 +178,15 @@ func (e *Runner) SetDataInitializer(builder func(cmd *cobra.Command, args []stri
 // This action can be executed explicitly out, when it is necessary to get the RunData
 // before actually executing Run, or implicitly when invoking Run.
 func (e *Runner) InitData(args []string) (RunData, error) {
-	if e.runData == nil && e.runDataInitializer != nil {
-		var err error
-		if e.runData, err = e.runDataInitializer(e.runCmd, args); err != nil {
-			return nil, err
-		}
+	if e.runData == nil {
+		 if e.runDataInitializer != nil {
+			 var err error
+			 if e.runData, err = e.runDataInitializer(e.runCmd, args); err != nil {
+				 return nil, err
+			 }
+		 } else {
+			 return nil, errors.Errorf("e.runData and e.runDataInitializer are both nil.")
+		 }
 	}
 
 	return e.runData, nil


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Add error return for InitData of Runner. Perhaps e.runData and e.runDataInitializer are both nil.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

/release-note-none
/priority backlog
/triage accepted