### PR TITLE
Automated cherry pick of #112076: Revert "promote

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -533,7 +533,6 @@ const (
 
 	// owner: @RobertKrawitz
 	// alpha: v1.15
-	// beta: v1.25
 	//
 	// Allow use of filesystems for ephemeral storage monitoring.
 	// Only applies if LocalStorageCapacityIsolation is set.
@@ -1033,7 +1032,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	LocalStorageCapacityIsolation: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.27
 
-	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: true, PreRelease: featuregate.Beta},
+	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Alpha},
 
 	LogarithmicScaleDown: {Default: true, PreRelease: featuregate.Beta},
 

--- a/test/e2e_node/quota_lsci_test.go
+++ b/test/e2e_node/quota_lsci_test.go
@@ -63,7 +63,7 @@ func runOneQuotaTest(f *framework.Framework, quotasRequested bool) {
 			if quotasRequested && !supportsQuotas("/var/lib/kubelet") {
 				// No point in running this as a positive test if quotas are not
 				// enabled on the underlying filesystem.
-				e2eskipper.Skipf("Cannot run LocalStorageCapacityIsolationFSQuotaMonitoring on filesystem without project quota enabled")
+				e2eskipper.Skipf("Cannot run LocalStorageCapacityIsolationQuotaMonitoring on filesystem without project quota enabled")
 			}
 			// setting a threshold to 0% disables; non-empty map overrides default value (necessary due to omitempty)
 			initialConfig.EvictionHard = map[string]string{"memory.available": "0%"}
@@ -90,7 +90,7 @@ func runOneQuotaTest(f *framework.Framework, quotasRequested bool) {
 	})
 }
 
-// LocalStorageCapacityIsolationFSQuotaMonitoring tests that quotas are
+// LocalStorageCapacityIsolationQuotaMonitoring tests that quotas are
 // used for monitoring rather than du.  The mechanism is to create a
 // pod that creates a file, deletes it, and writes data to it.  If
 // quotas are used to monitor, it will detect this deleted-but-in-use


### PR DESCRIPTION
Cherry pick of #112076 on release-1.25.

#112076: Revert "promote

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a 1.25 regression updating mounted configmaps when the LocalStorageCapacityIsolationFSQuotaMonitoring feature is enabled. LocalStorageCapacityIsolationFSQuotaMonitoring feature gate is demoted back to Alpha. 
```
