### PR TITLE
Respect MinReadySeconds in StatefulSet controller

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -617,7 +617,7 @@ func updateStatefulSetAfterInvariantEstablished(
 	// those pods and count the successful deletions. Update the status with the correct number of deletions.
 	unavailablePods := 0
 	for target := len(replicas) - 1; target >= 0; target-- {
-		if !isHealthy(replicas[target]) {
+		if !isRunningAndAvailable(replicas[target], set.Spec.MinReadySeconds) || isTerminating(replicas[target]) {
 			unavailablePods++
 		}
 	}

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -942,17 +942,17 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailable(t *testing.T) {
 
 }
 
-func setupForInvariant(t *testing.T) (*apps.StatefulSet, *fakeObjectManager, StatefulSetControlInterface, intstr.IntOrString, int) {
-	totalPods := 6
+func setupForInvariant(t *testing.T, totalPods int, maxUnavailableInt int, minReadySecs int, partition int) (*apps.StatefulSet, *fakeObjectManager, StatefulSetControlInterface, int) {
 	set := newStatefulSet(totalPods)
 	// update all pods >=3(3,4,5)
-	var partition int32 = 3
-	var maxUnavailable = intstr.FromInt(2)
+	var partitionInt32 int32 = int32(partition)
+	maxUnavailable := intstr.FromInt(maxUnavailableInt)
+	set = setMinReadySeconds(set, int32(minReadySecs))
 	set.Spec.UpdateStrategy = apps.StatefulSetUpdateStrategy{
 		Type: apps.RollingUpdateStatefulSetStrategyType,
 		RollingUpdate: func() *apps.RollingUpdateStatefulSetStrategy {
 			return &apps.RollingUpdateStatefulSetStrategy{
-				Partition:      &partition,
+				Partition:      &partitionInt32,
 				MaxUnavailable: &maxUnavailable,
 			}
 		}(),
@@ -968,7 +968,7 @@ func setupForInvariant(t *testing.T) (*apps.StatefulSet, *fakeObjectManager, Sta
 		t.Fatal(err)
 	}
 
-	return set, spc, ssc, maxUnavailable, totalPods
+	return set, spc, ssc, totalPods
 }
 
 func TestStatefulSetControlRollingUpdateWithMaxUnavailableInOrderedModeVerifyInvariant(t *testing.T) {
@@ -978,23 +978,105 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailableInOrderedModeVerifyInv
 	// to add more params here.
 	testCases := []struct {
 		ordinalOfPodToTerminate []int
+		ordinalOfPodUnavailable map[int]struct{}
+		expectedPodsAfterUpdate int
+		totalNumberPods         int
+		rollingUpdatePartition  int
+		minReadySecs            int
 	}{
+		{
+			ordinalOfPodToTerminate: []int{},
+			totalNumberPods:         6,
+			rollingUpdatePartition:  3,
+			expectedPodsAfterUpdate: 4,
+		},
+		{
+			ordinalOfPodToTerminate: []int{5},
+			totalNumberPods:         6,
+			rollingUpdatePartition:  3,
+			expectedPodsAfterUpdate: 5,
+		},
+		{
+			ordinalOfPodToTerminate: []int{3},
+			totalNumberPods:         6,
+			rollingUpdatePartition:  3,
+			expectedPodsAfterUpdate: 5,
+		},
+		{
+			ordinalOfPodToTerminate: []int{4},
+			totalNumberPods:         6,
+			rollingUpdatePartition:  3,
+			expectedPodsAfterUpdate: 5,
+		},
+		{
+			ordinalOfPodToTerminate: []int{5, 4},
+			totalNumberPods:         6,
+			rollingUpdatePartition:  3,
+			expectedPodsAfterUpdate: 6,
+		},
+		{
+			ordinalOfPodToTerminate: []int{5, 3},
+			totalNumberPods:         6,
+			rollingUpdatePartition:  3,
+			expectedPodsAfterUpdate: 6,
+		},
+		{
+			ordinalOfPodToTerminate: []int{4, 3},
+			totalNumberPods:         6,
+			rollingUpdatePartition:  3,
+			expectedPodsAfterUpdate: 6,
+		},
+		{
+			ordinalOfPodToTerminate: []int{5, 4, 3},
+			totalNumberPods:         6,
+			rollingUpdatePartition:  3,
+			expectedPodsAfterUpdate: 6,
+		},
+		{
+			ordinalOfPodToTerminate: []int{2}, // note this is an ordinal greater than partition(3)
+			totalNumberPods:         6,
+			rollingUpdatePartition:  3,
+			expectedPodsAfterUpdate: 5,
+		},
+		{
+			ordinalOfPodToTerminate: []int{1}, // note this is an ordinal greater than partition(3)
+			totalNumberPods:         6,
+			rollingUpdatePartition:  3,
+			expectedPodsAfterUpdate: 5,
+		},
 
-		{[]int{}},
-		{[]int{5}},
-		{[]int{3}},
-		{[]int{4}},
-		{[]int{5, 4}},
-		{[]int{5, 3}},
-		{[]int{4, 3}},
-		{[]int{5, 4, 3}},
-		{[]int{2}}, // note this is an ordinal greater than partition(3)
-		{[]int{1}}, // note this is an ordinal greater than partition(3)
+		{
+			ordinalOfPodUnavailable: map[int]struct{}{
+				0: {},
+				1: {},
+			},
+			totalNumberPods:         3,
+			minReadySecs:            2,
+			expectedPodsAfterUpdate: 3,
+		},
+		{
+			ordinalOfPodUnavailable: map[int]struct{}{
+				1: {},
+			},
+			totalNumberPods:         3,
+			minReadySecs:            2,
+			expectedPodsAfterUpdate: 2,
+		},
+		{
+			ordinalOfPodToTerminate: []int{2},
+			ordinalOfPodUnavailable: map[int]struct{}{
+				1: {},
+			},
+			totalNumberPods:         3,
+			minReadySecs:            2,
+			expectedPodsAfterUpdate: 3,
+		},
 	}
 	for _, tc := range testCases {
 		defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MaxUnavailableStatefulSet, true)()
-		set, spc, ssc, maxUnavailable, totalPods := setupForInvariant(t)
-		t.Run(fmt.Sprintf("terminating pod at ordinal %d", tc.ordinalOfPodToTerminate), func(t *testing.T) {
+		maxUnavailable := 2
+		set, spc, ssc, totalPods := setupForInvariant(t, tc.totalNumberPods, maxUnavailable, tc.minReadySecs, tc.rollingUpdatePartition)
+		t.Run(fmt.Sprintf("terminating %d; unavailable %v", tc.ordinalOfPodToTerminate, tc.ordinalOfPodUnavailable), func(t *testing.T) {
 			status := apps.StatefulSetStatus{Replicas: int32(totalPods)}
 			updateRevision := &apps.ControllerRevision{}
 
@@ -1003,6 +1085,15 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailableInOrderedModeVerifyInv
 				_, err := spc.addTerminatingPod(set, tc.ordinalOfPodToTerminate[i])
 				if err != nil {
 					t.Fatal(err)
+				}
+			}
+
+			for i := 0; i < totalPods; i++ {
+				if _, ok := tc.ordinalOfPodUnavailable[i]; ok {
+					// set to some time in the future
+					spc.setPodAvailable(set, i, time.Now().Add(time.Duration(2*tc.minReadySecs)*time.Second))
+				} else {
+					spc.setPodAvailable(set, i, time.Now().Add(time.Duration(-tc.minReadySecs)*time.Second))
 				}
 			}
 
@@ -1033,15 +1124,8 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailableInOrderedModeVerifyInv
 
 			sort.Sort(ascendingOrdinal(pods))
 
-			expecteddPodsToBeDeleted := maxUnavailable.IntValue() - len(tc.ordinalOfPodToTerminate)
-			if expecteddPodsToBeDeleted < 0 {
-				expecteddPodsToBeDeleted = 0
-			}
-
-			expectedPodsAfterUpdate := totalPods - expecteddPodsToBeDeleted
-
-			if len(pods) != expectedPodsAfterUpdate {
-				t.Errorf("Expected pods %v, got pods %v", expectedPodsAfterUpdate, len(pods))
+			if len(pods) != tc.expectedPodsAfterUpdate {
+				t.Errorf("Expected pods %v, got pods %v", tc.expectedPodsAfterUpdate, len(pods))
 			}
 
 		})


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Fixes #112307

When creating pods under `StatefulSet` that has `MinReadySeconds` configured, the controller currently does not respect  `MinReadySeconds`. See more details in the issue linked above.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #112307

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
