### PR TITLE
Add --disable-compression flag to kubectl

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -37,24 +37,25 @@ import (
 )
 
 const (
-	flagClusterName      = "cluster"
-	flagAuthInfoName     = "user"
-	flagContext          = "context"
-	flagNamespace        = "namespace"
-	flagAPIServer        = "server"
-	flagTLSServerName    = "tls-server-name"
-	flagInsecure         = "insecure-skip-tls-verify"
-	flagCertFile         = "client-certificate"
-	flagKeyFile          = "client-key"
-	flagCAFile           = "certificate-authority"
-	flagBearerToken      = "token"
-	flagImpersonate      = "as"
-	flagImpersonateUID   = "as-uid"
-	flagImpersonateGroup = "as-group"
-	flagUsername         = "username"
-	flagPassword         = "password"
-	flagTimeout          = "request-timeout"
-	flagCacheDir         = "cache-dir"
+	flagClusterName        = "cluster"
+	flagAuthInfoName       = "user"
+	flagContext            = "context"
+	flagNamespace          = "namespace"
+	flagAPIServer          = "server"
+	flagTLSServerName      = "tls-server-name"
+	flagInsecure           = "insecure-skip-tls-verify"
+	flagCertFile           = "client-certificate"
+	flagKeyFile            = "client-key"
+	flagCAFile             = "certificate-authority"
+	flagBearerToken        = "token"
+	flagImpersonate        = "as"
+	flagImpersonateUID     = "as-uid"
+	flagImpersonateGroup   = "as-group"
+	flagUsername           = "username"
+	flagPassword           = "password"
+	flagTimeout            = "request-timeout"
+	flagCacheDir           = "cache-dir"
+	flagDisableCompression = "disable-compression"
 )
 
 // RESTClientGetter is an interface that the ConfigFlags describe to provide an easier way to mock for commands
@@ -80,23 +81,24 @@ type ConfigFlags struct {
 	KubeConfig *string
 
 	// config flags
-	ClusterName      *string
-	AuthInfoName     *string
-	Context          *string
-	Namespace        *string
-	APIServer        *string
-	TLSServerName    *string
-	Insecure         *bool
-	CertFile         *string
-	KeyFile          *string
-	CAFile           *string
-	BearerToken      *string
-	Impersonate      *string
-	ImpersonateUID   *string
-	ImpersonateGroup *[]string
-	Username         *string
-	Password         *string
-	Timeout          *string
+	ClusterName        *string
+	AuthInfoName       *string
+	Context            *string
+	Namespace          *string
+	APIServer          *string
+	TLSServerName      *string
+	Insecure           *bool
+	CertFile           *string
+	KeyFile            *string
+	CAFile             *string
+	BearerToken        *string
+	Impersonate        *string
+	ImpersonateUID     *string
+	ImpersonateGroup   *[]string
+	Username           *string
+	Password           *string
+	Timeout            *string
+	DisableCompression *bool
 	// If non-nil, wrap config function can transform the Config
 	// before it is returned in ToRESTConfig function.
 	WrapConfigFn func(*rest.Config) *rest.Config
@@ -198,6 +200,9 @@ func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	}
 	if f.Insecure != nil {
 		overrides.ClusterInfo.InsecureSkipTLSVerify = *f.Insecure
+	}
+	if f.DisableCompression != nil {
+		overrides.ClusterInfo.DisableCompression = *f.DisableCompression
 	}
 
 	// bind context flags
@@ -393,6 +398,9 @@ func (f *ConfigFlags) AddFlags(flags *pflag.FlagSet) {
 	if f.Timeout != nil {
 		flags.StringVar(f.Timeout, flagTimeout, *f.Timeout, "The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests.")
 	}
+	if f.DisableCompression != nil {
+		flags.BoolVar(f.DisableCompression, flagDisableCompression, *f.DisableCompression, "If true, opt-out of response compression for all requests to the server")
+	}
 }
 
 // WithDeprecatedPasswordFlag enables the username and password config flags
@@ -424,26 +432,28 @@ func (f *ConfigFlags) WithWrapConfigFn(wrapConfigFn func(*rest.Config) *rest.Con
 func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 	impersonateGroup := []string{}
 	insecure := false
+	disableCompression := false
 
 	return &ConfigFlags{
 		Insecure:   &insecure,
 		Timeout:    utilpointer.String("0"),
 		KubeConfig: utilpointer.String(""),
 
-		CacheDir:         utilpointer.String(getDefaultCacheDir()),
-		ClusterName:      utilpointer.String(""),
-		AuthInfoName:     utilpointer.String(""),
-		Context:          utilpointer.String(""),
-		Namespace:        utilpointer.String(""),
-		APIServer:        utilpointer.String(""),
-		TLSServerName:    utilpointer.String(""),
-		CertFile:         utilpointer.String(""),
-		KeyFile:          utilpointer.String(""),
-		CAFile:           utilpointer.String(""),
-		BearerToken:      utilpointer.String(""),
-		Impersonate:      utilpointer.String(""),
-		ImpersonateUID:   utilpointer.String(""),
-		ImpersonateGroup: &impersonateGroup,
+		CacheDir:           utilpointer.String(getDefaultCacheDir()),
+		ClusterName:        utilpointer.String(""),
+		AuthInfoName:       utilpointer.String(""),
+		Context:            utilpointer.String(""),
+		Namespace:          utilpointer.String(""),
+		APIServer:          utilpointer.String(""),
+		TLSServerName:      utilpointer.String(""),
+		CertFile:           utilpointer.String(""),
+		KeyFile:            utilpointer.String(""),
+		CAFile:             utilpointer.String(""),
+		BearerToken:        utilpointer.String(""),
+		Impersonate:        utilpointer.String(""),
+		ImpersonateUID:     utilpointer.String(""),
+		ImpersonateGroup:   &impersonateGroup,
+		DisableCompression: &disableCompression,
 
 		usePersistentConfig: usePersistentConfig,
 		// The more groups you have, the more discovery requests you need to make.


### PR DESCRIPTION
#### What this PR does / why we need it:
Follow-up of https://github.com/kubernetes/kubernetes/pull/112309, and part-3 of the proposal in https://github.com/kubernetes/kubernetes/issues/112296.


#### Does this PR introduce a user-facing change?
```release-note
A new --disable-compression flag has been added to kubectl (default = false). When true, it opts out of response compression for all requests to the apiserver. This can help improve list call latencies significantly when client-server network bandwidth is ample (>30MB/s) or if the server is CPU-constrained.
```

/sig cli
/kind feature
/assign @liggitt @seans3 