### PR TITLE
[DO NOT MERGE] Revert "Merge pull request #111554 from paskal/paskal/clarify_default_cfs_period"

### DIFF
--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -59,7 +59,7 @@ var (
 		RegistryPullQPS:                 5,
 		HairpinMode:                     kubeletconfig.PromiscuousBridge,
 		NodeLeaseDurationSeconds:        1,
-		CPUCFSQuotaPeriod:               metav1.Duration{Duration: 25 * time.Microsecond},
+		CPUCFSQuotaPeriod:               metav1.Duration{Duration: 25 * time.Millisecond},
 		TopologyManagerScope:            kubeletconfig.PodTopologyManagerScope,
 		TopologyManagerPolicy:           kubeletconfig.SingleNumaNodeTopologyManagerPolicy,
 		ShutdownGracePeriod:             metav1.Duration{Duration: 30 * time.Second},
@@ -145,10 +145,10 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 			name: "specify CPUCFSQuotaPeriod without enabling CPUCFSQuotaPeriod",
 			configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
 				conf.FeatureGates = map[string]bool{"CustomCPUCFSQuotaPeriod": false}
-				conf.CPUCFSQuotaPeriod = metav1.Duration{Duration: 200 * time.Microsecond}
+				conf.CPUCFSQuotaPeriod = metav1.Duration{Duration: 200 * time.Millisecond}
 				return conf
 			},
-			errMsg: "invalid configuration: cpuCFSQuotaPeriod (--cpu-cfs-quota-period) {200µs} requires feature gate CustomCPUCFSQuotaPeriod",
+			errMsg: "invalid configuration: cpuCFSQuotaPeriod (--cpu-cfs-quota-period) {200ms} requires feature gate CustomCPUCFSQuotaPeriod",
 		},
 		{
 			name: "invalid CPUCFSQuotaPeriod",

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -44,7 +44,7 @@ const (
 	SharesPerCPU  = 1024
 	MilliCPUToCPU = 1000
 
-	// 100000 is equivalent to 100usec
+	// 100000 is equivalent to 100ms
 	QuotaPeriod    = 100000
 	MinQuotaPeriod = 1000
 )
@@ -52,8 +52,8 @@ const (
 // MilliCPUToQuota converts milliCPU to CFS quota and period values.
 func MilliCPUToQuota(milliCPU int64, period int64) (quota int64) {
 	// CFS quota is measured in two values:
-	//  - cfs_period_us=100usec (the amount of time to measure usage across given by period)
-	//  - cfs_quota=20usec (the amount of cpu time allowed to be used across a period)
+	//  - cfs_period_us=100ms (the amount of time to measure usage across given by period)
+	//  - cfs_quota=20ms (the amount of cpu time allowed to be used across a period)
 	// so in the above example, you are limited to 20% of a single CPU
 	// for multi-cpu environments, you just scale equivalent amounts
 	// see https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt for details

--- a/pkg/kubelet/kuberuntime/helpers_linux.go
+++ b/pkg/kubelet/kuberuntime/helpers_linux.go
@@ -22,7 +22,7 @@ package kuberuntime
 const (
 	milliCPUToCPU = 1000
 
-	// 100000 is equivalent to 100usec
+	// 100000 is equivalent to 100ms
 	quotaPeriod    = 100000
 	minQuotaPeriod = 1000
 )
@@ -30,8 +30,8 @@ const (
 // milliCPUToQuota converts milliCPU to CFS quota and period values
 func milliCPUToQuota(milliCPU int64, period int64) (quota int64) {
 	// CFS quota is measured in two values:
-	//  - cfs_period_us=100usec (the amount of time to measure usage across given by period)
-	//  - cfs_quota=20usec (the amount of cpu time allowed to be used across a period)
+	//  - cfs_period_us=100ms (the amount of time to measure usage across)
+	//  - cfs_quota=20ms (the amount of cpu time allowed to be used across a period)
 	// so in the above example, you are limited to 20% of a single CPU
 	// for multi-cpu environments, you just scale equivalent amounts
 	// see https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt for details


### PR DESCRIPTION
This reverts commit 2b5475b3fa5fefdb784f9b04bef3fab666ef19d7, reversing
changes made to b87a436aed9a4e708666b3656beac3a93dd3f762.

Testing PR to try to figure out what turned the alpha e2e job red: https://github.com/kubernetes/kubernetes/pull/112064#issuecomment-1228663459

```release-note
NONE
```

/hold
/test pull-kubernetes-e2e-gce-alpha-features