### PR TITLE
Optimize `Everything` and `Nothing` label selectors

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -74,11 +74,12 @@ type Selector interface {
 	RequiresExactMatch(label string) (value string, found bool)
 }
 
-var everythingSelector Selector = internalSelector{}
+// Sharing this saves 1 alloc per use; this is safe because it's immutable.
+var sharedEverythingSelector Selector = internalSelector{}
 
 // Everything returns a selector that matches all labels.
 func Everything() Selector {
-	return everythingSelector
+	return sharedEverythingSelector
 }
 
 type nothingSelector struct{}
@@ -93,11 +94,12 @@ func (n nothingSelector) RequiresExactMatch(label string) (value string, found b
 	return "", false
 }
 
-var internalNothingSelector Selector = nothingSelector{}
+// Sharing this saves 1 alloc per use; this is safe because it's immutable.
+var sharedNothingSelector Selector = nothingSelector{}
 
 // Nothing returns a selector that matches no labels
 func Nothing() Selector {
-	return internalNothingSelector
+	return sharedNothingSelector
 }
 
 // NewSelector returns a nil selector

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -74,9 +74,11 @@ type Selector interface {
 	RequiresExactMatch(label string) (value string, found bool)
 }
 
+var everythingSelector Selector = internalSelector{}
+
 // Everything returns a selector that matches all labels.
 func Everything() Selector {
-	return internalSelector{}
+	return everythingSelector
 }
 
 type nothingSelector struct{}
@@ -91,9 +93,11 @@ func (n nothingSelector) RequiresExactMatch(label string) (value string, found b
 	return "", false
 }
 
+var internalNothingSelector Selector = nothingSelector{}
+
 // Nothing returns a selector that matches no labels
 func Nothing() Selector {
-	return nothingSelector{}
+	return internalNothingSelector
 }
 
 // NewSelector returns a nil selector


### PR DESCRIPTION
#### What type of PR is this?

#### What this PR does / why we need it:
Currently each call makes 1 small alloc. This is not much, but it adds up when this is called millions of times. This simple change just moves to using a shared struct between everything.

This is safe as each operation on the Selector is not doing mutations.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
