### PR TITLE
Enable Parallel test execution in pkg/scheduler

### DIFF
--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -48,6 +48,7 @@ import (
 )
 
 func TestNodeAllocatableChanged(t *testing.T) {
+	t.Parallel()
 	newQuantity := func(value int64) resource.Quantity {
 		return *resource.NewQuantity(value, resource.BinarySI)
 	}
@@ -70,7 +71,9 @@ func TestNodeAllocatableChanged(t *testing.T) {
 			NewAllocatable: v1.ResourceList{v1.ResourceMemory: newQuantity(1024), v1.ResourceStorage: newQuantity(1024)},
 		},
 	} {
+		test := test
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			oldNode := &v1.Node{Status: v1.NodeStatus{Allocatable: test.OldAllocatable}}
 			newNode := &v1.Node{Status: v1.NodeStatus{Allocatable: test.NewAllocatable}}
 			changed := nodeAllocatableChanged(newNode, oldNode)
@@ -82,6 +85,7 @@ func TestNodeAllocatableChanged(t *testing.T) {
 }
 
 func TestNodeLabelsChanged(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		Name      string
 		Changed   bool
@@ -102,7 +106,9 @@ func TestNodeLabelsChanged(t *testing.T) {
 			NewLabels: map[string]string{"foo": "bar", "test": "value"},
 		},
 	} {
+		test := test
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			oldNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: test.OldLabels}}
 			newNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: test.NewLabels}}
 			changed := nodeLabelsChanged(newNode, oldNode)
