### PR TITLE
Enable Parallel test execution

### DIFF
--- a/pkg/controller/controller_ref_manager_test.go
+++ b/pkg/controller/controller_ref_manager_test.go
@@ -60,6 +60,7 @@ func newPod(podName string, label map[string]string, owner metav1.Object) *v1.Po
 }
 
 func TestClaimPods(t *testing.T) {
+	t.Parallel()
 	controllerKind := schema.GroupVersionKind{}
 	type test struct {
 		name    string
@@ -231,7 +232,9 @@ func TestClaimPods(t *testing.T) {
 		}(),
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			claimed, err := test.manager.ClaimPods(context.TODO(), test.pods)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -262,6 +265,7 @@ func TestClaimPods(t *testing.T) {
 }
 
 func TestGeneratePatchBytesForDelete(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		ownerUID     []types.UID
@@ -306,7 +310,9 @@ func TestGeneratePatchBytesForDelete(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, _ := GenerateDeleteOwnerRefStrategicMergeBytes(tt.dependentUID, tt.ownerUID, tt.finalizers...)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("generatePatchBytesForDelete() got = %s, want %s", got, tt.want)

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -168,6 +168,7 @@ func newReplicaSet(name string, replicas int) *apps.ReplicaSet {
 }
 
 func TestControllerExpectations(t *testing.T) {
+	t.Parallel()
 	ttl := 30 * time.Second
 	e, fakeClock := NewFakeControllerExpectationsLookup(ttl)
 	// In practice we can't really have add and delete expectations since we only either create or
@@ -232,6 +233,7 @@ func TestControllerExpectations(t *testing.T) {
 }
 
 func TestUIDExpectations(t *testing.T) {
+	t.Parallel()
 	uidExp := NewUIDTrackingControllerExpectations(NewControllerExpectations())
 	rcList := []*v1.ReplicationController{
 		newReplicationController(2),
@@ -284,6 +286,7 @@ func TestUIDExpectations(t *testing.T) {
 }
 
 func TestCreatePods(t *testing.T) {
+	t.Parallel()
 	ns := metav1.NamespaceDefault
 	body := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "empty_pod"}})
 	fakeHandler := utiltesting.FakeHandler{
@@ -322,6 +325,7 @@ func TestCreatePods(t *testing.T) {
 }
 
 func TestCreatePodsWithGenerateName(t *testing.T) {
+	t.Parallel()
 	ns := metav1.NamespaceDefault
 	body := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "empty_pod"}})
 	fakeHandler := utiltesting.FakeHandler{
@@ -363,6 +367,7 @@ func TestCreatePodsWithGenerateName(t *testing.T) {
 }
 
 func TestDeletePodsAllowsMissing(t *testing.T) {
+	t.Parallel()
 	fakeClient := fake.NewSimpleClientset()
 	podControl := RealPodControl{
 		KubeClient: fakeClient,
@@ -376,6 +381,7 @@ func TestDeletePodsAllowsMissing(t *testing.T) {
 }
 
 func TestActivePodFiltering(t *testing.T) {
+	t.Parallel()
 	// This rc is not needed by the test, only the newPodList to give the pods labels/a namespace.
 	rc := newReplicationController(0)
 	podList := newPodList(nil, 5, v1.PodRunning, rc)
@@ -403,6 +409,7 @@ func TestActivePodFiltering(t *testing.T) {
 }
 
 func TestSortingActivePods(t *testing.T) {
+	t.Parallel()
 	numPods := 9
 	// This rc is not needed by the test, only the newPodList to give the pods labels/a namespace.
 	rc := newReplicationController(0)
@@ -478,6 +485,7 @@ func TestSortingActivePods(t *testing.T) {
 }
 
 func TestSortingActivePodsWithRanks(t *testing.T) {
+	t.Parallel()
 	now := metav1.Now()
 	then1Month := metav1.Time{Time: now.AddDate(0, -1, 0)}
 	then2Hours := metav1.Time{Time: now.Add(-2 * time.Hour)}
@@ -601,6 +609,7 @@ func TestSortingActivePodsWithRanks(t *testing.T) {
 }
 
 func TestActiveReplicaSetsFiltering(t *testing.T) {
+	t.Parallel()
 	var replicaSets []*apps.ReplicaSet
 	replicaSets = append(replicaSets, newReplicaSet("zero", 0))
 	replicaSets = append(replicaSets, nil)
@@ -624,6 +633,7 @@ func TestActiveReplicaSetsFiltering(t *testing.T) {
 }
 
 func TestComputeHash(t *testing.T) {
+	t.Parallel()
 	collisionCount := int32(1)
 	otherCollisionCount := int32(2)
 	maxCollisionCount := int32(math.MaxInt32)
@@ -656,6 +666,7 @@ func TestComputeHash(t *testing.T) {
 }
 
 func TestRemoveTaintOffNode(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		nodeHandler    *testutil.FakeNodeHandler
@@ -830,6 +841,7 @@ func TestRemoveTaintOffNode(t *testing.T) {
 }
 
 func TestAddOrUpdateTaintOnNode(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		nodeHandler    *testutil.FakeNodeHandler

--- a/pkg/registry/core/service/ipallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair_test.go
@@ -52,6 +52,7 @@ func (r *mockRangeRegistry) CreateOrUpdate(alloc *api.RangeAllocation) error {
 }
 
 func TestRepair(t *testing.T) {
+	t.Parallel()
 	fakeClient := fake.NewSimpleClientset()
 	ipregistry := &mockRangeRegistry{
 		item: &api.RangeAllocation{Range: "192.168.1.0/24"},
@@ -77,6 +78,7 @@ func TestRepair(t *testing.T) {
 }
 
 func TestRepairLeak(t *testing.T) {
+	t.Parallel()
 	_, cidr, _ := netutils.ParseCIDRSloppy("192.168.1.0/24")
 	previous, err := ipallocator.NewInMemory(cidr)
 	if err != nil {
@@ -129,6 +131,7 @@ func TestRepairLeak(t *testing.T) {
 }
 
 func TestRepairWithExisting(t *testing.T) {
+	t.Parallel()
 	_, cidr, _ := netutils.ParseCIDRSloppy("192.168.1.0/24")
 	previous, err := ipallocator.NewInMemory(cidr)
 	if err != nil {
@@ -247,6 +250,7 @@ func makeIPNet(cidr string) *net.IPNet {
 	return net
 }
 func TestShouldWorkOnSecondary(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name             string
 		expectedFamilies []corev1.IPFamily
@@ -279,7 +283,9 @@ func TestShouldWorkOnSecondary(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
 			fakeClient := makeFakeClientSet()
 			primaryRegistry := makeRangeRegistry(t, tc.primaryNet.String())
@@ -323,6 +329,7 @@ func TestShouldWorkOnSecondary(t *testing.T) {
 }
 
 func TestRepairDualStack(t *testing.T) {
+	t.Parallel()
 	fakeClient := fake.NewSimpleClientset()
 	ipregistry := &mockRangeRegistry{
 		item: &api.RangeAllocation{Range: "192.168.1.0/24"},
@@ -361,6 +368,7 @@ func TestRepairDualStack(t *testing.T) {
 }
 
 func TestRepairLeakDualStack(t *testing.T) {
+	t.Parallel()
 	_, cidr, _ := netutils.ParseCIDRSloppy("192.168.1.0/24")
 	previous, err := ipallocator.NewInMemory(cidr)
 	if err != nil {
@@ -452,6 +460,7 @@ func TestRepairLeakDualStack(t *testing.T) {
 }
 
 func TestRepairWithExistingDualStack(t *testing.T) {
+	t.Parallel()
 	// because anything (other than allocator) depends
 	// on families assigned to service (not the value of IPFamilyPolicy)
 	// we can saftly create tests that has ipFamilyPolicy:nil

--- a/pkg/registry/core/service/portallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/portallocator/controller/repair_test.go
@@ -53,6 +53,7 @@ func (r *mockRangeRegistry) CreateOrUpdate(alloc *api.RangeAllocation) error {
 }
 
 func TestRepair(t *testing.T) {
+	t.Parallel()
 	fakeClient := fake.NewSimpleClientset()
 	registry := &mockRangeRegistry{
 		item: &api.RangeAllocation{Range: "100-200"},
@@ -78,6 +79,7 @@ func TestRepair(t *testing.T) {
 }
 
 func TestRepairLeak(t *testing.T) {
+	t.Parallel()
 	pr, _ := net.ParsePortRange("100-200")
 	previous, err := portallocator.NewInMemory(*pr)
 	if err != nil {
@@ -130,6 +132,7 @@ func TestRepairLeak(t *testing.T) {
 }
 
 func TestRepairWithExisting(t *testing.T) {
+	t.Parallel()
 	pr, _ := net.ParsePortRange("100-200")
 	previous, err := portallocator.NewInMemory(*pr)
 	if err != nil {
@@ -207,6 +210,7 @@ func TestRepairWithExisting(t *testing.T) {
 }
 
 func TestCollectServiceNodePorts(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		serviceSpec corev1.ServiceSpec
@@ -291,7 +295,9 @@ func TestCollectServiceNodePorts(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ports := collectServiceNodePorts(&corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "one"},
 				Spec:       tc.serviceSpec,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Since go v1.7, the go testing package provides the ability to run [tests in parallel](https://pkg.go.dev/testing#T.Parallel). As this [post](https://engineering.mercari.com/en/blog/entry/20220408-how_to_use_t_parallel/) describes, unit tests will run in parallel at the package level. Therefore, this change allows increasing the number of processes during the execution of SIG/apps unit tests

*Before
```bash
$ for i in {1..3}; do make test WHAT=./pkg/controller/ ; done
+++ [0914 15:07:24] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:07:26] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/controller        0.116s
+++ [0914 15:07:29] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:07:32] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/controller        0.116s
+++ [0914 15:07:34] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:07:36] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/controller        0.116s
$ for i in {1..3}; do make test WHAT=./pkg/registry/core/service/portallocator/controller/ ; done
+++ [0914 15:19:54] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:19:56] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/registry/core/service/portallocator/controller    0.077s
+++ [0914 15:19:59] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:20:01] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/registry/core/service/portallocator/controller    0.077s
+++ [0914 15:20:03] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:20:05] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/registry/core/service/portallocator/controller    0.079s
$ for i in {1..3}; do make test WHAT=./pkg/registry/core/service/ipallocator/controller/ ; done
+++ [0914 15:20:35] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:20:37] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/registry/core/service/ipallocator/controller      0.095s
+++ [0914 15:20:40] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:20:42] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/registry/core/service/ipallocator/controller      0.096s
+++ [0914 15:20:45] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:20:47] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/registry/core/service/ipallocator/controller      0.095s
```
*After
```bash
$ for i in {1..3}; do make test WHAT=./pkg/controller/ ; done
+++ [0914 15:07:57] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:07:59] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/controller        0.104s
+++ [0914 15:08:01] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:08:04] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/controller        0.086s
+++ [0914 15:08:06] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:08:09] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/controller        0.106s
$ for i in {1..3}; do make test WHAT=./pkg/registry/core/service/portallocator/controller/ ; done
+++ [0914 15:19:05] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:19:08] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/registry/core/service/portallocator/controller    0.074s
+++ [0914 15:19:10] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:19:12] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/registry/core/service/portallocator/controller    0.074s
+++ [0914 15:19:15] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:19:17] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/registry/core/service/portallocator/controller    0.063s
$ for i in {1..3}; do make test WHAT=./pkg/registry/core/service/ipallocator/controller/ ; done
+++ [0914 15:21:12] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:21:15] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/registry/core/service/ipallocator/controller      0.096s
+++ [0914 15:21:17] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:21:19] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/registry/core/service/ipallocator/controller      0.098s
+++ [0914 15:21:22] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 15:21:24] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/registry/core/service/ipallocator/controller      0.097s
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NA

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
