### PR TITLE
e2e: reduce built time for framework

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/klog/v2"
 
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
-	testapiserver "k8s.io/kubernetes/test/utils/apiserver"
+	"k8s.io/kubernetes/test/utils/kubeconfig"
 )
 
 const (
@@ -460,7 +460,7 @@ func AfterReadingAllFlags(t *TestContextType) {
 		// Check if we can use the in-cluster config
 		if clusterConfig, err := restclient.InClusterConfig(); err == nil {
 			if tempFile, err := os.CreateTemp(os.TempDir(), "kubeconfig-"); err == nil {
-				kubeConfig := testapiserver.CreateKubeConfig(clusterConfig)
+				kubeConfig := kubeconfig.CreateKubeConfig(clusterConfig)
 				clientcmd.WriteToFile(*kubeConfig, tempFile.Name())
 				t.KubeConfig = tempFile.Name()
 				klog.V(4).Infof("Using a temporary kubeconfig file from in-cluster config : %s", tempFile.Name())

--- a/test/utils/apiserver/testapiserver.go
+++ b/test/utils/apiserver/testapiserver.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/cert"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/utils/kubeconfig"
 )
 
 // TestAPIServer provides access to a running apiserver instance.
@@ -90,7 +91,7 @@ func writeKubeConfigForWardleServerToKASConnection(t *testing.T, kubeClientConfi
 		t.Logf("CA bundle %v\n", dynamiccertificates.GetHumanCertDetail(curr))
 	}
 
-	adminKubeConfig := CreateKubeConfig(wardleToKASKubeClientConfig)
+	adminKubeConfig := kubeconfig.CreateKubeConfig(wardleToKASKubeClientConfig)
 	tmpDir := t.TempDir()
 	kubeConfigFile := path.Join(tmpDir, "kube.config")
 	if err := clientcmd.WriteToFile(*adminKubeConfig, kubeConfigFile); err != nil {

--- a/test/utils/kubeconfig/kubeconfig.go
+++ b/test/utils/kubeconfig/kubeconfig.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apiserver
+package kubeconfig
 
 import (
 	"k8s.io/client-go/rest"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Pulling the CreateKubeConfig function from the expensive to build test/utils/apiserver package had a considerable impact on the overall build time because that package depends on a lot of other packages.

Because only that one function is needed by the framework, that extra build time can be avoided by moving it into its own package.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

From [Slack](https://kubernetes.slack.com/archives/C09QZ4DQB/p1662824701033819?thread_ts=1662823581.940549&cid=C09QZ4DQB):

```
Current master:

$ time go test -c ./test/e2e_kubeadm/

real	0m33.366s
user	11m24.289s
sys	0m52.712s

Commit b48b0eac6ad3556b343f54c26b49ed74cac276e3 (right before merging that e2e PR):

$ time go test -c ./test/e2e_kubeadm/

real	0m20.244s
user	4m31.203s
sys	0m25.742s

Both was done directly after go clean -cache -testcache. So it is slower.
```

With this PR:
```
$ time go test -c ./test/e2e_kubeadm/

real	0m20.025s
user	4m31.049s
sys	0m26.320s
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
