### PR TITLE
fix: `Node not found` when testcases is executed

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -645,7 +645,7 @@ func TestPreFilterState(t *testing.T) {
 			nodes: []*v1.Node{
 				st.MakeNode().Name("node-a").Label("node", "node-a").Label("foo", "").Obj(),
 				st.MakeNode().Name("node-b").Label("node", "node-b").Label("foo", "").Obj(),
-				st.MakeNode().Name("node-y").Label("node", "node-y").Label("bar", "").Obj(),
+				st.MakeNode().Name("node-c").Label("node", "node-c").Label("bar", "").Obj(),
 			},
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("p-a").Node("node-a").Label("bar", "").Obj(),
@@ -683,7 +683,7 @@ func TestPreFilterState(t *testing.T) {
 			nodes: []*v1.Node{
 				st.MakeNode().Name("node-a").Label("node", "node-a").Label("foo", "").Obj(),
 				st.MakeNode().Name("node-b").Label("node", "node-b").Label("foo", "").Obj(),
-				st.MakeNode().Name("node-y").Label("node", "node-y").Label("bar", "").Obj(),
+				st.MakeNode().Name("node-c").Label("node", "node-c").Label("bar", "").Obj(),
 			},
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("p-a").Node("node-a").Label("bar", "").Obj(),
@@ -760,7 +760,7 @@ func TestPreFilterState(t *testing.T) {
 			nodes: []*v1.Node{
 				st.MakeNode().Name("node-a").Label("node", "node-a").Label("foo", "").Obj(),
 				st.MakeNode().Name("node-b").Label("node", "node-b").Label("foo", "").Obj(),
-				st.MakeNode().Name("node-y").Label("node", "node-y").Label("bar", "").Obj(),
+				st.MakeNode().Name("node-c").Label("node", "node-c").Label("bar", "").Obj(),
 			},
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("p-a").Node("node-a").Label("bar", "").Obj(),


### PR DESCRIPTION
Signed-off-by: Dave Chen <dave.chen@arm.com>

/kind bug

Hit below errors when those testcases are executed.
```
=== RUN   TestPreFilterState/feature_gate_disabled_with_NodeAffinityPolicy
E0831 18:25:46.307834    9856 filtering.go:277] "Node not found"
=== RUN   TestPreFilterState/NodeAffinityPolicy_honored_with_labelSelectors
E0831 18:25:46.308288    9856 filtering.go:277] "Node not found"
=== RUN   TestPreFilterState/NodeAffinityPolicy_ignored_with_labelSelectors
=== RUN   TestPreFilterState/NodeAffinityPolicy_honored_with_nodeAffinity
E0831 18:25:46.309246    9856 filtering.go:277] "Node not found"
```

Should not a functional change but those errors are misleading in case there is any failures and we want to figure out the root cause.

more context: snapshot will create a node info with node as nil if pod is associated with non-existent node. The logic of the snapshot should be correct and we should just update the testcases instead.

```
nodeNameToInfo[nodeName] = framework.NewNodeInfo()
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
