### PR TITLE
Optimize turning a Set into a Selector

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -505,7 +505,7 @@ func TestPreFilterState(t *testing.T) {
 					{
 						MaxSkew:            3,
 						TopologyKey:        "node",
-						Selector:           labels.SelectorFromValidatedSet(labels.Set{"foo": "bar"}),
+						Selector:           mustConvertLabelSelectorAsSelector(t, st.MakeLabelSelector().Label("foo", "bar").Obj()),
 						MinDomains:         1,
 						NodeAffinityPolicy: v1.NodeInclusionPolicyHonor,
 						NodeTaintsPolicy:   v1.NodeInclusionPolicyIgnore,
@@ -513,7 +513,7 @@ func TestPreFilterState(t *testing.T) {
 					{
 						MaxSkew:            5,
 						TopologyKey:        "rack",
-						Selector:           labels.SelectorFromValidatedSet(labels.Set{"foo": "bar"}),
+						Selector:           mustConvertLabelSelectorAsSelector(t, st.MakeLabelSelector().Label("foo", "bar").Obj()),
 						MinDomains:         1,
 						NodeAffinityPolicy: v1.NodeInclusionPolicyHonor,
 						NodeTaintsPolicy:   v1.NodeInclusionPolicyIgnore,
@@ -1283,7 +1283,7 @@ func TestPreFilterState(t *testing.T) {
 					{
 						MaxSkew:            1,
 						TopologyKey:        "zone",
-						Selector:           labels.SelectorFromValidatedSet(labels.Set{"foo": "a"}),
+						Selector:           mustConvertLabelSelectorAsSelector(t, st.MakeLabelSelector().Label("foo", "a").Obj()),
 						MinDomains:         1,
 						NodeAffinityPolicy: v1.NodeInclusionPolicyHonor,
 						NodeTaintsPolicy:   v1.NodeInclusionPolicyIgnore,

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -505,7 +505,7 @@ func TestPreFilterState(t *testing.T) {
 					{
 						MaxSkew:            3,
 						TopologyKey:        "node",
-						Selector:           mustConvertLabelSelectorAsSelector(t, st.MakeLabelSelector().Label("foo", "bar").Obj()),
+						Selector:           labels.SelectorFromValidatedSet(labels.Set{"foo": "bar"}),
 						MinDomains:         1,
 						NodeAffinityPolicy: v1.NodeInclusionPolicyHonor,
 						NodeTaintsPolicy:   v1.NodeInclusionPolicyIgnore,
@@ -513,7 +513,7 @@ func TestPreFilterState(t *testing.T) {
 					{
 						MaxSkew:            5,
 						TopologyKey:        "rack",
-						Selector:           mustConvertLabelSelectorAsSelector(t, st.MakeLabelSelector().Label("foo", "bar").Obj()),
+						Selector:           labels.SelectorFromValidatedSet(labels.Set{"foo": "bar"}),
 						MinDomains:         1,
 						NodeAffinityPolicy: v1.NodeInclusionPolicyHonor,
 						NodeTaintsPolicy:   v1.NodeInclusionPolicyIgnore,
@@ -1283,7 +1283,7 @@ func TestPreFilterState(t *testing.T) {
 					{
 						MaxSkew:            1,
 						TopologyKey:        "zone",
-						Selector:           mustConvertLabelSelectorAsSelector(t, st.MakeLabelSelector().Label("foo", "a").Obj()),
+						Selector:           labels.SelectorFromValidatedSet(labels.Set{"foo": "a"}),
 						MinDomains:         1,
 						NodeAffinityPolicy: v1.NodeInclusionPolicyHonor,
 						NodeTaintsPolicy:   v1.NodeInclusionPolicyIgnore,

--- a/staging/src/k8s.io/apimachinery/pkg/labels/labels.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/labels.go
@@ -77,7 +77,7 @@ func (ls Set) AsValidatedSelector() (Selector, error) {
 // perform any validation.
 // According to our measurements this is significantly faster
 // in codepaths that matter at high scale.
-// Note: this method copies the Set; if the Set is immutable, consider wrapping it with SetSelector
+// Note: this method copies the Set; if the Set is immutable, consider wrapping it with ValidatedSetSelector
 // instead, which does not copy.
 func (ls Set) AsSelectorPreValidated() Selector {
 	return SelectorFromValidatedSet(ls)

--- a/staging/src/k8s.io/apimachinery/pkg/labels/labels.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/labels.go
@@ -77,6 +77,8 @@ func (ls Set) AsValidatedSelector() (Selector, error) {
 // perform any validation.
 // According to our measurements this is significantly faster
 // in codepaths that matter at high scale.
+// Note: this method copies the Set; if the Set is immutable, consider wrapping it with SetSelector
+// instead, which does not copy.
 func (ls Set) AsSelectorPreValidated() Selector {
 	return SelectorFromValidatedSet(ls)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -942,7 +942,7 @@ func ValidatedSelectorFromSet(ls Set) (Selector, error) {
 // SelectorFromValidatedSet returns a Selector which will match exactly the given Set.
 // A nil and empty Sets are considered equivalent to Everything().
 // It assumes that Set is already validated and doesn't do any validation.
-// Note: this method copies the Set; if the Set is immutable, consider wrapping it with SetSelector
+// Note: this method copies the Set; if the Set is immutable, consider wrapping it with ValidatedSetSelector
 // instead, which does not copy.
 func SelectorFromValidatedSet(ls Set) Selector {
 	if ls == nil || len(ls) == 0 {
@@ -966,15 +966,19 @@ func ParseToRequirements(selector string, opts ...field.PathOption) ([]Requireme
 	return parse(selector, field.ToPath(opts...))
 }
 
-// SetSelector wraps a Set, allowing it to implement the Selector interface. Unlike
+// ValidatedSetSelector wraps a Set, allowing it to implement the Selector interface. Unlike
 // Set.AsSelectorPreValidated (which copies the input Set), this type simply wraps the underlying
-// Set. As a result, it is substantially more efficient, but requires the caller to not mutate the
-// Set.
-// None of the Selector methods mutate the underlying Set, but Add() and Requirements() convert to the
-// less optimized version.
-type SetSelector Set
+// Set. As a result, it is substantially more efficient. A nil and empty Sets are considered
+// equivalent to Everything().
+//
+// Callers MUST ensure the underlying Set is not mutated, and that it is already validated. If these
+// constraints are not met, Set.AsValidatedSelector should be preferred
+//
+// None of the Selector methods mutate the underlying Set, but Add() and Requirements() convert to
+// the less optimized version.
+type ValidatedSetSelector Set
 
-func (s SetSelector) Matches(labels Labels) bool {
+func (s ValidatedSetSelector) Matches(labels Labels) bool {
 	for k, v := range s {
 		if !labels.Has(k) || v != labels.Get(k) {
 			return false
@@ -983,11 +987,11 @@ func (s SetSelector) Matches(labels Labels) bool {
 	return true
 }
 
-func (s SetSelector) Empty() bool {
+func (s ValidatedSetSelector) Empty() bool {
 	return len(s) == 0
 }
 
-func (s SetSelector) String() string {
+func (s ValidatedSetSelector) String() string {
 	keys := make([]string, 0, len(s))
 	for k := range s {
 		keys = append(keys, k)
@@ -1008,29 +1012,29 @@ func (s SetSelector) String() string {
 	return b.String()
 }
 
-func (s SetSelector) Add(r ...Requirement) Selector {
+func (s ValidatedSetSelector) Add(r ...Requirement) Selector {
 	return s.toFullSelector().Add(r...)
 }
 
-func (s SetSelector) Requirements() (requirements Requirements, selectable bool) {
+func (s ValidatedSetSelector) Requirements() (requirements Requirements, selectable bool) {
 	return s.toFullSelector().Requirements()
 }
 
-func (s SetSelector) DeepCopySelector() Selector {
-	res := make(SetSelector, len(s))
+func (s ValidatedSetSelector) DeepCopySelector() Selector {
+	res := make(ValidatedSetSelector, len(s))
 	for k, v := range s {
 		res[k] = v
 	}
 	return res
 }
 
-func (s SetSelector) RequiresExactMatch(label string) (value string, found bool) {
+func (s ValidatedSetSelector) RequiresExactMatch(label string) (value string, found bool) {
 	v, f := s[label]
 	return v, f
 }
 
-func (s SetSelector) toFullSelector() Selector {
+func (s ValidatedSetSelector) toFullSelector() Selector {
 	return SelectorFromValidatedSet(Set(s))
 }
 
-var _ Selector = SetSelector{}
+var _ Selector = ValidatedSetSelector{}

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -838,7 +838,7 @@ func BenchmarkSetSelector(b *testing.B) {
 	})
 
 	for i := 0; i < b.N; i++ {
-		s := SetSelector(set)
+		s := ValidatedSetSelector(set)
 		if s.Empty() {
 			b.Errorf("Unexpected selector")
 		}
@@ -869,7 +869,7 @@ func TestSetSelectorString(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.out, func(t *testing.T) {
-			if got := SetSelector(tt.set).String(); tt.out != got {
+			if got := ValidatedSetSelector(tt.set).String(); tt.out != got {
 				t.Fatalf("expected %v, got %v", tt.out, got)
 			}
 		})


### PR DESCRIPTION
Update:

The original PR transparently optimized SelectorFromValidatedSet. However, this also changed the semantics - without a copy, the Set could mutate and impact the Selector. To avoid this, we considered just copying the Set, but it ended up being worse than the existing SelectorFromValidatedSet. Ultimately, we settled on making a new type that makes Set implement Selector, requiring users to opt-in to this potentially unsafe behavior.

New benchmarks:
```
BenchmarkSelectorFromValidatedSet
BenchmarkSelectorFromValidatedSet-48             2909588               411.9 ns/op           192 B/op          5 allocs/op
BenchmarkSetSelector
BenchmarkSetSelector-48                          9846037               121.9 ns/op             0 B/op          0 allocs/op
```

A followup PR will be made to use the new SetSelector in k/k codepaths (where applicable).

---

This PR introduces an internal change to make common hot paths in controllers optimized. It should not impact user facing behavior.

Essentially, Selectors are pretty complicated  - they are slow to evaluate and expensive (allocs) to create. A very common selector, however, is one derived from a `Set`. Constructing a set is cheap, and sometimes free (example: we use the one already allocated from Service.spec.selector), and evaluating it is also cheap.

This adds an internal specialization for Set, so that it has a custom Selector implementation.

In real world application (Istio) at scale, we found that selector computation was 5-10% of CPU in many cases. We made a similar optimization internally (by not using Selector at all) and saw this drop to 0%. This PR brings the same optimzation to all users transparently.

Fixes #112647

Benchmark:

```
$ benchstat /tmp/{old,new}
name                         old time/op    new time/op    delta
SelectorFromValidatedSet-48     397ns ± 1%     123ns ± 0%   -68.87%  (p=0.008 n=5+5)

name                         old alloc/op   new alloc/op   delta
SelectorFromValidatedSet-48      192B ± 0%        0B       -100.00%  (p=0.008 n=5+5)

name                         old allocs/op  new allocs/op  delta
SelectorFromValidatedSet-48      5.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
