### PR TITLE
Revert "promote LocalStorageCapacityIsolationFSQuotaMonitoring to beta"

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -520,7 +520,6 @@ const (
 
 	// owner: @RobertKrawitz
 	// alpha: v1.15
-	// beta: v1.25
 	//
 	// Allow use of filesystems for ephemeral storage monitoring.
 	// Only applies if LocalStorageCapacityIsolation is set.
@@ -1016,7 +1015,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	LocalStorageCapacityIsolation: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.27
 
-	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: true, PreRelease: featuregate.Beta},
+	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Alpha},
 
 	LogarithmicScaleDown: {Default: true, PreRelease: featuregate.Beta},
 

--- a/test/e2e_node/quota_lsci_test.go
+++ b/test/e2e_node/quota_lsci_test.go
@@ -63,7 +63,7 @@ func runOneQuotaTest(f *framework.Framework, quotasRequested bool) {
 			if quotasRequested && !supportsQuotas("/var/lib/kubelet") {
 				// No point in running this as a positive test if quotas are not
 				// enabled on the underlying filesystem.
-				e2eskipper.Skipf("Cannot run LocalStorageCapacityIsolationFSQuotaMonitoring on filesystem without project quota enabled")
+				e2eskipper.Skipf("Cannot run LocalStorageCapacityIsolationQuotaMonitoring on filesystem without project quota enabled")
 			}
 			// setting a threshold to 0% disables; non-empty map overrides default value (necessary due to omitempty)
 			initialConfig.EvictionHard = map[string]string{"memory.available": "0%"}
@@ -90,7 +90,7 @@ func runOneQuotaTest(f *framework.Framework, quotasRequested bool) {
 	})
 }
 
-// LocalStorageCapacityIsolationFSQuotaMonitoring tests that quotas are
+// LocalStorageCapacityIsolationQuotaMonitoring tests that quotas are
 // used for monitoring rather than du.  The mechanism is to create a
 // pod that creates a file, deletes it, and writes data to it.  If
 // quotas are used to monitor, it will detect this deleted-but-in-use


### PR DESCRIPTION
Reverts kubernetes/kubernetes#107329

OpenShift found issues rendering updated ConfigMaps to pods. When ConfigMaps get updated within the API, they do not get rendered to the resulting pod's filesystem by the Kubelet with the following error:

```
Aug 26 20:22:30 test1-lkz4t-master-1 kubenswrapper[1474]: E0826 20:22:30.751336    1474 nestedpendingoperations.go:335] Operation for "{volumeName:kubernetes.io/configmap/d381fba5-463d-420a-8ef2-ba4d9a94846d-trusted-ca-bundle podName:d381fba5-463d-420a-8ef2-ba4d9a94846d nodeName:}" failed. No retries permitted until 2022-08-26 20:24:32.751309823 +0000 UTC m=+2312.350897767 (durationBeforeRetry 2m2s). Error: MountVolume.SetUp
 failed for volume "trusted-ca-bundle" (UniqueName: "kubernetes.io/configmap/d381fba5-463d-420a-8ef2-ba4d9a94846d-trusted-ca-bundle") pod "insights-operator-5655ffbd97-x2gqw" (UID: "d381fba5-463d-420a-8ef2-ba4d9a94846d") : requesting quota on existing directory /var/lib/kubelet/pods/d381fba5-463d-420a-8ef2-ba4d9a94846d/volumes/kubernetes.io~configmap/trusted-ca-bundle but different pod be50da94-ebf1-4cb0-9e0b-2949fd2bed7b f9
8fa631-4940-4217-9b82-4e5ad6720238
```

We will need to backport to 1.25.

```release-note
Fix a 1.25 regression updating mounted configmaps when the LocalStorageCapacityIsolationFSQuotaMonitoring feature is enabled. LocalStorageCapacityIsolationFSQuotaMonitoring feature gate is demoted back to Alpha. 
```

/sig node
/kind regression
/priority important-soon

cc @derekwaynecarr @pacoxu @dchen1107 @liggitt @deads2k 