### PR TITLE
e2e: Use framework helpers to create namespaces

### DIFF
--- a/test/e2e/network/scale/localrun/ingress_scale.go
+++ b/test/e2e/network/scale/localrun/ingress_scale.go
@@ -131,11 +131,12 @@ func main() {
 		}
 	}()
 
+	// This program is meant for local testing. It creates a Namespace
+	// directly instead of using the e2e test framework.
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNamespace,
 			Labels: map[string]string{
-				// TODO(https://github.com/kubernetes/kubernetes/issues/108298): route namespace creation via framework.Framework.CreateNamespace in 1.24
 				admissionapi.EnforceLevelLabel: string(admissionapi.LevelPrivileged),
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Use framework helpers to create namespaces for apimachinery webhook e2e tests

Note that an earlier (merged) PR took care of the netpol e2e tests, which are mentioned in #108298: #111789

The issue also mentions that the following code needs to be updated to use `CreateNamespace` from the framework:
https://github.com/kubernetes/kubernetes/blob/f313ef501a508cedfca9ed5543cdadbb8053c9b9/test/e2e/network/scale/localrun/ingress_scale.go#L134-L148

I disagree. This program is meant to be run locally for a very specific purpose. It is not a generic test (GCE-specific) and manual namespace creation seems intentional. To avoid future confusion, a comment was added. However, I am not very familiar with this program, so feel free to correct me.

#### Which issue(s) this PR fixes:

Fixes #108298 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: