### PR TITLE
[Don't Mind Me][Testing] Scale Test Watch Cache Pagination (tuning BTree degree)

### DIFF
--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/gogo/protobuf v1.3.2
+	github.com/google/btree v1.0.1
 	github.com/google/gnostic v0.5.7-v3refs
 	github.com/google/go-cmp v0.5.8
 	github.com/google/btree v1.0.1 // indirect
@@ -69,7 +70,6 @@ require (
 	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/btree v1.0.1 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/google/btree v1.0.1
 	github.com/google/gnostic v0.5.7-v3refs
 	github.com/google/go-cmp v0.5.8
-	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/gnostic v0.5.7-v3refs
 	github.com/google/go-cmp v0.5.8
+	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/btree_store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/btree_store.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacher
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/google/btree"
+	"k8s.io/client-go/tools/cache"
+)
+
+type btreeIndexer interface {
+	cache.Indexer
+	Clone() btreeIndexer
+}
+
+type btreeStore struct {
+	lock sync.RWMutex
+	tree *btree.BTree
+}
+
+func newBtreeStore(degree int) *btreeStore {
+	return &btreeStore{
+		tree: btree.New(degree),
+	}
+}
+
+func (t *btreeStore) Add(obj interface{}) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.addOrUpdateLocked(obj)
+}
+
+func (t *btreeStore) Update(obj interface{}) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.addOrUpdateLocked(obj)
+}
+
+func (t *btreeStore) Delete(obj interface{}) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	storeElem, ok := obj.(storeElement)
+	if !ok {
+		return fmt.Errorf("obj not a storeElement: %#v", obj)
+	}
+	item := t.tree.Delete(storeElem)
+	if item == nil {
+		return fmt.Errorf("obj does not exist")
+	}
+
+	return nil
+}
+
+func (t *btreeStore) List() []interface{} {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	items := make([]interface{}, 0, t.tree.Len())
+	t.tree.Ascend(func(i btree.Item) bool {
+		items = append(items, i.(interface{}))
+		return true
+	})
+
+	return items
+}
+
+func (t *btreeStore) ListKeys() []string {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	items := make([]string, 0, t.tree.Len())
+	t.tree.Ascend(func(i btree.Item) bool {
+		items = append(items, i.(storeElement).Key)
+		return true
+	})
+
+	return items
+}
+
+func (t *btreeStore) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	storeElem, ok := obj.(storeElement)
+	if !ok {
+		return nil, false, fmt.Errorf("obj is not a storeElement")
+	}
+	item = t.tree.Get(storeElem)
+	if item == nil {
+		return nil, false, nil
+	}
+
+	return item, false, nil
+}
+
+func (t *btreeStore) GetByKey(key string) (item interface{}, exists bool, err error) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	t.tree.Ascend(func(i btree.Item) bool {
+		if key == i.(storeElement).Key {
+			item = i
+			exists = true
+			return false
+		}
+		return true
+	})
+
+	return item, exists, nil
+}
+
+func (t *btreeStore) Replace(objs []interface{}, _ string) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.tree.Clear(false)
+	for _, obj := range objs {
+		err := t.addOrUpdateLocked(obj)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *btreeStore) Resync() error {
+	// Nothing to do.
+	return nil
+}
+
+// TODO(MadhavJivrajani): This is un-implemented for now. Stubbing this out
+// to implement cacher.Indexer
+func (t *btreeStore) Index(indexName string, obj interface{}) ([]interface{}, error) {
+	return nil, fmt.Errorf("yet to implement")
+}
+
+// TODO(MadhavJivrajani): This is un-implemented for now. Stubbing this out
+// to implement cacher.Indexer
+func (t *btreeStore) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	return nil, fmt.Errorf("yet to implement")
+}
+
+// TODO(MadhavJivrajani): This is un-implemented for now. Stubbing this out
+// to implement cacher.Indexer
+func (t *btreeStore) ListIndexFuncValues(indexName string) []string {
+	return nil
+}
+
+// TODO(MadhavJivrajani): This is un-implemented for now. Stubbing this out
+// to implement cacher.Indexer
+func (t *btreeStore) ByIndex(indexName, indexedValue string) ([]interface{}, error) {
+	return nil, fmt.Errorf("yet to implement")
+}
+
+// TODO(MadhavJivrajani): This is un-implemented for now. Stubbing this out
+// to implement cacher.Indexer
+func (t *btreeStore) GetIndexers() cache.Indexers {
+	return nil
+}
+
+// TODO(MadhavJivrajani): This is un-implemented for now. Stubbing this out
+// to implement cacher.Indexer
+func (t *btreeStore) AddIndexers(newIndexers cache.Indexers) error {
+	return fmt.Errorf("yet to implement")
+}
+
+func (t *btreeStore) Clone() btreeIndexer {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return &btreeStore{tree: t.tree.Clone()}
+}
+
+// addOrUpdateLocked assumes a lock is held and is used for Add
+// and Update operations.
+func (t *btreeStore) addOrUpdateLocked(obj interface{}) error {
+	// A nil obj cannot be entered into the btree,
+	// results in panic.
+	if obj == nil {
+		return fmt.Errorf("obj cannot be nil")
+	}
+	storeElem, ok := obj.(storeElement)
+	if !ok {
+		return fmt.Errorf("obj not a storeElement: %#v", obj)
+	}
+	t.tree.ReplaceOrInsert(storeElem)
+
+	return nil
+}
+
+// TODO: The goal is to make an acutal btreeIndexer.
+// For now, only cache.Store methods are implemented,
+// and the remaining methods of cache.Indexer are only
+// stubbed out.
+var _ btreeIndexer = (*btreeStore)(nil)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/btree_store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/btree_store_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacher
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/google/btree"
+)
+
+type item struct {
+	Key string
+}
+
+func (i *item) Less(than btree.Item) bool {
+	return i.Key < than.(*item).Key
+}
+
+type btreeTest struct {
+	tree btree.BTree
+}
+
+func newBTreeTest(degree int) btreeTest {
+	return btreeTest{tree: *btree.New(degree)}
+}
+
+func (t btreeTest) getByKey(key string) (itemRet interface{}, exists bool, err error) {
+	t.tree.Ascend(func(i btree.Item) bool {
+		if key == i.(*item).Key {
+			itemRet = i
+			exists = true
+			return false
+		}
+		return true
+	})
+
+	return itemRet, exists, nil
+}
+
+func Benchmark_BTreeGetByKey(b *testing.B) {
+	tree := newBTreeTest(9)
+	prefixes := []string{"/auth/", "/mutate/", "/universe/"}
+	for _, p := range prefixes {
+		for i := 0; i < 10000; i++ {
+			key := fmt.Sprintf("%s%d", p, i)
+			tree.tree.ReplaceOrInsert(&item{Key: key})
+		}
+	}
+
+	rand.Seed(100)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		prefixIndex := rand.Intn(3)
+		keyIndex := rand.Intn(10000)
+		key := fmt.Sprintf("%s%d", prefixes[prefixIndex], keyIndex)
+		b.StartTimer()
+		tree.getByKey(key)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -647,7 +647,7 @@ func (c *Cacher) shouldDelegateList(opts storage.ListOptions) (bool, error) {
 	return true, nil
 }
 
-func (c *Cacher) listItems(listRV uint64, key string, listOpts storage.ListOptions, trace *utiltrace.Trace, recursive bool) ([]interface{}, uint64, string, error) {
+func (c *Cacher) listItems(listRV uint64, key string, pred storage.SelectionPredicate, listOpts storage.ListOptions, trace *utiltrace.Trace, recursive bool) ([]interface{}, uint64, string, error) {
 	if !recursive {
 		obj, exists, readResourceVersion, err := c.watchCache.WaitUntilFreshAndGet(listRV, key, trace)
 		if err != nil {
@@ -658,7 +658,7 @@ func (c *Cacher) listItems(listRV uint64, key string, listOpts storage.ListOptio
 		}
 		return nil, readResourceVersion, "", nil
 	}
-	return c.watchCache.WaitUntilFreshAndList(listRV, key, listOpts, trace)
+	return c.watchCache.WaitUntilFreshAndList(listRV, key, listOpts, pred.MatcherIndex(), trace)
 }
 
 // GetList implements storage.Interface
@@ -713,7 +713,7 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 	}
 	filter := filterWithAttrsFunction(key, pred)
 
-	objs, readResourceVersion, indexUsed, err := c.listItems(listRV, key, opts, trace, recursive)
+	objs, readResourceVersion, indexUsed, err := c.listItems(listRV, key, pred, opts, trace, recursive)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -225,7 +225,7 @@ func newWatchCache(
 		endIndex:           0,
 		// store:               cache.NewIndexer(storeElementKey, storeElementIndexers(indexers)),
 		// TODO: figure out what the degree should be.
-		store:               newBtreeStore(storeElementKey, storeElementIndexers(indexers), 2),
+		store:               newBtreeStore(storeElementKey, storeElementIndexers(indexers), 6),
 		resourceVersion:     0,
 		listResourceVersion: 0,
 		eventHandler:        eventHandler,

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
@@ -117,7 +117,7 @@ func newCacheInterval(startIndex, endIndex int, indexer indexerFunc, indexValida
 // newCacheIntervalFromStore is meant to handle the case of rv=0, such that the events
 // returned by Next() need to be events from a List() done on the underlying store of
 // the watch cache.
-func newCacheIntervalFromStore(resourceVersion uint64, store cache.Indexer, getAttrsFunc attrFunc) (*watchCacheInterval, error) {
+func newCacheIntervalFromStore(resourceVersion uint64, store cache.Store, getAttrsFunc attrFunc) (*watchCacheInterval, error) {
 	buffer := &watchCacheIntervalBuffer{}
 	allItems := store.List()
 	buffer.buffer = make([]*watchCacheEvent, len(allItems))

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -387,7 +387,7 @@ func TestWaitUntilFreshAndList(t *testing.T) {
 	}()
 
 	// list by empty MatchValues.
-	list, resourceVersion, indexUsed, err := store.WaitUntilFreshAndList(5, nil, nil)
+	list, resourceVersion, indexUsed, err := store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestWaitUntilFreshAndList(t *testing.T) {
 		{IndexName: "l:label", Value: "value1"},
 		{IndexName: "f:spec.nodeName", Value: "node2"},
 	}
-	list, resourceVersion, indexUsed, err = store.WaitUntilFreshAndList(5, matchValues, nil)
+	list, resourceVersion, indexUsed, err = store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, matchValues, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -425,7 +425,7 @@ func TestWaitUntilFreshAndList(t *testing.T) {
 		{IndexName: "l:not-exist-label", Value: "whatever"},
 		{IndexName: "f:spec.nodeName", Value: "node2"},
 	}
-	list, resourceVersion, indexUsed, err = store.WaitUntilFreshAndList(5, matchValues, nil)
+	list, resourceVersion, indexUsed, err = store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, matchValues, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -443,7 +443,7 @@ func TestWaitUntilFreshAndList(t *testing.T) {
 	matchValues = []storage.MatchValue{
 		{IndexName: "l:not-exist-label", Value: "whatever"},
 	}
-	list, resourceVersion, indexUsed, err = store.WaitUntilFreshAndList(5, matchValues, nil)
+	list, resourceVersion, indexUsed, err = store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, matchValues, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -501,7 +501,7 @@ func TestWaitUntilFreshAndListTimeout(t *testing.T) {
 		store.Add(makeTestPod("bar", 5))
 	}()
 
-	_, _, _, err := store.WaitUntilFreshAndList(5, nil, nil)
+	_, _, _, err := store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, nil, nil)
 	if !errors.IsTimeout(err) {
 		t.Errorf("expected timeout error but got: %v", err)
 	}
@@ -526,7 +526,7 @@ func TestReflectorForWatchCache(t *testing.T) {
 	store := newTestWatchCache(5, &cache.Indexers{})
 
 	{
-		_, version, _, err := store.WaitUntilFreshAndList(0, nil, nil)
+		_, version, _, err := store.WaitUntilFreshAndList(0, "prefix/ns/", storage.ListOptions{}, nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -549,7 +549,7 @@ func TestReflectorForWatchCache(t *testing.T) {
 	r.ListAndWatch(wait.NeverStop)
 
 	{
-		_, version, _, err := store.WaitUntilFreshAndList(10, nil, nil)
+		_, version, _, err := store.WaitUntilFreshAndList(10, "prefix/ns/", storage.ListOptions{}, nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -387,7 +387,8 @@ func TestWaitUntilFreshAndList(t *testing.T) {
 	}()
 
 	// list by empty MatchValues.
-	list, resourceVersion, indexUsed, err := store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, nil, nil)
+	listResp, resourceVersion, indexUsed, err := store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, nil, nil)
+	list := listResp.objs
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -406,7 +407,8 @@ func TestWaitUntilFreshAndList(t *testing.T) {
 		{IndexName: "l:label", Value: "value1"},
 		{IndexName: "f:spec.nodeName", Value: "node2"},
 	}
-	list, resourceVersion, indexUsed, err = store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, matchValues, nil)
+	listResp, resourceVersion, indexUsed, err = store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, matchValues, nil)
+	list = listResp.objs
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -425,7 +427,8 @@ func TestWaitUntilFreshAndList(t *testing.T) {
 		{IndexName: "l:not-exist-label", Value: "whatever"},
 		{IndexName: "f:spec.nodeName", Value: "node2"},
 	}
-	list, resourceVersion, indexUsed, err = store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, matchValues, nil)
+	listResp, resourceVersion, indexUsed, err = store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, matchValues, nil)
+	list = listResp.objs
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -443,7 +446,8 @@ func TestWaitUntilFreshAndList(t *testing.T) {
 	matchValues = []storage.MatchValue{
 		{IndexName: "l:not-exist-label", Value: "whatever"},
 	}
-	list, resourceVersion, indexUsed, err = store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, matchValues, nil)
+	listResp, resourceVersion, indexUsed, err = store.WaitUntilFreshAndList(5, "prefix/ns/", storage.ListOptions{}, matchValues, nil)
+	list = listResp.objs
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/continue.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/continue.go
@@ -83,7 +83,7 @@ func DecodeContinue(continueValue, keyPrefix string) (fromKey string, rv int64, 
 func EncodeContinue(key, keyPrefix string, resourceVersion int64) (string, error) {
 	nextKey := strings.TrimPrefix(key, keyPrefix)
 	if nextKey == key {
-		return "", fmt.Errorf("unable to encode next field: the key and key prefix do not match")
+		return "", fmt.Errorf("unable to encode next field: the key and key prefix do not match %s %s", keyPrefix, key)
 	}
 	out, err := json.Marshal(&continueToken{APIVersion: "meta.k8s.io/v1", ResourceVersion: resourceVersion, StartKey: nextKey})
 	if err != nil {

--- a/staging/src/k8s.io/cloud-provider/go.mod
+++ b/staging/src/k8s.io/cloud-provider/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect

--- a/staging/src/k8s.io/cloud-provider/go.sum
+++ b/staging/src/k8s.io/cloud-provider/go.sum
@@ -164,6 +164,7 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/gnostic v0.5.7-v3refs h1:FhTMOKj2VhjpouxvWJAV1TL304uMlb9zcDqkl6cEI54=
 github.com/google/gnostic v0.5.7-v3refs/go.mod h1:73MKFl6jIHelAJNaBGFzt3SPtZULs9dYrGFt8OiIsHQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/staging/src/k8s.io/kube-aggregator/go.mod
+++ b/staging/src/k8s.io/kube-aggregator/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect

--- a/staging/src/k8s.io/kube-aggregator/go.sum
+++ b/staging/src/k8s.io/kube-aggregator/go.sum
@@ -161,6 +161,7 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/gnostic v0.5.7-v3refs h1:FhTMOKj2VhjpouxvWJAV1TL304uMlb9zcDqkl6cEI54=
 github.com/google/gnostic v0.5.7-v3refs/go.mod h1:73MKFl6jIHelAJNaBGFzt3SPtZULs9dYrGFt8OiIsHQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/staging/src/k8s.io/pod-security-admission/go.mod
+++ b/staging/src/k8s.io/pod-security-admission/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect

--- a/staging/src/k8s.io/pod-security-admission/go.sum
+++ b/staging/src/k8s.io/pod-security-admission/go.sum
@@ -163,6 +163,7 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/gnostic v0.5.7-v3refs h1:FhTMOKj2VhjpouxvWJAV1TL304uMlb9zcDqkl6cEI54=
 github.com/google/gnostic v0.5.7-v3refs/go.mod h1:73MKFl6jIHelAJNaBGFzt3SPtZULs9dYrGFt8OiIsHQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/staging/src/k8s.io/sample-apiserver/go.mod
+++ b/staging/src/k8s.io/sample-apiserver/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/uuid v1.1.2 // indirect

--- a/staging/src/k8s.io/sample-apiserver/go.sum
+++ b/staging/src/k8s.io/sample-apiserver/go.sum
@@ -161,6 +161,7 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/gnostic v0.5.7-v3refs h1:FhTMOKj2VhjpouxvWJAV1TL304uMlb9zcDqkl6cEI54=
 github.com/google/gnostic v0.5.7-v3refs/go.mod h1:73MKFl6jIHelAJNaBGFzt3SPtZULs9dYrGFt8OiIsHQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=


### PR DESCRIPTION
I noticed increased CPU and memory consumption in the scale tests as part of the CI for https://github.com/kubernetes/kubernetes/pull/108392. Creating this PR to try and tune the overhead if possible.

My current suspicion is that due to the current degree of the BTree being hardcoded to 2 (essentially a binary tree), the search is not as efficient as it could be. This suspicion arises from looking at the pprof profiles that are uploaded as part of the scalability tests ([here](https://gcsweb.k8s.io/gcs/kubernetes-jenkins/pr-logs/pull/108392/pull-kubernetes-e2e-gce-100-performance/1562750012998291456/artifacts/)). Looking at the top 10 nodes in the CPU profile, we get:
```
❯ go tool pprof 34.74.148.18_kube-apiserver_CPUProfile_load_2022-08-25T09-59-23Z.pprof
File: kube-apiserver
Type: cpu
Time: Aug 25, 2022 at 3:28pm (IST)
Duration: 30.09s, Total samples = 9.03s (30.01%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 3190ms, 35.33% of 9030ms total
Dropped 1014 nodes (cum <= 45.15ms)
Showing top 10 nodes out of 489
      flat  flat%   sum%        cum   cum%
     760ms  8.42%  8.42%      760ms  8.42%  runtime/internal/syscall.Syscall6
     720ms  7.97% 16.39%      720ms  7.97%  runtime.futex
     340ms  3.77% 20.16%      900ms  9.97%  runtime.scanobject
     250ms  2.77% 22.92%      430ms  4.76%  github.com/google/btree.(*node).iterate
     250ms  2.77% 25.69%      290ms  3.21%  runtime.findObject
     210ms  2.33% 28.02%      210ms  2.33%  runtime.epollwait
     180ms  1.99% 30.01%      410ms  4.54%  compress/flate.(*compressor).deflate
     180ms  1.99% 32.00%      180ms  1.99%  k8s.io/apiserver/pkg/storage/cacher.(*btreeStore).getByKeyLocked.func1
     160ms  1.77% 33.78%      290ms  3.21%  runtime.heapBitsSetType
     140ms  1.55% 35.33%      140ms  1.55%  math/big.addMulVVW
(pprof) 
```
Note `github.com/google/btree.(*node).iterate`.

We also see that the second node in the CPU profile here is `runtime.futex`. My current assumption is, if we do end up getting the CPU consumption of `GetByKey` down, we will also spend less time in a lock (since it is called under a read lock atm), further reducing CPU time here.

Following this hunch, I wrote a quick benchmark for `GetByKey` (https://github.com/kubernetes/kubernetes/commit/1bd14351ccc5b309192a9c2646a257f3a979a586), and after some benchmarking rounds locally, degree 6 seemed to consume the least time in `btree.(*node).iterate`. Each benchmark run consisted of 1,00,000 iterations (`-benchtime=100000x`). Of course, there is always the very plausible scenario that the benchmark is not nearly as representative as what happens in actuality, which is what this PR will help with by running the scale job!