### PR TITLE
fix a flag replace of container-runtime=remote

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -279,7 +279,8 @@ func CleanupKubeletDynamicEnvFileContainerRuntime(dryRun bool) error {
 func cleanupKubeletDynamicEnvFileContainerRuntime(str string) string {
 	const (
 		// `remote` is the only possible value
-		flag = "container-runtime"
+		containerRuntimeFlag = "container-runtime"
+		endpointFlag         = "container-runtime-endpoint"
 	)
 	// Trim the prefix
 	str = strings.TrimLeft(str, fmt.Sprintf("%s=\"", kubeadmconstants.KubeletEnvFileVariableName))
@@ -289,7 +290,7 @@ func cleanupKubeletDynamicEnvFileContainerRuntime(str string) string {
 	// its value to have the scheme prefix.
 	split := strings.Split(str, " ")
 	for i, s := range split {
-		if !strings.Contains(s, flag) {
+		if !(strings.Contains(s, containerRuntimeFlag) && !strings.Contains(s, endpointFlag)) {
 			continue
 		}
 		keyValue := strings.Split(s, "=")
@@ -309,6 +310,7 @@ func cleanupKubeletDynamicEnvFileContainerRuntime(str string) string {
 			}
 			continue
 		}
+
 		// remove the flag and value in one
 		split = append(split[:i], split[i+1:]...)
 	}

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
@@ -110,9 +110,14 @@ func TestCleanupKubeletDynamicEnvFileContainerRuntime(t *testing.T) {
 		expected string
 	}{
 		{
+			name:     "common flag",
+			input:    fmt.Sprintf("%s=\"--container-runtime=remote --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --pod-infra-container-image=registry.k8s.io/pause:3.8\"", constants.KubeletEnvFileVariableName),
+			expected: fmt.Sprintf("%s=\"--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --pod-infra-container-image=registry.k8s.io/pause:3.8\"", constants.KubeletEnvFileVariableName),
+		},
+		{
 			name:     "missing flag of interest",
-			input:    fmt.Sprintf("%s=\"--foo=abc --bar=def\"", constants.KubeletEnvFileVariableName),
-			expected: fmt.Sprintf("%s=\"--foo=abc --bar=def\"", constants.KubeletEnvFileVariableName),
+			input:    fmt.Sprintf("%s=\"--foo=abc --bar=def --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock\"", constants.KubeletEnvFileVariableName),
+			expected: fmt.Sprintf("%s=\"--foo=abc --bar=def --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock\"", constants.KubeletEnvFileVariableName),
 		},
 		{
 			name:     "add missing URL scheme",
@@ -121,13 +126,13 @@ func TestCleanupKubeletDynamicEnvFileContainerRuntime(t *testing.T) {
 		},
 		{
 			name:     "add missing URL scheme if there is no '=' after the flag name",
-			input:    fmt.Sprintf("%s=\"--foo=abc --container-runtime remote --bar=def\"", constants.KubeletEnvFileVariableName),
-			expected: fmt.Sprintf("%s=\"--foo=abc --bar=def\"", constants.KubeletEnvFileVariableName),
+			input:    fmt.Sprintf("%s=\"--foo=abc --container-runtime remote --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --bar=def\"", constants.KubeletEnvFileVariableName),
+			expected: fmt.Sprintf("%s=\"--foo=abc --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --bar=def\"", constants.KubeletEnvFileVariableName),
 		},
 		{
 			name:     "empty flag of interest value following '='",
-			input:    fmt.Sprintf("%s=\"--foo=abc --container-runtime= --bar=def\"", constants.KubeletEnvFileVariableName),
-			expected: fmt.Sprintf("%s=\"--foo=abc --bar=def\"", constants.KubeletEnvFileVariableName),
+			input:    fmt.Sprintf("%s=\"--foo=abc --container-runtime= --container-runtime-endpoint unix:///var/run/containerd/containerd.sock --bar=def\"", constants.KubeletEnvFileVariableName),
+			expected: fmt.Sprintf("%s=\"--foo=abc --container-runtime-endpoint unix:///var/run/containerd/containerd.sock --bar=def\"", constants.KubeletEnvFileVariableName),
 		},
 		{
 			name:     "empty flag of interest value without '='",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
caused by https://github.com/kubernetes/kubernetes/pull/112000/
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
maybe relate to https://github.com/kubernetes/kubeadm/issues/2750

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
