### PR TITLE
Disable compression for InClusterConfig

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -537,6 +537,7 @@ func InClusterConfig() (*Config, error) {
 		TLSClientConfig: tlsClientConfig,
 		BearerToken:     string(token),
 		BearerTokenFile: tokenFile,
+		DisableCompression: true,
 	}, nil
 }
 


### PR DESCRIPTION
Gzipping workloads is definitely more expensive than network contention on in-cluster, co-located controllers, which usually use the in-cluster config.

Disabling compression by default should automatically save a lot of cycles for apiservers.

/assign @lavalamp 

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
In-cluster configs now disable compression by default to save cycles on apiserver since network contention is law when co-located.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
