### PR TITLE
Add a "DisableCompression" option to kubeconfig

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -448,10 +448,12 @@ API rule violation: names_match,k8s.io/apimachinery/pkg/util/intstr,IntOrString,
 API rule violation: names_match,k8s.io/apimachinery/pkg/util/intstr,IntOrString,StrVal
 API rule violation: names_match,k8s.io/apimachinery/pkg/util/intstr,IntOrString,Type
 API rule violation: names_match,k8s.io/client-go/pkg/apis/clientauthentication/v1,Cluster,CertificateAuthorityData
+API rule violation: names_match,k8s.io/client-go/pkg/apis/clientauthentication/v1,Cluster,DisableCompression
 API rule violation: names_match,k8s.io/client-go/pkg/apis/clientauthentication/v1,Cluster,InsecureSkipTLSVerify
 API rule violation: names_match,k8s.io/client-go/pkg/apis/clientauthentication/v1,Cluster,ProxyURL
 API rule violation: names_match,k8s.io/client-go/pkg/apis/clientauthentication/v1,Cluster,TLSServerName
 API rule violation: names_match,k8s.io/client-go/pkg/apis/clientauthentication/v1beta1,Cluster,CertificateAuthorityData
+API rule violation: names_match,k8s.io/client-go/pkg/apis/clientauthentication/v1beta1,Cluster,DisableCompression
 API rule violation: names_match,k8s.io/client-go/pkg/apis/clientauthentication/v1beta1,Cluster,InsecureSkipTLSVerify
 API rule violation: names_match,k8s.io/client-go/pkg/apis/clientauthentication/v1beta1,Cluster,ProxyURL
 API rule violation: names_match,k8s.io/client-go/pkg/apis/clientauthentication/v1beta1,Cluster,TLSServerName

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -47274,6 +47274,13 @@ func schema_pkg_apis_clientauthentication_v1_Cluster(ref common.ReferenceCallbac
 							Format:      "",
 						},
 					},
+					"disable-compression": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DisableCompression allows client to opt-out of response compression for all requests to the server. This is useful to speed up requests (specifically lists) when client-server network bandwidth is ample, by saving time on compression (server-side) and decompression (client-side): https://github.com/kubernetes/kubernetes/issues/112296.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Config holds additional config data that is specific to the exec plugin with regards to the cluster being authenticated to.\n\nThis data is sourced from the clientcmd Cluster object's extensions[client.authentication.k8s.io/exec] field:\n\nclusters: - name: my-cluster\n  cluster:\n    ...\n    extensions:\n    - name: client.authentication.k8s.io/exec  # reserved extension name for per cluster exec config\n      extension:\n        audience: 06e3fbd18de8  # arbitrary config\n\nIn some environments, the user config may be exactly the same across many clusters (i.e. call this exec plugin) minus some details that are specific to each cluster such as the audience.  This field allows the per cluster config to be directly specified with the cluster info.  Using this field to store secret data is not recommended as one of the prime benefits of exec plugins is that no secrets need to be stored directly in the kubeconfig.",
@@ -47449,6 +47456,13 @@ func schema_pkg_apis_clientauthentication_v1beta1_Cluster(ref common.ReferenceCa
 						SchemaProps: spec.SchemaProps{
 							Description: "ProxyURL is the URL to the proxy to be used for all requests to this cluster.",
 							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"disable-compression": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DisableCompression allows client to opt-out of response compression for all requests to the server. This is useful to speed up requests (specifically lists) when client-server network bandwidth is ample, by saving time on compression (server-side) and decompression (client-side): https://github.com/kubernetes/kubernetes/issues/112296.",
+							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/types.go
@@ -98,6 +98,11 @@ type Cluster struct {
 	// cluster.
 	// +optional
 	ProxyURL string
+	// DisableCompression allows client to opt-out of response compression for all requests to the server. This is useful
+	// to speed up requests (specifically lists) when client-server network bandwidth is ample, by saving time on
+	// compression (server-side) and decompression (client-side): https://github.com/kubernetes/kubernetes/issues/112296.
+	// +optional
+	DisableCompression bool
 	// Config holds additional config data that is specific to the exec
 	// plugin with regards to the cluster being authenticated to.
 	//

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1/types.go
@@ -96,6 +96,11 @@ type Cluster struct {
 	// cluster.
 	// +optional
 	ProxyURL string `json:"proxy-url,omitempty"`
+	// DisableCompression allows client to opt-out of response compression for all requests to the server. This is useful
+	// to speed up requests (specifically lists) when client-server network bandwidth is ample, by saving time on
+	// compression (server-side) and decompression (client-side): https://github.com/kubernetes/kubernetes/issues/112296.
+	// +optional
+	DisableCompression bool `json:"disable-compression,omitempty"`
 	// Config holds additional config data that is specific to the exec
 	// plugin with regards to the cluster being authenticated to.
 	//

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1/zz_generated.conversion.go
@@ -86,6 +86,7 @@ func autoConvert_v1_Cluster_To_clientauthentication_Cluster(in *Cluster, out *cl
 	out.InsecureSkipTLSVerify = in.InsecureSkipTLSVerify
 	out.CertificateAuthorityData = *(*[]byte)(unsafe.Pointer(&in.CertificateAuthorityData))
 	out.ProxyURL = in.ProxyURL
+	out.DisableCompression = in.DisableCompression
 	if err := runtime.Convert_runtime_RawExtension_To_runtime_Object(&in.Config, &out.Config, s); err != nil {
 		return err
 	}
@@ -103,6 +104,7 @@ func autoConvert_clientauthentication_Cluster_To_v1_Cluster(in *clientauthentica
 	out.InsecureSkipTLSVerify = in.InsecureSkipTLSVerify
 	out.CertificateAuthorityData = *(*[]byte)(unsafe.Pointer(&in.CertificateAuthorityData))
 	out.ProxyURL = in.ProxyURL
+	out.DisableCompression = in.DisableCompression
 	if err := runtime.Convert_runtime_Object_To_runtime_RawExtension(&in.Config, &out.Config, s); err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1/types.go
@@ -96,6 +96,11 @@ type Cluster struct {
 	// cluster.
 	// +optional
 	ProxyURL string `json:"proxy-url,omitempty"`
+	// DisableCompression allows client to opt-out of response compression for all requests to the server. This is useful
+	// to speed up requests (specifically lists) when client-server network bandwidth is ample, by saving time on
+	// compression (server-side) and decompression (client-side): https://github.com/kubernetes/kubernetes/issues/112296.
+	// +optional
+	DisableCompression bool `json:"disable-compression,omitempty"`
 	// Config holds additional config data that is specific to the exec
 	// plugin with regards to the cluster being authenticated to.
 	//

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1/zz_generated.conversion.go
@@ -86,6 +86,7 @@ func autoConvert_v1beta1_Cluster_To_clientauthentication_Cluster(in *Cluster, ou
 	out.InsecureSkipTLSVerify = in.InsecureSkipTLSVerify
 	out.CertificateAuthorityData = *(*[]byte)(unsafe.Pointer(&in.CertificateAuthorityData))
 	out.ProxyURL = in.ProxyURL
+	out.DisableCompression = in.DisableCompression
 	if err := runtime.Convert_runtime_RawExtension_To_runtime_Object(&in.Config, &out.Config, s); err != nil {
 		return err
 	}
@@ -103,6 +104,7 @@ func autoConvert_clientauthentication_Cluster_To_v1beta1_Cluster(in *clientauthe
 	out.InsecureSkipTLSVerify = in.InsecureSkipTLSVerify
 	out.CertificateAuthorityData = *(*[]byte)(unsafe.Pointer(&in.CertificateAuthorityData))
 	out.ProxyURL = in.ProxyURL
+	out.DisableCompression = in.DisableCompression
 	if err := runtime.Convert_runtime_Object_To_runtime_RawExtension(&in.Config, &out.Config, s); err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/client-go/rest/exec.go
+++ b/staging/src/k8s.io/client-go/rest/exec.go
@@ -55,6 +55,7 @@ func ConfigToExecCluster(config *Config) (*clientauthenticationapi.Cluster, erro
 		InsecureSkipTLSVerify:    config.Insecure,
 		CertificateAuthorityData: caData,
 		ProxyURL:                 proxyURL,
+		DisableCompression:       config.DisableCompression,
 		Config:                   config.ExecProvider.Config,
 	}, nil
 }
@@ -79,6 +80,7 @@ func ExecClusterToConfig(cluster *clientauthenticationapi.Cluster) (*Config, err
 			ServerName: cluster.TLSServerName,
 			CAData:     cluster.CertificateAuthorityData,
 		},
-		Proxy: proxy,
+		Proxy:              proxy,
+		DisableCompression: cluster.DisableCompression,
 	}, nil
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
@@ -93,6 +93,11 @@ type Cluster struct {
 	// attach, port forward).
 	// +optional
 	ProxyURL string `json:"proxy-url,omitempty"`
+	// DisableCompression allows client to opt-out of response compression for all requests to the server. This is useful
+	// to speed up requests (specifically lists) when client-server network bandwidth is ample, by saving time on
+	// compression (server-side) and decompression (client-side): https://github.com/kubernetes/kubernetes/issues/112296.
+	// +optional
+	DisableCompression bool `json:"disable-compression,omitempty"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	// +optional
 	Extensions map[string]runtime.Object `json:"extensions,omitempty"`

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types_test.go
@@ -46,10 +46,12 @@ func Example_ofOptionsConfig() {
 		Server:                "https://alfa.org:8080",
 		InsecureSkipTLSVerify: true,
 		CertificateAuthority:  "path/to/my/cert-ca-filename",
+		DisableCompression:    true,
 	}
 	defaultConfig.Clusters["bravo"] = &Cluster{
 		Server:                "https://bravo.org:8080",
 		InsecureSkipTLSVerify: false,
+		DisableCompression:    false,
 	}
 	defaultConfig.AuthInfos["white-mage-via-cert"] = &AuthInfo{
 		ClientCertificate: "path/to/my/client-cert-filename",
@@ -94,6 +96,7 @@ func Example_ofOptionsConfig() {
 	//   alfa:
 	//     LocationOfOrigin: ""
 	//     certificate-authority: path/to/my/cert-ca-filename
+	//     disable-compression: true
 	//     insecure-skip-tls-verify: true
 	//     server: https://alfa.org:8080
 	//   bravo:

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
@@ -86,6 +86,11 @@ type Cluster struct {
 	// attach, port forward).
 	// +optional
 	ProxyURL string `json:"proxy-url,omitempty"`
+	// DisableCompression allows client to opt-out of response compression for all requests to the server. This is useful
+	// to speed up requests (specifically lists) when client-server network bandwidth is ample, by saving time on
+	// compression (server-side) and decompression (client-side): https://github.com/kubernetes/kubernetes/issues/112296.
+	// +optional
+	DisableCompression bool `json:"disable-compression,omitempty"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	// +optional
 	Extensions []NamedExtension `json:"extensions,omitempty"`

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/zz_generated.conversion.go
@@ -257,6 +257,7 @@ func autoConvert_v1_Cluster_To_api_Cluster(in *Cluster, out *api.Cluster, s conv
 	out.CertificateAuthority = in.CertificateAuthority
 	out.CertificateAuthorityData = *(*[]byte)(unsafe.Pointer(&in.CertificateAuthorityData))
 	out.ProxyURL = in.ProxyURL
+	out.DisableCompression = in.DisableCompression
 	if err := Convert_Slice_v1_NamedExtension_To_Map_string_To_runtime_Object(&in.Extensions, &out.Extensions, s); err != nil {
 		return err
 	}
@@ -276,6 +277,7 @@ func autoConvert_api_Cluster_To_v1_Cluster(in *api.Cluster, out *Cluster, s conv
 	out.CertificateAuthority = in.CertificateAuthority
 	out.CertificateAuthorityData = *(*[]byte)(unsafe.Pointer(&in.CertificateAuthorityData))
 	out.ProxyURL = in.ProxyURL
+	out.DisableCompression = in.DisableCompression
 	if err := Convert_Map_string_To_runtime_Object_To_Slice_v1_NamedExtension(&in.Extensions, &out.Extensions, s); err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -164,6 +164,8 @@ func (config *DirectClientConfig) ClientConfig() (*restclient.Config, error) {
 		clientConfig.Proxy = http.ProxyURL(u)
 	}
 
+	clientConfig.DisableCompression = configClusterInfo.DisableCompression
+
 	if config.overrides != nil && len(config.overrides.Timeout) > 0 {
 		timeout, err := ParseTimeout(config.overrides.Timeout)
 		if err != nil {

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -138,6 +138,22 @@ func createCAValidTestConfig() *clientcmdapi.Config {
 	return config
 }
 
+func TestDisableCompression(t *testing.T) {
+	config := createValidTestConfig()
+	clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{
+		ClusterInfo: clientcmdapi.Cluster{
+			DisableCompression: true,
+		},
+	}, nil)
+
+	actualCfg, err := clientBuilder.ClientConfig()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	matchBoolArg(true, actualCfg.DisableCompression, t)
+}
+
 func TestInsecureOverridesCA(t *testing.T) {
 	config := createCAValidTestConfig()
 	clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -73,8 +73,8 @@ var (
 			"red-user":    {Token: "a-different-red-token"},
 			"yellow-user": {Token: "yellow-token"}},
 		Clusters: map[string]*clientcmdapi.Cluster{
-			"cow-cluster":    {Server: "http://a-different-cow.org:8080", InsecureSkipTLSVerify: true},
-			"donkey-cluster": {Server: "http://donkey.org:8080", InsecureSkipTLSVerify: true}},
+			"cow-cluster":    {Server: "http://a-different-cow.org:8080", InsecureSkipTLSVerify: true, DisableCompression: true},
+			"donkey-cluster": {Server: "http://donkey.org:8080", InsecureSkipTLSVerify: true, DisableCompression: true}},
 		CurrentContext: "federal-context",
 	}
 )
@@ -736,6 +736,7 @@ func Example_mergingSomeWithConflict() {
 	//     server: http://cow.org:8080
 	//   name: cow-cluster
 	// - cluster:
+	//     disable-compression: true
 	//     insecure-skip-tls-verify: true
 	//     server: http://donkey.org:8080
 	//   name: donkey-cluster

--- a/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
@@ -74,6 +74,7 @@ type ClusterOverrideFlags struct {
 	InsecureSkipTLSVerify FlagInfo
 	TLSServerName         FlagInfo
 	ProxyURL              FlagInfo
+	DisableCompression    FlagInfo
 }
 
 // FlagInfo contains information about how to register a flag.  This struct is useful if you want to provide a way for an extender to
@@ -143,25 +144,26 @@ func (f FlagInfo) BindBoolFlag(flags *pflag.FlagSet, target *bool) FlagInfo {
 }
 
 const (
-	FlagClusterName      = "cluster"
-	FlagAuthInfoName     = "user"
-	FlagContext          = "context"
-	FlagNamespace        = "namespace"
-	FlagAPIServer        = "server"
-	FlagTLSServerName    = "tls-server-name"
-	FlagInsecure         = "insecure-skip-tls-verify"
-	FlagCertFile         = "client-certificate"
-	FlagKeyFile          = "client-key"
-	FlagCAFile           = "certificate-authority"
-	FlagEmbedCerts       = "embed-certs"
-	FlagBearerToken      = "token"
-	FlagImpersonate      = "as"
-	FlagImpersonateUID   = "as-uid"
-	FlagImpersonateGroup = "as-group"
-	FlagUsername         = "username"
-	FlagPassword         = "password"
-	FlagTimeout          = "request-timeout"
-	FlagProxyURL         = "proxy-url"
+	FlagClusterName        = "cluster"
+	FlagAuthInfoName       = "user"
+	FlagContext            = "context"
+	FlagNamespace          = "namespace"
+	FlagAPIServer          = "server"
+	FlagTLSServerName      = "tls-server-name"
+	FlagInsecure           = "insecure-skip-tls-verify"
+	FlagCertFile           = "client-certificate"
+	FlagKeyFile            = "client-key"
+	FlagCAFile             = "certificate-authority"
+	FlagEmbedCerts         = "embed-certs"
+	FlagBearerToken        = "token"
+	FlagImpersonate        = "as"
+	FlagImpersonateUID     = "as-uid"
+	FlagImpersonateGroup   = "as-group"
+	FlagUsername           = "username"
+	FlagPassword           = "password"
+	FlagTimeout            = "request-timeout"
+	FlagProxyURL           = "proxy-url"
+	FlagDisableCompression = "disable-compression"
 )
 
 // RecommendedConfigOverrideFlags is a convenience method to return recommended flag names prefixed with a string of your choosing
@@ -198,6 +200,7 @@ func RecommendedClusterOverrideFlags(prefix string) ClusterOverrideFlags {
 		InsecureSkipTLSVerify: FlagInfo{prefix + FlagInsecure, "", "false", "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure"},
 		TLSServerName:         FlagInfo{prefix + FlagTLSServerName, "", "", "If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used."},
 		ProxyURL:              FlagInfo{prefix + FlagProxyURL, "", "", "If provided, this URL will be used to connect via proxy"},
+		DisableCompression:    FlagInfo{prefix + FlagDisableCompression, "", "", "If true, opt-out of response compression for all requests to the server"},
 	}
 }
 
@@ -238,6 +241,7 @@ func BindClusterFlags(clusterInfo *clientcmdapi.Cluster, flags *pflag.FlagSet, f
 	flagNames.InsecureSkipTLSVerify.BindBoolFlag(flags, &clusterInfo.InsecureSkipTLSVerify)
 	flagNames.TLSServerName.BindStringFlag(flags, &clusterInfo.TLSServerName)
 	flagNames.ProxyURL.BindStringFlag(flags, &clusterInfo.ProxyURL)
+	flagNames.DisableCompression.BindBoolFlag(flags, &clusterInfo.DisableCompression)
 }
 
 // BindFlags is a convenience method to bind the specified flags to their associated variables


### PR DESCRIPTION
#### What this PR does / why we need it:
Part-2 of the proposal here - https://github.com/kubernetes/kubernetes/issues/112296
/kind feature

#### Does this PR introduce a user-facing change?
```release-note
A new "DisableCompression" field (default = false) has been added to kubeconfig under cluster info. When set to true, clients using the kubeconfig opt out of response compression for all requests to the apiserver. This can help improve list call latencies significantly when client-server network bandwidth is ample (>30MB/s) or if the server is CPU-constrained.
```

/assign @lavalamp @deads2k 
/sig api-machinery