### PR TITLE
Cleanup of TODO actions

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -332,13 +332,7 @@ function kube::build::short_hash() {
 # a workaround for bug https://github.com/docker/docker/issues/3968.
 function kube::build::destroy_container() {
   "${DOCKER[@]}" kill "$1" >/dev/null 2>&1 || true
-  if [[ $("${DOCKER[@]}" version --format '{{.Server.Version}}') = 17.06.0* ]]; then
-    # Workaround https://github.com/moby/moby/issues/33948.
-    # TODO: remove when 17.06.0 is not relevant anymore
-    DOCKER_API_VERSION=v1.29 "${DOCKER[@]}" wait "$1" >/dev/null 2>&1 || true
-  else
-    "${DOCKER[@]}" wait "$1" >/dev/null 2>&1 || true
-  fi
+  "${DOCKER[@]}" wait "$1" >/dev/null 2>&1 || true
   "${DOCKER[@]}" rm -f -v "$1" >/dev/null 2>&1 || true
 }
 

--- a/build/common.sh
+++ b/build/common.sh
@@ -326,13 +326,8 @@ function kube::build::short_hash() {
   echo "${short_hash:0:10}"
 }
 
-# Pedantically kill, wait-on and remove a container. The -f -v options
-# to rm don't actually seem to get the job done, so force kill the
-# container, wait to ensure it's stopped, then try the remove. This is
-# a workaround for bug https://github.com/docker/docker/issues/3968.
+
 function kube::build::destroy_container() {
-  "${DOCKER[@]}" kill "$1" >/dev/null 2>&1 || true
-  "${DOCKER[@]}" wait "$1" >/dev/null 2>&1 || true
   "${DOCKER[@]}" rm -f -v "$1" >/dev/null 2>&1 || true
 }
 

--- a/build/pause/Dockerfile_windows
+++ b/build/pause/Dockerfile_windows
@@ -18,8 +18,4 @@ ARG ARCH
 ADD bin/pause-windows-${ARCH}.exe /pause.exe
 ADD bin/wincat-windows-amd64 /Windows/System32/wincat.exe
 
-# NOTE(claudiub): docker buildx sets the PATH env variable to a Linux-like PATH,
-# which is not desirable. See: https://github.com/moby/buildkit/issues/1560
-# TODO(claudiub): remove this once the issue has been resolved.
-ENV PATH="C:\Windows\system32;C:\Windows;"
 ENTRYPOINT ["/pause.exe"]

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -157,11 +157,9 @@ export ENABLE_DOCKER_REGISTRY_CACHE=true
 #   glbc           - CE L7 Load Balancer Controller
 export ENABLE_L7_LOADBALANCING="${KUBE_ENABLE_L7_LOADBALANCING:-glbc}"
 
-# Optional: Enable Metrics Server. Metrics Server should be enable everywhere,
-# since it's a critical component, but in the first release we need a way to disable
-# this in case of stability issues.
-# TODO(piosz) remove this option once Metrics Server became a stable thing.
-export ENABLE_METRICS_SERVER="${KUBE_ENABLE_METRICS_SERVER:-true}"
+# Enable Metrics Server. Metrics Server should be enable everywhere,
+# since it's a critical component.
+export ENABLE_METRICS_SERVER=true
 
 # Optional: Metadata agent to setup as part of the cluster bring up:
 #   none        - No metadata agent

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -176,11 +176,9 @@ export ENABLE_DOCKER_REGISTRY_CACHE=true
 #   glbc           - CE L7 Load Balancer Controller
 export ENABLE_L7_LOADBALANCING=${KUBE_ENABLE_L7_LOADBALANCING:-glbc}
 
-# Optional: Enable Metrics Server. Metrics Server should be enable everywhere,
-# since it's a critical component, but in the first release we need a way to disable
-# this in case of stability issues.
-# TODO(piosz) remove this option once Metrics Server became a stable thing.
-export ENABLE_METRICS_SERVER=${KUBE_ENABLE_METRICS_SERVER:-true}
+# Enable Metrics Server. Metrics Server should be enable everywhere,
+# since it's a critical component.
+export ENABLE_METRICS_SERVER=true
 
 # Optional: Metadata agent to setup as part of the cluster bring up:
 #   none        - No metadata agent

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -518,11 +518,6 @@ function install-containerd-ubuntu {
   # Override to latest versions of containerd and runc
   systemctl stop containerd
   if [[ -n "${UBUNTU_INSTALL_CONTAINERD_VERSION:-}" ]]; then
-    # TODO(https://github.com/containerd/containerd/issues/2901): Remove this check once containerd has arm64 release.
-    if [[ $(dpkg --print-architecture) != "amd64" ]]; then
-      echo "Unable to automatically install containerd in non-amd64 image. Bailing out..."
-      exit 2
-    fi
     # containerd versions have slightly different url(s), so try both
     # shellcheck disable=SC2086
     ( curl ${CURL_FLAGS} \
@@ -534,11 +529,6 @@ function install-containerd-ubuntu {
     | tar --overwrite -xzv -C /usr/
   fi
   if [[ -n "${UBUNTU_INSTALL_RUNC_VERSION:-}" ]]; then
-    # TODO: Remove this check once runc has arm64 release.
-    if [[ $(dpkg --print-architecture) != "amd64" ]]; then
-      echo "Unable to automatically install runc in non-amd64. Bailing out..."
-      exit 2
-    fi
     # shellcheck disable=SC2086
     curl ${CURL_FLAGS} \
       --location \

--- a/cluster/images/etcd/Dockerfile.windows
+++ b/cluster/images/etcd/Dockerfile.windows
@@ -21,8 +21,3 @@ COPY etcd* etcdctl* /usr/local/bin/
 COPY cp* /usr/local/bin/
 COPY migrate-if-needed.bat /usr/local/bin/
 COPY migrate /usr/local/bin/migrate.exe
-
-# NOTE(claudiub): docker buildx sets the PATH env variable to a Linux-like PATH,
-# # which is not desirable. See: https://github.com/moby/buildkit/issues/1560
-# # TODO(claudiub): remove this once the issue has been resolved.
-ENV PATH="C:\usr\local\bin;C:\Windows\system32;C:\Windows;"

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -254,25 +254,6 @@ function check-curl-proxy-code()
   return 1
 }
 
-# TODO: Remove this function when we do the retry inside the kubectl commands. See #15333.
-function kubectl-with-retry()
-{
-  ERROR_FILE="${KUBE_TEMP}/kubectl-error"
-  preserve_err_file=${PRESERVE_ERR_FILE:-false}
-  for count in {0..3}; do
-    kubectl "$@" 2> "${ERROR_FILE}" || true
-    if grep -q "the object has been modified" "${ERROR_FILE}"; then
-      kube::log::status "retry $1, error: $(cat "${ERROR_FILE}")"
-      rm "${ERROR_FILE}"
-      sleep $((2**count))
-    else
-      if [ "$preserve_err_file" != true ] ; then
-        rm "${ERROR_FILE}"
-      fi
-      break
-    fi
-  done
-}
 
 # Waits for the pods with the given label to match the list of names. Don't call
 # this function unless you know the exact pod names, or expect no pods.


### PR DESCRIPTION
There are a lot of `TODO` references throughout the codebase. A some have underlying references to bugs, that have been fixed meanwhile, but the followup action hasn't been performed. 
This PR attempts to address the low hanging fruits at least.

Each addressed `TODO` is a separate commit so it's easier to cherry pick and also potentially roll back in case there are dragons. Additionally, it's better to read in a changelog than "fixed a bunch of todos"