### PR TITLE
Fix failing `test/e2e/storage/csi_mock_volume.go` test

### DIFF
--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -1731,8 +1731,8 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 			},
 		}
 		for _, t := range tests {
-			test := t
-			ginkgo.It(test.name, func() {
+			t := t
+			ginkgo.It(t.name, func() {
 				var nodeStageFsGroup, nodePublishFsGroup string
 				if framework.NodeOSDistroIs("windows") {
 					e2eskipper.Skipf("FSGroupPolicy is only applied on linux nodes -- skipping")
@@ -1740,7 +1740,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				init(testParameters{
 					disableAttach:          true,
 					registerDriver:         true,
-					enableVolumeMountGroup: test.enableVolumeMountGroup,
+					enableVolumeMountGroup: t.enableVolumeMountGroup,
 					hooks:                  createFSGroupRequestPreHook(&nodeStageFsGroup, &nodePublishFsGroup),
 				})
 				defer cleanup()
@@ -2479,14 +2479,14 @@ func createPreHook(method string, callback func(counter int64) error) *drivers.H
 func createFSGroupRequestPreHook(nodeStageFsGroup, nodePublishFsGroup *string) *drivers.Hooks {
 	return &drivers.Hooks{
 		Pre: func(ctx context.Context, fullMethod string, request interface{}) (reply interface{}, err error) {
-			nodeStageRequest, ok := request.(csipbv1.NodeStageVolumeRequest)
+			nodeStageRequest, ok := request.(*csipbv1.NodeStageVolumeRequest)
 			if ok {
 				mountVolume := nodeStageRequest.GetVolumeCapability().GetMount()
 				if mountVolume != nil {
 					*nodeStageFsGroup = mountVolume.VolumeMountGroup
 				}
 			}
-			nodePublishRequest, ok := request.(csipbv1.NodePublishVolumeRequest)
+			nodePublishRequest, ok := request.(*csipbv1.NodePublishVolumeRequest)
 			if ok {
 				mountVolume := nodePublishRequest.GetVolumeCapability().GetMount()
 				if mountVolume != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Fix failing `test/e2e/storage/csi_mock_volume.go` test

Followup on https://github.com/kubernetes/kubernetes/pull/111846. This
particular test was left out from that PR because once it was enabled it
started failing. It was desired to merge
https://github.com/kubernetes/kubernetes/pull/111846 irrespective of
this particular test.

The failure in the test was caused due to the
`createFSGroupRequestPreHook` mock CSI driver hook function assuming
that the request object passed to it is an instance of the respective
struct, but it's actually a pointer instead. This resulted in the hook
function not fulfilling its purpose, and the so the test failed.

#### Special notes for your reviewer:

Context for this PR https://github.com/kubernetes/kubernetes/pull/111846#issuecomment-1215075335

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: