### PR TITLE
add AssumeCache from volume binding to client-go

### DIFF
--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -7,6 +7,7 @@ go 1.19
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.12.0+incompatible
+	github.com/go-logr/logr v1.2.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/protobuf v1.5.2
@@ -37,7 +38,6 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect

--- a/staging/src/k8s.io/client-go/tools/cache/assume_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/assume_cache.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+// AssumeCache is a cache on top of the informer that allows for updating
+// objects outside of informer events and also restoring the informer
+// cache's version of the object.  Objects are assumed to be
+// Kubernetes API objects that implement meta.Interface
+type AssumeCache interface {
+	// Assume updates the object in-memory only
+	Assume(obj interface{}) error
+
+	// Restore the informer cache's version of the object
+	Restore(objName string)
+
+	// Get the object by name
+	Get(objName string) (interface{}, error)
+
+	// Get the API object by name
+	GetAPIObj(objName string) (interface{}, error)
+
+	// List all the objects in the cache
+	List(indexObj interface{}) []interface{}
+}
+
+type errWrongType struct {
+	typeName string
+	object   interface{}
+}
+
+func (e *errWrongType) Error() string {
+	return fmt.Sprintf("could not convert object to type %v: %+v", e.typeName, e.object)
+}
+
+type errNotFound struct {
+	typeName   string
+	objectName string
+}
+
+func (e *errNotFound) Error() string {
+	return fmt.Sprintf("could not find %v %q", e.typeName, e.objectName)
+}
+
+type errObjectName struct {
+	detailedErr error
+}
+
+func (e *errObjectName) Error() string {
+	return fmt.Sprintf("failed to get object name: %v", e.detailedErr)
+}
+
+// assumeCache stores two pointers to represent a single object:
+//   - The pointer to the informer object.
+//   - The pointer to the latest object, which could be the same as
+//     the informer object, or an in-memory object.
+//
+// An informer update always overrides the latest object pointer.
+//
+// Assume() only updates the latest object pointer.
+// Restore() sets the latest object pointer back to the informer object.
+// Get/List() always returns the latest object pointer.
+type assumeCache struct {
+	// Synchronizes updates to store
+	rwMutex sync.RWMutex
+
+	// describes the object stored
+	description string
+
+	// Stores objInfo pointers
+	store Indexer
+
+	// Index function for object
+	indexFunc IndexFunc
+	indexName string
+}
+
+type objInfo struct {
+	// name of the object
+	name string
+
+	// Latest version of object could be cached-only or from informer
+	latestObj interface{}
+
+	// Latest object from informer
+	apiObj interface{}
+}
+
+func objInfoKeyFunc(obj interface{}) (string, error) {
+	objInfo, ok := obj.(*objInfo)
+	if !ok {
+		return "", &errWrongType{"objInfo", obj}
+	}
+	return objInfo.name, nil
+}
+
+func (c *assumeCache) objInfoIndexFunc(obj interface{}) ([]string, error) {
+	objInfo, ok := obj.(*objInfo)
+	if !ok {
+		return []string{""}, &errWrongType{"objInfo", obj}
+	}
+	return c.indexFunc(objInfo.latestObj)
+}
+
+// NewAssumeCache creates an assume cache for general objects.
+func NewAssumeCache(informer SharedIndexInformer, description, indexName string, indexFunc IndexFunc) AssumeCache {
+	c := &assumeCache{
+		description: description,
+		indexFunc:   indexFunc,
+		indexName:   indexName,
+	}
+	indexers := Indexers{}
+	if indexName != "" && indexFunc != nil {
+		indexers[indexName] = c.objInfoIndexFunc
+	}
+	c.store = NewIndexer(objInfoKeyFunc, indexers)
+
+	// Unit tests don't use informers
+	if informer != nil {
+		informer.AddEventHandler(
+			ResourceEventHandlerFuncs{
+				AddFunc:    c.add,
+				UpdateFunc: c.update,
+				DeleteFunc: c.delete,
+			},
+		)
+	}
+	return c
+}
+
+func (c *assumeCache) add(obj interface{}) {
+	if obj == nil {
+		return
+	}
+
+	name, err := MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		klog.ErrorS(&errObjectName{err}, "Add failed")
+		return
+	}
+
+	c.rwMutex.Lock()
+	defer c.rwMutex.Unlock()
+
+	if objInfo, _ := c.getObjInfo(name); objInfo != nil {
+		newVersion, err := c.getObjVersion(name, obj)
+		if err != nil {
+			klog.ErrorS(err, "Add failed: couldn't get object version")
+			return
+		}
+
+		storedVersion, err := c.getObjVersion(name, objInfo.latestObj)
+		if err != nil {
+			klog.ErrorS(err, "Add failed: couldn't get stored object version")
+			return
+		}
+
+		// Only update object if version is newer.
+		// This is so we don't override assumed objects due to informer resync.
+		if newVersion <= storedVersion {
+			klog.V(10).InfoS("Skip adding object to assume cache because version is not newer than storedVersion", "description", c.description, "cacheKey", name, "newVersion", newVersion, "storedVersion", storedVersion)
+			return
+		}
+	}
+
+	objInfo := &objInfo{name: name, latestObj: obj, apiObj: obj}
+	if err = c.store.Update(objInfo); err != nil {
+		klog.InfoS("Error occurred while updating stored object", "err", err)
+	} else {
+		klog.V(10).InfoS("Adding object to assume cache", "description", c.description, "cacheKey", name, "assumeCache", obj)
+	}
+}
+
+func (c *assumeCache) update(oldObj interface{}, newObj interface{}) {
+	c.add(newObj)
+}
+
+func (c *assumeCache) delete(obj interface{}) {
+	if obj == nil {
+		return
+	}
+
+	name, err := MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		klog.ErrorS(&errObjectName{err}, "Failed to delete")
+		return
+	}
+
+	c.rwMutex.Lock()
+	defer c.rwMutex.Unlock()
+
+	objInfo := &objInfo{name: name}
+	err = c.store.Delete(objInfo)
+	if err != nil {
+		klog.ErrorS(err, "Failed to delete", "description", c.description, "cacheKey", name)
+	}
+}
+
+func (c *assumeCache) getObjVersion(name string, obj interface{}) (int64, error) {
+	objAccessor, err := meta.Accessor(obj)
+	if err != nil {
+		return -1, err
+	}
+
+	objResourceVersion, err := strconv.ParseInt(objAccessor.GetResourceVersion(), 10, 64)
+	if err != nil {
+		return -1, fmt.Errorf("error parsing ResourceVersion %q for %v %q: %s", objAccessor.GetResourceVersion(), c.description, name, err)
+	}
+	return objResourceVersion, nil
+}
+
+func (c *assumeCache) getObjInfo(name string) (*objInfo, error) {
+	obj, ok, err := c.store.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, &errNotFound{c.description, name}
+	}
+
+	objInfo, ok := obj.(*objInfo)
+	if !ok {
+		return nil, &errWrongType{"objInfo", obj}
+	}
+	return objInfo, nil
+}
+
+func (c *assumeCache) Get(objName string) (interface{}, error) {
+	c.rwMutex.RLock()
+	defer c.rwMutex.RUnlock()
+
+	objInfo, err := c.getObjInfo(objName)
+	if err != nil {
+		return nil, err
+	}
+	return objInfo.latestObj, nil
+}
+
+func (c *assumeCache) GetAPIObj(objName string) (interface{}, error) {
+	c.rwMutex.RLock()
+	defer c.rwMutex.RUnlock()
+
+	objInfo, err := c.getObjInfo(objName)
+	if err != nil {
+		return nil, err
+	}
+	return objInfo.apiObj, nil
+}
+
+func (c *assumeCache) List(indexObj interface{}) []interface{} {
+	c.rwMutex.RLock()
+	defer c.rwMutex.RUnlock()
+
+	allObjs := []interface{}{}
+	objs, err := c.store.Index(c.indexName, &objInfo{latestObj: indexObj})
+	if err != nil {
+		klog.ErrorS(err, "List index error")
+		return nil
+	}
+
+	for _, obj := range objs {
+		objInfo, ok := obj.(*objInfo)
+		if !ok {
+			klog.ErrorS(&errWrongType{"objInfo", obj}, "List error")
+			continue
+		}
+		allObjs = append(allObjs, objInfo.latestObj)
+	}
+	return allObjs
+}
+
+func (c *assumeCache) Assume(obj interface{}) error {
+	name, err := MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return &errObjectName{err}
+	}
+
+	c.rwMutex.Lock()
+	defer c.rwMutex.Unlock()
+
+	objInfo, err := c.getObjInfo(name)
+	if err != nil {
+		return err
+	}
+
+	newVersion, err := c.getObjVersion(name, obj)
+	if err != nil {
+		return err
+	}
+
+	storedVersion, err := c.getObjVersion(name, objInfo.latestObj)
+	if err != nil {
+		return err
+	}
+
+	if newVersion < storedVersion {
+		return fmt.Errorf("%v %q is out of sync (stored: %d, assume: %d)", c.description, name, storedVersion, newVersion)
+	}
+
+	// Only update the cached object
+	objInfo.latestObj = obj
+	klog.V(4).InfoS("Assumed object", "description", c.description, "cacheKey", name, "version", newVersion)
+	return nil
+}
+
+func (c *assumeCache) Restore(objName string) {
+	c.rwMutex.Lock()
+	defer c.rwMutex.Unlock()
+
+	objInfo, err := c.getObjInfo(objName)
+	if err != nil {
+		// This could be expected if object got deleted
+		klog.V(5).InfoS("Restore object", "description", c.description, "cacheKey", objName, "err", err)
+	} else {
+		objInfo.latestObj = objInfo.apiObj
+		klog.V(4).InfoS("Restored object", "description", c.description, "cacheKey", objName)
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/assume_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/assume_cache.go
@@ -26,6 +26,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 )
 
+// AssumeCacheInformer is the subset of a SharedInformer required by NewAssumeCache.
+type AssumeCacheInformer interface {
+	// AddEventHandler adds an event handler to the shared informer using the shared informer's resync
+	// period. Events to a single handler are delivered sequentially, but there is no coordination
+	// between different handlers.
+	AddEventHandler(handler ResourceEventHandler) (ResourceEventHandlerRegistration, error)
+}
+
 // AssumeCache is a cache on top of the informer that allows for updating
 // objects outside of informer events and also restoring the informer
 // cache's version of the object.  Objects are assumed to be
@@ -126,7 +134,7 @@ func (c *assumeCache) objInfoIndexFunc(obj interface{}) ([]string, error) {
 }
 
 // NewAssumeCache creates an assume cache for general objects.
-func NewAssumeCache(informer SharedIndexInformer, description, indexName string, indexFunc IndexFunc) AssumeCache {
+func NewAssumeCache(informer AssumeCacheInformer, description, indexName string, indexFunc IndexFunc) AssumeCache {
 	c := &assumeCache{
 		description: description,
 		indexFunc:   indexFunc,

--- a/staging/src/k8s.io/client-go/tools/cache/assume_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/assume_cache_test.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// persistentVolume is a simplified version of v1.PersistentVolume.
+type persistentVolume struct {
+	metav1.ObjectMeta
+
+	storageClassName string
+	claimRef         string
+}
+
+func makePV(name, storageClassName, resourceVersion string) *persistentVolume {
+	return &persistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			ResourceVersion: resourceVersion,
+		},
+		storageClassName: storageClassName,
+	}
+}
+
+type pvAssumeCache struct {
+	AssumeCache
+}
+
+func (c pvAssumeCache) ListPVs(storageClassName string) []*persistentVolume {
+	objs := c.List(&persistentVolume{
+		storageClassName: storageClassName,
+	})
+	var pvs []*persistentVolume
+	for _, obj := range objs {
+		if pv, ok := obj.(*persistentVolume); ok {
+			pvs = append(pvs, pv)
+		}
+	}
+	return pvs
+}
+
+func pvStorageClassIndexFunc(obj interface{}) ([]string, error) {
+	if pv, ok := obj.(*persistentVolume); ok {
+		return []string{pv.storageClassName}, nil
+	}
+	return []string{""}, fmt.Errorf("object is not a persistentVolume: %v", obj)
+}
+
+func newPVAssumeCache(informer SharedIndexInformer) pvAssumeCache {
+	return pvAssumeCache{NewAssumeCache(informer, "persistentVolume", "storageclass", pvStorageClassIndexFunc)}
+}
+
+func verifyListPVs(t *testing.T, cache pvAssumeCache, expectedPVs map[string]*persistentVolume, storageClassName string) {
+	pvList := cache.ListPVs(storageClassName)
+	if len(pvList) != len(expectedPVs) {
+		t.Errorf("ListPVs() returned %v PVs, expected %v", len(pvList), len(expectedPVs))
+	}
+	for _, pv := range pvList {
+		expectedPV, ok := expectedPVs[pv.Name]
+		if !ok {
+			t.Errorf("ListPVs() returned unexpected PV %q", pv.Name)
+		}
+		if expectedPV != pv {
+			t.Errorf("ListPVs() returned PV %p, expected %p", pv, expectedPV)
+		}
+	}
+}
+
+func verifyPV(cache pvAssumeCache, name string, expectedPV *persistentVolume) error {
+	pv, err := cache.Get(name)
+	if err != nil {
+		return err
+	}
+	if pv != expectedPV {
+		return fmt.Errorf("GetPV() returned %p, expected %p", pv, expectedPV)
+	}
+	return nil
+}
+
+func TestAssumePV(t *testing.T) {
+	scenarios := map[string]struct {
+		oldPV         *persistentVolume
+		newPV         *persistentVolume
+		shouldSucceed bool
+	}{
+		"success-same-version": {
+			oldPV:         makePV("pv1", "", "5"),
+			newPV:         makePV("pv1", "", "5"),
+			shouldSucceed: true,
+		},
+		"success-storageclass-same-version": {
+			oldPV:         makePV("pv1", "class1", "5"),
+			newPV:         makePV("pv1", "class1", "5"),
+			shouldSucceed: true,
+		},
+		"success-new-higher-version": {
+			oldPV:         makePV("pv1", "", "5"),
+			newPV:         makePV("pv1", "", "6"),
+			shouldSucceed: true,
+		},
+		"fail-old-not-found": {
+			oldPV:         makePV("pv2", "", "5"),
+			newPV:         makePV("pv1", "", "5"),
+			shouldSucceed: false,
+		},
+		"fail-new-lower-version": {
+			oldPV:         makePV("pv1", "", "5"),
+			newPV:         makePV("pv1", "", "4"),
+			shouldSucceed: false,
+		},
+		"fail-new-bad-version": {
+			oldPV:         makePV("pv1", "", "5"),
+			newPV:         makePV("pv1", "", "a"),
+			shouldSucceed: false,
+		},
+		"fail-old-bad-version": {
+			oldPV:         makePV("pv1", "", "a"),
+			newPV:         makePV("pv1", "", "5"),
+			shouldSucceed: false,
+		},
+	}
+
+	for name, scenario := range scenarios {
+		cache := newPVAssumeCache(nil)
+		internalCache, ok := cache.AssumeCache.(*assumeCache)
+		if !ok {
+			t.Fatalf("Failed to get internal cache")
+		}
+
+		// Add oldPV to cache
+		internalCache.add(scenario.oldPV)
+		if err := verifyPV(cache, scenario.oldPV.Name, scenario.oldPV); err != nil {
+			t.Errorf("Failed to GetPV() after initial update: %v", err)
+			continue
+		}
+
+		// Assume newPV
+		err := cache.Assume(scenario.newPV)
+		if scenario.shouldSucceed && err != nil {
+			t.Errorf("Test %q failed: Assume() returned error %v", name, err)
+		}
+		if !scenario.shouldSucceed && err == nil {
+			t.Errorf("Test %q failed: Assume() returned success but expected error", name)
+		}
+
+		// Check that GetPV returns correct PV
+		expectedPV := scenario.newPV
+		if !scenario.shouldSucceed {
+			expectedPV = scenario.oldPV
+		}
+		if err := verifyPV(cache, scenario.oldPV.Name, expectedPV); err != nil {
+			t.Errorf("Failed to GetPV() after initial update: %v", err)
+		}
+	}
+}
+
+func TestRestorePV(t *testing.T) {
+	cache := newPVAssumeCache(nil)
+	internalCache, ok := cache.AssumeCache.(*assumeCache)
+	if !ok {
+		t.Fatalf("Failed to get internal cache")
+	}
+
+	oldPV := makePV("pv1", "", "5")
+	newPV := makePV("pv1", "", "5")
+
+	// Restore PV that doesn't exist
+	cache.Restore("nothing")
+
+	// Add oldPV to cache
+	internalCache.add(oldPV)
+	if err := verifyPV(cache, oldPV.Name, oldPV); err != nil {
+		t.Fatalf("Failed to GetPV() after initial update: %v", err)
+	}
+
+	// Restore PV
+	cache.Restore(oldPV.Name)
+	if err := verifyPV(cache, oldPV.Name, oldPV); err != nil {
+		t.Fatalf("Failed to GetPV() after initial restore: %v", err)
+	}
+
+	// Assume newPV
+	if err := cache.Assume(newPV); err != nil {
+		t.Fatalf("Assume() returned error %v", err)
+	}
+	if err := verifyPV(cache, oldPV.Name, newPV); err != nil {
+		t.Fatalf("Failed to GetPV() after Assume: %v", err)
+	}
+
+	// Restore PV
+	cache.Restore(oldPV.Name)
+	if err := verifyPV(cache, oldPV.Name, oldPV); err != nil {
+		t.Fatalf("Failed to GetPV() after restore: %v", err)
+	}
+}
+
+func TestBasicPVCache(t *testing.T) {
+	cache := newPVAssumeCache(nil)
+	internalCache, ok := cache.AssumeCache.(*assumeCache)
+	if !ok {
+		t.Fatalf("Failed to get internal cache")
+	}
+
+	// Get object that doesn't exist
+	pv, err := cache.Get("nothere")
+	if err == nil {
+		t.Errorf("Get() returned unexpected success")
+	}
+	if pv != nil {
+		t.Errorf("Get() returned unexpected PV %+v", pv)
+	}
+
+	// Add a bunch of PVs
+	pvs := map[string]*persistentVolume{}
+	for i := 0; i < 10; i++ {
+		pv := makePV(fmt.Sprintf("test-pv%v", i), "", "1")
+		pvs[pv.Name] = pv
+		internalCache.add(pv)
+	}
+
+	// List them
+	verifyListPVs(t, cache, pvs, "")
+
+	// Update a PV
+	updatedPV := makePV("test-pv3", "", "2")
+	pvs[updatedPV.Name] = updatedPV
+	internalCache.update(nil, updatedPV)
+
+	// List them
+	verifyListPVs(t, cache, pvs, "")
+
+	// Delete a PV
+	deletedPV := pvs["test-pv7"]
+	delete(pvs, deletedPV.Name)
+	internalCache.delete(deletedPV)
+
+	// List them
+	verifyListPVs(t, cache, pvs, "")
+}
+
+func TestPVCacheWithStorageClasses(t *testing.T) {
+	cache := newPVAssumeCache(nil)
+	internalCache, ok := cache.AssumeCache.(*assumeCache)
+	if !ok {
+		t.Fatalf("Failed to get internal cache")
+	}
+
+	// Add a bunch of PVs
+	pvs1 := map[string]*persistentVolume{}
+	for i := 0; i < 10; i++ {
+		pv := makePV(fmt.Sprintf("test-pv%v", i), "class1", "1")
+		pvs1[pv.Name] = pv
+		internalCache.add(pv)
+	}
+
+	// Add a bunch of PVs
+	pvs2 := map[string]*persistentVolume{}
+	for i := 0; i < 10; i++ {
+		pv := makePV(fmt.Sprintf("test2-pv%v", i), "class2", "1")
+		pvs2[pv.Name] = pv
+		internalCache.add(pv)
+	}
+
+	// List them
+	verifyListPVs(t, cache, pvs1, "class1")
+	verifyListPVs(t, cache, pvs2, "class2")
+
+	// Update a PV
+	updatedPV := makePV("test-pv3", "class1", "2")
+	pvs1[updatedPV.Name] = updatedPV
+	internalCache.update(nil, updatedPV)
+
+	// List them
+	verifyListPVs(t, cache, pvs1, "class1")
+	verifyListPVs(t, cache, pvs2, "class2")
+
+	// Delete a PV
+	deletedPV := pvs1["test-pv7"]
+	delete(pvs1, deletedPV.Name)
+	internalCache.delete(deletedPV)
+
+	// List them
+	verifyListPVs(t, cache, pvs1, "class1")
+	verifyListPVs(t, cache, pvs2, "class2")
+}
+
+func TestAssumeUpdatePVCache(t *testing.T) {
+	cache := newPVAssumeCache(nil)
+	internalCache, ok := cache.AssumeCache.(*assumeCache)
+	if !ok {
+		t.Fatalf("Failed to get internal cache")
+	}
+
+	pvName := "test-pv0"
+
+	// Add a PV
+	pv := makePV(pvName, "", "1")
+	internalCache.add(pv)
+	if err := verifyPV(cache, pvName, pv); err != nil {
+		t.Fatalf("failed to get PV: %v", err)
+	}
+
+	// Assume PV
+	newPV := *pv
+	newPV.claimRef = "test-claim"
+	if err := cache.Assume(&newPV); err != nil {
+		t.Fatalf("failed to assume PV: %v", err)
+	}
+	if err := verifyPV(cache, pvName, &newPV); err != nil {
+		t.Fatalf("failed to get PV after assume: %v", err)
+	}
+
+	// Add old PV
+	internalCache.add(pv)
+	if err := verifyPV(cache, pvName, &newPV); err != nil {
+		t.Fatalf("failed to get PV after old PV added: %v", err)
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/assume_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/assume_cache_test.go
@@ -42,20 +42,13 @@ func makePV(name, storageClassName, resourceVersion string) *persistentVolume {
 }
 
 type pvAssumeCache struct {
-	AssumeCache
+	AssumeCache[*persistentVolume]
 }
 
 func (c pvAssumeCache) ListPVs(storageClassName string) []*persistentVolume {
-	objs := c.List(&persistentVolume{
+	return c.List(&persistentVolume{
 		storageClassName: storageClassName,
 	})
-	var pvs []*persistentVolume
-	for _, obj := range objs {
-		if pv, ok := obj.(*persistentVolume); ok {
-			pvs = append(pvs, pv)
-		}
-	}
-	return pvs
 }
 
 func pvStorageClassIndexFunc(obj interface{}) ([]string, error) {
@@ -66,7 +59,7 @@ func pvStorageClassIndexFunc(obj interface{}) ([]string, error) {
 }
 
 func newPVAssumeCache(informer AssumeCacheInformer) pvAssumeCache {
-	return pvAssumeCache{NewAssumeCache(informer, "persistentVolume", "storageclass", pvStorageClassIndexFunc)}
+	return pvAssumeCache{NewAssumeCache[*persistentVolume](informer, "persistentVolume", "storageclass", pvStorageClassIndexFunc)}
 }
 
 // fakeAssumeCacheInformer makes it possible to add/update/delete objects directly.
@@ -175,7 +168,7 @@ func TestAssumePV(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		cache := newPVAssumeCache(nil)
-		internalCache, ok := cache.AssumeCache.(*assumeCache)
+		internalCache, ok := cache.AssumeCache.(*assumeCache[*persistentVolume])
 		if !ok {
 			t.Fatalf("Failed to get internal cache")
 		}
@@ -209,7 +202,7 @@ func TestAssumePV(t *testing.T) {
 
 func TestRestorePV(t *testing.T) {
 	cache := newPVAssumeCache(nil)
-	internalCache, ok := cache.AssumeCache.(*assumeCache)
+	internalCache, ok := cache.AssumeCache.(*assumeCache[*persistentVolume])
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -249,7 +242,7 @@ func TestRestorePV(t *testing.T) {
 
 func TestBasicPVCache(t *testing.T) {
 	cache := newPVAssumeCache(nil)
-	internalCache, ok := cache.AssumeCache.(*assumeCache)
+	internalCache, ok := cache.AssumeCache.(*assumeCache[*persistentVolume])
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -293,7 +286,7 @@ func TestBasicPVCache(t *testing.T) {
 
 func TestPVCacheWithStorageClasses(t *testing.T) {
 	cache := newPVAssumeCache(nil)
-	internalCache, ok := cache.AssumeCache.(*assumeCache)
+	internalCache, ok := cache.AssumeCache.(*assumeCache[*persistentVolume])
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -339,7 +332,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 
 func TestAssumeUpdatePVCache(t *testing.T) {
 	cache := newPVAssumeCache(nil)
-	internalCache, ok := cache.AssumeCache.(*assumeCache)
+	internalCache, ok := cache.AssumeCache.(*assumeCache[*persistentVolume])
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/assume_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/assume_cache_test.go
@@ -56,11 +56,8 @@ func (c pvAssumeCache) ListPVs(storageClassName string) []*persistentVolume {
 	})
 }
 
-func pvStorageClassIndexFunc(obj interface{}) ([]string, error) {
-	if pv, ok := obj.(*persistentVolume); ok {
-		return []string{pv.storageClassName}, nil
-	}
-	return []string{""}, fmt.Errorf("object is not a persistentVolume: %v", obj)
+func pvStorageClassIndexFunc(pv *persistentVolume) ([]string, error) {
+	return []string{pv.storageClassName}, nil
 }
 
 func newPVAssumeCache(logger klog.Logger, informer AssumeCacheInformer) pvAssumeCache {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The AssumeCache in the kube-scheduler volume binding plugin solves a problem that other components also have: when storing objects in an informer cache, that cache is out-dated directly after making a change in the apiserver. If the component happens to do some work at that point that involves the updated object, it will do so based on stale information.

Components can be designed to handle this, for example by discarding changes if storing an updated object in the apiserver fails with a conflict error. Probably components have to be prepared for such a case anyway, but it is confusing.

#### Special notes for your reviewer:

This PR leaves the the volume binding plugin unchanged. Migrating that code can be handled separately.

Because this uses generics, each commit comes with benchmark results.

In contrast to the original code, the final version of the AssumeCache in this PR no longer makes assumptions about the content of the ResourceVersion field.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```