### PR TITLE
apf: don't omit flowschemas from reset fields test

### DIFF
--- a/test/integration/apiserver/apply/reset_fields_test.go
+++ b/test/integration/apiserver/apply/reset_fields_test.go
@@ -72,11 +72,7 @@ var resetFieldsStatusData = map[schema.GroupVersionResource]string{
 // resetFieldsStatusDefault conflicts with statusDefault
 const resetFieldsStatusDefault = `{"status": {"conditions": [{"type": "MyStatus", "status":"False"}]}}`
 
-var resetFieldsSkippedResources = map[string]struct{}{
-	// TODO: flowschemas is flaking,
-	// possible bug in the flowschemas controller.
-	"flowschemas": {},
-}
+var resetFieldsSkippedResources = map[string]struct{}{}
 
 // noConflicts is the set of reources for which
 // a conflict cannot occur.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
do not omit `flowschemas` from reset fields tests - `v1beta3` has the right annotations for strategic merge patch of the `Conditions`. Once https://github.com/kubernetes/kubernetes/pull/112306 merges we should enable `flowschemas` for reset fields test.

#### Which issue(s) this PR fixes:
Fixes #104842

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
