### PR TITLE
[release-1.25] CHANGELOG-1.25: Add missing changes for 1.25.2

### DIFF
--- a/CHANGELOG/CHANGELOG-1.25.md
+++ b/CHANGELOG/CHANGELOG-1.25.md
@@ -255,8 +255,11 @@ name | architectures
 
 ### Bug or Regression
 
+- Allow Label section in vsphere e2e cloudprovider configuration ([#112478](https://github.com/kubernetes/kubernetes/pull/112478), [@gnufied](https://github.com/gnufied)) [SIG Storage and Testing]
 - Correct the calculating error in podTopologySpread plugin to avoid unexpected scheduling results. ([#112531](https://github.com/kubernetes/kubernetes/pull/112531), [@kerthcet](https://github.com/kerthcet)) [SIG Scheduling]
 - Kube-apiserver: gzip compression switched from level 4 to level 1 to improve large list call latencies in exchange for higher network bandwidth usage (10-50% higher). This increases the headroom before very large unpaged list calls exceed request timeout limits. ([#112398](https://github.com/kubernetes/kubernetes/pull/112398), [@shyamjvs](https://github.com/shyamjvs)) [SIG API Machinery]
+- Kube-apiserver: resolved a regression that treated `304 Not Modified` responses from aggregated API servers as internal errors ([#112527](https://github.com/kubernetes/kubernetes/pull/112527), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
+- Kubeadm: allow RSA and ECDSA format keys in preflight check ([#112534](https://github.com/kubernetes/kubernetes/pull/112534), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
 
 ## Dependencies
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR cherry-picks the missing changelog entries for 1.25.2 from #112655.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assing @puerco @saschagrunert @cpanato @Verolop @palnabarun 
cc @kubernetes/release-managers 
