### PR TITLE
Automated cherry pick of #111428: Skip "instance not found" error for LB backend address pools

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -190,7 +190,9 @@ func (az *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, ser
 	lbStatus, err := az.getServiceLoadBalancerStatus(service, lb)
 	if err != nil {
 		klog.Errorf("getServiceLoadBalancerStatus(%s) failed: %v", serviceName, err)
-		return nil, err
+		if err != cloudprovider.InstanceNotFound {
+			return nil, err
+		}
 	}
 
 	var serviceIP *string

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -826,7 +826,9 @@ func (as *availabilitySet) EnsureHostInPool(service *v1.Service, nodeName types.
 		}
 
 		klog.Errorf("error: az.EnsureHostInPool(%s), az.VMSet.GetPrimaryInterface.Get(%s, %s), err=%v", nodeName, vmName, vmSetName, err)
-		return "", "", "", nil, err
+		if err != cloudprovider.InstanceNotFound {
+			return "", "", "", nil, err
+		}
 	}
 
 	if nic.ProvisioningState != nil && *nic.ProvisioningState == nicFailedState {


### PR DESCRIPTION
Cherry pick of #111428 on release-1.23.

#111428: Skip "instance not found" error for LB backend address pools

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```