### PR TITLE
Add e2e HPA Behavior Tests: Scale up and down controls

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -19,6 +19,7 @@ package autoscaling
 import (
 	"time"
 
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eautoscaling "k8s.io/kubernetes/test/e2e/framework/autoscaling"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -26,7 +27,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 )
 
-var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (non-default behavior)", func() {
+var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] [Feature:BHPA] Horizontal pod autoscaling (non-default behavior)", func() {
 	f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
@@ -376,6 +377,113 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			// Second scale event needs to respect limit window.
 			framework.ExpectEqual(timeWaitedFor2 > limitWindowLength, true, "waited %s, wanted more than %s", timeWaitedFor2, limitWindowLength)
 			framework.ExpectEqual(timeWaitedFor2 < deadline, true, "waited %s, wanted less than %s", timeWaitedFor2, deadline)
+		})
+	})
+
+	ginkgo.Describe("with both scale up and down controls configured", func() {
+		ginkgo.It("should keep recommendation within the range over two stabilization windows", func() {
+			ginkgo.By("setting up resource consumer and HPA")
+			initPods := 2
+			initCPUUsageTotal := initPods * usageForSingleReplica
+			upScaleStabilization := 3 * time.Minute
+			downScaleStabilization := 3 * time.Minute
+
+			rc := e2eautoscaling.NewDynamicResourceConsumer(
+				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
+				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
+			)
+			defer rc.CleanUp()
+
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+				rc, int32(targetCPUUtilizationPercent), 2, 10,
+				e2eautoscaling.HPABehaviorWithStabilizationWindows(upScaleStabilization, downScaleStabilization),
+			)
+			defer e2eautoscaling.DeleteHPAWithBehavior(rc, hpa.Name)
+
+			ginkgo.By("triggering scale up by increasing consumption")
+			rc.ConsumeCPU(5 * usageForSingleReplica)
+			waitDeadline := upScaleStabilization
+
+			ginkgo.By("verifying number of replicas stay in desired range within stabilisation window")
+			rc.EnsureDesiredReplicasInRange(2, 2, waitDeadline, hpa.Name)
+
+			ginkgo.By("waiting for replicas to scale up after stabilisation window passed")
+			waitStart := time.Now()
+			waitDeadline = maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer
+			rc.WaitForReplicas(4, waitDeadline)
+			timeWaited := time.Now().Sub(waitStart)
+			framework.Logf("time waited for scale up: %s", timeWaited)
+			framework.ExpectEqual(timeWaited < waitDeadline, true, "waited %s, wanted less than %s", timeWaited, waitDeadline)
+
+			ginkgo.By("triggering scale down by lowering consumption")
+			rc.ConsumeCPU(2 * usageForSingleReplica)
+			waitDeadline = downScaleStabilization
+
+			ginkgo.By("verifying number of replicas stay in desired range within stabilisation window")
+			rc.EnsureDesiredReplicasInRange(4, 4, waitDeadline, hpa.Name)
+
+			ginkgo.By("waiting for replicas to scale down after stabilisation window passed")
+			waitStart = time.Now()
+			waitDeadline = maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer
+			rc.WaitForReplicas(2, waitDeadline)
+			timeWaited = time.Now().Sub(waitStart)
+			framework.Logf("time waited for scale down: %s", timeWaited)
+			framework.ExpectEqual(timeWaited < waitDeadline, true, "waited %s, wanted less than %s", timeWaited, waitDeadline)
+		})
+
+		ginkgo.It("should keep recommendation within the range with stabilization window and pod limit rate", func() {
+			ginkgo.By("setting up resource consumer and HPA")
+			initPods := 2
+			initCPUUsageTotal := initPods * usageForSingleReplica
+			downScaleStabilization := 3 * time.Minute
+			limitWindowLength := 2 * time.Minute
+			podsLimitPerMinute := 1
+
+			rc := e2eautoscaling.NewDynamicResourceConsumer(
+				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
+				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
+			)
+			defer rc.CleanUp()
+
+			scaleUpRule := e2eautoscaling.HPAScalingRuleWithScalingPolicy(autoscalingv2.PodsScalingPolicy, int32(podsLimitPerMinute), int32(limitWindowLength.Seconds()))
+			scaleDownRule := e2eautoscaling.HPAScalingRuleWithStabilizationWindow(int32(downScaleStabilization.Seconds()))
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+				rc, int32(targetCPUUtilizationPercent), 2, 10,
+				e2eautoscaling.HPABehaviorWithScaleUpAndDownRules(scaleUpRule, scaleDownRule),
+			)
+			defer e2eautoscaling.DeleteHPAWithBehavior(rc, hpa.Name)
+
+			ginkgo.By("triggering scale up by increasing consumption")
+			rc.ConsumeCPU(4 * usageForSingleReplica)
+			waitDeadline := limitWindowLength
+
+			ginkgo.By("verifying number of replicas stay in desired range with pod limit rate")
+			rc.EnsureDesiredReplicasInRange(2, 3, waitDeadline, hpa.Name)
+
+			ginkgo.By("waiting for replicas to scale up")
+			waitStart := time.Now()
+			waitDeadline = limitWindowLength + maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer
+			rc.WaitForReplicas(4, waitDeadline)
+			timeWaited := time.Now().Sub(waitStart)
+			framework.Logf("time waited for scale up: %s", timeWaited)
+			framework.ExpectEqual(timeWaited < waitDeadline, true, "waited %s, wanted less than %s", timeWaited, waitDeadline)
+
+			ginkgo.By("triggering scale down by lowering consumption")
+			rc.ConsumeCPU(2 * usageForSingleReplica)
+
+			ginkgo.By("verifying number of replicas stay in desired range within stabilisation window")
+			waitDeadline = downScaleStabilization
+			rc.EnsureDesiredReplicasInRange(4, 4, waitDeadline, hpa.Name)
+
+			ginkgo.By("waiting for replicas to scale down after stabilisation window passed")
+			waitStart = time.Now()
+			waitDeadline = maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer
+			rc.WaitForReplicas(2, waitDeadline)
+			timeWaited = time.Now().Sub(waitStart)
+			framework.Logf("time waited for scale down: %s", timeWaited)
+			framework.ExpectEqual(timeWaited < waitDeadline, true, "waited %s, wanted less than %s", timeWaited, waitDeadline)
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
e2e test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Implementing e2e tests for HPA behavior, requested by https://github.com/kubernetes/kubernetes/issues/102369.

Specifically, this PR implements scale up/scale down controls: see also https://github.com/kubernetes/kubernetes/pull/97348.

It also refactors some common autoscaling utils.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #102369

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
    NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
