### PR TITLE
Remove race between kubelet startup and mounter rootfs

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -3442,6 +3442,10 @@ function main() {
   fi
   log-end 'SetupKubePodLogReadersGroupDir'
 
+  # Note prepare-mounter-rootfs must be called before the kubelet starts, as
+  # kubelet startup updates its nameserver.
+  log-wrap 'PrepareMounterRootfs' prepare-mounter-rootfs
+
   log-wrap 'StartKubelet' start-kubelet
 
   if [[ "${KUBERNETES_MASTER:-}" == "true" ]]; then
@@ -3470,7 +3474,6 @@ function main() {
     fi
   fi
   log-wrap 'ResetMotd' reset-motd
-  log-wrap 'PrepareMounterRootfs' prepare-mounter-rootfs
 
   # Wait for all background jobs to finish.
   wait


### PR DESCRIPTION
/kind bug

Fixes #112194

After discussion with cloud-provider-gce, we decided it would be best to make this change here as well as in cloud-provider-gce, since the ownership of k/k/cluster is still in flux.

The cloud provider gcp PR is https://github.com/kubernetes/cloud-provider-gcp/pull/365.

```release-note
Fix race condition in GCE between containerized mounter setup in the kubelet and node startup.
```
