### PR TITLE
Remove Overly Permissive File Modes 1/5

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -286,8 +286,8 @@ func (rules *ClientConfigLoadingRules) Migrate() error {
 		if err != nil {
 			return err
 		}
-		// destination is created with mode 0600 before umask
-		err = os.WriteFile(destination, data, 0600)
+		// destination is created with mode 0644 before umask
+		err = os.WriteFile(destination, data, 0644)
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -286,8 +286,8 @@ func (rules *ClientConfigLoadingRules) Migrate() error {
 		if err != nil {
 			return err
 		}
-		// destination is created with mode 0666 before umask
-		err = os.WriteFile(destination, data, 0666)
+		// destination is created with mode 0600 before umask
+		err = os.WriteFile(destination, data, 0600)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR updates the overly permissive file modes from 0666 to 0600 in the `Migrate` function in `staging/src/k8s.io/client-go/tools/clientcmd/loader.go`.

#### Which issue(s) this PR fixes:

Contributes to: #81116

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Change file creation permission from 660 to 600


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

