### PR TITLE
Add flag to kubectl top to display resource requests and limits.

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
@@ -18,6 +18,7 @@ package top
 
 import (
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -28,8 +29,8 @@ import (
 )
 
 const (
-	sortByCPU    = "cpu"
-	sortByMemory = "memory"
+	sortByCPU    = corev1.ResourceCPU
+	sortByMemory = corev1.ResourceMemory
 )
 
 var (

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -133,7 +133,7 @@ func (o *TopNodeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 
 func (o *TopNodeOptions) Validate() error {
 	if len(o.SortBy) > 0 {
-		if o.SortBy != sortByCPU && o.SortBy != sortByMemory {
+		if o.SortBy != sortByCPU.String() && o.SortBy != sortByMemory.String() {
 			return errors.New("--sort-by accepts only cpu or memory")
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_resource_adder.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_resource_adder.go
@@ -43,3 +43,15 @@ func (adder *ResourceAdder) AddPodMetrics(m *metricsapi.PodMetrics) {
 		}
 	}
 }
+
+// AddPodMetricsWithResources adds each pod metric to the total, as well as the resources
+func (adder *ResourceAdder) AddPodMetricsWithResources(m *metricsapi.PodMetrics, cache map[string]*ResourceContainerInfo) {
+	for _, c := range m.Containers {
+		container := cache[c.Name].Container
+		for _, res := range adder.resources {
+			total := adder.total[res]
+			total.Add(extractResource(&c, container, res))
+			adder.total[res] = total
+		}
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_resource_adder_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_resource_adder_test.go
@@ -52,10 +52,31 @@ func addContainerMetricsToPodMetrics(t *testing.T, podMetrics *metrics.PodMetric
 	podMetrics.Containers = append(podMetrics.Containers, containerMetrics)
 }
 
+func addContainerResourcesToPodResources(t *testing.T, pods *corev1.Pod, cpuReq, cpuLim, memReq, memLim string) {
+	t.Helper()
+	container := corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Limits:   corev1.ResourceList{},
+			Requests: corev1.ResourceList{},
+		},
+	}
+
+	container.Resources.Requests[corev1.ResourceCPU] = getResourceQuantity(t, cpuReq)
+	container.Resources.Limits[corev1.ResourceCPU] = getResourceQuantity(t, cpuLim)
+	container.Resources.Requests[corev1.ResourceMemory] = getResourceQuantity(t, memReq)
+	container.Resources.Limits[corev1.ResourceMemory] = getResourceQuantity(t, memLim)
+
+	pods.Spec.Containers = append(pods.Spec.Containers, container)
+}
+
 func initResourceAdder() *ResourceAdder {
 	resources := []corev1.ResourceName{
 		corev1.ResourceCPU,
 		corev1.ResourceMemory,
+		corev1.ResourceLimitsCPU,
+		corev1.ResourceRequestsCPU,
+		corev1.ResourceLimitsMemory,
+		corev1.ResourceRequestsMemory,
 	}
 	return NewResourceAdder(resources)
 }
@@ -113,6 +134,131 @@ func TestAddPodMetrics(t *testing.T) {
 			}
 			if !test.expectedMemUsage.Equal(memUsage) {
 				t.Errorf("expecting memeory usage %s but getting %s", test.expectedMemUsage.String(), memUsage.String())
+			}
+		})
+	}
+}
+
+func TestAddPodMetricsWithResources(t *testing.T) {
+	resourceAdder := initResourceAdder()
+
+	tests := []struct {
+		name               string
+		cpuUsage           string
+		cpuRequest         string
+		cpuLimit           string
+		memUsage           string
+		memRequest         string
+		memLimit           string
+		expectedCpuUsage   resource.Quantity
+		expectedCpuRequest resource.Quantity
+		expectedCpuLimit   resource.Quantity
+		expectedMemUsage   resource.Quantity
+		expectedMemRequest resource.Quantity
+		expectedMemLimit   resource.Quantity
+	}{
+		{
+			name:               "initial value",
+			cpuUsage:           "0",
+			cpuRequest:         "0",
+			cpuLimit:           "0",
+			memUsage:           "0",
+			memRequest:         "0",
+			memLimit:           "0",
+			expectedCpuUsage:   getResourceQuantity(t, "0"),
+			expectedCpuRequest: getResourceQuantity(t, "0"),
+			expectedCpuLimit:   getResourceQuantity(t, "0"),
+			expectedMemUsage:   getResourceQuantity(t, "0"),
+			expectedMemRequest: getResourceQuantity(t, "0"),
+			expectedMemLimit:   getResourceQuantity(t, "0"),
+		},
+		{
+			name:               "add first container metric",
+			cpuUsage:           "1m",
+			cpuRequest:         "1m",
+			cpuLimit:           "2m",
+			memUsage:           "10Mi",
+			memRequest:         "10Mi",
+			memLimit:           "20Mi",
+			expectedCpuUsage:   getResourceQuantity(t, "1m"),
+			expectedCpuRequest: getResourceQuantity(t, "1m"),
+			expectedCpuLimit:   getResourceQuantity(t, "2m"),
+			expectedMemUsage:   getResourceQuantity(t, "10Mi"),
+			expectedMemRequest: getResourceQuantity(t, "10Mi"),
+			expectedMemLimit:   getResourceQuantity(t, "20Mi"),
+		},
+		{
+			name:               "add second container metric",
+			cpuUsage:           "5m",
+			cpuRequest:         "1m",
+			cpuLimit:           "10m",
+			memUsage:           "25Mi",
+			memRequest:         "10Mi",
+			memLimit:           "30Mi",
+			expectedCpuUsage:   getResourceQuantity(t, "6m"),
+			expectedCpuRequest: getResourceQuantity(t, "2m"),
+			expectedCpuLimit:   getResourceQuantity(t, "12m"),
+			expectedMemUsage:   getResourceQuantity(t, "35Mi"),
+			expectedMemRequest: getResourceQuantity(t, "20Mi"),
+			expectedMemLimit:   getResourceQuantity(t, "50Mi"),
+		},
+		{
+			name:               "add third container zero metric",
+			cpuUsage:           "0m",
+			cpuRequest:         "0m",
+			cpuLimit:           "0m",
+			memUsage:           "0Mi",
+			memRequest:         "0Mi",
+			memLimit:           "0Mi",
+			expectedCpuUsage:   getResourceQuantity(t, "6m"),
+			expectedCpuRequest: getResourceQuantity(t, "2m"),
+			expectedCpuLimit:   getResourceQuantity(t, "12m"),
+			expectedMemUsage:   getResourceQuantity(t, "35Mi"),
+			expectedMemRequest: getResourceQuantity(t, "20Mi"),
+			expectedMemLimit:   getResourceQuantity(t, "50Mi"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := corev1.Pod{}
+			podMetrics := metrics.PodMetrics{}
+			addContainerMetricsToPodMetrics(t, &podMetrics, test.cpuUsage, test.memUsage)
+			addContainerResourcesToPodResources(t, &pod, test.cpuRequest, test.cpuLimit, test.memRequest, test.memLimit)
+
+			containerCache := make(map[string]*ResourceContainerInfo)
+
+			for _, c := range pod.Spec.Containers {
+				containerCache[c.Name] = &ResourceContainerInfo{
+					Name:      c.Name,
+					Container: &c,
+				}
+			}
+
+			resourceAdder.AddPodMetricsWithResources(&podMetrics, containerCache)
+			cpuUsage := resourceAdder.total["cpu"]
+			cpuReq := resourceAdder.total[corev1.ResourceRequestsCPU]
+			cpuLim := resourceAdder.total[corev1.ResourceLimitsCPU]
+			memUsage := resourceAdder.total["memory"]
+			memReq := resourceAdder.total[corev1.ResourceRequestsMemory]
+			memLim := resourceAdder.total[corev1.ResourceLimitsMemory]
+
+			if !test.expectedCpuUsage.Equal(cpuUsage) {
+				t.Errorf("expecting cpu usage %s but getting %s", test.expectedCpuUsage.String(), cpuUsage.String())
+			}
+			if !test.expectedCpuRequest.Equal(cpuReq) {
+				t.Errorf("expecting cpu request %s but getting %s", test.expectedCpuRequest.String(), cpuReq.String())
+			}
+			if !test.expectedCpuLimit.Equal(cpuLim) {
+				t.Errorf("expecting cpu limit %s but getting %s", test.expectedCpuLimit.String(), cpuLim.String())
+			}
+			if !test.expectedMemUsage.Equal(memUsage) {
+				t.Errorf("expecting memory usage %s but getting %s", test.expectedMemUsage.String(), memUsage.String())
+			}
+			if !test.expectedMemRequest.Equal(memReq) {
+				t.Errorf("expecting memory request %s but getting %s", test.expectedMemRequest.String(), memReq.String())
+			}
+			if !test.expectedMemLimit.Equal(memLim) {
+				t.Errorf("expecting memory limit %s but getting %s", test.expectedMemLimit.String(), memLim.String())
 			}
 		})
 	}

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_sorter.go
@@ -82,11 +82,11 @@ func (p *PodMetricsSorter) Less(i, j int) bool {
 	}
 }
 
-func NewPodMetricsSorter(metrics []metricsapi.PodMetrics, withNamespace bool, sortBy string) *PodMetricsSorter {
+func NewPodMetricsSorter(metrics []metricsapi.PodMetrics, pods map[string]*ResourcePodInfo, withNamespace, enumerate bool, sortBy string) *PodMetricsSorter {
 	var podMetrics = make([]v1.ResourceList, len(metrics))
 	if len(sortBy) > 0 {
 		for i, v := range metrics {
-			podMetrics[i] = getPodMetrics(&v)
+			podMetrics[i] = getPodMetrics(&v, pods, enumerate)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a flag `--enumerate` to `kubectl top pods ...` to output cpu/mem requests/limits

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubectl/issues/1214

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds a flag --enumerate to the kubectl top pods command. This flag displays the resource requests and limits for the cpu and memory of a pod to give admins a quick reference for resource usage relative to request.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
