### PR TITLE
Add validation for runtime endpoint flag

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -193,6 +193,13 @@ func ValidateKubeletFlags(f *KubeletFlags) error {
 		return fmt.Errorf("unsupported CRI runtime: %q, only %q is currently supported", f.ContainerRuntime, kubetypes.RemoteContainerRuntime)
 	}
 
+	// Note: maybe we can test it for being a valid socket address as an additional improvement.
+	// The only problem with it will be that some setups may not specify 'unix://' prefix.
+	// So just check empty for back compat.
+	if f.RemoteRuntimeEndpoint == "" {
+		return fmt.Errorf("the container runtime endpoint address was not specified or empty, use --container-runtime-endpoint to set")
+	}
+
 	return nil
 }
 

--- a/cmd/kubelet/app/options/options_test.go
+++ b/cmd/kubelet/app/options/options_test.go
@@ -183,7 +183,8 @@ func TestValidateKubeletFlags(t *testing.T) {
 				ContainerRuntimeOptions: config.ContainerRuntimeOptions{
 					ContainerRuntime: kubetypes.RemoteContainerRuntime,
 				},
-				NodeLabels: tt.labels,
+				RemoteRuntimeEndpoint: "unix:///run/containerd/containerd.sock",
+				NodeLabels:            tt.labels,
 			})
 
 			if tt.error && err == nil {

--- a/pkg/kubelet/cri/remote/remote_image.go
+++ b/pkg/kubelet/cri/remote/remote_image.go
@@ -63,7 +63,7 @@ func NewRemoteImageService(endpoint string, connectionTimeout time.Duration) (in
 
 	service := &remoteImageService{timeout: connectionTimeout}
 
-	if err := service.determineAPIVersion(conn); err != nil {
+	if err := service.determineAPIVersion(conn, endpoint); err != nil {
 		return nil, err
 	}
 
@@ -84,7 +84,7 @@ func (r *remoteImageService) useV1API() bool {
 // being upgraded, then the container runtime must also support the initially
 // selected version or the redial is expected to fail, which requires a restart
 // of kubelet.
-func (r *remoteImageService) determineAPIVersion(conn *grpc.ClientConn) error {
+func (r *remoteImageService) determineAPIVersion(conn *grpc.ClientConn, endpoint string) error {
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
@@ -99,7 +99,7 @@ func (r *remoteImageService) determineAPIVersion(conn *grpc.ClientConn) error {
 		r.imageClientV1alpha2 = runtimeapiV1alpha2.NewImageServiceClient(conn)
 
 	} else {
-		return fmt.Errorf("unable to determine image API version: %w", err)
+		return fmt.Errorf("unable to determine image API version with %q, or API is not implemented: %w", endpoint, err)
 	}
 
 	return nil

--- a/pkg/kubelet/cri/remote/remote_runtime.go
+++ b/pkg/kubelet/cri/remote/remote_runtime.go
@@ -108,7 +108,7 @@ func NewRemoteRuntimeService(endpoint string, connectionTimeout time.Duration, t
 		logReduction: logreduction.NewLogReduction(identicalErrorDelay),
 	}
 
-	if err := service.determineAPIVersion(conn); err != nil {
+	if err := service.determineAPIVersion(conn, endpoint); err != nil {
 		return nil, err
 	}
 
@@ -128,7 +128,7 @@ func (r *remoteRuntimeService) useV1API() bool {
 // being upgraded, then the container runtime must also support the initially
 // selected version or the redial is expected to fail, which requires a restart
 // of kubelet.
-func (r *remoteRuntimeService) determineAPIVersion(conn *grpc.ClientConn) error {
+func (r *remoteRuntimeService) determineAPIVersion(conn *grpc.ClientConn, endpoint string) error {
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
@@ -143,7 +143,7 @@ func (r *remoteRuntimeService) determineAPIVersion(conn *grpc.ClientConn) error 
 		r.runtimeClientV1alpha2 = runtimeapiV1alpha2.NewRuntimeServiceClient(conn)
 
 	} else {
-		return fmt.Errorf("unable to determine runtime API version: %w", err)
+		return fmt.Errorf("unable to determine runtime API version with %q, or API is not implemented: %w", endpoint, err)
 	}
 
 	return nil


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add validation to make the error msg more clearly, and also updated the CRI support error msg.

#### Which issue(s) this PR fixes:
Fixes #112541

#### Does this PR introduce a user-facing change?
```release-note
Added validation for the --container-runtime-endpoint flag of kubelet to be non-empty.
```