### PR TITLE
Sandeep issue todo resolved nedd of error defintions

### DIFF
--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/api.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/api.go
@@ -30,7 +30,7 @@ type ClientHandler interface {
 	PluginListAndWatchReceiver(string, *api.ListAndWatchResponse)
 }
 
-
+// TODO: evaluate whether we need these error definitions.
 const (
 	// errFailedToDialDevicePlugin is the error raised when the device plugin could not be
 	// reached on the registered socket

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/api.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/api.go
@@ -30,7 +30,7 @@ type ClientHandler interface {
 	PluginListAndWatchReceiver(string, *api.ListAndWatchResponse)
 }
 
-// TODO: evaluate whether we need these error definitions.
+
 const (
 	// errFailedToDialDevicePlugin is the error raised when the device plugin could not be
 	// reached on the registered socket


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
In this PR,I have removed the unwanted TO DO  - ( whether we need error definitions) from the source code. In have removed this TODO because the error definitions are really helpful for developers while reading the code, it makes the code better readable and also these error definitions are used in the code

#### Which issue(s) this PR fixes:
In this PR,I have removed the unwanted TO DO  - ( whether we need error definitions) from the source code. In have removed this TODO because the error definitions are really helpful for developers while reading the code, it makes the code better readable and also these error definitions are used in the code
Fixes #



#### Does this PR introduce a user-facing change?
NONE
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

