### PR TITLE
Automated cherry pick of #112157: Avoid propagating `search .` into containers /etc/resolv.conf

### DIFF
--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -268,9 +268,8 @@ func parseResolvConf(reader io.Reader) (nameservers []string, searches []string,
 			searches = []string{}
 			for _, s := range fields[1:] {
 				if s != "." {
-					s = strings.TrimSuffix(s, ".")
+					searches = append(searches, strings.TrimSuffix(s, "."))
 				}
-				searches = append(searches, s)
 			}
 		}
 		if fields[0] == "options" {

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -77,8 +77,11 @@ func TestParseResolvConf(t *testing.T) {
 		{"nameserver \t 1.2.3.4", []string{"1.2.3.4"}, []string{}, []string{}, false},
 		{"nameserver 1.2.3.4\nnameserver 5.6.7.8", []string{"1.2.3.4", "5.6.7.8"}, []string{}, []string{}, false},
 		{"nameserver 1.2.3.4 #comment", []string{"1.2.3.4"}, []string{}, []string{}, false},
-		{"search ", []string{}, []string{}, []string{}, false}, // search empty
-		{"search .", []string{}, []string{"."}, []string{}, false},
+		{"search ", []string{}, []string{}, []string{}, false},  // search empty
+		{"search .", []string{}, []string{}, []string{}, false}, // ignore lone dot
+		{"search . foo", []string{}, []string{"foo"}, []string{}, false},
+		{"search foo .", []string{}, []string{"foo"}, []string{}, false},
+		{"search foo .  bar", []string{}, []string{"foo", "bar"}, []string{}, false},
 		{"search foo", []string{}, []string{"foo"}, []string{}, false},
 		{"search foo bar", []string{}, []string{"foo", "bar"}, []string{}, false},
 		{"search foo. bar", []string{}, []string{"foo", "bar"}, []string{}, false},


### PR DESCRIPTION
Cherry pick of #112157 on release-1.25.

#112157: Avoid propagating `search .` into containers /etc/resolv.conf

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.25 regression propagating hosts' `search .` into containers' `/etc/resolv.conf` which can fail DNS resolution
```
