### PR TITLE
Avoid using the system:masters identity for aggregated API status

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -387,8 +387,10 @@ func (c *AvailableConditionController) sync(key string) error {
 						return
 					}
 
-					// setting the system-masters identity ensures that we will always have access rights
-					transport.SetAuthProxyHeaders(newReq, "system:kube-aggregator", []string{"system:masters"}, nil)
+					// make an authenticated request so that this is authorized via the system:discovery
+					// cluster role binding in environments that enable RBAC and authorization delegation
+					// avoid using the system:masters identity to prevent any possibility of SSRF
+					transport.SetAuthProxyHeaders(newReq, "system:kube-aggregator", nil, nil)
 					resp, err := discoveryClient.Do(newReq)
 					if resp != nil {
 						resp.Body.Close()

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -431,6 +432,14 @@ func TestSync(t *testing.T) {
 			}
 
 			testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				wantHeader := http.Header{
+					"Accept-Encoding": {"gzip"},
+					"User-Agent":      {"Go-http-client/1.1"},
+					"X-Remote-User":   {"system:kube-aggregator"},
+				}
+				if !reflect.DeepEqual(wantHeader, r.Header) {
+					t.Errorf("unexpected headers seen: %v", r.Header)
+				}
 				if tc.backendLocation != "" {
 					w.Header().Set("Location", tc.backendLocation)
 				}


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@microsoft.com>

/kind cleanup

```release-note
The Kubernetes API server no longer sets the system:masters group for discovery status checks against aggregated API servers.  These requests are still authenticated via the system:kube-aggregator user.
```