### PR TITLE
kube-proxy use debug log level for Service cache operations

### DIFF
--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -322,7 +322,7 @@ func (sct *ServiceChangeTracker) Update(previous, current *v1.Service) bool {
 	if reflect.DeepEqual(change.previous, change.current) {
 		delete(sct.items, namespacedName)
 	} else {
-		klog.V(2).InfoS("Service updated ports", "service", klog.KObj(svc), "portCount", len(change.current))
+		klog.V(4).InfoS("Service updated ports", "service", klog.KObj(svc), "portCount", len(change.current))
 	}
 	metrics.ServiceChangesPending.Set(float64(len(sct.items)))
 	return len(sct.items) > 0
@@ -438,9 +438,9 @@ func (sm *ServiceMap) merge(other ServiceMap) sets.String {
 		existingPorts.Insert(svcPortName.String())
 		_, exists := (*sm)[svcPortName]
 		if !exists {
-			klog.V(1).InfoS("Adding new service port", "portName", svcPortName, "servicePort", info)
+			klog.V(4).InfoS("Adding new service port", "portName", svcPortName, "servicePort", info)
 		} else {
-			klog.V(1).InfoS("Updating existing service port", "portName", svcPortName, "servicePort", info)
+			klog.V(4).InfoS("Updating existing service port", "portName", svcPortName, "servicePort", info)
 		}
 		(*sm)[svcPortName] = info
 	}
@@ -463,7 +463,7 @@ func (sm *ServiceMap) unmerge(other ServiceMap, UDPStaleClusterIP sets.String) {
 	for svcPortName := range other {
 		info, exists := (*sm)[svcPortName]
 		if exists {
-			klog.V(1).InfoS("Removing service port", "portName", svcPortName)
+			klog.V(4).InfoS("Removing service port", "portName", svcPortName)
 			if info.Protocol() == v1.ProtocolUDP {
 				UDPStaleClusterIP.Insert(info.ClusterIP().String())
 			}


### PR DESCRIPTION
Kube-proxy logs are flooded with thousands of lines from the cache information when using the default log level (2)

/kind cleanup
```release-note
NONE
```
I've seen this while playing with https://github.com/kubernetes/kubernetes/pull/112449,  trying to analyze the behavior of kube-proxy with thousands of services. 
These logs are not adding too much value and decreasing the performance of the proxy because it has to log one line per each service created or updated.

Based on the conventions, I think these should be log level 4

https://github.com/kubernetes/community/blob/d14dd595ebb353d17163ceeaa12439cde9662d1b/contributors/devel/sig-instrumentation/logging.md#what-method-to-use