@@ -114,6 +120,7 @@ func TestNodeLabelsChanged(t *testing.T) {
 }
 
 func TestNodeTaintsChanged(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		Name      string
 		Changed   bool
@@ -133,7 +140,9 @@ func TestNodeTaintsChanged(t *testing.T) {
 			NewTaints: []v1.Taint{{Key: "key", Value: "value2"}},
 		},
 	} {
+		test := test
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			oldNode := &v1.Node{Spec: v1.NodeSpec{Taints: test.OldTaints}}
 			newNode := &v1.Node{Spec: v1.NodeSpec{Taints: test.NewTaints}}
 			changed := nodeTaintsChanged(newNode, oldNode)
@@ -145,6 +154,7 @@ func TestNodeTaintsChanged(t *testing.T) {
 }
 
 func TestNodeConditionsChanged(t *testing.T) {
+	t.Parallel()
 	nodeConditionType := reflect.TypeOf(v1.NodeCondition{})
 	if nodeConditionType.NumField() != 6 {
 		t.Errorf("NodeCondition type has changed. The nodeConditionsChanged() function must be reevaluated.")
@@ -187,7 +197,9 @@ func TestNodeConditionsChanged(t *testing.T) {
 			NewConditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionTrue}},
 		},
 	} {
+		test := test
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			oldNode := &v1.Node{Status: v1.NodeStatus{Conditions: test.OldConditions}}
 			newNode := &v1.Node{Status: v1.NodeStatus{Conditions: test.NewConditions}}
 			changed := nodeConditionsChanged(newNode, oldNode)
@@ -199,6 +211,7 @@ func TestNodeConditionsChanged(t *testing.T) {
 }
 
 func TestUpdatePodInCache(t *testing.T) {
+	t.Parallel()
 	ttl := 10 * time.Second
 	nodeName := "node"
 
@@ -219,7 +232,9 @@ func TestUpdatePodInCache(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			sched := &Scheduler{
@@ -251,6 +266,7 @@ func withPodName(pod *v1.Pod, name string) *v1.Pod {
 }
 
 func TestPreCheckForNode(t *testing.T) {
+	t.Parallel()
 	cpu4 := map[v1.ResourceName]string{v1.ResourceCPU: "4"}
 	cpu8 := map[v1.ResourceName]string{v1.ResourceCPU: "8"}
 	cpu16 := map[v1.ResourceName]string{v1.ResourceCPU: "16"}
@@ -337,7 +353,9 @@ func TestPreCheckForNode(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			nodeInfo := framework.NewNodeInfo(tt.existingPods...)
 			nodeInfo.SetNode(tt.nodeFn())
 			preCheckFn := preCheckForNode(nodeInfo)
@@ -356,6 +374,7 @@ func TestPreCheckForNode(t *testing.T) {
 
 // test for informers of resources we care about is registered
 func TestAddAllEventHandlers(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                   string
 		gvkMap                 map[framework.GVK]framework.ActionType
@@ -429,7 +448,9 @@ func TestAddAllEventHandlers(t *testing.T) {
 	localSchemeBuilder.AddToScheme(scheme)
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -461,6 +482,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 }
 
 func TestAdmissionCheck(t *testing.T) {
+	t.Parallel()
 	nodeaffinityError := AdmissionResult{Name: nodeaffinity.Name, Reason: nodeaffinity.ErrReasonPod}
 	nodenameError := AdmissionResult{Name: nodename.Name, Reason: nodename.ErrReason}
 	nodeportsError := AdmissionResult{Name: nodeports.Name, Reason: nodeports.ErrReason}
@@ -502,7 +524,9 @@ func TestAdmissionCheck(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			nodeInfo := framework.NewNodeInfo(tt.existingPods...)
 			nodeInfo.SetNode(tt.node)
 

--- a/pkg/scheduler/extender_test.go
+++ b/pkg/scheduler/extender_test.go
@@ -41,6 +41,7 @@ import (
 )
 
 func TestSchedulerWithExtenders(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		registerPlugins []st.RegisterPluginFunc
@@ -330,6 +331,7 @@ func createNode(name string) *v1.Node {
 }
 
 func TestIsInterested(t *testing.T) {
+	t.Parallel()
 	mem := &HTTPExtender{
 		managedResources: sets.NewString(),
 	}
@@ -372,7 +374,9 @@ func TestIsInterested(t *testing.T) {
 			want: true,
 		},
 	} {
+		tc := tc
 		t.Run(tc.label, func(t *testing.T) {
+			t.Parallel()
 			if got := tc.extender.IsInterested(tc.pod); got != tc.want {
 				t.Fatalf("IsInterested(%v) = %v, wanted %v", tc.pod, got, tc.want)
 			}
@@ -381,6 +385,7 @@ func TestIsInterested(t *testing.T) {
 }
 
 func TestConvertToMetaVictims(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name              string
 		nodeNameToVictims map[string]*extenderv1.Victims
@@ -423,7 +428,9 @@ func TestConvertToMetaVictims(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := convertToMetaVictims(tt.nodeNameToVictims); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("convertToMetaVictims() = %v, want %v", got, tt.want)
 			}
@@ -432,6 +439,7 @@ func TestConvertToMetaVictims(t *testing.T) {
 }
 
 func TestConvertToVictims(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                  string
 		httpExtender          *HTTPExtender
@@ -488,7 +496,9 @@ func TestConvertToVictims(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// nodeInfos instantiations
 			nodeInfoList := make([]*framework.NodeInfo, 0, len(tt.nodeNames))
 			for i, nm := range tt.nodeNames {

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -319,6 +319,7 @@ func (t *TestPlugin) Filter(ctx context.Context, state *framework.CycleState, po
 }
 
 func TestSchedulerMultipleProfilesScheduling(t *testing.T) {
+	t.Parallel()
 	nodes := []runtime.Object{
 		st.MakeNode().Name("node1").UID("node1").Obj(),
 		st.MakeNode().Name("node2").UID("node2").Obj(),
@@ -445,6 +446,7 @@ func TestSchedulerMultipleProfilesScheduling(t *testing.T) {
 }
 
 func TestSchedulerScheduleOne(t *testing.T) {
+	t.Parallel()
 	testNode := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1", UID: types.UID("node1")}}
 	client := clientsetfake.NewSimpleClientset(&testNode)
 	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1()})
@@ -639,6 +641,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 }
 
 func TestSchedulerNoPhantomPodAfterExpire(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	queuedPodStore := clientcache.NewFIFO(clientcache.MetaNamespaceKeyFunc)
@@ -704,6 +707,7 @@ func TestSchedulerNoPhantomPodAfterExpire(t *testing.T) {
 }
 
 func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	queuedPodStore := clientcache.NewFIFO(clientcache.MetaNamespaceKeyFunc)
@@ -773,6 +777,7 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 }
 
 func TestSchedulerFailedSchedulingReasons(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	queuedPodStore := clientcache.NewFIFO(clientcache.MetaNamespaceKeyFunc)
@@ -855,6 +860,7 @@ func TestSchedulerFailedSchedulingReasons(t *testing.T) {
 }
 
 func TestSchedulerWithVolumeBinding(t *testing.T) {
+	t.Parallel()
 	findErr := fmt.Errorf("find err")
 	assumeErr := fmt.Errorf("assume err")
 	bindErr := fmt.Errorf("bind err")
@@ -1001,6 +1007,7 @@ func TestSchedulerWithVolumeBinding(t *testing.T) {
 }
 
 func TestSchedulerBinding(t *testing.T) {
+	t.Parallel()
 	table := []struct {
 		podName      string
 		extenders    []framework.Extender
@@ -1036,7 +1043,9 @@ func TestSchedulerBinding(t *testing.T) {
 	}
 
 	for _, test := range table {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			pod := st.MakePod().Name(test.podName).Obj()
 			defaultBound := false
 			client := clientsetfake.NewSimpleClientset(pod)
@@ -1084,6 +1093,7 @@ func TestSchedulerBinding(t *testing.T) {
 }
 
 func TestUpdatePod(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                     string
 		currentPodConditions     []v1.PodCondition
@@ -1225,7 +1235,9 @@ func TestUpdatePod(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			actualPatchRequests := 0
 			var actualPatchData string
 			cs := &clientsetfake.Clientset{}
@@ -1263,6 +1275,7 @@ func TestUpdatePod(t *testing.T) {
 }
 
 func TestSelectHost(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		list          framework.NodeScoreList
@@ -1310,7 +1323,9 @@ func TestSelectHost(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			// increase the randomness
 			for i := 0; i < 10; i++ {
 				got, err := selectHost(test.list)
@@ -1332,6 +1347,7 @@ func TestSelectHost(t *testing.T) {
 }
 
 func TestFindNodesThatPassExtenders(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                  string
 		extenders             []st.FakeExtender
@@ -1483,7 +1499,9 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var extenders []framework.Extender
 			for ii := range tt.extenders {
 				extenders = append(extenders, &tt.extenders[ii])
@@ -1511,6 +1529,7 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 }
 
 func TestSchedulerSchedulePod(t *testing.T) {
+	t.Parallel()
 	fts := feature.Features{}
 	tests := []struct {
 		name               string
@@ -1976,7 +1995,9 @@ func TestSchedulerSchedulePod(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			cache := internalcache.New(time.Duration(0), wait.NeverStop)
 			for _, pod := range test.pods {
 				cache.AddPod(pod)
@@ -2125,10 +2146,12 @@ func TestFindFitSomeError(t *testing.T) {
 	}
 
 	for _, node := range nodes {
+		node := node
 		if node.Name == pod.Name {
 			continue
 		}
 		t.Run(node.Name, func(t *testing.T) {
+			t.Parallel()
 			status, found := diagnosis.NodeToStatusMap[node.Name]
 			if !found {
 				t.Errorf("failed to find node %v in %v", node.Name, diagnosis.NodeToStatusMap)
@@ -2209,6 +2232,7 @@ func TestFindFitPredicateCallCounts(t *testing.T) {
 //     is the one being scheduled.
 //   - don't get the same score no matter what we schedule.
 func TestZeroRequest(t *testing.T) {
+	t.Parallel()
 	// A pod with no resources. We expect spreading to count it as having the default resources.
 	noResources := v1.PodSpec{
 		Containers: []v1.Container{
@@ -2297,7 +2321,9 @@ func TestZeroRequest(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			client := clientsetfake.NewSimpleClientset()
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 
@@ -2357,6 +2383,7 @@ func TestZeroRequest(t *testing.T) {
 var lowPriority, midPriority, highPriority = int32(0), int32(100), int32(1000)
 
 func TestNumFeasibleNodesToFind(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                     string
 		percentageOfNodesToScore int32
@@ -2398,7 +2425,9 @@ func TestNumFeasibleNodesToFind(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			sched := &Scheduler{
 				percentageOfNodesToScore: tt.percentageOfNodesToScore,
 			}
@@ -2453,6 +2482,7 @@ func TestFairEvaluationForNodes(t *testing.T) {
 }
 
 func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                  string
 		pod                   *v1.Pod
@@ -2479,7 +2509,9 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			// create three nodes in the cluster.
 			nodes := makeNodeList([]string{"node1", "node2", "node3"})
 			client := clientsetfake.NewSimpleClientset(test.pod)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -49,6 +49,7 @@ import (
 )
 
 func TestSchedulerCreation(t *testing.T) {
+	t.Parallel()
 	invalidRegistry := map[string]frameworkruntime.PluginFactory{
 		defaultbinder.Name: defaultbinder.New,
 	}
@@ -166,7 +167,9 @@ func TestSchedulerCreation(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			client := fake.NewSimpleClientset()
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 
@@ -231,6 +234,7 @@ func TestSchedulerCreation(t *testing.T) {
 }
 
 func TestFailureHandler(t *testing.T) {
+	t.Parallel()
 	testPod := st.MakePod().Name("test-pod").Namespace(v1.NamespaceDefault).Obj()
 	testPodUpdated := testPod.DeepCopy()
 	testPodUpdated.Labels = map[string]string{"foo": ""}
@@ -262,7 +266,9 @@ func TestFailureHandler(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -314,6 +320,7 @@ func TestFailureHandler(t *testing.T) {
 }
 
 func TestFailureHandler_NodeNotFound(t *testing.T) {
+	t.Parallel()
 	nodeFoo := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 	nodeBar := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "bar"}}
 	testPod := st.MakePod().Name("test-pod").Namespace(v1.NamespaceDefault).Obj()
@@ -340,7 +347,9 @@ func TestFailureHandler_NodeNotFound(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -383,6 +392,7 @@ func TestFailureHandler_NodeNotFound(t *testing.T) {
 }
 
 func TestFailureHandler_PodAlreadyBound(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -476,6 +486,7 @@ func initScheduler(stop <-chan struct{}, cache internalcache.Cache, queue intern
 }
 
 func TestInitPluginsWithIndexers(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		// the plugin registration ordering must not matter, being map traversal random
@@ -538,7 +549,9 @@ func TestInitPluginsWithIndexers(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			fakeInformerFactory := NewInformerFactory(&fake.Clientset{}, 0*time.Second)
 
 			var registerPluginFuncs []st.RegisterPluginFunc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Since go v1.7, the go testing package provides the ability to run [tests in parallel](https://pkg.go.dev/testing#T.Parallel). As this [post](https://engineering.mercari.com/en/blog/entry/20220408-how_to_use_t_parallel/) describes, unit tests will run in parallel at the package level. Therefore, this change allows increasing the number of processes during the execution of SIG/scheduling unit tests

* Before (forcing testing cleanup):
```bash
$ for i in {1..3}; do make test WHAT=./pkg/scheduler/; done
+++ [0914 12:42:23] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 12:42:25] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/scheduler 6.445s
+++ [0914 12:42:34] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 12:42:37] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/scheduler 6.424s
+++ [0914 12:42:46] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 12:42:48] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/scheduler 6.461s
```
* After (forcing testing cleanup):
```bash
$ for i in {1..3}; do make test WHAT=./pkg/scheduler/; done
+++ [0914 12:43:59] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 12:44:01] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/scheduler 1.160s
+++ [0914 12:44:05] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 12:44:08] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/scheduler 1.160s
+++ [0914 12:44:12] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0914 12:44:14] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/scheduler 1.159s
```



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NA

#### Special notes for your reviewer:

I have to force the testing cache to make sure improvements are achieved
```bash
$ git diff hack/make-rules/test.sh
diff --git a/hack/make-rules/test.sh b/hack/make-rules/test.sh
index d58bc929752..01465b9be7b 100755
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -257,6 +257,7 @@ runTests() {
 
   verifyPathsToPackagesUnderTest "$@"
 
+  go clean -testcache
   # If we're not collecting coverage, run all requested tests with one 'go test'
   # command, which is much faster.
   if [[ ! ${KUBE_COVER} =~ ^[yY]$ ]]; then
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
