### PR TITLE
pkg/util/coverage: update fakeTestDeps impl

### DIFF
--- a/pkg/util/coverage/fake_test_deps.go
+++ b/pkg/util/coverage/fake_test_deps.go
@@ -18,6 +18,8 @@ package coverage
 
 import (
 	"io"
+	"reflect"
+	"time"
 )
 
 // This is an implementation of testing.testDeps. It doesn't need to do anything, because
@@ -26,6 +28,18 @@ import (
 //
 //nolint:unused // U1000 see comment above, we know it's unused normally.
 type fakeTestDeps struct{}
+
+// https://go.dev/src/testing/fuzz.go#L88
+//
+//nolint:unused // U1000 see comment above, we know it's unused normally.
+type corpusEntry = struct {
+	Parent     string
+	Path       string
+	Data       []byte
+	Values     []any
+	Generation int
+	IsSeed     bool
+}
 
 //nolint:unused // U1000 see comment above, we know it's unused normally.
 func (fakeTestDeps) ImportPath() string {
@@ -36,6 +50,9 @@ func (fakeTestDeps) ImportPath() string {
 func (fakeTestDeps) MatchString(pat, str string) (bool, error) {
 	return false, nil
 }
+
+//nolint:unused // U1000 see comment above, we know it's unused normally.
+func (fakeTestDeps) SetPanicOnExit0(bool) {}
 
 //nolint:unused // U1000 see comment above, we know it's unused normally.
 func (fakeTestDeps) StartCPUProfile(io.Writer) error {
@@ -62,3 +79,29 @@ func (fakeTestDeps) WriteHeapProfile(io.Writer) error {
 func (fakeTestDeps) WriteProfileTo(string, io.Writer, int) error {
 	return nil
 }
+
+//nolint:unused // U1000 see comment above, we know it's unused normally.
+func (fakeTestDeps) CoordinateFuzzing(time.Duration, int64, time.Duration, int64, int, []corpusEntry, []reflect.Type, string, string) error {
+	return nil
+}
+
+//nolint:unused // U1000 see comment above, we know it's unused normally.
+func (fakeTestDeps) RunFuzzWorker(func(corpusEntry) error) error {
+	return nil
+}
+
+//nolint:unused // U1000 see comment above, we know it's unused normally.
+func (fakeTestDeps) ReadCorpus(string, []reflect.Type) ([]corpusEntry, error) {
+	return nil, nil
+}
+
+//nolint:unused // U1000 see comment above, we know it's unused normally.
+func (fakeTestDeps) CheckCorpus([]any, []reflect.Type) error {
+	return nil
+}
+
+//nolint:unused // U1000 see comment above, we know it's unused normally.
+func (fakeTestDeps) ResetCoverage() {}
+
+//nolint:unused // U1000 see comment above, we know it's unused normally.
+func (fakeTestDeps) SnapshotCoverage() {}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

This attempts to bring our e2e coverage jobs back to green:
- https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-coverage-conformance
- https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-coverage-e2e-gci-gce

The jobs are failing to build coverage-instrumented kubernetes binaries
because `testing.testDeps` has had more methods added since these jobs
were originally created.

#### Which issue(s) this PR fixes: n/a

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/pull/67971 is the PR that
originally introduced this if you're looking for context on what this is
for

#### Does this PR introduce a user-facing change?
```release-note
NONE
```