### PR TITLE
Update_ineligible_endpoints.yaml : add createCoreV1NamespacedBinding to the list

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -442,4 +442,6 @@
 - endpoint: deleteCoreV1CollectionNode
   reason: Kubernetes distribution would reasonably not allow this action via the API
   link: https://github.com/kubernetes/kubernetes/issues/109379 
-  
+- endpoint: createCoreV1NamespacedBinding
+  reason: Endpoint was deprectated in 1.17
+  link: https://github.com/kubernetes/kubernetes/pull/47041  

--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -443,5 +443,5 @@
   reason: Kubernetes distribution would reasonably not allow this action via the API
   link: https://github.com/kubernetes/kubernetes/issues/109379 
 - endpoint: createCoreV1NamespacedBinding
-  reason: Endpoint was deprectated in 1.17
+  reason: Endpoint was deprecated in 1.17
   link: https://github.com/kubernetes/kubernetes/pull/47041  

--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -443,5 +443,5 @@
   reason: Kubernetes distribution would reasonably not allow this action via the API
   link: https://github.com/kubernetes/kubernetes/issues/109379 
 - endpoint: createCoreV1NamespacedBinding
-  reason: Endpoint was deprecated in 1.17
+  reason: Endpoint was deprecated in 1.7
   link: https://github.com/kubernetes/kubernetes/pull/47041  


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Endpoint was deprecated back in 1.7
- createCoreV1NamespacedBinding 

**Special notes for your reviewer:**

**Which issue(s) this PR fixes:**

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig architecture
/area conformance
/sig api-machinery