### PR TITLE
Fix Flake: On TearDown script, delete all firewall-rules with a single gcloud run

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2576,11 +2576,13 @@ function create-cloud-nat-router() {
 }
 
 function delete-all-firewall-rules() {
-  if fws=$(gcloud compute firewall-rules list --project "${NETWORK_PROJECT}" --filter="network=${NETWORK}" --format="value(name)"); then
-    echo "Deleting firewall rules remaining in network ${NETWORK}: ${fws}"
-    delete-firewall-rules "$fws"
+  local -a fws
+  kube::util::read-array fws < <(gcloud compute firewall-rules list --project "${NETWORK_PROJECT}" --filter="network=${NETWORK}" --format="value(name)")
+  if (( "${#fws[@]}" > 0 )); then
+    echo "Deleting firewall rules remaining in network ${NETWORK}: ${fws[*]}"
+    delete-firewall-rules "${fws[@]}"
   else
-    echo "Failed to list firewall rules from the network ${NETWORK}"
+    echo "No firewall rules in network ${NETWORK}"
   fi
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

The kubemark-100 scalability tests fails on TearDown frequently (11% times - 13 out of 114 latest runs).
https://testgrid.k8s.io/sig-scalability-kubemark#kubemark-100

The fail happens as the script tries to delete subnetwork, which is still used by firewalls, see example buildlog:
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-kubemark-100-gce/1565151670835351552

In the code:
https://github.com/kubernetes/kubernetes/blob/5fa65e989bbc949c3cb4fb3a155d39bf49d8b9b1/cluster/gce/util.sh#L3758-L3760

So it looks like, the `delete-all-firewall-rules` is not fully finished.

The firewalls deletion happens in a loop and `kube::util::wait-for-jobs` guard in the end, which could be problematic
As a fix, I moved a delete all into a single gcloud command, which should be more solid.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
