### PR TITLE
grpc: set localhost Authority to unix client calls

### DIFF
--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/client.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/client.go
@@ -119,6 +119,7 @@ func dial(unixSocketPath string) (api.DevicePluginClient, *grpc.ClientConn, erro
 	defer cancel()
 
 	c, err := grpc.DialContext(ctx, unixSocketPath,
+		grpc.WithAuthority("localhost"),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithBlock(),
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {

--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -535,6 +535,7 @@ func newGrpcConn(addr csiAddr, metricsManager *MetricsManager) (*grpc.ClientConn
 
 	return grpc.Dial(
 		string(addr),
+		grpc.WithAuthority("localhost"),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(func(ctx context.Context, target string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, network, target)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Several reports exist (both with device plugins and CSI) that kubelet w/ grpc-go sends invalid Authority header and some non grpc-go servers reject these unix domain socket client connections.

grpc-go sets the Authority header correct when the dial address is in a format where the its address scheme can be determined.

Instead of making changes to get the all server addresses to unix:// prefixed format, set `grpc.WithAuthority("localhost")` client connection override to get the same result.

#### Which issue(s) this PR fixes:

Fixes #107093
Fixes #109081
Fixes #108254
Closes #109559

#### Special notes for your reviewer:
The alternative approach could be to ensure all addresses are sanitized and set to use `unix://` scheme:  `TrimPrefix()` + `Snprintf()` .

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: