### PR TITLE
auth/exec: only close connections that are past the TLS handshake

### DIFF
--- a/staging/src/k8s.io/client-go/util/connrotation/connrotation_test.go
+++ b/staging/src/k8s.io/client-go/util/connrotation/connrotation_test.go
@@ -23,6 +23,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 func TestCloseAll(t *testing.T) {
@@ -48,6 +50,56 @@ func TestCloseAll(t *testing.T) {
 			case <-closed:
 			case <-deadline:
 				t.Fatalf("iteration %d: 1s after CloseAll only %d/%d connections closed", i, j, numConns)
+			}
+		}
+	}
+}
+
+func TestCloseAllGraceful(t *testing.T) {
+	closed := make(chan struct{}, 50)
+	dialFn := func(ctx context.Context, network, address string) (net.Conn, error) {
+		var once sync.Once
+		return closeOnlyConn{onClose: func() {
+			once.Do(func() {
+				closed <- struct{}{}
+			})
+		}}, nil
+	}
+	dialer := NewDialer(dialFn)
+
+	const numConns = 10
+
+	// Outer loop to ensure Dialer is re-usable after CloseAllGraceful.
+	for i := 0; i < 5; i++ {
+		ready := make(chan struct{})
+		var wg sync.WaitGroup
+		for j := 0; j < numConns; j++ {
+			conn, err := dialer.Dial("", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-ready
+				conn.(GracefulRotation).GetCertOrTLSHandshakeComplete()
+			}()
+		}
+		dialer.CloseAllGraceful()
+		select {
+		case <-closed:
+			t.Fatalf("iteration %d: CloseAllGraceful closed unmarked connections", i)
+		case <-time.After(time.Second):
+		}
+		close(ready)
+		wg.Wait()
+		dialer.CloseAllGraceful()
+		deadline := time.After(time.Second)
+		for j := 0; j < numConns; j++ {
+			select {
+			case <-closed:
+			case <-deadline:
+				t.Fatalf("iteration %d: 1s after CloseAllGraceful only %d/%d connections closed", i, j, numConns)
 			}
 		}
 	}
@@ -98,6 +150,83 @@ func TestCloseAllRace(t *testing.T) {
 
 	// Ensure CloseAll ran after all dials
 	dialer.CloseAll()
+
+	// Expect all connections to close within 5 seconds
+	for start := time.Now(); time.Since(start) < 5*time.Second; time.Sleep(10 * time.Millisecond) {
+		// Ensure all connections were closed
+		if c := atomic.LoadInt64(&conns); c == 0 {
+			break
+		} else {
+			t.Logf("got %d open connections, want 0, will retry", c)
+		}
+	}
+	// Ensure all connections were closed
+	if c := atomic.LoadInt64(&conns); c != 0 {
+		t.Fatalf("got %d open connections, want 0", c)
+	}
+}
+
+// TestCloseAllGracefulRace ensures CloseAllGraceful works with connections being simultaneously dialed
+func TestCloseAllGracefulRace(t *testing.T) {
+	conns := int64(0)
+	dialer := NewDialer(func(ctx context.Context, network, address string) (net.Conn, error) {
+		var once sync.Once
+		return closeOnlyConn{onClose: func() {
+			once.Do(func() {
+				// simulate slow close
+				time.Sleep(time.Duration(rand.IntnRange(10, 100)) * time.Millisecond)
+				atomic.AddInt64(&conns, -1)
+			})
+		}}, nil
+	})
+
+	const raceCount = 5000
+	begin := &sync.WaitGroup{}
+	begin.Add(1)
+
+	wg := &sync.WaitGroup{}
+
+	// Close all as fast as we can
+	wg.Add(1)
+	go func() {
+		begin.Wait()
+		defer wg.Done()
+		for i := 0; i < raceCount; i++ {
+			dialer.CloseAllGraceful()
+		}
+	}()
+
+	// Dial as fast as we can
+	wg.Add(1)
+	go func() {
+		begin.Wait()
+		defer wg.Done()
+		for i := 0; i < raceCount; i++ {
+			conn, err := dialer.Dial("", "")
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			atomic.AddInt64(&conns, 1)
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// have connections be marked at random times
+				time.Sleep(time.Duration(rand.IntnRange(10, 100)) * time.Millisecond)
+				conn.(GracefulRotation).GetCertOrTLSHandshakeComplete()
+			}()
+		}
+	}()
+
+	// Trigger both goroutines as close to the same time as possible
+	begin.Done()
+
+	// Wait for goroutines
+	wg.Wait()
+
+	// Ensure CloseAllGraceful ran after all dials
+	dialer.CloseAllGraceful()
 
 	// Expect all connections to close within 5 seconds
 	for start := time.Now(); time.Since(start) < 5*time.Second; time.Sleep(10 * time.Millisecond) {


### PR DESCRIPTION
This change addresses an edge case in our connection closing logic.

Consider the following scenario:

1. Exec plugin is configured
2. Exec plugin uses certificate based auth
3. Exec plugin returns a new certificate per invocation
4. Exec plugin sets expirationTimestamp based on some external source
5. The external source and the client (i.e. kubectl) disagree on
   what the current time is
6. The external source gives the exec plugin an expirationTimestamp
   that is considered to be in the past from the perspective of the
   client (i.e. the certificate is considered to already be expired)

Call stack for a client like kubectl:

1. exec.Authenticator.UpdateTransportConfig sets up Wrap and GetCert
2. exec.roundTripper.RoundTrip is called
3. getCreds, no creds, refreshCredsLocked -> gets first certificate
4. r.base.RoundTrip is called
5. a.cert gets called to fill the TLS config with a cert
6. getCreds, "expired" creds, refreshCredsLocked -> gets second
   certificate.  sees old creds with cert and closes connections.
   This happens to be the _current_ connection and thus auth fails
   with a "use of closed connection" error.

Signed-off-by: Monis Khan <mok@microsoft.com>

```release-note
Fix "use of closed network connection" error seen under particular configurations of client-go credential plugins.
```