### PR TITLE
Automated cherry pick of #112507: Fix calculating error when adding nominated pods in

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -206,15 +206,15 @@ func (pl *PodTopologySpread) updateWithPod(s *preFilterState, updatedPod, preemp
 		if !constraint.Selector.Matches(podLabelSet) {
 			continue
 		}
+
 		if pl.enableNodeInclusionPolicyInPodTopologySpread &&
-			!constraint.matchNodeInclusionPolicies(updatedPod, node, requiredSchedulingTerm) {
+			!constraint.matchNodeInclusionPolicies(preemptorPod, node, requiredSchedulingTerm) {
 			continue
 		}
 
 		k, v := constraint.TopologyKey, node.Labels[constraint.TopologyKey]
 		pair := topologyPair{key: k, value: v}
 		s.TpPairToMatchNum[pair] += delta
-
 		s.TpKeyToCriticalPaths[k].update(v, s.TpPairToMatchNum[pair])
 	}
 }


### PR DESCRIPTION
Cherry pick of #112507 on release-1.25.

#112507: Fix calculating error when adding nominated pods in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Correct the calculating error in podTopologySpread plugin to avoid unexpected scheduling results.
```