### PR TITLE
Add --advertise-port option to kube-apiserver to configure kubernetes.default.svc port

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -54,6 +54,7 @@ func TestAddFlags(t *testing.T) {
 		"--enable-admission-plugins=AlwaysDeny",
 		"--admission-control-config-file=/admission-control-config",
 		"--advertise-address=192.168.10.10",
+		"--advertise-port=6443",
 		"--allow-privileged=false",
 		"--anonymous-auth=false",
 		"--apiserver-count=5",
@@ -132,6 +133,7 @@ func TestAddFlags(t *testing.T) {
 		AllowPrivileged:        false,
 		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
 			AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
+			AdvertisePort:               6443,
 			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 			MaxRequestsInFlight:         400,
 			MaxMutatingRequestsInFlight: 200,

--- a/pkg/controlplane/controller.go
+++ b/pkg/controlplane/controller.go
@@ -101,6 +101,10 @@ func (c *completedConfig) NewBootstrapController(legacyRESTStorage corerest.Lega
 		}
 	}
 
+	if c.GenericConfig.AdvertisePort > 0 {
+		publicServicePort = int(c.GenericConfig.AdvertisePort)
+	}
+
 	systemNamespaces := []string{metav1.NamespaceSystem, metav1.NamespacePublic, corev1.NamespaceNodeLease}
 
 	return &Controller{

--- a/pkg/controlplane/controller.go
+++ b/pkg/controlplane/controller.go
@@ -101,8 +101,8 @@ func (c *completedConfig) NewBootstrapController(legacyRESTStorage corerest.Lega
 		}
 	}
 
-	if c.GenericConfig.AdvertisePort > 0 {
-		publicServicePort = int(c.GenericConfig.AdvertisePort)
+	if c.GenericConfig.PublicPort > 0 {
+		publicServicePort = int(c.GenericConfig.PublicPort)
 	}
 
 	systemNamespaces := []string{metav1.NamespaceSystem, metav1.NamespacePublic, corev1.NamespaceNodeLease}

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -251,11 +251,6 @@ type Config struct {
 	// rejected with a 429 status code and a 'Retry-After' response.
 	ShutdownSendRetryAfter bool
 
-	// AdvertisePort is used when the targetPort and port used in the kubernetes.default.svc service and
-	// endpoint is different than the one used for binding. This configuration is needed in case of a front proxy is
-	// used in front of kube-apiserver
-	AdvertisePort int
-
 	//===========================================================================
 	// values below here are targets for removal
 	//===========================================================================
@@ -264,6 +259,11 @@ type Config struct {
 	// kube-proxy, services, etc.) can reach the GenericAPIServer.
 	// If nil or 0.0.0.0, the host's default interface will be used.
 	PublicAddress net.IP
+
+	// PublicPort is used when the targetPort and port used in the kubernetes.default.svc service and
+	// endpoint is different than the one used for binding. This configuration is needed in case of a front proxy is
+	// used in front of kube-apiserver.
+	PublicPort int
 
 	// EquivalentResourceRegistry provides information about resources equivalent to a given resource,
 	// and the kind associated with a given resource. As resources are installed, they are registered here.

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -251,6 +251,11 @@ type Config struct {
 	// rejected with a 429 status code and a 'Retry-After' response.
 	ShutdownSendRetryAfter bool
 
+	// AdvertisePort is used when the targetPort and port used in the kubernetes.default.svc service and
+	// endpoint is different than the one used for binding. This configuration is needed in case of a front proxy is
+	// used in front of kube-apiserver
+	AdvertisePort int
+
 	//===========================================================================
 	// values below here are targets for removal
 	//===========================================================================

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -97,7 +97,7 @@ func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
 	c.MaxRequestBodyBytes = s.MaxRequestBodyBytes
 	c.PublicAddress = s.AdvertiseAddress
 	c.ShutdownSendRetryAfter = s.ShutdownSendRetryAfter
-	c.AdvertisePort = s.AdvertisePort
+	c.PublicPort = s.AdvertisePort
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -124,7 +124,7 @@ func (s *ServerRunOptions) Validate() []error {
 	errors := []error{}
 
 	if s.AdvertisePort < 0 || s.AdvertisePort > 65535 {
-		errors = append(errors, fmt.Errorf("--advertise-port %v must be between 0 and 65535, inclusive. 0 for turning off", s.AdvertisePort))
+		errors = append(errors, fmt.Errorf("--advertise-port %v must be between 0 and 65535, inclusive", s.AdvertisePort))
 	}
 	if s.LivezGracePeriod < 0 {
 		errors = append(errors, fmt.Errorf("--livez-grace-period can not be a negative value"))

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
@@ -169,7 +169,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			expectErr: "--strict-transport-security-directives invalid, allowed values: max-age=expireTime, includeSubDomains, preload. see https://tools.ietf.org/html/rfc6797#section-6.1 for more information",
 		},
 		{
-			name: "Test when AdvertisePort is too high value",
+			name: "Test when PublicPort is too high value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				AdvertisePort:               843235,

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
@@ -180,9 +180,9 @@ func TestServerRunOptionsValidate(t *testing.T) {
 				MinRequestTimeout:           1800,
 				JSONPatchMaxCopyBytes:       10 * 1024 * 1024,
 				MaxRequestBodyBytes:         10 * 1024 * 1024,
-				ShutdownDelayDuration:       -time.Second,
+				ShutdownDelayDuration:       time.Second,
 			},
-			expectErr: "--advertise-port 843235 must be between 0 and 65535, inclusive. 0 for turning off",
+			expectErr: "--advertise-port 843235 must be between 0 and 65535, inclusive",
 		},
 		{
 			name: "Test when ServerRunOptions is valid",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
@@ -35,6 +35,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when MaxRequestsInFlight is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         -400,
 				MaxMutatingRequestsInFlight: 200,
@@ -49,6 +50,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when MaxMutatingRequestsInFlight is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: -200,
@@ -63,6 +65,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when RequestTimeout is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -77,6 +80,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when MinRequestTimeout is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -91,6 +95,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when JSONPatchMaxCopyBytes is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -105,6 +110,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when MaxRequestBodyBytes is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -119,6 +125,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when LivezGracePeriod is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -134,6 +141,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when MinimalShutdownDuration is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -161,9 +169,26 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			expectErr: "--strict-transport-security-directives invalid, allowed values: max-age=expireTime, includeSubDomains, preload. see https://tools.ietf.org/html/rfc6797#section-6.1 for more information",
 		},
 		{
+			name: "Test when AdvertisePort is too high value",
+			testOptions: &ServerRunOptions{
+				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
+				AdvertisePort:               843235,
+				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
+				MaxRequestsInFlight:         400,
+				MaxMutatingRequestsInFlight: 200,
+				RequestTimeout:              time.Duration(2) * time.Minute,
+				MinRequestTimeout:           1800,
+				JSONPatchMaxCopyBytes:       10 * 1024 * 1024,
+				MaxRequestBodyBytes:         10 * 1024 * 1024,
+				ShutdownDelayDuration:       -time.Second,
+			},
+			expectErr: "--advertise-port 843235 must be between 0 and 65535, inclusive. 0 for turning off",
+		},
+		{
 			name: "Test when ServerRunOptions is valid",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				HSTSDirectives:              []string{"max-age=31536000", "includeSubDomains", "preload"},
 				MaxRequestsInFlight:         400,

--- a/test/integration/controlplane/kube_apiserver_test.go
+++ b/test/integration/controlplane/kube_apiserver_test.go
@@ -627,129 +627,94 @@ func TestMultiAPIServerNodePortAllocation(t *testing.T) {
 
 }
 
-// TestMultiMasterDefaultPort tests that the bind port of the kube-apiserver is then used as targetPort in the kubernetes.default.svc server
-// and also as port in the kubernetes.default.svc endpoints
-func TestMultiMasterDefaultPort(t *testing.T) {
-	var kubeAPIServers []*kubeapiservertesting.TestServer
-	var clientAPIServers []*kubernetes.Clientset
+// TestAPIServerDefaultPort tests that the bind port of the kube-apiserver is then used as targetPort in
+// the kubernetes.default.svc service and also as the port in the kubernetes.default.svc endpoints
+func TestAPIServerDefaultPort(t *testing.T) {
 	etcd := framework.SharedEtcd()
 
-	instanceOptions := &kubeapiservertesting.TestServerInstanceOptions{
-		DisableStorageCleanup: true,
-	}
+	instanceOptions := kubeapiservertesting.NewDefaultTestServerOptions()
 
-	// cleanup the registry storage
-	defer registry.CleanupStorage()
+	// start apiserver
+	t.Log("starting api server")
+	server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{
+		"--endpoint-reconciler-type", "lease",
+		"--advertise-address", fmt.Sprintf("10.0.1.1"),
+	}, etcd)
+	defer server.TearDownFn()
 
-	// create 1 api servers and 1 clients: cannot test with multiple ones because then there would be a conflict as each one has a different bind port configured
-	for i := 0; i < 1; i++ {
-		// start master count api server
-		t.Logf("starting api server: %d", i)
-		server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{
-			"--endpoint-reconciler-type", "lease",
-			"--advertise-address", fmt.Sprintf("10.0.1.%v", i+1),
-		}, etcd)
-		kubeAPIServers = append(kubeAPIServers, server)
-
-		// verify kube API servers have registered and create a client
-		if err := wait.PollImmediate(3*time.Second, 2*time.Minute, func() (bool, error) {
-			client, err := kubernetes.NewForConfig(kubeAPIServers[i].ClientConfig)
-			if err != nil {
-				t.Logf("create client error: %v", err)
-				return false, nil
-			}
-			clientAPIServers = append(clientAPIServers, client)
-			services, err := client.CoreV1().Services("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
-			if err != nil {
-				t.Logf("error fetching services: %v", err)
-				return false, nil
-			}
-			if !reflect.DeepEqual([]int{server.ServerOpts.SecureServing.BindPort}, getServiceTargetPorts(services)) {
-				t.Logf("error comparing target port in services with bind port set: Bind port %v vs targetPort %v", server.ServerOpts.SecureServing.BindPort, getServiceTargetPorts(services))
-				return false, nil
-			}
-			endpoints, err := client.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
-			if err != nil {
-				t.Logf("error fetching endpoints: %v", err)
-				return false, nil
-			}
-			if !reflect.DeepEqual([]int{server.ServerOpts.SecureServing.BindPort}, getEndpointPorts(endpoints)) {
-				t.Logf("error comparing endpoints port with advertise-port: %v", getEndpointPorts(endpoints))
-				return false, nil
-			}
-			return true, nil
-		}); err != nil {
-			t.Fatalf("did not find only lease endpoints: %v", err)
+	// verify kube API server has registered and create a client
+	if err := wait.PollImmediate(3*time.Second, 2*time.Minute, func() (bool, error) {
+		client, err := kubernetes.NewForConfig(server.ClientConfig)
+		if err != nil {
+			t.Logf("create client error: %v", err)
+			return false, nil
 		}
+		services, err := client.CoreV1().Services("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+		if err != nil {
+			t.Logf("error fetching services: %v", err)
+			return false, nil
+		}
+		if e, a := []int{server.ServerOpts.SecureServing.BindPort}, getServiceTargetPorts(services); !reflect.DeepEqual(e, a) {
+			t.Logf("error comparing target port in services with bind port set: Bind port %v vs targetPort %v", server.ServerOpts.SecureServing.BindPort, a)
+			return false, nil
+		}
+		endpoints, err := client.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+		if err != nil {
+			t.Logf("error fetching endpoints: %v", err)
+			return false, nil
+		}
+		if e, a := []int{server.ServerOpts.SecureServing.BindPort}, getEndpointPorts(endpoints); !reflect.DeepEqual(e, a) {
+			t.Logf("error comparing target port in endpoints with bind port set: Bind port %v vs targetPort %v", server.ServerOpts.SecureServing.BindPort, a)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("did not find only lease endpoints: %v", err)
 	}
-
-	// shutdown the api servers
-	for _, server := range kubeAPIServers {
-		server.TearDownFn()
-	}
-
 }
 
 // TestMultiMasterAdvertisePort tests that when using the --advertise-port the targetPort in the kubernetes.default.svc server
 // and also as port in the kubernetes.default.svc endpoints and it's the value specified there
-func TestMultiMasterAdvertisePort(t *testing.T) {
-	var kubeAPIServers []*kubeapiservertesting.TestServer
-	var clientAPIServers []*kubernetes.Clientset
+func TestAPIServerAdvertisePort(t *testing.T) {
 	etcd := framework.SharedEtcd()
+	instanceOptions := kubeapiservertesting.NewDefaultTestServerOptions()
 
-	instanceOptions := &kubeapiservertesting.TestServerInstanceOptions{
-		DisableStorageCleanup: true,
-	}
+	// start apiserver
+	t.Log("starting api server")
+	server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{
+		"--endpoint-reconciler-type", "lease",
+		"--advertise-address", fmt.Sprintf("10.0.1.1"),
+		"--advertise-port", "8443",
+	}, etcd)
+	defer server.TearDownFn()
 
-	// cleanup the registry storage
-	defer registry.CleanupStorage()
-
-	// create 2 api servers and 2 clients
-	for i := 0; i < 2; i++ {
-		// start master count api server
-		t.Logf("starting api server: %d", i)
-		server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{
-			"--endpoint-reconciler-type", "lease",
-			"--advertise-address", fmt.Sprintf("10.0.1.%v", i+1),
-			"--advertise-port", "8443",
-		}, etcd)
-		kubeAPIServers = append(kubeAPIServers, server)
-
-		// verify kube API servers have registered and create a client
-		if err := wait.PollImmediate(3*time.Second, 2*time.Minute, func() (bool, error) {
-			client, err := kubernetes.NewForConfig(kubeAPIServers[i].ClientConfig)
-			if err != nil {
-				t.Logf("create client error: %v", err)
-				return false, nil
-			}
-			clientAPIServers = append(clientAPIServers, client)
-			services, err := client.CoreV1().Services("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
-			if err != nil {
-				t.Logf("error fetching services: %v", err)
-				return false, nil
-			}
-			if !reflect.DeepEqual([]int{server.ServerOpts.GenericServerRunOptions.AdvertisePort}, getServiceTargetPorts(services)) {
-				t.Logf("error comparing target port in services with advertise-port set: %v", getServiceTargetPorts(services))
-				return false, nil
-			}
-			endpoints, err := client.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
-			if err != nil {
-				t.Logf("error fetching endpoints: %v", err)
-				return false, nil
-			}
-			if !reflect.DeepEqual([]int{server.ServerOpts.GenericServerRunOptions.AdvertisePort}, getEndpointPorts(endpoints)) {
-				t.Logf("error comparing endpoints port with advertise-port: %v", getEndpointPorts(endpoints))
-				return false, nil
-			}
-			return true, nil
-		}); err != nil {
-			t.Fatalf("did not find only lease endpoints: %v", err)
+	// verify kube API server has registered and create a client
+	if err := wait.PollImmediate(3*time.Second, 2*time.Minute, func() (bool, error) {
+		client, err := kubernetes.NewForConfig(server.ClientConfig)
+		if err != nil {
+			t.Logf("create client error: %v", err)
+			return false, nil
 		}
+		services, err := client.CoreV1().Services("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+		if err != nil {
+			t.Logf("error fetching services: %v", err)
+			return false, nil
+		}
+		if e, a := []int{server.ServerOpts.SecureServing.BindPort}, getServiceTargetPorts(services); !reflect.DeepEqual(e, a) {
+			t.Logf("error comparing target port in services with bind port set: Bind port %v vs targetPort %v", server.ServerOpts.SecureServing.BindPort, a)
+			return false, nil
+		}
+		endpoints, err := client.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+		if err != nil {
+			t.Logf("error fetching endpoints: %v", err)
+			return false, nil
+		}
+		if e, a := []int{server.ServerOpts.SecureServing.BindPort}, getEndpointPorts(endpoints); !reflect.DeepEqual(e, a) {
+			t.Logf("error comparing target port in endpoints with bind port set: Bind port %v vs targetPort %v", server.ServerOpts.SecureServing.BindPort, a)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("did not find only lease endpoints: %v", err)
 	}
-
-	// shutdown the api servers
-	for _, server := range kubeAPIServers {
-		server.TearDownFn()
-	}
-
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When running a proxy (authenticating or not) on the same node of the kube-apiserver it's necessary to specifify the port that will be used in the kubernetes.default.svc service and endpoints because it might be different than the one used for binding.

For example: kube-apiserver might be binded to 127.0.0.1:9443 and the proxy to 0.0.0.0:6443.

#### Which issue(s) this PR fixes:

Replaces #100538

#### Special notes for your reviewer:

There was a review performed on this last year that went stale - I have rebased the PR and addressed the previous review (in the older PR).

I am now working to add integration tests to cover the cases @aojea mentioned previously, namely what happens if multiple apiservers all set different `--advertise-port` values (+ also what happens if one apiserver does _not_ set the value, but others do).

#### Does this PR introduce a user-facing change?
```release-note
kube-apiserver: add --advertise-port option to control the port number published in the kubernetes.default.svc Service object
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Usage]: TBD - need to open documentation/website PR
```
