### PR TITLE
remove podOverhead feature gate as a feature is now GA since 1.24

### DIFF
--- a/pkg/api/v1/resource/helpers.go
+++ b/pkg/api/v1/resource/helpers.go
@@ -27,7 +27,7 @@ import (
 )
 
 // PodRequestsAndLimits returns a dictionary of all defined resources summed up for all
-// containers of the pod. If PodOverhead feature is enabled, pod overhead is added to the
+// containers of the pod. Pod overhead is added to the
 // total container resource requests and to the total container limits which have a
 // non-zero quantity.
 func PodRequestsAndLimits(pod *v1.Pod) (reqs, limits v1.ResourceList) {
@@ -57,7 +57,7 @@ func podRequestsAndLimitsWithoutOverhead(pod *v1.Pod, reqs, limits v1.ResourceLi
 }
 
 // PodRequestsAndLimitsReuse returns a dictionary of all defined resources summed up for all
-// containers of the pod. If PodOverhead feature is enabled, pod overhead is added to the
+// containers of the pod. Pod overhead is added to the
 // total container resource requests and to the total container limits which have a
 // non-zero quantity. The caller may avoid allocations of resource lists by passing
 // a requests and limits list to the function, which will be cleared before use.
@@ -67,7 +67,7 @@ func PodRequestsAndLimitsReuse(pod *v1.Pod, reuseReqs, reuseLimits v1.ResourceLi
 
 	podRequestsAndLimitsWithoutOverhead(pod, reqs, limits)
 
-	// if PodOverhead feature is supported, add overhead for running a pod
+	// Add overhead for running a pod
 	// to the sum of requests and to non-zero limits:
 	if pod.Spec.Overhead != nil {
 		addResourceList(reqs, pod.Spec.Overhead)
@@ -143,7 +143,7 @@ func GetResourceRequestQuantity(pod *v1.Pod, resourceName v1.ResourceName) resou
 		}
 	}
 
-	// if PodOverhead feature is supported, add overhead for running a pod
+	// Add overhead for running a pod
 	// to the total requests if the resource total is non-zero
 	if pod.Spec.Overhead != nil {
 		if podOverhead, ok := pod.Spec.Overhead[resourceName]; ok && !requestQuantity.IsZero() {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -630,14 +630,6 @@ const (
 	// sandbox creation and network configuration completes successfully
 	PodHasNetworkCondition featuregate.Feature = "PodHasNetworkCondition"
 
-	// owner: @egernst
-	// alpha: v1.16
-	// beta: v1.18
-	// ga: v1.24
-	//
-	// Enables PodOverhead, for accounting pod overheads which are specific to a given RuntimeClass
-	PodOverhead featuregate.Feature = "PodOverhead"
-
 	// owner: @liggitt, @tallclair, sig-auth
 	// alpha: v1.22
 	// beta: v1.23
@@ -1008,8 +1000,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	PodDisruptionConditions: {Default: false, PreRelease: featuregate.Alpha},
 
 	PodHasNetworkCondition: {Default: false, PreRelease: featuregate.Alpha},
-
-	PodOverhead: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
 
 	PodSecurity: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
@@ -107,8 +107,8 @@ func (r *resourceAllocationScorer) calculateResourceAllocatableRequest(nodeInfo 
 	return 0, 0
 }
 
-// calculatePodResourceRequest returns the total non-zero requests. If Overhead is defined for the pod and the
-// PodOverhead feature is enabled, the Overhead is added to the result.
+// calculatePodResourceRequest returns the total non-zero requests. If Overhead is defined for the pod
+// the Overhead is added to the result.
 // podResourceRequest = max(sum(podSpec.Containers), podSpec.InitContainers) + overHead
 func (r *resourceAllocationScorer) calculatePodResourceRequest(pod *v1.Pod, resource v1.ResourceName) int64 {
 	var podRequest int64

--- a/pkg/scheduler/metrics/resources/resources.go
+++ b/pkg/scheduler/metrics/resources/resources.go
@@ -177,7 +177,7 @@ func recordMetricWithUnit(
 }
 
 // podRequestsAndLimitsByLifecycle returns a dictionary of all defined resources summed up for all
-// containers of the pod. If PodOverhead feature is enabled, pod overhead is added to the
+// containers of the pod. Pod overhead is added to the
 // total container resource requests and to the total container limits which have a
 // non-zero quantity. The caller may avoid allocations of resource lists by passing
 // a requests and limits list to the function, which will be cleared before use.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node

#### What this PR does / why we need it:

Just a cleanup of old feature gate

KEP: https://github.com/kubernetes/enhancements/issues/688

```release-note
PodOverhead feature gate was removed as the feature is in GA since 1.24
```
