### PR TITLE
kubelet: make registry qps/Burst to limit parallerel pulling count

### DIFF
--- a/pkg/kubelet/images/helpers.go
+++ b/pkg/kubelet/images/helpers.go
@@ -42,7 +42,6 @@ func throttleImagePulling(imageService kubecontainer.ImageService, qps float32, 
 		qps:              qps,
 		burst:            burst,
 		currentPullCount: 0,
-		lock:             sync.Mutex{},
 	}
 }
 
@@ -60,7 +59,7 @@ var (
 	errPullQPSExceeded   error = fmt.Errorf("pull QPS exceeded")
 )
 
-func (ts throttledImageService) PullImage(ctx context.Context, image kubecontainer.ImageSpec, secrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+func (ts *throttledImageService) PullImage(ctx context.Context, image kubecontainer.ImageSpec, secrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	if ts.limiter.TryAccept() {
 		err := wait.PollImmediate(100*time.Microsecond, 5*time.Minute, func() (done bool, err error) {
 			if ts.AcceptOne() {

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -139,9 +139,9 @@ func pullerTestCases() []pullerTestCase {
 			qps:        400.0,
 			burst:      600,
 			expected: []pullerExpects{
-				{[]string{"GetImageRef", "PullImage"}, nil},
-				{[]string{"GetImageRef", "PullImage"}, nil},
-				{[]string{"GetImageRef", "PullImage"}, nil},
+				{[]string{"GetImageRef"}, ErrImagePull},
+				{[]string{"GetImageRef"}, ErrImagePull},
+				{[]string{"GetImageRef"}, ErrImagePullBackOff},
 			}},
 		// image present, non-zero qps, try to pull when qps exceeded
 		{containerImage: "present_image",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/blob/bcea98234f0fdc5ce4e976758977eec72b13bfd4/pkg/kubelet/images/helpers.go#L46-L51

The current rate limit is just an API qps/burst to calling the pull image request.
It doesn't wait for the image pulling done.
- as a result, if the qps and burst are 5, there can be more than 5 image pulling at the same time. 
- in the first second, start pulling 5 images
- in the second second, start pulling another 5 images


#### Which issue(s) this PR fixes:

Fixes #112044

#### Special notes for your reviewer:
The limit should wait until an image was pulled and start a new one

#### Does this PR introduce a user-facing change?

```release-note
None
```
