### PR TITLE
Fix editor launch with Windows cmd.exe when KUBE_EDITOR has spaces in path

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editor.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editor.go
@@ -17,17 +17,10 @@ limitations under the License.
 package editor
 
 import (
-	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
-
-	"k8s.io/klog/v2"
-
-	"k8s.io/kubectl/pkg/util/term"
 )
 
 const (
@@ -94,45 +87,6 @@ func defaultEnvEditor(envs []string) ([]string, bool) {
 	// rather than parse the shell arguments ourselves, punt to the shell
 	shell := defaultEnvShell()
 	return append(shell, editor), true
-}
-
-func (e Editor) args(path string) []string {
-	args := make([]string, len(e.Args))
-	copy(args, e.Args)
-	if e.Shell {
-		last := args[len(args)-1]
-		args[len(args)-1] = fmt.Sprintf("%s %q", last, path)
-	} else {
-		args = append(args, path)
-	}
-	return args
-}
-
-// Launch opens the described or returns an error. The TTY will be protected, and
-// SIGQUIT, SIGTERM, and SIGINT will all be trapped.
-func (e Editor) Launch(path string) error {
-	if len(e.Args) == 0 {
-		return fmt.Errorf("no editor defined, can't open %s", path)
-	}
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return err
-	}
-	args := e.args(abs)
-	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
-	klog.V(5).Infof("Opening file with editor %v", args)
-	if err := (term.TTY{In: os.Stdin, TryDev: true}).Safe(cmd.Run); err != nil {
-		if err, ok := err.(*exec.Error); ok {
-			if err.Err == exec.ErrNotFound {
-				return fmt.Errorf("unable to launch the editor %q", strings.Join(e.Args, " "))
-			}
-		}
-		return fmt.Errorf("there was a problem with the editor %q", strings.Join(e.Args, " "))
-	}
-	return nil
 }
 
 // LaunchTempFile reads the provided stream into a temporary file in the given directory

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/launcher_others.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/launcher_others.go
@@ -1,0 +1,70 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package editor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	"k8s.io/kubectl/pkg/util/term"
+)
+
+func (e Editor) args(path string) []string {
+	args := make([]string, len(e.Args))
+	copy(args, e.Args)
+	if e.Shell {
+		last := args[len(args)-1]
+		args[len(args)-1] = fmt.Sprintf("%s %q", last, path)
+	} else {
+		args = append(args, path)
+	}
+	return args
+}
+
+// Launch opens the described or returns an error. The TTY will be protected, and
+// SIGQUIT, SIGTERM, and SIGINT will all be trapped.
+func (e Editor) Launch(path string) error {
+	if len(e.Args) == 0 {
+		return fmt.Errorf("no editor defined, can't open %s", path)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	args := e.args(abs)
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	klog.V(5).Infof("Opening file with editor %v", args)
+	if err := (term.TTY{In: os.Stdin, TryDev: true}).Safe(cmd.Run); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return fmt.Errorf("unable to launch the editor %q", strings.Join(e.Args, " "))
+		}
+		return fmt.Errorf("there was a problem with the editor %q", strings.Join(e.Args, " "))
+	}
+	return nil
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/launcher_windows.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/launcher_windows.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package editor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"k8s.io/klog/v2"
+
+	"k8s.io/kubectl/pkg/util/term"
+)
+
+// Enclose argument in double-quotes. Double each double-quote character as
+// an escape sequence.
+func cmdQuoteArg(arg string) string {
+	var result strings.Builder
+	result.WriteString(`"`)
+	result.WriteString(strings.ReplaceAll(arg, `"`, `""`))
+	result.WriteString(`"`)
+	return result.String()
+}
+
+func (e Editor) args(path string) []string {
+	args := make([]string, len(e.Args))
+	copy(args, e.Args)
+	if e.Shell {
+		last := args[len(args)-1]
+		if args[0] == windowsShell {
+			// Use double-quotation around whole command line string
+			// See https://stackoverflow.com/a/6378038
+			args[len(args)-1] = fmt.Sprintf(`"%s %s"`, last, cmdQuoteArg(path))
+		} else {
+			args[len(args)-1] = fmt.Sprintf("%s %q", last, path)
+		}
+	} else {
+		args = append(args, path)
+	}
+	return args
+}
+
+// Launch opens the described or returns an error. The TTY will be protected, and
+// SIGQUIT, SIGTERM, and SIGINT will all be trapped.
+func (e Editor) Launch(path string) error {
+	if len(e.Args) == 0 {
+		return fmt.Errorf("no editor defined, can't open %s", path)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	args := e.args(abs)
+	var cmd *exec.Cmd
+	if e.Shell && args[0] == windowsShell {
+		// Pass all arguments to cmd.exe as one string
+		// See https://pkg.go.dev/os/exec#Command
+		cmd = exec.Command(args[0])
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+		cmd.SysProcAttr.CmdLine = strings.Join(args, " ")
+	} else {
+		cmd = exec.Command(args[0], args[1:]...)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	klog.V(5).Infof("Opening file with editor %v", args)
+	if err := (term.TTY{In: os.Stdin, TryDev: true}).Safe(cmd.Run); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return fmt.Errorf("unable to launch the editor %q", strings.Join(e.Args, " "))
+		}
+		return fmt.Errorf("there was a problem with the editor %q", strings.Join(e.Args, " "))
+	}
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

When on Windows and cmd.exe and we are not able to parse the EDITOR/KUBE_EDITOR environmental variables into arguments, the Go language documentation [mentions](https://pkg.go.dev/os/exec) that when executing cmd.exe, special care needs to be taken regarding arguments - pass whole command line as a string and not as separate arguments with `SysProcAttr.CmdLine`.

Moreover, when doing this, the whole string after `cmd /C` needs to be [double-quoted](https://stackoverflow.com/a/6378038). 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72734

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed EDITOR/KUBE_EDITOR with double-quoted paths with spaces when on Windows cmd.exe.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
