### PR TITLE
Automated cherry pick of #112299: Reduce default gzip compression level from 4 to 1 in

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -143,8 +143,10 @@ var gzipPool = &sync.Pool{
 }
 
 const (
-	// defaultGzipContentEncodingLevel is set to 4 which uses less CPU than the default level
-	defaultGzipContentEncodingLevel = 4
+	// defaultGzipContentEncodingLevel is set to 1 which uses least CPU compared to higher levels, yet offers
+	// similar compression ratios (off by at most 1.5x, but typically within 1.1x-1.3x). For further details see -
+	// https://github.com/kubernetes/kubernetes/issues/112296
+	defaultGzipContentEncodingLevel = 1
 	// defaultGzipThresholdBytes is compared to the size of the first write from the stream
 	// (usually the entire object), and if the size is smaller no gzipping will be performed
 	// if the client requests it.


### PR DESCRIPTION
Cherry pick of #112299 on release-1.23.

#112299: Reduce default gzip compression level from 4 to 1 in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### Release note
```release-note
kube-apiserver: gzip compression switched from level 4 to level 1 to improve large list call latencies in exchange for higher network bandwidth usage (10-50% higher). This increases the headroom before very large unpaged list calls exceed request timeout limits.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
Detailed doc showing why this change is safe and useful - https://docs.google.com/document/d/1rMlYKOVyujboAEG2epxSYdx7eyevC7dypkD_kUlBxn4
```