### PR TITLE
Add YAML document separator in kubectl label

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/yaml.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/yaml.go
@@ -32,8 +32,10 @@ import (
 // The input object is assumed to be in the internal version of an API and is converted
 // to the given version first.
 // If PrintObj() is called multiple times, objects are separated with a '---' separator.
+
+var printCount int64
+
 type YAMLPrinter struct {
-	printCount int64
 }
 
 // PrintObj prints the data as YAML.
@@ -45,8 +47,8 @@ func (p *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		return fmt.Errorf(InternalObjectPrinterErr)
 	}
 
-	count := atomic.AddInt64(&p.printCount, 1)
-	if count > 1 {
+	atomic.AddInt64(&printCount, 1)
+	if printCount > 1 {
 		if _, err := w.Write([]byte("---\n")); err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -277,7 +277,6 @@ func (o *LabelOptions) RunLabel() error {
 	}
 
 	// TODO: support bulk generic output a la Get
-	operationCounter := 0
 	return r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
 			return err
@@ -393,11 +392,6 @@ func (o *LabelOptions) RunLabel() error {
 		if err != nil {
 			return err
 		}
-
-		if operationCounter > 0 && *o.PrintFlags.OutputFormat == "yaml" {
-			fmt.Fprintf(o.Out, "---\n")
-		}
-		operationCounter++
 		return printer.PrintObj(info.Object, o.Out)
 	})
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -277,6 +277,7 @@ func (o *LabelOptions) RunLabel() error {
 	}
 
 	// TODO: support bulk generic output a la Get
+	operationCounter := 0
 	return r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
 			return err
@@ -392,6 +393,11 @@ func (o *LabelOptions) RunLabel() error {
 		if err != nil {
 			return err
 		}
+
+		if operationCounter > 0 && *o.PrintFlags.OutputFormat == "yaml" {
+			fmt.Fprintf(o.Out, "---\n")
+		}
+		operationCounter++
 		return printer.PrintObj(info.Object, o.Out)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 
Adds a document separator to kubectl label when printing multiple YAML objects.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1265

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Yes. Now, if more than one label is passed to kubectl label and YAML output is chosen, the YAML objects are separated by a document separator (`---`).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
