### PR TITLE
kubeadm: remove container-runtime=remote

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
@@ -86,6 +86,12 @@ func runKubeletConfigPhase() func(c workflow.RunData) error {
 			return nil
 		}
 
+		// TODO: Temporary workaround. Remove in 1.27:
+		// https://github.com/kubernetes/kubeadm/issues/2626
+		if err := upgrade.CleanupKubeletDynamicEnvFileContainerRuntime(dryRun); err != nil {
+			return err
+		}
+
 		fmt.Println("[upgrade] The configuration for this node was successfully updated!")
 		fmt.Println("[upgrade] Now you should go ahead and upgrade the kubelet package using your package manager.")
 		return nil

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -76,8 +76,6 @@ func WriteKubeletDynamicEnvFile(cfg *kubeadmapi.ClusterConfiguration, nodeReg *k
 func buildKubeletArgMapCommon(opts kubeletFlagsOpts) map[string]string {
 	kubeletFlags := map[string]string{}
 	kubeletFlags["container-runtime-endpoint"] = opts.nodeRegOpts.CRISocket
-	// container runtime is by default docker in kubelet v1.23, so it can be removed in v1.26
-	kubeletFlags["container-runtime"] = "remote"
 
 	// This flag passes the pod infra container image (e.g. "pause" image) to the kubelet
 	// and prevents its garbage collection

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -42,7 +42,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 				},
 			},
 			expected: map[string]string{
-				"container-runtime":          "remote",
 				"container-runtime-endpoint": "unix:///var/run/containerd/containerd.sock",
 				"hostname-override":          "override-name",
 			},
@@ -68,7 +67,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 				registerTaintsUsingFlags: true,
 			},
 			expected: map[string]string{
-				"container-runtime":          "remote",
 				"container-runtime-endpoint": "unix:///var/run/containerd/containerd.sock",
 				"register-with-taints":       "foo=bar:baz,key=val:eff",
 			},
@@ -82,7 +80,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 				pauseImage: "registry.k8s.io/pause:3.8",
 			},
 			expected: map[string]string{
-				"container-runtime":          "remote",
 				"container-runtime-endpoint": "unix:///var/run/containerd/containerd.sock",
 				"pod-infra-container-image":  "registry.k8s.io/pause:3.8",
 			},

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 )
@@ -104,7 +103,7 @@ func TestRollbackFiles(t *testing.T) {
 	}
 }
 
-func TestUpdateKubeletDynamicEnvFileWithURLScheme(t *testing.T) {
+func TestCleanupKubeletDynamicEnvFileContainerRuntime(t *testing.T) {
 	tcases := []struct {
 		name     string
 		input    string
@@ -117,28 +116,28 @@ func TestUpdateKubeletDynamicEnvFileWithURLScheme(t *testing.T) {
 		},
 		{
 			name:     "add missing URL scheme",
-			input:    fmt.Sprintf("%s=\"--foo=abc --container-runtime-endpoint=/some/endpoint --bar=def\"", constants.KubeletEnvFileVariableName),
-			expected: fmt.Sprintf("%s=\"--foo=abc --container-runtime-endpoint=%s:///some/endpoint --bar=def\"", constants.KubeletEnvFileVariableName, kubeadmapiv1.DefaultContainerRuntimeURLScheme),
+			input:    fmt.Sprintf("%s=\"--foo=abc --container-runtime=remote --bar=def\"", constants.KubeletEnvFileVariableName),
+			expected: fmt.Sprintf("%s=\"--foo=abc --bar=def\"", constants.KubeletEnvFileVariableName),
 		},
 		{
 			name:     "add missing URL scheme if there is no '=' after the flag name",
-			input:    fmt.Sprintf("%s=\"--foo=abc --container-runtime-endpoint /some/endpoint --bar=def\"", constants.KubeletEnvFileVariableName),
-			expected: fmt.Sprintf("%s=\"--foo=abc --container-runtime-endpoint %s:///some/endpoint --bar=def\"", constants.KubeletEnvFileVariableName, kubeadmapiv1.DefaultContainerRuntimeURLScheme),
+			input:    fmt.Sprintf("%s=\"--foo=abc --container-runtime remote --bar=def\"", constants.KubeletEnvFileVariableName),
+			expected: fmt.Sprintf("%s=\"--foo=abc --bar=def\"", constants.KubeletEnvFileVariableName),
 		},
 		{
 			name:     "empty flag of interest value following '='",
-			input:    fmt.Sprintf("%s=\"--foo=abc --container-runtime-endpoint= --bar=def\"", constants.KubeletEnvFileVariableName),
-			expected: fmt.Sprintf("%s=\"--foo=abc --container-runtime-endpoint= --bar=def\"", constants.KubeletEnvFileVariableName),
+			input:    fmt.Sprintf("%s=\"--foo=abc --container-runtime= --bar=def\"", constants.KubeletEnvFileVariableName),
+			expected: fmt.Sprintf("%s=\"--foo=abc --bar=def\"", constants.KubeletEnvFileVariableName),
 		},
 		{
 			name:     "empty flag of interest value without '='",
-			input:    fmt.Sprintf("%s=\"--foo=abc --container-runtime-endpoint --bar=def\"", constants.KubeletEnvFileVariableName),
-			expected: fmt.Sprintf("%s=\"--foo=abc --container-runtime-endpoint --bar=def\"", constants.KubeletEnvFileVariableName),
+			input:    fmt.Sprintf("%s=\"--foo=abc --container-runtime --bar=def\"", constants.KubeletEnvFileVariableName),
+			expected: fmt.Sprintf("%s=\"--foo=abc --bar=def\"", constants.KubeletEnvFileVariableName),
 		},
 	}
 	for _, tt := range tcases {
 		t.Run(tt.name, func(t *testing.T) {
-			output := updateKubeletDynamicEnvFileWithURLScheme(tt.input)
+			output := cleanupKubeletDynamicEnvFileContainerRuntime(tt.input)
 			if output != tt.expected {
 				t.Errorf("expected output: %q, got: %q", tt.expected, output)
 			}


### PR DESCRIPTION
/kind cleanup
follow up of https://github.com/kubernetes/kubernetes/issues/106893

```release-note
kubeadm: remove the usage of the --container-runtime=remote flag for the kubelet during kubeadm init/join/upgrade. The flag value "remote" has been the only possible value since dockershim was removed from the kubelet.
```
