### PR TITLE
Fix HPA E2E CustomResourceDefinition test

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -246,7 +246,6 @@ func (a *HorizontalController) processNextWorkItem(ctx context.Context) bool {
 // all metrics computed.
 func (a *HorizontalController) computeReplicasForMetrics(ctx context.Context, hpa *autoscalingv2.HorizontalPodAutoscaler, scale *autoscalingv1.Scale,
 	metricSpecs []autoscalingv2.MetricSpec) (replicas int32, metric string, statuses []autoscalingv2.MetricStatus, timestamp time.Time, err error) {
-
 	if scale.Status.Selector == "" {
 		errMsg := "selector is required"
 		a.eventRecorder.Event(hpa, v1.EventTypeWarning, "SelectorRequired", errMsg)

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -95,6 +95,8 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: C
 				minPods:          1,
 				maxPods:          2,
 				firstScale:       2,
+				resourceType:     cpuResource,
+				metricTargetType: utilizationMetricType,
 			}
 			st.run("rc-light", e2eautoscaling.KindRC, f)
 		})
@@ -107,6 +109,8 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: C
 				minPods:          1,
 				maxPods:          2,
 				firstScale:       1,
+				resourceType:     cpuResource,
+				metricTargetType: utilizationMetricType,
 			}
 			st.run("rc-light", e2eautoscaling.KindRC, f)
 		})
@@ -126,7 +130,7 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: C
 
 	ginkgo.Describe("CustomResourceDefinition", func() {
 		ginkgo.It("Should scale with a CRD targetRef", func() {
-			st := &HPAScaleTest{
+			scaleTest := &HPAScaleTest{
 				initPods:         1,
 				initCPUTotal:     150,
 				perPodCPURequest: 200,
@@ -134,9 +138,10 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: C
 				minPods:          1,
 				maxPods:          2,
 				firstScale:       2,
-				targetRef:        e2eautoscaling.CustomCRDTargetRef(),
+				resourceType:     cpuResource,
+				metricTargetType: utilizationMetricType,
 			}
-			st.run("crd-light", e2eautoscaling.KindCRD, f)
+			scaleTest.run("foo-crd", e2eautoscaling.KindCRD, f)
 		})
 	})
 })
@@ -179,7 +184,6 @@ type HPAScaleTest struct {
 	cpuBurst         int
 	memBurst         int
 	secondScale      int32
-	targetRef        autoscalingv2.CrossVersionObjectReference
 	resourceType     v1.ResourceName
 	metricTargetType autoscalingv2.MetricTargetType
 }

--- a/test/e2e/framework/resource/resources.go
+++ b/test/e2e/framework/resource/resources.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -26,8 +27,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
 	scaleclient "k8s.io/client-go/scale"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -73,6 +76,39 @@ func DeleteResourceAndWaitForGC(c clientset.Interface, kind schema.GroupKind, ns
 		}
 		return err
 	}
