### PR TITLE
Set correct SELinux label for host paths volumes created by host path provisioner

### DIFF
--- a/pkg/kubelet/config/defaults.go
+++ b/pkg/kubelet/config/defaults.go
@@ -28,5 +28,6 @@ const (
 	DefaultKubeletPluginContainersDirName    = "plugin-containers"
 	DefaultKubeletPodResourcesDirName        = "pod-resources"
 	KubeletPluginsDirSELinuxLabel            = "system_u:object_r:container_file_t:s0"
+	KubeletContainersSharedSELinuxLabel      = "system_u:object_r:container_file_t:s0"
 	DefaultKubeletCheckpointsDirName         = "checkpoints"
 )

--- a/pkg/volume/hostpath/host_path.go
+++ b/pkg/volume/hostpath/host_path.go
@@ -21,17 +21,19 @@ import (
 	"os"
 	"regexp"
 
-	"k8s.io/mount-utils"
+	"github.com/opencontainers/selinux/go-selinux"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
 	"k8s.io/kubernetes/pkg/volume/util/recyclerclient"
 	"k8s.io/kubernetes/pkg/volume/validation"
+	"k8s.io/mount-utils"
 )
 
 // ProbeVolumePlugins is the primary entrypoint for volume plugins.
@@ -320,7 +322,17 @@ func (r *hostPathProvisioner) Provision(selectedNode *v1.Node, allowedTopologies
 		pv.Spec.AccessModes = r.plugin.GetAccessModes()
 	}
 
-	return pv, os.MkdirAll(pv.Spec.HostPath.Path, 0750)
+	if err := os.MkdirAll(pv.Spec.HostPath.Path, 0750); err != nil {
+		return nil, err
+	}
+	if selinux.GetEnabled() {
+		err := selinux.SetFileLabel(pv.Spec.HostPath.Path, config.KubeletContainersSharedSELinuxLabel)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set selinux label for %q: %v", pv.Spec.HostPath.Path, err)
+		}
+	}
+
+	return pv, nil
 }
 
 // hostPathDeleter deletes a hostPath PV from the cluster.


### PR DESCRIPTION
These host paths have a well known location under /tmp/hostpath_pv
and are therefore safe to be labeled with the shared SELinux label.

Without this label, the mounted volumes cannot be accessed by the
container processes.

Signed-off-by: Mrunal Patel <mpatel@redhat.com>


#### What type of PR is this?


/kind bug



#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #112020 

#### Special notes for your reviewer:


```release-note
Fix SELinux label for host path volumes created by host path provisioner
```

cc: @rphillips @haircommander 
