### PR TITLE
remove hardcoded UsingLegacyCadvisorStats workaround for CRI-O

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -646,7 +646,7 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 
 	if kubeDeps.CAdvisorInterface == nil {
 		imageFsInfoProvider := cadvisor.NewImageFsInfoProvider(s.RemoteRuntimeEndpoint)
-		kubeDeps.CAdvisorInterface, err = cadvisor.New(imageFsInfoProvider, s.RootDirectory, cgroupRoots, cadvisor.UsingLegacyCadvisorStats(s.RemoteRuntimeEndpoint), s.LocalStorageCapacityIsolation)
+		kubeDeps.CAdvisorInterface, err = cadvisor.New(imageFsInfoProvider, s.RootDirectory, cgroupRoots, s.LocalStorageCapacityIsolation)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubelet/cadvisor/cadvisor_unsupported.go
+++ b/pkg/kubelet/cadvisor/cadvisor_unsupported.go
@@ -33,7 +33,7 @@ type cadvisorUnsupported struct {
 var _ Interface = new(cadvisorUnsupported)
 
 // New creates a new cAdvisor Interface for unsupported systems.
-func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupsRoots []string, usingLegacyStats, localStorageCapacityIsolation bool) (Interface, error) {
+func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupsRoots []string, localStorageCapacityIsolation bool) (Interface, error) {
 	return &cadvisorUnsupported{}, nil
 }
 

--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -19,16 +19,9 @@ package cadvisor
 import (
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapi2 "github.com/google/cadvisor/info/v2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
-)
-
-const (
-	// CrioSocket is the path to the CRI-O socket.
-	// Please keep this in sync with the one in:
-	// github.com/google/cadvisor/tree/master/container/crio/client.go
-	CrioSocket = "/var/run/crio/crio.sock"
 )
 
 // CapacityFromMachineInfo returns the capacity of the resources from the machine info.
@@ -61,13 +54,4 @@ func EphemeralStorageCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceLis
 			resource.BinarySI),
 	}
 	return c
-}
-
-// UsingLegacyCadvisorStats returns true if container stats are provided by cadvisor instead of through the CRI.
-// CRI integrations should get container metrics via CRI.
-// TODO: cri-o relies on cadvisor as a temporary workaround. The code should
-// be removed. Related issue:
-// https://github.com/kubernetes/kubernetes/issues/51798
-func UsingLegacyCadvisorStats(runtimeEndpoint string) bool {
-	return runtimeEndpoint == CrioSocket || runtimeEndpoint == "unix://"+CrioSocket
 }

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -38,10 +38,7 @@ import (
 )
 
 // cadvisorStatsProvider implements the containerStatsProvider interface by
-// getting the container stats from cAdvisor. This is needed by
-// integrations which do not provide stats from CRI. See
-// `pkg/kubelet/cadvisor/util.go#UsingLegacyCadvisorStats` for the logic for
-// determining which integrations do not provide stats from CRI.
+// getting the container stats from cAdvisor. This is no longer needed, and should be removed.
 type cadvisorStatsProvider struct {
 	// cadvisor is used to get the stats of the cgroup for the containers that
 	// are managed by pods.


### PR DESCRIPTION
This workaround was implemented due to performance issues, but has since caused a new issue https://github.com/kubernetes/kubernetes/issues/106957 that users are working around by switching away from CRI-O, or renaming their CRI socket from /var/run to /run to fool the string comparison we use to detect CRI-O. Since it appears CRI-O now works fine without this hack, I think we can just remove it to alleviate some headache.

I'm not 100% sure if this is no longer needed, but that's why I'm opening the PR. If this looks good to others, I can rip out the rest of the legacy implementation as well.
