### PR TITLE
Pass the context for AzureFile

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_file.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_file.go
@@ -19,23 +19,25 @@ limitations under the License.
 package azure
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	"k8s.io/legacy-cloud-providers/azure/clients/fileclient"
 )
 
 // create file share
-func (az *Cloud) createFileShare(resourceGroupName, accountName string, shareOptions *fileclient.ShareOptions) error {
-	return az.FileClient.CreateFileShare(resourceGroupName, accountName, shareOptions)
+func (az *Cloud) createFileShare(ctx context.Context, resourceGroupName, accountName string, shareOptions *fileclient.ShareOptions) error {
+	return az.FileClient.CreateFileShare(ctx, resourceGroupName, accountName, shareOptions)
 }
 
-func (az *Cloud) deleteFileShare(resourceGroupName, accountName, name string) error {
-	return az.FileClient.DeleteFileShare(resourceGroupName, accountName, name)
+func (az *Cloud) deleteFileShare(ctx context.Context, resourceGroupName, accountName, name string) error {
+	return az.FileClient.DeleteFileShare(ctx, resourceGroupName, accountName, name)
 }
 
-func (az *Cloud) resizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
-	return az.FileClient.ResizeFileShare(resourceGroupName, accountName, name, sizeGiB)
+func (az *Cloud) resizeFileShare(ctx context.Context, resourceGroupName, accountName, name string, sizeGiB int) error {
+	return az.FileClient.ResizeFileShare(ctx, resourceGroupName, accountName, name, sizeGiB)
 }
 
-func (az *Cloud) getFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error) {
-	return az.FileClient.GetFileShare(resourceGroupName, accountName, name)
+func (az *Cloud) getFileShare(ctx context.Context, resourceGroupName, accountName, name string) (storage.FileShare, error) {
+	return az.FileClient.GetFileShare(ctx, resourceGroupName, accountName, name)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storage.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storage.go
@@ -19,6 +19,7 @@ limitations under the License.
 package azure
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
@@ -37,7 +38,7 @@ const (
 
 // CreateFileShare creates a file share, using a matching storage account type, account kind, etc.
 // storage account will be created if specified account is not found
-func (az *Cloud) CreateFileShare(accountOptions *AccountOptions, shareOptions *fileclient.ShareOptions) (string, string, error) {
+func (az *Cloud) CreateFileShare(ctx context.Context, accountOptions *AccountOptions, shareOptions *fileclient.ShareOptions) (string, string, error) {
 	if accountOptions == nil {
 		return "", "", fmt.Errorf("account options is nil")
 	}
@@ -58,7 +59,7 @@ func (az *Cloud) CreateFileShare(accountOptions *AccountOptions, shareOptions *f
 		return "", "", fmt.Errorf("could not get storage key for storage account %s: %v", accountOptions.Name, err)
 	}
 
-	if err := az.createFileShare(accountOptions.ResourceGroup, accountName, shareOptions); err != nil {
+	if err := az.createFileShare(ctx, accountOptions.ResourceGroup, accountName, shareOptions); err != nil {
 		return "", "", fmt.Errorf("failed to create share %s in account %s: %v", shareOptions.Name, accountName, err)
 	}
 	klog.V(4).Infof("created share %s in account %s", shareOptions.Name, accountOptions.Name)
@@ -66,8 +67,8 @@ func (az *Cloud) CreateFileShare(accountOptions *AccountOptions, shareOptions *f
 }
 
 // DeleteFileShare deletes a file share using storage account name and key
-func (az *Cloud) DeleteFileShare(resourceGroup, accountName, shareName string) error {
-	if err := az.deleteFileShare(resourceGroup, accountName, shareName); err != nil {
+func (az *Cloud) DeleteFileShare(ctx context.Context, resourceGroup, accountName, shareName string) error {
+	if err := az.deleteFileShare(ctx, resourceGroup, accountName, shareName); err != nil {
 		return err
 	}
 	klog.V(4).Infof("share %s deleted", shareName)
@@ -75,11 +76,11 @@ func (az *Cloud) DeleteFileShare(resourceGroup, accountName, shareName string) e
 }
 
 // ResizeFileShare resizes a file share
-func (az *Cloud) ResizeFileShare(resourceGroup, accountName, name string, sizeGiB int) error {
-	return az.resizeFileShare(resourceGroup, accountName, name, sizeGiB)
+func (az *Cloud) ResizeFileShare(ctx context.Context, resourceGroup, accountName, name string, sizeGiB int) error {
+	return az.resizeFileShare(ctx, resourceGroup, accountName, name, sizeGiB)
 }
 
 // GetFileShare gets a file share
-func (az *Cloud) GetFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error) {
-	return az.getFileShare(resourceGroupName, accountName, name)
+func (az *Cloud) GetFileShare(ctx context.Context, resourceGroupName, accountName, name string) (storage.FileShare, error) {
+	return az.getFileShare(ctx, resourceGroupName, accountName, name)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storage_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storage_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package azure
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -142,7 +143,7 @@ func TestCreateFileShare(t *testing.T) {
 	for _, test := range tests {
 		mockFileClient := mockfileclient.NewMockInterface(ctrl)
 		cloud.FileClient = mockFileClient
-		mockFileClient.EXPECT().CreateFileShare(gomock.Any(), gomock.Any(), gomock.Any()).Return(test.err).AnyTimes()
+		mockFileClient.EXPECT().CreateFileShare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(test.err).AnyTimes()
 
 		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
 		cloud.StorageAccountClient = mockStorageAccountsClient
@@ -164,7 +165,7 @@ func TestCreateFileShare(t *testing.T) {
 			RequestGiB: test.gb,
 		}
 
-		account, key, err := cloud.CreateFileShare(mockAccount, mockFileShare)
+		account, key, err := cloud.CreateFileShare(context.TODO(), mockAccount, mockFileShare)
 		if test.expectErr && err == nil {
 			t.Errorf("unexpected non-error")
 			continue
@@ -215,9 +216,9 @@ func TestDeleteFileShare(t *testing.T) {
 	for _, test := range tests {
 		mockFileClient := mockfileclient.NewMockInterface(ctrl)
 		cloud.FileClient = mockFileClient
-		mockFileClient.EXPECT().DeleteFileShare(gomock.Any(), gomock.Any(), gomock.Any()).Return(test.err).Times(1)
+		mockFileClient.EXPECT().DeleteFileShare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(test.err).Times(1)
 
-		err := cloud.DeleteFileShare(test.rg, test.acct, test.name)
+		err := cloud.DeleteFileShare(context.TODO(), test.rg, test.acct, test.name)
 		if test.expectErr && err == nil {
 			t.Errorf("unexpected non-error")
 			continue
@@ -235,7 +236,7 @@ func TestResizeFileShare(t *testing.T) {
 
 	cloud := &Cloud{}
 	mockFileClient := mockfileclient.NewMockInterface(ctrl)
-	mockFileClient.EXPECT().ResizeFileShare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockFileClient.EXPECT().ResizeFileShare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	cloud.FileClient = mockFileClient
 
 	tests := []struct {
@@ -260,7 +261,7 @@ func TestResizeFileShare(t *testing.T) {
 		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
 		cloud.StorageAccountClient = mockStorageAccountsClient
 
-		err := cloud.ResizeFileShare(test.rg, test.acct, test.name, test.gb)
+		err := cloud.ResizeFileShare(context.TODO(), test.rg, test.acct, test.name, test.gb)
 		if test.expectErr && err == nil {
 			t.Errorf("unexpected non-error")
 			continue
@@ -278,7 +279,7 @@ func TestGetFileShare(t *testing.T) {
 
 	cloud := &Cloud{}
 	mockFileClient := mockfileclient.NewMockInterface(ctrl)
-	mockFileClient.EXPECT().GetFileShare(gomock.Any(), gomock.Any(), gomock.Any()).Return(storage.FileShare{}, nil).AnyTimes()
+	mockFileClient.EXPECT().GetFileShare(context.TODO(), gomock.Any(), gomock.Any(), gomock.Any()).Return(storage.FileShare{}, nil).AnyTimes()
 	cloud.FileClient = mockFileClient
 
 	tests := []struct {
@@ -301,7 +302,7 @@ func TestGetFileShare(t *testing.T) {
 		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
 		cloud.StorageAccountClient = mockStorageAccountsClient
 
-		_, err := cloud.GetFileShare(test.rg, test.acct, test.name)
+		_, err := cloud.GetFileShare(context.TODO(), test.rg, test.acct, test.name)
 		if test.expectErr && err == nil {
 			t.Errorf("unexpected non-error")
 			continue

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/azure_fileclient.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/azure_fileclient.go
@@ -53,11 +53,11 @@ func New(config *azclients.ClientConfig) *Client {
 }
 
 // CreateFileShare creates a file share
-func (c *Client) CreateFileShare(resourceGroupName, accountName string, shareOptions *ShareOptions) error {
+func (c *Client) CreateFileShare(ctx context.Context, resourceGroupName, accountName string, shareOptions *ShareOptions) error {
 	if shareOptions == nil {
 		return fmt.Errorf("share options is nil")
 	}
-	result, err := c.GetFileShare(resourceGroupName, accountName, shareOptions.Name)
+	result, err := c.GetFileShare(ctx, resourceGroupName, accountName, shareOptions.Name)
 	if err == nil {
 		klog.V(2).Infof("file share(%s) under account(%s) rg(%s) already exists", shareOptions.Name, accountName, resourceGroupName)
 		return nil
@@ -76,23 +76,23 @@ func (c *Client) CreateFileShare(resourceGroupName, accountName string, shareOpt
 		Name:                &shareOptions.Name,
 		FileShareProperties: fileShareProperties,
 	}
-	_, err = c.fileSharesClient.Create(context.Background(), resourceGroupName, accountName, shareOptions.Name, fileShare)
+	_, err = c.fileSharesClient.Create(ctx, resourceGroupName, accountName, shareOptions.Name, fileShare)
 
 	return err
 }
 
 // DeleteFileShare deletes a file share
-func (c *Client) DeleteFileShare(resourceGroupName, accountName, name string) error {
-	_, err := c.fileSharesClient.Delete(context.Background(), resourceGroupName, accountName, name)
+func (c *Client) DeleteFileShare(ctx context.Context, resourceGroupName, accountName, name string) error {
+	_, err := c.fileSharesClient.Delete(ctx, resourceGroupName, accountName, name)
 
 	return err
 }
 
 // ResizeFileShare resizes a file share
-func (c *Client) ResizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
+func (c *Client) ResizeFileShare(ctx context.Context, resourceGroupName, accountName, name string, sizeGiB int) error {
 	quota := int32(sizeGiB)
 
-	share, err := c.fileSharesClient.Get(context.Background(), resourceGroupName, accountName, name, storage.Stats)
+	share, err := c.fileSharesClient.Get(ctx, resourceGroupName, accountName, name, storage.Stats)
 	if err != nil {
 		return fmt.Errorf("failed to get file share(%s), : %v", name, err)
 	}
@@ -104,7 +104,7 @@ func (c *Client) ResizeFileShare(resourceGroupName, accountName, name string, si
 	}
 
 	share.FileShareProperties.ShareQuota = &quota
-	_, err = c.fileSharesClient.Update(context.Background(), resourceGroupName, accountName, name, share)
+	_, err = c.fileSharesClient.Update(ctx, resourceGroupName, accountName, name, share)
 	if err != nil {
 		return fmt.Errorf("failed to update quota on file share(%s), err: %v", name, err)
 	}
@@ -115,6 +115,6 @@ func (c *Client) ResizeFileShare(resourceGroupName, accountName, name string, si
 }
 
 // GetFileShare gets a file share
-func (c *Client) GetFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error) {
-	return c.fileSharesClient.Get(context.Background(), resourceGroupName, accountName, name, storage.Stats)
+func (c *Client) GetFileShare(ctx context.Context, resourceGroupName, accountName, name string) (storage.FileShare, error) {
+	return c.fileSharesClient.Get(ctx, resourceGroupName, accountName, name, storage.Stats)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/interface.go
@@ -19,14 +19,16 @@ limitations under the License.
 package fileclient
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 )
 
 // Interface is the client interface for creating file shares, interface for test injection.
 // mockgen -source=$GOPATH/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/interface.go -package=mockfileclient Interface > $GOPATH/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/interface.go
 type Interface interface {
-	CreateFileShare(resourceGroupName, accountName string, shareOptions *ShareOptions) error
-	DeleteFileShare(resourceGroupName, accountName, name string) error
-	ResizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error
-	GetFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error)
+	CreateFileShare(ctx context.Context, resourceGroupName, accountName string, shareOptions *ShareOptions) error
+	DeleteFileShare(ctx context.Context, resourceGroupName, accountName, name string) error
+	ResizeFileShare(ctx context.Context, resourceGroupName, accountName, name string, sizeGiB int) error
+	GetFileShare(ctx context.Context, resourceGroupName, accountName, name string) (storage.FileShare, error)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/interface.go
@@ -19,88 +19,90 @@ limitations under the License.
 package mockfileclient
 
 import (
+	context "context"
+	reflect "reflect"
+
 	storage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	gomock "github.com/golang/mock/gomock"
 	fileclient "k8s.io/legacy-cloud-providers/azure/clients/fileclient"
-	reflect "reflect"
 )
 
-// MockInterface is a mock of Interface interface
+// MockInterface is a mock of Interface interface.
 type MockInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockInterfaceMockRecorder
 }
 
-// MockInterfaceMockRecorder is the mock recorder for MockInterface
+// MockInterfaceMockRecorder is the mock recorder for MockInterface.
 type MockInterfaceMockRecorder struct {
 	mock *MockInterface
 }
 
-// NewMockInterface creates a new mock instance
+// NewMockInterface creates a new mock instance.
 func NewMockInterface(ctrl *gomock.Controller) *MockInterface {
 	mock := &MockInterface{ctrl: ctrl}
 	mock.recorder = &MockInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
 }
 
-// CreateFileShare mocks base method
-func (m *MockInterface) CreateFileShare(resourceGroupName, accountName string, shareOptions *fileclient.ShareOptions) error {
+// CreateFileShare mocks base method.
+func (m *MockInterface) CreateFileShare(ctx context.Context, resourceGroupName, accountName string, shareOptions *fileclient.ShareOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateFileShare", resourceGroupName, accountName, shareOptions)
+	ret := m.ctrl.Call(m, "CreateFileShare", ctx, resourceGroupName, accountName, shareOptions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CreateFileShare indicates an expected call of CreateFileShare
-func (mr *MockInterfaceMockRecorder) CreateFileShare(resourceGroupName, accountName, shareOptions interface{}) *gomock.Call {
+// CreateFileShare indicates an expected call of CreateFileShare.
+func (mr *MockInterfaceMockRecorder) CreateFileShare(ctx, resourceGroupName, accountName, shareOptions interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFileShare", reflect.TypeOf((*MockInterface)(nil).CreateFileShare), resourceGroupName, accountName, shareOptions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFileShare", reflect.TypeOf((*MockInterface)(nil).CreateFileShare), ctx, resourceGroupName, accountName, shareOptions)
 }
 
-// DeleteFileShare mocks base method
-func (m *MockInterface) DeleteFileShare(resourceGroupName, accountName, name string) error {
+// DeleteFileShare mocks base method.
+func (m *MockInterface) DeleteFileShare(ctx context.Context, resourceGroupName, accountName, name string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteFileShare", resourceGroupName, accountName, name)
+	ret := m.ctrl.Call(m, "DeleteFileShare", ctx, resourceGroupName, accountName, name)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteFileShare indicates an expected call of DeleteFileShare
-func (mr *MockInterfaceMockRecorder) DeleteFileShare(resourceGroupName, accountName, name interface{}) *gomock.Call {
+// DeleteFileShare indicates an expected call of DeleteFileShare.
+func (mr *MockInterfaceMockRecorder) DeleteFileShare(ctx, resourceGroupName, accountName, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFileShare", reflect.TypeOf((*MockInterface)(nil).DeleteFileShare), resourceGroupName, accountName, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFileShare", reflect.TypeOf((*MockInterface)(nil).DeleteFileShare), ctx, resourceGroupName, accountName, name)
 }
 
-// ResizeFileShare mocks base method
-func (m *MockInterface) ResizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
+// GetFileShare mocks base method.
+func (m *MockInterface) GetFileShare(ctx context.Context, resourceGroupName, accountName, name string) (storage.FileShare, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResizeFileShare", resourceGroupName, accountName, name, sizeGiB)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ResizeFileShare indicates an expected call of ResizeFileShare
-func (mr *MockInterfaceMockRecorder) ResizeFileShare(resourceGroupName, accountName, name, sizeGiB interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeFileShare", reflect.TypeOf((*MockInterface)(nil).ResizeFileShare), resourceGroupName, accountName, name, sizeGiB)
-}
-
-// GetFileShare mocks base method
-func (m *MockInterface) GetFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFileShare", resourceGroupName, accountName, name)
+	ret := m.ctrl.Call(m, "GetFileShare", ctx, resourceGroupName, accountName, name)
 	ret0, _ := ret[0].(storage.FileShare)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetFileShare indicates an expected call of GetFileShare
-func (mr *MockInterfaceMockRecorder) GetFileShare(resourceGroupName, accountName, name interface{}) *gomock.Call {
+// GetFileShare indicates an expected call of GetFileShare.
+func (mr *MockInterfaceMockRecorder) GetFileShare(ctx, resourceGroupName, accountName, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileShare", reflect.TypeOf((*MockInterface)(nil).GetFileShare), resourceGroupName, accountName, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileShare", reflect.TypeOf((*MockInterface)(nil).GetFileShare), ctx, resourceGroupName, accountName, name)
+}
+
+// ResizeFileShare mocks base method.
+func (m *MockInterface) ResizeFileShare(ctx context.Context, resourceGroupName, accountName, name string, sizeGiB int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResizeFileShare", ctx, resourceGroupName, accountName, name, sizeGiB)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResizeFileShare indicates an expected call of ResizeFileShare.
+func (mr *MockInterfaceMockRecorder) ResizeFileShare(ctx, resourceGroupName, accountName, name, sizeGiB interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeFileShare", reflect.TypeOf((*MockInterface)(nil).ResizeFileShare), ctx, resourceGroupName, accountName, name, sizeGiB)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
As the description in the issue https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/1083, here we reuse the context from external-provisioner to cancel the context when timeout. Then the volume won't be locked in driver.
Now, we update the parameters in cloud provider azure. Then we will update azurefile csi driver repo to consume the new parameters.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/1083

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
