### PR TITLE
Add zone field to vsphere test cloudconfig

### DIFF
--- a/test/e2e/storage/vsphere/config.go
+++ b/test/e2e/storage/vsphere/config.go
@@ -85,6 +85,11 @@ type ConfigFile struct {
 		DefaultDatastore string `gcfg:"default-datastore"`
 		ResourcePoolPath string `gcfg:"resourcepool-path"`
 	}
+	// Tag categories and tags which correspond to "built-in node labels: zones and region"
+	Labels struct {
+		Zone   string `gcfg:"zone"`
+		Region string `gcfg:"region"`
+	}
 }
 
 // GetVSphereInstances parses vsphere.conf and returns VSphere instances


### PR DESCRIPTION
This allows same configuration of cloudprovider and test. 

Helps with e2e of vsphere intree driver


```release-note
Allow Label section in vsphere e2e cloudprovider configuration
```