### PR TITLE
Update changelogs for 1.25.2, 1.24.6, 1.23.12, and 1.22.15

### DIFF
--- a/CHANGELOG/CHANGELOG-1.22.md
+++ b/CHANGELOG/CHANGELOG-1.22.md
@@ -469,6 +469,8 @@ name | architectures
 ### Bug or Regression
 
 - Kube-apiserver: gzip compression switched from level 4 to level 1 to improve large list call latencies in exchange for higher network bandwidth usage (10-50% higher). This increases the headroom before very large unpaged list calls exceed request timeout limits. ([#112401](https://github.com/kubernetes/kubernetes/pull/112401), [@shyamjvs](https://github.com/shyamjvs)) [SIG API Machinery]
+- Kube-apiserver: resolved a regression that treated `304 Not Modified` responses from aggregated API servers as internal errors ([#112530](https://github.com/kubernetes/kubernetes/pull/112530), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
+- Kubeadm: allow RSA and ECDSA format keys in preflight check ([#112537](https://github.com/kubernetes/kubernetes/pull/112537), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
 
 ## Dependencies
 

--- a/CHANGELOG/CHANGELOG-1.23.md
+++ b/CHANGELOG/CHANGELOG-1.23.md
@@ -416,6 +416,8 @@ name | architectures
 ### Bug or Regression
 
 - Kube-apiserver: gzip compression switched from level 4 to level 1 to improve large list call latencies in exchange for higher network bandwidth usage (10-50% higher). This increases the headroom before very large unpaged list calls exceed request timeout limits. ([#112400](https://github.com/kubernetes/kubernetes/pull/112400), [@shyamjvs](https://github.com/shyamjvs)) [SIG API Machinery]
+- Kube-apiserver: resolved a regression that treated `304 Not Modified` responses from aggregated API servers as internal errors ([#112529](https://github.com/kubernetes/kubernetes/pull/112529), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
+- Kubeadm: allow RSA and ECDSA format keys in preflight check ([#112536](https://github.com/kubernetes/kubernetes/pull/112536), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
 
 ## Dependencies
 

--- a/CHANGELOG/CHANGELOG-1.24.md
+++ b/CHANGELOG/CHANGELOG-1.24.md
@@ -331,7 +331,10 @@ name | architectures
 
 ### Bug or Regression
 
+- Allow Label section in vsphere e2e cloudprovider configuration ([#112479](https://github.com/kubernetes/kubernetes/pull/112479), [@gnufied](https://github.com/gnufied)) [SIG Storage and Testing]
 - Kube-apiserver: gzip compression switched from level 4 to level 1 to improve large list call latencies in exchange for higher network bandwidth usage (10-50% higher). This increases the headroom before very large unpaged list calls exceed request timeout limits. ([#112399](https://github.com/kubernetes/kubernetes/pull/112399), [@shyamjvs](https://github.com/shyamjvs)) [SIG API Machinery]
+- Kube-apiserver: resolved a regression that treated `304 Not Modified` responses from aggregated API servers as internal errors ([#112528](https://github.com/kubernetes/kubernetes/pull/112528), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
+- Kubeadm: allow RSA and ECDSA format keys in preflight check ([#112535](https://github.com/kubernetes/kubernetes/pull/112535), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
 
 ## Dependencies
 

--- a/CHANGELOG/CHANGELOG-1.25.md
+++ b/CHANGELOG/CHANGELOG-1.25.md
@@ -255,8 +255,11 @@ name | architectures
 
 ### Bug or Regression
 
+- Allow Label section in vsphere e2e cloudprovider configuration ([#112478](https://github.com/kubernetes/kubernetes/pull/112478), [@gnufied](https://github.com/gnufied)) [SIG Storage and Testing]
 - Correct the calculating error in podTopologySpread plugin to avoid unexpected scheduling results. ([#112531](https://github.com/kubernetes/kubernetes/pull/112531), [@kerthcet](https://github.com/kerthcet)) [SIG Scheduling]
 - Kube-apiserver: gzip compression switched from level 4 to level 1 to improve large list call latencies in exchange for higher network bandwidth usage (10-50% higher). This increases the headroom before very large unpaged list calls exceed request timeout limits. ([#112398](https://github.com/kubernetes/kubernetes/pull/112398), [@shyamjvs](https://github.com/shyamjvs)) [SIG API Machinery]
+- Kube-apiserver: resolved a regression that treated `304 Not Modified` responses from aggregated API servers as internal errors ([#112527](https://github.com/kubernetes/kubernetes/pull/112527), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
+- Kubeadm: allow RSA and ECDSA format keys in preflight check ([#112534](https://github.com/kubernetes/kubernetes/pull/112534), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
 
 ## Dependencies
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

While cutting the patch releases today, we discovered that the release-notes tool is omitting some release notes when generating the changelog. It seems that if the cherry-pick PR has an empty release note block, that PR will be omitted. The desired behavior is that the release-notes tool should take the release note from the parent PR. We're currently investigating why is this not happening. Until then, this PR manually fixes changelogs for 1.25.2, 1.24.6, 1.23.12, and 1.22.15.

Older patch releases are affected by this as well, but we'll potentially tackle this some other time.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assign @puerco @cpanato @Verolop @saschagrunert @palnabarun 
cc @kubernetes/release-managers 