### PR TITLE
Automated cherry pick of #112650: kubelet: increase log level for Path does not exist message

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -303,7 +303,7 @@ func (kl *Kubelet) getPodVolumePathListFromDisk(podUID types.UID) ([]string, err
 	if pathExists, pathErr := mount.PathExists(podVolDir); pathErr != nil {
 		return volumes, fmt.Errorf("error checking if path %q exists: %v", podVolDir, pathErr)
 	} else if !pathExists {
-		klog.InfoS("Path does not exist", "path", podVolDir)
+		klog.V(6).InfoS("Path does not exist", "path", podVolDir)
 		return volumes, nil
 	}
 


### PR DESCRIPTION
Cherry pick of #112650 on release-1.25.

#112650: kubelet: increase log level for Path does not exist message

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```