### PR TITLE
HPA : Enhance error message to capture POD details

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -430,7 +430,7 @@ func calculatePodRequests(pods []*v1.Pod, container string, resource v1.Resource
 				if containerRequest, ok := c.Resources.Requests[resource]; ok {
 					podSum += containerRequest.MilliValue()
 				} else {
-					return nil, fmt.Errorf("missing request for %s", resource)
+					return nil, fmt.Errorf("missing request for %s in container %s of Pod %s", resource, c.Name, pod.ObjectMeta.Name)
 				}
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
As per the discussion in #79365 , the error message needs to provide POD and container details on failing to scale a new POD.

#### Which issue(s) this PR fixes:
Fixes #79365 

#### Does this PR introduce a user-facing change?
Yes


#### Special notes for your reviewer:
#### Does this PR introduce a user-facing change?
```release-note
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: