### PR TITLE
client-go: make transport cacheable using Interfaces instead of callback functions

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_cache_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_cache_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec_test // separate package to prevent circular import
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// TestExecTLSCache asserts the semantics of the TLS cache when exec auth is used.
+//
+// In particular, when:
+//   - multiple identical rest configs exist as distinct objects, and
+//   - these rest configs use exec auth, and
+//   - these rest configs are used to create distinct clientsets, then
+//
+// the underlying TLS config is shared between those clientsets.
+func TestExecTLSCache(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	config1 := &rest.Config{
+		Host: "https://localhost",
+		ExecProvider: &clientcmdapi.ExecConfig{
+			Command:         "./testdata/test-plugin.sh",
+			APIVersion:      "client.authentication.k8s.io/v1",
+			InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
+		},
+	}
+	client1 := clientset.NewForConfigOrDie(config1)
+
+	config2 := &rest.Config{
+		Host: "https://localhost",
+		ExecProvider: &clientcmdapi.ExecConfig{
+			Command:         "./testdata/test-plugin.sh",
+			APIVersion:      "client.authentication.k8s.io/v1",
+			InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
+		},
+	}
+	client2 := clientset.NewForConfigOrDie(config2)
+
+	config3 := &rest.Config{
+		Host: "https://localhost",
+		ExecProvider: &clientcmdapi.ExecConfig{
+			Command:         "./testdata/test-plugin.sh",
+			Args:            []string{"make this exec auth different"},
+			APIVersion:      "client.authentication.k8s.io/v1",
+			InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
+		},
+	}
+	client3 := clientset.NewForConfigOrDie(config3)
+
+	_, _ = client1.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	_, _ = client2.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	_, _ = client3.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+
+	rt1 := client1.RESTClient().(*rest.RESTClient).Client.Transport
+	rt2 := client2.RESTClient().(*rest.RESTClient).Client.Transport
+	rt3 := client3.RESTClient().(*rest.RESTClient).Client.Transport
+
+	tlsConfig1, err := utilnet.TLSClientConfig(rt1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsConfig2, err := utilnet.TLSClientConfig(rt2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsConfig3, err := utilnet.TLSClientConfig(rt3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tlsConfig1 == nil {
+		t.Error("expected non-nil TLS configs for 1")
+	}
+
+	if tlsConfig2 == nil {
+		t.Error("expected non-nil TLS configs for 2")
+	}
+	if tlsConfig3 == nil {
+		t.Error("expected non-nil TLS configs for 3")
+	}
+
+	if tlsConfig1 != tlsConfig2 {
+		t.Error("expected the same TLS config for matching exec config via rest config")
+	}
+
+	if tlsConfig1 == tlsConfig3 {
+		t.Error("expected different TLS config for non-matching exec config via rest config")
+	}
+}

--- a/staging/src/k8s.io/client-go/rest/exec_test.go
+++ b/staging/src/k8s.io/client-go/rest/exec_test.go
@@ -250,8 +250,18 @@ func TestConfigToExecClusterRoundtrip(t *testing.T) {
 		func(r *func(ctx context.Context, network, addr string) (net.Conn, error), f fuzz.Continue) {
 			*r = fakeDialFunc
 		},
+		func(r *Dialer, f fuzz.Continue) {
+			dialer := &fakeDialer{}
+			f.Fuzz(dialer)
+			*r = dialer
+		},
 		func(r *func(*http.Request) (*url.URL, error), f fuzz.Continue) {
 			*r = fakeProxyFunc
+		},
+		func(r *Proxier, f fuzz.Continue) {
+			proxier := &fakeProxier{}
+			f.Fuzz(proxier)
+			*r = proxier
 		},
 		func(r *runtime.Object, f fuzz.Continue) {
 			unknown := &runtime.Unknown{}
@@ -291,6 +301,8 @@ func TestConfigToExecClusterRoundtrip(t *testing.T) {
 		expected.WarningHandler = nil
 		expected.Timeout = 0
 		expected.Dial = nil
+		expected.Dialer = nil
+		expected.Proxier = nil
 
 		// Manually set URLs so we don't get an error when parsing these during the roundtrip.
 		if expected.Host != "" {

--- a/staging/src/k8s.io/client-go/rest/transport.go
+++ b/staging/src/k8s.io/client-go/rest/transport.go
@@ -108,8 +108,10 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 			Groups:   c.Impersonate.Groups,
 			Extra:    c.Impersonate.Extra,
 		},
-		Dial:  c.Dial,
-		Proxy: c.Proxy,
+		Dial:    c.Dial,
+		Dialer:  c.Dialer,
+		Proxy:   c.Proxy,
+		Proxier: c.Proxier,
 	}
 
 	if c.ExecProvider != nil && c.AuthProvider != nil {

--- a/staging/src/k8s.io/client-go/transport/cache_test.go
+++ b/staging/src/k8s.io/client-go/transport/cache_test.go
@@ -24,6 +24,18 @@ import (
 	"testing"
 )
 
+type fakeDialer struct{}
+
+func (f fakeDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return nil, nil
+}
+
+type fakeCert struct{}
+
+func (f fakeCert) GetCertificate() (*tls.Certificate, error) {
+	return nil, nil
+}
+
 func TestTLSConfigKey(t *testing.T) {
 	// Make sure config fields that don't affect the tls config don't affect the cache key
 	identicalConfigurations := map[string]*Config{
@@ -68,6 +80,8 @@ func TestTLSConfigKey(t *testing.T) {
 		"no tls":   {},
 		"dialer":   {Dial: dialer.DialContext},
 		"dialer2":  {Dial: func(ctx context.Context, network, address string) (net.Conn, error) { return nil, nil }},
+		"dialer3":  {Dial: dialer.DialContext, Dialer: &dialer},
+		"dialer4":  {Dial: dialer.DialContext, Dialer: &fakeDialer{}},
 		"insecure": {TLS: TLSConfig{Insecure: true}},
 		"cadata 1": {TLS: TLSConfig{CAData: []byte{1}}},
 		"cadata 2": {TLS: TLSConfig{CAData: []byte{2}}},
@@ -126,6 +140,13 @@ func TestTLSConfigKey(t *testing.T) {
 			TLS: TLSConfig{
 				KeyData: []byte{1},
 				GetCert: func() (*tls.Certificate, error) { return nil, nil },
+			},
+		},
+		"getCert3": {
+			TLS: TLSConfig{
+				KeyData: []byte{1},
+				GetCert: getCert,
+				Cert:    &fakeCert{},
 			},
 		},
 		"getCert1, key 2": {

--- a/staging/src/k8s.io/client-go/transport/transport.go
+++ b/staging/src/k8s.io/client-go/transport/transport.go
@@ -116,7 +116,13 @@ func TLSConfigFor(c *Config) (*tls.Config, error) {
 				return dynamicCertLoader()
 			}
 			if c.HasCertCallback() {
-				cert, err := c.TLS.GetCert()
+				var getCertFunc func() (*tls.Certificate, error)
+				if c.TLS.Cert != nil {
+					getCertFunc = c.TLS.Cert.GetCertificate
+				} else {
+					getCertFunc = c.TLS.GetCert
+				}
+				cert, err := getCertFunc()
 				if err != nil {
 					return nil, err
 				}

--- a/test/integration/client/exec_test.go
+++ b/test/integration/client/exec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -26,6 +27,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -40,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -51,6 +54,9 @@ import (
 	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/connrotation"
+	"k8s.io/component-base/logs"
+	"k8s.io/kubectl/pkg/cmd/apply"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
 )
@@ -430,6 +436,160 @@ func v1beta1TestsFromV1Tests(v1Tests []execPluginClientTestData) []execPluginCli
 		v1beta1Tests = append(v1beta1Tests, v1beta1Test)
 	}
 	return v1beta1Tests
+}
+
+type fakeDialerWithCounter struct {
+	mu      sync.Mutex
+	counter int
+}
+
+func (d *fakeDialerWithCounter) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	d.mu.Lock()
+	d.counter++
+	fmt.Println("dialing ...", network, address)
+	d.mu.Unlock()
+	return (&net.Dialer{}).DialContext(ctx, network, address)
+}
+
+func (d *fakeDialerWithCounter) calls() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.counter
+}
+
+// Test that validate that only one transport is created when using kubectl apply
+func TestApplyMultipleItems(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		execPlugin bool
+	}{
+		{
+			name:       "without exec plugin",
+			execPlugin: false,
+		},
+		{
+			name:       "with exec plugin",
+			execPlugin: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, clientAuthorizedToken, _, _ := startTestServer(t)
+			actualMetrics := captureMetrics(t)
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			kconfig := `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: "` + result.ClientConfig.Host + `"
+    insecure-skip-tls-verify: true
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+users:
+- name: test
+`
+			if test.execPlugin {
+				kconfig = kconfig + `
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1
+      env:
+      - name: EXEC_PLUGIN_OUTPUT
+        value: '{"kind": "ExecCredential", "apiVersion": "client.authentication.k8s.io/v1", "status": {"token": "` + clientAuthorizedToken + `"}}'
+      args: ["--random-arg-to-avoid-authenticator-cache-hits","` + rand.String(10) + `"]
+      command: "` + filepath.Join(cwd, "testdata", "exec-plugin.sh") + `"
+      interactiveMode: IfAvailable
+`
+			}
+
+			kubeconfig, err := os.CreateTemp("", "kubeconfig")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			kubeconfig.WriteString(kconfig)
+			kubeconfig.Close()
+
+			originalArgs := os.Args
+			originalKubeconfig, wasSet := os.LookupEnv("KUBECONFIG")
+			t.Cleanup(func() {
+				os.Args = originalArgs
+				if wasSet {
+					os.Setenv("KUBECONFIG", originalKubeconfig)
+				}
+				os.Remove(kubeconfig.Name())
+			})
+
+			defer cmdutil.DefaultBehaviorOnFatal()
+			cmdutil.BehaviorOnFatal(func(msg string, code int) {
+				t.Error(msg, code)
+			})
+
+			dialer := &fakeDialerWithCounter{}
+			clientGetter := genericclioptions.NewConfigFlags(true)
+			clientGetter.WithWrapConfigFn(func(c *rest.Config) *rest.Config {
+				c.Dialer = dialer
+				return c
+			})
+			f := cmdutil.NewFactory(clientGetter)
+			stdin := &bytes.Buffer{}
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			iostreams := genericclioptions.IOStreams{In: stdin, Out: stdout, ErrOut: stderr}
+			cmd := apply.NewCmdApply("kubectl", f, iostreams)
+			clientGetter.AddFlags(cmd.Flags())
+			os.Args = []string{"apply", "--kubeconfig", kubeconfig.Name(), "--filename", "testdata/exec-plugin-apply.yaml"}
+			if !test.execPlugin {
+				os.Args = append(os.Args, "--token", clientAuthorizedToken)
+			}
+			fmt.Println("before apply")
+			//logs.GlogSetter("9")
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			logs.GlogSetter("2")
+			fmt.Println("after apply")
+
+			// t.Log(stdout.String())
+			// t.Log(stderr.String())
+
+			if test.execPlugin && len(actualMetrics.calls) != 1 {
+				t.Errorf("expected 1 call, got %d", len(actualMetrics.calls))
+			}
+
+			// one per object + discovery
+			if dialer.calls() != 1 {
+				t.Errorf("expected 1 call, got %d", dialer.calls())
+			}
+
+			dialer2 := &fakeDialerWithCounter{}
+			c := rest.CopyConfig(result.ClientConfig)
+			c.Dialer = dialer2
+			client := clientset.NewForConfigOrDie(c)
+			if _, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), "exec-test1", metav1.GetOptions{}); err != nil {
+				t.Error(err)
+			}
+			if _, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), "exec-test10", metav1.GetOptions{}); err != nil {
+				t.Error(err)
+			}
+			if dialer2.calls() != 1 {
+				t.Errorf("expected 1 call, got %d", dialer2.calls())
+			}
+		})
+	}
 }
 
 func TestExecPluginViaClient(t *testing.T) {

--- a/test/integration/client/testdata/exec-plugin-apply.yaml
+++ b/test/integration/client/testdata/exec-plugin-apply.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exec-test1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exec-test2
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exec-test3
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exec-test4
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exec-test5
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exec-test6
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exec-test7
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exec-test8
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exec-test9
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exec-test10
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exec-test11


### PR DESCRIPTION
/kind feature
/kind api-change
/kind deprecation

#### What this PR does / why we need it:

The client-go constructors generates the Transport used by the clients,  and caches it when possible.

However, when the users need to add custom callbacks to the configuration, specifically the options

https://github.com/kubernetes/kubernetes/blob/48c8183fc42f2e64ecfde0c9fa8b03f637392a10/staging/src/k8s.io/client-go/rest/config.go#L133-L134

https://github.com/kubernetes/kubernetes/blob/48c8183fc42f2e64ecfde0c9fa8b03f637392a10/staging/src/k8s.io/client-go/rest/config.go#L140-L141

That are cascaded to the transport config

https://github.com/kubernetes/kubernetes/blob/48c8183fc42f2e64ecfde0c9fa8b03f637392a10/staging/src/k8s.io/client-go/transport/config.go#L70-L78

that also has another callback

https://github.com/kubernetes/kubernetes/blob/48c8183fc42f2e64ecfde0c9fa8b03f637392a10/staging/src/k8s.io/client-go/transport/config.go#L146


This causes that transport is not cacheable when one of this option is set

https://github.com/kubernetes/kubernetes/blob/48c8183fc42f2e64ecfde0c9fa8b03f637392a10/staging/src/k8s.io/client-go/transport/cache.go#L141-L143

and this can cause that clients generate a lot of connections for the same destination, this is especially problematic for `kubectl` , that generates one transport for each type, causing the exhausing of TCP port easily.

Some changes were introduced to fix this problem https://github.com/kubernetes/kubernetes/pull/105490, but until all users of client-go move to that approach, we need to be able to cache as much as possible.

This PR adds 3 new configuration options based on Interfaces to deprecate the current callbacks on the configuration options.

#### Which issue(s) this PR fixes:
Fixes #111911

#### Special notes for your reviewer:

This is based on the assumption that interfaces can be used as key of maps https://go.dev/play/p/PgBOb_wF2nH

We should have some expert on the area verifying this assumption

#### Does this PR introduce a user-facing change?
```release-note
client-go rest and transport: add two new interfaces types on both packages:

type Dialer interface {
	DialContext(ctx context.Context, network, address string) (net.Conn, error)
}

type Proxier interface {
	Proxy(*http.Request) (*url.URL, error)
}

client-go rest: Config deprecate the options
- Dial func(ctx context.Context, network, address string) (net.Conn, error)
- Proxy func(*http.Request) (*url.URL, error)
 
in favor of two new options that implement the new interfaces:
- Dialer Dialer
- Proxier Proxier

client-go transport: add a new interface
type Certificate interface {
	GetCertificate() (*tls.Certificate, error)
}

client-go transport: TLSConfig deprecate the `GetCert func() (*tls.Certificate, error)` in favor of a new option `Cert Certificate`

This is required to make the transport cacheable, since functions in golang are not comparable.
```
