### PR TITLE
kubeadm: Add the option to cleanup the `tmp` directory

### DIFF
--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -148,4 +148,7 @@ const (
 
 	// Print the addon manifests to STDOUT instead of installing them.
 	PrintManifest = "print-manifest"
+
+	// CleanupTmpDir flag indicates whether reset will cleanup the tmp dir
+	CleanupTmpDir = "cleanup-tmp-dir"
 )

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -47,6 +48,7 @@ func NewCleanupNodePhase() workflow.Phase {
 		InheritFlags: []string{
 			options.CertificatesDir,
 			options.NodeCRISocket,
+			options.CleanupTmpDir,
 		},
 	}
 }
@@ -103,7 +105,12 @@ func runCleanupNode(c workflow.RunData) error {
 	if certsDir != kubeadmapiv1.DefaultCertificatesDir {
 		klog.Warningf("[reset] WARNING: Cleaning a non-default certificates directory: %q\n", certsDir)
 	}
+
 	dirsToClean = append(dirsToClean, certsDir)
+	if r.CleanupTmpDir() {
+		tempDir := path.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.TempDirForKubeadm)
+		dirsToClean = append(dirsToClean, tempDir)
+	}
 	resetConfigDir(kubeadmconstants.KubernetesDir, dirsToClean, r.DryRun())
 
 	if r.Cfg() != nil && features.Enabled(r.Cfg().FeatureGates, features.RootlessControlPlane) {

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
@@ -142,6 +142,17 @@ func TestConfigDirCleaner(t *testing.T) {
 				"test-path",
 			},
 		},
+		"cleanup temp directory": {
+			setupDirs: []string{
+				"tmp",
+			},
+			setupFiles: []string{
+				"tmp/kubeadm-init-dryrun2845575027",
+			},
+			verifyExists: []string{
+				"tmp",
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -176,6 +187,7 @@ func TestConfigDirCleaner(t *testing.T) {
 			dirsToClean := []string{
 				filepath.Join(tmpDir, test.resetDir),
 				filepath.Join(tmpDir, kubeadmconstants.ManifestsSubDirName),
+				filepath.Join(tmpDir, kubeadmconstants.TempDirForKubeadm),
 			}
 			resetConfigDir(tmpDir, dirsToClean, false)
 
@@ -185,6 +197,7 @@ func TestConfigDirCleaner(t *testing.T) {
 			assertNotExists(t, filepath.Join(tmpDir, kubeadmconstants.KubeletKubeConfigFileName))
 			assertDirEmpty(t, filepath.Join(tmpDir, "manifests"))
 			assertDirEmpty(t, filepath.Join(tmpDir, "pki"))
+			assertDirEmpty(t, filepath.Join(tmpDir, "tmp"))
 
 			// Verify the files as requested by the test:
 			for _, path := range test.verifyExists {

--- a/cmd/kubeadm/app/cmd/phases/reset/data.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/data.go
@@ -36,4 +36,5 @@ type resetData interface {
 	Client() clientset.Interface
 	CertificatesDir() string
 	CRISocketPath() string
+	CleanupTmpDir() bool
 }

--- a/cmd/kubeadm/app/cmd/phases/reset/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/data_test.go
@@ -39,3 +39,4 @@ func (t *testData) DryRun() bool                       { return false }
 func (t *testData) Client() clientset.Interface        { return nil }
 func (t *testData) CertificatesDir() string            { return "" }
 func (t *testData) CRISocketPath() string              { return "" }
+func (t *testData) CleanupTmpDir() bool                { return false }


### PR DESCRIPTION
The `tmp` is created by `kubeadm` but is never removed, the
size is expected to be expanded as time goes by.

Add one bool option to cleanup the `tmp` dir, the flag is
off by default.

Here is what I see on my desktop,
```
# du -sh /etc/kubernetes/tmp
2.2G    /etc/kubernetes/tmp
```


Signed-off-by: Dave Chen <dave.chen@arm.com>

/kind feature


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: add the flag "--cleanup-tmp-dir" for "kubeadm reset". It will cleanup the contents of "/etc/kubernetes/tmp". The flag is off by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig cluster-lifecycle