### PR TITLE
clients: clarify a misleading comment

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
@@ -33,8 +33,7 @@ type Interface interface {
 	CrV1() crv1.CrV1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	crV1 *crv1.CrV1Client

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
@@ -35,8 +35,7 @@ type Interface interface {
 	ApiextensionsV1() apiextensionsv1.ApiextensionsV1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	apiextensionsV1beta1 *apiextensionsv1beta1.ApiextensionsV1beta1Client

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/deprecated/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/deprecated/clientset.go
@@ -34,8 +34,7 @@ type Interface interface {
 	ApiextensionsV1() apiextensionsv1.ApiextensionsV1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	apiextensionsV1beta1 *apiextensionsv1beta1.ApiextensionsV1beta1Client

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -125,8 +125,7 @@ type Interface interface {
 	StorageV1alpha1() storagev1alpha1.StorageV1alpha1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	admissionregistrationV1      *admissionregistrationv1.AdmissionregistrationV1Client

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
@@ -108,8 +108,7 @@ type Interface interface {
 `
 
 var clientsetTemplate = `
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*$.DiscoveryClient|raw$
     $range .allGroups$$.LowerCaseGroupGoName$$.Version$ *$.PackageAlias$.$.GroupGoName$$.Version$Client

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/clientset.go
@@ -33,8 +33,7 @@ type Interface interface {
 	ExampleGroupV1() examplegroupv1.ExampleGroupV1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	exampleGroupV1 *examplegroupv1.ExampleGroupV1Client

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/clientset.go
@@ -33,8 +33,7 @@ type Interface interface {
 	ExampleV1() examplev1.ExampleV1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	exampleV1 *examplev1.ExampleV1Client

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/clientset.go
@@ -37,8 +37,7 @@ type Interface interface {
 	ThirdExample() thirdexampleinternalversion.ThirdExampleInterface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	example       *exampleinternalversion.ExampleClient

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/clientset.go
@@ -37,8 +37,7 @@ type Interface interface {
 	ThirdExampleV1() thirdexamplev1.ThirdExampleV1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	exampleV1       *examplev1.ExampleV1Client

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/clientset.go
@@ -35,8 +35,7 @@ type Interface interface {
 	SecondExampleV1() secondexamplev1.SecondExampleV1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	exampleV1       *examplev1.ExampleV1Client

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
@@ -35,8 +35,7 @@ type Interface interface {
 	ApiregistrationV1() apiregistrationv1.ApiregistrationV1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	apiregistrationV1beta1 *apiregistrationv1beta1.ApiregistrationV1beta1Client

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/deprecated/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/deprecated/clientset.go
@@ -34,8 +34,7 @@ type Interface interface {
 	ApiregistrationV1() apiregistrationv1.ApiregistrationV1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	apiregistrationV1beta1 *apiregistrationv1beta1.ApiregistrationV1beta1Client

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/deprecated/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/deprecated/clientset.go
@@ -34,8 +34,7 @@ type Interface interface {
 	MetricsV1beta1() metricsv1beta1.MetricsV1beta1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	metricsV1alpha1 *metricsv1alpha1.MetricsV1alpha1Client

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
@@ -35,8 +35,7 @@ type Interface interface {
 	MetricsV1beta1() metricsv1beta1.MetricsV1beta1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	metricsV1alpha1 *metricsv1alpha1.MetricsV1alpha1Client

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/clientset.go
@@ -35,8 +35,7 @@ type Interface interface {
 	WardleV1beta1() wardlev1beta1.WardleV1beta1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	wardleV1alpha1 *wardlev1alpha1.WardleV1alpha1Client

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
@@ -33,8 +33,7 @@ type Interface interface {
 	SamplecontrollerV1alpha1() samplecontrollerv1alpha1.SamplecontrollerV1alpha1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	samplecontrollerV1alpha1 *samplecontrollerv1alpha1.SamplecontrollerV1alpha1Client


### PR DESCRIPTION
It's clear that client-sets contain many versions of one group, so this comment just seems to be out-dated.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind cleanup
/kind documentation

```release-note
NONE
```

```docs

```
