### PR TITLE
Write e2e test for Read, Replace ReplicationController scale endpoints +2 Endpoints

### DIFF
--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -390,6 +391,36 @@ var _ = SIGDescribe("ReplicationController", func() {
 			return err
 		})
 	})
+
+	ginkgo.It("should get and update a ReplicationController scale", func() {
+		rcClient := f.ClientSet.CoreV1().ReplicationControllers(ns)
+		rcName := "e2e-rc-" + utilrand.String(5)
+		initialRCReplicaCount := int32(1)
+		expectedRCReplicaCount := int32(2)
+
+		ginkgo.By(fmt.Sprintf("Creating ReplicationController %q", rcName))
+		rc := newRC(rcName, initialRCReplicaCount, map[string]string{"name": rcName}, WebserverImageName, WebserverImage, nil)
+		_, err := rcClient.Create(context.TODO(), rc, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "Failed to create ReplicationController: %v", err)
+
+		err = wait.PollImmediate(1*time.Second, 1*time.Minute, checkReplicationControllerStatusReplicaCount(f, rcName, initialRCReplicaCount))
+		framework.ExpectNoError(err, "failed to confirm the quantity of ReplicationController replicas")
+
+		ginkgo.By(fmt.Sprintf("Getting scale subresource for ReplicationController %q", rcName))
+		scale, err := rcClient.GetScale(context.TODO(), rcName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "Failed to get scale subresource: %v", err)
+		framework.ExpectEqual(scale.Status.Replicas, initialRCReplicaCount, "Failed to get the current replica count")
+
+		ginkgo.By("Updating a scale subresource")
+		scale.ResourceVersion = "" // indicate the scale update should be unconditional
+		scale.Spec.Replicas = expectedRCReplicaCount
+		_, err = rcClient.UpdateScale(context.TODO(), rcName, scale, metav1.UpdateOptions{})
+		framework.ExpectNoError(err, "Failed to update scale subresource: %v", err)
+
+		ginkgo.By(fmt.Sprintf("Verifying replicas where modified for replication controller %q", rcName))
+		err = wait.PollImmediate(1*time.Second, 1*time.Minute, checkReplicationControllerStatusReplicaCount(f, rcName, expectedRCReplicaCount))
+		framework.ExpectNoError(err, "failed to confirm the quantity of ReplicationController replicas")
+	})
 })
 
 func newRC(rsName string, replicas int32, rcPodLabels map[string]string, imageName string, image string, args []string) *v1.ReplicationController {
@@ -729,4 +760,21 @@ func watchUntilWithoutRetry(ctx context.Context, watcher watch.Interface, condit
 		}
 	}
 	return lastEvent, nil
+}
+
+func checkReplicationControllerStatusReplicaCount(f *framework.Framework, rcName string, quantity int32) func() (bool, error) {
+	return func() (bool, error) {
+
+		framework.Logf("Get Replication Controller %q to confirm replicas", rcName)
+		rc, err := f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Get(context.TODO(), rcName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if rc.Status.Replicas != quantity {
+			return false, nil
+		}
+		framework.Logf("Found %d replicas for %q replication controller", quantity, rc.Name)
+		return true, nil
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- readCoreV1NamespacedReplicationControllerScale
- replaceCoreV1NamespacedReplicationControllerScale

**Which issue(s) this PR fixes:**
Fixes #112585

**Testgrid Link:** 
[testgrid-link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.get.and.update.a.ReplicationController.scale)

**Special notes for your reviewer:**
Adds +2 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance