### PR TITLE
fix endpoint slice controller logging format error

### DIFF
--- a/pkg/controller/endpointslice/topologycache/topologycache.go
+++ b/pkg/controller/endpointslice/topologycache/topologycache.go
@@ -212,7 +212,7 @@ func (t *TopologyCache) SetNodes(nodes []*v1.Node) {
 	defer t.lock.Unlock()
 
 	if totalCPU.IsZero() || !sufficientNodeInfo || len(cpuByZone) < 2 {
-		klog.V(2).Infof("Insufficient node info for topology hints (%d zones, %s CPU, %t)", len(cpuByZone), totalCPU.MilliValue(), sufficientNodeInfo)
+		klog.V(2).Infof("Insufficient node info for topology hints (%d zones, %s CPU, %t)", len(cpuByZone), totalCPU.String(), sufficientNodeInfo)
 		t.sufficientNodeInfo = false
 		t.cpuByZone = nil
 		t.cpuRatiosByZone = nil


### PR DESCRIPTION

/kind cleanup
```release-note
NONE
```
Found while debugging with @tssurya this feature

> I0916 12:07:25.844075       1 topologycache.go:215] Insufficient node info for topology hints (0 zones, %!s(int64=0) CPU, false)

/sig network