### PR TITLE
Automated cherry pick of #104359: Add APF's priorityLevel to httplog.go
#108631: Remove apf_fd from httplog
#109109: For each call, log apf_execution_time
#111109: Always log APF InitialSeats and FinalSeats values

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
@@ -125,14 +125,10 @@ func WithPriorityAndFairness(
 			workEstimate := workEstimator(r, classification.FlowSchemaName, classification.PriorityLevelName)
 
 			fcmetrics.ObserveWorkEstimatedSeats(classification.PriorityLevelName, classification.FlowSchemaName, workEstimate.MaxSeats())
-			// nolint:logcheck // Not using the result of klog.V
-			// inside the if branch is okay, we just use it to
-			// determine whether the additional information should
-			// be added.
-			if klog.V(4).Enabled() {
-				httplog.AddKeyValue(ctx, "apf_iseats", workEstimate.InitialSeats)
-				httplog.AddKeyValue(ctx, "apf_fseats", workEstimate.FinalSeats)
-			}
+			httplog.AddKeyValue(ctx, "apf_iseats", workEstimate.InitialSeats)
+			httplog.AddKeyValue(ctx, "apf_fseats", workEstimate.FinalSeats)
+			httplog.AddKeyValue(ctx, "apf_additionalLatency", workEstimate.AdditionalLatency)
+
 			return workEstimate
 		}
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -836,13 +836,12 @@ func (cfgCtlr *configController) startRequest(ctx context.Context, rd RequestDig
 	if plState.pl.Spec.Type == flowcontrol.PriorityLevelEnablementExempt {
 		noteFn(selectedFlowSchema, plState.pl, "")
 		klog.V(7).Infof("startRequest(%#+v) => fsName=%q, distMethod=%#+v, plName=%q, immediate", rd, selectedFlowSchema.Name, selectedFlowSchema.Spec.DistinguisherMethod, plName)
-		return selectedFlowSchema, plState.pl, true, immediateRequest{}, time.Time{}
+		return selectedFlowSchema, plState.pl, true, immediateRequest{}, time.Time{}, ""
 	}
 	var numQueues int32
 	if plState.pl.Spec.Limited.LimitResponse.Type == flowcontrol.LimitResponseTypeQueue {
 		numQueues = plState.pl.Spec.Limited.LimitResponse.Queuing.Queues
 	}
-	var flowDistinguisher string
 	var hashValue uint64
 	if numQueues > 1 {
 		flowDistinguisher = computeFlowDistinguisher(rd, selectedFlowSchema.Spec.DistinguisherMethod)
@@ -858,7 +857,7 @@ func (cfgCtlr *configController) startRequest(ctx context.Context, rd RequestDig
 	if idle {
 		cfgCtlr.maybeReapReadLocked(plName, plState)
 	}
-	return selectedFlowSchema, plState.pl, false, req, startWaitingTime
+	return selectedFlowSchema, plState.pl, false, req, startWaitingTime, flowDistinguisher
 }
 
 // maybeReap will remove the last internal traces of the named


### PR DESCRIPTION
Cherry pick of #104359 #108631 #109109 #111109 on release-1.24.

#104359: Add APF's priorityLevel to httplog.go
#108631: Remove apf_fd from httplog
#109109: For each call, log apf_execution_time
#111109: Always log APF InitialSeats and FinalSeats values

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```