### PR TITLE
Add dafaultSpanName for webhook tracing

### DIFF
--- a/staging/src/k8s.io/component-base/tracing/utils.go
+++ b/staging/src/k8s.io/component-base/tracing/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tracing
 
 import (
+	"fmt"
 	"context"
 	"net/http"
 
@@ -77,6 +78,7 @@ func NewProvider(ctx context.Context,
 func WithTracing(handler http.Handler, tp oteltrace.TracerProvider, serviceName string) http.Handler {
 	opts := []otelhttp.Option{
 		otelhttp.WithPropagators(Propagators()),
+		otelhttp.WithSpanNameFormatter(defaultTransportSpanFormatter),
 		otelhttp.WithTracerProvider(tp),
 	}
 	// With Noop TracerProvider, the otelhttp still handles context propagation.
@@ -105,4 +107,9 @@ func WrapperFor(tp oteltrace.TracerProvider) transport.WrapperFunc {
 // Propagators returns the recommended set of propagators.
 func Propagators() propagation.TextMapPropagator {
 	return propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
+}
+
+// Default span name formatter for http req
+func defaultTransportSpanFormatter(_ string, r *http.Request) string {
+	return fmt.Sprintf("%s %s", r.Method, r.URL.Host)
 }


### PR DESCRIPTION
Signed-off-by: xiaoxu <lexuscyborg103@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Webhook request spans only show spanName as `GET`/`POST`. Following the open-telemetry standard of spanName, it's recommended to use `Method + Host` as spanName.

![image](https://user-images.githubusercontent.com/10649416/186878474-7cc8ad7b-78af-44b9-b35f-e62df3c5de38.png)

#### Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/112059

Before: 
![image](https://user-images.githubusercontent.com/10649416/186885369-27a2f3d3-f21d-48a8-b24c-fc4c4815310b.png)

After:
![image](https://user-images.githubusercontent.com/10649416/186885431-d15e3691-36a1-4e0f-87d8-3f257ad1b60d.png)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
