### PR TITLE
Enable Parallel test execution

### DIFF
--- a/pkg/controlplane/controller_test.go
+++ b/pkg/controlplane/controller_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestCreateOrUpdateMasterService(t *testing.T) {
+	t.Parallel()
 	singleStack := corev1.IPFamilyPolicySingleStack
 	ns := metav1.NamespaceDefault
 	om := func(name string) metav1.ObjectMeta {
@@ -440,6 +441,7 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 }
 
 func Test_completedConfig_NewBootstrapController(t *testing.T) {
+	t.Parallel()
 
 	_, ipv4cidr, err := netutils.ParseCIDRSloppy("192.168.0.0/24")
 	if err != nil {
@@ -575,7 +577,9 @@ func Test_completedConfig_NewBootstrapController(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := &completedConfig{
 				GenericConfig: tt.config.Complete(nil),
 				ExtraConfig:   tt.extraConfig,

--- a/pkg/controlplane/import_known_versions_test.go
+++ b/pkg/controlplane/import_known_versions_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestGroupVersions(t *testing.T) {
+	t.Parallel()
 	// legacyUnsuffixedGroups contains the groups released prior to deciding that kubernetes API groups should be dns-suffixed
 	// new groups should be suffixed with ".k8s.io" (https://github.com/kubernetes/kubernetes/pull/31887#issuecomment-244462396)
 	legacyUnsuffixedGroups := sets.NewString(
@@ -79,6 +80,7 @@ var allowedNonstandardJSONNames = map[reflect.Type]string{
 }
 
 func TestTypeTags(t *testing.T) {
+	t.Parallel()
 	if err := apinamingtest.VerifyTagNaming(legacyscheme.Scheme, typesAllowedTags, allowedNonstandardJSONNames); err != nil {
 		t.Errorf("%v", err)
 	}

--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -165,6 +165,7 @@ func TestLegacyRestStorageStrategies(t *testing.T) {
 }
 
 func TestCertificatesRestStorageStrategies(t *testing.T) {
+	t.Parallel()
 	_, etcdserver, apiserverCfg, _ := newInstance(t)
 	defer etcdserver.Terminate(t)
 
@@ -194,6 +195,7 @@ func newInstance(t *testing.T) (*Instance, *etcd3testing.EtcdTestServer, Config,
 
 // TestVersion tests /version
 func TestVersion(t *testing.T) {
+	t.Parallel()
 	s, etcdserver, _, _ := newInstance(t)
 	defer etcdserver.Terminate(t)
 
@@ -231,6 +233,7 @@ func decodeResponse(resp *http.Response, obj interface{}) error {
 // Because we need to be backwards compatible with release 1.1, at endpoints
 // that exist in release 1.1, the responses should have empty APIVersion.
 func TestAPIVersionOfDiscoveryEndpoints(t *testing.T) {
+	t.Parallel()
 	apiserver, etcdserver, _, assert := newInstance(t)
 	defer etcdserver.Terminate(t)
 
@@ -288,6 +291,7 @@ func TestAPIVersionOfDiscoveryEndpoints(t *testing.T) {
 
 // This test doesn't cover the apiregistration and apiextensions group, as they are installed by other apiservers.
 func TestStorageVersionHashes(t *testing.T) {
+	t.Parallel()
 	apiserver, etcdserver, _, _ := newInstance(t)
 	defer etcdserver.Terminate(t)
 
@@ -335,6 +339,7 @@ func TestStorageVersionHashes(t *testing.T) {
 }
 
 func TestNoAlphaVersionsEnabledByDefault(t *testing.T) {
+	t.Parallel()
 	config := DefaultAPIResourceConfigSource()
 	for gv, enable := range config.GroupVersionConfigs {
 		if enable && strings.Contains(gv.Version, "alpha") {
@@ -344,6 +349,7 @@ func TestNoAlphaVersionsEnabledByDefault(t *testing.T) {
 }
 
 func TestNoBetaVersionsEnabledByDefault(t *testing.T) {
+	t.Parallel()
 	config := DefaultAPIResourceConfigSource()
 	for gv, enable := range config.GroupVersionConfigs {
 		if enable && strings.Contains(gv.Version, "beta") {
@@ -353,6 +359,7 @@ func TestNoBetaVersionsEnabledByDefault(t *testing.T) {
 }
 
 func TestNewBetaResourcesEnabledByDefault(t *testing.T) {
+	t.Parallel()
 	// legacyEnabledBetaResources is nearly a duplication from elsewhere.  This is intentional.  These types already have
 	// GA equivalents available and should therefore never have a beta enabled by default again.
 	legacyEnabledBetaResources := map[schema.GroupVersionResource]bool{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Since go v1.7, the go testing package provides the ability to run [tests in parallel](https://pkg.go.dev/testing#T.Parallel). As this [post](https://engineering.mercari.com/en/blog/entry/20220408-how_to_use_t_parallel/) describes, unit tests will run in parallel at the package level. Therefore, this change allows increasing the number of processes during the execution of SIG/api-machinery unit tests

* Before
```bash
$ for i in {1..3}; do make test WHAT=./pkg/controlplane/ ; done
+++ [0915 13:02:50] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0915 13:02:52] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/controlplane      4.114s
+++ [0915 13:03:01] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0915 13:03:04] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/controlplane      3.493s
+++ [0915 13:03:11] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0915 13:03:14] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/controlplane      3.366s
```
* After
```bash
$ for i in {1..3}; do make test WHAT=./pkg/controlplane/ ; done
+++ [0915 13:03:45] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0915 13:03:47] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/controlplane      1.972s
+++ [0915 13:03:53] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0915 13:03:55] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/controlplane      2.462s
+++ [0915 13:04:02] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0915 13:04:04] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/controlplane      2.187s
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NA

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```