### PR TITLE
Enable Parallel test execution

### DIFF
--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -44,6 +44,7 @@ func (proxier *FakeProxier) deleteEndpoints(endpoints *v1.Endpoints) {
 }
 
 func TestGetLocalEndpointIPs(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		endpointsMap EndpointsMap
 		expected     map[types.NamespacedName]sets.String
@@ -182,6 +183,7 @@ func makeTestEndpoints(namespace, name string, eptFunc func(*v1.Endpoints)) *v1.
 
 // This is a coarse test, but it offers some modicum of confidence as the code is evolved.
 func TestEndpointsToEndpointsMap(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		desc         string
 		newEndpoints *v1.Endpoints
@@ -450,7 +452,9 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 
 			epTracker := NewEndpointChangeTracker("test-hostname", nil, tc.ipFamily, nil, nil)
 
@@ -477,6 +481,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 }
 
 func TestUpdateEndpointsMap(t *testing.T) {
+	t.Parallel()
 	var nodeName = testHostname
 
 	emptyEndpoint := func(ept *v1.Endpoints) {
@@ -1315,7 +1320,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	}
 
 	for tci, tc := range testCases {
+		tc := tc
+		tci := tci
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			fp := newFakeProxier(v1.IPv4Protocol, time.Time{})
 			fp.hostname = nodeName
 
@@ -1386,6 +1394,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 }
 
 func TestLastChangeTriggerTime(t *testing.T) {
+	t.Parallel()
 	startTime := time.Date(2018, 01, 01, 0, 0, 0, 0, time.UTC)
 	t_1 := startTime.Add(-time.Second)
 	t0 := startTime.Add(time.Second)
@@ -1516,6 +1525,7 @@ func TestLastChangeTriggerTime(t *testing.T) {
 }
 
 func TestEndpointSliceUpdate(t *testing.T) {
+	t.Parallel()
 	fqdnSlice := generateEndpointSlice("svc1", "ns1", 2, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)})
 	fqdnSlice.AddressType = discovery.AddressTypeFQDN
 
@@ -1773,7 +1783,9 @@ func TestEndpointSliceUpdate(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			initializeCache(tc.endpointChangeTracker.endpointSliceCache, tc.startingSlices)
 
 			got := tc.endpointChangeTracker.EndpointSliceUpdate(tc.paramEndpointSlice, tc.paramRemoveSlice)
@@ -1799,6 +1811,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 }
 
 func TestCheckoutChanges(t *testing.T) {
+	t.Parallel()
 	svcPortName0 := ServicePortName{types.NamespacedName{Namespace: "ns1", Name: "svc1"}, "port-0", v1.ProtocolTCP}
 	svcPortName1 := ServicePortName{types.NamespacedName{Namespace: "ns1", Name: "svc1"}, "port-1", v1.ProtocolTCP}
 
@@ -1849,7 +1862,9 @@ func TestCheckoutChanges(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			for _, slice := range tc.appliedSlices {
 				tc.endpointChangeTracker.EndpointSliceUpdate(slice, false)
 			}

--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestEndpointsMapFromESC(t *testing.T) {
+	t.Parallel()
 	testCases := map[string]struct {
 		endpointSlices []*discovery.EndpointSlice
 		hostname       string
@@ -203,7 +204,9 @@ func TestEndpointsMapFromESC(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			esCache := NewEndpointSliceCache(tc.hostname, v1.IPv4Protocol, nil, nil)
 
 			cmc := newCacheMutationCheck(tc.endpointSlices)
@@ -218,6 +221,7 @@ func TestEndpointsMapFromESC(t *testing.T) {
 }
 
 func TestEndpointInfoByServicePort(t *testing.T) {
+	t.Parallel()
 	testCases := map[string]struct {
 		namespacedName types.NamespacedName
 		endpointSlices []*discovery.EndpointSlice
@@ -306,7 +310,9 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			esCache := NewEndpointSliceCache(tc.hostname, v1.IPv4Protocol, nil, nil)
 
 			for _, endpointSlice := range tc.endpointSlices {
@@ -322,6 +328,7 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 }
 
 func TestEsInfoChanged(t *testing.T) {
+	t.Parallel()
 	p80 := int32(80)
 	p443 := int32(443)
 	tcpProto := v1.ProtocolTCP
@@ -435,7 +442,9 @@ func TestEsInfoChanged(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			cmc := newCacheMutationCheck([]*discovery.EndpointSlice{tc.initialSlice})
 
 			if tc.initialSlice != nil {

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -86,6 +86,7 @@ func makeServicePortName(ns, name, port string, protocol v1.Protocol) ServicePor
 }
 
 func TestServiceToServiceMap(t *testing.T) {
+	t.Parallel()
 	testClusterIPv4 := "10.0.0.1"
 	testExternalIPv4 := "8.8.8.8"
 	testSourceRangeIPv4 := "0.0.0.0/1"
@@ -464,7 +465,9 @@ func TestServiceToServiceMap(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			svcTracker := NewServiceChangeTracker(nil, tc.ipFamily, nil, nil)
 			// outputs
 			newServices := svcTracker.serviceToServiceMap(tc.service)
@@ -549,6 +552,7 @@ func (fake *FakeProxier) deleteService(service *v1.Service) {
 }
 
 func TestServiceMapUpdateHeadless(t *testing.T) {
+	t.Parallel()
 	fp := newFakeProxier(v1.IPv4Protocol, time.Time{})
 
 	makeServiceMap(fp,
@@ -580,6 +584,7 @@ func TestServiceMapUpdateHeadless(t *testing.T) {
 }
 
 func TestUpdateServiceTypeExternalName(t *testing.T) {
+	t.Parallel()
 	fp := newFakeProxier(v1.IPv4Protocol, time.Time{})
 
 	makeServiceMap(fp,
@@ -605,6 +610,7 @@ func TestUpdateServiceTypeExternalName(t *testing.T) {
 }
 
 func TestBuildServiceMapAddRemove(t *testing.T) {
+	t.Parallel()
 	fp := newFakeProxier(v1.IPv4Protocol, time.Time{})
 
 	services := []*v1.Service{
@@ -708,6 +714,7 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 }
 
 func TestBuildServiceMapServiceUpdate(t *testing.T) {
+	t.Parallel()
 	fp := newFakeProxier(v1.IPv4Protocol, time.Time{})
 
 	servicev1 := makeTestService("ns1", "svc1", func(svc *v1.Service) {

--- a/pkg/proxy/topology_test.go
+++ b/pkg/proxy/topology_test.go
@@ -46,6 +46,7 @@ func checkExpectedEndpoints(expected sets.String, actual []Endpoint) error {
 }
 
 func TestCategorizeEndpoints(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name         string
 		hintsEnabled bool
@@ -474,7 +475,9 @@ func TestCategorizeEndpoints(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareHints, tc.hintsEnabled)()
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ProxyTerminatingEndpoints, tc.pteEnabled)()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Since go v1.7, the go testing package provides the ability to run [tests in parallel](https://pkg.go.dev/testing#T.Parallel). As this [post](https://engineering.mercari.com/en/blog/entry/20220408-how_to_use_t_parallel/) describes, unit tests will run in parallel at the package level. Therefore, this change allows increasing the number of processes during the execution of SIG/network unit tests

*Before
```bash
$ for i in {1..3}; do make test WHAT=./pkg/proxy/ ; done
+++ [0914 16:24:36] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 16:24:38] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/proxy     0.094s
+++ [0914 16:24:42] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 16:24:44] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/proxy     0.089s
+++ [0914 16:24:46] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 16:24:48] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/proxy     0.085s
```
*After
```bash
$ for i in {1..3}; do make test WHAT=./pkg/proxy/ ; done
+++ [0914 16:25:35] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 16:25:37] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/proxy     0.075s
+++ [0914 16:25:41] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 16:25:43] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/proxy     0.075s
+++ [0914 16:25:45] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 16:25:48] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/proxy     0.075s
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NA

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
