### PR TITLE
kubectl run: deprecate unused / nonuseful flags

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -166,6 +166,23 @@ func NewCmdRun(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Co
 	addRunFlags(cmd, o)
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodAttachTimeout)
+
+	// Deprecate the cascade flag. If set, it has no practical effect since the created pod has no dependents.
+	// TODO: Remove the cascade flag from the run command in kubectl 1.29
+	cmd.Flags().MarkDeprecated("cascade", "because it is not relevant for this command. It will be removed in version 1.29.")
+
+	// Deprecate and hide unused flags.
+	// These flags are being added to the run command by DeleteFlags to support pod deletion after attach,
+	// but they are not used if set, so they effectively do nothing.
+	// TODO: Remove these flags from the run command in kubectl 1.29
+	cmd.Flags().MarkDeprecated("filename", "because it is not used by this command. It will be removed in version 1.29.")
+	cmd.Flags().MarkDeprecated("force", "because it is not used by this command. It will be removed in version 1.29.")
+	cmd.Flags().MarkDeprecated("grace-period", "because it is not used by this command. It will be removed in version 1.29.")
+	cmd.Flags().MarkDeprecated("kustomize", "because it is not used by this command. It will be removed in version 1.29.")
+	cmd.Flags().MarkDeprecated("recursive", "because it is not used by this command. It will be removed in version 1.29.")
+	cmd.Flags().MarkDeprecated("timeout", "because it is not used by this command. It will be removed in version 1.29.")
+	cmd.Flags().MarkDeprecated("wait", "because it is not used by this command. It will be removed in version 1.29.")
+
 	return cmd
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

The --cascade flag, has no practical effect when used, so it is being deprecated.

The following flags, which are unused and ignored by kubectl run, 
have been deprecated:

--filename
--force
--grace-period
--kustomize
--recursive
--timeout
--wait

This PR hides them and sets a deprecation message, so that they can be removed in a future release (1 year = kubectl 1.29 if this makes it into kubectl 1.26).

#### Which issue(s) this PR fixes:
Fixes #108630

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Deprecated the following kubectl run flags, which are ignored if set: --cascade, --filename, --force, --grace-period, --kustomize, --recursive, --timeout, --wait
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
