### PR TITLE
Refactor kubectl label to untie CLI flags from runtime options

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -61,8 +61,6 @@ type LabelFlags struct {
 	RecordFlags *genericclioptions.RecordFlags
 	PrintFlags  *genericclioptions.PrintFlags
 
-	Recorder genericclioptions.Recorder
-
 	Overwrite       bool
 	List            bool
 	Local           bool
@@ -83,9 +81,7 @@ func NewLabelFlags(f cmdutil.Factory, streams genericclioptions.IOStreams) *Labe
 		Factory: f,
 
 		RecordFlags: genericclioptions.NewRecordFlags(),
-		Recorder:    genericclioptions.NoopRecorder{},
-
-		PrintFlags: genericclioptions.NewPrintFlags("labeled").WithTypeSetter(scheme.Scheme),
+		PrintFlags:  genericclioptions.NewPrintFlags("labeled").WithTypeSetter(scheme.Scheme),
 
 		IOStreams: streams,
 	}
@@ -114,8 +110,7 @@ type LabelOptions struct {
 	// Filename options
 	resource.FilenameOptions
 
-	PrintFlags *genericclioptions.PrintFlags
-	ToPrinter  func(string) (printers.ResourcePrinter, error)
+	ToPrinter func(string) (printers.ResourcePrinter, error)
 
 	// Common user flags
 	overwrite       bool
@@ -202,7 +197,7 @@ func (f *LabelFlags) ToOptions(cmd *cobra.Command, args []string) (*LabelOptions
 	var err error
 
 	f.RecordFlags.Complete(cmd)
-	f.Recorder, err = f.RecordFlags.ToRecorder()
+	recorder, err := f.RecordFlags.ToRecorder()
 	if err != nil {
 		return nil, err
 	}
@@ -244,8 +239,7 @@ func (f *LabelFlags) ToOptions(cmd *cobra.Command, args []string) (*LabelOptions
 	return &LabelOptions{
 		FilenameOptions: f.FilenameOptions,
 
-		PrintFlags: f.PrintFlags,
-		ToPrinter:  toPrinter,
+		ToPrinter: toPrinter,
 
 		overwrite:       f.Overwrite,
 		list:            f.List,
@@ -263,7 +257,7 @@ func (f *LabelFlags) ToOptions(cmd *cobra.Command, args []string) (*LabelOptions
 		newLabels:    newLabels,
 		removeLabels: removeLabels,
 
-		Recorder: f.Recorder,
+		Recorder: recorder,
 
 		namespace:                    namespace,
 		enforceNamespace:             enforceNamespace,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -192,6 +192,7 @@ func NewCmdLabel(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 			cmdutil.CheckErr(o.RunLabel())
 		},
 	}
+	flags.AddFlags(cmd)
 
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
@@ -702,11 +702,11 @@ pod/foo not labeled
 
 			flags := NewLabelFlags(tf, iostreams)
 			options, err := flags.ToOptions(cmd, tc.args)
-			if tc.overwrite {
-				options.overwrite = true
-			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.overwrite {
+				options.overwrite = true
 			}
 			if err := options.Validate(); err != nil {
 				t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR unties CLI flags from runtime options in the `kubectl label` command. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubectl/issues/1046

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
