### PR TITLE
e2e framework: better error when service account creation times out

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -328,7 +328,10 @@ func waitForServiceAccountInNamespace(c clientset.Interface, ns, serviceAccountN
 		}
 		return false, nil
 	})
-	return err
+	if err != nil {
+		return fmt.Errorf("wait for service account %q in namespace %q: %w", serviceAccountName, ns, err)
+	}
+	return nil
 }
 
 // WaitForDefaultServiceAccountInNamespace waits for the default service account to be provisioned


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When waiting for the default service account in a new namespace, not finding
one was reported as "unexpected error: timed out waiting for the condition"...

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
