### PR TITLE
Enable Parallel in pkg/scheduler/scheduler_test.go file

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -49,6 +49,7 @@ import (
 )
 
 func TestSchedulerCreation(t *testing.T) {
+	t.Parallel()
 	invalidRegistry := map[string]frameworkruntime.PluginFactory{
 		defaultbinder.Name: defaultbinder.New,
 	}
@@ -166,7 +167,9 @@ func TestSchedulerCreation(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			client := fake.NewSimpleClientset()
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 
@@ -231,6 +234,7 @@ func TestSchedulerCreation(t *testing.T) {
 }
 
 func TestFailureHandler(t *testing.T) {
+	t.Parallel()
 	testPod := st.MakePod().Name("test-pod").Namespace(v1.NamespaceDefault).Obj()
 	testPodUpdated := testPod.DeepCopy()
 	testPodUpdated.Labels = map[string]string{"foo": ""}
@@ -262,7 +266,9 @@ func TestFailureHandler(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -314,6 +320,7 @@ func TestFailureHandler(t *testing.T) {
 }
 
 func TestFailureHandler_NodeNotFound(t *testing.T) {
+	t.Parallel()
 	nodeFoo := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 	nodeBar := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "bar"}}
 	testPod := st.MakePod().Name("test-pod").Namespace(v1.NamespaceDefault).Obj()
@@ -340,7 +347,9 @@ func TestFailureHandler_NodeNotFound(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -383,6 +392,7 @@ func TestFailureHandler_NodeNotFound(t *testing.T) {
 }
 
 func TestFailureHandler_PodAlreadyBound(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -476,6 +486,7 @@ func initScheduler(stop <-chan struct{}, cache internalcache.Cache, queue intern
 }
 
 func TestInitPluginsWithIndexers(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		// the plugin registration ordering must not matter, being map traversal random
@@ -538,7 +549,9 @@ func TestInitPluginsWithIndexers(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			fakeInformerFactory := NewInformerFactory(&fake.Clientset{}, 0*time.Second)
 
 			var registerPluginFuncs []st.RegisterPluginFunc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Since go v1.7, the go testing package provides the ability to run [tests in parallel](https://pkg.go.dev/testing#T.Parallel). As this [post](https://engineering.mercari.com/en/blog/entry/20220408-how_to_use_t_parallel/) describes, unit tests will run in parallel at the package level. Therefore, this change allows increasing the number of processes during the execution of unit tests for pkg/scheduler/scheduler_test.go file

* Performance metrics **before** the change:
```bash
$ make clean
+++ [0912 17:05:42] Verifying Prerequisites....
+++ [0912 17:05:43] Removing _output directory
$ make test WHAT=./pkg/scheduler/
+++ [0912 17:05:47] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0912 17:05:55] Building go targets for linux/amd64
    k8s.io/code-generator/cmd/prerelease-lifecycle-gen (non-static)
+++ [0912 17:06:00] Generating prerelease lifecycle code for 27 targets
+++ [0912 17:06:01] Building go targets for linux/amd64
    k8s.io/code-generator/cmd/deepcopy-gen (non-static)
+++ [0912 17:06:04] Generating deepcopy code for 242 targets
+++ [0912 17:06:09] Building go targets for linux/amd64
    k8s.io/code-generator/cmd/defaulter-gen (non-static)
+++ [0912 17:06:11] Generating defaulter code for 95 targets
+++ [0912 17:06:17] Building go targets for linux/amd64
    k8s.io/code-generator/cmd/conversion-gen (non-static)
+++ [0912 17:06:19] Generating conversion code for 132 targets
+++ [0912 17:06:32] Building go targets for linux/amd64
    k8s.io/kube-openapi/cmd/openapi-gen (non-static)
+++ [0912 17:06:40] Generating openapi code for KUBE
+++ [0912 17:06:49] Generating openapi code for AGGREGATOR
+++ [0912 17:06:50] Generating openapi code for APIEXTENSIONS
+++ [0912 17:06:51] Generating openapi code for CODEGEN
+++ [0912 17:06:52] Generating openapi code for SAMPLEAPISERVER
+++ [0912 17:06:53] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/scheduler 6.474s
```

* Performance metrics **after** the change:
```bash
$ make clean
+++ [0912 17:08:02] Verifying Prerequisites....
+++ [0912 17:08:02] Removing _output directory
$ make test WHAT=./pkg/scheduler/
+++ [0912 17:08:07] Building go targets for linux/amd64
    k8s.io/kubernetes/hack/make-rules/helpers/go2make (non-static)
+++ [0912 17:08:16] Building go targets for linux/amd64
    k8s.io/code-generator/cmd/prerelease-lifecycle-gen (non-static)
+++ [0912 17:08:20] Generating prerelease lifecycle code for 27 targets
+++ [0912 17:08:22] Building go targets for linux/amd64
    k8s.io/code-generator/cmd/deepcopy-gen (non-static)
+++ [0912 17:08:24] Generating deepcopy code for 242 targets
+++ [0912 17:08:29] Building go targets for linux/amd64
    k8s.io/code-generator/cmd/defaulter-gen (non-static)
+++ [0912 17:08:30] Generating defaulter code for 95 targets
+++ [0912 17:08:37] Building go targets for linux/amd64
    k8s.io/code-generator/cmd/conversion-gen (non-static)
+++ [0912 17:08:39] Generating conversion code for 132 targets
+++ [0912 17:08:51] Building go targets for linux/amd64
    k8s.io/kube-openapi/cmd/openapi-gen (non-static)
+++ [0912 17:09:00] Generating openapi code for KUBE
+++ [0912 17:09:09] Generating openapi code for AGGREGATOR
+++ [0912 17:09:10] Generating openapi code for APIEXTENSIONS
+++ [0912 17:09:11] Generating openapi code for CODEGEN
+++ [0912 17:09:12] Generating openapi code for SAMPLEAPISERVER
+++ [0912 17:09:13] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/pkg/scheduler 6.453s
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NA

#### Special notes for your reviewer:
This effort tries to reduce the number of issues reported by [this linter](https://github.com/kunwardeep/paralleltest)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```