### PR TITLE
Ensure metric 'running_managed_controllers' is registered

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -540,6 +540,7 @@ func CreateControllerContext(s *config.CompletedConfig, rootClientBuilder, clien
 		ResyncPeriod:                    ResyncPeriod(s),
 		ControllerManagerMetrics:        controllersmetrics.NewControllerManagerMetrics("kube-controller-manager"),
 	}
+	controllersmetrics.Register()
 	return ctx, nil
 }
 

--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -460,6 +460,7 @@ func CreateControllerContext(s *cloudcontrollerconfig.CompletedConfig, clientBui
 		ResyncPeriod:                    ResyncPeriod(s),
 		ControllerManagerMetrics:        controllersmetrics.NewControllerManagerMetrics("cloud-controller-manager"),
 	}
+	controllersmetrics.Register()
 	return ctx, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A set of PRs for #111029 should expose `running_managed_controllers` in KCM and CCM. However, `Register` is not invoked by KCM/CCM code directly. Effectively, metric is not registered in Prometheus.

Instead of invoking `Register` from KCM/CCM code, I'm making it a part of object creation. Similar approach for metric registration is used here: https://github.com/kubernetes/kubernetes/blob/ca09ed0fe2c245a0df4f533aa29f7b48a8672cff/pkg/controller/endpointslice/endpointslice_controller.go#L80-L97

#### Which issue(s) this PR fixes:

Ref #111029

To close we need to ensure those metrics work in 1.25

#### Special notes for your reviewer:

I want to backport it to 1.25, as those metrics should be available in 1.25 version.

#### Does this PR introduce a user-facing change?
No, already covered in release notes for 1.25
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
- [KEP-2436](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2436-controller-manager-leader-migration) 
- [Mentioned during Cloud Provider Extraction/Migration (April 21st, 2022)](https://docs.google.com/document/d/1KLsGGzNXQbsPeELCeF_q-f0h0CEGSe20xiwvcR2NlYM/edit)
- First PR - #111033 
- Second PR - #11462
- Third PR - #111466
/sig cloud-provider
