### PR TITLE
Fix: Cronjob will no longer works when updated in sometimes

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2_test.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2_test.go
@@ -455,7 +455,7 @@ func TestControllerV2SyncCronJob(t *testing.T) {
 			expectUpdateStatus:         true,
 			jobPresentInCJActiveStatus: true,
 		},
-		"prev ran but done, is time, create job failed, A": {
+		"prev ran but done, is time, job has existed, but get failed, A": {
 			concurrencyPolicy:          "Allow",
 			schedule:                   onTheHour,
 			deadline:                   noDead,
@@ -463,6 +463,7 @@ func TestControllerV2SyncCronJob(t *testing.T) {
 			jobCreationTime:            justAfterThePriorHour(),
 			now:                        *justAfterTheHour(),
 			jobCreateError:             errors.NewAlreadyExists(schema.GroupResource{Resource: "job", Group: "batch"}, ""),
+			jobGetErr:                  errors.NewBadRequest("request is failed"),
 			expectErr:                  true,
 			expectUpdateStatus:         true,
 			jobPresentInCJActiveStatus: true,


### PR DESCRIPTION
when update cronjob after posting a job and before update the status, the cronjob status will update failed, but the job has been created, the next sync time, will create again and get a job without nothing, then the nil job will update into the cronjob status active list.  
for example：

                ...
		status:
		 active:
		 - apiVersion: batch/v1
		   kind: Job
		lastScheduleTime: "2022-08-17T02:05:00Z"

the cronjob will do not work any more.

/kind bug
