### PR TITLE
kmsv2: enable logging for kmsv2 enc/dec operations

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/value"
 	kmstypes "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/v2alpha1"
 	"k8s.io/apiserver/pkg/storage/value/encrypt/envelope/metrics"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/lru"
 )
 
@@ -122,6 +123,7 @@ func (t *envelopeTransformer) TransformFromStorage(ctx context.Context, data []b
 			value.RecordCacheMiss()
 		}
 		uid := string(uuid.NewUUID())
+		klog.V(6).InfoS("Decrypting content using envelope service", "uid", uid, "key", string(dataCtx.AuthenticatedData()))
 		key, err := t.envelopeService.Decrypt(ctx, uid, &DecryptRequest{
 			Ciphertext:  encryptedObject.EncryptedDEK,
 			KeyID:       encryptedObject.KeyID,
@@ -149,6 +151,7 @@ func (t *envelopeTransformer) TransformToStorage(ctx context.Context, data []byt
 	}
 
 	uid := string(uuid.NewUUID())
+	klog.V(6).InfoS("Encrypting content using envelope service", "uid", uid, "key", string(dataCtx.AuthenticatedData()))
 	resp, err := t.envelopeService.Encrypt(ctx, uid, newKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt DEK, error: %w", err)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR enables structured logging around the `KMSv2` Envelope.

#### Which issue(s) this PR fixes:
Fixes #111923

#### Special notes for your reviewer:
Changes in the PR has been put in place based on the comment in https://github.com/kubernetes/kubernetes/pull/111126#discussion_r935134439 

#### Does this PR introduce a user-facing change?
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
None
```
