### PR TITLE
Removed force_tcp flag from defaults.

### DIFF
--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -63,9 +63,7 @@ data:
         reload
         loop
         bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
-        forward . __PILLAR__CLUSTER__DNS__ {
-                force_tcp
-        }
+        forward . __PILLAR__CLUSTER__DNS__
         prometheus :9253
         health __PILLAR__LOCAL__DNS__:8080
         }
@@ -75,9 +73,7 @@ data:
         reload
         loop
         bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
-        forward . __PILLAR__CLUSTER__DNS__ {
-                force_tcp
-        }
+        forward . __PILLAR__CLUSTER__DNS__
         prometheus :9253
         }
     ip6.arpa:53 {
@@ -86,9 +82,7 @@ data:
         reload
         loop
         bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
-        forward . __PILLAR__CLUSTER__DNS__ {
-                force_tcp
-        }
+        forward . __PILLAR__CLUSTER__DNS__
         prometheus :9253
         }
     .:53 {


### PR DESCRIPTION
`force_tcp` flag completely disables UDP communication which is used by default in DNS protocol, that needlessly increase resolve latency and provides no additional benefits
There are certain conditions when resolver MUST switch to TCP (like response payload >512 bytes, however DNS extensions allow bigger payloads in UDP nowadays). It's even less reasonable to use force_tcp flag between node_local_cache and local resolver as LAN use jumbo frames (MTU>9000 bytes) nowadays.
In addition to that, AWS VPC resolver throttles packet rate at 1000 per second, with TCP 3-way handshake that limit is easily breached at resolve rates close to 200 queries per second.

Originated from https://github.com/kubernetes/kops/pull/14121#issuecomment-1224167011 (contains more details on subj)