### PR TITLE
Automated cherry pick of #111109: Always log APF InitialSeats and FinalSeats values

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
@@ -125,14 +125,10 @@ func WithPriorityAndFairness(
 			workEstimate := workEstimator(r, classification.FlowSchemaName, classification.PriorityLevelName)
 
 			fcmetrics.ObserveWorkEstimatedSeats(classification.PriorityLevelName, classification.FlowSchemaName, workEstimate.MaxSeats())
-			// nolint:logcheck // Not using the result of klog.V
-			// inside the if branch is okay, we just use it to
-			// determine whether the additional information should
-			// be added.
-			if klog.V(4).Enabled() {
-				httplog.AddKeyValue(ctx, "apf_iseats", workEstimate.InitialSeats)
-				httplog.AddKeyValue(ctx, "apf_fseats", workEstimate.FinalSeats)
-			}
+			httplog.AddKeyValue(ctx, "apf_iseats", workEstimate.InitialSeats)
+			httplog.AddKeyValue(ctx, "apf_fseats", workEstimate.FinalSeats)
+			httplog.AddKeyValue(ctx, "apf_additionalLatency", workEstimate.AdditionalLatency)
+
 			return workEstimate
 		}
 


### PR DESCRIPTION
Cherry pick of #111109 on release-1.24.

#111109: Always log APF InitialSeats and FinalSeats values

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Always log APF InitialSeats and FinalSeats values
```