### PR TITLE
Kubeadm cleanup for taint / toleration with master label

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -32,7 +32,6 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
@@ -156,16 +155,6 @@ func runApply(flags *applyFlags, args []string) error {
 	// Now; perform the upgrade procedure
 	if err := PerformControlPlaneUpgrade(flags, client, waiter, cfg); err != nil {
 		return errors.Wrap(err, "[upgrade/apply] FATAL")
-	}
-
-	// Clean this up in 1.26
-	// TODO: https://github.com/kubernetes/kubeadm/issues/2200
-	fmt.Printf("[upgrade/postupgrade] Removing the old taint %s from all control plane Nodes. "+
-		"After this step only the %s taint will be present on control plane Nodes.\n",
-		kubeadmconstants.OldControlPlaneTaint.String(),
-		kubeadmconstants.ControlPlaneTaint.String())
-	if err := upgrade.RemoveOldControlPlaneTaint(client); err != nil {
-		return err
 	}
 
 	// Upgrade RBAC rules and addons.

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -254,10 +254,6 @@ const (
 	// CertificateKeySize specifies the size of the key used to encrypt certificates on uploadcerts phase
 	CertificateKeySize = 32
 
-	// LabelNodeRoleOldControlPlane specifies that a node hosts control-plane components
-	// DEPRECATED: https://github.com/kubernetes/kubeadm/issues/2200
-	LabelNodeRoleOldControlPlane = "node-role.kubernetes.io/master"
-
 	// LabelNodeRoleControlPlane specifies that a node hosts control-plane components
 	LabelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"
 
@@ -439,20 +435,6 @@ const (
 )
 
 var (
-	// OldControlPlaneTaint is the taint to apply on the PodSpec for being able to run that Pod on the control-plane
-	// DEPRECATED: https://github.com/kubernetes/kubeadm/issues/2200
-	OldControlPlaneTaint = v1.Taint{
-		Key:    LabelNodeRoleOldControlPlane,
-		Effect: v1.TaintEffectNoSchedule,
-	}
-
-	// OldControlPlaneToleration is the toleration to apply on the PodSpec for being able to run that Pod on the control-plane
-	// DEPRECATED: https://github.com/kubernetes/kubeadm/issues/2200
-	OldControlPlaneToleration = v1.Toleration{
-		Key:    LabelNodeRoleOldControlPlane,
-		Effect: v1.TaintEffectNoSchedule,
-	}
-
 	// ControlPlaneTaint is the taint to apply on the PodSpec for being able to run that Pod on the control-plane
 	ControlPlaneTaint = v1.Taint{
 		Key:    LabelNodeRoleControlPlane,

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -105,15 +105,13 @@ func EnsureDNSAddon(cfg *kubeadmapi.ClusterConfiguration, client clientset.Inter
 func coreDNSAddon(cfg *kubeadmapi.ClusterConfiguration, client clientset.Interface, replicas *int32, out io.Writer, printManifest bool) error {
 	// Get the YAML manifest
 	coreDNSDeploymentBytes, err := kubeadmutil.ParseTemplate(CoreDNSDeployment, struct {
-		DeploymentName, Image, OldControlPlaneTaintKey, ControlPlaneTaintKey string
-		Replicas                                                             *int32
+		DeploymentName, Image, ControlPlaneTaintKey string
+		Replicas                                    *int32
 	}{
-		DeploymentName: kubeadmconstants.CoreDNSDeploymentName,
-		Image:          images.GetDNSImage(cfg),
-		// TODO: https://github.com/kubernetes/kubeadm/issues/2200
-		OldControlPlaneTaintKey: kubeadmconstants.LabelNodeRoleOldControlPlane,
-		ControlPlaneTaintKey:    kubeadmconstants.LabelNodeRoleControlPlane,
-		Replicas:                replicas,
+		DeploymentName:       kubeadmconstants.CoreDNSDeploymentName,
+		Image:                images.GetDNSImage(cfg),
+		ControlPlaneTaintKey: kubeadmconstants.LabelNodeRoleControlPlane,
+		Replicas:             replicas,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error when parsing CoreDNS deployment template")

--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -43,14 +43,13 @@ func TestCompileManifests(t *testing.T) {
 			name:     "CoreDNSDeployment manifest",
 			manifest: CoreDNSDeployment,
 			data: struct {
-				DeploymentName, Image, OldControlPlaneTaintKey, ControlPlaneTaintKey string
-				Replicas                                                             *int32
+				DeploymentName, Image, ControlPlaneTaintKey string
+				Replicas                                    *int32
 			}{
-				DeploymentName:          "foo",
-				Image:                   "foo",
-				OldControlPlaneTaintKey: "foo",
-				ControlPlaneTaintKey:    "foo",
-				Replicas:                &replicas,
+				DeploymentName:       "foo",
+				Image:                "foo",
+				ControlPlaneTaintKey: "foo",
+				Replicas:             &replicas,
 			},
 		},
 		{
@@ -127,15 +126,14 @@ func TestDeploymentsHaveSystemClusterCriticalPriorityClassName(t *testing.T) {
 			name:     "CoreDNSDeployment",
 			manifest: CoreDNSDeployment,
 			data: struct {
-				DeploymentName, Image, OldControlPlaneTaintKey, ControlPlaneTaintKey, CoreDNSConfigMapName string
-				Replicas                                                                                   *int32
+				DeploymentName, Image, ControlPlaneTaintKey, CoreDNSConfigMapName string
+				Replicas                                                          *int32
 			}{
-				DeploymentName:          "foo",
-				Image:                   "foo",
-				OldControlPlaneTaintKey: "foo",
-				ControlPlaneTaintKey:    "foo",
-				CoreDNSConfigMapName:    "foo",
-				Replicas:                &replicas,
+				DeploymentName:       "foo",
+				Image:                "foo",
+				ControlPlaneTaintKey: "foo",
+				CoreDNSConfigMapName: "foo",
+				Replicas:             &replicas,
 			},
 		},
 	}

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -92,8 +92,6 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-      - key: {{ .OldControlPlaneTaintKey }}
-        effect: NoSchedule
       - key: {{ .ControlPlaneTaintKey }}
         effect: NoSchedule
       nodeSelector:

--- a/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane_test.go
+++ b/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane_test.go
@@ -89,7 +89,6 @@ func TestMarkControlPlane(t *testing.T) {
 		{
 			name: "has taint and should merge with wanted taint",
 			existingLabels: []string{
-				kubeadmconstants.LabelNodeRoleOldControlPlane,
 				kubeadmconstants.LabelNodeRoleControlPlane,
 				kubeadmconstants.LabelExcludeFromExternalLB,
 			},

--- a/cmd/kubeadm/app/phases/upgrade/health.go
+++ b/cmd/kubeadm/app/phases/upgrade/health.go
@@ -125,10 +125,6 @@ func createJob(client clientset.Interface, cfg *kubeadmapi.ClusterConfiguration)
 					},
 					Tolerations: []v1.Toleration{
 						{
-							Key:    constants.LabelNodeRoleOldControlPlane,
-							Effect: v1.TaintEffectNoSchedule,
-						},
-						{
 							Key:    constants.LabelNodeRoleControlPlane,
 							Effect: v1.TaintEffectNoSchedule,
 						},


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
xref https://github.com/kubernetes/kubeadm/issues/2200


#### Special notes for your reviewer:
#### Does this PR introduce a user-facing change?

```release-note
kubeadm: remove the toleration for the "node-role.kubernetes.io/master" taint from the CoreDNS deployment of kubeadm. With the 1.25 release of kubeadm the taint "node-role.kubernetes.io/master" is no longer applied to control plane nodes and the toleration for it can be removed with the release of 1.26. You can also perform the same toleration removal from your own addon manifests.
```
