### PR TITLE
transport/cache: statically assert that tlsCacheKey is comparable

### DIFF
--- a/staging/src/k8s.io/client-go/transport/cache_go118.go
+++ b/staging/src/k8s.io/client-go/transport/cache_go118.go
@@ -1,0 +1,24 @@
+//go:build go1.18
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transport
+
+// assert at compile time that tlsCacheKey is comparable in a way that will never panic at runtime.
+var _ = isComparable[tlsCacheKey]
+
+func isComparable[T comparable]() {}


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@microsoft.com>

/kind cleanup
/triage accepted
/priority backlog
/assign @liggitt @aojea 

```release-note
NONE
```