### PR TITLE
kubelet: drop bitArray implementation

### DIFF
--- a/pkg/kubelet/userns_manager_test.go
+++ b/pkg/kubelet/userns_manager_test.go
@@ -54,13 +54,11 @@ func TestUserNsManagerAllocate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, userNsLength, int(length), "m.isSet(%d).length=%v", allocated, length)
 	assert.Equal(t, true, m.isSet(allocated), "m.isSet(%d)", allocated)
-	assert.Equal(t, userNsLength*2, int(allocated))
 
 	allocated2, length2, err := m.allocateOne("two")
 	assert.NoError(t, err)
 	assert.NotEqual(t, allocated, allocated2, "allocated != allocated2")
 	assert.Equal(t, length, length2, "length == length2")
-	assert.Equal(t, uint32(userNsLength*3), allocated2)
 
 	// verify that re-adding the same pod with the same settings won't fail
 	err = m.record("two", allocated2, length2)
@@ -78,7 +76,6 @@ func TestUserNsManagerAllocate(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		allocated, length, err = m.allocateOne(types.UID(fmt.Sprintf("%d", i)))
 		assert.Equal(t, userNsLength, int(length), "length is not the expected. iter: %v", i)
-		assert.Equal(t, userNsLength*(i+2), int(allocated), "firstID is not the expected. iter: %v", i)
 		assert.NoError(t, err)
 		allocs = append(allocs, allocated)
 	}
@@ -304,43 +301,5 @@ func TestUserNsManagerHostIDFromMapping(t *testing.T) {
 				t.Errorf("expected: %v - got: %v", tc.expHostId, id)
 			}
 		})
-	}
-}
-
-func BenchmarkBitmaskFindAndSetFirstZero(t *testing.B) {
-	b := makeBitArray(userNsLength)
-	for i := 0; i < userNsLength; i++ {
-		_, found := b.findAvailable()
-		assert.True(t, found)
-	}
-}
-
-func BenchmarkBitmaskSetAndClear(t *testing.B) {
-	b := makeBitArray(userNsLength)
-	for i := uint32(0); i < userNsLength; i++ {
-		b.set(i)
-		b.clear(i)
-	}
-}
-
-func BenchmarkBitmaskFindAndSetFirstZeroAndClear(t *testing.B) {
-	b := makeBitArray(userNsLength)
-	for i := 0; i < userNsLength; i++ {
-		ret, found := b.findAvailable()
-		assert.True(t, found)
-		b.clear(ret)
-	}
-}
-
-func BenchmarkBitmaskFindAndSetFirstZeroAndClear0Every2(t *testing.B) {
-	// it is an interesting edge case as it forces a full scan
-	// on each second allocation.
-	b := makeBitArray(userNsLength)
-	for i := 0; i < userNsLength; i++ {
-		_, found := b.findAvailable()
-		assert.True(t, found)
-		if i%2 == 0 {
-			b.clear(0)
-		}
 	}
 }


### PR DESCRIPTION
drop bitArray implementation and use the bitmap implementation from
k8s.io/kubernetes/pkg/registry/core/service/allocator.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

use the bitmap implementation that exists for k8s.io/kubernetes/pkg/registry/core/service/allocator instead of definiting a similar type with the same functionalities.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
