### PR TITLE
aws: skip health rules if they are a subnet of the client rule

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
@@ -34,9 +34,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
-	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -840,8 +840,12 @@ func (c *Cloud) updateInstanceSecurityGroupsForNLB(lbName string, instances map[
 		for sgID, sg := range clusterSGs {
 			sgPerms := NewIPPermissionSet(sg.IpPermissions...).Ungroup()
 			if desiredSGIDs.Has(sgID) {
-				if err := c.updateInstanceSecurityGroupForNLBTraffic(sgID, sgPerms, healthRuleAnnotation, "tcp", healthCheckPorts, subnetCIDRs); err != nil {
-					return err
+				// If the client rule is 1) all addresses 2) tcp and 3) has same ports as the healthcheck,
+				// then the health rules are a subset of the client rule and are not needed.
+				if len(clientCIDRs) != 1 || clientCIDRs[0] != "0.0.0.0/0" || clientProtocol != "tcp" || !healthCheckPorts.Equal(clientPorts) {
+					if err := c.updateInstanceSecurityGroupForNLBTraffic(sgID, sgPerms, healthRuleAnnotation, "tcp", healthCheckPorts, subnetCIDRs); err != nil {
+						return err
+					}
 				}
 				if err := c.updateInstanceSecurityGroupForNLBTraffic(sgID, sgPerms, clientRuleAnnotation, clientProtocol, clientPorts, clientCIDRs); err != nil {
 					return err


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
See merged cloud-provider-aws PR https://github.com/kubernetes/cloud-provider-aws/pull/437

#### Does this PR introduce a user-facing change?
```release-note
Services of type LoadBalancer create fewer AWS security group rules in most cases
```
