### PR TITLE
make applyconfiguration-gen work in non-kube repositiories

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/args/args.go
@@ -50,8 +50,9 @@ func NewDefaults() (*args.GeneratorArgs, *CustomArgs) {
 	customArgs := &CustomArgs{
 		ExternalApplyConfigurations: map[types.Name]string{
 			// Always include TypeMeta and ObjectMeta. They are sufficient for the vast majority of use cases.
-			{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "TypeMeta"}:   "k8s.io/client-go/applyconfigurations/meta/v1",
-			{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "ObjectMeta"}: "k8s.io/client-go/applyconfigurations/meta/v1",
+			{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "TypeMeta"}:       "k8s.io/client-go/applyconfigurations/meta/v1",
+			{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "ObjectMeta"}:     "k8s.io/client-go/applyconfigurations/meta/v1",
+			{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "OwnerReference"}: "k8s.io/client-go/applyconfigurations/meta/v1",
 		},
 	}
 	genericArgs.CustomArgs = customArgs

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
@@ -169,7 +169,6 @@ func (g *applyConfigurationGenerator) generateWithFuncs(t *types.Type, typeParam
 				EmbeddedIn: embed,
 			}
 			if memberParams.Member.Embedded {
-
 				g.generateWithFuncs(member.Type, typeParams, sw, &memberParams)
 				if !jsonTags.inline {
 					// non-inlined embeds are nillable and need a "ensure exists" utility function
@@ -177,12 +176,13 @@ func (g *applyConfigurationGenerator) generateWithFuncs(t *types.Type, typeParam
 				}
 				continue
 			}
+
 			// For slices where the items are generated apply configuration types, accept varargs of
 			// pointers of the type as "with" function arguments so the "with" function can be used like so:
 			// WithFoos(Foo().WithName("x"), Foo().WithName("y"))
 			if t := deref(member.Type); t.Kind == types.Slice && g.refGraph.isApplyConfig(t.Elem) {
 				memberParams.ArgType = &types.Type{Kind: types.Pointer, Elem: memberType.Elem}
-				g.generateMemberWithForSlice(sw, memberParams)
+				g.generateMemberWithForSlice(sw, member, memberParams)
 				continue
 			}
 			// Note: There are no maps where the values are generated apply configurations (because
@@ -194,7 +194,7 @@ func (g *applyConfigurationGenerator) generateWithFuncs(t *types.Type, typeParam
 			switch memberParams.Member.Type.Kind {
 			case types.Slice:
 				memberParams.ArgType = memberType.Elem
-				g.generateMemberWithForSlice(sw, memberParams)
+				g.generateMemberWithForSlice(sw, member, memberParams)
 			case types.Map:
 				g.generateMemberWithForMap(sw, memberParams)
 			default:
@@ -264,20 +264,39 @@ func (g *applyConfigurationGenerator) generateMemberWith(sw *generator.SnippetWr
 	sw.Do("}\n", memberParams)
 }
 
-func (g *applyConfigurationGenerator) generateMemberWithForSlice(sw *generator.SnippetWriter, memberParams memberParams) {
+func (g *applyConfigurationGenerator) generateMemberWithForSlice(sw *generator.SnippetWriter, member types.Member, memberParams memberParams) {
+	memberIsPointerToSlice := member.Type.Kind == types.Pointer
+	if memberIsPointerToSlice {
+		sw.Do(ensureNonEmbedSliceExists, memberParams)
+	}
+
 	sw.Do("// With$.Member.Name$ adds the given value to the $.Member.Name$ field in the declarative configuration\n", memberParams)
 	sw.Do("// and returns the receiver, so that objects can be build by chaining \"With\" function invocations.\n", memberParams)
 	sw.Do("// If called multiple times, values provided by each call will be appended to the $.Member.Name$ field.\n", memberParams)
 	sw.Do("func (b *$.ApplyConfig.ApplyConfiguration|public$) With$.Member.Name$(values ...$.ArgType|raw$) *$.ApplyConfig.ApplyConfiguration|public$ {\n", memberParams)
 	g.ensureEnbedExistsIfApplicable(sw, memberParams)
+
+	if memberIsPointerToSlice {
+		sw.Do("b.ensure$.MemberType.Elem|public$Exists()\n", memberParams)
+	}
+
 	sw.Do("  for i := range values {\n", memberParams)
 	if memberParams.ArgType.Kind == types.Pointer {
 		sw.Do("if values[i] == nil {\n", memberParams)
 		sw.Do("  panic(\"nil value passed to With$.Member.Name$\")\n", memberParams)
 		sw.Do("}\n", memberParams)
-		sw.Do("b.$.Member.Name$ = append(b.$.Member.Name$, *values[i])\n", memberParams)
+
+		if memberIsPointerToSlice {
+			sw.Do("*b.$.Member.Name$ = append(*b.$.Member.Name$, *values[i])\n", memberParams)
+		} else {
+			sw.Do("b.$.Member.Name$ = append(b.$.Member.Name$, *values[i])\n", memberParams)
+		}
 	} else {
-		sw.Do("b.$.Member.Name$ = append(b.$.Member.Name$, values[i])\n", memberParams)
+		if memberIsPointerToSlice {
+			sw.Do("*b.$.Member.Name$ = append(*b.$.Member.Name$, values[i])\n", memberParams)
+		} else {
+			sw.Do("b.$.Member.Name$ = append(b.$.Member.Name$, values[i])\n", memberParams)
+		}
 	}
 	sw.Do("  }\n", memberParams)
 	sw.Do("  return b\n", memberParams)
@@ -313,6 +332,14 @@ var ensureEmbedExists = `
 func (b *$.ApplyConfig.ApplyConfiguration|public$) ensure$.MemberType.Elem|public$Exists() {
   if b.$.MemberType.Elem|public$ == nil {
     b.$.MemberType.Elem|public$ = &$.MemberType.Elem|raw${}
+  }
+}
+`
+
+var ensureNonEmbedSliceExists = `
+func (b *$.ApplyConfig.ApplyConfiguration|public$) ensure$.MemberType.Elem|public$Exists() {
+  if b.$.Member.Name$ == nil {
+    b.$.Member.Name$ = &[]$.MemberType.Elem|raw${}
   }
 }
 `

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
@@ -97,12 +97,9 @@ func (g *applyConfigurationGenerator) GenerateType(c *generator.Context, t *type
 	g.generateStruct(sw, typeParams)
 
 	if typeParams.Tags.GenerateClient {
-		switch {
-		case !hasObjectMetaField(t):
-			sw.Do(clientgenTypeConstructorWithoutObjectMeta, typeParams)
-		case typeParams.Tags.NonNamespaced:
+		if typeParams.Tags.NonNamespaced {
 			sw.Do(clientgenTypeConstructorNonNamespaced, typeParams)
-		default:
+		} else {
 			sw.Do(clientgenTypeConstructorNamespaced, typeParams)
 		}
 		if typeParams.OpenAPIType != nil {
@@ -122,15 +119,6 @@ func (g *applyConfigurationGenerator) GenerateType(c *generator.Context, t *type
 func hasTypeMetaField(t *types.Type) bool {
 	for _, member := range t.Members {
 		if typeMeta.Name == member.Type.Name && member.Embedded {
-			return true
-		}
-	}
-	return false
-}
-
-func hasObjectMetaField(t *types.Type) bool {
-	for _, member := range t.Members {
-		if objectMeta.Name == member.Type.Name && member.Embedded {
 			return true
 		}
 	}
@@ -369,17 +357,6 @@ func $.ApplyConfig.Type|public$(name string) *$.ApplyConfig.ApplyConfiguration|p
 }
 `
 
-var clientgenTypeConstructorWithoutObjectMeta = `
-// $.ApplyConfig.Type|public$ constructs an declarative configuration of the $.ApplyConfig.Type|public$ type for use with
-// apply.
-func $.ApplyConfig.Type|public$(name string) *$.ApplyConfig.ApplyConfiguration|public$ {
-  b := &$.ApplyConfig.ApplyConfiguration|public${}
-  b.WithKind("$.ApplyConfig.Type|singularKind$")
-  b.WithAPIVersion("$.APIVersion$")
-  return b
-}
-`
-
 var constructorWithTypeMeta = `
 // $.ApplyConfig.ApplyConfiguration|public$ constructs an declarative configuration of the $.ApplyConfig.Type|public$ type for use with
 // apply.
@@ -425,18 +402,7 @@ func Extract$.ApplyConfig.Type|public$Status($.Struct|private$ *$.Struct|raw$, f
 }
 `, typeParams)
 	}
-	if !hasObjectMetaField(typeParams.Struct) {
-		sw.Do(`
-func extract$.ApplyConfig.Type|public$($.Struct|private$ *$.Struct|raw$, fieldManager string, subresource string) (*$.ApplyConfig.ApplyConfiguration|public$, error) {
-	b := &$.ApplyConfig.ApplyConfiguration|public${}
-	err := $.ExtractInto|raw$($.Struct|private$, $.ParserFunc|raw$().Type("$.OpenAPIType$"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-`, typeParams)
-
-	} else { // it has objectMeta
-		sw.Do(`
+	sw.Do(`
 func extract$.ApplyConfig.Type|public$($.Struct|private$ *$.Struct|raw$, fieldManager string, subresource string) (*$.ApplyConfig.ApplyConfiguration|public$, error) {
 	b := &$.ApplyConfig.ApplyConfiguration|public${}
 	err := $.ExtractInto|raw$($.Struct|private$, $.ParserFunc|raw$().Type("$.OpenAPIType$"), fieldManager, b, subresource)
@@ -445,9 +411,8 @@ func extract$.ApplyConfig.Type|public$($.Struct|private$ *$.Struct|raw$, fieldMa
 	}
 	b.WithName($.Struct|private$.Name)
 `, typeParams)
-		if !typeParams.Tags.NonNamespaced {
-			sw.Do("b.WithNamespace($.Struct|private$.Namespace)\n", typeParams)
-		}
+	if !typeParams.Tags.NonNamespaced {
+		sw.Do("b.WithNamespace($.Struct|private$.Namespace)\n", typeParams)
 	}
 	sw.Do(`
 	b.WithKind("$.ApplyConfig.Type|singularKind$")

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
@@ -118,7 +118,7 @@ func (g *applyConfigurationGenerator) GenerateType(c *generator.Context, t *type
 
 func hasTypeMetaField(t *types.Type) bool {
 	for _, member := range t.Members {
-		if typeMeta.Name == member.Type.Name {
+		if typeMeta.Name == member.Type.Name && member.Embedded {
 			return true
 		}
 	}

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/packages.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/packages.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/klog/v2"
 
 	applygenargs "k8s.io/code-generator/cmd/applyconfiguration-gen/args"
+	"k8s.io/code-generator/cmd/client-gen/generators/util"
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 )
 
@@ -236,8 +237,10 @@ func packageTypesForInputDirs(context *generator.Context, inputDirs []string, ou
 			klog.Warningf("Skipping internal package: %s", p.Path)
 			continue
 		}
-		gv := groupVersion(p)
-		pkg := filepath.Join(outputPath, gv.Group.PackageName(), strings.ToLower(gv.Version.NonEmpty()))
+		// this is how the client generator finds the package we are creating. It uses the API package name, not the group name.
+		_, gvPackageString := util.ParsePathGroupVersion(p.Path)
+
+		pkg := filepath.Join(outputPath, strings.ToLower(gvPackageString))
 		pkgTypes[pkg] = p
 	}
 	return pkgTypes

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/packages.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/packages.go
@@ -82,6 +82,13 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 		var toGenerate []applyConfig
 		for _, t := range p.Types {
+			// If we don't have an ObjectMeta field, we lack the information required to make the Apply or ApplyStatus call
+			// to the kube-apiserver, so we don't need to generate the type at all
+			clientTags := genclientTags(t)
+			if clientTags.GenerateClient && !hasObjectMetaField(t) {
+				klog.V(5).Infof("skipping type %v because does not have ObjectMeta", t)
+				continue
+			}
 			if typePkg, ok := refs[t.Name]; ok {
 				toGenerate = append(toGenerate, applyConfig{
 					Type:               t,
@@ -237,9 +244,11 @@ func packageTypesForInputDirs(context *generator.Context, inputDirs []string, ou
 			klog.Warningf("Skipping internal package: %s", p.Path)
 			continue
 		}
-		// this is how the client generator finds the package we are creating. It uses the API package name, not the group name.
+		// This is how the client generator finds the package we are creating. It uses the API package name, not the group name.
+		// This matches the approach of the client-gen, so the two generator can work together.
+		// For example, if openshift/api/cloudnetwork/v1 contains an apigroup cloud.network.openshift.io, the client-gen
+		// builds a package called cloudnetwork/v1 to contain it. This change makes the applyconfiguration-gen use the same.
 		_, gvPackageString := util.ParsePathGroupVersion(p.Path)
-
 		pkg := filepath.Join(outputPath, strings.ToLower(gvPackageString))
 		pkgTypes[pkg] = p
 	}
@@ -276,4 +285,13 @@ func isInternalPackage(p *types.Package) bool {
 func isInternal(m types.Member) bool {
 	_, ok := lookupJSONTags(m)
 	return !ok
+}
+
+func hasObjectMetaField(t *types.Type) bool {
+	for _, member := range t.Members {
+		if objectMeta.Name == member.Type.Name && member.Embedded {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
When using this generator from another repo, its necessary to add OwnerReference to avoid generation like

```
func (b *APIRequestCountApplyConfiguration) WithOwnerReferences(values ...metav1.OwnerReference) *APIRequestCountApplyConfiguration {
```

that won't compile

This fixes several problems
1. add metav1.OwnerReference to the default external configurations to ease generation
2. add handling for types that have non-embedded TypeMeta
3. fix flag handling for --external-applyconfigurations so it can be used.
4. make it work with resources without objectmeta so the generated code compiles
5. make it handle pointers to slices

/kind bug
/priority important-soon
/sig api-machinery
/assign @jpbetz 

```release-note
NONE
```