### PR TITLE
Simplify P&F concurrency test

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1499,7 +1499,6 @@ k8s.io/apiserver/pkg/admission/plugin/webhook/namespace
 k8s.io/apiserver/pkg/admission/plugin/webhook/object
 k8s.io/apiserver/pkg/admission/plugin/webhook/request
 k8s.io/apiserver/pkg/admission/plugin/webhook/rules
-k8s.io/apiserver/pkg/admission/plugin/webhook/testcerts
 k8s.io/apiserver/pkg/admission/plugin/webhook/validating
 k8s.io/apiserver/pkg/admission/testing
 k8s.io/apiserver/pkg/apis/apiserver


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Instead of setting up a webhook authorizer to inject delays for specific clients, wrap the authorizer implementation.

```release-note
NONE
```

/cc @deads2k @MikeSpreitzer @cyang49