### PR TITLE
e2e: improve description of framework callbacks

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -155,7 +155,7 @@ func NewFramework(baseName string, options Options, client clientset.Interface) 
 		Timeouts:                 NewTimeoutContextWithDefaults(),
 	}
 
-	ginkgo.BeforeEach(f.BeforeEach)
+	ginkgo.BeforeEach(f.BeforeEach, AnnotatedLocation("set up framework"))
 
 	return f
 }
@@ -167,10 +167,10 @@ func (f *Framework) BeforeEach() {
 	// remains valid as long as possible.
 	//
 	// In addition, AfterEach will not be called if a test never gets here.
-	ginkgo.DeferCleanup(f.AfterEach)
+	ginkgo.DeferCleanup(f.AfterEach, AnnotatedLocation("tear down framework"))
 
 	// Registered later and thus runs before deleting namespaces.
-	ginkgo.DeferCleanup(f.dumpNamespaceInfo)
+	ginkgo.DeferCleanup(f.dumpNamespaceInfo, AnnotatedLocation("dump namespaces"))
 
 	ginkgo.By("Creating a kubernetes client")
 	config, err := LoadConfig()

--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"path"
+
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+// AnnotatedLocation can be used to provide more informative source code
+// locations by passing the result as additional parameter to a
+// BeforeEach/AfterEach/DeferCleanup/It/etc.
+func AnnotatedLocation(annotation string) types.CodeLocation {
+	codeLocation := types.NewCodeLocation(1)
+	codeLocation.FileName = path.Base(codeLocation.FileName)
+	codeLocation = types.NewCustomCodeLocation(annotation + " | " + codeLocation.String())
+	return codeLocation
+}

--- a/test/e2e/framework/internal/unittests/cleanup/cleanup_test.go
+++ b/test/e2e/framework/internal/unittests/cleanup/cleanup_test.go
@@ -49,7 +49,7 @@ import (
 //
 // This must be line #50.
 
-var _ = ginkgo.Describe("framework", func() {
+var _ = ginkgo.Describe("e2e", func() {
 	ginkgo.BeforeEach(func() {
 		framework.Logf("before")
 	})
@@ -75,30 +75,30 @@ var _ = ginkgo.Describe("framework", func() {
 })
 
 const (
-	ginkgoOutput = `[BeforeEach] framework
+	ginkgoOutput = `[BeforeEach] e2e
   cleanup_test.go:53
 INFO: before
-[BeforeEach] framework
-  framework.go:xxx
+[BeforeEach] e2e
+  set up framework | framework.go:xxx
 STEP: Creating a kubernetes client
 INFO: >>> kubeConfig: yyy/kube.config
 STEP: Building a namespace api object, basename test-namespace
 INFO: Skipping waiting for service account
 [It] works
   cleanup_test.go:66
-[AfterEach] framework
+[AfterEach] e2e
   cleanup_test.go:59
 INFO: after
-[DeferCleanup] framework
+[DeferCleanup] e2e
   cleanup_test.go:71
 INFO: cleanup first
-[DeferCleanup] framework
+[DeferCleanup] e2e
   cleanup_test.go:68
 INFO: cleanup last
-[DeferCleanup] framework
-  framework.go:xxx
-[DeferCleanup] framework
-  framework.go:xxx
+[DeferCleanup] e2e
+  dump namespaces | framework.go:xxx
+[DeferCleanup] e2e
+  tear down framework | framework.go:xxx
 STEP: Destroying namespace "test-namespace-zzz" for this suite.
 `
 )
@@ -145,7 +145,7 @@ func TestCleanup(t *testing.T) {
 
 	expected := output.SuiteResults{
 		output.TestResult{
-			Name:            "framework works",
+			Name:            "e2e works",
 			NormalizeOutput: normalizeOutput,
 			Output:          ginkgoOutput,
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When Ginkgo shows a BeforeEach/AfterEach/DeferCleanup, then it can only show the source code where the callback was registered because there is no description parameter. This can be improved by passing a custom CodeLocation.

Because a description like "set up framework" might not be enough, the source code is still shown, too.


#### Which issue(s) this PR fixes:
Related-to: https://github.com/onsi/ginkgo/issues/1023

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
