### PR TITLE
Add `kubelet` CRI v1alpha2 API check

### DIFF
--- a/pkg/kubelet/cri/remote/remote_image.go
+++ b/pkg/kubelet/cri/remote/remote_image.go
@@ -97,6 +97,9 @@ func (r *remoteImageService) determineAPIVersion(conn *grpc.ClientConn) error {
 	} else if status.Code(err) == codes.Unimplemented {
 		klog.V(2).InfoS("Falling back to CRI v1alpha2 image API (deprecated)")
 		r.imageClientV1alpha2 = runtimeapiV1alpha2.NewImageServiceClient(conn)
+		if _, err := r.imageClientV1alpha2.ImageFsInfo(ctx, &runtimeapiV1alpha2.ImageFsInfoRequest{}); err != nil {
+			return fmt.Errorf("call CRI v1alpha2 image ImageFsInfo API failed: %w", err)
+		}
 
 	} else {
 		return fmt.Errorf("unable to determine image API version: %w", err)

--- a/pkg/kubelet/cri/remote/remote_runtime.go
+++ b/pkg/kubelet/cri/remote/remote_runtime.go
@@ -141,6 +141,9 @@ func (r *remoteRuntimeService) determineAPIVersion(conn *grpc.ClientConn) error 
 	} else if status.Code(err) == codes.Unimplemented {
 		klog.V(2).InfoS("Falling back to CRI v1alpha2 runtime API (deprecated)")
 		r.runtimeClientV1alpha2 = runtimeapiV1alpha2.NewRuntimeServiceClient(conn)
+		if _, err := r.runtimeClientV1alpha2.Version(ctx, &runtimeapiV1alpha2.VersionRequest{}); err != nil {
+			return fmt.Errorf("call CRI v1alpha2 runtime Version API failed: %w", err)
+		}
 
 	} else {
 		return fmt.Errorf("unable to determine runtime API version: %w", err)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Add CRI v1alpha2 runtime/image API check at the early stage, to prevent the API error in later step.

#### Which issue(s) this PR fixes:
Fixes #112548

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```