### PR TITLE
[DO NOT MERGE][TESTING] cluster: Set GOGC to 63 for testing memory overhead

### DIFF
--- a/cluster/gce/gci/configure-kubeapiserver.sh
+++ b/cluster/gce/gci/configure-kubeapiserver.sh
@@ -333,7 +333,7 @@ function start-kube-apiserver {
     params+=" --egress-selector-config-file=/etc/srv/kubernetes/egress_selector_configuration.yaml"
   fi
 
-  local container_env="{\"name\": \"GOGC\", \"value\": \"63\"}"
+  local container_env="{\"name\": \"GOGC\", \"value\": \"87\"}"
   if [[ -n "${ENABLE_CACHE_MUTATION_DETECTOR:-}" ]]; then
     if [[ -n "${container_env}" ]]; then
       container_env="${container_env}, "

--- a/cluster/gce/gci/configure-kubeapiserver.sh
+++ b/cluster/gce/gci/configure-kubeapiserver.sh
@@ -333,8 +333,11 @@ function start-kube-apiserver {
     params+=" --egress-selector-config-file=/etc/srv/kubernetes/egress_selector_configuration.yaml"
   fi
 
-  local container_env=""
+  local container_env="{\"name\": \"GOGC\", \"value\": \"63\"}"
   if [[ -n "${ENABLE_CACHE_MUTATION_DETECTOR:-}" ]]; then
+    if [[ -n "${container_env}" ]]; then
+      container_env="${container_env}, "
+    fi
     container_env+="{\"name\": \"KUBE_CACHE_MUTATION_DETECTOR\", \"value\": \"${ENABLE_CACHE_MUTATION_DETECTOR}\"}"
   fi
   if [[ -n "${ENABLE_PATCH_CONVERSION_DETECTOR:-}" ]]; then


### PR DESCRIPTION
I'm hoping to better understand the memory overhead that versions of Go greater than and including go1.18 cause for the API Server (and potentially other components too) due to changes in the GC algorithm (please see https://github.com/kubernetes/kubernetes/issues/108357 for more info).

This commit makes the same change as https://github.com/kubernetes/kubernetes/pull/108411, creating a draft PR to try and understand things better since the artifacts for that have been cleaned up by Prow.