### PR TITLE
Unify success output of kubectl delete with other operations

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -445,5 +445,5 @@ func (o *DeleteOptions) PrintObj(info *resource.Info) {
 	}
 
 	// understandable output by default
-	fmt.Fprintf(o.Out, "%s \"%s\" %s\n", kindString, info.Name, operation)
+	fmt.Fprintf(o.Out, "%s/%s %s\n", kindString, info.Name, operation)
 }

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -1482,7 +1482,7 @@ run_namespace_tests() {
   kube::test::get_object_assert 'namespaces/my-namespace' "{{$id_field}}" 'my-namespace'
   output_message=$(! kubectl delete namespace -n my-namespace --all 2>&1 "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" 'Warning: deleting cluster-scoped resources'
-  kube::test::if_has_string "${output_message}" 'namespace "my-namespace" deleted'
+  kube::test::if_has_string "${output_message}" 'namespace/my-namespace deleted'
 
   ### Quota
   kubectl create namespace quotas

--- a/test/cmd/rbac.sh
+++ b/test/cmd/rbac.sh
@@ -42,7 +42,7 @@ run_clusterroles_tests() {
   kube::test::get_object_assert clusterrole/pod-admin "{{range.rules}}{{range.verbs}}{{.}}:{{end}}{{end}}" '\*:'
   output_message=$(kubectl delete clusterrole pod-admin -n test 2>&1 "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" 'Warning: deleting cluster-scoped resources'
-  kube::test::if_has_string "${output_message}" 'clusterrole.rbac.authorization.k8s.io "pod-admin" deleted'
+  kube::test::if_has_string "${output_message}" 'clusterrole.rbac.authorization.k8s.io/pod-admin deleted'
 
   kubectl create "${kube_flags[@]}" clusterrole pod-admin --verb=* --resource=pods
   kube::test::get_object_assert clusterrole/pod-admin "{{range.rules}}{{range.verbs}}{{.}}:{{end}}{{end}}" '\*:'

--- a/test/cmd/storage.sh
+++ b/test/cmd/storage.sh
@@ -47,7 +47,7 @@ run_persistent_volumes_tests() {
   kube::test::get_object_assert pv "{{range.items}}{{$id_field}}:{{end}}" 'pv0001:'
   output_message=$(kubectl delete pv -n test --all 2>&1 "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" 'Warning: deleting cluster-scoped resources'
-  kube::test::if_has_string "${output_message}" 'persistentvolume "pv0001" deleted'
+  kube::test::if_has_string "${output_message}" 'persistentvolume/pv0001 deleted'
   kube::test::get_object_assert pv "{{range.items}}{{$id_field}}:{{end}}" ''
 
   set +o nounset


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

All operations except the delete option print the success message in the format of `<KIND>/<NAME> <OPERATION>`, while the delete option prints `<KIND> "<NAME>" <OPERATION>`. This patch unifies the success output of all operations.

For example:
```
$ kubectl create namespace test
namespace/test created
$ kubectl label namespace test foo=bar
namespace/test labeled
$ kubectl annotate namespace test foo=bar
namespace/test annotated
$ kubectl edit namespace test
namespace/test edited
$ kubectl delete namespace test
namespace "test" deleted
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
