### PR TITLE
Automated cherry pick of #112357: kube-scheduler: add taints filtering logic consistent with

### DIFF
--- a/pkg/scheduler/framework/plugins/helper/taint.go
+++ b/pkg/scheduler/framework/plugins/helper/taint.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import v1 "k8s.io/api/core/v1"
+
+// DoNotScheduleTaintsFilterFunc returns the filter function that can
+// filter out the node taints that reject scheduling Pod on a Node.
+func DoNotScheduleTaintsFilterFunc() func(t *v1.Taint) bool {
+	return func(t *v1.Taint) bool {
+		// PodToleratesNodeTaints is only interested in NoSchedule and NoExecute taints.
+		return t.Effect == v1.TaintEffectNoSchedule || t.Effect == v1.TaintEffectNoExecute
+	}
+}

--- a/pkg/scheduler/framework/plugins/helper/taint_test.go
+++ b/pkg/scheduler/framework/plugins/helper/taint_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestDoNotScheduleTaintsFilterFunc(t *testing.T) {
+	tests := []struct {
+		name     string
+		taint    *v1.Taint
+		expected bool
+	}{
+		{
+			name: "should include the taints with NoSchedule effect",
+			taint: &v1.Taint{
+				Effect: v1.TaintEffectNoSchedule,
+			},
+			expected: true,
+		},
+		{
+			name: "should include the taints with NoExecute effect",
+			taint: &v1.Taint{
+				Effect: v1.TaintEffectNoExecute,
+			},
+			expected: true,
+		},
+		{
+			name: "should not include the taints with PreferNoSchedule effect",
+			taint: &v1.Taint{
+				Effect: v1.TaintEffectPreferNoSchedule,
+			},
+			expected: false,
+		},
+	}
+
+	filterPredicate := DoNotScheduleTaintsFilterFunc()
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			if got := filterPredicate(test.taint); got != test.expected {
+				t.Errorf("unexpected result, expected %v but got %v", test.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/common.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/common.go
@@ -52,7 +52,7 @@ func (tsc *topologySpreadConstraint) matchNodeInclusionPolicies(pod *v1.Pod, nod
 	}
 
 	if tsc.NodeTaintsPolicy == v1.NodeInclusionPolicyHonor {
-		if _, untolerated := v1helper.FindMatchingUntoleratedTaint(node.Spec.Taints, pod.Spec.Tolerations, nil); untolerated {
+		if _, untolerated := v1helper.FindMatchingUntoleratedTaint(node.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc()); untolerated {
 			return false
 		}
 	}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -56,7 +56,7 @@ var (
 	fooSelector        = st.MakeLabelSelector().Exists("foo").Obj()
 	barSelector        = st.MakeLabelSelector().Exists("bar").Obj()
 
-	taints = []v1.Taint{{Key: v1.TaintNodeUnschedulable, Value: "", Effect: v1.TaintEffectPreferNoSchedule}}
+	taints = []v1.Taint{{Key: v1.TaintNodeUnschedulable, Value: "", Effect: v1.TaintEffectNoSchedule}}
 )
 
 func (p *criticalPaths) sort() {

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -67,12 +67,7 @@ func (pl *TaintToleration) Filter(ctx context.Context, state *framework.CycleSta
 		return framework.AsStatus(fmt.Errorf("invalid nodeInfo"))
 	}
 
-	filterPredicate := func(t *v1.Taint) bool {
-		// PodToleratesNodeTaints is only interested in NoSchedule and NoExecute taints.
-		return t.Effect == v1.TaintEffectNoSchedule || t.Effect == v1.TaintEffectNoExecute
-	}
-
-	taint, isUntolerated := v1helper.FindMatchingUntoleratedTaint(node.Spec.Taints, pod.Spec.Tolerations, filterPredicate)
+	taint, isUntolerated := v1helper.FindMatchingUntoleratedTaint(node.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc())
 	if !isUntolerated {
 		return nil
 	}

--- a/test/integration/scheduler/filters/filters_test.go
+++ b/test/integration/scheduler/filters/filters_test.go
@@ -57,7 +57,7 @@ const pollInterval = 100 * time.Millisecond
 var (
 	ignorePolicy = v1.NodeInclusionPolicyIgnore
 	honorPolicy  = v1.NodeInclusionPolicyHonor
-	taints       = []v1.Taint{{Key: v1.TaintNodeUnschedulable, Value: "", Effect: v1.TaintEffectPreferNoSchedule}}
+	taints       = []v1.Taint{{Key: v1.TaintNodeUnschedulable, Value: "", Effect: v1.TaintEffectNoSchedule}}
 )
 
 // TestInterPodAffinity verifies that scheduler's inter pod affinity and


### PR DESCRIPTION
Cherry pick of #112357 on release-1.25.

#112357: kube-scheduler: add taints filtering logic consistent with

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```