### PR TITLE
Update branch rules in publishing rules to Go 1.18.6

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -16,7 +16,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/code-generator
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
@@ -42,7 +42,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
@@ -78,7 +78,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/api
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -138,7 +138,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -204,7 +204,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-base
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -266,7 +266,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -334,7 +334,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apiserver
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -418,7 +418,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -524,7 +524,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -628,7 +628,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -727,7 +727,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -810,7 +810,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/metrics
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -876,7 +876,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -944,7 +944,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1015,7 +1015,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1087,7 +1087,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubelet
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1159,7 +1159,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1237,7 +1237,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1331,7 +1331,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1439,7 +1439,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1515,7 +1515,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1567,7 +1567,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1604,7 +1604,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
@@ -1692,7 +1692,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1761,7 +1761,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cri-api
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
@@ -1839,7 +1839,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubectl
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1933,7 +1933,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.24
-    go: 1.18.5
+    go: 1.18.6
     dependencies:
     - repository: api
       branch: release-1.24


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Update branch rules in publishing rules to Go 1.18.6

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2658

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/cc @kubernetes/release-engineering 