### PR TITLE
Initialize Name earlier in the Create process: GenerateName

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -387,6 +387,9 @@ func (e *Store) Create(ctx context.Context, obj runtime.Object, createValidation
 		return nil, err
 	} else {
 		rest.FillObjectMetaSystemFields(objectMeta)
+		if len(objectMeta.GetGenerateName()) > 0 && len(objectMeta.GetName()) == 0 {
+			objectMeta.SetName(e.CreateStrategy.GenerateName(objectMeta.GetGenerateName()))
+		}
 	}
 
 	if e.BeginCreate != nil {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -2845,3 +2845,72 @@ func TestValidateIndexers(t *testing.T) {
 		}
 	}
 }
+
+type predictableNameGenerator struct {
+	index int
+}
+
+func (p *predictableNameGenerator) GenerateName(base string) string {
+	p.index++
+	return fmt.Sprintf("%s%d", base, p.index)
+}
+
+func TestStoreCreateGenerateNameConflict(t *testing.T) {
+	// podA will be stored with name foo12345
+	podA := &example.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo1", Namespace: "test"},
+		Spec:       example.PodSpec{NodeName: "machine"},
+	}
+	// podB will generate the same name as podA "foo1" in the first try
+	podB := &example.Pod{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "foo", Namespace: "test"},
+		Spec:       example.PodSpec{NodeName: "machine2"},
+	}
+
+	testContext := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
+	destroyFunc, registry := NewTestGenericStoreRegistry(t)
+	defer destroyFunc()
+	// re-define delete strategy to have graceful delete capability
+	defaultCreateStrategy := &testRESTStrategy{scheme, &predictableNameGenerator{}, true, false, true}
+	registry.CreateStrategy = defaultCreateStrategy
+
+	// create the object (DeepCopy because the registry mutates the objects)
+	objA, err := registry.Create(testContext, podA.DeepCopy(), rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// get the object
+	checkobjA, err := registry.Get(testContext, podA.Name, &metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// verify objects are equal
+	if e, a := objA, checkobjA; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+
+	// now try to create the second pod (DeepCopy because the registry mutate the objects)
+	_, err = registry.Create(testContext, podB.DeepCopy(), rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if !errors.IsAlreadyExists(err) {
+		t.Errorf("Unexpected error: %+v", err)
+	}
+
+	// check the 'alraedy exists' msg correspond to the generated name
+	msg := &err.(*errors.StatusError).ErrStatus.Message
+	if !strings.Contains(*msg, "already exists, the server was not able to generate a unique name for the object") {
+		t.Errorf("Unexpected error without the 'was not able to generate a unique name' in message: %v", err)
+	}
+
+	// now try to create the second pod again
+	objB, err := registry.Create(testContext, podB.DeepCopy(), rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if objB.(*example.Pod).Name != "foo2" && objB.(*example.Pod).GenerateName != "foo" {
+		t.Errorf("Unexpected object: %+v", objB)
+	}
+
+}


### PR DESCRIPTION
/kind bug
/kind cleanup

```release-note
NONE
```

Following up on `Initialize UID earlier in the Create process` #110646 

Before:
Create()
BeginCreate()
BeforeCreate()
GenerateName() if Name empty and len(GenerateName) > 0 <---------------------
strategy code

After:
Create()
GenerateName() if Name empty and len(GenerateName) > 0 <---------------------
BeginCreate()
BeforeCreate()
strategy code



Some comments from the slack discussion https://kubernetes.slack.com/archives/C0EG7JC6T/p1661439190979379

> thockin:  our REST semantics don't allow for unnamed resources and I don't think we want to make naming even more resource-centric

> liggit: moving it would make PrepareForCreate unable to tell if the name was user-specified or generated, and would remove the ability of PrepareForCreate to influence the generated name by modifying metadata.generateName
moving it would make PrepareForCreate unable to tell if the name was user-specified or generated, and would remove the ability of PrepareForCreate to influence the generated name by modifying metadata.generateName
> but I don't see any PrepareForCreate implementations that do anything like that, fortunately
> and the NameGenerator interface only takes metadata.generateName as the input param, so no name generation can directly depend on any other data in the object



Jordan expressed some possible issues

> and would this relocation change what happens if a generated name gets a conflict? if we would retry the generation internally previously, we'd want to make sure we'd still retry (I don't actually know if we automatically retry internally or not)

I've added a test to check the behavior before and after and it always pass