### PR TITLE
Automated cherry pick of #112520: Do not return err if CSIdriver is not found

### DIFF
--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -582,6 +582,9 @@ func (p *csiPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error)
 		}
 		csiDriver, err := p.getCSIDriver(driver)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
 			return false, err
 		}
 		if csiDriver.Spec.SELinuxMount != nil {

--- a/pkg/volume/csi/csi_util_test.go
+++ b/pkg/volume/csi/csi_util_test.go
@@ -87,7 +87,9 @@ func makeTestVol(name string, driverName string) *api.Volume {
 
 func getTestCSIDriver(name string, podInfoMount *bool, attachable *bool, volumeLifecycleModes []storagev1.VolumeLifecycleMode) *storagev1.CSIDriver {
 	defaultFSGroupPolicy := storagev1.ReadWriteOnceWithFSTypeFSGroupPolicy
-	return &storagev1.CSIDriver{
+	seLinuxMountSupport := true
+	noSElinuxMountSupport := false
+	driver := &storagev1.CSIDriver{
 		ObjectMeta: meta.ObjectMeta{
 			Name: name,
 		},
@@ -98,6 +100,13 @@ func getTestCSIDriver(name string, podInfoMount *bool, attachable *bool, volumeL
 			FSGroupPolicy:        &defaultFSGroupPolicy,
 		},
 	}
+	switch driver.Name {
+	case "supports_selinux":
+		driver.Spec.SELinuxMount = &seLinuxMountSupport
+	case "no_selinux":
+		driver.Spec.SELinuxMount = &noSElinuxMountSupport
+	}
+	return driver
 }
 
 func TestSaveVolumeData(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #112520 on release-1.25.

#112520: Do not return err if CSIdriver is not found

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```