+	deleteObject := func() error {
+		background := metav1.DeletePropagationBackground
+		return testutils.DeleteResource(c, kind, ns, name, metav1.DeleteOptions{PropagationPolicy: &background})
+	}
+	return deleteObjectAndWaitForGC(c, rtObject, deleteObject, ns, name, kind.String())
+}
+
+// DeleteCustomResourceAndWaitForGC deletes only given resource and waits for GC to delete the pods.
+// Enables to provide a custom resourece client, e.g. to fetch a CRD object.
+func DeleteCustomResourceAndWaitForGC(c clientset.Interface, dynamicClient dynamic.Interface, scaleClient scaleclient.ScalesGetter, gvr schema.GroupVersionResource, ns, name string) error {
+	ginkgo.By(fmt.Sprintf("deleting %v %s in namespace %s, will wait for the garbage collector to delete the pods", gvr, name, ns))
+	resourceClient := dynamicClient.Resource(gvr).Namespace(ns)
+	_, err := resourceClient.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			framework.Logf("%v %s not found: %v", gvr, name, err)
+			return nil
+		}
+		return err
+	}
+	scaleObj, err := scaleClient.Scales(ns).Get(context.TODO(), gvr.GroupResource(), name, metav1.GetOptions{})
+	if err != nil {
+		framework.Logf("error while trying to get scale subresource of kind %v with name %v: %v", gvr, name, err)
+		return nil
+	}
+	deleteObject := func() error {
+		background := metav1.DeletePropagationBackground
+		return resourceClient.Delete(context.TODO(), name, metav1.DeleteOptions{PropagationPolicy: &background})
+	}
+	return deleteObjectAndWaitForGC(c, scaleObj, deleteObject, ns, name, gvr.String())
+}
+
+func deleteObjectAndWaitForGC(c clientset.Interface, rtObject runtime.Object, deleteObject func() error, ns, name, description string) error {
 	selector, err := GetSelectorFromRuntimeObject(rtObject)
 	if err != nil {
 		return err
@@ -88,14 +124,18 @@ func DeleteResourceAndWaitForGC(c clientset.Interface, kind schema.GroupKind, ns
 	}
 
 	defer ps.Stop()
-	falseVar := false
-	deleteOption := metav1.DeleteOptions{OrphanDependents: &falseVar}
 	startTime := time.Now()
-	if err := testutils.DeleteResourceWithRetries(c, kind, ns, name, deleteOption); err != nil {
+	if err := testutils.RetryWithExponentialBackOff(func() (bool, error) {
+		err := deleteObject()
+		if err == nil || apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to delete object with non-retriable error: %v", err)
+	}); err != nil {
 		return err
 	}
 	deleteTime := time.Since(startTime)
-	framework.Logf("Deleting %v %s took: %v", kind, name, deleteTime)
+	framework.Logf("Deleting %v %s took: %v", description, name, deleteTime)
 
 	var interval, timeout time.Duration
 	switch {
@@ -119,7 +159,7 @@ func DeleteResourceAndWaitForGC(c clientset.Interface, kind schema.GroupKind, ns
 		return fmt.Errorf("error while waiting for pods to become inactive %s: %v", name, err)
 	}
 	terminatePodTime := time.Since(startTime) - deleteTime
-	framework.Logf("Terminating %v %s pods took: %v", kind, name, terminatePodTime)
+	framework.Logf("Terminating %v %s pods took: %v", description, name, terminatePodTime)
 
 	// In gce, at any point, small percentage of nodes can disappear for
 	// ~10 minutes due to hostError. 20 minutes should be long enough to

--- a/test/utils/delete_resources.go
+++ b/test/utils/delete_resources.go
@@ -32,7 +32,7 @@ import (
 	extensionsinternal "k8s.io/kubernetes/pkg/apis/extensions"
 )
 
-func deleteResource(c clientset.Interface, kind schema.GroupKind, namespace, name string, options metav1.DeleteOptions) error {
+func DeleteResource(c clientset.Interface, kind schema.GroupKind, namespace, name string, options metav1.DeleteOptions) error {
 	switch kind {
 	case api.Kind("Pod"):
 		return c.CoreV1().Pods(namespace).Delete(context.TODO(), name, options)
@@ -59,7 +59,7 @@ func deleteResource(c clientset.Interface, kind schema.GroupKind, namespace, nam
 
 func DeleteResourceWithRetries(c clientset.Interface, kind schema.GroupKind, namespace, name string, options metav1.DeleteOptions) error {
 	deleteFunc := func() (bool, error) {
-		err := deleteResource(c, kind, namespace, name, options)
+		err := DeleteResource(c, kind, namespace, name, options)
 		if err == nil || apierrors.IsNotFound(err) {
 			return true, nil
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Fix for a failing e2e test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Major fix for running HPA E2E CustomResourceDefinition test. This specifically adds all necessary utilities around creating a CRD, creating an instance and making sure HPA is able to fetch number of Replicas from CRD's status via scale client.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes bug(s) introduced by https://github.com/kubernetes/kubernetes/pull/111865

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
    NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
