### PR TITLE
Automated cherry pick of #112159: Update to use GA PodSecurity webhook image

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/50-deployment.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/50-deployment.yaml
@@ -28,7 +28,7 @@ spec:
             secretName: pod-security-webhook
       containers:
         - name: pod-security-webhook
-          image: registry.k8s.io/sig-auth/pod-security-webhook:v1.23-beta.0
+          image: registry.k8s.io/sig-auth/pod-security-webhook:v1.25.0
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - name: webhook


### PR DESCRIPTION
Cherry pick of #112159 on release-1.25.

#112159: Update to use GA PodSecurity webhook image

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```