### PR TITLE
Promote CoreV1NamespaceReplace Test +1 Endpoint

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -384,6 +384,13 @@
     MUST cause pods created by that RC to be orphaned.
   release: v1.9
   file: test/e2e/apimachinery/garbage_collector.go
+- testname: Namespace, apply update to a namespace
+  codename: '[sig-api-machinery] Namespaces [Serial] should apply an update to a Namespace
+    [Conformance]'
+  description: When updating the namespace it MUST succeed and the field MUST equal
+    the new value.
+  release: v1.26
+  file: test/e2e/apimachinery/namespace.go
 - testname: Namespace, apply changes to a namespace status
   codename: '[sig-api-machinery] Namespaces [Serial] should apply changes to a namespace
     status [Conformance]'

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -356,7 +356,13 @@ var _ = SIGDescribe("Namespaces [Serial]", func() {
 		framework.Logf("Status.Condition: %#v", statusUpdated.Status.Conditions[len(statusUpdated.Status.Conditions)-1])
 	})
 
-	ginkgo.It("should apply an update to a Namespace", func() {
+	/*
+		Release: v1.26
+		Testname: Namespace, apply update to a namespace
+		Description: When updating the namespace it MUST
+		succeed and the field MUST equal the new value.
+	*/
+	framework.ConformanceIt("should apply an update to a Namespace", func() {
 		var err error
 		var updatedNamespace *v1.Namespace
 		ns := f.Namespace.Name


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceCoreV1Namespace

**Which issue(s) this PR fixes:**
Fixes #111847

**Testgrid Link:** 
[testgrid-link](https://testgrid.k8s.io/sig-api-machinery-gce-gke#gce-serial&graph-metrics=test-duration-minutes&include-filter-by-regex=should.apply.an.update.to.a.Namespace&width=20)

**Special notes for your reviewer:**
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance