### PR TITLE
Add additional Delaying Queue methods which enable finer control over the delaying and de-duplication features

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -2847,7 +2847,7 @@ func (t *trackingWorkqueue) ShuttingDown() bool {
 	return t.limiter.ShuttingDown()
 }
 func (t *trackingWorkqueue) AddWithOptions(item interface{}, opts workqueue.DelayingOptions) {
-	t.limiter.AddWithOptions(item, opts)
+	t.Add(item)
 }
 func (t *trackingWorkqueue) DoneWaiting(item interface{}) {
 	t.limiter.DoneWaiting(item)

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -2846,6 +2846,18 @@ func (t *trackingWorkqueue) ShutDownWithDrain() {
 func (t *trackingWorkqueue) ShuttingDown() bool {
 	return t.limiter.ShuttingDown()
 }
+func (t *trackingWorkqueue) AddWithOptions(item interface{}, opts workqueue.DelayingOptions) {
+	t.limiter.AddWithOptions(item, opts)
+}
+func (t *trackingWorkqueue) DoneWaiting(item interface{}) {
+	t.limiter.DoneWaiting(item)
+}
+func (t *trackingWorkqueue) IsWaiting(item interface{}) (bool, time.Duration) {
+	return t.limiter.IsWaiting(item)
+}
+func (t *trackingWorkqueue) LenWaiting() int {
+	return t.limiter.LenWaiting()
+}
 
 func (t *trackingWorkqueue) queue(item interface{}) {
 	if _, queued := t.pendingMap[item]; queued {

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -2815,6 +2815,10 @@ func (t *trackingWorkqueue) Get() (interface{}, bool) {
 	t.dequeue(item)
 	return item, shutdown
 }
+func (t *trackingWorkqueue) IsQueued(item interface{}) bool {
+	_, ok := t.pendingMap[item]
+	return ok
+}
 func (t *trackingWorkqueue) Done(item interface{}) {
 	t.limiter.Done(item)
 }

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -4705,6 +4705,26 @@ func (f *fakeRateLimitingQueue) AddAfter(item interface{}, duration time.Duratio
 	f.item = item
 	f.duration = duration
 }
+func (f *fakeRateLimitingQueue) AddWithOptions(item interface{}, opts workqueue.DelayingOptions) {
+	f.item = item
+	f.duration = opts.Duration
+}
+func (f *fakeRateLimitingQueue) DoneWaiting(item interface{}) {
+	f.item = nil
+	f.duration = time.Duration(0)
+}
+func (f *fakeRateLimitingQueue) IsWaiting(item interface{}) (bool, time.Duration) {
+	if f.item == nil {
+		return false, time.Duration(0)
+	}
+	return true, f.duration
+}
+func (f *fakeRateLimitingQueue) LenWaiting() int {
+	if f.item == nil {
+		return 0
+	}
+	return 1
+}
 
 func TestJobBackoff(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -27,11 +27,55 @@ import (
 
 // DelayingInterface is an Interface that can Add an item at a later time. This makes it easier to
 // requeue items after failures without ending up in a hot-loop.
+// A Delaying queue can be thought of two separate queues that work together - an 'active' queue of
+// items which we want to process ASAP and a 'waiting' queue of items which must wait for a period of time
+// to elapse before they are popped from the 'waiting' queue and added to the 'active' queue.
 type DelayingInterface interface {
 	Interface
 	// AddAfter adds an item to the workqueue after the indicated duration has passed
 	AddAfter(item interface{}, duration time.Duration)
 }
+
+// ExpandedDelayingInterface provides additional control over the behaviour of the delaying behaviour and allows
+// us to keep the original interface intact for legacy clients.
+type ExpandedDelayingInterface interface {
+	DelayingInterface
+	// AddWithOptions allows full control over the delaying queue features.
+	AddWithOptions(item interface{}, opts ExpandedDelayingOptions)
+	// DoneWaiting will remove an item from the 'waiting' queue.
+	// If you want to cancel 'active' queued items you need to call Done().
+	DoneWaiting(item interface{})
+}
+
+// ExpandedDelayingOptions toggle implementation specific options for use with ExpandedDelayingInterface
+type ExpandedDelayingOptions struct {
+	// Duration specifies for how long this item should be delayed before being added back into the 'active' queue.
+	Duration time.Duration
+	// Waiting specifies how you want the waitingLoop to treat items that are already present in the 'waiting' queue.
+	WhenWaiting AlreadyWaitingBehaviour
+	// PermitActiveAndWaiting overrides the default queue behaviour which ensures that an item is not allowed to be simultaneously
+	// queued in both the 'active' and 'waiting' queues.
+	// Setting PermitActiveAndWaiting to 'true' results in the following: -
+	// 1. A item with a delay (Duration > 0) can be queued to 'waiting' when the same item is in the 'active' queue.
+	// 2. A 'waiting' item will remain queued if the same item is subsequently queued to the 'active' queue with this option set.
+	PermitActiveAndWaiting bool
+	// Synchronous defines whether to wait for an item to be processed into the queue (or be dropped) before returning.
+	Synchronous bool
+}
+
+// AlreadyWaitingBehaviour defines different choices of how to handle a delayed add when there is already the same item in the 'waiting' queue.
+type AlreadyWaitingBehaviour int
+
+const (
+	// TakeShorter will modify the waiting item's wait time only if the incoming item has as shorter delay duration.
+	TakeShorter AlreadyWaitingBehaviour = iota
+	// TakeLonger will modify the waiting item's wait time only if the incoming item has a longer delay duration.
+	TakeLonger
+	// TakeIncoming will always adjust the delay of the waiting item with the delay of the incoming item unless they are equal.
+	TakeIncoming
+	// TakeExisting will never modify the waiting item's wait time, so effectively works as an "add only if the item is not already in the 'waiting' queue."
+	TakeExisting
+)
 
 // DelayingQueueConfig specifies optional configurations to customize a DelayingInterface.
 type DelayingQueueConfig struct {
@@ -52,13 +96,13 @@ type DelayingQueueConfig struct {
 // NewDelayingQueue constructs a new workqueue with delayed queuing ability.
 // NewDelayingQueue does not emit metrics. For use with a MetricsProvider, please use
 // NewDelayingQueueWithConfig instead and specify a name.
-func NewDelayingQueue() DelayingInterface {
+func NewDelayingQueue() *delayingType {
 	return NewDelayingQueueWithConfig(DelayingQueueConfig{})
 }
 
 // NewDelayingQueueWithConfig constructs a new workqueue with options to
 // customize different properties.
-func NewDelayingQueueWithConfig(config DelayingQueueConfig) DelayingInterface {
+func NewDelayingQueueWithConfig(config DelayingQueueConfig) *delayingType {
 	if config.Clock == nil {
 		config.Clock = clock.RealClock{}
 	}
@@ -93,7 +137,7 @@ func NewNamedDelayingQueue(name string) DelayingInterface {
 // NewDelayingQueueWithCustomClock constructs a new named workqueue
 // with ability to inject real or fake clock for testing purposes.
 // Deprecated: Use NewDelayingQueueWithConfig instead.
-func NewDelayingQueueWithCustomClock(clock clock.WithTicker, name string) DelayingInterface {
+func NewDelayingQueueWithCustomClock(clock clock.WithTicker, name string) *delayingType {
 	return NewDelayingQueueWithConfig(DelayingQueueConfig{
 		Name:  name,
 		Clock: clock,
@@ -102,46 +146,91 @@ func NewDelayingQueueWithCustomClock(clock clock.WithTicker, name string) Delayi
 
 func newDelayingQueue(clock clock.WithTicker, q Interface, name string, provider MetricsProvider) *delayingType {
 	ret := &delayingType{
-		Interface:       q,
-		clock:           clock,
-		heartbeat:       clock.NewTicker(maxWait),
-		stopCh:          make(chan struct{}),
-		waitingForAddCh: make(chan *waitFor, 1000),
-		metrics:         newRetryMetrics(name, provider),
+		Interface:          q,
+		clock:              clock,
+		nextReadyAtTimerCh: make(<-chan time.Time),
+		heartbeat:          clock.NewTicker(maxWait),
+		stopCh:             make(chan struct{}),
+		waitingForAddCh:    make(chan *waitFor, 1000),
+		metrics:            newRetryMetrics(name, provider),
 	}
 
 	go ret.waitingLoop()
 	return ret
 }
 
-// delayingType wraps an Interface and provides delayed re-enquing
+// delayingType wraps an Interface and provides delayed re-enqueuing
 type delayingType struct {
 	Interface
+
+	// afterFill - a list of waitFor that require processing after the queue has filled and nextReadyAt
+	// has been re-calculated.
+	afterFill []*waitFor
 
 	// clock tracks time for delayed firing
 	clock clock.Clock
 
-	// stopCh lets us signal a shutdown to the waiting loop
-	stopCh chan struct{}
-	// stopOnce guarantees we only signal shutdown a single time
-	stopOnce sync.Once
+	// headReadyTime tracks the next time the head of the 'waiting' queue should become active.
+	headReadyTime time.Time
 
 	// heartbeat ensures we wait no more than maxWait before firing
 	heartbeat clock.Ticker
 
-	// waitingForAddCh is a buffered channel that feeds waitingForAdd
-	waitingForAddCh chan *waitFor
-
 	// metrics counts the number of retries
 	metrics retryMetrics
+
+	// nextReadyAtTimer is a timer used to create nextReadyAt signals when an item matures ready
+	// for queuing in the 'active' queue.
+	nextReadyAtTimer clock.Timer
+
+	// nextReadyAtTimerCh is the channel to return the signal from the timer.const
+	// We set it explicitly so that we can set it to 'never' by detaching it from the timer.
+	nextReadyAtTimerCh <-chan time.Time
+
+	// stopCh lets us signal a shutdown to the waitingLoop
+	stopCh chan struct{}
+	// stopOnce guarantees we only signal shutdown a single time
+	stopOnce sync.Once
+
+	// waitingForAddCh is a buffered channel that feeds waitingForAdd
+	waitingForAddCh chan *waitFor
 }
+
+var _ DelayingInterface = &delayingType{}
+var _ ExpandedDelayingInterface = &delayingType{}
+var _ Interface = &delayingType{}
+
+// waitForAction defines what we are asking the queue to do (which is usually queue an item but can be other things)
+type waitForAction int
+
+const (
+	// waitForActionQueue - queue the item in the delaying queue
+	waitForActionQueue waitForAction = iota
+	// waitForActionDoneWaiting - forget the item provided if 'waiting'
+	waitForActionDoneWaiting
+	// waitForActionIsWaiting - report back on an item existing in the 'waiting' queue.
+	waitForActionIsWaiting
+	// waitForActionLenWaiting - report back on the waiting queue length
+	waitForActionLenWaiting
+	// waitForActionNextReady - report back on the next item to be ready.
+	waitForActionNextReady
+	// waitForActionSyncFill - close return channel when the 'waiting' queue is filled
+	// and the nextReadyAt timer has been updated.
+	waitForActionSyncFill
+)
 
 // waitFor holds the data to add and the time it should be added
 type waitFor struct {
+	action  waitForAction
 	data    t
 	readyAt time.Time
 	// index in the priority queue (heap)
 	index int
+	// options defines how the caller would like the item to behave.
+	options ExpandedDelayingOptions
+	// returnCh allows the caller to block pending the processing and to also return
+	// a response value which can represent a stat such as existence or 'waiting' queue length.
+	returnCh chan waitingLoopResponse
 }
 
 // waitForPriorityQueue implements a priority queue for waitFor items.
@@ -223,6 +312,102 @@ func (q *delayingType) AddAfter(item interface{}, duration time.Duration) {
 	}
 }
 
+// AddWithOptions gives callers more control over the queueing behaviour.
+// Calls are asynchronous unless option Synchronous is set.
+func (q *delayingType) AddWithOptions(item interface{}, opts ExpandedDelayingOptions) {
+	q.sendItemToWaitingLoop(item, opts, waitForActionQueue)
+}
+
+// ForgetWaiting removes an item from the delayed queue, effectively cancelling its future processing.
+func (q *delayingType) DoneWaiting(item interface{}) {
+	q.sendItemToWaitingLoop(item, ExpandedDelayingOptions{}, waitForActionDoneWaiting)
+}
+
+// isWaiting returns a bool indicating whether the given item is queued in the 'waiting' queue.
+// The client can call IsQueued() in order to determine whether an item is queued in the 'active' queue.
+func (q *delayingType) isWaiting(item interface{}) (bool, time.Duration) {
+	result := q.sendItemToWaitingLoop(item, ExpandedDelayingOptions{Synchronous: true}, waitForActionIsWaiting)
+	if result.exists != nil && result.nextReady != nil {
+		return *result.exists, *result.nextReady
+	}
+	return false, 0
+}
+
+// lenWaiting returns an int representing the number of items queued in the 'waiting' queue.
+// The client can call Len() in order to determine the number of items in the 'active' queue.
+func (q *delayingType) lenWaiting() int {
+	result := q.sendItemToWaitingLoop(nil, ExpandedDelayingOptions{Synchronous: true}, waitForActionLenWaiting)
+	if result.length != nil {
+		return *result.length
+	}
+	return 0
+}
+
+// nextReady returns the item at the head of the 'waiting' queue and how long it has left to wait.
+func (q *delayingType) nextReady() (interface{}, time.Duration) {
+	result := q.sendItemToWaitingLoop(nil, ExpandedDelayingOptions{Synchronous: true}, waitForActionNextReady)
+	if result.nextReady != nil {
+		return result.item, *result.nextReady
+	}
+	return nil, 0
+}
+
+// syncFill blocks until the delaying queue has drained all items from its feeder channel, processed
+// them into their appropriate queue and updated the nextReadyAt time as necessary.
+func (q *delayingType) syncFill() {
+	q.sendItemToWaitingLoop(nil, ExpandedDelayingOptions{Synchronous: true}, waitForActionSyncFill)
+}
+
+// sendItemToWaitingLoop facilitates the different interface methods and performs the actual add, sending,
+// forgetting an item, by sending an appropriate message through to the waitingLoop.
+func (q *delayingType) sendItemToWaitingLoop(item interface{}, opts ExpandedDelayingOptions, action waitForAction) waitingLoopResponse {
+	var result waitingLoopResponse
+
+	// don't add if we're already shutting down
+	if q.Interface.ShuttingDown() {
+		return result
+	}
+
+	// Add the item into the delaying queue (either the 'active' or 'waiting' queue)
+	waitEntry := &waitFor{
+		action:  action,
+		data:    item,
+		readyAt: q.clock.Now().Add(opts.Duration),
+		options: opts,
+	}
+
+	// For synchronous calls we will create a channel that we can wait to be released (closed).
+	var cb chan waitingLoopResponse
+	if opts.Synchronous {
+		cb = make(chan waitingLoopResponse)
+		waitEntry.returnCh = cb
+	}
+
+	// Send the entry to the waitingLoop...
+	select {
+	case <-q.stopCh:
+		// unblock if ShutDown() is called
+	case q.waitingForAddCh <- waitEntry:
+		// wait for call-back if we asked for one...
+		if opts.Synchronous {
+			select {
+			case <-q.stopCh:
+			case result = <-cb:
+			}
+		}
+	}
+	return result
+}
+
+// waitingLoopResponse describes the message that is returned from the waiting loop when a response
+// is requested/required.  It contains the different answer types that may be in the response.
+type waitingLoopResponse struct {
+	item      interface{}
+	exists    *bool
+	length    *int
+	nextReady *time.Duration
+}
+
 // maxWait keeps a max bound on the wait time. It's just insurance against weird things happening.
 // Checking the queue every 10 seconds isn't expensive and we know that we'll never end up with an
 // expired item sitting for more than 10 seconds.
@@ -231,12 +416,6 @@ const maxWait = 10 * time.Second
 // waitingLoop runs until the workqueue is shutdown and keeps a check on the list of items to be added.
 func (q *delayingType) waitingLoop() {
 	defer utilruntime.HandleCrash()
-
-	// Make a placeholder channel to use when there are no items in our list
-	never := make(<-chan time.Time)
-
-	// Make a timer that expires when the item at the head of the waiting queue is ready
-	var nextReadyAtTimer clock.Timer
 
 	waitingForQueue := &waitForPriorityQueue{}
 	heap.Init(waitingForQueue)
@@ -248,30 +427,20 @@ func (q *delayingType) waitingLoop() {
 			return
 		}
 
-		now := q.clock.Now()
-
 		// Add ready entries
 		for waitingForQueue.Len() > 0 {
 			entry := waitingForQueue.Peek().(*waitFor)
-			if entry.readyAt.After(now) {
+			if entry.readyAt.After(q.clock.Now()) {
 				break
 			}
-
 			entry = heap.Pop(waitingForQueue).(*waitFor)
-			q.Add(entry.data)
+			q.Interface.Add(entry.data)
 			delete(waitingEntryByData, entry.data)
 		}
 
 		// Set up a wait for the first item's readyAt (if one exists)
-		nextReadyAt := never
-		if waitingForQueue.Len() > 0 {
-			if nextReadyAtTimer != nil {
-				nextReadyAtTimer.Stop()
-			}
-			entry := waitingForQueue.Peek().(*waitFor)
-			nextReadyAtTimer = q.clock.NewTimer(entry.readyAt.Sub(now))
-			nextReadyAt = nextReadyAtTimer.C()
-		}
+		q.calculateNextReadyAt(waitingForQueue)
+		q.handleReportingAndSync(waitingForQueue, waitingEntryByData)
 
 		select {
 		case <-q.stopCh:
@@ -280,25 +449,17 @@ func (q *delayingType) waitingLoop() {
 		case <-q.heartbeat.C():
 			// continue the loop, which will add ready items
 
-		case <-nextReadyAt:
+		case <-q.nextReadyAtTimerCh:
 			// continue the loop, which will add ready items
 
 		case waitEntry := <-q.waitingForAddCh:
-			if waitEntry.readyAt.After(q.clock.Now()) {
-				insert(waitingForQueue, waitingEntryByData, waitEntry)
-			} else {
-				q.Add(waitEntry.data)
-			}
+			q.processArrivingWaitForEntry(waitingForQueue, waitingEntryByData, waitEntry)
 
 			drained := false
 			for !drained {
 				select {
 				case waitEntry := <-q.waitingForAddCh:
-					if waitEntry.readyAt.After(q.clock.Now()) {
-						insert(waitingForQueue, waitingEntryByData, waitEntry)
-					} else {
-						q.Add(waitEntry.data)
-					}
+					q.processArrivingWaitForEntry(waitingForQueue, waitingEntryByData, waitEntry)
 				default:
 					drained = true
 				}
@@ -307,19 +468,166 @@ func (q *delayingType) waitingLoop() {
 	}
 }
 
-// insert adds the entry to the priority queue, or updates the readyAt if it already exists in the queue
+// insert adds the entry to the 'waiting' queue, or updates the readyAt if it already exists in the queue
+// It returns a boolean to indicate that the entry was inserted or not.
 func insert(q *waitForPriorityQueue, knownEntries map[t]*waitFor, entry *waitFor) {
-	// if the entry already exists, update the time only if it would cause the item to be queued sooner
+	// if the entry already exists, update the time according to the entry.options.WhenWaiting
 	existing, exists := knownEntries[entry.data]
 	if exists {
-		if existing.readyAt.After(entry.readyAt) {
+		var replace bool
+		switch entry.options.WhenWaiting {
+		case TakeShorter:
+			replace = existing.readyAt.After(entry.readyAt)
+		case TakeLonger:
+			replace = existing.readyAt.Before(entry.readyAt)
+		case TakeIncoming:
+			replace = !existing.readyAt.Equal(entry.readyAt)
+		}
+		if replace {
 			existing.readyAt = entry.readyAt
+			existing.options = entry.options
 			heap.Fix(q, existing.index)
 		}
-
 		return
 	}
 
 	heap.Push(q, entry)
 	knownEntries[entry.data] = entry
+}
+
+// calculateNextReadyAt recalculates the nextReadyAtTime as follows:
+// - removes the timer when the 'waiting' queue is empty.
+// - resets the timer when the head 'waiting' item has changed.
+// - creates a new timer when 1+ items are queued to an empty 'waiting' queue.
+func (q *delayingType) calculateNextReadyAt(w *waitForPriorityQueue) {
+	var head *waitFor
+
+	// early escape when the timer has not changed
+	if w.Len() > 0 {
+		head = w.Peek().(*waitFor)
+		if q.headReadyTime.Equal(head.readyAt) {
+			return
+		}
+	}
+
+	// reset timer
+	if q.nextReadyAtTimer != nil {
+		q.nextReadyAtTimerCh = make(<-chan time.Time)
+		q.nextReadyAtTimer.Stop()
+		q.nextReadyAtTimer = nil
+		q.headReadyTime = time.Time{}
+	}
+
+	// create new timer
+	if head != nil {
+		now := q.clock.Now()
+		q.nextReadyAtTimer = q.clock.NewTimer(head.readyAt.Sub(now))
+		q.nextReadyAtTimerCh = q.nextReadyAtTimer.C()
+		q.headReadyTime = head.readyAt
+	}
+}
+
+// handleReportingAndSync loops through the inspection requests and syncs and loops through providing the answers
+// and closing the return channel.
+func (q *delayingType) handleReportingAndSync(w *waitForPriorityQueue, knownEntries map[t]*waitFor) {
+	if len(q.afterFill) == 0 {
+		return
+	}
+
+	for _, req := range q.afterFill {
+		r := waitingLoopResponse{}
+		switch req.action {
+		case waitForActionIsWaiting:
+			_, exists := knownEntries[req.data]
+			r.exists = &exists
+			nr := req.readyAt.Sub(q.clock.Now())
+			r.nextReady = &nr
+		case waitForActionLenWaiting:
+			l := w.Len()
+			r.length = &l
+		case waitForActionNextReady:
+			if w.Len() > 0 {
+				r.item = w.Peek().(*waitFor).data
+				nr := q.headReadyTime.Sub(q.clock.Now())
+				r.nextReady = &nr
+			}
+		case waitForActionSyncFill:
+		}
+		req.returnCh <- r
+		close(req.returnCh)
+	}
+	q.afterFill = nil
+}
+
+// processArrivingWaitForEntry receives messages received from clients a takes the appropriate queuing based
+// upon the entry.action requested.
+// When performing the waitForActionQueue action it behaves as follows:
+//   - An entry is dropped if it is already actively queued (much like Add() on the Interface)
+//   - Delayed items are inserted into the 'waiting' queue according to their Waiting option (TakeShorter by default)
+//   - Immediate items will be dropped when the TakeLonger Waiting option is set and they are already present in 'waiting'.
+//   - Immediate items will pre-empt/remove items in the 'waiting' queue unless the PermitActiveAndWaiting option is set.
+func (q *delayingType) processArrivingWaitForEntry(w *waitForPriorityQueue, knownEntries map[t]*waitFor, entry *waitFor) {
+	// handle the different message actions
+	switch entry.action {
+	case waitForActionIsWaiting, waitForActionLenWaiting, waitForActionNextReady, waitForActionSyncFill:
+		// all of these actions are processed in the call handleReportingAndSync()
+		if entry.returnCh == nil {
+			return
+		}
+		q.afterFill = append(q.afterFill, entry)
+		return
+	case waitForActionDoneWaiting:
+		// remove entry from the 'waiting' queue
+		existing, exists := knownEntries[entry.data]
+		if exists {
+			// remove the item from the 'waiting' queue
+			heap.Remove(w, existing.index)
+			delete(knownEntries, entry.data)
+		}
+		return
+	case waitForActionQueue:
+		// add entry to either 'active' or 'waiting' queues (dependent on delay and settings)
+		if entry.returnCh != nil {
+			defer close(entry.returnCh)
+		}
+
+		// Perform de-duplication between the 'waiting' queue against items in the 'active' queue unless
+		// disabled by PermitActiveAndWaiting.
+		if !entry.options.PermitActiveAndWaiting && q.Interface.IsQueued(entry.data) {
+			return
+		}
+
+		// drop if the incoming item if the caller wishes to keep the existing item if it exists.
+		existing, exists := knownEntries[entry.data]
+		if exists && entry.options.WhenWaiting == TakeExisting {
+			return
+		}
+
+		// delayed add (to 'waiting' queue)
+		if entry.readyAt.After(q.clock.Now()) {
+			// inform the metrics of the retry (moved from AddAfter())
+			q.metrics.retry()
+
+			// insert the entry into the 'waiting' queue with appropriate insertion strategy defined by options.Waiting
+			insert(w, knownEntries, entry)
+			return
+		}
+
+		// immediate add (to 'active' queue)
+		if exists {
+			// items in the 'waiting' queue must be longer than an immediate add, if we TakeLonger we must drop this add.
+			if entry.options.WhenWaiting == TakeLonger {
+				return
+			}
+			// This covers both the TakeShorter and TakeIncoming cases because this is incoming and must be the shortest
+			// right now too.  We will remove/pre-empt the item in the 'waiting' queue unless disabled.
+			if !entry.options.PermitActiveAndWaiting {
+				heap.Remove(w, existing.index)
+				delete(knownEntries, entry.data)
+			}
+		}
+
+		// Perform the immediate add to the 'active' queue.
+		q.Interface.Add(entry.data)
+	}
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -480,13 +480,13 @@ func (q *delayingType) waitingLoop() {
 			// continue the loop, which will add ready items
 
 		case msg := <-q.waitingForAddCh:
-			q.processArrivingWaitForEntry(waitingForQueue, waitingEntryByData, msg)
+			q.processArrivingWaitLoopMessage(waitingForQueue, waitingEntryByData, msg)
 
 			drained := false
 			for !drained {
 				select {
 				case msg := <-q.waitingForAddCh:
-					q.processArrivingWaitForEntry(waitingForQueue, waitingEntryByData, msg)
+					q.processArrivingWaitLoopMessage(waitingForQueue, waitingEntryByData, msg)
 				default:
 					drained = true
 				}
@@ -587,14 +587,14 @@ func (q *delayingType) handleReportingAndSync(w *waitForPriorityQueue, knownEntr
 	q.afterFill = nil
 }
 
-// processArrivingWaitForEntry receives messages received from clients a takes the appropriate queuing based
+// processArrivingWaitLoopMessage receives messages received from clients a takes the appropriate queuing based
 // upon the entry.action requested.
 // When performing the msgActionQueue action it behaves as follows:
 //   - An entry is dropped if it is already actively queued (much like Add() on the Interface)
 //   - Delayed items are inserted into the 'waiting' queue according to their Waiting option (TakeShorter by default)
 //   - Immediate items will be dropped when the TakeLonger Waiting option is set and they are already present in 'waiting'.
 //   - Immediate items will pre-empt/remove items in the 'waiting' queue unless the PermitActiveAndWaiting option is set.
-func (q *delayingType) processArrivingWaitForEntry(w *waitForPriorityQueue, knownEntries map[t]*waitFor, msg *waitLoopMessage) {
+func (q *delayingType) processArrivingWaitLoopMessage(w *waitForPriorityQueue, knownEntries map[t]*waitFor, msg *waitLoopMessage) {
 	// handle the different message actions
 	switch msg.action {
 	case msgActionIsWaiting, msgActionLenWaiting, msgActionNextReady, msgActionSyncFill:

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -311,7 +311,13 @@ func (q *delayingType) AddAfter(item interface{}, duration time.Duration) {
 	select {
 	case <-q.stopCh:
 		// unblock if ShutDown() is called
-	case q.waitingForAddCh <- &waitFor{data: item, readyAt: q.clock.Now().Add(duration)}:
+	case q.waitingForAddCh <- &waitFor{
+		data:    item,
+		readyAt: q.clock.Now().Add(duration),
+		options: ExpandedDelayingOptions{
+			PermitActiveAndWaiting: true,
+		}}:
+		// set PermitActiveAndWaiting to true so that the "active" and "waiting" queues act in isolation from each other.
 	}
 }
 

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -302,8 +302,6 @@ func (q *delayingType) AddAfter(item interface{}, duration time.Duration) {
 		return
 	}
 
-	q.metrics.retry()
-
 	// immediately add things with no delay
 	if duration <= 0 {
 		q.Add(item)

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -96,13 +96,13 @@ type DelayingQueueConfig struct {
 // NewDelayingQueue constructs a new workqueue with delayed queuing ability.
 // NewDelayingQueue does not emit metrics. For use with a MetricsProvider, please use
 // NewDelayingQueueWithConfig instead and specify a name.
-func NewDelayingQueue() *delayingType {
+func NewDelayingQueue() DelayingInterface {
 	return NewDelayingQueueWithConfig(DelayingQueueConfig{})
 }
 
 // NewDelayingQueueWithConfig constructs a new workqueue with options to
 // customize different properties.
-func NewDelayingQueueWithConfig(config DelayingQueueConfig) *delayingType {
+func NewDelayingQueueWithConfig(config DelayingQueueConfig) DelayingInterface {
 	if config.Clock == nil {
 		config.Clock = clock.RealClock{}
 	}
@@ -137,14 +137,14 @@ func NewNamedDelayingQueue(name string) DelayingInterface {
 // NewDelayingQueueWithCustomClock constructs a new named workqueue
 // with ability to inject real or fake clock for testing purposes.
 // Deprecated: Use NewDelayingQueueWithConfig instead.
-func NewDelayingQueueWithCustomClock(clock clock.WithTicker, name string) *delayingType {
+func NewDelayingQueueWithCustomClock(clock clock.WithTicker, name string) DelayingInterface {
 	return NewDelayingQueueWithConfig(DelayingQueueConfig{
 		Name:  name,
 		Clock: clock,
 	})
 }
 
-func newDelayingQueue(clock clock.WithTicker, q Interface, name string, provider MetricsProvider) *delayingType {
+func newDelayingQueue(clock clock.WithTicker, q Interface, name string, provider MetricsProvider) DelayingInterface {
 	ret := &delayingType{
 		Interface:          q,
 		clock:              clock,

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -543,10 +543,12 @@ func (q *delayingType) handleReportingAndSync(w *waitForPriorityQueue, knownEntr
 		r := waitingLoopResponse{}
 		switch req.action {
 		case waitForActionIsWaiting:
-			_, exists := knownEntries[req.data]
+			item, exists := knownEntries[req.data]
 			r.exists = &exists
-			nr := req.readyAt.Sub(q.clock.Now())
-			r.nextReady = &nr
+			if item != nil {
+				nr := item.readyAt.Sub(q.clock.Now())
+				r.nextReady = &nr
+			}
 		case waitForActionLenWaiting:
 			l := w.Len()
 			r.length = &l

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -464,7 +464,8 @@ func (q *delayingType) waitingLoop() {
 		// signal, otherwise ticking a clock to the ready time before hitting the select would cause the
 		// select nextReadyAtTimerCh not to fire.  This check is as close to the select as we can make it.
 		if waitingForQueue.Len() > 0 {
-			if q.headReadyTime.Equal(q.clock.Now()) || q.headReadyTime.Before(q.clock.Now()) {
+			now := q.clock.Now()
+			if q.headReadyTime.Equal(now) || q.headReadyTime.Before(now) {
 				continue
 			}
 		}

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -144,7 +144,7 @@ func NewDelayingQueueWithCustomClock(clock clock.WithTicker, name string) Delayi
 	})
 }
 
-func newDelayingQueue(clock clock.WithTicker, q Interface, name string, provider MetricsProvider) DelayingInterface {
+func newDelayingQueue(clock clock.WithTicker, q Interface, name string, provider MetricsProvider) *delayingType {
 	ret := &delayingType{
 		Interface:          q,
 		clock:              clock,

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package workqueue
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -27,6 +28,11 @@ import (
 	testingclock "k8s.io/utils/clock/testing"
 )
 
+const (
+	DefaultWaitTimeout = 2 * time.Second      // The default duration we will wait before giving up when polling for a result.
+	DefaultWaitStep    = 5 * time.Millisecond // The default pause between attempted polls when polling for a result.
+)
+
 func TestSimpleQueue(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock})
@@ -34,9 +40,7 @@ func TestSimpleQueue(t *testing.T) {
 	first := "foo"
 
 	q.AddAfter(first, 50*time.Millisecond)
-	if err := waitForWaitingQueueToFill(q); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	q.syncFill()
 
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
@@ -44,7 +48,7 @@ func TestSimpleQueue(t *testing.T) {
 
 	fakeClock.Step(60 * time.Millisecond)
 
-	if err := waitForAdded(q, 1); err != nil {
+	if err := waitForActiveQueueDepth(q, 1); err != nil {
 		t.Errorf("should have added")
 	}
 	item, _ := q.Get()
@@ -53,20 +57,291 @@ func TestSimpleQueue(t *testing.T) {
 	// step past the next heartbeat
 	fakeClock.Step(10 * time.Second)
 
-	err := wait.Poll(1*time.Millisecond, 30*time.Millisecond, func() (done bool, err error) {
+	ctx := context.TODO()
+	err := wait.PollUntilContextTimeout(ctx, DefaultWaitStep, DefaultWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		if q.Len() > 0 {
 			return false, fmt.Errorf("added to queue")
 		}
-
 		return false, nil
 	})
-	if err != wait.ErrWaitTimeout {
+	if !wait.Interrupted(err) {
 		t.Errorf("expected timeout, got: %v", err)
 	}
 
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
 	}
+}
+
+// TestImmediateAdd calls to Add() should 'promote' items out of waiting (i.e. delete from waiting)
+// and immediately add them (via the waitingLoop)
+func TestImmediateAdd(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
+	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+
+	first := "foo"
+	second := "foo"
+
+	q.AddAfter(first, 1*time.Second)
+	q.syncFill()
+	assertDelayedQueueState(t, q, QueueState{
+		waiting: []interface{}{first},
+	})
+	// the immediate add leaves the waiting item in the queue
+	q.Add(second)
+	assertDelayedQueueState(t, q, QueueState{
+		active:  []interface{}{second},
+		waiting: []interface{}{first},
+	})
+	item, _ := q.Get()
+	q.Done(item)
+
+	// The first item is still in the waiting queue
+	assertDelayedQueueState(t, q, QueueState{
+		waiting: []interface{}{first},
+	})
+
+	// Add an immediate add with AddWithOptions will remove the waiting item
+	q.AddWithOptions(second, ExpandedDelayingOptions{})
+	q.syncFill()
+	assertDelayedQueueState(t, q, QueueState{
+		active: []interface{}{second},
+	})
+	item, _ = q.Get()
+	q.Done(item)
+
+	// Show that AddWithOptions with the PermitActiveAndWaiting option gives us the original behaviour again
+	q.AddAfter(first, 1*time.Second)
+	q.syncFill()
+	assertDelayedQueueState(t, q, QueueState{
+		waiting: []interface{}{first},
+	})
+	q.AddWithOptions(second, ExpandedDelayingOptions{PermitActiveAndWaiting: true})
+	q.syncFill()
+	assertDelayedQueueState(t, q, QueueState{
+		active:  []interface{}{second},
+		waiting: []interface{}{first},
+	})
+	item, _ = q.Get()
+	q.Done(item)
+}
+
+// TestOptionsTakeLongerTakeExisting - these options give the client an ability to perform a conditional add but
+// only when the item isn't already queued.  This functionality also applies to immediate adds made by the AddWithOptions
+// method.
+func TestOptionsTakeLongerTakeExisting(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
+	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+
+	first := "foo"
+	second := "foo"
+	third := "bar"
+
+	// add an item into the waiting queue.
+	q.AddAfter(first, 2*time.Second)
+
+	// attempt to immediately add an item using TakeLonger option
+	q.AddWithOptions(second, ExpandedDelayingOptions{WhenWaiting: TakeLonger})
+	assertDelayedQueueState(t, q, QueueState{
+		waiting: []interface{}{first},
+	})
+
+	// attempt to immediately add an item using TakeExisting option
+	q.AddWithOptions(second, ExpandedDelayingOptions{WhenWaiting: TakeExisting})
+	assertDelayedQueueState(t, q, QueueState{
+		waiting: []interface{}{first},
+	})
+
+	// attempt to add an item not queued should queue successfully...
+	q.AddWithOptions(third, ExpandedDelayingOptions{WhenWaiting: TakeExisting})
+	assertDelayedQueueState(t, q, QueueState{
+		active:  []interface{}{third},
+		waiting: []interface{}{first},
+	})
+
+	// step past the original delayed item and process it from the active queue
+	fakeClock.Step(5 * time.Second)
+	if err := waitForActiveQueueDepth(q, 2); err != nil {
+		t.Fatalf("the first item should have been queued")
+	}
+	assertDelayedQueueState(t, q, QueueState{
+		active: []interface{}{first, third},
+	})
+	// pop them both off the queue
+	item, _ := q.Get()
+	q.Done(item)
+	item, _ = q.Get()
+	q.Done(item)
+
+	// add the second item again with DropIfWaiting which should now succeed
+	q.AddWithOptions(second, ExpandedDelayingOptions{WhenWaiting: TakeExisting})
+	assertDelayedQueueState(t, q, QueueState{
+		active: []interface{}{second},
+	})
+}
+
+// TestDelayedInsertTakeShorter - tests the insert behaviour with this WhenWaiting behaviour (the default)
+func TestDelayedInsertTakeShorter(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
+	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+
+	first := "baz"
+	second := "foo"
+	third := "foo"
+
+	// add an item into the waiting queue.
+	q.AddAfter(first, 10*time.Second)
+	q.AddAfter(second, 10*time.Second)
+	// attempt add delayed again with a shorter time time out and TakeShorter option.
+	q.AddWithOptions(third, ExpandedDelayingOptions{Duration: 1 * time.Second, WhenWaiting: TakeShorter})
+	q.syncFill()
+	// step past the shorter item and confirm that it got queued.
+	fakeClock.Step(2 * time.Second)
+	if err := waitForActiveQueueDepth(q, 1); err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	// we should be left with baz in waiting and foo should now be active
+	assertDelayedQueueState(t, q, QueueState{
+		active:  []interface{}{third},
+		waiting: []interface{}{first},
+	})
+}
+
+// TestDelayedInsertTakeLonger- tests the insert behaviour with this WhenWaiting behaviour.
+func TestDelayedInsertTakeLonger(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
+	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+
+	first := "baz"
+	second := "foo"
+	third := "foo"
+	fourth := "foo"
+
+	// add an item into the waiting queue.
+	q.AddAfter(first, 60*time.Second)
+	q.AddAfter(second, 5*time.Second)
+	// attempt add delayed again with a shorter time time out and TakeLonger option.
+	q.AddWithOptions(third, ExpandedDelayingOptions{Duration: 1 * time.Second, WhenWaiting: TakeLonger})
+	q.syncFill()
+	// step past the shorter item and confirm that it didn't get queued
+	fakeClock.Step(2 * time.Second)
+	if err := waitForActiveQueueDepth(q, 1); !wait.Interrupted(err) {
+		t.Fatalf("expected timeout, got: %v", err)
+	}
+	// Add a longer delay with the expectation of pushing the ready later...
+	q.AddWithOptions(fourth, ExpandedDelayingOptions{Duration: 20 * time.Second, WhenWaiting: TakeLonger})
+	q.syncFill()
+	// step past the original delayed item and check it queues.
+	fakeClock.Step(4 * time.Second)
+	if err := waitForActiveQueueDepth(q, 1); !wait.Interrupted(err) {
+		t.Fatalf("expected timeout, got: %v", err)
+	}
+	// step past the new longer delay and prove our longer item was queued.
+	fakeClock.Step(30 * time.Second)
+	if err := waitForActiveQueueDepth(q, 1); err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	// we should be left with baz in waiting and foo should now be active
+	assertDelayedQueueState(t, q, QueueState{
+		active:  []interface{}{third},
+		waiting: []interface{}{first},
+	})
+}
+
+// TestDelayedInsertTakeLonger- tests the insert behaviour with this WhenWaiting behaviour.
+func TestDelayedInsertTakeIncoming(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
+	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+
+	first := "baz"
+	second := "foo"
+	third := "foo"
+	fourth := "foo"
+	fifth := "foo"
+
+	q.AddAfter(first, 60*time.Second)
+	// Shorter case...
+	q.AddAfter(second, 5*time.Second)
+	// attempt add delayed again with a shorter time time out and TakeShorter option.
+	q.AddWithOptions(third, ExpandedDelayingOptions{Duration: 1 * time.Second, WhenWaiting: TakeIncoming})
+	q.syncFill()
+	// step past the shorter item and confirm that it got queued
+	fakeClock.Step(2 * time.Second)
+	if err := waitForActiveQueueDepth(q, 1); err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	assertDelayedQueueState(t, q, QueueState{
+		active:  []interface{}{second},
+		waiting: []interface{}{first},
+	})
+	item, _ := q.Get()
+	q.Done(item)
+
+	// Longer case...
+	q.AddAfter(fourth, 5*time.Second)
+	// attempt add delayed again with a shorter time time out and TakeIncoming option.
+	q.AddWithOptions(fifth, ExpandedDelayingOptions{Duration: 20 * time.Second, WhenWaiting: TakeIncoming})
+	q.syncFill()
+	// step past the first waiting time... and prove the original delay got increased by the incoming.
+	fakeClock.Step(10 * time.Second)
+	if err := waitForActiveQueueDepth(q, 1); !wait.Interrupted(err) {
+		t.Fatalf("expected timeout, got: %v", err)
+	}
+	// we should be left with baz in waiting and foo should now be active
+	assertDelayedQueueState(t, q, QueueState{
+		waiting: []interface{}{first, fifth},
+	})
+}
+
+// TestRemoveWaiting
+func TestRemoveWaiting(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
+	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+
+	first := "foo"
+	second := "bar"
+	third := "baz"
+
+	q.AddAfter(first, 1*time.Second)
+	q.AddAfter(second, 500*time.Millisecond)
+	q.AddAfter(third, 250*time.Millisecond)
+	assertDelayedQueueState(t, q, QueueState{
+		waiting: []interface{}{first, second, third},
+	})
+
+	q.DoneWaiting(second)
+	assertDelayedQueueState(t, q, QueueState{
+		waiting: []interface{}{first, third},
+	})
+
+	// add again
+	q.AddAfter(second, 500*time.Millisecond)
+	assertDelayedQueueState(t, q, QueueState{
+		waiting: []interface{}{first, second, third},
+	})
+
+	q.DoneWaiting(third)
+	assertDelayedQueueState(t, q, QueueState{
+		waiting: []interface{}{first, second},
+	})
+
+	fakeClock.Step(2 * time.Second)
+
+	if err := waitForActiveQueueDepth(q, 2); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	actualFirst, _ := q.Get()
+	q.Done(actualFirst)
+	if !reflect.DeepEqual(actualFirst, second) {
+		t.Errorf("expected %v, got %v", second, actualFirst)
+	}
+	actualSecond, _ := q.Get()
+	q.Done(actualSecond)
+	if !reflect.DeepEqual(actualSecond, first) {
+		t.Errorf("expected %v, got %v", first, actualSecond)
+	}
+
+	assertDelayedQueueState(t, q, QueueState{})
 }
 
 func TestDeduping(t *testing.T) {
@@ -76,20 +351,15 @@ func TestDeduping(t *testing.T) {
 	first := "foo"
 
 	q.AddAfter(first, 50*time.Millisecond)
-	if err := waitForWaitingQueueToFill(q); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
 	q.AddAfter(first, 70*time.Millisecond)
-	if err := waitForWaitingQueueToFill(q); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	q.syncFill()
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
 	}
 
 	// step past the first block, we should receive now
 	fakeClock.Step(60 * time.Millisecond)
-	if err := waitForAdded(q, 1); err != nil {
+	if err := waitForActiveQueueDepth(q, 1); err != nil {
 		t.Errorf("should have added")
 	}
 	item, _ := q.Get()
@@ -104,15 +374,13 @@ func TestDeduping(t *testing.T) {
 	// test again, but this time the earlier should override
 	q.AddAfter(first, 50*time.Millisecond)
 	q.AddAfter(first, 30*time.Millisecond)
-	if err := waitForWaitingQueueToFill(q); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	q.syncFill()
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
 	}
 
 	fakeClock.Step(40 * time.Millisecond)
-	if err := waitForAdded(q, 1); err != nil {
+	if err := waitForActiveQueueDepth(q, 1); err != nil {
 		t.Errorf("should have added")
 	}
 	item, _ = q.Get()
@@ -120,6 +388,7 @@ func TestDeduping(t *testing.T) {
 
 	// step past the second add
 	fakeClock.Step(20 * time.Millisecond)
+	q.syncFill()
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
 	}
@@ -135,9 +404,7 @@ func TestAddTwoFireEarly(t *testing.T) {
 
 	q.AddAfter(first, 1*time.Second)
 	q.AddAfter(second, 50*time.Millisecond)
-	if err := waitForWaitingQueueToFill(q); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	q.syncFill()
 
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
@@ -145,7 +412,7 @@ func TestAddTwoFireEarly(t *testing.T) {
 
 	fakeClock.Step(60 * time.Millisecond)
 
-	if err := waitForAdded(q, 1); err != nil {
+	if err := waitForActiveQueueDepth(q, 1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	item, _ := q.Get()
@@ -154,9 +421,10 @@ func TestAddTwoFireEarly(t *testing.T) {
 	}
 
 	q.AddAfter(third, 2*time.Second)
+	q.syncFill()
 
 	fakeClock.Step(1 * time.Second)
-	if err := waitForAdded(q, 1); err != nil {
+	if err := waitForActiveQueueDepth(q, 1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	item, _ = q.Get()
@@ -165,7 +433,7 @@ func TestAddTwoFireEarly(t *testing.T) {
 	}
 
 	fakeClock.Step(2 * time.Second)
-	if err := waitForAdded(q, 1); err != nil {
+	if err := waitForActiveQueueDepth(q, 1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	item, _ = q.Get()
@@ -185,9 +453,7 @@ func TestCopyShifting(t *testing.T) {
 	q.AddAfter(first, 1*time.Second)
 	q.AddAfter(second, 500*time.Millisecond)
 	q.AddAfter(third, 250*time.Millisecond)
-	if err := waitForWaitingQueueToFill(q); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	q.syncFill()
 
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
@@ -195,7 +461,7 @@ func TestCopyShifting(t *testing.T) {
 
 	fakeClock.Step(2 * time.Second)
 
-	if err := waitForAdded(q, 3); err != nil {
+	if err := waitForActiveQueueDepth(q, 3); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	actualFirst, _ := q.Get()
@@ -209,6 +475,113 @@ func TestCopyShifting(t *testing.T) {
 	actualThird, _ := q.Get()
 	if !reflect.DeepEqual(actualThird, first) {
 		t.Errorf("expected %v, got %v", first, actualThird)
+	}
+}
+
+// TestCalculatenextReadyAt tests that the nextReadyAt timer is being correctly updated when the head item on the
+// 'waiting' queue changes.
+func TestCalculatenextReadyAt(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
+	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+
+	first := "foo"
+	second := "bar"
+	third := "baz"
+	fourth := "apple"
+	fifth := "orange"
+
+	item, ready := q.nextReady()
+	if ready != 0 {
+		t.Fatal("the next ready duration should start at 0 for an empty queue")
+	}
+	if item != nil {
+		t.Fatal("there should be no next item on an empty queue")
+	}
+
+	// the next ready at should take on the value of the first item queued
+	q.AddWithOptions(first, ExpandedDelayingOptions{Duration: 5 * time.Second})
+	item, ready = q.nextReady()
+	if item != first {
+		t.Fatal("the next ready item should be the item when there is only one queued")
+	}
+	if ready != 5*time.Second {
+		t.Fatal("the next ready time was not set correctly")
+	}
+	// stepping the item off the queue should update the next ready at properly
+	fakeClock.Step(6 * time.Second)
+	if err := waitForActiveQueueDepth(q, 1); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	_, ready = q.nextReady()
+	if ready != 0 {
+		t.Fatal("the next ready duration should start at 0 for an empty waiting queue")
+	}
+
+	// the next ready at should update when a new shortest item is added
+	q.AddWithOptions(second, ExpandedDelayingOptions{Duration: 30 * time.Second})
+	item, ready = q.nextReady()
+	if item != second {
+		t.Fatal("the next ready item should be the item when there is only one queued")
+	}
+	if ready != 30*time.Second {
+		t.Fatalf("The next ready at time does not match the newly added item")
+	}
+
+	// the next ready at time should not change unless the head changes
+	q.AddWithOptions(third, ExpandedDelayingOptions{Duration: 40 * time.Second})
+	item, ready = q.nextReady()
+	if item != second {
+		t.Fatal("the second item should still be the next ready")
+	}
+	if ready != 30*time.Second {
+		t.Fatalf("the next ready at time is not correct for the second item")
+	}
+
+	// and it should updated when the head changes...
+	q.AddWithOptions(fourth, ExpandedDelayingOptions{Duration: 20 * time.Second})
+	item, ready = q.nextReady()
+	if item != fourth {
+		t.Fatal("the forth item should be the next ready")
+	}
+	if ready != 20*time.Second {
+		t.Fatalf("the next ready at time is not correct for the fourth item")
+	}
+
+	// step the clock forward 25 seconds
+	// second now has 5 seconds left
+	// third now has 15 seconds left
+	// fourth is now ready and pops to 'active' queue
+	fakeClock.Step(25 * time.Second)
+	if err := waitForActiveQueueDepth(q, 2); err != nil { // active queue should contain foo and baz
+		t.Fatalf("unexpected err: %v", err)
+	}
+	item, ready = q.nextReady()
+	if item != second {
+		t.Fatal("the second item should be the next ready")
+	}
+	if ready != 5*time.Second {
+		t.Fatalf("the next ready at time is not correct for the second item")
+	}
+
+	// forgetting/deleting the head item should update the next ready at time.
+	q.DoneWaiting(second)
+	item, ready = q.nextReady()
+	if item != third {
+		t.Fatal("the third item should be the next ready")
+	}
+	if ready != 15*time.Second {
+		t.Fatalf("the next ready at time is not correct for the third item")
+	}
+
+	// the next ready at time should change when an immediate item pre-empts the 'waiting' item
+	q.AddWithOptions(fifth, ExpandedDelayingOptions{Duration: 30 * time.Second})
+	q.AddWithOptions(third, ExpandedDelayingOptions{})
+	item, ready = q.nextReady()
+	if item != fifth {
+		t.Fatal("the fifth item should be the next ready")
+	}
+	if ready != 30*time.Second {
+		t.Fatalf("the next ready at time is not correct for the fifth item")
 	}
 }
 
@@ -229,8 +602,10 @@ func BenchmarkDelayingQueue_AddAfter(b *testing.B) {
 	}
 }
 
-func waitForAdded(q DelayingInterface, depth int) error {
-	return wait.Poll(1*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+// waitForActiveQueueDepth will poll until the active queue depth matches the desired depth, or times out.
+func waitForActiveQueueDepth(q DelayingInterface, depth int) error {
+	ctx := context.TODO()
+	return wait.PollUntilContextTimeout(ctx, DefaultWaitStep, DefaultWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		if q.Len() == depth {
 			return true, nil
 		}
@@ -239,12 +614,45 @@ func waitForAdded(q DelayingInterface, depth int) error {
 	})
 }
 
-func waitForWaitingQueueToFill(q DelayingInterface) error {
-	return wait.Poll(1*time.Millisecond, 10*time.Second, func() (done bool, err error) {
-		if len(q.(*delayingType).waitingForAddCh) == 0 {
-			return true, nil
-		}
+// QueueState provides a convenient way to confirm the both the Active and Waiting parts of the delaying queue
+// are in the correct state
+type QueueState struct {
+	active  []interface{}
+	waiting []interface{}
+}
 
-		return false, nil
-	})
+// assertQueueState allows us to assert exactly what items we expect to be in the 'active' and 'waiting' queues.
+// This is more declarative and thorough than observing all of the behaviours from the 'active' queue alone.
+func assertDelayedQueueState(t *testing.T, q *delayingType, qs QueueState) {
+	var errored bool
+
+	// check the 'waiting' queue
+	wlen := q.lenWaiting()
+	if wlen != len(qs.waiting) {
+		t.Errorf("the waiting queue has %d queued items but we expected %d", wlen, len(qs.waiting))
+		errored = true
+	}
+	for _, w := range qs.waiting {
+		waiting, _ := q.isWaiting(w)
+		if !waiting {
+			t.Errorf("item %v was expected to be waiting but isn't", w)
+			errored = true
+		}
+	}
+
+	// check 'active' queue
+	if q.Len() != len(qs.active) {
+		t.Errorf("the active q has %d queued items but we expected %d", q.Len(), len(qs.active))
+		errored = true
+	}
+	for _, a := range qs.active {
+		if !q.IsQueued(a) {
+			t.Errorf("item %v was expected to be actively queued but isn't", a)
+			errored = true
+		}
+	}
+
+	if errored {
+		t.Fatalf("assertQueueState (%+v) does not match actual", qs)
+	}
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
@@ -627,13 +627,13 @@ func assertDelayedQueueState(t *testing.T, q *delayingType, qs QueueState) {
 	var errored bool
 
 	// check the 'waiting' queue
-	wlen := q.lenWaiting()
+	wlen := q.LenWaiting()
 	if wlen != len(qs.waiting) {
 		t.Errorf("the waiting queue has %d queued items but we expected %d", wlen, len(qs.waiting))
 		errored = true
 	}
 	for _, w := range qs.waiting {
-		waiting, _ := q.isWaiting(w)
+		waiting, _ := q.IsWaiting(w)
 		if !waiting {
 			t.Errorf("item %v was expected to be waiting but isn't", w)
 			errored = true

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
@@ -105,17 +105,21 @@ func TestImmediateAdd(t *testing.T) {
 	q.AddWithOptions(second, ExpandedDelayingOptions{})
 	q.syncFill()
 	assertDelayedQueueState(t, q, QueueState{
-		active: []interface{}{second},
+		active: []interface{}{first},
 	})
+
+	// AddAfter should always queue a waiting item when it is already in the "active" queue
+	q.AddAfter(first, 1*time.Second)
+	q.syncFill()
+	assertDelayedQueueState(t, q, QueueState{
+		active:  []interface{}{first},
+		waiting: []interface{}{first},
+	})
+	// remove the active "foo"
 	item, _ = q.Get()
 	q.Done(item)
 
 	// Show that AddWithOptions with the PermitActiveAndWaiting option gives us the original behaviour again
-	q.AddAfter(first, 1*time.Second)
-	q.syncFill()
-	assertDelayedQueueState(t, q, QueueState{
-		waiting: []interface{}{first},
-	})
 	q.AddWithOptions(second, ExpandedDelayingOptions{PermitActiveAndWaiting: true})
 	q.syncFill()
 	assertDelayedQueueState(t, q, QueueState{

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
@@ -35,7 +35,7 @@ const (
 
 func TestSimpleQueue(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock})
+	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock}).(*delayingType)
 
 	first := "foo"
 
@@ -77,7 +77,7 @@ func TestSimpleQueue(t *testing.T) {
 // and immediately add them (via the waitingLoop)
 func TestImmediateAdd(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
-	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+	q := NewDelayingQueueWithCustomClock(fakeClock, "").(*delayingType)
 
 	first := "foo"
 	second := "foo"
@@ -135,7 +135,7 @@ func TestImmediateAdd(t *testing.T) {
 // method.
 func TestOptionsTakeLongerTakeExisting(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
-	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+	q := NewDelayingQueueWithCustomClock(fakeClock, "").(*delayingType)
 
 	first := "foo"
 	second := "foo"
@@ -187,7 +187,7 @@ func TestOptionsTakeLongerTakeExisting(t *testing.T) {
 // TestDelayedInsertTakeShorter - tests the insert behaviour with this WhenWaiting behaviour (the default)
 func TestDelayedInsertTakeShorter(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
-	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+	q := NewDelayingQueueWithCustomClock(fakeClock, "").(*delayingType)
 
 	first := "baz"
 	second := "foo"
@@ -214,7 +214,7 @@ func TestDelayedInsertTakeShorter(t *testing.T) {
 // TestDelayedInsertTakeLonger- tests the insert behaviour with this WhenWaiting behaviour.
 func TestDelayedInsertTakeLonger(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
-	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+	q := NewDelayingQueueWithCustomClock(fakeClock, "").(*delayingType)
 
 	first := "baz"
 	second := "foo"
@@ -255,7 +255,7 @@ func TestDelayedInsertTakeLonger(t *testing.T) {
 // TestDelayedInsertTakeLonger- tests the insert behaviour with this WhenWaiting behaviour.
 func TestDelayedInsertTakeIncoming(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
-	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+	q := NewDelayingQueueWithCustomClock(fakeClock, "").(*delayingType)
 
 	first := "baz"
 	second := "foo"
@@ -300,7 +300,7 @@ func TestDelayedInsertTakeIncoming(t *testing.T) {
 // TestRemoveWaiting
 func TestRemoveWaiting(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
-	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+	q := NewDelayingQueueWithCustomClock(fakeClock, "").(*delayingType)
 
 	first := "foo"
 	second := "bar"
@@ -349,7 +349,7 @@ func TestRemoveWaiting(t *testing.T) {
 
 func TestDeduping(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock})
+	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock}).(*delayingType)
 
 	first := "foo"
 
@@ -399,7 +399,7 @@ func TestDeduping(t *testing.T) {
 
 func TestAddTwoFireEarly(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock})
+	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock}).(*delayingType)
 
 	first := "foo"
 	second := "bar"
@@ -447,7 +447,7 @@ func TestAddTwoFireEarly(t *testing.T) {
 
 func TestCopyShifting(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock})
+	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock}).(*delayingType)
 
 	first := "foo"
 	second := "bar"
@@ -537,7 +537,7 @@ func TestReportQueueState(t *testing.T) {
 // 'waiting' queue changes.
 func TestCalculatenextReadyAt(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(1 * time.Second))
-	q := NewDelayingQueueWithCustomClock(fakeClock, "")
+	q := NewDelayingQueueWithCustomClock(fakeClock, "").(*delayingType)
 
 	first := "foo"
 	second := "bar"

--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -167,6 +167,31 @@ func TestLen(t *testing.T) {
 	}
 }
 
+// TestIsQueued ensures that we can check the active queue for specific objects.
+func TestIsQueued(t *testing.T) {
+	q := workqueue.New()
+
+	q.Add("foo")
+	q.Add("bar")
+	if !q.IsQueued("foo") {
+		t.Errorf("Expected foo to be reported as queued")
+	}
+	if !q.IsQueued("bar") {
+		t.Errorf("Expected bar to be reported as queued")
+	}
+	if q.IsQueued("baz") {
+		t.Errorf("baz should not be reported as queued")
+	}
+	_, _ = q.Get()
+	if q.IsQueued("foo") {
+		t.Errorf("foo should no longer be reported as queued")
+	}
+	q.Add("foo")
+	if !q.IsQueued("foo") {
+		t.Errorf("foo should be queued whilst it is processing but not done")
+	}
+}
+
 func TestReinsert(t *testing.T) {
 	q := workqueue.New()
 	q.Add("foo")

--- a/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue_test.go
@@ -32,19 +32,19 @@ func TestRateLimitingQueue(t *testing.T) {
 		clock:           fakeClock,
 		heartbeat:       fakeClock.NewTicker(maxWait),
 		stopCh:          make(chan struct{}),
-		waitingForAddCh: make(chan *waitFor, 1000),
+		waitingForAddCh: make(chan *waitLoopMessage, 1000),
 		metrics:         newRetryMetrics("", nil),
 	}
 	queue.DelayingInterface = delayingQueue
 
 	queue.AddRateLimited("one")
 	waitEntry := <-delayingQueue.waitingForAddCh
-	if e, a := 1*time.Millisecond, waitEntry.readyAt.Sub(fakeClock.Now()); e != a {
+	if e, a := 1*time.Millisecond, waitEntry.item.readyAt.Sub(fakeClock.Now()); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 	queue.AddRateLimited("one")
 	waitEntry = <-delayingQueue.waitingForAddCh
-	if e, a := 2*time.Millisecond, waitEntry.readyAt.Sub(fakeClock.Now()); e != a {
+	if e, a := 2*time.Millisecond, waitEntry.item.readyAt.Sub(fakeClock.Now()); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 	if e, a := 2, queue.NumRequeues("one"); e != a {
@@ -53,12 +53,12 @@ func TestRateLimitingQueue(t *testing.T) {
 
 	queue.AddRateLimited("two")
 	waitEntry = <-delayingQueue.waitingForAddCh
-	if e, a := 1*time.Millisecond, waitEntry.readyAt.Sub(fakeClock.Now()); e != a {
+	if e, a := 1*time.Millisecond, waitEntry.item.readyAt.Sub(fakeClock.Now()); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 	queue.AddRateLimited("two")
 	waitEntry = <-delayingQueue.waitingForAddCh
-	if e, a := 2*time.Millisecond, waitEntry.readyAt.Sub(fakeClock.Now()); e != a {
+	if e, a := 2*time.Millisecond, waitEntry.item.readyAt.Sub(fakeClock.Now()); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -68,7 +68,7 @@ func TestRateLimitingQueue(t *testing.T) {
 	}
 	queue.AddRateLimited("one")
 	waitEntry = <-delayingQueue.waitingForAddCh
-	if e, a := 1*time.Millisecond, waitEntry.readyAt.Sub(fakeClock.Now()); e != a {
+	if e, a := 1*time.Millisecond, waitEntry.item.readyAt.Sub(fakeClock.Now()); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

A delaying queue is best thought of as an **'active'** queue coupled with a **'waiting'** queue where items can sit out a length of time before they automatically mature out of **'waiting'** and into the **'active'** queue part.  They are most often used by controllers wanting to remember to retry something that failed.

This PR offers the following benefits:

* Preserves original `Add()` and `AddAfter()` behaviour in order to support existing clients without surprises.
* New behaviours in the `DelayingInterface` which allow finer control of queuing:
  * `AddWithOptions()` that allows clients finer control over the queueing behaviour.
  * `DoneWaiting()` so a client can remove an item from the **'waiting'** queue.
  * `IsWaiting()` reports back if an item is in the **'waiting'** queue.
  * `LenWaiting()` reports the length of the **'waiting'** queue.
* A new method in the **'active'** queue `Interface`: 
  *   `IsQueued()` reports back if an item is in the **'active'** queue.

`AddWithOptions()` is asynchronous and will often return back to the client faster than calling `Add()` or `AddAfter()`.

For existing clients, calling `Add()` and `AddAfter()` will continue to work exactly as before, but if a client moves to using `AddWithOptions()` - they can then control features which enable/disable deduplication of items between the "active" and "waiting" queue, where the item is already waiting choose which delay you want to use (the shortest, longest, existing, incoming).

All clients can now ask the DelayingQueue whether a specific item is in the "waiting" queue with `IsWaiting()` whether an item is queued in the "active" queue with `IsQueued()`.  To get the length of the "waiting" queue they can call `LenWaiting()` and for the "active" queue `Len()` (which is an existing implementation).

It is already possible to forget an item from the "active" queue by calling the method `Done()`.  This PR adds a corresponding feature for the "waiting" queue by calling `DoneWaiting()`.

#### Which issue(s) this PR fixes:

Fixes #112325
Fixes #110642

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
