### PR TITLE
use generic slis as entrypoint for healthcheck metrics 

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/prometheus/slis/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/slis/registry.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slis
+
+import (
+	"k8s.io/component-base/metrics"
+)
+
+var (
+	// Registry exposes the SLI registry so that additional SLIs can be
+	// added on a per-component basis.
+	Registry = metrics.NewKubeRegistry()
+)

--- a/staging/src/k8s.io/component-base/metrics/prometheus/slis/routes.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/slis/routes.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slis
+
+import (
+	"net/http"
+	"sync"
+
+	"k8s.io/component-base/metrics"
+)
+
+var (
+	installOnce          = sync.Once{}
+	installWithResetOnce = sync.Once{}
+)
+
+type mux interface {
+	Handle(path string, handler http.Handler)
+}
+
+type SLIMetrics struct{}
+
+// Install adds the DefaultMetrics handler
+func (s SLIMetrics) Install(m mux) {
+	installOnce.Do(func() {
+		Register(Registry)
+		m.Handle("/metrics/slis", metrics.HandlerFor(Registry, metrics.HandlerOpts{}))
+	})
+}
+
+type SLIMetricsWithReset struct{}
+
+// Install adds the DefaultMetrics handler
+func (s SLIMetricsWithReset) Install(m mux) {
+	installWithResetOnce.Do(func() {
+		Register(Registry)
+		m.Handle("/metrics/slis", metrics.HandlerWithReset(Registry, metrics.HandlerOpts{}))
+	})
+}

--- a/staging/src/k8s.io/component-base/metrics/wrappers.go
+++ b/staging/src/k8s.io/component-base/metrics/wrappers.go
@@ -145,6 +145,12 @@ type Gatherer interface {
 	prometheus.Gatherer
 }
 
+// Registerer is the interface for the part of a registry in charge of registering
+// the collected metrics.
+type Registerer interface {
+	prometheus.Registerer
+}
+
 // GaugeFunc is a Gauge whose value is determined at collect time by calling a
 // provided function.
 //


### PR DESCRIPTION
...and expose convenience functions for setting stuff up

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

We need some convenience functions for wiring up component health SLI metrics. This accomplishes that.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

