### PR TITLE
Enable Parallel test execution in pkg/kubelet

### DIFF
--- a/pkg/kubelet/active_deadline_test.go
+++ b/pkg/kubelet/active_deadline_test.go
@@ -44,6 +44,7 @@ func (m *mockPodStatusProvider) GetPodStatus(uid types.UID) (v1.PodStatus, bool)
 
 // TestActiveDeadlineHandler verifies the active deadline handler functions as expected.
 func TestActiveDeadlineHandler(t *testing.T) {
+	t.Parallel()
 	pods := newTestPods(4)
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	podStatusProvider := &mockPodStatusProvider{pods: pods}

--- a/pkg/kubelet/kubelet_getters_test.go
+++ b/pkg/kubelet/kubelet_getters_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestKubeletDirs(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet

--- a/pkg/kubelet/kubelet_network_test.go
+++ b/pkg/kubelet/kubelet_network_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestGetIPTablesMark(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		bit    int
 		expect string

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -161,6 +161,7 @@ func (lcm *localCM) GetCapacity(localStorageCapacityIsolation bool) v1.ResourceL
 }
 
 func TestUpdateNewNodeStatus(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		desc                string
 		nodeStatusMaxImages int32
@@ -176,7 +177,9 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			// generate one more in inputImageList than we configure the Kubelet to report,
 			// or 5 images if unlimited
 			numTestImages := int(tc.nodeStatusMaxImages) + 1
@@ -315,6 +318,7 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 }
 
 func TestUpdateExistingNodeStatus(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -506,6 +510,7 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 }
 
 func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -572,6 +577,7 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 }
 
 func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -781,6 +787,7 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 }
 
 func TestUpdateNodeStatusError(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -792,6 +799,7 @@ func TestUpdateNodeStatusError(t *testing.T) {
 }
 
 func TestUpdateNodeStatusWithLease(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	clock := testKubelet.fakeClock
@@ -1030,6 +1038,7 @@ func TestUpdateNodeStatusWithLease(t *testing.T) {
 }
 
 func TestUpdateNodeStatusAndVolumesInUseWithNodeLease(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		desc                  string
 		existingVolumes       []v1.UniqueVolumeName // volumes to initially populate volumeManager
@@ -1077,7 +1086,9 @@ func TestUpdateNodeStatusAndVolumesInUseWithNodeLease(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			// Setup
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
@@ -1128,6 +1139,7 @@ func TestUpdateNodeStatusAndVolumesInUseWithNodeLease(t *testing.T) {
 }
 
 func TestRegisterWithApiServer(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -1186,6 +1198,7 @@ func TestRegisterWithApiServer(t *testing.T) {
 }
 
 func TestTryRegisterWithApiServer(t *testing.T) {
+	t.Parallel()
 	alreadyExists := &apierrors.StatusError{
 		ErrStatus: metav1.Status{Reason: metav1.StatusReasonAlreadyExists},
 	}
@@ -1345,6 +1358,7 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 }
 
 func TestUpdateNewNodeStatusTooLargeReservation(t *testing.T) {
+	t.Parallel()
 	const nodeStatusMaxImages = 5
 
 	// generate one more in inputImageList than we configure the Kubelet to report
@@ -1415,6 +1429,7 @@ func TestUpdateNewNodeStatusTooLargeReservation(t *testing.T) {
 }
 
 func TestUpdateDefaultLabels(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	testKubelet.kubelet.kubeClient = nil // ensure only the heartbeat client is used
 
@@ -1720,6 +1735,7 @@ func TestUpdateDefaultLabels(t *testing.T) {
 }
 
 func TestUpdateDefaultResources(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name         string
 		initialNode  *v1.Node
@@ -1930,6 +1946,7 @@ func TestUpdateDefaultResources(t *testing.T) {
 }
 
 func TestReconcileHugePageResource(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	hugePageResourceName64Ki := v1.ResourceName("hugepages-64Ki")
 	hugePageResourceName2Mi := v1.ResourceName("hugepages-2Mi")
@@ -2222,6 +2239,7 @@ func TestReconcileHugePageResource(t *testing.T) {
 
 }
 func TestReconcileExtendedResource(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	testKubelet.kubelet.kubeClient = nil // ensure only the heartbeat client is used
 	testKubelet.kubelet.containerManager = cm.NewStubContainerManagerWithExtendedResource(true /* shouldResetExtendedResourceCapacity*/)
@@ -2410,6 +2428,7 @@ func TestReconcileExtendedResource(t *testing.T) {
 }
 
 func TestValidateNodeIPParam(t *testing.T) {
+	t.Parallel()
 	type test struct {
 		nodeIP   string
 		success  bool
@@ -2501,6 +2520,7 @@ func TestValidateNodeIPParam(t *testing.T) {
 }
 
 func TestRegisterWithApiServerWithTaint(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -2547,6 +2567,7 @@ func TestRegisterWithApiServerWithTaint(t *testing.T) {
 }
 
 func TestNodeStatusHasChanged(t *testing.T) {
+	t.Parallel()
 	fakeNow := metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
 	fakeFuture := metav1.Time{Time: fakeNow.Time.Add(time.Minute)}
 	readyCondition := v1.NodeCondition{
@@ -2691,7 +2712,9 @@ func TestNodeStatusHasChanged(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			originalStatusCopy := tc.originalStatus.DeepCopy()
 			statusCopy := tc.status.DeepCopy()
 			changed := nodeStatusHasChanged(tc.originalStatus, tc.status)
@@ -2703,6 +2726,7 @@ func TestNodeStatusHasChanged(t *testing.T) {
 }
 
 func TestUpdateNodeAddresses(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet

--- a/pkg/kubelet/kubelet_pods_linux_test.go
+++ b/pkg/kubelet/kubelet_pods_linux_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestMakeMounts(t *testing.T) {
+	t.Parallel()
 	bTrue := true
 	propagationHostToContainer := v1.MountPropagationHostToContainer
 	propagationBidirectional := v1.MountPropagationBidirectional
@@ -241,7 +242,10 @@ func TestMakeMounts(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		name := name
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			fhu := hostutil.NewFakeHostUtil(nil)
 			fsp := &subpath.FakeSubpath{}
 			pod := v1.Pod{
@@ -271,6 +275,7 @@ func TestMakeMounts(t *testing.T) {
 }
 
 func TestMakeBlockVolumes(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -379,7 +384,9 @@ func TestMakeBlockVolumes(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			pod := v1.Pod{
 				Spec: v1.PodSpec{
 					HostNetwork: true,

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -60,6 +60,7 @@ import (
 )
 
 func TestNodeHostsFileContent(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		hostsFileName            string
 		hostAliases              []v1.HostAlias
@@ -173,7 +174,9 @@ fe00::2	ip6-allrouters
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
 		t.Run(testCase.hostsFileName, func(t *testing.T) {
+			t.Parallel()
 			tmpdir, err := writeHostsFile(testCase.hostsFileName, testCase.rawHostsFileContent)
 			require.NoError(t, err, "could not create a temp hosts file")
 			defer os.RemoveAll(tmpdir)
@@ -196,6 +199,7 @@ func writeHostsFile(filename string, cfg string) (string, error) {
 }
 
 func TestManagedHostsFileContent(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		hostIPs         []string
 		hostName        string
@@ -299,6 +303,7 @@ fd00::6	podFoo.domainFoo	podFoo
 }
 
 func TestRunInContainerNoSuchPod(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -318,6 +323,7 @@ func TestRunInContainerNoSuchPod(t *testing.T) {
 }
 
 func TestRunInContainer(t *testing.T) {
+	t.Parallel()
 	for _, testError := range []error{nil, errors.New("bar")} {
 		testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 		defer testKubelet.Cleanup()
@@ -384,6 +390,7 @@ func buildService(name, namespace, clusterIP, protocol string, port int) *v1.Ser
 }
 
 func TestMakeEnvironmentVariables(t *testing.T) {
+	t.Parallel()
 	trueVal := true
 	services := []*v1.Service{
 		buildService("kubernetes", metav1.NamespaceDefault, "1.2.3.1", "TCP", 8081),
@@ -1673,7 +1680,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			fakeRecorder := record.NewFakeRecorder(1)
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			testKubelet.kubelet.recorder = fakeRecorder
@@ -1861,6 +1870,7 @@ func withID(status v1.ContainerStatus, id string) v1.ContainerStatus {
 }
 
 func TestPodPhaseWithRestartAlways(t *testing.T) {
+	t.Parallel()
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		Containers: []v1.Container{
@@ -1961,6 +1971,7 @@ func TestPodPhaseWithRestartAlways(t *testing.T) {
 }
 
 func TestPodPhaseWithRestartAlwaysInitContainers(t *testing.T) {
+	t.Parallel()
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		InitContainers: []v1.Container{
@@ -2064,6 +2075,7 @@ func TestPodPhaseWithRestartAlwaysInitContainers(t *testing.T) {
 }
 
 func TestPodPhaseWithRestartNever(t *testing.T) {
+	t.Parallel()
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		Containers: []v1.Container{
@@ -2164,6 +2176,7 @@ func TestPodPhaseWithRestartNever(t *testing.T) {
 }
 
 func TestPodPhaseWithRestartNeverInitContainers(t *testing.T) {
+	t.Parallel()
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		InitContainers: []v1.Container{
@@ -2267,6 +2280,7 @@ func TestPodPhaseWithRestartNeverInitContainers(t *testing.T) {
 }
 
 func TestPodPhaseWithRestartOnFailure(t *testing.T) {
+	t.Parallel()
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		Containers: []v1.Container{
@@ -2384,6 +2398,7 @@ func TestPodPhaseWithRestartOnFailure(t *testing.T) {
 // }
 
 func TestConvertToAPIContainerStatuses(t *testing.T) {
+	t.Parallel()
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		Containers: []v1.Container{
@@ -2455,7 +2470,9 @@ func TestConvertToAPIContainerStatuses(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
 			kl := testKubelet.kubelet
@@ -2475,6 +2492,7 @@ func TestConvertToAPIContainerStatuses(t *testing.T) {
 }
 
 func Test_generateAPIPodStatus(t *testing.T) {
+	t.Parallel()
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		Containers: []v1.Container{
@@ -2913,6 +2931,7 @@ func findContainerStatusByName(status v1.PodStatus, name string) *v1.ContainerSt
 }
 
 func TestGetExec(t *testing.T) {
+	t.Parallel()
 	const (
 		podName                = "podFoo"
 		podNamespace           = "nsFoo"
@@ -2962,7 +2981,9 @@ func TestGetExec(t *testing.T) {
 	}}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
 			kubelet := testKubelet.kubelet
@@ -2996,6 +3017,7 @@ func TestGetExec(t *testing.T) {
 }
 
 func TestGetPortForward(t *testing.T) {
+	t.Parallel()
 	const (
 		podName                = "podFoo"
 		podNamespace           = "nsFoo"
@@ -3049,6 +3071,7 @@ func TestGetPortForward(t *testing.T) {
 }
 
 func TestHasHostMountPVC(t *testing.T) {
+	t.Parallel()
 	type testcase struct {
 		pvError         error
 		pvcError        error
@@ -3142,13 +3165,17 @@ func TestHasHostMountPVC(t *testing.T) {
 	}
 
 	for k, v := range tests {
+		k := k
+		v := v
 		t.Run(k, func(t *testing.T) {
+			t.Parallel()
 			run(t, v)
 		})
 	}
 }
 
 func TestHasNonNamespacedCapability(t *testing.T) {
+	t.Parallel()
 	createPodWithCap := func(caps []v1.Capability) *v1.Pod {
 		pod := &v1.Pod{
 			Spec: v1.PodSpec{
@@ -3190,6 +3217,7 @@ func TestHasNonNamespacedCapability(t *testing.T) {
 }
 
 func TestHasHostVolume(t *testing.T) {
+	t.Parallel()
 	pod := &v1.Pod{
 		Spec: v1.PodSpec{
 			Volumes: []v1.Volume{
@@ -3215,6 +3243,7 @@ func TestHasHostVolume(t *testing.T) {
 }
 
 func TestHasHostNamespace(t *testing.T) {
+	t.Parallel()
 	tests := map[string]struct {
 		ps       v1.PodSpec
 		expected bool
@@ -3264,6 +3293,7 @@ func TestHasHostNamespace(t *testing.T) {
 }
 
 func TestTruncatePodHostname(t *testing.T) {
+	t.Parallel()
 	for c, test := range map[string]struct {
 		input  string
 		output string
@@ -3293,6 +3323,7 @@ func TestTruncatePodHostname(t *testing.T) {
 }
 
 func TestGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name          string
 		nodeAddresses []v1.NodeAddress
@@ -3389,7 +3420,9 @@ func TestGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
 			kl := testKubelet.kubelet
@@ -3425,6 +3458,7 @@ func TestGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
 }
 
 func TestNodeAddressUpdatesGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name           string
 		nodeIPs        []string
@@ -3493,7 +3527,9 @@ func TestNodeAddressUpdatesGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
 			kl := testKubelet.kubelet
@@ -3538,6 +3574,7 @@ func TestNodeAddressUpdatesGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
 }
 
 func TestGenerateAPIPodStatusPodIPs(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name      string
 		nodeIP    string
@@ -3642,7 +3679,9 @@ func TestGenerateAPIPodStatusPodIPs(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
 			kl := testKubelet.kubelet
@@ -3671,6 +3710,7 @@ func TestGenerateAPIPodStatusPodIPs(t *testing.T) {
 }
 
 func TestSortPodIPs(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name        string
 		nodeIP      string
@@ -3746,7 +3786,9 @@ func TestSortPodIPs(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
 			kl := testKubelet.kubelet
@@ -3763,6 +3805,7 @@ func TestSortPodIPs(t *testing.T) {
 }
 
 func TestConvertToAPIContainerStatusesDataRace(t *testing.T) {
+	t.Parallel()
 	pod := podWithUIDNameNs("12345", "test-pod", "test-namespace")
 
 	testTimestamp := time.Unix(123456789, 987654321)

--- a/pkg/kubelet/kubelet_resources_test.go
+++ b/pkg/kubelet/kubelet_resources_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestPodResourceLimitsDefaulting(t *testing.T) {
+	t.Parallel()
 	tk := newTestKubelet(t, true)
 	defer tk.Cleanup()
 	tk.kubelet.nodeLister = &testNodeLister{

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -409,6 +409,7 @@ func newTestPods(count int) []*v1.Pod {
 }
 
 func TestSyncLoopAbort(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -429,6 +430,7 @@ func TestSyncLoopAbort(t *testing.T) {
 }
 
 func TestSyncPodsStartPod(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -446,6 +448,7 @@ func TestSyncPodsStartPod(t *testing.T) {
 }
 
 func TestHandlePodCleanupsPerQOS(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 
@@ -510,6 +513,7 @@ func TestHandlePodCleanupsPerQOS(t *testing.T) {
 }
 
 func TestDispatchWorkOfCompletedPod(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -589,6 +593,7 @@ func TestDispatchWorkOfCompletedPod(t *testing.T) {
 }
 
 func TestDispatchWorkOfActivePod(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -643,6 +648,7 @@ func TestDispatchWorkOfActivePod(t *testing.T) {
 }
 
 func TestHandlePodCleanups(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 
@@ -671,6 +677,7 @@ func TestHandlePodCleanups(t *testing.T) {
 }
 
 func TestHandlePodRemovesWhenSourcesAreReady(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -744,6 +751,7 @@ func checkPodStatus(t *testing.T, kl *Kubelet, pod *v1.Pod, phase v1.PodPhase) {
 
 // Tests that we handle port conflicts correctly by setting the failed status in status map.
 func TestHandlePortConflicts(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kl := testKubelet.kubelet
@@ -794,6 +802,7 @@ func TestHandlePortConflicts(t *testing.T) {
 
 // Tests that we handle host name conflicts correctly by setting the failed status in status map.
 func TestHandleHostNameConflicts(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kl := testKubelet.kubelet
@@ -837,6 +846,7 @@ func TestHandleHostNameConflicts(t *testing.T) {
 
 // Tests that we handle not matching labels selector correctly by setting the failed status in status map.
 func TestHandleNodeSelector(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kl := testKubelet.kubelet
@@ -879,6 +889,7 @@ func TestHandleNodeSelector(t *testing.T) {
 
 // Tests that we handle not matching labels selector correctly by setting the failed status in status map.
 func TestHandleNodeSelectorBasedOnOS(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		nodeLabels  map[string]string
@@ -906,7 +917,9 @@ func TestHandleNodeSelectorBasedOnOS(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
 			kl := testKubelet.kubelet
@@ -944,6 +957,7 @@ func TestHandleNodeSelectorBasedOnOS(t *testing.T) {
 
 // Tests that we handle exceeded resources correctly by setting the failed status in status map.
 func TestHandleMemExceeded(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kl := testKubelet.kubelet
@@ -999,6 +1013,7 @@ func TestHandleMemExceeded(t *testing.T) {
 // Tests that we handle result of interface UpdatePluginResources correctly
 // by setting corresponding status in status map.
 func TestHandlePluginResources(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kl := testKubelet.kubelet
@@ -1132,6 +1147,7 @@ func TestHandlePluginResources(t *testing.T) {
 
 // TODO(filipg): This test should be removed once StatusSyncer can do garbage collection without external signal.
 func TestPurgingObsoleteStatusMapEntries(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 
@@ -1155,6 +1171,7 @@ func TestPurgingObsoleteStatusMapEntries(t *testing.T) {
 }
 
 func TestValidateContainerLogStatus(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -1304,6 +1321,7 @@ func TestValidateContainerLogStatus(t *testing.T) {
 }
 
 func TestCreateMirrorPod(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		updateType kubetypes.SyncPodType
@@ -1320,6 +1338,7 @@ func TestCreateMirrorPod(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
 
@@ -1342,6 +1361,7 @@ func TestCreateMirrorPod(t *testing.T) {
 }
 
 func TestDeleteOutdatedMirrorPod(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 
@@ -1378,6 +1398,7 @@ func TestDeleteOutdatedMirrorPod(t *testing.T) {
 }
 
 func TestDeleteOrphanedMirrorPods(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 
@@ -1446,6 +1467,7 @@ func TestDeleteOrphanedMirrorPods(t *testing.T) {
 }
 
 func TestGetContainerInfoForMirrorPods(t *testing.T) {
+	t.Parallel()
 	// pods contain one static and one mirror pod with the same name but
 	// different UIDs.
 	pods := []*v1.Pod{
@@ -1510,6 +1532,7 @@ func TestGetContainerInfoForMirrorPods(t *testing.T) {
 }
 
 func TestNetworkErrorsWithoutHostNetwork(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -1541,6 +1564,7 @@ func TestNetworkErrorsWithoutHostNetwork(t *testing.T) {
 }
 
 func TestFilterOutInactivePods(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -1590,6 +1614,7 @@ func TestFilterOutInactivePods(t *testing.T) {
 }
 
 func TestCheckpointContainer(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -1664,7 +1689,9 @@ func TestCheckpointContainer(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			options := &runtimeapi.CheckpointContainerRequest{}
 			if test.checkpointLocation != "" {
 				options.Location = test.checkpointLocation
@@ -1703,6 +1730,7 @@ func TestCheckpointContainer(t *testing.T) {
 }
 
 func TestSyncPodsSetStatusToFailedForPodsThatRunTooLong(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	fakeRuntime := testKubelet.fakeRuntime
@@ -1752,6 +1780,7 @@ func TestSyncPodsSetStatusToFailedForPodsThatRunTooLong(t *testing.T) {
 }
 
 func TestSyncPodsDoesNotSetPodsThatDidNotRunTooLongToFailed(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	fakeRuntime := testKubelet.fakeRuntime
@@ -1817,6 +1846,7 @@ func podWithUIDNameNsSpec(uid types.UID, name, namespace string, spec v1.PodSpec
 }
 
 func TestDeletePodDirsForDeletedPods(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kl := testKubelet.kubelet
@@ -1853,6 +1883,7 @@ func syncAndVerifyPodDir(t *testing.T, testKubelet *TestKubelet, pods []*v1.Pod,
 }
 
 func TestDoesNotDeletePodDirsForTerminatedPods(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kl := testKubelet.kubelet
@@ -1870,6 +1901,7 @@ func TestDoesNotDeletePodDirsForTerminatedPods(t *testing.T) {
 }
 
 func TestDoesNotDeletePodDirsIfContainerIsRunning(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	runningPod := &kubecontainer.Pod{
@@ -1900,6 +1932,7 @@ func TestDoesNotDeletePodDirsIfContainerIsRunning(t *testing.T) {
 }
 
 func TestGetPodsToSync(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -1931,6 +1964,7 @@ func TestGetPodsToSync(t *testing.T) {
 }
 
 func TestGenerateAPIPodStatusWithSortedContainers(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -1984,6 +2018,7 @@ func verifyContainerStatuses(t *testing.T, statuses []v1.ContainerStatus, expect
 
 // Test generateAPIPodStatus with different reason cache and old api pod status.
 func TestGenerateAPIPodStatusWithReasonCache(t *testing.T) {
+	t.Parallel()
 	// The following waiting reason and message  are generated in convertStatusToAPIStatus()
 	testTimestamp := time.Unix(123456789, 987654321)
 	testErrorReason := fmt.Errorf("test-error")
@@ -2204,6 +2239,7 @@ func TestGenerateAPIPodStatusWithReasonCache(t *testing.T) {
 
 // Test generateAPIPodStatus with different restart policies.
 func TestGenerateAPIPodStatusWithDifferentRestartPolicies(t *testing.T) {
+	t.Parallel()
 	testErrorReason := fmt.Errorf("test-error")
 	emptyContainerID := (&kubecontainer.ContainerID{}).String()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
@@ -2369,6 +2405,7 @@ func (a *testPodAdmitHandler) Admit(attrs *lifecycle.PodAdmitAttributes) lifecyc
 
 // Test verifies that the kubelet invokes an admission handler during HandlePodAdditions.
 func TestHandlePodAdditionsInvokesPodAdmitHandlers(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kl := testKubelet.kubelet
@@ -2430,6 +2467,7 @@ func (a *testPodSyncLoopHandler) ShouldSync(pod *v1.Pod) bool {
 
 // TestGetPodsToSyncInvokesPodSyncLoopHandlers ensures that the get pods to sync routine invokes the handler.
 func TestGetPodsToSyncInvokesPodSyncLoopHandlers(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -2466,6 +2504,7 @@ func (a *testPodSyncHandler) ShouldEvict(pod *v1.Pod) lifecycle.ShouldEvictRespo
 
 // TestGenerateAPIPodStatusInvokesPodSyncHandlers invokes the handlers and reports the proper status
 func TestGenerateAPIPodStatusInvokesPodSyncHandlers(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -2484,6 +2523,7 @@ func TestGenerateAPIPodStatusInvokesPodSyncHandlers(t *testing.T) {
 }
 
 func TestSyncTerminatingPodKillPod(t *testing.T) {
+	t.Parallel()
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kl := testKubelet.kubelet
@@ -2510,6 +2550,7 @@ func TestSyncTerminatingPodKillPod(t *testing.T) {
 }
 
 func TestSyncLabels(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		existingNode     *v1.Node
@@ -2538,7 +2579,9 @@ func TestSyncLabels(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			testKubelet := newTestKubelet(t, false)
 			defer testKubelet.Cleanup()
 			kl := testKubelet.kubelet

--- a/pkg/kubelet/kubelet_volumes_linux_test.go
+++ b/pkg/kubelet/kubelet_volumes_linux_test.go
@@ -54,6 +54,7 @@ func validateDirNotExists(dir string) error {
 }
 
 func TestCleanupOrphanedPodDirs(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -171,7 +172,10 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		name := name
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
 			kubelet := testKubelet.kubelet
@@ -201,6 +205,7 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 }
 
 func TestPodVolumesExistWithMount(t *testing.T) {
+	t.Parallel()
 	poduid := types.UID("poduid")
 	testCases := map[string]struct {
 		prepareFunc func(kubelet *Kubelet) error
@@ -293,7 +298,10 @@ func TestPodVolumesExistWithMount(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		name := name
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
 			kubelet := testKubelet.kubelet

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestListVolumesForPod(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -96,6 +97,7 @@ func TestListVolumesForPod(t *testing.T) {
 }
 
 func TestPodVolumesExist(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -210,6 +212,7 @@ func TestPodVolumesExist(t *testing.T) {
 }
 
 func TestVolumeAttachAndMountControllerDisabled(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -269,6 +272,7 @@ func TestVolumeAttachAndMountControllerDisabled(t *testing.T) {
 }
 
 func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -358,6 +362,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 }
 
 func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -442,6 +447,7 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 }
 
 func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}

--- a/pkg/kubelet/pod_container_deletor_test.go
+++ b/pkg/kubelet/pod_container_deletor_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestGetContainersToDeleteInPodWithFilter(t *testing.T) {
+	t.Parallel()
 	pod := kubecontainer.PodStatus{
 		ContainerStatuses: []*kubecontainer.Status{
 			{
@@ -87,6 +88,7 @@ func TestGetContainersToDeleteInPodWithFilter(t *testing.T) {
 }
 
 func TestGetContainersToDeleteInPod(t *testing.T) {
+	t.Parallel()
 	pod := kubecontainer.PodStatus{
 		ContainerStatuses: []*kubecontainer.Status{
 			{
@@ -149,6 +151,7 @@ func TestGetContainersToDeleteInPod(t *testing.T) {
 }
 
 func TestGetContainersToDeleteInPodWithNoMatch(t *testing.T) {
+	t.Parallel()
 	pod := kubecontainer.PodStatus{
 		ContainerStatuses: []*kubecontainer.Status{
 			{

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -358,6 +358,7 @@ func drainAllWorkers(podWorkers *podWorkers) {
 }
 
 func TestUpdatePod(t *testing.T) {
+	t.Parallel()
 	podWorkers, processed := createPodWorkers()
 
 	numPods := 20
@@ -396,6 +397,7 @@ func TestUpdatePod(t *testing.T) {
 }
 
 func TestUpdatePodWithTerminatedPod(t *testing.T) {
+	t.Parallel()
 	podWorkers, _ := createPodWorkers()
 	terminatedPod := newPodWithPhase("0000-0000-0000", "done-pod", v1.PodSucceeded)
 	orphanedPod := &kubecontainer.Pod{ID: "0000-0000-0001", Name: "orphaned-pod"}
@@ -426,6 +428,7 @@ func TestUpdatePodWithTerminatedPod(t *testing.T) {
 }
 
 func TestUpdatePodForRuntimePod(t *testing.T) {
+	t.Parallel()
 	podWorkers, processed := createPodWorkers()
 
 	// ignores running pod of wrong sync type
@@ -457,6 +460,7 @@ func TestUpdatePodForRuntimePod(t *testing.T) {
 }
 
 func TestUpdatePodForTerminatedRuntimePod(t *testing.T) {
+	t.Parallel()
 	podWorkers, processed := createPodWorkers()
 
 	now := time.Now()
@@ -486,6 +490,7 @@ func TestUpdatePodForTerminatedRuntimePod(t *testing.T) {
 }
 
 func TestUpdatePodDoesNotForgetSyncPodKill(t *testing.T) {
+	t.Parallel()
 	podWorkers, processed := createPodWorkers()
 	numPods := 20
 	for i := 0; i < numPods; i++ {
@@ -566,6 +571,7 @@ func newTerminalPhaseSync(fn syncPodFnType) *terminalPhaseSync {
 }
 
 func TestTerminalPhaseTransition(t *testing.T) {
+	t.Parallel()
 	podWorkers, _ := createPodWorkers()
 	var channels WorkChannel
 	podWorkers.workerChannelFn = channels.Intercept
@@ -614,6 +620,7 @@ func TestTerminalPhaseTransition(t *testing.T) {
 }
 
 func TestStaticPodExclusion(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -1074,6 +1081,7 @@ func (w *WorkChannel) Intercept(uid types.UID, ch chan podWork) (outCh <-chan po
 }
 
 func TestSyncKnownPods(t *testing.T) {
+	t.Parallel()
 	podWorkers, _ := createPodWorkers()
 
 	numPods := 20
@@ -1217,6 +1225,7 @@ func TestSyncKnownPods(t *testing.T) {
 }
 
 func Test_removeTerminatedWorker(t *testing.T) {
+	t.Parallel()
 	podUID := types.UID("pod-uid")
 
 	testCases := []struct {
@@ -1262,7 +1271,9 @@ func Test_removeTerminatedWorker(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			podWorkers, _ := createPodWorkers()
 			podWorkers.podSyncStatuses[podUID] = tc.podSyncStatus
 			podWorkers.startedStaticPodsByFullname = tc.startedStaticPodsByFullname
@@ -1309,6 +1320,7 @@ func (kl *simpleFakeKubelet) syncTerminatedPod(ctx context.Context, pod *v1.Pod,
 // TestFakePodWorkers verifies that the fakePodWorkers behaves the same way as the real podWorkers
 // for their invocation of the syncPodFn.
 func TestFakePodWorkers(t *testing.T) {
+	t.Parallel()
 	fakeRecorder := &record.FakeRecorder{}
 	fakeRuntime := &containertest.FakeRuntime{}
 	fakeCache := containertest.NewFakeCache(fakeRuntime)
@@ -1376,6 +1388,7 @@ func TestFakePodWorkers(t *testing.T) {
 
 // TestKillPodNowFunc tests the blocking kill pod function works with pod workers as expected.
 func TestKillPodNowFunc(t *testing.T) {
+	t.Parallel()
 	fakeRecorder := &record.FakeRecorder{}
 	podWorkers, processed := createPodWorkers()
 	killPodFunc := killPodNow(podWorkers, fakeRecorder)
@@ -1406,6 +1419,7 @@ func TestKillPodNowFunc(t *testing.T) {
 }
 
 func Test_allowPodStart(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		desc                               string
 		pod                                *v1.Pod
@@ -1708,7 +1722,9 @@ func Test_allowPodStart(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			podWorkers, _ := createPodWorkers()
 			if tc.podSyncStatuses != nil {
 				podWorkers.podSyncStatuses = tc.podSyncStatuses

--- a/pkg/kubelet/reason_cache_test.go
+++ b/pkg/kubelet/reason_cache_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestReasonCache(t *testing.T) {
+	t.Parallel()
 	// Create test sync result
 	syncResult := kubecontainer.PodSyncResult{}
 	results := []*kubecontainer.SyncResult{

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -52,6 +52,7 @@ import (
 )
 
 func TestRunOnce(t *testing.T) {
+	t.Parallel()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 

--- a/pkg/kubelet/userns_manager_test.go
+++ b/pkg/kubelet/userns_manager_test.go
@@ -175,6 +175,7 @@ func TestUserNsManagerParseUserNsFile(t *testing.T) {
 }
 
 func TestUserNsManagerHostIDFromMapping(t *testing.T) {
+	t.Parallel()
 	// mapping []*runtimeapi.IDMapping, containerId *int64
 
 	cases := []struct {
@@ -283,7 +284,9 @@ func TestUserNsManagerHostIDFromMapping(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			var containerId *int64
 			if tc.containerId != -1 {
 				containerId = &tc.containerId


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Since go v1.7, the go testing package provides the ability to run [tests in parallel](https://pkg.go.dev/testing#T.Parallel). As this [post](https://engineering.mercari.com/en/blog/entry/20220408-how_to_use_t_parallel/) describes, unit tests will run in parallel at the package level. Therefore, this change allows increasing the number of processes during the execution of SIG/node unit tests

* Before
```bash
$ for i in {1..3}; do make test WHAT=./pkg/kubelet/ ; done
+++ [0915 12:19:14] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0915 12:19:16] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/kubelet   15.481s
+++ [0915 12:19:40] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0915 12:19:43] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/kubelet   15.605s
+++ [0915 12:20:04] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0915 12:20:06] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/kubelet   15.724s
```
* After
```bash
$ for i in {1..3}; do make test WHAT=./pkg/kubelet/ ; done
+++ [0915 12:21:42] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0915 12:21:44] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/kubelet   5.860s
+++ [0915 12:21:56] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0915 12:21:58] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/kubelet   6.061s
+++ [0915 12:22:10] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0915 12:22:12] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/kubelet   5.854s
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NA

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
