### PR TITLE
e2e framework: pod polling

### DIFF
--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -41,7 +41,11 @@ import (
 
 // errPodCompleted is returned by PodRunning or PodContainerRunning to indicate that
 // the pod has already reached completed state.
-var errPodCompleted = fmt.Errorf("pod ran to completion")
+var errPodCompleted = fmt.Errorf("pod ran to completion successfully")
+
+// errPodFailed is returned by PodRunning or PodContainerRunning to indicate that
+// the pod has already reached a permanent failue state.
+var errPodFailed = fmt.Errorf("pod failed permanently")
 
 // LabelLogOnPodFailure can be used to mark which Pods will have their logs logged in the case of
 // a test failure. By default, if there are no Pods with this label, only the first 5 Pods will

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -18,6 +18,7 @@ package pod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,11 +42,11 @@ import (
 
 // errPodCompleted is returned by PodRunning or PodContainerRunning to indicate that
 // the pod has already reached completed state.
-var errPodCompleted = fmt.Errorf("pod ran to completion successfully")
+var errPodCompleted = FinalError(errors.New("pod ran to completion successfully"))
 
 // errPodFailed is returned by PodRunning or PodContainerRunning to indicate that
 // the pod has already reached a permanent failue state.
-var errPodFailed = fmt.Errorf("pod failed permanently")
+var errPodFailed = FinalError(errors.New("pod failed permanently"))
 
 // LabelLogOnPodFailure can be used to mark which Pods will have their logs logged in the case of
 // a test failure. By default, if there are no Pods with this label, only the first 5 Pods will

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -403,7 +403,9 @@ func WaitTimeoutForPodRunningInNamespace(c clientset.Interface, podName, namespa
 		switch pod.Status.Phase {
 		case v1.PodRunning:
 			return true, nil
-		case v1.PodFailed, v1.PodSucceeded:
+		case v1.PodFailed:
+			return false, errPodFailed
+		case v1.PodSucceeded:
 			return false, errPodCompleted
 		}
 		return false, nil
@@ -441,7 +443,10 @@ func WaitForPodNoLongerRunningInNamespace(c clientset.Interface, podName, namesp
 func WaitTimeoutForPodReadyInNamespace(c clientset.Interface, podName, namespace string, timeout time.Duration) error {
 	return WaitForPodCondition(c, namespace, podName, "running and ready", timeout, func(pod *v1.Pod) (bool, error) {
 		switch pod.Status.Phase {
-		case v1.PodFailed, v1.PodSucceeded:
+		case v1.PodFailed:
+			e2elog.Logf("The phase of Pod %s is %s which is unexpected, pod status: %#v", pod.Name, pod.Status.Phase, pod.Status)
+			return false, errPodFailed
+		case v1.PodSucceeded:
 			e2elog.Logf("The phase of Pod %s is %s which is unexpected, pod status: %#v", pod.Name, pod.Status.Phase, pod.Status)
 			return false, errPodCompleted
 		case v1.PodRunning:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When polling for a running, we want to get:
- clear error messages about an unexpected state (failed or completed successfully)
- abort polling early when a pod enters a final unexpected state

#### Which issue(s) this PR fixes:
Fixes #109732

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @tallclair 