### PR TITLE
[WIP] Fix godocs lists after upgrading to Go 1.9

### DIFF
--- a/pkg/apis/admissionregistration/types.go
+++ b/pkg/apis/admissionregistration/types.go
@@ -421,10 +421,10 @@ type MutatingWebhook struct {
 	// if the object being admitted is modified by other admission plugins after the initial webhook call.
 	// Webhooks that specify this option *must* be idempotent, and hence able to process objects they previously admitted.
 	// Note:
-	// * the number of additional invocations is not guaranteed to be exactly one.
-	// * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again.
-	// * webhooks that use this option may be reordered to minimize the number of additional invocations.
-	// * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
+	// - the number of additional invocations is not guaranteed to be exactly one.
+	// - if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again.
+	// - webhooks that use this option may be reordered to minimize the number of additional invocations.
+	// - to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
 	//
 	// Defaults to "Never".
 	// +optional

--- a/pkg/apis/certificates/validation/validation.go
+++ b/pkg/apis/certificates/validation/validation.go
@@ -59,8 +59,8 @@ type certificateValidationOptions struct {
 	allowBothApprovedAndDenied bool
 
 	// The following are bad things we tolerate for compatibility reasons:
-	// * in requests made via the v1beta1 API
-	// * in update requests where the problem is already present in the persisted object
+	// - in requests made via the v1beta1 API
+	// - in update requests where the problem is already present in the persisted object
 
 	// allow modifying status.certificate on an update where the old object has a different certificate
 	allowResettingCertificate bool

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -448,8 +448,8 @@ type PersistentVolumeClaimSpec struct {
 	// +optional
 	VolumeMode *PersistentVolumeMode
 	// This field can be used to specify either:
-	// * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-	// * An existing PVC (PersistentVolumeClaim)
+	// - An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+	// - An existing PVC (PersistentVolumeClaim)
 	// If the provisioner or an external controller can support the specified data source,
 	// it will create a new volume based on the contents of the specified data source.
 	// If the AnyVolumeDataSource feature gate is enabled, this field will always have
@@ -467,9 +467,9 @@ type PersistentVolumeClaimSpec struct {
 	// compatibility, both fields (DataSource and DataSourceRef) will be set to the same
 	// value automatically if one of them is empty and the other is non-empty.
 	// There are two important differences between DataSource and DataSourceRef:
-	// * While DataSource only allows two specific types of objects, DataSourceRef
+	// - While DataSource only allows two specific types of objects, DataSourceRef
 	//   allows any non-core object, as well as PersistentVolumeClaim objects.
-	// * While DataSource ignores disallowed values (dropping them), DataSourceRef
+	// - While DataSource ignores disallowed values (dropping them), DataSourceRef
 	//   preserves all values, and generates an error if a disallowed value is
 	//   specified.
 	// (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
@@ -4009,9 +4009,9 @@ type Service struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ServiceAccount binds together:
-// * a name, understood by users, and perhaps by peripheral systems, for an identity
-// * a principal that can be authenticated and authorized
-// * a set of secrets
+// - a name, understood by users, and perhaps by peripheral systems, for an identity
+// - a principal that can be authenticated and authorized
+// - a set of secrets
 type ServiceAccount struct {
 	metav1.TypeMeta
 	// +optional

--- a/pkg/apis/discovery/types.go
+++ b/pkg/apis/discovery/types.go
@@ -35,9 +35,9 @@ type EndpointSlice struct {
 	// All addresses in this slice must be the same type. This field is
 	// immutable after creation. The following address types are currently
 	// supported:
-	// * IPv4: Represents an IPv4 Address.
-	// * IPv6: Represents an IPv6 Address.
-	// * FQDN: Represents a Fully Qualified Domain Name.
+	// - IPv4: Represents an IPv4 Address.
+	// - IPv6: Represents an IPv6 Address.
+	// - FQDN: Represents a Fully Qualified Domain Name.
 	AddressType AddressType
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
@@ -150,9 +150,9 @@ type EndpointPort struct {
 	// name. If the EndpointSlice is derived from a Kubernetes service, this
 	// corresponds to the Service.ports[].name.
 	// Name must either be an empty string or pass DNS_LABEL validation:
-	// * must be no more than 63 characters long.
-	// * must consist of lower case alphanumeric characters or '-'.
-	// * must start and end with an alphanumeric character.
+	// - must be no more than 63 characters long.
+	// - must consist of lower case alphanumeric characters or '-'.
+	// - must start and end with an alphanumeric character.
 	Name *string
 	// The IP protocol for this port.
 	// Must be UDP, TCP, or SCTP.

--- a/pkg/apis/rbac/validation/validation.go
+++ b/pkg/apis/rbac/validation/validation.go
@@ -27,8 +27,8 @@ import (
 
 // ValidateRBACName is exported to allow types outside of the RBAC API group to reuse this validation logic
 // Minimal validation of names for roles and bindings. Identical to the validation for Openshift. See:
-// * https://github.com/kubernetes/kubernetes/blob/60db507b279ce45bd16ea3db49bf181f2aeb3c3d/pkg/api/validation/name.go
-// * https://github.com/openshift/origin/blob/388478c40e751c4295dcb9a44dd69e5ac65d0e3b/pkg/api/helpers.go
+// - https://github.com/kubernetes/kubernetes/blob/60db507b279ce45bd16ea3db49bf181f2aeb3c3d/pkg/api/validation/name.go
+// - https://github.com/openshift/origin/blob/388478c40e751c4295dcb9a44dd69e5ac65d0e3b/pkg/api/helpers.go
 func ValidateRBACName(name string, prefix bool) []string {
 	return path.IsValidPathSegmentName(name)
 }

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -128,9 +128,9 @@ func StaticResyncPeriodFunc(resyncPeriod time.Duration) ResyncPeriodFunc {
 //	ControlleeExpectation = pair of atomic counters to track controllee's creation/deletion
 //	ControllerExpectationsStore = TTLStore + a ControlleeExpectation per controller
 //
-// * Once set expectations can only be lowered
-// * A controller isn't synced till its expectations are either fulfilled, or expire
-// * Controllers that don't set expectations will get woken up for every matching controllee
+// - Once set expectations can only be lowered
+// - A controller isn't synced till its expectations are either fulfilled, or expire
+// - Controllers that don't set expectations will get woken up for every matching controllee
 
 // ExpKeyFunc to parse out the key from a ControlleeExpectation
 var ExpKeyFunc = func(obj interface{}) (string, error) {

--- a/pkg/controller/daemon/update.go
+++ b/pkg/controller/daemon/update.go
@@ -57,13 +57,13 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 	// are necessary, and let the core loop create new instances on those nodes.
 	//
 	// Assumptions:
-	// * Expect manage loop to allow no more than one pod per node
-	// * Expect manage loop will create new pods
-	// * Expect manage loop will handle failed pods
-	// * Deleted pods do not count as unavailable so that updates make progress when nodes are down
+	// - Expect manage loop to allow no more than one pod per node
+	// - Expect manage loop will create new pods
+	// - Expect manage loop will handle failed pods
+	// - Deleted pods do not count as unavailable so that updates make progress when nodes are down
 	// Invariants:
-	// * The number of new pods that are unavailable must be less than maxUnavailable
-	// * A node with an available old pod is a candidate for deletion if it does not violate other invariants
+	// - The number of new pods that are unavailable must be less than maxUnavailable
+	// - A node with an available old pod is a candidate for deletion if it does not violate other invariants
 	//
 	if maxSurge == 0 {
 		var numUnavailable int
@@ -130,14 +130,14 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 	// to maxSurge extra pods
 	//
 	// Assumptions:
-	// * Expect manage loop to allow no more than two pods per node, one old, one new
-	// * Expect manage loop will create new pods if there are no pods on node
-	// * Expect manage loop will handle failed pods
-	// * Deleted pods do not count as unavailable so that updates make progress when nodes are down
+	// - Expect manage loop to allow no more than two pods per node, one old, one new
+	// - Expect manage loop will create new pods if there are no pods on node
+	// - Expect manage loop will handle failed pods
+	// - Deleted pods do not count as unavailable so that updates make progress when nodes are down
 	// Invariants:
-	// * A node with an unavailable old pod is a candidate for immediate new pod creation
-	// * An old available pod is deleted if a new pod is available
-	// * No more than maxSurge new pods are created for old available pods at any one time
+	// - A node with an unavailable old pod is a candidate for immediate new pod creation
+	// - An old available pod is deleted if a new pod is available
+	// - No more than maxSurge new pods are created for old available pods at any one time
 	//
 	var oldPodsToDelete []string
 	var candidateNewNodes []string

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/klog/v2"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -617,8 +617,8 @@ func (dc *DeploymentController) syncDeployment(ctx context.Context, key string) 
 	// List all Pods owned by this Deployment, grouped by their ReplicaSet.
 	// Current uses of the podMap are:
 	//
-	// * check if a Pod is labeled correctly with the pod-template-hash label.
-	// * check that no old Pods are running in the middle of Recreate Deployments.
+	// - check if a Pod is labeled correctly with the pod-template-hash label.
+	// - check that no old Pods are running in the middle of Recreate Deployments.
 	podMap, err := dc.getPodMapForDeployment(d, rsList)
 	if err != nil {
 		return err

--- a/pkg/controller/deployment/rolling.go
+++ b/pkg/controller/deployment/rolling.go
@@ -96,9 +96,9 @@ func (dc *DeploymentController) reconcileOldReplicaSets(ctx context.Context, all
 	maxUnavailable := deploymentutil.MaxUnavailable(*deployment)
 
 	// Check if we can scale down. We can scale down in the following 2 cases:
-	// * Some old replica sets have unhealthy replicas, we could safely scale down those unhealthy replicas since that won't further
+	// - Some old replica sets have unhealthy replicas, we could safely scale down those unhealthy replicas since that won't further
 	//  increase unavailability.
-	// * New replica set has scaled up and it's replicas becomes ready, then we can scale down old replica sets in a further step.
+	// - New replica set has scaled up and it's replicas becomes ready, then we can scale down old replica sets in a further step.
 	//
 	// maxScaledDown := allPodsCount - minAvailable - newReplicaSetPodsUnavailable
 	// take into account not only maxUnavailable and any surge pods that have been created, but also unavailable pods from
@@ -107,23 +107,23 @@ func (dc *DeploymentController) reconcileOldReplicaSets(ctx context.Context, all
 	//
 	// Concrete example:
 	//
-	// * 10 replicas
-	// * 2 maxUnavailable (absolute number, not percent)
-	// * 3 maxSurge (absolute number, not percent)
+	// - 10 replicas
+	// - 2 maxUnavailable (absolute number, not percent)
+	// - 3 maxSurge (absolute number, not percent)
 	//
 	// case 1:
-	// * Deployment is updated, newRS is created with 3 replicas, oldRS is scaled down to 8, and newRS is scaled up to 5.
-	// * The new replica set pods crashloop and never become available.
-	// * allPodsCount is 13. minAvailable is 8. newRSPodsUnavailable is 5.
-	// * A node fails and causes one of the oldRS pods to become unavailable. However, 13 - 8 - 5 = 0, so the oldRS won't be scaled down.
-	// * The user notices the crashloop and does kubectl rollout undo to rollback.
-	// * newRSPodsUnavailable is 1, since we rolled back to the good replica set, so maxScaledDown = 13 - 8 - 1 = 4. 4 of the crashlooping pods will be scaled down.
-	// * The total number of pods will then be 9 and the newRS can be scaled up to 10.
+	// - Deployment is updated, newRS is created with 3 replicas, oldRS is scaled down to 8, and newRS is scaled up to 5.
+	// - The new replica set pods crashloop and never become available.
+	// - allPodsCount is 13. minAvailable is 8. newRSPodsUnavailable is 5.
+	// - A node fails and causes one of the oldRS pods to become unavailable. However, 13 - 8 - 5 = 0, so the oldRS won't be scaled down.
+	// - The user notices the crashloop and does kubectl rollout undo to rollback.
+	// - newRSPodsUnavailable is 1, since we rolled back to the good replica set, so maxScaledDown = 13 - 8 - 1 = 4. 4 of the crashlooping pods will be scaled down.
+	// - The total number of pods will then be 9 and the newRS can be scaled up to 10.
 	//
 	// case 2:
 	// Same example, but pushing a new pod template instead of rolling back (aka "roll over"):
-	// * The new replica set created must start with 0 replicas because allPodsCount is already at 13.
-	// * However, newRSPodsUnavailable would also be 0, so the 2 old replica sets could be scaled down by 5 (13 - 8 - 0), which would then
+	// - The new replica set created must start with 0 replicas because allPodsCount is already at 13.
+	// - However, newRSPodsUnavailable would also be 0, so the 2 old replica sets could be scaled down by 5 (13 - 8 - 0), which would then
 	// allow the new replica set to be scaled up by 5.
 	minAvailable := *(deployment.Spec.Replicas) - maxUnavailable
 	newRSUnavailablePodCount := *(newRS.Spec.Replicas) - newRS.Status.AvailableReplicas

--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -749,9 +749,9 @@ func DeploymentTimedOut(deployment *apps.Deployment, newStatus *apps.DeploymentS
 	// If the previous condition has been a successful rollout then we shouldn't try to
 	// estimate any progress. Scenario:
 	//
-	// * progressDeadlineSeconds is smaller than the difference between now and the time
+	// - progressDeadlineSeconds is smaller than the difference between now and the time
 	//   the last rollout finished in the past.
-	// * the creation of a new ReplicaSet triggers a resync of the Deployment prior to the
+	// - the creation of a new ReplicaSet triggers a resync of the Deployment prior to the
 	//   cached copy of the Deployment getting updated with the status.condition that indicates
 	//   the creation of the new ReplicaSet.
 	//

--- a/pkg/controller/endpointslice/metrics/cache.go
+++ b/pkg/controller/endpointslice/metrics/cache.go
@@ -101,8 +101,8 @@ func (spc *ServicePortCache) totals(maxEndpointsPerSlice int) (int, int, int) {
 // UpdateServicePortCache updates a ServicePortCache in the global cache for a
 // given Service and updates the corresponding metrics.
 // Parameters:
-// * serviceNN refers to a NamespacedName representing the Service.
-// * spCache refers to a ServicePortCache for the specified Service.
+// - serviceNN refers to a NamespacedName representing the Service.
+// - spCache refers to a ServicePortCache for the specified Service.
 func (c *Cache) UpdateServicePortCache(serviceNN types.NamespacedName, spCache *ServicePortCache) {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/pkg/controller/endpointslicemirroring/metrics/cache.go
+++ b/pkg/controller/endpointslicemirroring/metrics/cache.go
@@ -90,8 +90,8 @@ func (spc *EndpointPortCache) numEndpoints() int {
 // UpdateEndpointPortCache updates a EndpointPortCache in the global cache for a
 // given Service and updates the corresponding metrics.
 // Parameters:
-// * endpointsNN refers to a NamespacedName representing the Endpoints resource.
-// * epCache refers to a EndpointPortCache for the specified Endpoints reosource.
+// - endpointsNN refers to a NamespacedName representing the Endpoints resource.
+// - epCache refers to a EndpointPortCache for the specified Endpoints reosource.
 func (c *Cache) UpdateEndpointPortCache(endpointsNN types.NamespacedName, epCache *EndpointPortCache) {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -1050,8 +1050,8 @@ func TestConflictingData(t *testing.T) {
 			},
 		},
 		// child in namespace A with owner reference to namespaced type in namespace B
-		// * should be deleted immediately
-		// * event should be logged in namespace A with involvedObject of bad-child indicating the error
+		// - should be deleted immediately
+		// - event should be logged in namespace A with involvedObject of bad-child indicating the error
 		{
 			name: "bad child in ns1 -> owner in ns2 (child first)",
 			steps: []step{
@@ -1137,8 +1137,8 @@ func TestConflictingData(t *testing.T) {
 			},
 		},
 		// child that is cluster-scoped with owner reference to namespaced type in namespace B
-		// * should not be deleted
-		// * event should be logged in namespace kube-system with involvedObject of bad-child indicating the error
+		// - should not be deleted
+		// - event should be logged in namespace kube-system with involvedObject of bad-child indicating the error
 		{
 			name: "bad cluster-scoped child -> owner in ns1 (child first)",
 			steps: []step{
@@ -1205,9 +1205,9 @@ func TestConflictingData(t *testing.T) {
 			},
 		},
 		// child pointing at non-preferred still-served apiVersion of parent object (e.g. rbac/v1beta1)
-		// * should not be deleted prematurely
-		// * should not repeatedly poll attemptToDelete while waiting
-		// * should be deleted when the actual parent is deleted
+		// - should not be deleted prematurely
+		// - should not repeatedly poll attemptToDelete while waiting
+		// - should be deleted when the actual parent is deleted
 		{
 			name: "good child -> existing owner with non-preferred accessible API version",
 			steps: []step{
@@ -1282,8 +1282,8 @@ func TestConflictingData(t *testing.T) {
 			},
 		},
 		// child pointing at no-longer-served apiVersion of still-existing parent object (e.g. extensions/v1beta1 deployment)
-		// * should not be deleted (this is indistinguishable from referencing an unknown kind/version)
-		// * virtual parent should not repeatedly poll attemptToDelete once real parent is observed
+		// - should not be deleted (this is indistinguishable from referencing an unknown kind/version)
+		// - virtual parent should not repeatedly poll attemptToDelete once real parent is observed
 		{
 			name: "child -> existing owner with inaccessible API version (child first)",
 			steps: []step{
@@ -1394,9 +1394,9 @@ func TestConflictingData(t *testing.T) {
 			},
 		},
 		// child pointing at no-longer-served apiVersion of no-longer-existing parent object (e.g. extensions/v1beta1 deployment)
-		// * should not be deleted (this is indistinguishable from referencing an unknown kind/version)
-		// * should repeatedly poll attemptToDelete
-		// * should not block deletion of legitimate children of missing deployment
+		// - should not be deleted (this is indistinguishable from referencing an unknown kind/version)
+		// - should repeatedly poll attemptToDelete
+		// - should not block deletion of legitimate children of missing deployment
 		{
 			name: "child -> non-existent owner with inaccessible API version (inaccessible parent apiVersion first)",
 			steps: []step{
@@ -1584,8 +1584,8 @@ func TestConflictingData(t *testing.T) {
 			},
 		},
 		// child pointing at incorrect apiVersion/kind of still-existing parent object (e.g. core/v1 Secret with uid=123, where an apps/v1 Deployment with uid=123 exists)
-		// * should be deleted immediately
-		// * should not trigger deletion of legitimate children of parent
+		// - should be deleted immediately
+		// - should not trigger deletion of legitimate children of parent
 		{
 			name: "bad child -> existing owner with incorrect API version (bad child, good child, bad parent delete, good parent)",
 			steps: []step{

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -87,7 +87,7 @@ type namespacedResourcesDeleter struct {
 //     (updates the namespace phase if it is not yet marked terminating)
 //
 // After deleting the resources:
-// * It removes finalizer token from the given namespace.
+// - It removes finalizer token from the given namespace.
 //
 // Returns an error if any of those steps fail.
 // Returns ResourcesRemainingError if it deleted some resources but needs

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -43,9 +43,9 @@ import (
 const (
 	// namespaceDeletionGracePeriod is the time period to wait before processing a received namespace event.
 	// This allows time for the following to occur:
-	// * lifecycle admission plugins on HA apiservers to also observe a namespace
+	// - lifecycle admission plugins on HA apiservers to also observe a namespace
 	//   deletion and prevent new objects from being created in the terminating namespace
-	// * non-leader etcd servers to observe last-minute object creations in a namespace
+	// - non-leader etcd servers to observe last-minute object creations in a namespace
 	//   so this controller's cleanup can actually clean up all objects
 	namespaceDeletionGracePeriod = 5 * time.Second
 )

--- a/pkg/kubelet/cloudresource/cloud_request_manager.go
+++ b/pkg/kubelet/cloudresource/cloud_request_manager.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
@@ -62,9 +62,9 @@ func NewSyncManager(cloud cloudprovider.Interface, nodeName types.NodeName, sync
 		// nodeAddressesErr) of the sync loop under the condition that a result has
 		// been saved at least once. The semantics here are:
 		//
-		// * Readers of the result will wait on the monitor until the first result
+		// - Readers of the result will wait on the monitor until the first result
 		//   has been saved.
-		// * The sync loop (i.e. the only writer), will signal all waiters every
+		// - The sync loop (i.e. the only writer), will signal all waiters every
 		//   time it updates the result.
 		nodeAddressesMonitor: sync.NewCond(&sync.Mutex{}),
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2068,11 +2068,11 @@ func TestGenerateAPIPodStatusWithReasonCache(t *testing.T) {
 			},
 		},
 		// For terminated container:
-		// * If there is no recent start error record, State should be Terminated, LastTerminationState should be retrieved from
+		// - If there is no recent start error record, State should be Terminated, LastTerminationState should be retrieved from
 		// second latest terminated status;
-		// * If there is recent start error record, State should be Waiting, LastTerminationState should be retrieved from latest
+		// - If there is recent start error record, State should be Waiting, LastTerminationState should be retrieved from latest
 		// terminated status;
-		// * If ExitCode = 0, restart policy is RestartPolicyOnFailure, the container shouldn't be restarted. No matter there is
+		// - If ExitCode = 0, restart policy is RestartPolicyOnFailure, the container shouldn't be restarted. No matter there is
 		// recent start error or not, State should be Terminated, LastTerminationState should be retrieved from second latest
 		// terminated status.
 		{
@@ -2138,9 +2138,9 @@ func TestGenerateAPIPodStatusWithReasonCache(t *testing.T) {
 			},
 		},
 		// For Unknown Container Status:
-		// * In certain situations a container can be running and fail to retrieve the status which results in
-		// * a transition to the Unknown state. Prior to this fix, a container would make an invalid transition
-		// * from Running->Waiting. This test validates the correct behavior of transitioning from Running->Terminated.
+		// - In certain situations a container can be running and fail to retrieve the status which results in
+		// - a transition to the Unknown state. Prior to this fix, a container would make an invalid transition
+		// - from Running->Waiting. This test validates the correct behavior of transitioning from Running->Terminated.
 		{
 			containers: []v1.Container{{Name: "unknown"}},
 			statuses: []*kubecontainer.Status{

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -166,10 +166,10 @@ func calcRestartCountByLogDir(path string) (int, error) {
 
 // startContainer starts a container and returns a message indicates why it is failed on error.
 // It starts the container through the following steps:
-// * pull the image
-// * create the container
-// * start the container
-// * run the post start lifecycle hooks (if applicable)
+// - pull the image
+// - create the container
+// - start the container
+// - run the post start lifecycle hooks (if applicable)
 func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandboxConfig *runtimeapi.PodSandboxConfig, spec *startSpec, pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, podIP string, podIPs []string) (string, error) {
 	container := spec.container
 
@@ -654,8 +654,8 @@ func (m *kubeGenericRuntimeManager) restoreSpecsFromContainerLabels(containerID 
 }
 
 // killContainer kills a container through the following steps:
-// * Run the pre-stop lifecycle hooks (if applicable).
-// * Stop the container.
+// - Run the pre-stop lifecycle hooks (if applicable).
+// - Stop the container.
 func (m *kubeGenericRuntimeManager) killContainer(pod *v1.Pod, containerID kubecontainer.ContainerID, containerName string, message string, reason containerKillReason, gracePeriodOverride *int64) error {
 	var containerSpec *v1.Container
 	if pod != nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -400,11 +400,11 @@ func (cgc *containerGC) evictPodLogsDirectories(allSourcesReady bool) error {
 // not ready and containing no containers.
 //
 // GarbageCollect consists of the following steps:
-// * gets evictable containers which are not active and created more than gcPolicy.MinAge ago.
-// * removes oldest dead containers for each pod by enforcing gcPolicy.MaxPerPodContainer.
-// * removes oldest dead containers by enforcing gcPolicy.MaxContainers.
-// * gets evictable sandboxes which are not ready and contains no containers.
-// * removes evictable sandboxes.
+// - gets evictable containers which are not active and created more than gcPolicy.MinAge ago.
+// - removes oldest dead containers for each pod by enforcing gcPolicy.MaxPerPodContainer.
+// - removes oldest dead containers by enforcing gcPolicy.MaxContainers.
+// - gets evictable sandboxes which are not ready and contains no containers.
+// - removes evictable sandboxes.
 func (cgc *containerGC) GarbageCollect(gcPolicy kubecontainer.GCPolicy, allSourcesReady bool, evictNonDeletedPods bool) error {
 	errors := []error{}
 	// Remove evictable containers

--- a/pkg/kubelet/token/token_manager.go
+++ b/pkg/kubelet/token/token_manager.go
@@ -95,12 +95,12 @@ type Manager struct {
 
 // GetServiceAccountToken gets a service account token for a pod from cache or
 // from the TokenRequest API. This process is as follows:
-// * Check the cache for the current token request.
-// * If the token exists and does not require a refresh, return the current token.
-// * Attempt to refresh the token.
-// * If the token is refreshed successfully, save it in the cache and return the token.
-// * If refresh fails and the old token is still valid, log an error and return the old token.
-// * If refresh fails and the old token is no longer valid, return an error
+// - Check the cache for the current token request.
+// - If the token exists and does not require a refresh, return the current token.
+// - Attempt to refresh the token.
+// - If the token is refreshed successfully, save it in the cache and return the token.
+// - If refresh fails and the old token is still valid, log an error and return the old token.
+// - If refresh fails and the old token is no longer valid, return an error
 func (m *Manager) GetServiceAccountToken(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
 	key := keyFunc(name, namespace, tr)
 

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1665,8 +1665,8 @@ func getNodeInternalIP(node *api.Node) string {
 
 // findNodeRoles returns the roles of a given node.
 // The roles are determined by looking for:
-// * a node-role.kubernetes.io/<role>="" label
-// * a kubernetes.io/role="<role>" label
+// - a node-role.kubernetes.io/<role>="" label
+// - a kubernetes.io/role="<role>" label
 func findNodeRoles(node *api.Node) []string {
 	roles := sets.NewString()
 	for k, v := range node.Labels {

--- a/pkg/proxy/topology.go
+++ b/pkg/proxy/topology.go
@@ -139,11 +139,11 @@ func CategorizeEndpoints(endpoints []Endpoint, svcInfo ServicePort, nodeLabels m
 
 // canUseTopology returns true if topology aware routing is enabled and properly configured
 // in this cluster. That is, it checks that:
-// * The TopologyAwareHints feature is enabled
-// * The "service.kubernetes.io/topology-aware-hints" annotation on this Service is set to "Auto"
-// * The node's labels include "topology.kubernetes.io/zone"
-// * All of the endpoints for this Service have a topology hint
-// * At least one endpoint for this Service is hinted for this node's zone.
+// - The TopologyAwareHints feature is enabled
+// - The "service.kubernetes.io/topology-aware-hints" annotation on this Service is set to "Auto"
+// - The node's labels include "topology.kubernetes.io/zone"
+// - All of the endpoints for this Service have a topology hint
+// - At least one endpoint for this Service is hinted for this node's zone.
 func canUseTopology(endpoints []Endpoint, svcInfo ServicePort, nodeLabels map[string]string) bool {
 	hintsAnnotation := svcInfo.HintsAnnotation()
 	if hintsAnnotation != "Auto" && hintsAnnotation != "auto" {

--- a/pkg/quota/v1/evaluator/core/persistent_volume_claims.go
+++ b/pkg/quota/v1/evaluator/core/persistent_volume_claims.go
@@ -48,8 +48,8 @@ var pvcResources = []corev1.ResourceName{
 // For example, if you want to quota storage by storage class, you would have a declaration
 // that follows <storage-class>.storageclass.storage.k8s.io/<resource>.
 // For example:
-// * gold.storageclass.storage.k8s.io/: 500Gi
-// * bronze.storageclass.storage.k8s.io/requests.storage: 500Gi
+// - gold.storageclass.storage.k8s.io/: 500Gi
+// - bronze.storageclass.storage.k8s.io/requests.storage: 500Gi
 const storageClassSuffix string = ".storageclass.storage.k8s.io/"
 
 /* TODO: prune?

--- a/pkg/registry/core/service/ipallocator/controller/repair.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair.go
@@ -44,10 +44,10 @@ import (
 // and logs any errors, and then sets the compacted and accurate list of all allocated IPs.
 //
 // Handles:
-// * Duplicate ClusterIP assignments caused by operator action or undetected race conditions
-// * ClusterIPs that do not match the currently configured range
-// * Allocations to services that were not actually created due to a crash or powerloss
-// * Migrates old versions of Kubernetes services into the atomic ipallocator model automatically
+// - Duplicate ClusterIP assignments caused by operator action or undetected race conditions
+// - ClusterIPs that do not match the currently configured range
+// - Allocations to services that were not actually created due to a crash or powerloss
+// - Migrates old versions of Kubernetes services into the atomic ipallocator model automatically
 //
 // Can be run at infrequent intervals, and is best performed on startup of the master.
 // Is level driven and idempotent - all valid ClusterIPs will be updated into the ipallocator

--- a/pkg/scheduler/framework/plugins/volumebinding/binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder.go
@@ -535,8 +535,8 @@ var (
 )
 
 // checkBindings runs through all the PVCs in the Pod and checks:
-// * if the PVC is fully bound
-// * if there are any conditions that require binding to fail and be retried
+// - if the PVC is fully bound
+// - if there are any conditions that require binding to fail and be retried
 //
 // It returns true when all of the Pod's PVCs are fully bound, and error if
 // binding (and scheduling) needs to be retried

--- a/pkg/util/tail/tail.go
+++ b/pkg/util/tail/tail.go
@@ -62,8 +62,8 @@ func ReadAtMost(path string, max int64) ([]byte, bool, error) {
 }
 
 // FindTailLineStartIndex returns the start of last nth line.
-// * If n < 0, return the beginning of the file.
-// * If n >= 0, return the beginning of last nth line.
+// - If n < 0, return the beginning of the file.
+// - If n >= 0, return the beginning of last nth line.
 // Notice that if the last line is incomplete (no end-of-line), it will not be counted
 // as one line.
 func FindTailLineStartIndex(f io.ReadSeeker, n int64) (int64, error) {

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -88,12 +88,12 @@ type OperationExecutor interface {
 	// If a volume has 'Filesystem' volumeMode, MountVolume mounts the
 	// volume to the pod specified in volumeToMount.
 	// Specifically it will:
-	// * Wait for the device to finish attaching (for attachable volumes only).
-	// * Mount device to global mount path (for attachable volumes only).
-	// * Update actual state of world to reflect volume is globally mounted (for
+	// - Wait for the device to finish attaching (for attachable volumes only).
+	// - Mount device to global mount path (for attachable volumes only).
+	// - Update actual state of world to reflect volume is globally mounted (for
 	//   attachable volumes only).
-	// * Mount the volume to the pod specific path.
-	// * Update actual state of world to reflect volume is mounted to the pod
+	// - Mount the volume to the pod specific path.
+	// - Update actual state of world to reflect volume is mounted to the pod
 	//   path.
 	// The parameter "isRemount" is informational and used to adjust logging
 	// verbosity. An initial mount is more log-worthy than a remount, for
@@ -102,11 +102,11 @@ type OperationExecutor interface {
 	// For 'Block' volumeMode, this method creates a symbolic link to
 	// the volume from both the pod specified in volumeToMount and global map path.
 	// Specifically it will:
-	// * Wait for the device to finish attaching (for attachable volumes only).
-	// * Update actual state of world to reflect volume is globally mounted/mapped.
-	// * Map volume to global map path using symbolic link.
-	// * Map the volume to the pod device map path using symbolic link.
-	// * Update actual state of world to reflect volume is mounted/mapped to the pod path.
+	// - Wait for the device to finish attaching (for attachable volumes only).
+	// - Update actual state of world to reflect volume is globally mounted/mapped.
+	// - Map volume to global map path using symbolic link.
+	// - Map the volume to the pod device map path using symbolic link.
+	// - Update actual state of world to reflect volume is mounted/mapped to the pod path.
 	MountVolume(waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorld ActualStateOfWorldMounterUpdater, isRemount bool) error
 
 	// If a volume has 'Filesystem' volumeMode, UnmountVolume unmounts the

--- a/staging/src/k8s.io/api/admissionregistration/v1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1/types.go
@@ -443,10 +443,10 @@ type MutatingWebhook struct {
 	// if the object being admitted is modified by other admission plugins after the initial webhook call.
 	// Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted.
 	// Note:
-	// * the number of additional invocations is not guaranteed to be exactly one.
-	// * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again.
-	// * webhooks that use this option may be reordered to minimize the number of additional invocations.
-	// * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
+	// - the number of additional invocations is not guaranteed to be exactly one.
+	// - if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again.
+	// - webhooks that use this option may be reordered to minimize the number of additional invocations.
+	// - to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
 	//
 	// Defaults to "Never".
 	// +optional

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
@@ -463,10 +463,10 @@ type MutatingWebhook struct {
 	// if the object being admitted is modified by other admission plugins after the initial webhook call.
 	// Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted.
 	// Note:
-	// * the number of additional invocations is not guaranteed to be exactly one.
-	// * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again.
-	// * webhooks that use this option may be reordered to minimize the number of additional invocations.
-	// * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
+	// - the number of additional invocations is not guaranteed to be exactly one.
+	// - if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again.
+	// - webhooks that use this option may be reordered to minimize the number of additional invocations.
+	// - to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
 	//
 	// Defaults to "Never".
 	// +optional

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -493,8 +493,8 @@ type PersistentVolumeClaimSpec struct {
 	// +optional
 	VolumeMode *PersistentVolumeMode `json:"volumeMode,omitempty" protobuf:"bytes,6,opt,name=volumeMode,casttype=PersistentVolumeMode"`
 	// dataSource field can be used to specify either:
-	// * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-	// * An existing PVC (PersistentVolumeClaim)
+	// - An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+	// - An existing PVC (PersistentVolumeClaim)
 	// If the provisioner or an external controller can support the specified data source,
 	// it will create a new volume based on the contents of the specified data source.
 	// If the AnyVolumeDataSource feature gate is enabled, this field will always have
@@ -512,9 +512,9 @@ type PersistentVolumeClaimSpec struct {
 	// compatibility, both fields (DataSource and DataSourceRef) will be set to the same
 	// value automatically if one of them is empty and the other is non-empty.
 	// There are two important differences between DataSource and DataSourceRef:
-	// * While DataSource only allows two specific types of objects, DataSourceRef
+	// - While DataSource only allows two specific types of objects, DataSourceRef
 	//   allows any non-core object, as well as PersistentVolumeClaim objects.
-	// * While DataSource ignores disallowed values (dropping them), DataSourceRef
+	// - While DataSource ignores disallowed values (dropping them), DataSourceRef
 	//   preserves all values, and generates an error if a disallowed value is
 	//   specified.
 	// (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
@@ -4701,9 +4701,9 @@ type ServiceList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ServiceAccount binds together:
-// * a name, understood by users, and perhaps by peripheral systems, for an identity
-// * a principal that can be authenticated and authorized
-// * a set of secrets
+// - a name, understood by users, and perhaps by peripheral systems, for an identity
+// - a principal that can be authenticated and authorized
+// - a set of secrets
 type ServiceAccount struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.

--- a/staging/src/k8s.io/api/discovery/v1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1/types.go
@@ -36,9 +36,9 @@ type EndpointSlice struct {
 	// All addresses in this slice must be the same type. This field is
 	// immutable after creation. The following address types are currently
 	// supported:
-	// * IPv4: Represents an IPv4 Address.
-	// * IPv6: Represents an IPv6 Address.
-	// * FQDN: Represents a Fully Qualified Domain Name.
+	// - IPv4: Represents an IPv4 Address.
+	// - IPv6: Represents an IPv6 Address.
+	// - FQDN: Represents a Fully Qualified Domain Name.
 	AddressType AddressType `json:"addressType" protobuf:"bytes,4,rep,name=addressType"`
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
@@ -160,9 +160,9 @@ type EndpointPort struct {
 	// name. If the EndpointSlice is dervied from a Kubernetes service, this
 	// corresponds to the Service.ports[].name.
 	// Name must either be an empty string or pass DNS_LABEL validation:
-	// * must be no more than 63 characters long.
-	// * must consist of lower case alphanumeric characters or '-'.
-	// * must start and end with an alphanumeric character.
+	// - must be no more than 63 characters long.
+	// - must consist of lower case alphanumeric characters or '-'.
+	// - must start and end with an alphanumeric character.
 	// Default is empty string.
 	Name *string `json:"name,omitempty" protobuf:"bytes,1,name=name"`
 	// The IP protocol for this port.

--- a/staging/src/k8s.io/api/discovery/v1beta1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1beta1/types.go
@@ -40,9 +40,9 @@ type EndpointSlice struct {
 	// All addresses in this slice must be the same type. This field is
 	// immutable after creation. The following address types are currently
 	// supported:
-	// * IPv4: Represents an IPv4 Address.
-	// * IPv6: Represents an IPv6 Address.
-	// * FQDN: Represents a Fully Qualified Domain Name.
+	// - IPv4: Represents an IPv4 Address.
+	// - IPv6: Represents an IPv6 Address.
+	// - FQDN: Represents a Fully Qualified Domain Name.
 	AddressType AddressType `json:"addressType" protobuf:"bytes,4,rep,name=addressType"`
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
@@ -98,12 +98,12 @@ type Endpoint struct {
 	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
 	// Topology may include a maximum of 16 key/value pairs. This includes, but
 	// is not limited to the following well known keys:
-	// * kubernetes.io/hostname: the value indicates the hostname of the node
+	// - kubernetes.io/hostname: the value indicates the hostname of the node
 	//   where the endpoint is located. This should match the corresponding
 	//   node label.
-	// * topology.kubernetes.io/zone: the value indicates the zone where the
+	// - topology.kubernetes.io/zone: the value indicates the zone where the
 	//   endpoint is located. This should match the corresponding node label.
-	// * topology.kubernetes.io/region: the value indicates the region where the
+	// - topology.kubernetes.io/region: the value indicates the region where the
 	//   endpoint is located. This should match the corresponding node label.
 	// This field is deprecated and will be removed in future api versions.
 	// +optional
@@ -165,9 +165,9 @@ type EndpointPort struct {
 	// name. If the EndpointSlice is dervied from a Kubernetes service, this
 	// corresponds to the Service.ports[].name.
 	// Name must either be an empty string or pass DNS_LABEL validation:
-	// * must be no more than 63 characters long.
-	// * must consist of lower case alphanumeric characters or '-'.
-	// * must start and end with an alphanumeric character.
+	// - must be no more than 63 characters long.
+	// - must consist of lower case alphanumeric characters or '-'.
+	// - must start and end with an alphanumeric character.
 	// Default is empty string.
 	Name *string `json:"name,omitempty" protobuf:"bytes,1,name=name"`
 	// The IP protocol for this port.

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -797,15 +797,15 @@ type HTTPIngressPath struct {
 
 	// PathType determines the interpretation of the Path matching. PathType can
 	// be one of the following values:
-	// * Exact: Matches the URL path exactly.
-	// * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+	// - Exact: Matches the URL path exactly.
+	// - Prefix: Matches based on a URL path prefix split by '/'. Matching is
 	//   done on a path element by element basis. A path element refers is the
 	//   list of labels in the path split by the '/' separator. A request is a
 	//   match for path p if every p is an element-wise prefix of p of the
 	//   request path. Note that if the last element of the path is a substring
 	//   of the last element in request path, it is not a match (e.g. /foo/bar
 	//   matches /foo/bar/baz, but does not match /foo/barbaz).
-	// * ImplementationSpecific: Interpretation of the Path matching is up to
+	// - ImplementationSpecific: Interpretation of the Path matching is up to
 	//   the IngressClass. Implementations can treat this as a separate PathType
 	//   or treat it identically to Prefix or Exact path types.
 	// Implementations are required to support all path types.

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -461,15 +461,15 @@ type HTTPIngressPath struct {
 
 	// PathType determines the interpretation of the Path matching. PathType can
 	// be one of the following values:
-	// * Exact: Matches the URL path exactly.
-	// * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+	// - Exact: Matches the URL path exactly.
+	// - Prefix: Matches based on a URL path prefix split by '/'. Matching is
 	//   done on a path element by element basis. A path element refers is the
 	//   list of labels in the path split by the '/' separator. A request is a
 	//   match for path p if every p is an element-wise prefix of p of the
 	//   request path. Note that if the last element of the path is a substring
 	//   of the last element in request path, it is not a match (e.g. /foo/bar
 	//   matches /foo/bar/baz, but does not match /foo/barbaz).
-	// * ImplementationSpecific: Interpretation of the Path matching is up to
+	// - ImplementationSpecific: Interpretation of the Path matching is up to
 	//   the IngressClass. Implementations can treat this as a separate PathType
 	//   or treat it identically to Prefix or Exact path types.
 	// Implementations are required to support all path types.

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -235,15 +235,15 @@ type HTTPIngressPath struct {
 
 	// PathType determines the interpretation of the Path matching. PathType can
 	// be one of the following values:
-	// * Exact: Matches the URL path exactly.
-	// * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+	// - Exact: Matches the URL path exactly.
+	// - Prefix: Matches based on a URL path prefix split by '/'. Matching is
 	//   done on a path element by element basis. A path element refers is the
 	//   list of labels in the path split by the '/' separator. A request is a
 	//   match for path p if every p is an element-wise prefix of p of the
 	//   request path. Note that if the last element of the path is a substring
 	//   of the last element in request path, it is not a match (e.g. /foo/bar
 	//   matches /foo/bar/baz, but does not match /foo/barbaz).
-	// * ImplementationSpecific: Interpretation of the Path matching is up to
+	// - ImplementationSpecific: Interpretation of the Path matching is up to
 	//   the IngressClass. Implementations can treat this as a separate PathType
 	//   or treat it identically to Prefix or Exact path types.
 	// Implementations are required to support all path types.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types.go
@@ -390,9 +390,9 @@ type CustomResourceSubresources struct {
 
 // CustomResourceSubresourceStatus defines how to serve the status subresource for CustomResources.
 // Status is represented by the `.status` JSON path inside of a CustomResource. When set,
-// * exposes a /status subresource for the custom resource
-// * PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza
-// * PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza
+// - exposes a /status subresource for the custom resource
+// - PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza
+// - PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza
 type CustomResourceSubresourceStatus struct{}
 
 // CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types.go
@@ -409,9 +409,9 @@ type CustomResourceSubresources struct {
 
 // CustomResourceSubresourceStatus defines how to serve the status subresource for CustomResources.
 // Status is represented by the `.status` JSON path inside of a CustomResource. When set,
-// * exposes a /status subresource for the custom resource
-// * PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza
-// * PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza
+// - exposes a /status subresource for the custom resource
+// - PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza
+// - PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza
 type CustomResourceSubresourceStatus struct{}
 
 // CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
@@ -450,9 +450,9 @@ type CustomResourceSubresources struct {
 
 // CustomResourceSubresourceStatus defines how to serve the status subresource for CustomResources.
 // Status is represented by the `.status` JSON path inside of a CustomResource. When set,
-// * exposes a /status subresource for the custom resource
-// * PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza
-// * PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza
+// - exposes a /status subresource for the custom resource
+// - PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza
+// - PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza
 type CustomResourceSubresourceStatus struct{}
 
 // CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
@@ -44,9 +44,9 @@ const (
 
 // ValidateStructural checks that s is a structural schema with the invariants:
 //
-// * structurality: both `ForbiddenGenerics` and `ForbiddenExtensions` only have zero values, with the two exceptions for IntOrString.
-// * RawExtension: for every schema with `x-kubernetes-embedded-resource: true`, `x-kubernetes-preserve-unknown-fields: true` and `type: object` are set
-// * IntOrString: for `x-kubernetes-int-or-string: true` either `type` is empty under `anyOf` and `allOf` or the schema structure is one of these:
+// - structurality: both `ForbiddenGenerics` and `ForbiddenExtensions` only have zero values, with the two exceptions for IntOrString.
+// - RawExtension: for every schema with `x-kubernetes-embedded-resource: true`, `x-kubernetes-preserve-unknown-fields: true` and `type: object` are set
+// - IntOrString: for `x-kubernetes-int-or-string: true` either `type` is empty under `anyOf` and `allOf` or the schema structure is one of these:
 //
 //  1. anyOf:
 //     - type: integer
@@ -57,9 +57,9 @@ const (
 //     - type: string
 //     - ... zero or more
 //
-// * every specified field or array in s is also specified outside of value validation.
-// * metadata at the root can only restrict the name and generateName, and not be specified at all in nested contexts.
-// * additionalProperties at the root is not allowed.
+// - every specified field or array in s is also specified outside of value validation.
+// - metadata at the root can only restrict the name and generateName, and not be specified at all in nested contexts.
+// - additionalProperties at the root is not allowed.
 func ValidateStructural(fldPath *field.Path, s *Structural) field.ErrorList {
 	allErrs := field.ErrorList{}
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/compatibility.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/compatibility.go
@@ -54,18 +54,18 @@ type CompatibilityTestOptions struct {
 	// TestDataDirCurrentVersion points to a directory containing compatibility test data for the current version.
 	// Complete() populates this with "<TestDataDir>/HEAD" if unset.
 	// Within this directory, `<group>.<version>.<kind>.[json|yaml|pb]` files are required to exist, and are:
-	// * verified to match serialized FilledObjects[GVK]
-	// * verified to decode without error
-	// * verified to round-trip byte-for-byte when re-encoded
-	// * verified to be semantically equal when decoded into memory
+	// - verified to match serialized FilledObjects[GVK]
+	// - verified to decode without error
+	// - verified to round-trip byte-for-byte when re-encoded
+	// - verified to be semantically equal when decoded into memory
 	TestDataDirCurrentVersion string
 
 	// TestDataDirsPreviousVersions is a list of directories containing compatibility test data for previous versions.
 	// Complete() populates this with "<TestDataDir>/v*" directories if nil.
 	// Within these directories, `<group>.<version>.<kind>.[json|yaml|pb]` files are optional. If present, they are:
-	// * verified to decode without error
-	// * verified to round-trip byte-for-byte when re-encoded (or to match a `<group>.<version>.<kind>.[json|yaml|pb].after_roundtrip.[json|yaml|pb]` file if it exists)
-	// * verified to be semantically equal when decoded into memory
+	// - verified to decode without error
+	// - verified to round-trip byte-for-byte when re-encoded (or to match a `<group>.<version>.<kind>.[json|yaml|pb].after_roundtrip.[json|yaml|pb]` file if it exists)
+	// - verified to be semantically equal when decoded into memory
 	TestDataDirsPreviousVersions []string
 
 	// Kinds is a list of fully qualified kinds to test.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/allocator_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/allocator_test.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 package runtime
 
 import (

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/allocator_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/allocator_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+
 package runtime
 
 import (

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -117,10 +117,10 @@ func IsFullyQualifiedDomainName(fldPath *field.Path, name string) field.ErrorLis
 
 // Allowed characters in an HTTP Path as defined by RFC 3986. A HTTP path may
 // contain:
-// * unreserved characters (alphanumeric, '-', '.', '_', '~')
-// * percent-encoded octets
-// * sub-delims ("!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "=")
-// * a colon character (":")
+// - unreserved characters (alphanumeric, '-', '.', '_', '~')
+// - percent-encoded octets
+// - sub-delims ("!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "=")
+// - a colon character (":")
 const httpPathFmt string = `[A-Za-z0-9/\-._~%!$&'()*+,;=:]+`
 
 var httpPathRegexp = regexp.MustCompile("^" + httpPathFmt + "$")

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion.go
@@ -69,9 +69,9 @@ func NewVersionedAttributes(attr admission.Attributes, gvk schema.GroupVersionKi
 // ConvertVersionedAttributes converts VersionedObject and VersionedOldObject to the specified kind, if needed.
 // If attr.VersionedKind already matches the requested kind, no conversion is performed.
 // If conversion is required:
-// * attr.VersionedObject is used as the source for the new object if Dirty=true (and is round-tripped through attr.Attributes.Object, clearing Dirty in the process)
-// * attr.Attributes.Object is used as the source for the new object if Dirty=false
-// * attr.Attributes.OldObject is used as the source for the old object
+// - attr.VersionedObject is used as the source for the new object if Dirty=true (and is round-tripped through attr.Attributes.Object, clearing Dirty in the process)
+// - attr.Attributes.Object is used as the source for the new object if Dirty=false
+// - attr.Attributes.OldObject is used as the source for the old object
 func ConvertVersionedAttributes(attr *VersionedAttributes, gvk schema.GroupVersionKind, o admission.ObjectInterfaces) error {
 	// we already have the desired kind, we're done
 	if attr.VersionedKind == gvk {

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -513,9 +513,9 @@ func (config *DirectClientConfig) getCluster() (clientcmdapi.Cluster, error) {
 		mergo.Merge(mergedClusterInfo, config.overrides.ClusterInfo, mergo.WithOverride)
 	}
 
-	// * An override of --insecure-skip-tls-verify=true and no accompanying CA/CA data should clear already-set CA/CA data
+	// - An override of --insecure-skip-tls-verify=true and no accompanying CA/CA data should clear already-set CA/CA data
 	// otherwise, a kubeconfig containing a CA reference would return an error that "CA and insecure-skip-tls-verify couldn't both be set".
-	// * An override of --certificate-authority should also override TLS skip settings and CA data, otherwise existing CA data will take precedence.
+	// - An override of --certificate-authority should also override TLS skip settings and CA data, otherwise existing CA data will take precedence.
 	if config.overrides != nil {
 		caLen := len(config.overrides.ClusterInfo.CertificateAuthority)
 		caDataLen := len(config.overrides.ClusterInfo.CertificateAuthorityData)

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
@@ -4253,9 +4253,9 @@ type Device struct {
 	// Path of the device on the host.
 	HostPath string `protobuf:"bytes,2,opt,name=host_path,json=hostPath,proto3" json:"host_path,omitempty"`
 	// Cgroups permissions of the device, candidates are one or more of
-	// * r - allows container to read from the specified device.
-	// * w - allows container to write to the specified device.
-	// * m - allows container to create device files that do not yet exist.
+	// - r - allows container to read from the specified device.
+	// - w - allows container to write to the specified device.
+	// - m - allows container to create device files that do not yet exist.
 	Permissions          string   `protobuf:"bytes,3,opt,name=permissions,proto3" json:"permissions,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_sizecache        int32    `json:"-"`

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/constants.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/constants.go
@@ -38,7 +38,7 @@ const (
 
 // LogTag is the tag of a log line in CRI container log.
 // Currently defined log tags:
-// * First tag: Partial/Full - P/F.
+// - First tag: Partial/Full - P/F.
 // The field in the container log format can be extended to include multiple
 // tags by using a delimiter, but changes should be rare. If it becomes clear
 // that better extensibility is desired, a more extensible format (e.g., json)

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.pb.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.pb.go
@@ -4218,9 +4218,9 @@ type Device struct {
 	// Path of the device on the host.
 	HostPath string `protobuf:"bytes,2,opt,name=host_path,json=hostPath,proto3" json:"host_path,omitempty"`
 	// Cgroups permissions of the device, candidates are one or more of
-	// * r - allows container to read from the specified device.
-	// * w - allows container to write to the specified device.
-	// * m - allows container to create device files that do not yet exist.
+	// - r - allows container to read from the specified device.
+	// - w - allows container to write to the specified device.
+	// - m - allows container to create device files that do not yet exist.
 	Permissions          string   `protobuf:"bytes,3,opt,name=permissions,proto3" json:"permissions,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_sizecache        int32    `json:"-"`

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/constants.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/constants.go
@@ -38,7 +38,7 @@ const (
 
 // LogTag is the tag of a log line in CRI container log.
 // Currently defined log tags:
-// * First tag: Partial/Full - P/F.
+// - First tag: Partial/Full - P/F.
 // The field in the container log format can be extended to include multiple
 // tags by using a delimiter, but changes should be rare. If it becomes clear
 // that better extensibility is desired, a more extensible format (e.g., json)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -5559,8 +5559,8 @@ func backendStringer(backend *networkingv1beta1.IngressBackend) string {
 
 // findNodeRoles returns the roles of a given node.
 // The roles are determined by looking for:
-// * a node-role.kubernetes.io/<role>="" label
-// * a kubernetes.io/role="<role>" label
+// - a node-role.kubernetes.io/<role>="" label
+// - a kubernetes.io/role="<role>" label
 func findNodeRoles(node *corev1.Node) []string {
 	roles := sets.NewString()
 	for k, v := range node.Labels {

--- a/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1alpha/api.pb.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1alpha/api.pb.go
@@ -464,9 +464,9 @@ type DeviceSpec struct {
 	// Path of the device on the host.
 	HostPath string `protobuf:"bytes,2,opt,name=host_path,json=hostPath,proto3" json:"host_path,omitempty"`
 	// Cgroups permissions of the device, candidates are one or more of
-	// * r - allows container to read from the specified device.
-	// * w - allows container to write to the specified device.
-	// * m - allows container to create device files that do not yet exist.
+	// - r - allows container to read from the specified device.
+	// - w - allows container to write to the specified device.
+	// - m - allows container to create device files that do not yet exist.
 	Permissions          string   `protobuf:"bytes,3,opt,name=permissions,proto3" json:"permissions,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_sizecache        int32    `json:"-"`

--- a/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.pb.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.pb.go
@@ -1013,9 +1013,9 @@ type DeviceSpec struct {
 	// Path of the device on the host.
 	HostPath string `protobuf:"bytes,2,opt,name=host_path,json=hostPath,proto3" json:"host_path,omitempty"`
 	// Cgroups permissions of the device, candidates are one or more of
-	// * r - allows container to read from the specified device.
-	// * w - allows container to write to the specified device.
-	// * m - allows container to create device files that do not yet exist.
+	// - r - allows container to read from the specified device.
+	// - w - allows container to write to the specified device.
+	// - m - allows container to create device files that do not yet exist.
 	Permissions          string   `protobuf:"bytes,3,opt,name=permissions,proto3" json:"permissions,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_sizecache        int32    `json:"-"`

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -4604,10 +4604,10 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
 		// fail. We delete the loadbalancer first. This does leave the
 		// possibility of zombie target groups if DeleteLoadBalancer() fails
 		//
-		// * Get target groups for NLB
-		// * Delete Load Balancer
-		// * Delete target groups
-		// * Clean up SecurityGroupRules
+		// - Get target groups for NLB
+		// - Delete Load Balancer
+		// - Delete target groups
+		// - Clean up SecurityGroupRules
 		{
 
 			targetGroups, err := c.elbv2.DescribeTargetGroups(

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_config.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_config.go
@@ -35,9 +35,9 @@ const (
 )
 
 // The config type for Azure cloud provider secret. Supported values are:
-// * file   : The values are read from local cloud-config file.
-// * secret : The values from secret would override all configures from local cloud-config file.
-// * merge  : The values from secret would override only configurations that are explicitly set in the secret. This is the default value.
+// - file   : The values are read from local cloud-config file.
+// - secret : The values from secret would override all configures from local cloud-config file.
+// - merge  : The values from secret would override only configurations that are explicitly set in the secret. This is the default value.
 type cloudConfigType string
 
 const (

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -166,7 +166,7 @@ func (az *Cloud) getAzureLoadBalancerName(clusterName string, vmSetName string, 
 
 // isMasterNode returns true if the node has a master role label.
 // The master role is determined by looking for:
-// * a kubernetes.io/role="master" label
+// - a kubernetes.io/role="master" label
 func isMasterNode(node *v1.Node) bool {
 	if val, ok := node.Labels[nodeLabelRole]; ok && val == "master" {
 		return true

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instances.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instances.go
@@ -713,8 +713,8 @@ func (g *Cloud) isCurrentInstance(instanceID string) bool {
 }
 
 // ComputeHostTags grabs all tags from all instances being added to the pool.
-// * The longest tag that is a prefix of the instance name is used
-// * If any instance has no matching prefix tag, return error
+// - The longest tag that is a prefix of the instance name is used
+// - If any instance has no matching prefix tag, return error
 // Invoking this method to get host tags is risky since it depends on the
 // format of the host names in the cluster. Only use it as a fallback if
 // gce.nodeTags is unspecified

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/moby/sys/mountinfo"
 	"io/fs"
 	"io/ioutil"
 	"os"
@@ -33,6 +32,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/moby/sys/mountinfo"
 
 	"k8s.io/klog/v2"
 	utilexec "k8s.io/utils/exec"
@@ -195,15 +196,15 @@ func (mounter *Mounter) doMount(mounterPath string, mountCmd string, source stri
 		// systemd-run --description=... --scope -- mount -t <type> <what> <where>
 		//
 		// Expected flow:
-		// * systemd-run creates a transient scope (=~ cgroup) and executes its
+		// - systemd-run creates a transient scope (=~ cgroup) and executes its
 		//   argument (/bin/mount) there.
-		// * mount does its job, forks a fuse daemon if necessary and finishes.
+		// - mount does its job, forks a fuse daemon if necessary and finishes.
 		//   (systemd-run --scope finishes at this point, returning mount's exit
 		//   code and stdout/stderr - thats one of --scope benefits).
-		// * systemd keeps the fuse daemon running in the scope (i.e. in its own
+		// - systemd keeps the fuse daemon running in the scope (i.e. in its own
 		//   cgroup) until the fuse daemon dies (another --scope benefit).
 		//   Kubelet service can be restarted and the fuse daemon survives.
-		// * When the fuse daemon dies (e.g. during unmount) systemd removes the
+		// - When the fuse daemon dies (e.g. during unmount) systemd removes the
 		//   scope automatically.
 		//
 		// systemd-mount is not used because it's too new for older distros

--- a/staging/src/k8s.io/pod-security-admission/admission/admission.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/admission.go
@@ -278,10 +278,10 @@ func (a *Admission) ValidateNamespace(ctx context.Context, attrs api.Attributes)
 		}
 
 		// Skip dry-running pods:
-		// * if the enforce policy is unchanged
-		// * if the new enforce policy is privileged
-		// * if the new enforce is the same version and level was relaxed
-		// * for exempt namespaces
+		// - if the enforce policy is unchanged
+		// - if the new enforce policy is privileged
+		// - if the new enforce is the same version and level was relaxed
+		// - for exempt namespaces
 		if newPolicy.Enforce == oldPolicy.Enforce {
 			return sharedAllowedResponse
 		}
@@ -627,7 +627,7 @@ func (a *Admission) PolicyToEvaluate(labels map[string]string) (api.Policy, fiel
 
 // isSignificantPodUpdate determines whether a pod update should trigger a policy evaluation.
 // Relevant mutable pod fields as of 1.21 are image annotations:
-// * https://github.com/kubernetes/kubernetes/blob/release-1.21/pkg/apis/core/validation/validation.go#L3947-L3949
+// - https://github.com/kubernetes/kubernetes/blob/release-1.21/pkg/apis/core/validation/validation.go#L3947-L3949
 func isSignificantPodUpdate(pod, oldPod *corev1.Pod) bool {
 	// TODO: invert this logic to only allow specific update types.
 	if len(pod.Spec.Containers) != len(oldPod.Spec.Containers) {

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -546,8 +546,8 @@ func validateProxyVerbRequest(client *http.Client, urlString string, httpVerb st
 
 func doProxy(f *framework.Framework, path string, i int) (body []byte, statusCode int, d time.Duration, err error) {
 	// About all of the proxy accesses in this file:
-	// * AbsPath is used because it preserves the trailing '/'.
-	// * Do().Raw() is used (instead of DoRaw()) because it will turn an
+	// - AbsPath is used because it preserves the trailing '/'.
+	// - Do().Raw() is used (instead of DoRaw()) because it will turn an
 	//   error from apiserver proxy into an actual error, and there is no
 	//   chance of the things we are talking to being confused for an error
 	//   that apiserver would have emitted.

--- a/test/e2e/storage/testsuites/fsgroupchangepolicy.go
+++ b/test/e2e/storage/testsuites/fsgroupchangepolicy.go
@@ -145,8 +145,8 @@ func (s *fsGroupChangePolicyTestSuite) DefineTests(driver storageframework.TestD
 		finalExpectedSubDirFileOwnership  int    // Final expected ownership of the file in the sub directory (/mnt/volume1/subdir/file2), as part of the second pod
 		// Whether the test can run for drivers that support volumeMountGroup capability.
 		// For CSI drivers that support volumeMountGroup:
-		// * OnRootMismatch policy is not supported.
-		// * It may not be possible to chgrp after mounting a volume.
+		// - OnRootMismatch policy is not supported.
+		// - It may not be possible to chgrp after mounting a volume.
 		supportsVolumeMountGroup bool
 	}{
 		// Test cases for 'Always' policy

--- a/test/e2e_node/remote/types.go
+++ b/test/e2e_node/remote/types.go
@@ -28,26 +28,26 @@ type TestSuite interface {
 	// SetupTestPackage setup the test package in the given directory. TestSuite
 	// should put all necessary binaries and dependencies into the path. The caller
 	// will:
-	// * create a tarball with the directory.
-	// * deploy the tarball to the testing host.
-	// * untar the tarball to the testing workspace on the testing host.
+	// - create a tarball with the directory.
+	// - deploy the tarball to the testing host.
+	// - untar the tarball to the testing workspace on the testing host.
 	SetupTestPackage(path, systemSpecName string) error
 	// RunTest runs test on the node in the given workspace and returns test output
 	// and test error if there is any.
-	// * host is the target node to run the test.
-	// * workspace is the directory on the testing host the test is running in. Note
+	// - host is the target node to run the test.
+	// - workspace is the directory on the testing host the test is running in. Note
 	//   that the test package is unpacked in the workspace before running the test.
-	// * results is the directory the test should write result into. All logs should be
+	// - results is the directory the test should write result into. All logs should be
 	//   saved as *.log, all junit file should start with junit*.
-	// * imageDesc is the description of the image the test is running on.
+	// - imageDesc is the description of the image the test is running on.
 	//   It will be used for logging purpose only.
-	// * junitFilePrefix is the prefix of output junit file.
-	// * testArgs is the arguments passed to test.
-	// * ginkgoArgs is the arguments passed to ginkgo.
-	// * systemSpecName is the name of the system spec used for validating the
+	// - junitFilePrefix is the prefix of output junit file.
+	// - testArgs is the arguments passed to test.
+	// - ginkgoArgs is the arguments passed to ginkgo.
+	// - systemSpecName is the name of the system spec used for validating the
 	//   image on which the test runs.
-	// * extraEnvs is the extra environment variables needed for node e2e tests.
-	// * runtimeConfig is the API runtime configuration used for node e2e tests.
-	// * timeout is the test timeout.
+	// - extraEnvs is the extra environment variables needed for node e2e tests.
+	// - runtimeConfig is the API runtime configuration used for node e2e tests.
+	// - timeout is the test timeout.
 	RunTest(host, workspace, results, imageDesc, junitFilePrefix, testArgs, ginkgoArgs, systemSpecName, extraEnvs, runtimeConfig string, timeout time.Duration) (string, error)
 }

--- a/test/e2e_node/services/services.go
+++ b/test/e2e_node/services/services.go
@@ -56,9 +56,9 @@ func NewE2EServices(monitorParent bool) *E2EServices {
 // want their glog output to pollute the test result. So we run the binary in
 // run-services-mode to start e2e services in another process.
 // The function starts 2 processes:
-// * internal e2e services: services which statically linked in the test binary - apiserver, etcd and
+// - internal e2e services: services which statically linked in the test binary - apiserver, etcd and
 // namespace controller.
-// * kubelet: kubelet binary is outside. (We plan to move main kubelet start logic out when we have
+// - kubelet: kubelet binary is outside. (We plan to move main kubelet start logic out when we have
 // standard kubelet launcher)
 func (e *E2EServices) Start(featureGates map[string]bool) error {
 	var err error

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/env_provider.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/env_provider.go
@@ -24,9 +24,9 @@ var (
 //
 // Environment variables used:
 //
-// * Access Key ID:     AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY
+// - Access Key ID:     AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY
 //
-// * Secret Access Key: AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY
+// - Secret Access Key: AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY
 type EnvProvider struct {
 	retrieved bool
 }

--- a/vendor/github.com/dustin/go-humanize/number.go
+++ b/vendor/github.com/dustin/go-humanize/number.go
@@ -42,9 +42,9 @@ var (
 )
 
 // FormatFloat produces a formatted number as string based on the following user-specified criteria:
-// * thousands separator
-// * decimal separator
-// * decimal precision
+// - thousands separator
+// - decimal separator
+// - decimal precision
 //
 // Usage: s := RenderFloat(format, n)
 // The format parameter tells how to render the number n.

--- a/vendor/github.com/gogo/protobuf/types/any.pb.go
+++ b/vendor/github.com/gogo/protobuf/types/any.pb.go
@@ -118,10 +118,10 @@ type Any struct {
 	// scheme `http`, `https`, or no scheme, one can optionally set up a type
 	// server that maps type URLs to message definitions as follows:
 	//
-	// * If no scheme is provided, `https` is assumed.
-	// * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+	// - If no scheme is provided, `https` is assumed.
+	// - An HTTP GET on the URL must yield a [google.protobuf.Type][]
 	//   value in binary format, or produce an error.
-	// * Applications are allowed to cache lookup results based on the
+	// - Applications are allowed to cache lookup results based on the
 	//   URL, or have them precompiled into a binary to avoid any
 	//   lookup. Therefore, binary compatibility needs to be preserved
 	//   on changes to types. (Use versioned type names to manage

--- a/vendor/github.com/google/cel-go/cel/program.go
+++ b/vendor/github.com/google/cel-go/cel/program.go
@@ -36,9 +36,9 @@ type Program interface {
 	// If the `OptTrackState`, `OptTrackCost` or `OptExhaustiveEval` flags are used, the `details` response will
 	// be non-nil. Given this caveat on `details`, the return state from evaluation will be:
 	//
-	// *  `val`, `details`, `nil` - Successful evaluation of a non-error result.
-	// *  `val`, `details`, `err` - Successful evaluation to an error result.
-	// *  `nil`, `details`, `err` - Unsuccessful evaluation.
+	// -  `val`, `details`, `nil` - Successful evaluation of a non-error result.
+	// -  `val`, `details`, `err` - Successful evaluation to an error result.
+	// -  `nil`, `details`, `err` - Unsuccessful evaluation.
 	//
 	// An unsuccessful evaluation is typically the result of a series of incompatible `EnvOption`
 	// or `ProgramOption` values used in the creation of the evaluation environment or executable

--- a/vendor/github.com/opencontainers/runc/libcontainer/container_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/container_linux.go
@@ -1268,10 +1268,10 @@ func (c *linuxContainer) makeCriuRestoreMountpoints(m *configs.Mount) error {
 	case "cgroup":
 		// No mount point(s) need to be created:
 		//
-		// * for v1, mount points are saved by CRIU because
+		// - for v1, mount points are saved by CRIU because
 		//   /sys/fs/cgroup is a tmpfs mount
 		//
-		// * for v2, /sys/fs/cgroup is a real mount, but
+		// - for v2, /sys/fs/cgroup is a real mount, but
 		//   the mountpoint appears as soon as /sys is mounted
 		return nil
 	case "bind":
@@ -1396,8 +1396,8 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 	}
 	defer imageDir.Close()
 	// CRIU has a few requirements for a root directory:
-	// * it must be a mount point
-	// * its parent must not be overmounted
+	// - it must be a mount point
+	// - its parent must not be overmounted
 	// c.config.Rootfs is bind-mounted to a temporary directory
 	// to satisfy these requirements.
 	root := filepath.Join(c.root, "criu-root")

--- a/vendor/github.com/prometheus/procfs/net_softnet.go
+++ b/vendor/github.com/prometheus/procfs/net_softnet.go
@@ -26,8 +26,8 @@ import (
 
 // For the proc file format details,
 // See:
-// * Linux 2.6.23 https://elixir.bootlin.com/linux/v2.6.23/source/net/core/dev.c#L2343
-// * Linux 4.17 https://elixir.bootlin.com/linux/v4.17/source/net/core/net-procfs.c#L162
+// - Linux 2.6.23 https://elixir.bootlin.com/linux/v2.6.23/source/net/core/dev.c#L2343
+// - Linux 4.17 https://elixir.bootlin.com/linux/v4.17/source/net/core/net-procfs.c#L162
 // and https://elixir.bootlin.com/linux/v4.17/source/include/linux/netdevice.h#L2810.
 
 // SoftnetStat contains a single row of data from /proc/net/softnet_stat.

--- a/vendor/github.com/prometheus/procfs/proc_stat.go
+++ b/vendor/github.com/prometheus/procfs/proc_stat.go
@@ -144,8 +144,8 @@ func (p Proc) Stat() (ProcStat, error) {
 
 	// Check the following resources for the details about the particular stat
 	// fields and their data types:
-	// * https://man7.org/linux/man-pages/man5/proc.5.html
-	// * https://man7.org/linux/man-pages/man3/scanf.3.html
+	// - https://man7.org/linux/man-pages/man5/proc.5.html
+	// - https://man7.org/linux/man-pages/man3/scanf.3.html
 	_, err = fmt.Fscan(
 		bytes.NewBuffer(data[r+2:]),
 		&s.State,

--- a/vendor/github.com/russross/blackfriday/block.go
+++ b/vendor/github.com/russross/blackfriday/block.go
@@ -148,8 +148,8 @@ func (p *parser) block(out *bytes.Buffer, data []byte) {
 
 		// an itemized/unordered list:
 		//
-		// * Item 1
-		// * Item 2
+		// - Item 1
+		// - Item 2
 		//
 		// also works with + or -
 		if p.uliPrefix(data) > 0 {

--- a/vendor/github.com/russross/blackfriday/markdown.go
+++ b/vendor/github.com/russross/blackfriday/markdown.go
@@ -310,21 +310,21 @@ func MarkdownBasic(input []byte) []byte {
 // MarkdownCommon is a convenience function for simple rendering.
 // It processes markdown input with common extensions enabled, including:
 //
-// * Smartypants processing with smart fractions and LaTeX dashes
+// - Smartypants processing with smart fractions and LaTeX dashes
 //
-// * Intra-word emphasis suppression
+// - Intra-word emphasis suppression
 //
-// * Tables
+// - Tables
 //
-// * Fenced code blocks
+// - Fenced code blocks
 //
-// * Autolinking
+// - Autolinking
 //
-// * Strikethrough support
+// - Strikethrough support
 //
-// * Strict header parsing
+// - Strict header parsing
 //
-// * Custom Header IDs
+// - Custom Header IDs
 func MarkdownCommon(input []byte) []byte {
 	// set up the HTML renderer
 	renderer := HtmlRenderer(commonHtmlFlags, "", "")

--- a/vendor/github.com/russross/blackfriday/v2/block.go
+++ b/vendor/github.com/russross/blackfriday/v2/block.go
@@ -156,8 +156,8 @@ func (p *Markdown) block(data []byte) {
 
 		// an itemized/unordered list:
 		//
-		// * Item 1
-		// * Item 2
+		// - Item 1
+		// - Item 2
 		//
 		// also works with + or -
 		if p.uliPrefix(data) > 0 {

--- a/vendor/github.com/sirupsen/logrus/formatter.go
+++ b/vendor/github.com/sirupsen/logrus/formatter.go
@@ -16,9 +16,9 @@ const (
 // The Formatter interface is used to implement a custom Formatter. It takes an
 // `Entry`. It exposes all the fields, including the default ones:
 //
-// * `entry.Data["msg"]`. The message passed from Info, Warn, Error ..
-// * `entry.Data["time"]`. The timestamp.
-// * `entry.Data["level"]. The level the entry was logged at.
+// - `entry.Data["msg"]`. The message passed from Info, Warn, Error ..
+// - `entry.Data["time"]`. The timestamp.
+// - `entry.Data["level"]. The level the entry was logged at.
 //
 // Any additional fields added with `WithField` or `WithFields` are also in
 // `entry.Data`. Format is expected to return an array of bytes which are then
@@ -30,12 +30,12 @@ type Formatter interface {
 // This is to not silently overwrite `time`, `msg`, `func` and `level` fields when
 // dumping it. If this code wasn't there doing:
 //
-//  logrus.WithField("level", 1).Info("hello")
+//	logrus.WithField("level", 1).Info("hello")
 //
 // Would just silently drop the user provided level. Instead with this code
 // it'll logged as:
 //
-//  {"level": "info", "fields.level": 1, "msg": "hello", "time": "..."}
+//	{"level": "info", "fields.level": 1, "msg": "hello", "time": "..."}
 //
 // It's not exported because it's still using Data in an opinionated way. It's to
 // avoid code duplication between the two default formatters.

--- a/vendor/go.etcd.io/etcd/server/v3/etcdserver/apply.go
+++ b/vendor/go.etcd.io/etcd/server/v3/etcdserver/apply.go
@@ -549,10 +549,10 @@ func applyCompares(rv mvcc.ReadView, cmps []*pb.Compare) bool {
 // If the comparison succeeds, it returns true. Otherwise, returns false.
 func applyCompare(rv mvcc.ReadView, c *pb.Compare) bool {
 	// TODO: possible optimizations
-	// * chunk reads for large ranges to conserve memory
-	// * rewrite rules for common patterns:
+	// - chunk reads for large ranges to conserve memory
+	// - rewrite rules for common patterns:
 	//	ex. "[a, b) createrev > 0" => "limit 1 /\ kvs > 0"
-	// * caching
+	// - caching
 	rr, err := rv.Range(context.TODO(), c.Key, mkGteRange(c.RangeEnd), mvcc.RangeOptions{})
 	if err != nil {
 		return false

--- a/vendor/go.opencensus.io/trace/trace.go
+++ b/vendor/go.opencensus.io/trace/trace.go
@@ -542,9 +542,9 @@ type defaultIDGenerator struct {
 	// divisible by 8, on both 32-bit and 64-bit machines when
 	// performing atomic increments and accesses.
 	// See:
-	// * https://github.com/census-instrumentation/opencensus-go/issues/587
-	// * https://github.com/census-instrumentation/opencensus-go/issues/865
-	// * https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	// - https://github.com/census-instrumentation/opencensus-go/issues/587
+	// - https://github.com/census-instrumentation/opencensus-go/issues/865
+	// - https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	nextSpanID uint64
 	spanIDInc  uint64
 

--- a/vendor/go.uber.org/zap/zapcore/buffered_write_syncer.go
+++ b/vendor/go.uber.org/zap/zapcore/buffered_write_syncer.go
@@ -112,8 +112,8 @@ func (s *BufferedWriteSyncer) Write(bs []byte) (int, error) {
 	}
 
 	// To avoid partial writes from being flushed, we manually flush the existing buffer if:
-	// * The current write doesn't fit into the buffer fully, and
-	// * The buffer is not empty (since bufio will not split large writes when the buffer is empty)
+	// - The current write doesn't fit into the buffer fully, and
+	// - The buffer is not empty (since bufio will not split large writes when the buffer is empty)
 	if len(bs) > s.writer.Available() && s.writer.Buffered() > 0 {
 		if err := s.writer.Flush(); err != nil {
 			return 0, err

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -2774,12 +2774,12 @@ func cloneHeader(h http.Header) http.Header {
 
 // The Life Of A Write is like this:
 //
-// * Handler calls w.Write or w.WriteString ->
-// * -> rws.bw (*bufio.Writer) ->
-// * (Handler might call Flush)
-// * -> chunkWriter{rws}
-// * -> responseWriterState.writeChunk(p []byte)
-// * -> responseWriterState.writeChunk (most of the magic; see comment there)
+// - Handler calls w.Write or w.WriteString ->
+// - -> rws.bw (*bufio.Writer) ->
+// - (Handler might call Flush)
+// - -> chunkWriter{rws}
+// - -> responseWriterState.writeChunk(p []byte)
+// - -> responseWriterState.writeChunk (most of the magic; see comment there)
 func (w *responseWriter) Write(p []byte) (n int, err error) {
 	return w.write(len(p), p, "")
 }

--- a/vendor/google.golang.org/genproto/googleapis/api/expr/v1alpha1/syntax.pb.go
+++ b/vendor/google.golang.org/genproto/googleapis/api/expr/v1alpha1/syntax.pb.go
@@ -997,13 +997,13 @@ func (x *Expr_CreateStruct) GetEntries() []*Expr_CreateStruct_Entry {
 // Aggregate type macros may be applied to all elements in a list or all keys
 // in a map:
 //
-// *  `all`, `exists`, `exists_one` -  test a predicate expression against
+// -  `all`, `exists`, `exists_one` -  test a predicate expression against
 //    the inputs and return `true` if the predicate is satisfied for all,
 //    any, or only one value `list.all(x, x < 10)`.
-// *  `filter` - test a predicate expression against the inputs and return
+// -  `filter` - test a predicate expression against the inputs and return
 //    the subset of elements which satisfy the predicate:
 //    `payments.filter(p, p > 1000)`.
-// *  `map` - apply an expression to all elements in the input and return the
+// -  `map` - apply an expression to all elements in the input and return the
 //    output aggregate type: `[1, 2, 3].map(i, i * i)`.
 //
 // The `has(m.x)` macro tests whether the property `x` is present in struct

--- a/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
+++ b/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
@@ -228,10 +228,10 @@ type Any struct {
 	// scheme `http`, `https`, or no scheme, one can optionally set up a type
 	// server that maps type URLs to message definitions as follows:
 	//
-	// * If no scheme is provided, `https` is assumed.
-	// * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+	// - If no scheme is provided, `https` is assumed.
+	// - An HTTP GET on the URL must yield a [google.protobuf.Type][]
 	//   value in binary format, or produce an error.
-	// * Applications are allowed to cache lookup results based on the
+	// - Applications are allowed to cache lookup results based on the
 	//   URL, or have them precompiled into a binary to avoid any
 	//   lookup. Therefore, binary compatibility needs to be preserved
 	//   on changes to types. (Use versioned type names to manage

--- a/vendor/k8s.io/gengo/types/types.go
+++ b/vendor/k8s.io/gengo/types/types.go
@@ -351,7 +351,7 @@ type Type struct {
 	ConstValue *string
 
 	// TODO: Add:
-	// * channel direction
+	// - channel direction
 
 	// If Kind == Array
 	Len int64

--- a/vendor/sigs.k8s.io/kustomize/kyaml/kio/filters/merge3.go
+++ b/vendor/sigs.k8s.io/kustomize/kyaml/kio/filters/merge3.go
@@ -289,11 +289,11 @@ func duplicateError(source, filePath string) error {
 
 // DefaultResourceHandler is the default implementation of the ResourceHandler
 // interface. It uses the following rules:
-// * Keep dest if resource only exists in dest.
-// * Keep updated if resource added in updated.
-// * Delete dest if updated has been deleted.
-// * Don't add the resource back if removed from dest.
-// * Otherwise merge.
+// - Keep dest if resource only exists in dest.
+// - Keep updated if resource added in updated.
+// - Delete dest if updated has been deleted.
+// - Don't add the resource back if removed from dest.
+// - Otherwise merge.
 type DefaultResourceHandler struct{}
 
 func (*DefaultResourceHandler) Handle(original, updated, dest *yaml.RNode) (ResourceMergeStrategy, error) {

--- a/vendor/sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/util/validation/validation.go
+++ b/vendor/sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/util/validation/validation.go
@@ -119,10 +119,10 @@ func IsFullyQualifiedDomainName(fldPath *field.Path, name string) field.ErrorLis
 
 // Allowed characters in an HTTP Path as defined by RFC 3986. A HTTP path may
 // contain:
-// * unreserved characters (alphanumeric, '-', '.', '_', '~')
-// * percent-encoded octets
-// * sub-delims ("!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "=")
-// * a colon character (":")
+// - unreserved characters (alphanumeric, '-', '.', '_', '~')
+// - percent-encoded octets
+// - sub-delims ("!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "=")
+// - a colon character (":")
 const httpPathFmt string = `[A-Za-z0-9/\-._~%!$&'()*+,;=:]+`
 
 var httpPathRegexp = regexp.MustCompile("^" + httpPathFmt + "$")

--- a/vendor/sigs.k8s.io/kustomize/kyaml/yaml/rnode.go
+++ b/vendor/sigs.k8s.io/kustomize/kyaml/yaml/rnode.go
@@ -326,10 +326,10 @@ func (rn *RNode) GetMeta() (ResourceMeta, error) {
 //
 // Analogous to http://www.linfo.org/pipes.html
 //
-// * rn is provided as input to the first Filter.
-// * if any Filter returns an error, immediately return the error
-// * if any Filter returns a nil RNode, immediately return nil, nil
-// * if all Filters succeed with non-empty results, return the final result
+// - rn is provided as input to the first Filter.
+// - if any Filter returns an error, immediately return the error
+// - if any Filter returns a nil RNode, immediately return nil, nil
+// - if all Filters succeed with non-empty results, return the final result
 func (rn *RNode) Pipe(functions ...Filter) (*RNode, error) {
 	// check if rn is nil to make chaining Pipe calls easier
 	if rn == nil {

--- a/vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath/set.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath/set.go
@@ -81,14 +81,14 @@ func (s *Set) Intersection(s2 *Set) *Set {
 }
 
 // Difference returns a Set containing elements which:
-// * appear in s
-// * do not appear in s2
+// - appear in s
+// - do not appear in s2
 //
 // In other words, for leaf fields, this acts like a regular set difference
 // operation. When non leaf fields are compared with leaf fields ("parents"
 // which contain "children"), the effect is:
-// * parent - child = parent
-// * child - parent = {empty set}
+// - parent - child = parent
+// - child - parent = {empty set}
 func (s *Set) Difference(s2 *Set) *Set {
 	return &Set{
 		Members:  *s.Members.Difference(&s2.Members),
@@ -97,8 +97,8 @@ func (s *Set) Difference(s2 *Set) *Set {
 }
 
 // RecursiveDifference returns a Set containing elements which:
-// * appear in s
-// * do not appear in s2
+// - appear in s
+// - do not appear in s2
 //
 // Compared to a regular difference,
 // this removes every field **and its children** from s that is contained in s2.

--- a/vendor/sigs.k8s.io/structured-merge-diff/v4/merge/update.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/v4/merge/update.go
@@ -211,9 +211,9 @@ func (s *Updater) Apply(liveObject, configObject *typed.TypedValue, version fiel
 }
 
 // prune will remove a field, list or map item, iff:
-// * applyingManager applied it last time
-// * applyingManager didn't apply it this time
-// * no other applier claims to manage it
+// - applyingManager applied it last time
+// - applyingManager didn't apply it this time
+// - no other applier claims to manage it
 func (s *Updater) prune(merged *typed.TypedValue, managers fieldpath.ManagedFields, applyingManager string, lastSet fieldpath.VersionedSet) (*typed.TypedValue, error) {
 	if lastSet == nil || lastSet.Set().Empty() {
 		return merged, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR updates comments throughout the codebase that use `// *` to generate lists using godoc. Starting with godoc 1.9, `// -` is required to generate lists.

https://go.dev/doc/comment 

#### Which issue(s) this PR fixes:
Fixes #111701

#### Special notes for your reviewer:
- Where it makes sense, I've replaced `// *` with `// -`. 
- I've skipped comments where the intent of the author is unclear.
- I've skipped any generated code, such as the .proto files.


#### Does this PR introduce a user-facing change?
NONE


