### PR TITLE
Fix PVC nil pointer dereference during migration-enabled volume expand

### DIFF
--- a/pkg/volume/util/resize_util.go
+++ b/pkg/volume/util/resize_util.go
@@ -54,11 +54,6 @@ type resizeProcessStatus struct {
 	processed bool
 }
 
-// ClaimToClaimKey return namespace/name string for pvc
-func ClaimToClaimKey(claim *v1.PersistentVolumeClaim) string {
-	return fmt.Sprintf("%s/%s", claim.Namespace, claim.Name)
-}
-
 // UpdatePVSize updates just pv size after cloudprovider resizing is successful
 func UpdatePVSize(
 	pv *v1.PersistentVolume,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/issues/111891 reported nil pointer dereference in KCM. Stack trace shows it happened because `SetClaimResizer` returned nil pvc and non-nil err, this nil PVC was passed to `ClaimToClaimKey` which panicked. 

I think it is also possible for nil pointer dereference to happen at the informer `Get` which could also return nil pvc and non-nil err so I updated that as well to avoid dereferencing pvc object.

Finally, I updated every other place in this function that tries to call either `util.ClaimToClaimKey(pvc)` or `util.GetPersistentVolumeClaimQualifiedName(pvc)` for consistency and because they're unnecessary when we already have the `key`

#### Which issue(s) this PR fixes:
Fixes #111891

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
