### PR TITLE
Avoid following redirects in aggregator availability controller

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -264,6 +264,9 @@ func (c *AvailableConditionController) sync(key string) error {
 		Transport: restTransport,
 		// the request should happen quickly.
 		Timeout: 5 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	apiService := originalAPIService.DeepCopy()

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -392,7 +392,7 @@ func TestAggregatedAPIServerRejectRedirectResponse(t *testing.T) {
 		if strings.HasSuffix(r.URL.Path, "tryRedirect") {
 			http.Redirect(w, r, redirectedURL+"/redirectTarget", http.StatusMovedPermanently)
 		} else {
-			http.Redirect(w, r, redirectedURL, http.StatusMovedPermanently)
+			w.WriteHeader(http.StatusOK)
 		}
 	}))
 	defer redirectServer.Close()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### Which issue(s) this PR fixes:
Fixes #112683

#### Special notes for your reviewer:

/cc @enj @deads2k 

```release-note
kube-apiserver: redirects from backend API servers are no longer followed when checking availability with requests to `/apis/$group/$version`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
