### PR TITLE
add(scheduler): add the benchmark test for the schedulePod function

### DIFF
--- a/pkg/scheduler/testing/fake_plugins.go
+++ b/pkg/scheduler/testing/fake_plugins.go
@@ -22,7 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
@@ -151,6 +151,34 @@ func (pl *FakePreFilterPlugin) PreFilterExtensions() framework.PreFilterExtensio
 func NewFakePreFilterPlugin(name string, result *framework.PreFilterResult, status *framework.Status) frameworkruntime.PluginFactory {
 	return func(_ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
 		return &FakePreFilterPlugin{
+			Result: result,
+			Status: status,
+			name:   name,
+		}, nil
+	}
+}
+
+// FakePreScorePlugin is a test filter plugin.
+type FakePreScorePlugin struct {
+	Result *framework.PreFilterResult
+	Status *framework.Status
+	name   string
+}
+
+// Name returns name of the plugin.
+func (pl *FakePreScorePlugin) Name() string {
+	return pl.name
+}
+
+// PreFilter invoked at the PreFilter extension point.
+func (pl *FakePreScorePlugin) PreScore(_ context.Context, _ *framework.CycleState, _ *v1.Pod, _ []*v1.Node) *framework.Status {
+	return pl.Status
+}
+
+// NewFakePreScorePlugin initializes a fakePreFilterPlugin and returns it.
+func NewFakePreScorePlugin(name string, result *framework.PreFilterResult, status *framework.Status) frameworkruntime.PluginFactory {
+	return func(_ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
+		return &FakePreScorePlugin{
 			Result: result,
 			Status: status,
 			name:   name,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature ?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:


This PR adds the benchmark test which is only for the `scheduler.schedulePod`  function.

We have `scheduler_perf`. It is more like an integration test that is checking the whole performance of the scheduler (= all in-tree plugins + the scheduling framework) through the scenario.
https://github.com/kubernetes/kubernetes/tree/master/test/integration/scheduler_perf

whereas, the new `BenchmarkSchedulePod` is focusing on measuring the `scheduler.schedulePod` function

```
go test -benchmem -run=^$ -bench ^BenchmarkSchedulePod$ k8s.io/kubernetes/pkg/scheduler

goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/pkg/scheduler
cpu: AMD EPYC 7B13
BenchmarkSchedulePod/Scheduler_has_some_filter_plugins,_but_has_no_other_plugins.-16         	   17749	     57673 ns/op	   10804 B/op	     145 allocs/op
BenchmarkSchedulePod/Scheduler_has_some_score_plugins,_but_has_no_other_plugins.-16          	    5307	    233585 ns/op	   63123 B/op	      99 allocs/op
BenchmarkSchedulePod/Scheduler_has_some_pre_filter_plugins,_but_has_no_other_plugins.-16     	  197985	      5723 ns/op	    4202 B/op	      15 allocs/op
BenchmarkSchedulePod/Scheduler_has_some_pre_score_plugins,_but_has_no_other_plugins.-16      	  196276	      5767 ns/op	    4202 B/op	      15 allocs/op
BenchmarkSchedulePod/Scheduler_has_some_extenders,_but_has_no_plugins.-16                    	    1462	    828448 ns/op	  714905 B/op	    4852 allocs/op
BenchmarkSchedulePod/Scheduler_has_extenders_and_all_kinds_of_plugins.-16                    	    1041	   1096620 ns/op	  778827 B/op	    5036 allocs/op
PASS
ok  	k8s.io/kubernetes/pkg/scheduler	14.180s
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/107556. I want to make sure there is only acceptable (or hopefully no) performance degradation while implementing #107556.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
