### PR TITLE
Avoid propagating "search ." into containers /etc/resolv.conf

### DIFF
--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -268,9 +268,8 @@ func parseResolvConf(reader io.Reader) (nameservers []string, searches []string,
 			searches = []string{}
 			for _, s := range fields[1:] {
 				if s != "." {
-					s = strings.TrimSuffix(s, ".")
+					searches = append(searches, strings.TrimSuffix(s, "."))
 				}
-				searches = append(searches, s)
 			}
 		}
 		if fields[0] == "options" {

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -77,8 +77,11 @@ func TestParseResolvConf(t *testing.T) {
 		{"nameserver \t 1.2.3.4", []string{"1.2.3.4"}, []string{}, []string{}, false},
 		{"nameserver 1.2.3.4\nnameserver 5.6.7.8", []string{"1.2.3.4", "5.6.7.8"}, []string{}, []string{}, false},
 		{"nameserver 1.2.3.4 #comment", []string{"1.2.3.4"}, []string{}, []string{}, false},
-		{"search ", []string{}, []string{}, []string{}, false}, // search empty
-		{"search .", []string{}, []string{"."}, []string{}, false},
+		{"search ", []string{}, []string{}, []string{}, false},  // search empty
+		{"search .", []string{}, []string{}, []string{}, false}, // ignore lone dot
+		{"search . foo", []string{}, []string{"foo"}, []string{}, false},
+		{"search foo .", []string{}, []string{"foo"}, []string{}, false},
+		{"search foo .  bar", []string{}, []string{"foo", "bar"}, []string{}, false},
 		{"search foo", []string{}, []string{"foo"}, []string{}, false},
 		{"search foo bar", []string{}, []string{"foo", "bar"}, []string{}, false},
 		{"search foo. bar", []string{}, []string{"foo", "bar"}, []string{}, false},


### PR DESCRIPTION
Starting in Kubelet v1.25.0, on certain hosts (those with a FQDN hostname and recent systemd), a "search ." in `/etc/resolv.conf` will now propagate into containers (it did not before v1.25). This breaks musl-based DNS resolution (e.g. any alpine image) for Pods running on such nodes.

https://github.com/kubernetes/kubernetes/issues/112135 provides a lot of details. 

#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

~This reverts commit 5832b84200340344dc0a3e3a360375b3718aa8cd to fix a regression introduced in v1.25.0 (v1.25.0-alpha.1 to be specific). Without this change. alpine or other musl-based containers will fail DNS resolution on certain nodes (described in issue).~

Adapts https://github.com/kubernetes/kubernetes/pull/109441 to avoid propagating `search .` into containers `/etc/resolv.conf`

#### Which issue(s) this PR fixes:

Fixes #112135

#### Does this PR introduce a user-facing change?

```release-note
Fixes a 1.25 regression propagating hosts' `search .` into containers' `/etc/resolv.conf` which can fail DNS resolution
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

* Regression: https://github.com/kubernetes/kubernetes/pull/109441
* Bug Report: https://github.com/kubernetes/kubernetes/issues/112135
* Great details: https://github.com/coreos/fedora-coreos-tracker/issues/1287#issuecomment-1232763947 with packet capture
* Flagged to musl: https://www.openwall.com/lists/musl/2022/08/31/1

Historical:

* systemd change: https://github.com/systemd/systemd/pull/17201
* Host-level workaround: https://github.com/openshift/okd-machine-os/pull/159, https://github.com/poseidon/typhoon/pull/1224
