### PR TITLE
cloud-provider: Fix additional flags not printed on help and usage

### DIFF
--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -117,24 +117,14 @@ the cloud specific control loops shipped with Kubernetes.`,
 	if flag.CommandLine.Lookup("cloud-provider-gce-l7lb-src-cidrs") != nil {
 		globalflag.Register(namedFlagSets.FlagSet("generic"), "cloud-provider-gce-l7lb-src-cidrs")
 	}
-	for _, f := range namedFlagSets.FlagSets {
-		fs.AddFlagSet(f)
-	}
-	for _, f := range additionalFlags.FlagSets {
+
+	allFlagSets := cliflag.MergeNamedFlagSets(namedFlagSets, additionalFlags)
+	for _, f := range allFlagSets.FlagSets {
 		fs.AddFlagSet(f)
 	}
 
-	usageFmt := "Usage:\n  %s\n"
 	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
-	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
-		fmt.Fprintf(cmd.OutOrStderr(), usageFmt, cmd.UseLine())
-		cliflag.PrintSections(cmd.OutOrStderr(), namedFlagSets, cols)
-		return nil
-	})
-	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n"+usageFmt, cmd.Long, cmd.UseLine())
-		cliflag.PrintSections(cmd.OutOrStdout(), namedFlagSets, cols)
-	})
+	cliflag.SetUsageAndHelpFunc(cmd, allFlagSets, cols)
 
 	return cmd
 }

--- a/staging/src/k8s.io/component-base/cli/flag/sectioned.go
+++ b/staging/src/k8s.io/component-base/cli/flag/sectioned.go
@@ -62,8 +62,8 @@ func (nfs *NamedFlagSets) FlagSet(name string) *pflag.FlagSet {
 func MergeNamedFlagSets(nfss ...NamedFlagSets) NamedFlagSets {
 	newNFS := NamedFlagSets{}
 	for _, nfs := range nfss {
-		for _, flagName := range nfs.Order {
-			*newNFS.FlagSet(flagName) = *nfs.FlagSet(flagName)
+		for _, flagSetName := range nfs.Order {
+			newNFS.FlagSet(flagSetName).AddFlagSet(nfs.FlagSet(flagSetName))
 		}
 	}
 	return newNFS

--- a/staging/src/k8s.io/component-base/cli/flag/sectioned.go
+++ b/staging/src/k8s.io/component-base/cli/flag/sectioned.go
@@ -58,6 +58,17 @@ func (nfs *NamedFlagSets) FlagSet(name string) *pflag.FlagSet {
 	return nfs.FlagSets[name]
 }
 
+// MergeNamedFlagSets merges the given NamedFlagSets into a new NamedFlagSets instance with all flags combined.
+func MergeNamedFlagSets(nfss ...NamedFlagSets) NamedFlagSets {
+	newNFS := NamedFlagSets{}
+	for _, nfs := range nfss {
+		for _, flagName := range nfs.Order {
+			*newNFS.FlagSet(flagName) = *nfs.FlagSet(flagName)
+		}
+	}
+	return newNFS
+}
+
 // PrintSections prints the given names flag sets in sections, with the maximal given column number.
 // If cols is zero, lines are not wrapped.
 func PrintSections(w io.Writer, fss NamedFlagSets, cols int) {

--- a/staging/src/k8s.io/component-base/cli/flag/sectioned_test.go
+++ b/staging/src/k8s.io/component-base/cli/flag/sectioned_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,18 +17,67 @@ limitations under the License.
 package flag
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestMergeNamedFlagSets(t *testing.T) {
+func TestMergeNamedFlagSetsNoArguments(t *testing.T) {
+	assert.Len(t, MergeNamedFlagSets().FlagSets, 0)
+}
+
+func getNFS(n int) NamedFlagSets {
+	nfs := NamedFlagSets{}
+	fs := nfs.FlagSet(fmt.Sprintf("flagSet%d", n))
+	fs.String(fmt.Sprintf("name%d", n), fmt.Sprintf("value%d", n), "")
+	return nfs
+}
+
+func assertNFS(t *testing.T, nfs, merged NamedFlagSets) {
+	require.Len(t, merged.FlagSets, 1)
+	require.NotNil(t, merged.FlagSets["flagSet1"])
+	assert.Equal(t, nfs.Order, merged.Order)
+	s, err := merged.FlagSets["flagSet1"].GetString("name1")
+	require.NoError(t, err)
+	assert.Equal(t, "value1", s)
+}
+
+func TestMergeNamedFlagSetsOneArgument(t *testing.T) {
+	nfs1 := getNFS(1)
+	merged := MergeNamedFlagSets(nfs1)
+	assertNFS(t, nfs1, merged)
+}
+
+func TestMergeNamedFlagSetsTwoArgumentsWithNameCollision(t *testing.T) {
+	nfs1 := getNFS(1)
+	nfs2 := getNFS(1)
+	merged := MergeNamedFlagSets(nfs1, nfs2)
+	assertNFS(t, nfs1, merged)
+}
+
+func TestMergeNamedFlagSetsTwoArguments(t *testing.T) {
 	nfs1 := NamedFlagSets{}
-	nfs1.FlagSet("flagSet1")
+	fs1 := nfs1.FlagSet("flagSet1")
+	fs1.String("name1", "value1", "usage1")
 
 	nfs2 := NamedFlagSets{}
-	nfs2.FlagSet("flagSet2")
+	fs2 := nfs2.FlagSet("flagSet2")
+	fs2.String("name2", "value2", "usage2")
 
-	nfs3 := MergeNamedFlagSets(nfs1, nfs2)
-	assert.Len(t, nfs3.FlagSets, 2)
+	merged := MergeNamedFlagSets(nfs1, nfs2)
+
+	require.Len(t, merged.FlagSets, 2)
+	assert.Equal(t, append(nfs1.Order, nfs2.Order...), merged.Order)
+
+	require.NotNil(t, fs1, merged.FlagSets["flagSet1"])
+	s, err := merged.FlagSets["flagSet1"].GetString("name1")
+	require.NoError(t, err)
+	assert.Equal(t, "value1", s)
+
+	require.NotNil(t, fs2, merged.FlagSets["flagSet2"])
+	s, err = merged.FlagSets["flagSet2"].GetString("name2")
+	require.NoError(t, err)
+	assert.Equal(t, "value2", s)
 }

--- a/staging/src/k8s.io/component-base/cli/flag/sectioned_test.go
+++ b/staging/src/k8s.io/component-base/cli/flag/sectioned_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeNamedFlagSets(t *testing.T) {
+	nfs1 := NamedFlagSets{}
+	nfs1.FlagSet("flagSet1")
+
+	nfs2 := NamedFlagSets{}
+	nfs2.FlagSet("flagSet2")
+
+	nfs3 := MergeNamedFlagSets(nfs1, nfs2)
+	assert.Len(t, nfs3.FlagSets, 2)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR makes additional flags to be shown in the usage and help commands.

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/cloud-provider/issues/62

#### Special notes for your reviewer:

The issue referenced above contains instructions to reproduce the issue, which could also be used to validate this change.

#### Does this PR introduce a user-facing change?

```release-note
Fixed Additional flags are not print when usage and help commands are executed [kubernetes/cloud-provider#62](https://github.com/kubernetes/cloud-provider/issues/62): 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
