### PR TITLE
enable health check SLI metrics for apiserver

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -210,7 +210,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: "system:monitoring"},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("get").URLs(
-					"/metrics",
+					"/metrics", "/metrics/slis",
 					"/livez", "/readyz", "/healthz",
 					"/livez/*", "/readyz/*", "/healthz/*",
 				).RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -934,6 +934,7 @@ items:
     - /livez
     - /livez/*
     - /metrics
+    - /metrics/slis
     - /readyz
     - /readyz/*
     verbs:

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -67,6 +67,7 @@ import (
 	"k8s.io/client-go/informers"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/component-base/logs"
+	"k8s.io/component-base/metrics/prometheus/slis"
 	"k8s.io/klog/v2"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -884,8 +885,10 @@ func installAPI(s *GenericAPIServer, c *Config) {
 	if c.EnableMetrics {
 		if c.EnableProfiling {
 			routes.MetricsWithReset{}.Install(s.Handler.NonGoRestfulMux)
+			slis.SLIMetricsWithReset{}.Install(s.Handler.NonGoRestfulMux)
 		} else {
 			routes.DefaultMetrics{}.Install(s.Handler.NonGoRestfulMux)
+			slis.SLIMetrics{}.Install(s.Handler.NonGoRestfulMux)
 		}
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -169,6 +169,7 @@ func TestNewWithDelegate(t *testing.T) {
 		"/livez/poststarthook/storage-object-count-tracker-hook",
 		"/livez/poststarthook/wrapping-post-start-hook",
 		"/metrics",
+		"/metrics/slis",
 		"/readyz",
 		"/readyz/delegate-health",
 		"/readyz/informer-sync",

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -18,6 +18,7 @@ package healthz
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/server/httplog"
+	"k8s.io/component-base/metrics/prometheus/slis"
 	"k8s.io/klog/v2"
 )
 
@@ -237,6 +239,7 @@ func handleRootHealth(name string, firstTimeHealthy func(), checks ...HealthChec
 				continue
 			}
 			if err := check.Check(r); err != nil {
+				slis.ObserveHealthcheck(context.Background(), check.Name(), name, slis.Error)
 				// don't include the error since this endpoint is public.  If someone wants more detail
 				// they should have explicit permission to the detailed checks.
 				fmt.Fprintf(&individualCheckOutput, "[-]%s failed: reason withheld\n", check.Name())
@@ -244,6 +247,7 @@ func handleRootHealth(name string, firstTimeHealthy func(), checks ...HealthChec
 				fmt.Fprintf(&failedVerboseLogOutput, "[-]%s failed: %v\n", check.Name(), err)
 				failedChecks = append(failedChecks, check.Name())
 			} else {
+				slis.ObserveHealthcheck(context.Background(), check.Name(), name, slis.Success)
 				fmt.Fprintf(&individualCheckOutput, "[+]%s ok\n", check.Name())
 			}
 		}

--- a/staging/src/k8s.io/component-base/metrics/prometheus/slis/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/slis/metrics_test.go
@@ -39,9 +39,7 @@ func TestObserveHealthcheck(t *testing.T) {
 	initialOutput := `
         # HELP kubernetes_healthcheck [ALPHA] This metric records the result of a single healthcheck.
         # TYPE kubernetes_healthcheck gauge
-        kubernetes_healthcheck{name="healthcheck-a",status="error",type="healthz"} 1
-        kubernetes_healthcheck{name="healthcheck-a",status="pending",type="healthz"} 0
-        kubernetes_healthcheck{name="healthcheck-a",status="success",type="healthz"} 0
+        kubernetes_healthcheck{name="healthcheck-a",type="healthz"} 0
         # HELP kubernetes_healthchecks_total [ALPHA] This metric records the results of all healthcheck.
         # TYPE kubernetes_healthchecks_total counter
         kubernetes_healthchecks_total{name="healthcheck-a",status="error",type="healthz"} 1
@@ -54,23 +52,6 @@ func TestObserveHealthcheck(t *testing.T) {
 		want     string
 	}{
 		{
-			desc:     "test pending",
-			name:     healthcheckName,
-			hcType:   "healthz",
-			hcStatus: Pending,
-			want: `
-        # HELP kubernetes_healthcheck [ALPHA] This metric records the result of a single healthcheck.
-        # TYPE kubernetes_healthcheck gauge
-        kubernetes_healthcheck{name="healthcheck-a",status="error",type="healthz"} 0
-        kubernetes_healthcheck{name="healthcheck-a",status="pending",type="healthz"} 1
-        kubernetes_healthcheck{name="healthcheck-a",status="success",type="healthz"} 0
-        # HELP kubernetes_healthchecks_total [ALPHA] This metric records the results of all healthcheck.
-        # TYPE kubernetes_healthchecks_total counter
-        kubernetes_healthchecks_total{name="healthcheck-a",status="error",type="healthz"} 1
-        kubernetes_healthchecks_total{name="healthcheck-a",status="pending",type="healthz"} 1
-`,
-		},
-		{
 			desc:     "test success",
 			name:     healthcheckName,
 			hcType:   "healthz",
@@ -78,9 +59,7 @@ func TestObserveHealthcheck(t *testing.T) {
 			want: `
         # HELP kubernetes_healthcheck [ALPHA] This metric records the result of a single healthcheck.
         # TYPE kubernetes_healthcheck gauge
-        kubernetes_healthcheck{name="healthcheck-a",status="error",type="healthz"} 0
-        kubernetes_healthcheck{name="healthcheck-a",status="pending",type="healthz"} 0
-        kubernetes_healthcheck{name="healthcheck-a",status="success",type="healthz"} 1
+        kubernetes_healthcheck{name="healthcheck-a",type="healthz"} 1
         # HELP kubernetes_healthchecks_total [ALPHA] This metric records the results of all healthcheck.
         # TYPE kubernetes_healthchecks_total counter
         kubernetes_healthchecks_total{name="healthcheck-a",status="error",type="healthz"} 1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1978,6 +1978,7 @@ k8s.io/component-base/metrics/prometheus/controllers
 k8s.io/component-base/metrics/prometheus/feature
 k8s.io/component-base/metrics/prometheus/ratelimiter
 k8s.io/component-base/metrics/prometheus/restclient
+k8s.io/component-base/metrics/prometheus/slis
 k8s.io/component-base/metrics/prometheus/version
 k8s.io/component-base/metrics/prometheus/workqueue
 k8s.io/component-base/metrics/prometheusextension


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

This PR enables healthcheck metrics for apiserver. The output of the metrics looks like this:

```
# HELP kubernetes_healthcheck [ALPHA] This metric records the result of a single healthcheck.
# TYPE kubernetes_healthcheck gauge
kubernetes_healthcheck{name="autoregister-completion",type="healthz"} 1
kubernetes_healthcheck{name="autoregister-completion",type="readyz"} 1
kubernetes_healthcheck{name="etcd",type="healthz"} 1
kubernetes_healthcheck{name="etcd",type="readyz"} 1
kubernetes_healthcheck{name="etcd-readiness",type="readyz"} 1
kubernetes_healthcheck{name="informer-sync",type="readyz"} 1
kubernetes_healthcheck{name="log",type="healthz"} 1
kubernetes_healthcheck{name="log",type="readyz"} 1
kubernetes_healthcheck{name="ping",type="healthz"} 1
kubernetes_healthcheck{name="ping",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/aggregator-reload-proxy-client-cert",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/aggregator-reload-proxy-client-cert",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/apiservice-openapi-controller",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/apiservice-openapi-controller",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/apiservice-openapiv3-controller",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/apiservice-openapiv3-controller",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/apiservice-registration-controller",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/apiservice-registration-controller",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/apiservice-status-available-controller",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/apiservice-status-available-controller",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/bootstrap-controller",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/bootstrap-controller",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/crd-informer-synced",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/crd-informer-synced",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/generic-apiserver-start-informers",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/generic-apiserver-start-informers",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/kube-apiserver-autoregistration",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/kube-apiserver-autoregistration",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/priority-and-fairness-config-consumer",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/priority-and-fairness-config-consumer",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/priority-and-fairness-config-producer",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/priority-and-fairness-config-producer",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/priority-and-fairness-filter",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/priority-and-fairness-filter",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/rbac/bootstrap-roles",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/rbac/bootstrap-roles",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/scheduling/bootstrap-system-priority-classes",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/scheduling/bootstrap-system-priority-classes",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/start-apiextensions-controllers",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/start-apiextensions-controllers",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/start-apiextensions-informers",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/start-apiextensions-informers",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/start-cluster-authentication-info-controller",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/start-cluster-authentication-info-controller",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/start-kube-aggregator-informers",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/start-kube-aggregator-informers",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/start-kube-apiserver-admission-initializer",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/start-kube-apiserver-admission-initializer",type="readyz"} 1
kubernetes_healthcheck{name="poststarthook/storage-object-count-tracker-hook",type="healthz"} 1
kubernetes_healthcheck{name="poststarthook/storage-object-count-tracker-hook",type="readyz"} 1
kubernetes_healthcheck{name="shutdown",type="readyz"} 1
# HELP kubernetes_healthchecks_total [ALPHA] This metric records the results of all healthcheck.
# TYPE kubernetes_healthchecks_total counter
kubernetes_healthchecks_total{name="autoregister-completion",status="error",type="readyz"} 1
kubernetes_healthchecks_total{name="autoregister-completion",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="autoregister-completion",status="success",type="readyz"} 14
kubernetes_healthchecks_total{name="etcd",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="etcd",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="etcd-readiness",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="informer-sync",status="error",type="readyz"} 1
kubernetes_healthchecks_total{name="informer-sync",status="success",type="readyz"} 14
kubernetes_healthchecks_total{name="log",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="log",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="ping",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="ping",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/aggregator-reload-proxy-client-cert",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/aggregator-reload-proxy-client-cert",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/apiservice-openapi-controller",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/apiservice-openapi-controller",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/apiservice-openapiv3-controller",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/apiservice-openapiv3-controller",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/apiservice-registration-controller",status="error",type="readyz"} 1
kubernetes_healthchecks_total{name="poststarthook/apiservice-registration-controller",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/apiservice-registration-controller",status="success",type="readyz"} 14
kubernetes_healthchecks_total{name="poststarthook/apiservice-status-available-controller",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/apiservice-status-available-controller",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/bootstrap-controller",status="error",type="readyz"} 1
kubernetes_healthchecks_total{name="poststarthook/bootstrap-controller",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/bootstrap-controller",status="success",type="readyz"} 14
kubernetes_healthchecks_total{name="poststarthook/crd-informer-synced",status="error",type="readyz"} 1
kubernetes_healthchecks_total{name="poststarthook/crd-informer-synced",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/crd-informer-synced",status="success",type="readyz"} 14
kubernetes_healthchecks_total{name="poststarthook/generic-apiserver-start-informers",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/generic-apiserver-start-informers",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/kube-apiserver-autoregistration",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/kube-apiserver-autoregistration",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/priority-and-fairness-config-consumer",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/priority-and-fairness-config-consumer",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/priority-and-fairness-config-producer",status="error",type="readyz"} 2
kubernetes_healthchecks_total{name="poststarthook/priority-and-fairness-config-producer",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/priority-and-fairness-config-producer",status="success",type="readyz"} 13
kubernetes_healthchecks_total{name="poststarthook/priority-and-fairness-filter",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/priority-and-fairness-filter",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/rbac/bootstrap-roles",status="error",type="readyz"} 14
kubernetes_healthchecks_total{name="poststarthook/rbac/bootstrap-roles",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/rbac/bootstrap-roles",status="success",type="readyz"} 1
kubernetes_healthchecks_total{name="poststarthook/scheduling/bootstrap-system-priority-classes",status="error",type="readyz"} 10
kubernetes_healthchecks_total{name="poststarthook/scheduling/bootstrap-system-priority-classes",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/scheduling/bootstrap-system-priority-classes",status="success",type="readyz"} 5
kubernetes_healthchecks_total{name="poststarthook/start-apiextensions-controllers",status="error",type="readyz"} 1
kubernetes_healthchecks_total{name="poststarthook/start-apiextensions-controllers",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/start-apiextensions-controllers",status="success",type="readyz"} 14
kubernetes_healthchecks_total{name="poststarthook/start-apiextensions-informers",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/start-apiextensions-informers",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/start-cluster-authentication-info-controller",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/start-cluster-authentication-info-controller",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/start-kube-aggregator-informers",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/start-kube-aggregator-informers",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/start-kube-apiserver-admission-initializer",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/start-kube-apiserver-admission-initializer",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="poststarthook/storage-object-count-tracker-hook",status="success",type="healthz"} 1
kubernetes_healthchecks_total{name="poststarthook/storage-object-count-tracker-hook",status="success",type="readyz"} 15
kubernetes_healthchecks_total{name="shutdown",status="success",type="readyz"} 15
```


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Expose health check SLI metrics on "metrics/slis" for apiserver
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [KEP: kubernetes-component-health-slis](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3466-kubernetes-component-health-slis)

