### PR TITLE
Add metric for max no. of CIDRs available

### DIFF
--- a/pkg/controller/nodeipam/ipam/cidrset/cidr_set.go
+++ b/pkg/controller/nodeipam/ipam/cidrset/cidr_set.go
@@ -79,7 +79,6 @@ func NewCIDRSet(clusterCIDR *net.IPNet, subNetMaskSize int) (*CidrSet, error) {
 	clusterMask := clusterCIDR.Mask
 	clusterMaskSize, bits := clusterMask.Size()
 
-	var maxCIDRs int
 	if (clusterCIDR.IP.To4() == nil) && (subNetMaskSize-clusterMaskSize > clusterSubnetMaxDiff) {
 		return nil, ErrCIDRSetSubNetTooBig
 	}
@@ -87,15 +86,18 @@ func NewCIDRSet(clusterCIDR *net.IPNet, subNetMaskSize int) (*CidrSet, error) {
 	// register CidrSet metrics
 	registerCidrsetMetrics()
 
-	maxCIDRs = 1 << uint32(subNetMaskSize-clusterMaskSize)
-	return &CidrSet{
+	maxCIDRs := getMaxCIDRs(subNetMaskSize, clusterMaskSize)
+	cidrSet := &CidrSet{
 		clusterCIDR:     clusterCIDR,
 		nodeMask:        net.CIDRMask(subNetMaskSize, bits),
 		clusterMaskSize: clusterMaskSize,
 		maxCIDRs:        maxCIDRs,
 		nodeMaskSize:    subNetMaskSize,
 		label:           clusterCIDR.String(),
-	}, nil
+	}
+	cidrSetMaxCidrs.WithLabelValues(cidrSet.label).Set(float64(maxCIDRs))
+
+	return cidrSet, nil
 }
 
 func (s *CidrSet) indexToCIDRBlock(index int) *net.IPNet {
@@ -292,4 +294,10 @@ func (s *CidrSet) getIndexForIP(ip net.IP) (int, error) {
 	}
 
 	return 0, fmt.Errorf("invalid IP: %v", ip)
+}
+
+// getMaxCIDRs returns the max number of CIDRs that can be obtained by subdividing a mask of size `clusterMaskSize`
+// into subnets with mask of size `subNetMaskSize`.
+func getMaxCIDRs(subNetMaskSize, clusterMaskSize int) int {
+	return 1 << uint32(subNetMaskSize-clusterMaskSize)
 }

--- a/pkg/controller/nodeipam/ipam/cidrset/cidr_set_test.go
+++ b/pkg/controller/nodeipam/ipam/cidrset/cidr_set_test.go
@@ -836,12 +836,24 @@ func TestCIDRSetv6(t *testing.T) {
 func TestCidrSetMetrics(t *testing.T) {
 	cidr := "10.0.0.0/16"
 	_, clusterCIDR, _ := netutils.ParseCIDRSloppy(cidr)
+	clearMetrics(map[string]string{"clusterCIDR": cidr})
+
 	// We have 256 free cidrs
 	a, err := NewCIDRSet(clusterCIDR, 24)
 	if err != nil {
 		t.Fatalf("unexpected error creating CidrSet: %v", err)
 	}
-	clearMetrics(map[string]string{"clusterCIDR": cidr})
+
+	clusterMaskSize, _ := clusterCIDR.Mask.Size()
+	max := getMaxCIDRs(24, clusterMaskSize)
+	em := testMetrics{
+		usage:      0,
+		allocs:     0,
+		releases:   0,
+		allocTries: 0,
+		max:        float64(max),
+	}
+	expectMetrics(t, cidr, em)
 
 	// Allocate next all
 	for i := 1; i <= 256; i++ {
@@ -854,16 +866,18 @@ func TestCidrSetMetrics(t *testing.T) {
 			allocs:     float64(i),
 			releases:   0,
 			allocTries: 0,
+			max:        float64(max),
 		}
 		expectMetrics(t, cidr, em)
 	}
 	// Release all
 	a.Release(clusterCIDR)
-	em := testMetrics{
+	em = testMetrics{
 		usage:      0,
 		allocs:     256,
 		releases:   256,
 		allocTries: 0,
+		max:        float64(max),
 	}
 	expectMetrics(t, cidr, em)
 
@@ -874,30 +888,43 @@ func TestCidrSetMetrics(t *testing.T) {
 		allocs:     512,
 		releases:   256,
 		allocTries: 0,
+		max:        float64(max),
 	}
 	expectMetrics(t, cidr, em)
-
 }
 
 func TestCidrSetMetricsHistogram(t *testing.T) {
 	cidr := "10.0.0.0/16"
 	_, clusterCIDR, _ := netutils.ParseCIDRSloppy(cidr)
+	clearMetrics(map[string]string{"clusterCIDR": cidr})
+
 	// We have 256 free cidrs
 	a, err := NewCIDRSet(clusterCIDR, 24)
 	if err != nil {
 		t.Fatalf("unexpected error creating CidrSet: %v", err)
 	}
-	clearMetrics(map[string]string{"clusterCIDR": cidr})
+
+	clusterMaskSize, _ := clusterCIDR.Mask.Size()
+	max := getMaxCIDRs(24, clusterMaskSize)
+	em := testMetrics{
+		usage:      0,
+		allocs:     0,
+		releases:   0,
+		allocTries: 0,
+		max:        float64(max),
+	}
+	expectMetrics(t, cidr, em)
 
 	// Allocate half of the range
 	// Occupy does not update the nextCandidate
 	_, halfClusterCIDR, _ := netutils.ParseCIDRSloppy("10.0.0.0/17")
 	a.Occupy(halfClusterCIDR)
-	em := testMetrics{
+	em = testMetrics{
 		usage:      0.5,
 		allocs:     128,
 		releases:   0,
 		allocTries: 0,
+		max:        float64(max),
 	}
 	expectMetrics(t, cidr, em)
 	// Allocate next should iterate until the next free cidr
@@ -911,6 +938,7 @@ func TestCidrSetMetricsHistogram(t *testing.T) {
 		allocs:     129,
 		releases:   0,
 		allocTries: 128,
+		max:        float64(max),
 	}
 	expectMetrics(t, cidr, em)
 }
@@ -919,26 +947,53 @@ func TestCidrSetMetricsDual(t *testing.T) {
 	// create IPv4 cidrSet
 	cidrIPv4 := "10.0.0.0/16"
 	_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy(cidrIPv4)
+	clearMetrics(map[string]string{"clusterCIDR": cidrIPv4})
+
 	a, err := NewCIDRSet(clusterCIDRv4, 24)
 	if err != nil {
 		t.Fatalf("unexpected error creating CidrSet: %v", err)
 	}
-	clearMetrics(map[string]string{"clusterCIDR": cidrIPv4})
+
+	clusterMaskSize, _ := clusterCIDRv4.Mask.Size()
+	maxIPv4 := getMaxCIDRs(24, clusterMaskSize)
+	em := testMetrics{
+		usage:      0,
+		allocs:     0,
+		releases:   0,
+		allocTries: 0,
+		max:        float64(maxIPv4),
+	}
+	expectMetrics(t, cidrIPv4, em)
+
 	// create IPv6 cidrSet
 	cidrIPv6 := "2001:db8::/48"
 	_, clusterCIDRv6, _ := netutils.ParseCIDRSloppy(cidrIPv6)
+	clearMetrics(map[string]string{"clusterCIDR": cidrIPv6})
+
 	b, err := NewCIDRSet(clusterCIDRv6, 64)
 	if err != nil {
 		t.Fatalf("unexpected error creating CidrSet: %v", err)
 	}
-	clearMetrics(map[string]string{"clusterCIDR": cidrIPv6})
+
+	clusterMaskSize, _ = clusterCIDRv6.Mask.Size()
+	maxIPv6 := getMaxCIDRs(64, clusterMaskSize)
+	em = testMetrics{
+		usage:      0,
+		allocs:     0,
+		releases:   0,
+		allocTries: 0,
+		max:        float64(maxIPv6),
+	}
+	expectMetrics(t, cidrIPv6, em)
+
 	// Allocate all
 	a.Occupy(clusterCIDRv4)
-	em := testMetrics{
+	em = testMetrics{
 		usage:      1,
 		allocs:     256,
 		releases:   0,
 		allocTries: 0,
+		max:        float64(maxIPv4),
 	}
 	expectMetrics(t, cidrIPv4, em)
 
@@ -948,6 +1003,7 @@ func TestCidrSetMetricsDual(t *testing.T) {
 		allocs:     65536,
 		releases:   0,
 		allocTries: 0,
+		max:        float64(maxIPv6),
 	}
 	expectMetrics(t, cidrIPv6, em)
 
@@ -958,6 +1014,7 @@ func TestCidrSetMetricsDual(t *testing.T) {
 		allocs:     256,
 		releases:   256,
 		allocTries: 0,
+		max:        float64(maxIPv4),
 	}
 	expectMetrics(t, cidrIPv4, em)
 	b.Release(clusterCIDRv6)
@@ -966,9 +1023,47 @@ func TestCidrSetMetricsDual(t *testing.T) {
 		allocs:     65536,
 		releases:   65536,
 		allocTries: 0,
+		max:        float64(maxIPv6),
 	}
 	expectMetrics(t, cidrIPv6, em)
+}
 
+func Test_getMaxCIDRs(t *testing.T) {
+	cidrIPv4 := "10.0.0.0/16"
+	_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy(cidrIPv4)
+
+	cidrIPv6 := "2001:db8::/48"
+	_, clusterCIDRv6, _ := netutils.ParseCIDRSloppy(cidrIPv6)
+
+	tests := []struct {
+		name             string
+		subNetMaskSize   int
+		clusterCIDR      *net.IPNet
+		expectedMaxCIDRs int
+	}{
+		{
+			name:             "IPv4",
+			subNetMaskSize:   24,
+			clusterCIDR:      clusterCIDRv4,
+			expectedMaxCIDRs: 256,
+		},
+		{
+			name:             "IPv6",
+			subNetMaskSize:   64,
+			clusterCIDR:      clusterCIDRv6,
+			expectedMaxCIDRs: 65536,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clusterMaskSize, _ := test.clusterCIDR.Mask.Size()
+			maxCIDRs := getMaxCIDRs(test.subNetMaskSize, clusterMaskSize)
+			if test.expectedMaxCIDRs != maxCIDRs {
+				t.Errorf("incorrect maxCIDRs, expected: %d, got: %d", test.expectedMaxCIDRs, maxCIDRs)
+			}
+		})
+	}
 }
 
 // Metrics helpers
@@ -977,6 +1072,7 @@ func clearMetrics(labels map[string]string) {
 	cidrSetReleases.Delete(labels)
 	cidrSetUsage.Delete(labels)
 	cidrSetAllocationTriesPerRequest.Delete(labels)
+	cidrSetMaxCidrs.Delete(labels)
 }
 
 type testMetrics struct {
@@ -984,6 +1080,7 @@ type testMetrics struct {
 	allocs     float64
 	releases   float64
 	allocTries float64
+	max        float64
 }
 
 func expectMetrics(t *testing.T, label string, em testMetrics) {
@@ -1004,6 +1101,10 @@ func expectMetrics(t *testing.T, label string, em testMetrics) {
 	m.allocTries, err = testutil.GetHistogramMetricValue(cidrSetAllocationTriesPerRequest.WithLabelValues(label))
 	if err != nil {
 		t.Errorf("failed to get %s value, err: %v", cidrSetAllocationTriesPerRequest.Name, err)
+	}
+	m.max, err = testutil.GetGaugeMetricValue(cidrSetMaxCidrs.WithLabelValues(label))
+	if err != nil {
+		t.Errorf("failed to get %s value, err: %v", cidrSetMaxCidrs.Name, err)
 	}
 
 	if m != em {

--- a/pkg/controller/nodeipam/ipam/cidrset/metrics.go
+++ b/pkg/controller/nodeipam/ipam/cidrset/metrics.go
@@ -44,6 +44,16 @@ var (
 		},
 		[]string{"clusterCIDR"},
 	)
+	// This is a gauge, as in theory, a limit can increase or decrease.
+	cidrSetMaxCidrs = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem:      nodeIpamSubsystem,
+			Name:           "cirdset_max_cidrs",
+			Help:           "Maximum number of CIDRs that can be allocated.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"clusterCIDR"},
+	)
 	cidrSetUsage = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem:      nodeIpamSubsystem,
@@ -72,6 +82,7 @@ func registerCidrsetMetrics() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(cidrSetAllocations)
 		legacyregistry.MustRegister(cidrSetReleases)
+		legacyregistry.MustRegister(cidrSetMaxCidrs)
 		legacyregistry.MustRegister(cidrSetUsage)
 		legacyregistry.MustRegister(cidrSetAllocationTriesPerRequest)
 	})

--- a/pkg/controller/nodeipam/ipam/multicidrset/metrics.go
+++ b/pkg/controller/nodeipam/ipam/multicidrset/metrics.go
@@ -44,6 +44,16 @@ var (
 		},
 		[]string{"clusterCIDR"},
 	)
+	// This is a gauge, as in theory, a limit can increase or decrease.
+	cidrSetMaxCidrs = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem:      nodeIpamSubsystem,
+			Name:           "multicirdset_max_cidrs",
+			Help:           "Maximum number of CIDRs that can be allocated.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"clusterCIDR"},
+	)
 	cidrSetUsage = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem:      nodeIpamSubsystem,
@@ -72,6 +82,7 @@ func registerCidrsetMetrics() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(cidrSetAllocations)
 		legacyregistry.MustRegister(cidrSetReleases)
+		legacyregistry.MustRegister(cidrSetMaxCidrs)
 		legacyregistry.MustRegister(cidrSetUsage)
 		legacyregistry.MustRegister(cidrSetAllocationTriesPerRequest)
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add a metric which exposes the max number of CIDRs available for a given `CidrSet` and `MultiCIDRSet`. It makes it simple for admins to know how many CIDRs can be further allocated, before the allocator runs out of them.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #111711

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
New metrics `cidrset_cidrs_max_total` and `multicidrset_cidrs_max_total` expose the max number of CIDRs that can be allocated.
``` 

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
