### PR TITLE
[WIP]When kubelet enable rotate-certificates and bootstrap, request CSR in foreground

### DIFF
--- a/pkg/kubelet/certificate/bootstrap/bootstrap.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap.go
@@ -55,39 +55,39 @@ const tmpPrivateKeyFile = "kubelet-client.key.tmp"
 // kubeconfigPath on disk is populated based on bootstrapPath but pointing to the location of the client cert
 // in certDir. This preserves the historical behavior of bootstrapping where on subsequent restarts the
 // most recent client cert is used to request new client certs instead of the initial token.
-func LoadClientConfig(kubeconfigPath, bootstrapPath, certDir string) (certConfig, userConfig *restclient.Config, err error) {
+func LoadClientConfig(kubeconfigPath, bootstrapPath, certDir string) (certConfig, userConfig *restclient.Config, bootstraping bool, err error) {
 	if len(bootstrapPath) == 0 {
 		clientConfig, err := loadRESTClientConfig(kubeconfigPath)
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to load kubeconfig: %v", err)
+			return nil, nil, false, fmt.Errorf("unable to load kubeconfig: %v", err)
 		}
 		klog.V(2).InfoS("No bootstrapping requested, will use kubeconfig")
-		return clientConfig, restclient.CopyConfig(clientConfig), nil
+		return clientConfig, restclient.CopyConfig(clientConfig), false, nil
 	}
 
 	store, err := certificate.NewFileStore("kubelet-client", certDir, certDir, "", "")
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to build bootstrap cert store")
+		return nil, nil, false, fmt.Errorf("unable to build bootstrap cert store")
 	}
 
 	ok, err := isClientConfigStillValid(kubeconfigPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 
 	// use the current client config
 	if ok {
 		clientConfig, err := loadRESTClientConfig(kubeconfigPath)
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to load kubeconfig: %v", err)
+			return nil, nil, false, fmt.Errorf("unable to load kubeconfig: %v", err)
 		}
 		klog.V(2).InfoS("Current kubeconfig file contents are still valid, no bootstrap necessary")
-		return clientConfig, restclient.CopyConfig(clientConfig), nil
+		return clientConfig, restclient.CopyConfig(clientConfig), false, nil
 	}
 
 	bootstrapClientConfig, err := loadRESTClientConfig(bootstrapPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to load bootstrap kubeconfig: %v", err)
+		return nil, nil, true, fmt.Errorf("unable to load bootstrap kubeconfig: %v", err)
 	}
 
 	clientConfig := restclient.AnonymousClientConfig(bootstrapClientConfig)
@@ -95,10 +95,10 @@ func LoadClientConfig(kubeconfigPath, bootstrapPath, certDir string) (certConfig
 	clientConfig.KeyFile = pemPath
 	clientConfig.CertFile = pemPath
 	if err := writeKubeconfigFromBootstrapping(clientConfig, kubeconfigPath, pemPath); err != nil {
-		return nil, nil, err
+		return nil, nil, true, err
 	}
 	klog.V(2).InfoS("Use the bootstrap credentials to request a cert, and set kubeconfig to point to the certificate dir")
-	return bootstrapClientConfig, clientConfig, nil
+	return bootstrapClientConfig, clientConfig, true, nil
 }
 
 // LoadClientCert requests a client cert for kubelet if the kubeconfigPath file does not exist.

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
@@ -64,6 +64,9 @@ type Manager interface {
 	// be very conservative and only return true if recent communication has
 	// occurred with the server.
 	ServerHealthy() bool
+	// Returns true if it changed the cert, false otherwise. Error is only returned in
+	// exceptional cases.
+	RotateCerts() (bool, error)
 }
 
 // Config is the set of configuration parameters available for a new Manager.
@@ -429,10 +432,10 @@ func (m *manager) getClientset() (clientset.Interface, error) {
 	return m.clientsetFn(current)
 }
 
-// RotateCerts is exposed for testing only and is not a part of the public interface.
-// Returns true if it changed the cert, false otherwise. Error is only returned in
-// exceptional cases.
 func (m *manager) RotateCerts() (bool, error) {
+	if m.forceRotation {
+		m.forceRotation = false
+	}
 	return m.rotateCerts()
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When kubelet enable rotate-certificates and bootstrap, request CSR in foreground. It can help to reduce the uncertainty of node register time.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/112170

#### Special notes for your reviewer:

Now when kubelet enable rotate-certificates and bootstrap-kubeconfig, it will request CSR in background. With the delayed CSR approval, kubelet use the bootstrap token to register, but the bootstrap token has no permission. It will need wait 10s to change client transport tls config.

Requesting CSR in foreground, even the CSR delayed a seconds, the kubelet will register successfully Immediately after the CSR approved. It don't need to wait 10s for the certificate check.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
