### PR TITLE
kubeadm: revert dedup prefix unix:// in node annotation

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
@@ -20,21 +20,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
 
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
-	patchnodephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/patchnode"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
-	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
 )
 
@@ -90,31 +84,6 @@ func runKubeletConfigPhase() func(c workflow.RunData) error {
 				return errors.Wrap(err, "error printing files on dryrun")
 			}
 			return nil
-		}
-
-		// Handle a dupliate prefix URL scheme in the Node CRI socket.
-		// Older versions of kubeadm(v1.24.0~2) upgrade may add one or two extra prefix `unix://`
-		// TODO: this fix can be removed in 1.26 once all user node sockets have a correct URL scheme:
-		// https://github.com/kubernetes/kubeadm/issues/2426
-		var dupURLScheme bool
-		nro := &kubeadmapi.NodeRegistrationOptions{}
-		if !dryRun {
-			if err := configutil.GetNodeRegistration(data.KubeConfigPath(), data.Client(), nro); err != nil {
-				return errors.Wrap(err, "could not retrieve the node registration options for this node")
-			}
-			dupURLScheme = strings.HasPrefix(nro.CRISocket, kubeadmapiv1.DefaultContainerRuntimeURLScheme+"://"+kubeadmapiv1.DefaultContainerRuntimeURLScheme+"://")
-		}
-		if dupURLScheme {
-			if !dryRun {
-				newSocket := strings.ReplaceAll(nro.CRISocket, kubeadmapiv1.DefaultContainerRuntimeURLScheme+"://", "")
-				newSocket = kubeadmapiv1.DefaultContainerRuntimeURLScheme + "://" + newSocket
-				klog.V(2).Infof("ensuring that Node %q has a CRI socket annotation with correct URL scheme %q", nro.Name, newSocket)
-				if err := patchnodephase.AnnotateCRISocket(data.Client(), nro.Name, newSocket); err != nil {
-					return errors.Wrapf(err, "error updating the CRI socket for Node %q", nro.Name)
-				}
-			} else {
-				fmt.Println("[upgrade] Would update the node CRI socket path to remove dup URL scheme prefix")
-			}
 		}
 
 		fmt.Println("[upgrade] The configuration for this node was successfully updated!")

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -34,13 +33,11 @@ import (
 	"k8s.io/klog/v2"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
-	patchnodephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/patchnode"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
@@ -222,29 +219,6 @@ func enforceRequirements(flags *applyPlanFlags, args []string, dryRun bool, upgr
 	// If the user told us to print this information out; do it!
 	if flags.printConfig {
 		printConfiguration(&cfg.ClusterConfiguration, os.Stdout, printer)
-	}
-
-	// Handle a dupliate prefix URL scheme in the Node CRI socket.
-	// Older versions of kubeadm(v1.24.0~2) upgrade may add one or two extra prefix `unix://`
-	// TODO: this fix can be removed in 1.26 once all user node sockets have a correct URL scheme:
-	// https://github.com/kubernetes/kubeadm/issues/2426
-	dupURLScheme := strings.HasPrefix(cfg.NodeRegistration.CRISocket, kubeadmapiv1.DefaultContainerRuntimeURLScheme+"://"+kubeadmapiv1.DefaultContainerRuntimeURLScheme+"://")
-	if dupURLScheme {
-		socket := strings.ReplaceAll(cfg.NodeRegistration.CRISocket, kubeadmapiv1.DefaultContainerRuntimeURLScheme+"://", "")
-		cfg.NodeRegistration.CRISocket = kubeadmapiv1.DefaultContainerRuntimeURLScheme + "://" + socket
-		var hostname string
-		if len(cfg.NodeRegistration.Name) > 0 {
-			hostname = cfg.NodeRegistration.Name
-		} else {
-			hostname, err = os.Hostname()
-			if err != nil {
-				return nil, nil, nil, errors.Wrapf(err, "failed to get hostname")
-			}
-		}
-		klog.V(2).Infof("ensuring that Node %q has a CRI socket annotation with correct URL scheme %q", hostname, cfg.NodeRegistration.CRISocket)
-		if err := patchnodephase.AnnotateCRISocket(client, hostname, cfg.NodeRegistration.CRISocket); err != nil {
-			return nil, nil, nil, errors.Wrapf(err, "error updating the CRI socket for Node %q", cfg.NodeRegistration.CRISocket)
-		}
 	}
 
 	// Use a real version getter interface that queries the API server, the kubeadm client and the Kubernetes CI system for latest versions


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
follow up of https://github.com/kubernetes/kubernetes/pull/110656/ (remove the de-dup logic for v1.24.0-2.)
- v1.25.x has no issue and will fix it during upgrade

#### Which issue(s) this PR fixes:
xref https://github.com/kubernetes/kubeadm/issues/2426
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
