### PR TITLE
Optimizing: scheduler cache node  Initialize cap

### DIFF
--- a/pkg/scheduler/internal/cache/node_tree.go
+++ b/pkg/scheduler/internal/cache/node_tree.go
@@ -38,7 +38,7 @@ type nodeTree struct {
 // newNodeTree creates a NodeTree from nodes.
 func newNodeTree(nodes []*v1.Node) *nodeTree {
 	nt := &nodeTree{
-		tree: make(map[string][]string),
+		tree: make(map[string][]string, len(nodes)),
 	}
 	for _, n := range nodes {
 		nt.addNode(n)

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/sets_ippermissions.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/sets_ippermissions.go
@@ -38,7 +38,7 @@ type IPPermissionPredicate interface {
 
 // NewIPPermissionSet creates a new IPPermissionSet
 func NewIPPermissionSet(items ...*ec2.IpPermission) IPPermissionSet {
-	s := make(IPPermissionSet)
+	s := make(IPPermissionSet, len(items))
 	s.Insert(items...)
 	return s
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/sets_ippermissions.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/sets_ippermissions.go
@@ -38,7 +38,7 @@ type IPPermissionPredicate interface {
 
 // NewIPPermissionSet creates a new IPPermissionSet
 func NewIPPermissionSet(items ...*ec2.IpPermission) IPPermissionSet {
-	s := make(IPPermissionSet, len(items))
+	s := make(IPPermissionSet)
 	s.Insert(items...)
 	return s
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Optimizing make does not allocate memory

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```