### PR TITLE
volumebinding: handle special delete event in AssumeCache

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/assume_cache.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/assume_cache.go
@@ -206,7 +206,7 @@ func (c *assumeCache) delete(obj interface{}) {
 		return
 	}
 
-	name, err := cache.MetaNamespaceKeyFunc(obj)
+	name, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		klog.ErrorS(&errObjectName{err}, "Failed to delete")
 		return


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Sometimes an informer might not directly send the deleted object to the OnDelete callback, but rather a DeletedFinalStateUnknown. The AssumeCache did not handle that case.

#### Special notes for your reviewer:

Found during code review. Not sure whether this has actually affected anyone.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
