### PR TITLE
Prevent AvailableController recheck storms in network partition

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -533,7 +533,7 @@ func (c *AvailableConditionController) addAPIService(obj interface{}) {
 	if castObj.Spec.Service != nil {
 		c.rebuildAPIServiceCache()
 	}
-	c.checkIfNotInBackoff(castObj.Name)
+	c.queueAddIfNotInBackoff(castObj.Name)
 }
 
 func (c *AvailableConditionController) updateAPIService(oldObj, newObj interface{}) {
@@ -543,10 +543,10 @@ func (c *AvailableConditionController) updateAPIService(oldObj, newObj interface
 	if !reflect.DeepEqual(castObj.Spec.Service, oldCastObj.Spec.Service) {
 		c.rebuildAPIServiceCache()
 	}
-	c.checkIfNotInBackoff(oldCastObj.Name)
+	c.queueAddIfNotInBackoff(oldCastObj.Name)
 }
 
-func (c *AvailableConditionController) checkIfNotInBackoff(apiservice string) {
+func (c *AvailableConditionController) queueAddIfNotInBackoff(apiservice string) {
 	if c.queue.NumRequeues(apiservice) > 0 {
 		klog.V(4).Infof("Skipping check of %s due to it being rate-limited", apiservice)
 		return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Please see a more detailed explanation of the problem in the issue https://github.com/kubernetes/kubernetes/issues/111890

External kubernetes API extensions are regularly checked for availability by every apiserver running its own instance of the "AvailableConditionController".

In the event of a network partition, there is a fight over the global shared "Available" condition on the apiservice object with apiserver instances in disagreement rapidly toggling the condition between "available" and "unavailable".  This behaviour escalates due to the failing apiserver scheduling extra checks through its exponential backoff and each toggling of the state itself triggering a fresh set of checks across all apiserver instances.  We observed a huge increase in checks performed and "Available" condition changes.

This PR prevents an AvailableConditionController with failing checks from executing new checks whilst it is already re-queuing a failed check, i.e. make it truly adhere to its exponential backoff in the case of a failure.  By preventing rapid rechecking and subsequent setting of the condition we slow down the fight between apiservers and the number of checks on the backend service.

#### Behaviour With This PR

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/1453938/188011898-cc503da3-95b2-4548-810d-798251339af1.png">

1. An informer update to apiservice 'X' queues the check to the dirty set (labeled queue).  Let's call it 'X1'.
2. 'X1' gets picked up, put in the processing set and is executed.
3. The 'X1' check fails and the rate-limiter is used to requeue 'X1' to the delayed queue with an appropriate delay.
4. Another informer update to apiservice 'X' 'X2' is ignored because we know there is already a rate-limited retry for 'X' queued.
5. Another informer update 'X3' is similarly just ignored.
6. An update to a Service or Endpoint is different, these are let straight through so 'X4' is queued in the dirty set.
7. 'X4' gets picked up for processing before 'X1' moves out of waiting.
8. The 'X4' check also fails and so gets the next exponential delay which will always be more or the same as 'X1' (if this was happening when the rate-limiter hits its 30s maximum delay limit).  In this scenario 'X4' is effectively discarded and 'X1' remains queued (because its wait is shorter).  Had X1 been promoted to the dirty queue _before_ the 'X4' failure called AddAfter() then we would see 'X4' successfully admitted to the wait queue and X1 would shortly be processed.

It's important to remember that although I'm talking about X1, X4 etc, they really just mean the same thing - "go check X".

#### Recovery Time

Whilst this has an impact on recovery time, it is preferable to the storm of requests, and even in the worst case scenario where all apiservers are backing off 30 seconds, depending the number of apiservers deployed, there is a good chance that a check will succeed well before 30 seconds after the service has recovered.  The absolute worst case scenario is 30 seconds.
 
Whilst this PR limits the re-checking of backend apiservices triggered through apiservice object changes, it does not limit changes made to services and endpoints.  They will continue to work as they did previously, immediately queuing a check to any impacted apiservices (because updates to these objects are more likely to represent a change in state of the real world which will impact the availability of the service and they are not encumbered by a condition attribute).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #111890 (https://github.com/kubernetes/kubernetes/issues/111890)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
