### PR TITLE
api/core/v1/types: Align Node documentation

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5303,7 +5303,7 @@ type Node struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec defines the behavior of a node.
-	// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	// +optional
 	Spec NodeSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 


### PR DESCRIPTION
This PR improves documentation for the `Spec` field of a `Node`, by aligning it with docs for the other fields on the same struct.

/kind cleanup
/kind documentation
