### PR TITLE
client-go: remove reference to TPR in examples

### DIFF
--- a/staging/src/k8s.io/client-go/examples/README.md
+++ b/staging/src/k8s.io/client-go/examples/README.md
@@ -37,7 +37,7 @@ import _ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 - [**Work queues**](./workqueue): Create a hotloop-free controller with the
   rate-limited workqueue and the [informer framework][informer].
-- [**Custom Resource Definition (successor of TPR)**](https://git.k8s.io/apiextensions-apiserver/examples/client-go):
+- [**Custom Resource Definition (CRD)**](https://git.k8s.io/apiextensions-apiserver/examples/client-go):
   Register a custom resource type with the API, create/update/query this custom
   type, and write a controller that drives the cluster state based on the changes to
   the custom resources.


### PR DESCRIPTION
5 years after third party resources were removed, we're probably just confusing readers with this reference.

/kind cleanup
/kind documentation

```release-note
NONE
```