### PR TITLE
ResourceQuota of storage can't support more than 9Pi

### DIFF
--- a/pkg/apis/core/v1/validation/validation.go
+++ b/pkg/apis/core/v1/validation/validation.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"k8s.io/api/core/v1"
@@ -90,7 +91,9 @@ func ValidateResourceQuantityValue(resource string, value resource.Quantity, fld
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, ValidateNonnegativeQuantity(value, fldPath)...)
 	if helper.IsIntegerResourceName(resource) {
-		if value.MilliValue()%int64(1000) != int64(0) {
+		if value.Value() >=  (math.MaxInt64/10) {
+			allErrs = append(allErrs, field.Invalid(fldPath, value, fmt.Errorf("quantity is too great: %v", value).Error()))
+		} else if value.ScaledValue(-1)%int64(10) != int64(0) {
 			allErrs = append(allErrs, field.Invalid(fldPath, value, isNotIntegerErrorMsg))
 		}
 	}

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5976,8 +5976,11 @@ func ValidateResourceQuotaSpec(resourceQuotaSpec *core.ResourceQuotaSpec, fld *f
 func ValidateResourceQuantityValue(resource string, value resource.Quantity, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, ValidateNonnegativeQuantity(value, fldPath)...)
+
 	if helper.IsIntegerResourceName(resource) {
-		if value.MilliValue()%int64(1000) != int64(0) {
+		if value.Value() >=  (math.MaxInt64/10) {
+			allErrs = append(allErrs, field.Invalid(fldPath, value, fmt.Errorf("quantity is too great: %v", value).Error()))
+		} else if value.ScaledValue(-1)%int64(10) != int64(0) {
 			allErrs = append(allErrs, field.Invalid(fldPath, value, isNotIntegerErrorMsg))
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
 
/kind bug

**What this PR does / why we need it**:
When I want to change storage class resourcequota to 9Pi, there are errors it reported that the changed value must be an integer.
```
must be an integer
```


**Which issue(s) this PR fixes**:
The issue is because when do the value validation for whether it is an integer or not, it will converted to mili value aka multiple 1000 then divid 1000. 

```
// ValidateResourceQuantityValue enforces that specified quantity is valid for specified resource
func ValidateResourceQuantityValue(resource string, value resource.Quantity, fldPath *field.Path) field.ErrorList {
	allErrs := field.ErrorList{}
	allErrs = append(allErrs, ValidateNonnegativeQuantity(value, fldPath)...)
	if helper.IsIntegerResourceName(resource) {
		if value.MilliValue()%int64(1000) != int64(0) {
			allErrs = append(allErrs, field.Invalid(fldPath, value, isNotIntegerErrorMsg))
		}
	}
	return allErrs
}
```
When it converted to mili value, it makes int64 overflow.
The fix is use `value * 10/ 10` instead of `value * 1000/1000`, it will make max storage class resourcequota support  from < 9Pi to < 900Pi.
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix the resourcequota overflow issue
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
