### PR TITLE
Automated cherry pick of #101882: kubelet: more resilient node allocatable ephemeral-storage

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -1046,7 +1046,31 @@ func isKernelPid(pid int) bool {
 	return err != nil && os.IsNotExist(err)
 }
 
+// GetCapacity returns node capacity data for "cpu", "memory", "ephemeral-storage", and "huge-pages*"
+// At present this method is only invoked when introspecting ephemeral storage
 func (cm *containerManagerImpl) GetCapacity() v1.ResourceList {
+	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.LocalStorageCapacityIsolation) {
+		// We store allocatable ephemeral-storage in the capacity property once we Start() the container manager
+		if _, ok := cm.capacity[v1.ResourceEphemeralStorage]; !ok {
+			// If we haven't yet stored the capacity for ephemeral-storage, we can try to fetch it directly from cAdvisor,
+			if cm.cadvisorInterface != nil {
+				rootfs, err := cm.cadvisorInterface.RootFsInfo()
+				if err != nil {
+					klog.ErrorS(err, "Unable to get rootfs data from cAdvisor interface")
+					// If the rootfsinfo retrieval from cAdvisor fails for any reason, fallback to returning the capacity property with no ephemeral storage data
+					return cm.capacity
+				}
+				// We don't want to mutate cm.capacity here so we'll manually construct a v1.ResourceList from it,
+				// and add ephemeral-storage
+				capacityWithEphemeralStorage := v1.ResourceList{}
+				for rName, rQuant := range cm.capacity {
+					capacityWithEphemeralStorage[rName] = rQuant
+				}
+				capacityWithEphemeralStorage[v1.ResourceEphemeralStorage] = cadvisor.EphemeralStorageCapacityFromFsInfo(rootfs)[v1.ResourceEphemeralStorage]
+				return capacityWithEphemeralStorage
+			}
+		}
+	}
 	return cm.capacity
 }
 


### PR DESCRIPTION
Cherry pick of #101882 on release-1.23.

#101882: kubelet: more resilient node allocatable ephemeral-storage

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```