### PR TITLE
Fixing typo in kubectl describe.go

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -855,8 +855,8 @@ func describePod(pod *corev1.Pod, events *corev1.EventList) (string, error) {
 	})
 }
 
-func printController(controllee metav1.Object) string {
-	if controllerRef := metav1.GetControllerOf(controllee); controllerRef != nil {
+func printController(controller metav1.Object) string {
+	if controllerRef := metav1.GetControllerOf(controller); controllerRef != nil {
 		return fmt.Sprintf("%s/%s", controllerRef.Kind, controllerRef.Name)
 	}
 	return ""


### PR DESCRIPTION
/kind cleanup

```release-note
   Fix typo from `controllee` to `controller` in kubectl `describe.go`
```

