### PR TITLE
Tiny comment cleanup in pkg/apis/apps/types.go

### DIFF
--- a/pkg/apis/apps/types.go
+++ b/pkg/apis/apps/types.go
@@ -342,9 +342,7 @@ type Deployment struct {
 
 // DeploymentSpec specifies the state of a Deployment.
 type DeploymentSpec struct {
-	// Number of desired pods. This is a pointer to distinguish between explicit
-	// zero and not specified. Defaults to 1.
-	// +optional
+	// Number of desired pods.
 	Replicas int32
 
 	// Label selector for pods. Existing ReplicaSets whose pods are


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove incorrect mention of pointer in comment: https://github.com/kubernetes/kubernetes/blob/72f96d9c722961ddd27911a7dde2e464f9e44198/pkg/apis/apps/types.go#L345-L348
This `DeploymentSpec` struct is used internally; the ones used for serialization do have a pointer and this text was most likely copied from there and not corrected.

Thanks to @liggitt for explaining this to me on Slack.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

