### PR TITLE
Tolerate EventSeries with count of 1

### DIFF
--- a/pkg/apis/core/validation/events_test.go
+++ b/pkg/apis/core/validation/events_test.go
@@ -709,7 +709,7 @@ zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz`,
 				},
 			},
 			valid: false,
-			msg:   "non-nil series with cound < 2",
+			msg:   "non-nil series with count < 1",
 		},
 		{
 			Event: &core.Event{
@@ -733,6 +733,30 @@ zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz`,
 			},
 			valid: false,
 			msg:   "non-nil series with empty lastObservedTime",
+		},
+		{
+			Event: &core.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: metav1.NamespaceSystem,
+				},
+				InvolvedObject: core.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Node",
+				},
+				EventTime:           someTime,
+				ReportingController: "k8s.io/my-controller",
+				ReportingInstance:   "node-xyz",
+				Action:              "Do",
+				Reason:              "Because",
+				Type:                "Normal",
+				Series: &core.EventSeries{
+					Count:            1,
+					LastObservedTime: someTime,
+				},
+			},
+			valid: true,
+			msg:   "non-nil series with count of 1",
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

There was a discrepancy between client-go and the kube-apiserver, the client was emitting events with a starting serie count of 1 when the server was expecting a starting count of 2. To prevent any incompatibility with old clients, we need to tolerate event series that have a starting count of 1.

#### Special notes for your reviewer:

This is a follow-up to #112334 aiming to make the kube-apiserver compatible with older clients submitting events with an incorrect series count.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Tolerate a discrepancy between client-go and the kube-apiserver causing isomorphic events to be rejected when they have a series count of 1.
```

/cc @liggitt 