### PR TITLE
Ensure go-to-protobuf gen can run when not in GOPATH

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go
@@ -51,6 +51,7 @@ type Generator struct {
 	KeepGogoproto        bool
 	SkipGeneratedRewrite bool
 	DropEmbeddedFields   string
+	TrimPathPrefix       string
 }
 
 func New() *Generator {
@@ -97,6 +98,7 @@ func (g *Generator) BindFlags(flag *flag.FlagSet) {
 	flag.BoolVar(&g.KeepGogoproto, "keep-gogoproto", g.KeepGogoproto, "If true, the generated IDL will contain gogoprotobuf extensions which are normally removed")
 	flag.BoolVar(&g.SkipGeneratedRewrite, "skip-generated-rewrite", g.SkipGeneratedRewrite, "If true, skip fixing up the generated.pb.go file (debugging only).")
 	flag.StringVar(&g.DropEmbeddedFields, "drop-embedded-fields", g.DropEmbeddedFields, "Comma-delimited list of embedded Go types to omit from generated protobufs")
+	flag.StringVar(&g.TrimPathPrefix, "trim-path-prefix", g.TrimPathPrefix, "If set, trim the specified prefix from --output-package when generating files.")
 }
 
 func Run(g *Generator) {
@@ -202,6 +204,7 @@ func Run(g *Generator) {
 
 	c.Verify = g.Common.VerifyOnly
 	c.FileTypes["protoidl"] = NewProtoFile()
+	c.TrimPathPrefix = g.TrimPathPrefix
 
 	// order package by imports, importees first
 	deps := deps(c, protobufNames.packages)
@@ -270,6 +273,22 @@ func Run(g *Generator) {
 		if p.Vendored {
 			path = filepath.Join(g.VendorOutputBase, p.ImportPath())
 			outputPath = filepath.Join(g.VendorOutputBase, p.OutputPath())
+		}
+
+		// When working outside of GOPATH, we typically won't want to generate the
+		// full path for a package. For example, if our current project's root/base
+		// package is github.com/foo/bar, outDir=., p.Path()=github.com/foo/bar/generated,
+		// then we really want to be writing files to ./generated, not ./github.com/foo/bar/generated.
+		// The following will trim a path prefix (github.com/foo/bar) from p.Path() to arrive at
+		// a relative path that works with projects not in GOPATH.
+		if g.TrimPathPrefix != "" {
+			separator := string(filepath.Separator)
+			if !strings.HasSuffix(g.TrimPathPrefix, separator) {
+				g.TrimPathPrefix += separator
+			}
+
+			path = strings.TrimPrefix(path, g.TrimPathPrefix)
+			outputPath = strings.TrimPrefix(outputPath, g.TrimPathPrefix)
 		}
 
 		// generate the gogoprotobuf protoc


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Gengo added support for generators to run both inside and outside of the GOPATH in https://github.com/kubernetes/gengo/pull/221. However, not all of the generators in `k8s.io/code-generator` rely on this code so the fix didn't work universally.

This PR adjusts the `go-to-protobuf` generator to work in a similar way to other generators.

Now, if you include `--trim-path-prefix` with the name of the package, the generator will work outside of the GOPATH as well.

Note, when proto go files are generated, the output has the source file name within it, this means there will be a diff between generating inside and outside of the GOPATH. I would recommend updating all generator scripts to run `GOPATH= go-to-protobuf ...` to get consistent results

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
