### PR TITLE
[pending UserNamespace beta]promote LocalStorageCapacityIsolationFSQuotaMonitoring to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -527,8 +527,9 @@ const (
 	// Enables cleaning up of secret-based service account tokens.
 	LegacyServiceAccountTokenCleanUp featuregate.Feature = "LegacyServiceAccountTokenCleanUp"
 
-	// owner: @RobertKrawitz
+	// owner: @RobertKrawitz @pacoxu
 	// alpha: v1.15
+	// beta: v1.29
 	//
 	// Allow use of filesystems for ephemeral storage monitoring.
 	// Only applies if LocalStorageCapacityIsolation is set.
@@ -1094,7 +1095,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	LegacyServiceAccountTokenCleanUp: {Default: false, PreRelease: featuregate.Alpha},
 
-	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Alpha},
+	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: true, PreRelease: featuregate.Beta},
 
 	LogarithmicScaleDown: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
This reverts commit 32a90f5f359a6afe84e6d1e9ae64604f7b9c4dbe.
This feature gate was promoted to beta only in v1.25.0 and was reverted in v1.25.1 for a regression issue.

See the history in https://github.com/kubernetes/kubernetes/pull/107329 and https://github.com/kubernetes/kubernetes/pull/112076

The KEP can be found in  https://github.com/kubernetes/enhancements/pull/2697

**Action Items:**
- [x] add some metrics or make more visibility https://github.com/kubernetes/kubernetes/pull/107201
- [x]  benchmark the feature ⬆️  the comments above. 
- [x] add some warning log for long time cost volume calculation https://github.com/kubernetes/kubernetes/pull/107490
- [x] check e2e testings: e2e evolution (LocalStorageCapacityIsolationQuotaMonitoring [Slow] [Serial] [Disruptive] [Feature:LocalStorageCapacityIsolationQuota][NodeFeature:LSCIQuotaMonitoring]) 
- [ ] need some feedbacks 
- [x] https://github.com/kubernetes/kubernetes/issues/83107 （[I tested it](https://github.com/kubernetes/kubernetes/issues/83107#issuecomment-1096731583). It will work immediately if we enable this  feature gate ）
- [x] fix a bug: during kubelet restart. https://github.com/kubernetes/kubernetes/pull/107302 (This may be the cause of below issue.
- [x] **rending configmap regression**: https://github.com/kubernetes/kubernetes/issues/112081
- [x] new issue that is reported:  https://github.com/kubernetes/kubernetes/issues/114506
- [x] https://github.com/kubernetes/kubernetes/issues/115309 (may be dup with #112081)
- [ ] https://github.com/kubernetes/kubernetes/pull/112626#issuecomment-1864986501 kernel @haircommander pointed out that `it's in a user namespace it can't change the projid` and if not, project ID could be changed. So we want to wait for User Namespace beta before promoting this to beta.

/kind feature
Xrefs https://github.com/kubernetes/enhancements/issues/1029

```release-note
promote LocalStorageCapacityIsolationFSQuotaMonitoring to beta
```