### PR TITLE
graduate ServiceIPStaticSubrange to GA

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -758,6 +758,7 @@ const (
 	// kep: http://kep.k8s.io/3070
 	// alpha: v1.24
 	// beta: v1.25
+	// ga: v1.26
 	//
 	// Subdivide the ClusterIP range for dynamic and static IP allocation.
 	ServiceIPStaticSubrange featuregate.Feature = "ServiceIPStaticSubrange"
@@ -1077,7 +1078,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	SeccompDefault: {Default: true, PreRelease: featuregate.Beta},
 
-	ServiceIPStaticSubrange: {Default: true, PreRelease: featuregate.Beta},
+	ServiceIPStaticSubrange: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.28
 
 	ServiceInternalTrafficPolicy: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/registry/core/service/ipallocator/allocator.go
+++ b/pkg/registry/core/service/ipallocator/allocator.go
@@ -22,9 +22,7 @@ import (
 	"math/big"
 	"net"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/registry/core/service/allocator"
 	netutils "k8s.io/utils/net"
 )
@@ -124,10 +122,7 @@ func New(cidr *net.IPNet, allocatorFactory allocator.AllocatorWithOffsetFactory)
 		metrics: &emptyMetricsRecorder{}, // disabled by default
 	}
 
-	offset := 0
-	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceIPStaticSubrange) {
-		offset = calculateRangeOffset(cidr)
-	}
+	offset := calculateRangeOffset(cidr)
 
 	var err error
 	r.alloc, err = allocatorFactory(r.max, rangeSpec, offset)

--- a/pkg/registry/core/service/ipallocator/allocator_test.go
+++ b/pkg/registry/core/service/ipallocator/allocator_test.go
@@ -22,11 +22,8 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/testutil"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/features"
 	netutils "k8s.io/utils/net"
 )
 
@@ -181,8 +178,6 @@ func TestAllocateTiny(t *testing.T) {
 }
 
 func TestAllocateReserved(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceIPStaticSubrange, true)()
-
 	_, cidr, err := netutils.ParseCIDRSloppy("192.168.1.0/25")
 	if err != nil {
 		t.Fatal(err)
@@ -425,8 +420,6 @@ func TestNewFromSnapshot(t *testing.T) {
 
 func TestClusterIPMetrics(t *testing.T) {
 	clearMetrics()
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceIPStaticSubrange, true)()
-
 	// create IPv4 allocator
 	cidrIPv4 := "10.0.0.0/24"
 	_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy(cidrIPv4)
@@ -539,8 +532,6 @@ func TestClusterIPMetrics(t *testing.T) {
 
 func TestClusterIPAllocatedMetrics(t *testing.T) {
 	clearMetrics()
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceIPStaticSubrange, true)()
-
 	// create IPv4 allocator
 	cidrIPv4 := "10.0.0.0/25"
 	_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy(cidrIPv4)

--- a/pkg/registry/core/service/ipallocator/storage/storage_test.go
+++ b/pkg/registry/core/service/ipallocator/storage/storage_test.go
@@ -26,11 +26,8 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	"k8s.io/apiserver/pkg/storage/storagebackend/factory"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/registry/core/service/allocator"
 	allocatorstore "k8s.io/kubernetes/pkg/registry/core/service/allocator/storage"
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
@@ -121,8 +118,6 @@ func TestStore(t *testing.T) {
 }
 
 func TestAllocateReserved(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceIPStaticSubrange, true)()
-
 	_, storage, _, si, destroyFunc := newStorage(t)
 	defer destroyFunc()
 	if err := si.Create(context.TODO(), key(), validNewRangeAllocation(), nil, 0); err != nil {
@@ -169,8 +164,6 @@ func TestAllocateReserved(t *testing.T) {
 }
 
 func TestAllocateReservedDynamicBlockExhausted(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceIPStaticSubrange, true)()
-
 	_, storage, _, si, destroyFunc := newStorage(t)
 	defer destroyFunc()
 	if err := si.Create(context.TODO(), key(), validNewRangeAllocation(), nil, 0); err != nil {


### PR DESCRIPTION

/kind feature

The feature has been working without problems during last release, it is  a small change and the feature gate is nothing more than a protection to allow safe rollbacks in case of an unexpected bug.

https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3070-reserved-service-ip-range


```release-note
Graduate ServiceIPStaticSubrange feature to GA
```


```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3070
- [Blog]: https://kubernetes.io/blog/2022/05/23/service-ip-dynamic-and-static-allocation/
```
