### PR TITLE
(kubectl patch): Add descriptive message when patch type is unsupported

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -23,9 +23,11 @@ import (
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -270,6 +272,9 @@ func (o *PatchOptions) RunPatch() error {
 				WithSubresource(o.Subresource)
 			patchedObj, err := helper.Patch(namespace, name, patchType, patchBytes, nil)
 			if err != nil {
+				if apierrors.IsUnsupportedMediaType(err) {
+					return errors.Wrap(err, fmt.Sprintf("%s is not supported by %s", patchType, mapping.GroupVersionKind))
+				}
 				return err
 			}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

`kubectl patch` commands fails when patch type is strategic merge patch for CRDs. This PR handles `UnsupportedMediaType` error and shows descriptive message to user.

Example error:
```
error: application/strategic-merge-patch+json is not supported by samplecontroller.k8s.io/v1alpha1, Kind=Foo: the body of the request was in an unknown format - accepted media types include: application/json-patch+json, application/merge-patch+json, application/apply-patch+yaml
```

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1280

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Change error message when resource is not supported by given patch type in kubectl patch
```