### PR TITLE
add GlobalEnv admission controller: using single annotation `global.env` value in namespace

### DIFF
--- a/plugin/pkg/admission/globalenv/admission.go
+++ b/plugin/pkg/admission/globalenv/admission.go
@@ -1,0 +1,304 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package globalenv contains an admission controller that modifies every new Pod to force
+// the env of all containers to add global envs. The global envs are defined in the namespace annotation.
+// The annotation key is "global-envs". The annotation value is a string with `,` as split char.
+// For example: "TEST=test,FOO=foo"
+package globalenv
+
+import (
+	"context"
+	"io"
+	"regexp"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/core/pods"
+)
+
+var validEnvNameRegexp = regexp.MustCompile("[^a-zA-Z0-9_]")
+
+const (
+	// PluginName indicates name of admission plugin.
+	PluginName = "GlobalEnv"
+	// globalEnvKey is the annotation key that holds the global env of the namespace
+	globalEnvKey = "global.env"
+)
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return NewGlobalEnv(), nil
+	})
+}
+
+// GlobalEnv is an implementation of admission.Interface.
+// It looks at namespace annotation for global env prefix.
+// It will add extra env to all new pods according to the global env of the namespace.
+type GlobalEnv struct {
+	*admission.Handler
+	client          kubernetes.Interface
+	namespaceLister corev1listers.NamespaceLister
+}
+
+var _ admission.MutationInterface = &GlobalEnv{}
+var _ admission.ValidationInterface = &GlobalEnv{}
+
+// Admit makes an admission decision based on the request attributes
+func (g *GlobalEnv) Admit(ctx context.Context, attributes admission.Attributes, o admission.ObjectInterfaces) (err error) {
+	// Ignore all calls to subresources or resources other than pods.
+	if shouldIgnore(attributes) {
+		return nil
+	}
+	pod, ok := attributes.GetObject().(*api.Pod)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+	}
+
+	pods.VisitContainersWithPath(&pod.Spec, field.NewPath("spec"), func(c *api.Container, _ *field.Path) bool {
+		globalEnv, err := g.getNamespaceGlobalEnv(pod.Namespace)
+		if err != nil {
+			klog.ErrorS(err, "Failed to get global env annotation of the namespace", "pod", klog.KObj(pod))
+		}
+		if len(globalEnv) > 0 {
+			globalEnvKeyValue := make(map[string]string)
+			for _, env := range globalEnv {
+				globalEnvKeyValue[env.Name] = env.Value
+			}
+			var envs []api.EnvVar
+			// if global env will override the pod env, log more information
+			for _, env := range c.Env {
+				if value, ok := globalEnvKeyValue[env.Name]; ok {
+					envs = append(envs, api.EnvVar{Name: env.Name, Value: value})
+					delete(globalEnvKeyValue, env.Name)
+					if value != env.Value {
+						klog.InfoS("Global Env will override pod env", "pod", klog.KObj(pod), "env", env)
+					}
+				} else {
+					envs = append(envs, api.EnvVar{Name: env.Name, Value: env.Value})
+				}
+			}
+			for key, value := range globalEnvKeyValue {
+				envs = append(envs, api.EnvVar{Name: key, Value: value})
+			}
+			c.Env = envs
+		}
+		return true
+	})
+
+	return nil
+}
+
+// Validate makes sure that pod env is not overwrited by a different value
+func (g *GlobalEnv) Validate(ctx context.Context, attributes admission.Attributes, o admission.ObjectInterfaces) (err error) {
+	if shouldIgnore(attributes) {
+		return nil
+	}
+
+	pod, ok := attributes.GetObject().(*api.Pod)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+	}
+
+	var allErrs []error
+	pods.VisitContainersWithPath(&pod.Spec, field.NewPath("spec"), func(c *api.Container, p *field.Path) bool {
+		// TODO: Should return error if global env will override pod env?
+		globalEnvKeyValue, err := g.getNamespaceGlobalEnvMap(pod.Namespace)
+		if err != nil {
+			klog.ErrorS(err, "Failed to get global env annotation of the namespace", "pod", klog.KObj(pod))
+		}
+		if len(globalEnvKeyValue) > 0 {
+			for _, env := range c.Env {
+				if value, ok := globalEnvKeyValue[env.Name]; ok && value != env.Value {
+					allErrs = append(allErrs, field.Forbidden(p.Child("env"), "global env should not override current env"))
+				}
+			}
+		}
+		return true
+	})
+	if len(allErrs) > 0 {
+		return utilerrors.NewAggregate(allErrs)
+	}
+
+	return nil
+}
+
+// SetExternalKubeClientSet sets th client
+func (p *GlobalEnv) SetExternalKubeClientSet(client kubernetes.Interface) {
+	p.client = client
+}
+
+// SetExternalKubeInformerFactory initializes the Informer Factory
+func (p *GlobalEnv) SetExternalKubeInformerFactory(f informers.SharedInformerFactory) {
+	namespaceInformer := f.Core().V1().Namespaces()
+	p.namespaceLister = namespaceInformer.Lister()
+	p.SetReadyFunc(namespaceInformer.Informer().HasSynced)
+}
+
+// in exceptional cases, this can result in two live calls, but once the cache catches up, that will stop.
+func (g *GlobalEnv) getNamespace(nsName string) (*corev1.Namespace, error) {
+	namespace, err := g.namespaceLister.Get(nsName)
+	if apierrors.IsNotFound(err) {
+		// in case of latency in our caches, make a call direct to storage to verify that it truly exists or not
+		namespace, err = g.client.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, err
+			}
+			return nil, apierrors.NewInternalError(err)
+		}
+	} else if err != nil {
+		return nil, apierrors.NewInternalError(err)
+	}
+
+	return namespace, nil
+}
+func (g *GlobalEnv) getNamespaceGlobalEnvMap(nsName string) (map[string]string, error) {
+	ns, err := g.getNamespace(nsName)
+	if err != nil {
+		return nil, err
+	}
+	return extractGlobalEnvMap(ns)
+}
+
+func (g *GlobalEnv) getNamespaceGlobalEnv(nsName string) ([]api.EnvVar, error) {
+	ns, err := g.getNamespace(nsName)
+	if err != nil {
+		return nil, err
+	}
+	return extractGlobalEnv(ns)
+}
+
+func extractGlobalEnvMap(ns *corev1.Namespace) (map[string]string, error) {
+	globalEnvKeyValue := make(map[string]string)
+	annotation := ns.Annotations["global.env"]
+	envs := strings.Split(annotation, ",")
+	for _, env := range envs {
+		if len(env) == 0 {
+			continue
+		}
+		envKey, envValue, _ := strings.Cut(env, "=")
+		globalEnvKeyValue[keyToEnvName(envKey)] = envValue
+	}
+	return globalEnvKeyValue, nil
+}
+
+func extractGlobalEnv(ns *corev1.Namespace) ([]api.EnvVar, error) {
+	var globalEnv []api.EnvVar
+	annotation := ns.Annotations[globalEnvKey]
+	envs := strings.Split(annotation, ",")
+	for _, env := range envs {
+		if len(env) == 0 {
+			continue
+		}
+		envKey, envValue, _ := strings.Cut(env, "=")
+		globalEnv = append(globalEnv, api.EnvVar{
+			Name:  keyToEnvName(envKey),
+			Value: envValue,
+		})
+	}
+	return globalEnv, nil
+}
+
+// check if it's update and it doesn't change the env by the pod spec
+func isUpdateWithNoEnv(attributes admission.Attributes) bool {
+	if attributes.GetOperation() != admission.Update {
+		return false
+	}
+
+	pod, ok := attributes.GetObject().(*api.Pod)
+	if !ok {
+		klog.Warningf("Resource was marked with kind Pod but pod was unable to be converted.")
+		return false
+	}
+
+	oldPod, ok := attributes.GetOldObject().(*api.Pod)
+	if !ok {
+		klog.Warningf("Resource was marked with kind Pod but old pod was unable to be converted.")
+		return false
+	}
+
+	oldEnv := []api.EnvVar{}
+	pods.VisitContainersWithPath(&oldPod.Spec, field.NewPath("spec"), func(c *api.Container, _ *field.Path) bool {
+		oldEnv = append(oldEnv, c.Env...)
+		return true
+	})
+
+	newEnv := []api.EnvVar{}
+	pods.VisitContainersWithPath(&pod.Spec, field.NewPath("spec"), func(c *api.Container, _ *field.Path) bool {
+		newEnv = append(newEnv, c.Env...)
+		return true
+	})
+
+	return envSliceEquals(oldEnv, newEnv)
+}
+
+// envSliceEquals will ignore order
+func envSliceEquals(expected, current []api.EnvVar) bool {
+	if len(expected) != len(current) {
+		return false
+	}
+	diff := map[string]string{}
+	for _, env := range expected {
+		diff[env.Name] = env.Value
+	}
+	for _, env := range current {
+		if diff[env.Name] != env.Value {
+			return false
+		} else {
+			delete(diff, env.Name)
+		}
+	}
+	return len(diff) == 0
+}
+
+func shouldIgnore(attributes admission.Attributes) bool {
+	// Ignore all calls to subresources or resources other than pods.
+	if len(attributes.GetSubresource()) != 0 || attributes.GetResource().GroupResource() != api.Resource("pods") {
+		return true
+	}
+
+	if isUpdateWithNoEnv(attributes) {
+		return true
+	}
+	return false
+}
+
+func keyToEnvName(key string) string {
+	envName := strings.ToUpper(validEnvNameRegexp.ReplaceAllString(key, "_"))
+	if envName != key {
+		klog.InfoS("Key transerred to env name", "key", key, "envName", envName)
+	}
+	return envName
+}
+
+// NewGlobalEnv creates a new global env admission control handler
+func NewGlobalEnv() *GlobalEnv {
+	return &GlobalEnv{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}
+}

