### PR TITLE
Update to use GA PodSecurity webhook image

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/50-deployment.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/50-deployment.yaml
@@ -28,7 +28,7 @@ spec:
             secretName: pod-security-webhook
       containers:
         - name: pod-security-webhook
-          image: registry.k8s.io/sig-auth/pod-security-webhook:v1.23-beta.0
+          image: registry.k8s.io/sig-auth/pod-security-webhook:v1.25.0
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - name: webhook


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Updates example manifests to use the GA version of the PodSecurity admission webhook image.

/hold for https://github.com/kubernetes/k8s.io/pull/4168

```release-note
NONE
```

/cc @tallclair 
/sig auth