### PR TITLE
Automated cherry pick of #104359: Add APF's priorityLevel to httplog.go
#106628: apf: add initial and final seats to httplog
#108631: Remove apf_fd from httplog
#109109: For each call, log apf_execution_time
#111109: Always log APF InitialSeats and FinalSeats values

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
@@ -122,7 +122,14 @@ func WithPriorityAndFairness(
 				return workEstimator(r, "", "")
 			}
 
-			return workEstimator(r, classification.FlowSchemaName, classification.PriorityLevelName)
+			workEstimate := workEstimator(r, classification.FlowSchemaName, classification.PriorityLevelName)
+
+			fcmetrics.ObserveWorkEstimatedSeats(classification.PriorityLevelName, classification.FlowSchemaName, workEstimate.MaxSeats())
+			httplog.AddKeyValue(ctx, "apf_iseats", workEstimate.InitialSeats)
+			httplog.AddKeyValue(ctx, "apf_fseats", workEstimate.FinalSeats)
+			httplog.AddKeyValue(ctx, "apf_additionalLatency", workEstimate.AdditionalLatency)
+
+			return workEstimate
 		}
 
 		var served bool

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -835,13 +835,12 @@ func (cfgCtlr *configController) startRequest(ctx context.Context, rd RequestDig
 	if plState.pl.Spec.Type == flowcontrol.PriorityLevelEnablementExempt {
 		noteFn(selectedFlowSchema, plState.pl, "")
 		klog.V(7).Infof("startRequest(%#+v) => fsName=%q, distMethod=%#+v, plName=%q, immediate", rd, selectedFlowSchema.Name, selectedFlowSchema.Spec.DistinguisherMethod, plName)
-		return selectedFlowSchema, plState.pl, true, immediateRequest{}, time.Time{}
+		return selectedFlowSchema, plState.pl, true, immediateRequest{}, time.Time{}, ""
 	}
 	var numQueues int32
 	if plState.pl.Spec.Limited.LimitResponse.Type == flowcontrol.LimitResponseTypeQueue {
 		numQueues = plState.pl.Spec.Limited.LimitResponse.Queuing.Queues
 	}
-	var flowDistinguisher string
 	var hashValue uint64
 	if numQueues > 1 {
 		flowDistinguisher = computeFlowDistinguisher(rd, selectedFlowSchema.Spec.DistinguisherMethod)
@@ -857,7 +856,7 @@ func (cfgCtlr *configController) startRequest(ctx context.Context, rd RequestDig
 	if idle {
 		cfgCtlr.maybeReapReadLocked(plName, plState)
 	}
-	return selectedFlowSchema, plState.pl, false, req, startWaitingTime
+	return selectedFlowSchema, plState.pl, false, req, startWaitingTime, flowDistinguisher
 }
 
 // maybeReap will remove the last internal traces of the named

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -835,12 +835,13 @@ func (cfgCtlr *configController) startRequest(ctx context.Context, rd RequestDig
 	if plState.pl.Spec.Type == flowcontrol.PriorityLevelEnablementExempt {
 		noteFn(selectedFlowSchema, plState.pl, "")
 		klog.V(7).Infof("startRequest(%#+v) => fsName=%q, distMethod=%#+v, plName=%q, immediate", rd, selectedFlowSchema.Name, selectedFlowSchema.Spec.DistinguisherMethod, plName)
-		return selectedFlowSchema, plState.pl, true, immediateRequest{}, time.Time{}, ""
+		return selectedFlowSchema, plState.pl, true, immediateRequest{}, time.Time{}
 	}
 	var numQueues int32
 	if plState.pl.Spec.Limited.LimitResponse.Type == flowcontrol.LimitResponseTypeQueue {
 		numQueues = plState.pl.Spec.Limited.LimitResponse.Queuing.Queues
 	}
+	var flowDistinguisher string
 	var hashValue uint64
 	if numQueues > 1 {
 		flowDistinguisher = computeFlowDistinguisher(rd, selectedFlowSchema.Spec.DistinguisherMethod)
@@ -856,7 +857,7 @@ func (cfgCtlr *configController) startRequest(ctx context.Context, rd RequestDig
 	if idle {
 		cfgCtlr.maybeReapReadLocked(plName, plState)
 	}
-	return selectedFlowSchema, plState.pl, false, req, startWaitingTime, flowDistinguisher
+	return selectedFlowSchema, plState.pl, false, req, startWaitingTime
 }
 
 // maybeReap will remove the last internal traces of the named

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"time"
 
+	"k8s.io/apiserver/pkg/server/httplog"
 	"k8s.io/apiserver/pkg/server/mux"
 	fq "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing"
 	"k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock"
@@ -186,7 +187,9 @@ func (cfgCtlr *configController) Handle(ctx context.Context, requestDigest Reque
 		executed = true
 		startExecutionTime := time.Now()
 		defer func() {
-			metrics.ObserveExecutionDuration(ctx, pl.Name, fs.Name, time.Since(startExecutionTime))
+			executionTime := time.Since(startExecutionTime)
+			httplog.AddKeyValue(ctx, "apf_execution_time", executionTime)
+			metrics.ObserveExecutionDuration(ctx, pl.Name, fs.Name, executionTime)
 		}()
 		execFn()
 	})

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
@@ -310,6 +310,19 @@ var (
 		},
 		[]string{priorityLevel, "success"},
 	)
+	apiserverWorkEstimatedSeats = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "work_estimated_seats",
+			Help:      "Number of estimated seats (maximum of initial and final seats) associated with requests in API Priority and Fairness",
+			// the upper bound comes from the maximum number of seats a request
+			// can occupy which is currently set at 10.
+			Buckets:        []float64{1, 2, 4, 10},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{priorityLevel, flowSchema},
+	)
 
 	metrics = Registerables{
 		apiserverRejectedRequestsTotal,
@@ -328,6 +341,7 @@ var (
 		apiserverRequestExecutionSeconds,
 		watchCountSamples,
 		apiserverEpochAdvances,
+		apiserverWorkEstimatedSeats,
 	}.
 		Append(PriorityLevelExecutionSeatsObserverGenerator.metrics()...).
 		Append(PriorityLevelConcurrencyObserverPairGenerator.metrics()...).
@@ -403,4 +417,9 @@ func ObserveWatchCount(ctx context.Context, priorityLevel, flowSchema string, co
 // AddEpochAdvance notes an advance of the progress meter baseline for a given priority level
 func AddEpochAdvance(ctx context.Context, priorityLevel string, success bool) {
 	apiserverEpochAdvances.WithContext(ctx).WithLabelValues(priorityLevel, strconv.FormatBool(success)).Inc()
+}
+
+// ObserveWorkEstimatedSeats notes a sampling of estimated seats associated with a request
+func ObserveWorkEstimatedSeats(priorityLevel, flowSchema string, seats int) {
+	apiserverWorkEstimatedSeats.WithLabelValues(priorityLevel, flowSchema).Observe(float64(seats))
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
@@ -30,6 +30,10 @@ const (
 	minimumSeats = 1
 
 	// the maximum number of seats a request can occupy
+	//
+	// NOTE: work_estimate_seats_samples metric uses the value of maximumSeats
+	// as the upper bound, so when we change maximumSeats we should also
+	// update the buckets of the metric.
 	maximumSeats = 10
 )
 


### PR DESCRIPTION
Cherry pick of #104359 #106628 #108631 #109109 #111109 on release-1.23.

#104359: Add APF's priorityLevel to httplog.go
#106628: apf: add initial and final seats to httplog
#108631: Remove apf_fd from httplog
#109109: For each call, log apf_execution_time
#111109: Always log APF InitialSeats and FinalSeats values

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```