### PR TITLE
Automated cherry pick of #112427: Add zone field to vsphere test cloudconfig

### DIFF
--- a/test/e2e/storage/vsphere/config.go
+++ b/test/e2e/storage/vsphere/config.go
@@ -85,6 +85,11 @@ type ConfigFile struct {
 		DefaultDatastore string `gcfg:"default-datastore"`
 		ResourcePoolPath string `gcfg:"resourcepool-path"`
 	}
+	// Tag categories and tags which correspond to "built-in node labels: zones and region"
+	Labels struct {
+		Zone   string `gcfg:"zone"`
+		Region string `gcfg:"region"`
+	}
 }
 
 // GetVSphereInstances parses vsphere.conf and returns VSphere instances


### PR DESCRIPTION
Cherry pick of #112427 on release-1.24.

#112427: Add zone field to vsphere test cloudconfig

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Allow Label section in vsphere e2e cloudprovider configuration
```