### PR TITLE
[release-1.22] CHANGELOG-1.22: Add missing changes for 1.22.15

### DIFF
--- a/CHANGELOG/CHANGELOG-1.22.md
+++ b/CHANGELOG/CHANGELOG-1.22.md
@@ -469,6 +469,8 @@ name | architectures
 ### Bug or Regression
 
 - Kube-apiserver: gzip compression switched from level 4 to level 1 to improve large list call latencies in exchange for higher network bandwidth usage (10-50% higher). This increases the headroom before very large unpaged list calls exceed request timeout limits. ([#112401](https://github.com/kubernetes/kubernetes/pull/112401), [@shyamjvs](https://github.com/shyamjvs)) [SIG API Machinery]
+- Kube-apiserver: resolved a regression that treated `304 Not Modified` responses from aggregated API servers as internal errors ([#112530](https://github.com/kubernetes/kubernetes/pull/112530), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
+- Kubeadm: allow RSA and ECDSA format keys in preflight check ([#112537](https://github.com/kubernetes/kubernetes/pull/112537), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
 
 ## Dependencies
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR cherry-picks the missing changelog entries for 1.22.15 from #112655.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assing @puerco @saschagrunert @cpanato @Verolop @palnabarun 
cc @kubernetes/release-managers 
