### PR TITLE
client-go/rest: remove unused error return

### DIFF
--- a/pkg/client/tests/remotecommand_test.go
+++ b/pkg/client/tests/remotecommand_test.go
@@ -213,10 +213,7 @@ func TestStream(t *testing.T) {
 					GroupVersion: schema.GroupVersion{Group: "x"},
 					Negotiator:   runtime.NewClientNegotiator(legacyscheme.Codecs.WithoutConversion(), schema.GroupVersion{Group: "x"}),
 				}
-				c, err := restclient.NewRESTClient(url, "", config, nil, nil)
-				if err != nil {
-					t.Fatalf("failed to create a client: %v", err)
-				}
+				c := restclient.NewRESTClient(url, "", config, nil, nil)
 				req := c.Post().Resource("testing")
 
 				if exec {

--- a/staging/src/k8s.io/client-go/rest/client.go
+++ b/staging/src/k8s.io/client-go/rest/client.go
@@ -105,7 +105,7 @@ type RESTClient struct {
 
 // NewRESTClient creates a new RESTClient. This client performs generic REST functions
 // such as Get, Put, Post, and Delete on specified paths.
-func NewRESTClient(baseURL *url.URL, versionedAPIPath string, config ClientContentConfig, rateLimiter flowcontrol.RateLimiter, client *http.Client) (*RESTClient, error) {
+func NewRESTClient(baseURL *url.URL, versionedAPIPath string, config ClientContentConfig, rateLimiter flowcontrol.RateLimiter, client *http.Client) *RESTClient {
 	if len(config.ContentType) == 0 {
 		config.ContentType = "application/json"
 	}
@@ -125,7 +125,7 @@ func NewRESTClient(baseURL *url.URL, versionedAPIPath string, config ClientConte
 		rateLimiter:      rateLimiter,
 
 		Client: client,
-	}, nil
+	}
 }
 
 // GetRateLimiter returns rate limiter for a given client, or nil if it's called on a nil client
@@ -157,8 +157,7 @@ func readExpBackoffConfig() BackoffManager {
 // Verb begins a request with a verb (GET, POST, PUT, DELETE).
 //
 // Example usage of RESTClient's request building interface:
-// c, err := NewRESTClient(...)
-// if err != nil { ... }
+// c := NewRESTClient(...)
 // resp, err := c.Verb("GET").
 //
 //	Path("pods").

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -374,11 +374,11 @@ func RESTClientForConfigAndClient(config *Config, httpClient *http.Client) (*RES
 		Negotiator:         runtime.NewClientNegotiator(config.NegotiatedSerializer, gv),
 	}
 
-	restClient, err := NewRESTClient(baseURL, versionedAPIPath, clientContent, rateLimiter, httpClient)
-	if err == nil && config.WarningHandler != nil {
+	restClient := NewRESTClient(baseURL, versionedAPIPath, clientContent, rateLimiter, httpClient)
+	if config.WarningHandler != nil {
 		restClient.warningHandler = config.WarningHandler
 	}
-	return restClient, err
+	return restClient, nil
 }
 
 // UnversionedRESTClientFor is the same as RESTClientFor, except that it allows
@@ -441,11 +441,11 @@ func UnversionedRESTClientForConfigAndClient(config *Config, httpClient *http.Cl
 		Negotiator:         runtime.NewClientNegotiator(config.NegotiatedSerializer, gv),
 	}
 
-	restClient, err := NewRESTClient(baseURL, versionedAPIPath, clientContent, rateLimiter, httpClient)
-	if err == nil && config.WarningHandler != nil {
+	restClient := NewRESTClient(baseURL, versionedAPIPath, clientContent, rateLimiter, httpClient)
+	if config.WarningHandler != nil {
 		restClient.warningHandler = config.WarningHandler
 	}
-	return restClient, err
+	return restClient, nil
 }
 
 // SetKubernetesDefaults sets default values on the provided client config for accessing the

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -2260,12 +2260,7 @@ func testRESTClientWithConfig(t testing.TB, srv *httptest.Server, contentConfig 
 		c = srv.Client()
 	}
 	versionedAPIPath := defaultResourcePathWithPrefix("", "", "", "")
-	client, err := NewRESTClient(base, versionedAPIPath, contentConfig, nil, c)
-	if err != nil {
-		t.Fatalf("failed to create a client: %v", err)
-	}
-	return client
-
+	return NewRESTClient(base, versionedAPIPath, contentConfig, nil, c)
 }
 
 func testRESTClient(t testing.TB, srv *httptest.Server) *RESTClient {


### PR DESCRIPTION
This function has not been able to return a non-nil error since 3b780c64
in 2019.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind cleanup

```release-note
NONE
```

```docs

```

/cc @smarterclayton 
