### PR TITLE
Automated cherry pick of #112526: Limit redirect proxy handling to redirected responses

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -268,7 +268,7 @@ func (h *UpgradeAwareHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		oldModifyResponse := proxy.ModifyResponse
 		proxy.ModifyResponse = func(response *http.Response) error {
 			code := response.StatusCode
-			if code >= 300 && code <= 399 {
+			if code >= 300 && code <= 399 && len(response.Header.Get("Location")) > 0 {
 				// close the original response
 				response.Body.Close()
 				msg := "the backend attempted to redirect this request, which is not permitted"

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
@@ -724,6 +724,7 @@ func TestRejectForwardingRedirectsOption(t *testing.T) {
 		name                      string
 		rejectForwardingRedirects bool
 		serverStatusCode          int
+		redirect                  string
 		expectStatusCode          int
 		expectBody                []byte
 	}{
@@ -738,8 +739,24 @@ func TestRejectForwardingRedirectsOption(t *testing.T) {
 			name:                      "reject redirection enabled in proxy, backend server sending 301 response",
 			rejectForwardingRedirects: true,
 			serverStatusCode:          301,
+			redirect:                  "/",
 			expectStatusCode:          502,
 			expectBody:                []byte(`the backend attempted to redirect this request, which is not permitted`),
+		},
+		{
+			name:                      "reject redirection enabled in proxy, backend server sending 304 response with a location header",
+			rejectForwardingRedirects: true,
+			serverStatusCode:          304,
+			redirect:                  "/",
+			expectStatusCode:          502,
+			expectBody:                []byte(`the backend attempted to redirect this request, which is not permitted`),
+		},
+		{
+			name:                      "reject redirection enabled in proxy, backend server sending 304 response with no location header",
+			rejectForwardingRedirects: true,
+			serverStatusCode:          304,
+			expectStatusCode:          304,
+			expectBody:                []byte{}, // client doesn't read the body for 304 responses
 		},
 		{
 			name:                      "reject redirection disabled in proxy, backend server sending 200 response",
@@ -752,6 +769,7 @@ func TestRejectForwardingRedirectsOption(t *testing.T) {
 			name:                      "reject redirection disabled in proxy, backend server sending 301 response",
 			rejectForwardingRedirects: false,
 			serverStatusCode:          301,
+			redirect:                  "/",
 			expectStatusCode:          301,
 			expectBody:                originalBody,
 		},
@@ -760,6 +778,9 @@ func TestRejectForwardingRedirectsOption(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Set up a backend server
 			backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.redirect != "" {
+					w.Header().Set("Location", tc.redirect)
+				}
 				w.WriteHeader(tc.serverStatusCode)
 				w.Write(originalBody)
 			}))


### PR DESCRIPTION
Cherry pick of #112526 on release-1.23.

#112526: Limit redirect proxy handling to redirected responses

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kube-apiserver: resolved a 1.23.11 regression that treated `304 Not Modified` responses from aggregated API servers as internal errors
```