### PR TITLE
kubeadm: remove MutateImageRepository for registry change

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	patchnodephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/patchnode"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
-	"k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
@@ -74,15 +73,6 @@ func loadConfig(cfgPath string, client clientset.Interface, skipComponentConfigs
 	// This is probably 90% of the time. So we handle it first.
 	if cfgPath == "" {
 		cfg, err := configutil.FetchInitConfigurationFromCluster(client, printer, logPrefix, false, skipComponentConfigs)
-		// In case we fetch a configuration from the cluster, mutate the ImageRepository field
-		// to be 'registry.k8s.io', if it was 'k8s.gcr.io'.
-		// TODO: Remove this in 1.26
-		// https://github.com/kubernetes/kubeadm/issues/2671
-		if err == nil {
-			if err := uploadconfig.MutateImageRepository(cfg, client); err != nil {
-				return nil, false, err
-			}
-		}
 		return cfg, false, err
 	}
 

--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -34,7 +34,6 @@ import (
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane"
-	"k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
@@ -120,14 +119,6 @@ func runDiff(flags *diffFlags, args []string) error {
 			return errors.Wrapf(err, "couldn't create a Kubernetes client from file %q", flags.kubeConfigPath)
 		}
 		cfg, err = configutil.FetchInitConfigurationFromCluster(client, nil, "upgrade/diff", false, false)
-		// In case we fetch a configuration from the cluster, mutate the ImageRepository field
-		// to be 'registry.k8s.io', if it was 'k8s.gcr.io'. Don't mutate the in-cluster value by passing
-		// nil as the client field; this is done only on "apply".
-		// TODO: Remove this in 1.26
-		// https://github.com/kubernetes/kubeadm/issues/2671
-		if err == nil {
-			_ = uploadconfig.MutateImageRepository(cfg, nil)
-		}
 	}
 	if err != nil {
 		return err

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -33,7 +33,6 @@ import (
 	phases "k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/upgrade/node"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 )
 
@@ -146,12 +145,6 @@ func newNodeData(cmd *cobra.Command, args []string, options *nodeOptions, out io
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch the kubeadm-config ConfigMap")
 	}
-	// In case we fetch a configuration from the cluster, mutate the ImageRepository field
-	// to be 'registry.k8s.io', if it was 'k8s.gcr.io'. Don't mutate the in-cluster value by passing
-	// nil as the client field; this is done only on "apply".
-	// TODO: Remove this in 1.26
-	// https://github.com/kubernetes/kubeadm/issues/2671
-	_ = uploadconfig.MutateImageRepository(cfg, nil)
 
 	ignorePreflightErrorsSet, err := validation.ValidateIgnorePreflightErrors(options.ignorePreflightErrors, cfg.NodeRegistration.IgnorePreflightErrors)
 	if err != nil {

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
@@ -19,12 +19,10 @@ package uploadconfig
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -121,26 +119,4 @@ func UploadConfiguration(cfg *kubeadmapi.InitConfiguration, client clientset.Int
 			},
 		},
 	})
-}
-
-// MutateImageRepository mutates the imageRepository field in the ClusterConfiguration
-// to 'registry.k8s.io' in case it was the legacy default 'k8s.gcr.io'
-// TODO: Remove this in 1.26
-// https://github.com/kubernetes/kubeadm/issues/2671
-func MutateImageRepository(cfg *kubeadmapi.InitConfiguration, client clientset.Interface) error {
-	if cfg.ImageRepository != "k8s.gcr.io" {
-		return nil
-	}
-	cfg.ImageRepository = "registry.k8s.io"
-	// If the client is nil assume that we don't want to mutate the in-cluster config
-	if client == nil {
-		return nil
-	}
-	klog.V(1).Info("updating the ClusterConfiguration.ImageRepository field in the kube-system/kubeadm-config " +
-		"ConfigMap to be 'registry.k8s.io' instead of the legacy default of 'k8s.gcr.io'")
-	if err := UploadConfiguration(cfg, client); err != nil {
-		return errors.Wrap(err, "could not mutate the ClusterConfiguration.ImageRepository field in "+
-			"the kube-system/kubeadm-config ConfigMap")
-	}
-	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

follow todo in https://github.com/kubernetes/kubernetes/pull/110343

#### Which issue(s) this PR fixes:
part of  https://github.com/kubernetes/kubeadm/issues/2671

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
