### PR TITLE
do not assume backend on e2e service jig

### DIFF
--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -902,24 +902,20 @@ func testEndpointReachability(endpoint string, port int32, protocol v1.Protocol,
 	cmd := ""
 	switch protocol {
 	case v1.ProtocolTCP:
-		cmd = fmt.Sprintf("echo hostName | nc -v -t -w 2 %s %v", endpoint, port)
+		cmd = fmt.Sprintf("nc -v -z -w 2 %s %v", endpoint, port)
 	case v1.ProtocolUDP:
-		cmd = fmt.Sprintf("echo hostName | nc -v -u -w 2 %s %v", endpoint, port)
+		cmd = fmt.Sprintf("nc -v -z -u -w 2 %s %v", endpoint, port)
 	default:
 		return fmt.Errorf("service reachability check is not supported for %v", protocol)
 	}
 
 	err := wait.PollImmediate(1*time.Second, ServiceReachabilityShortPollTimeout, func() (bool, error) {
-		stdout, err := framework.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
+		_, err := framework.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
 		if err != nil {
 			framework.Logf("Service reachability failing with error: %v\nRetrying...", err)
 			return false, nil
 		}
-		trimmed := strings.TrimSpace(stdout)
-		if trimmed != "" {
-			return true, nil
-		}
-		return false, nil
+		return true, nil
 	})
 	if err != nil {
 		return fmt.Errorf("service is not reachable within %v timeout on endpoint %s over %s protocol", ServiceReachabilityShortPollTimeout, ep, protocol)


### PR DESCRIPTION

/kind cleanup

#### What this PR does / why we need it:

The e2e test contains a helper to test Services, but there was some assumptions on the images used to run the test that are no longer valid.


Modify the method on the Service helper to assert connectivity only, without assuming which server is answering

Seen here, while debugging https://github.com/kubernetes/kubernetes/issues/112442

```
    Sep 21 15:15:24.283: INFO: Running '/home/prow/go/src/github.com/Rajalakshmi-Girish/kubetest2-plugins/_rundir/40ab04a4-39bb-11ed-a7e5-0242ac110002/kubectl --kubeconfig=/home/prow/go/src/github.com/Rajalakshmi-Girish/kubetest2-plugins/config1-1663771308/kubeconfig --namespace=services-7866 exec execpod-affinity8bfxv -- /bin/sh -x -c echo hostName | nc -v -t -w 2 affinity-nodeport-timeout 80'
    Sep 21 15:15:26.482: INFO: stderr: "+ echo hostName\n+ nc -v -t -w 2 affinity-nodeport-timeout 80\nConnection to affinity-nodeport-timeout 80 port [tcp/http] succeeded!\n"
    Sep 21 15:15:26.482: INFO: stdout: "HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain; charset=utf-8\r\nConnection: close\r\n\r\n400 Bad Request"
```

The connectivity test works but the message is confusing

```release-note
NONE
```
