### PR TITLE
update go domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ That said, if you have questions, reach out to us
 [containerized applications]: https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/
 [developer's documentation]: https://git.k8s.io/community/contributors/devel#readme
 [Docker environment]: https://docs.docker.com/engine
-[Go environment]: https://golang.org/doc/install
+[Go environment]: https://go.dev/doc/install
 [GoPkg]: https://pkg.go.dev/k8s.io/kubernetes
 [GoPkg Widget]: https://pkg.go.dev/badge/k8s.io/kubernetes.svg
 [interactive tutorial]: https://kubernetes.io/docs/tutorials/kubernetes-basics

--- a/staging/src/k8s.io/kubectl/README.md
+++ b/staging/src/k8s.io/kubectl/README.md
@@ -19,7 +19,7 @@ cli client. That client will eventually move here too.
 
 - No dependence on `k8s.io/kubernetes`. Dependence on other repositories is fine.
 
-- Code must be usefully [commented](https://golang.org/doc/effective_go.html#commentary).
+- Code must be usefully [commented](https://go.dev/doc/effective_go#commentary).
   Not only for developers on the project, but also for external users of these packages.
 
 - When reviewing PRs, you are encouraged to use Golang's [code review

--- a/staging/src/k8s.io/sample-apiserver/docs/minikube-walkthrough.md
+++ b/staging/src/k8s.io/sample-apiserver/docs/minikube-walkthrough.md
@@ -4,7 +4,7 @@ This document will take you through setting up and trying the sample apiserver o
 
 ## Pre requisites
 
-- Go 1.7.x or later installed and setup. More information can be found at [go installation](https://golang.org/doc/install)
+- Go 1.7.x or later installed and setup. More information can be found at [go installation](https://go.dev/doc/install)
 - Dockerhub account to push the image to [Dockerhub](https://hub.docker.com/)
 
 ## Install Minikube


### PR DESCRIPTION
update go domain name
golang.org -> go.dev

What type of PR is this?
/kind documentation

What this PR does / why we need it:
I feel like this is forgotten content and needs to be revised.