--- a/plugin/pkg/admission/globalenv/admission_test.go
+++ b/plugin/pkg/admission/globalenv/admission_test.go
@@ -1,0 +1,357 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package globalenv
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
+	admissiontesting "k8s.io/apiserver/pkg/admission/testing"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+func TestAdmission(t *testing.T) {
+	tests := []struct {
+		globalenv     string
+		namespaceName string
+		current       []api.EnvVar
+		expected      []api.EnvVar
+		admit         bool
+		testName      string
+	}{
+		{
+			testName:      "override case",
+			namespaceName: "test1",
+			globalenv:     "TEST=a,FOO=foo",
+			current:       []api.EnvVar{},
+			admit:         true,
+			expected: []api.EnvVar{
+				{
+					Name:  "TEST",
+					Value: "a",
+				},
+				{
+					Name:  "FOO",
+					Value: "foo",
+				},
+			},
+		},
+		{
+			testName:      "admit false",
+			namespaceName: "test2",
+			globalenv:     "",
+			current:       []api.EnvVar{},
+			admit:         true,
+			expected:      []api.EnvVar{},
+		},
+	}
+	for _, test := range tests {
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        test.namespaceName,
+				Namespace:   "",
+				Annotations: map[string]string{},
+			},
+		}
+		if len(test.globalenv) > 0 {
+			namespace.Annotations = map[string]string{globalEnvKey: string(test.globalenv)}
+		}
+		mockClient := fake.NewSimpleClientset(namespace)
+		handler, informerFactory, err := newHandlerForTest(mockClient)
+		if err != nil {
+			t.Fatalf("unexpected error initializing handler: %v", err)
+		}
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		informerFactory.Start(stopCh)
+
+		pod := renderPod(test.namespaceName, test.current)
+		err = admissiontesting.WithReinvocationTesting(t, handler).Admit(
+			context.TODO(),
+			admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), test.namespaceName, namespace.ObjectMeta.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil),
+			nil,
+		)
+		if test.admit && err != nil {
+			t.Errorf("Test: %s, expected no error but got: %s", test.testName, err)
+		} else if !test.admit && err == nil {
+			t.Errorf("Test: %s, expected an error", test.testName)
+		}
+
+		for _, c := range pod.Spec.InitContainers {
+			if !envSliceEquals(test.expected, c.Env) {
+				t.Errorf("Test: %s, Container %v: expected env var  %v, got %v", test.testName, c, test.expected, c.Env)
+			}
+		}
+		for _, c := range pod.Spec.Containers {
+			if !envSliceEquals(test.expected, c.Env) {
+				t.Errorf("Test: %s, Container %v: expected env var  %v, got %v", test.testName, c, test.expected, c.Env)
+			}
+		}
+	}
+}
+
+// func TestValidate(t *testing.T) {
+// 	namespace := "test"
+// 	handler := &AlwaysPullImages{}
+// 	pod := api.Pod{
+// 		ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: namespace},
+// 		Spec: api.PodSpec{
+// 			InitContainers: []api.Container{
+// 				{Name: "init1", Image: "image"},
+// 				{Name: "init2", Image: "image", ImagePullPolicy: api.PullNever},
+// 				{Name: "init3", Image: "image", ImagePullPolicy: api.PullIfNotPresent},
+// 				{Name: "init4", Image: "image", ImagePullPolicy: api.PullAlways},
+// 			},
+// 			Containers: []api.Container{
+// 				{Name: "ctr1", Image: "image"},
+// 				{Name: "ctr2", Image: "image", ImagePullPolicy: api.PullNever},
+// 				{Name: "ctr3", Image: "image", ImagePullPolicy: api.PullIfNotPresent},
+// 				{Name: "ctr4", Image: "image", ImagePullPolicy: api.PullAlways},
+// 			},
+// 		},
+// 	}
+// 	expectedError := `[` +
+// 		`pods "123" is forbidden: spec.initContainers[0].imagePullPolicy: Unsupported value: "": supported values: "Always", ` +
+// 		`pods "123" is forbidden: spec.initContainers[1].imagePullPolicy: Unsupported value: "Never": supported values: "Always", ` +
+// 		`pods "123" is forbidden: spec.initContainers[2].imagePullPolicy: Unsupported value: "IfNotPresent": supported values: "Always", ` +
+// 		`pods "123" is forbidden: spec.containers[0].imagePullPolicy: Unsupported value: "": supported values: "Always", ` +
+// 		`pods "123" is forbidden: spec.containers[1].imagePullPolicy: Unsupported value: "Never": supported values: "Always", ` +
+// 		`pods "123" is forbidden: spec.containers[2].imagePullPolicy: Unsupported value: "IfNotPresent": supported values: "Always"]`
+// 	err := handler.Validate(context.TODO(), admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil), nil)
+// 	if err == nil {
+// 		t.Fatal("missing expected error")
+// 	}
+// 	if err.Error() != expectedError {
+// 		t.Fatal(err)
+// 	}
+// }
+
+// // TestOtherResources ensures that this admission controller is a no-op for other resources,
+// // subresources, and non-pods.
+// func TestOtherResources(t *testing.T) {
+// 	namespace := "testnamespace"
+// 	name := "testname"
+// 	pod := &api.Pod{
+// 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+// 		Spec: api.PodSpec{
+// 			Containers: []api.Container{
+// 				{Name: "ctr2", Image: "image", ImagePullPolicy: api.PullNever},
+// 			},
+// 		},
+// 	}
+// 	tests := []struct {
+// 		name        string
+// 		kind        string
+// 		resource    string
+// 		subresource string
+// 		object      runtime.Object
+// 		expectError bool
+// 	}{
+// 		{
+// 			name:     "non-pod resource",
+// 			kind:     "Foo",
+// 			resource: "foos",
+// 			object:   pod,
+// 		},
+// 		{
+// 			name:        "pod subresource",
+// 			kind:        "Pod",
+// 			resource:    "pods",
+// 			subresource: "exec",
+// 			object:      pod,
+// 		},
+// 		{
+// 			name:        "non-pod object",
+// 			kind:        "Pod",
+// 			resource:    "pods",
+// 			object:      &api.Service{},
+// 			expectError: true,
+// 		},
+// 	}
+
+// 	for _, tc := range tests {
+// 		handler := admissiontesting.WithReinvocationTesting(t, &AlwaysPullImages{})
+
+// 		err := handler.Admit(context.TODO(), admission.NewAttributesRecord(tc.object, nil, api.Kind(tc.kind).WithVersion("version"), namespace, name, api.Resource(tc.resource).WithVersion("version"), tc.subresource, admission.Create, &metav1.CreateOptions{}, false, nil), nil)
+
+// 		if tc.expectError {
+// 			if err == nil {
+// 				t.Errorf("%s: unexpected nil error", tc.name)
+// 			}
+// 			continue
+// 		}
+
+// 		if err != nil {
+// 			t.Errorf("%s: unexpected error: %v", tc.name, err)
+// 			continue
+// 		}
+
+// 		if e, a := api.PullNever, pod.Spec.Containers[0].ImagePullPolicy; e != a {
+// 			t.Errorf("%s: image pull policy was changed to %s", tc.name, a)
+// 		}
+// 	}
+
+// }
+
+// // TestUpdatePod ensures that this admission controller is a no-op for update pod if no
+// // images were changed in the new pod spec.
+// func TestUpdatePod(t *testing.T) {
+// 	namespace := "testnamespace"
+// 	name := "testname"
+// 	oldPod := &api.Pod{
+// 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+// 		Spec: api.PodSpec{
+// 			Containers: []api.Container{
+// 				{Name: "ctr2", Image: "image", ImagePullPolicy: api.PullIfNotPresent},
+// 			},
+// 		},
+// 	}
+// 	// only add new annotation
+// 	pod := &api.Pod{
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name:      name,
+// 			Namespace: namespace,
+// 			Annotations: map[string]string{
+// 				"test": "test",
+// 			},
+// 		},
+// 		Spec: api.PodSpec{
+// 			Containers: []api.Container{
+// 				{Name: "ctr2", Image: "image", ImagePullPolicy: api.PullIfNotPresent},
+// 			},
+// 		},
+// 	}
+// 	// add new label and change image
+// 	podWithNewImage := &api.Pod{
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name:      name,
+// 			Namespace: namespace,
+// 			Annotations: map[string]string{
+// 				"test": "test",
+// 			},
+// 		},
+// 		Spec: api.PodSpec{
+// 			Containers: []api.Container{
+// 				{Name: "ctr2", Image: "image2", ImagePullPolicy: api.PullIfNotPresent},
+// 			},
+// 		},
+// 	}
+// 	tests := []struct {
+// 		name         string
+// 		kind         string
+// 		resource     string
+// 		subresource  string
+// 		object       runtime.Object
+// 		oldObject    runtime.Object
+// 		expectError  bool
+// 		expectIgnore bool
+// 	}{
+// 		{
+// 			name:         "update IfNotPresent pod annotations",
+// 			kind:         "Pod",
+// 			resource:     "pods",
+// 			subresource:  "finalizers",
+// 			object:       pod,
+// 			oldObject:    oldPod,
+// 			expectIgnore: true,
+// 		},
+// 		{
+// 			name:        "update IfNotPresent pod image",
+// 			kind:        "Pod",
+// 			resource:    "pods",
+// 			subresource: "finalizers",
+// 			object:      podWithNewImage,
+// 			oldObject:   oldPod,
+// 		},
+// 	}
+
+// 	for _, tc := range tests {
+// 		handler := admissiontesting.WithReinvocationTesting(t, &AlwaysPullImages{})
+
+// 		err := handler.Admit(context.TODO(), admission.NewAttributesRecord(tc.object, tc.oldObject, api.Kind(tc.kind).WithVersion("version"), namespace, name, api.Resource(tc.resource).WithVersion("version"), tc.subresource, admission.Create, &metav1.UpdateOptions{}, false, nil), nil)
+
+// 		if tc.expectError {
+// 			if err == nil {
+// 				t.Errorf("%s: unexpected nil error", tc.name)
+// 			}
+// 			continue
+// 		}
+// 		if tc.expectIgnore {
+// 			if e, a := api.PullIfNotPresent, pod.Spec.Containers[0].ImagePullPolicy; e != a {
+// 				t.Errorf("%s: image pull policy was changed to %s", tc.name, a)
+// 			}
+// 			continue
+// 		}
+
+// 		if err != nil {
+// 			t.Errorf("%s: unexpected error: %v", tc.name, err)
+// 			continue
+// 		}
+// 	}
+// }
+
+// TODO ignore order
+func envSliceEquals(expected, current []api.EnvVar) bool {
+	if len(expected) != len(current) {
+		return false
+	}
+	for i := 0; i < len(expected); i++ {
+		if expected[i] != current[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func renderPod(namespace string, env []api.EnvVar) api.Pod {
+	pod := api.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: namespace},
+		Spec: api.PodSpec{
+			InitContainers: []api.Container{
+				{Name: "init1", Image: "image", Env: env},
+			},
+			Containers: []api.Container{
+				{Name: "ctr1", Image: "image", Env: env},
+				{Name: "ctr2", Image: "image", Env: env},
+				// {Name: "ctr3", Image: "image"},
+				// {Name: "ctr4", Image: "image"},
+			},
+		},
+	}
+
+	return pod
+}
+
+// newHandlerForTest returns the admission controller configured for testing.
+func newHandlerForTest(c kubernetes.Interface) (*GlobalEnv, informers.SharedInformerFactory, error) {
+	f := informers.NewSharedInformerFactory(c, 5*time.Minute)
+	handler := NewGlobalEnv()
+	pluginInitializer := genericadmissioninitializer.New(c, f, nil, nil, nil)
+	pluginInitializer.Initialize(handler)
+	err := admission.ValidateInitialization(handler)
+	handler.SetExternalKubeInformerFactory(f)
+	handler.SetExternalKubeClientSet(c)
+	return handler, f, err
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
The open issue was opened a long time ago and keeps active.

#### Which issue(s) this PR fixes:
Fixes #48180
![image](https://user-images.githubusercontent.com/2010320/193056274-3d0ae661-02b7-4df5-9cf8-9f90e6fcff55.png)


#### Special notes for your reviewer:

This pr is an implementation of proposal 2 in https://github.com/kubernetes/kubernetes/issues/48180#issuecomment-867455423.

> Proposal 2: We can implement it as a new AdmissinoController, you can enable or disable it on the apiserver side.
> 
> A configmap: namespace kube-system configmap which is named cluster-wide-envs
> ** Or a namespace annotation named `global.env`, which works for pods in the namespace.**
> ** If enabled, the admission controller will add envFrom. configMapRef to every pod in the cluster**

env can save in multi places: the initial implement with namespace annotation.
1. in a configmap for all
2. in a configmap: key for namespace, value like A=B,C=D  
3. in namespace annotation


#### Does this PR introduce a user-facing change?
```release-note
add GlobalEnv admission controller: namespaced annotation to add default envs to pods
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
Not sure if a KEP is needed.
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/3612
```
