### PR TITLE
UT address already in use error

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,19 +79,47 @@ func NewTestConfig(t *testing.T) *embed.Config {
 	return cfg
 }
 
+func startEtcd(t *testing.T, cfg *embed.Config) (e *embed.Etcd, cfgR *embed.Config, err error) {
+	cfgR = NewTestConfig(t)
+	if cfg != nil {
+		cfgR.ExperimentalWatchProgressNotifyInterval = cfg.ExperimentalWatchProgressNotifyInterval
+		cfgR.ClientTLSInfo = cfg.ClientTLSInfo
+		if len(cfg.ClientTLSInfo.CertFile) > 0 && len(cfg.ClientTLSInfo.KeyFile) > 0 {
+			for i := range cfgR.LCUrls {
+				cfgR.LCUrls[i].Scheme = "https"
+			}
+			for i := range cfgR.ACUrls {
+				cfgR.ACUrls[i].Scheme = "https"
+			}
+		}
+	}
+
+	e, err = embed.StartEtcd(cfgR)
+	return e, cfgR, err
+}
+
 // RunEtcd starts an embedded etcd server with the provided config
 // (or NewTestConfig(t) if nil), and returns a client connected to the server.
 // The server is terminated when the test ends.
 func RunEtcd(t *testing.T, cfg *embed.Config) *clientv3.Client {
 	t.Helper()
-
-	if cfg == nil {
-		cfg = NewTestConfig(t)
-	}
-
-	e, err := embed.StartEtcd(cfg)
-	if err != nil {
-		t.Fatal(err)
+	var e *embed.Etcd
+	var err error
+	step := 0
+	for {
+		e, cfg, err = startEtcd(t, cfg)
+		if err != nil {
+			if strings.Contains(err.Error(), "bind: address already in use") {
+				time.Sleep(100 * time.Millisecond)
+				if step >= 5 {
+					break
+				}
+				step = step + 1
+				continue
+			}
+			t.Fatal(err)
+		}
+		break
 	}
 	t.Cleanup(e.Close)
 


### PR DESCRIPTION
Clean up taint_manager_test.go


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
![image](https://user-images.githubusercontent.com/28477081/186661884-e7dfd846-e1a9-4cca-ba75-1ad39f18b93f.png)

Locate the problem by looking at the code ，I found that this method (src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go:36)
has problems when used concurrently,And in this method also has a note to remind ,as this It is possible but unlikely that someone else will bind this port before we get a chance to use it.

This test case is unstable, and this test case often fails when we run ci
I reproduced the bug again
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/111626/pull-kubernetes-unit/1554366875930988544
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
"NONE"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
