### PR TITLE
kubelet: append options to pod if there are multi options in /etc/resolv.conf

### DIFF
--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -273,11 +273,31 @@ func parseResolvConf(reader io.Reader) (nameservers []string, searches []string,
 			}
 		}
 		if fields[0] == "options" {
-			options = fields[1:]
+			options = appendOptions(options, fields[1:]...)
 		}
 	}
 
 	return nameservers, searches, options, utilerrors.NewAggregate(allErrors)
+}
+
+// appendOptions appends options to the given list, but does not add duplicates.
+// append option will overwrite the previous one either in new line or in the same line.
+func appendOptions(options []string, newOption ...string) []string {
+	var optionMap = make(map[string]string)
+	for _, option := range options {
+		optName := strings.Split(option, ":")[0]
+		optionMap[optName] = option
+	}
+	for _, option := range newOption {
+		optName := strings.Split(option, ":")[0]
+		optionMap[optName] = option
+	}
+
+	options = []string{}
+	for _, v := range optionMap {
+		options = append(options, v)
+	}
+	return options
 }
 
 func (c *Configurer) getHostDNSConfig() (*runtimeapi.DNSConfig, error) {

--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -280,26 +280,6 @@ func parseResolvConf(reader io.Reader) (nameservers []string, searches []string,
 	return nameservers, searches, options, utilerrors.NewAggregate(allErrors)
 }
 
-// appendOptions appends options to the given list, but does not add duplicates.
-// append option will overwrite the previous one either in new line or in the same line.
-func appendOptions(options []string, newOption ...string) []string {
-	var optionMap = make(map[string]string)
-	for _, option := range options {
-		optName := strings.Split(option, ":")[0]
-		optionMap[optName] = option
-	}
-	for _, option := range newOption {
-		optName := strings.Split(option, ":")[0]
-		optionMap[optName] = option
-	}
-
-	options = []string{}
-	for _, v := range optionMap {
-		options = append(options, v)
-	}
-	return options
-}
-
 func (c *Configurer) getHostDNSConfig() (*runtimeapi.DNSConfig, error) {
 	var hostDNS, hostSearch, hostOptions []string
 	// Get host DNS settings
@@ -369,6 +349,26 @@ func mergeDNSOptions(existingDNSConfigOptions []string, dnsConfigOptions []v1.Po
 			op = op + ":" + opValue
 		}
 		options = append(options, op)
+	}
+	return options
+}
+
+// appendOptions appends options to the given list, but does not add duplicates.
+// append option will overwrite the previous one either in new line or in the same line.
+func appendOptions(options []string, newOption ...string) []string {
+	var optionMap = make(map[string]string)
+	for _, option := range options {
+		optName := strings.Split(option, ":")[0]
+		optionMap[optName] = option
+	}
+	for _, option := range newOption {
+		optName := strings.Split(option, ":")[0]
+		optionMap[optName] = option
+	}
+
+	options = []string{}
+	for _, v := range optionMap {
+		options = append(options, v)
 	}
 	return options
 }

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -92,7 +92,11 @@ func TestParseResolvConf(t *testing.T) {
 		{"#comment\nnameserver 1.2.3.4\n#comment\nsearch foo\ncomment", []string{"1.2.3.4"}, []string{"foo"}, []string{}, false},
 		{"options ", []string{}, []string{}, []string{}, false},
 		{"options ndots:5 attempts:2", []string{}, []string{}, []string{"ndots:5", "attempts:2"}, false},
+		{"options ndots:1 ndots:5 attempts:2", []string{}, []string{}, []string{"ndots:5", "attempts:2"}, false},
+		{"options ndots:1 edns0 attempts:2 single-request-reopen", []string{}, []string{}, []string{"edns0", "attempts:2", "single-request-reopen", "ndots:1"}, false},
 		{"options ndots:1\noptions ndots:5 attempts:3", []string{}, []string{}, []string{"ndots:5", "attempts:3"}, false},
+		{"options ndots:1 timeout:3 timeout:1 attempts:3\noptions ndots:5", []string{}, []string{}, []string{"ndots:5", "timeout:1", "attempts:3"}, false},
+		{"options ndots:1 attempts:3\noptions ndots:1 attempts:3 ndots:5", []string{}, []string{}, []string{"ndots:5", "attempts:3"}, false},
 		{"nameserver 1.2.3.4\nsearch foo\nnameserver 5.6.7.8\nsearch bar\noptions ndots:5 attempts:4", []string{"1.2.3.4", "5.6.7.8"}, []string{"bar"}, []string{"ndots:5", "attempts:4"}, false},
 	}
 	for i, tc := range testCases {

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -105,7 +105,7 @@ func TestParseResolvConf(t *testing.T) {
 			require.NoError(t, err)
 			assert.EqualValues(t, tc.nameservers, ns, "test case [%d]: name servers", i)
 			assert.EqualValues(t, tc.searches, srch, "test case [%d] searches", i)
-			assert.EqualValues(t, tc.options, opts, "test case [%d] options", i)
+			assert.EqualValues(t, sets.NewString(tc.options...), sets.NewString(opts...), "test case [%d] options", i)
 		} else {
 			require.Error(t, err, "tc.searches %v", tc.searches)
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
```
options timeout:1 
options attempts:3
```
kubelet will be loading above reslov.conf as below.
```
options timeout:1 attempts:3
```

#### Which issue(s) this PR fixes:

Fixes #112323

#### Special notes for your reviewer:

**The feature was added by #54773 long time ago by @phsiao following the design https://github.com/kubernetes/community/pull/1276.**

However, per https://github.com/kubernetes/kubernetes/pull/91052#issuecomment-629557368 as Tim pointed out that 
>  If you want to specify multiple options, combine them on a single line in resolv.conf

**we may keep it as.**


I tried centos/ubuntu, both will append extra options to the options list and overwrite them if it already exists by the later settings.

If we want to keep the same behavior, we can accept this pr as a bug fix.


#### Does this PR introduce a user-facing change?

```release-note
kubelet: when there are multi option lines in /etc/resolv.conf, merge all options into one line in a pod with the `Default` DNS policy.
```

####  Design details
```
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/504-configurable-pod-dns#proposal
```