### PR TITLE
Automated cherry pick of #111663: Cleanup service sync path

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -86,16 +86,13 @@ type Controller struct {
 	eventRecorder       record.EventRecorder
 	nodeLister          corelisters.NodeLister
 	nodeListerSynced    cache.InformerSynced
-	// services that need to be synced
-	queue workqueue.RateLimitingInterface
-
-	// nodeSyncLock ensures there is only one instance of triggerNodeSync getting executed at one time
-	// and protects internal states (needFullSync) of nodeSync
-	nodeSyncLock sync.Mutex
-	// nodeSyncCh triggers nodeSyncLoop to run
-	nodeSyncCh chan interface{}
-	// lastSyncedNodes is used when reconciling node state and keeps track of the last synced set of
-	// nodes. Access to this attribute by multiple go-routines is protected by nodeSyncLock
+	// services and nodes that need to be synced
+	serviceQueue workqueue.RateLimitingInterface
+	nodeQueue    workqueue.RateLimitingInterface
+	// lastSyncedNodes is used when reconciling node state and keeps track of
+	// the last synced set of nodes. This field is concurrently safe because the
+	// nodeQueue is serviced by only one go-routine, so node events are not
+	// processed concurrently.
 	lastSyncedNodes []*v1.Node
 }
 
@@ -128,10 +125,9 @@ func New(
 		eventRecorder:    recorder,
 		nodeLister:       nodeInformer.Lister(),
 		nodeListerSynced: nodeInformer.Informer().HasSynced,
-		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "service"),
-		// nodeSyncCh has a size 1 buffer. Only one pending sync signal would be cached.
-		nodeSyncCh:      make(chan interface{}, 1),
-		lastSyncedNodes: []*v1.Node{},
+		serviceQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "service"),
+		nodeQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "node"),
+		lastSyncedNodes:  []*v1.Node{},
 	}
 
 	serviceInformer.Informer().AddEventHandlerWithResyncPeriod(
@@ -162,7 +158,7 @@ func New(
 	nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(cur interface{}) {
-				s.triggerNodeSync()
+				s.enqueueNode(cur)
 			},
 			UpdateFunc: func(old, cur interface{}) {
 				oldNode, ok := old.(*v1.Node)
@@ -179,13 +175,13 @@ func New(
 					return
 				}
 
-				s.triggerNodeSync()
+				s.enqueueNode(curNode)
 			},
 			DeleteFunc: func(old interface{}) {
-				s.triggerNodeSync()
+				s.enqueueNode(old)
 			},
 		},
-		time.Duration(0),
+		nodeSyncPeriod,
 	)
 
 	if err := s.init(); err != nil {
@@ -202,7 +198,17 @@ func (c *Controller) enqueueService(obj interface{}) {
 		runtime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", obj, err))
 		return
 	}
-	c.queue.Add(key)
+	c.serviceQueue.Add(key)
+}
+
+// obj could be an *v1.Service, or a DeletionFinalStateUnknown marker item.
+func (c *Controller) enqueueNode(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", obj, err))
+		return
+	}
+	c.nodeQueue.Add(key)
 }
 
 // Run starts a background goroutine that watches for changes to services that
@@ -217,7 +223,8 @@ func (c *Controller) enqueueService(obj interface{}) {
 // object.
 func (c *Controller) Run(ctx context.Context, workers int, controllerManagerMetrics *controllersmetrics.ControllerManagerMetrics) {
 	defer runtime.HandleCrash()
-	defer c.queue.ShutDown()
+	defer c.serviceQueue.ShutDown()
+	defer c.nodeQueue.ShutDown()
 
 	// Start event processing pipeline.
 	c.eventBroadcaster.StartStructuredLogging(0)
@@ -234,65 +241,60 @@ func (c *Controller) Run(ctx context.Context, workers int, controllerManagerMetr
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.UntilWithContext(ctx, c.worker, time.Second)
+		go wait.UntilWithContext(ctx, c.serviceWorker, time.Second)
 	}
 
-	go c.nodeSyncLoop(ctx, workers)
-	go wait.Until(c.triggerNodeSync, nodeSyncPeriod, ctx.Done())
+	// Initialize one go-routine servicing node events. This ensure we only
+	// process one node at any given moment in time
+	go wait.UntilWithContext(ctx, func(ctx context.Context) { c.nodeWorker(ctx, workers) }, time.Second)
 
 	<-ctx.Done()
 }
 
-// triggerNodeSync triggers a nodeSync asynchronously
-func (c *Controller) triggerNodeSync() {
-	c.nodeSyncLock.Lock()
-	defer c.nodeSyncLock.Unlock()
-	select {
-	case c.nodeSyncCh <- struct{}{}:
-		klog.V(4).Info("Triggering nodeSync")
-		return
-	default:
-		klog.V(4).Info("A pending nodeSync is already in queue")
-		return
+// worker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (c *Controller) serviceWorker(ctx context.Context) {
+	for c.processNextServiceItem(ctx) {
 	}
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 // It enforces that the syncHandler is never invoked concurrently with the same key.
-func (c *Controller) worker(ctx context.Context) {
-	for c.processNextWorkItem(ctx) {
+func (c *Controller) nodeWorker(ctx context.Context, workers int) {
+	for c.processNextNodeItem(ctx, workers) {
 	}
 }
 
-// nodeSyncLoop takes nodeSync signal and triggers nodeSync
-func (c *Controller) nodeSyncLoop(ctx context.Context, workers int) {
-	klog.V(4).Info("nodeSyncLoop Started")
-	for {
-		select {
-		case <-c.nodeSyncCh:
-			klog.V(4).Info("nodeSync has been triggered")
-			c.nodeSyncInternal(ctx, workers)
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-func (c *Controller) processNextWorkItem(ctx context.Context) bool {
-	key, quit := c.queue.Get()
+func (c *Controller) processNextNodeItem(ctx context.Context, workers int) bool {
+	key, quit := c.nodeQueue.Get()
 	if quit {
 		return false
 	}
-	defer c.queue.Done(key)
+	defer c.nodeQueue.Done(key)
+
+	for serviceToRetry := range c.syncNodes(ctx, workers) {
+		c.serviceQueue.Add(serviceToRetry)
+	}
+
+	c.nodeQueue.Forget(key)
+	return true
+}
+
+func (c *Controller) processNextServiceItem(ctx context.Context) bool {
+	key, quit := c.serviceQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.serviceQueue.Done(key)
 
 	err := c.syncService(ctx, key.(string))
 	if err == nil {
-		c.queue.Forget(key)
+		c.serviceQueue.Forget(key)
 		return true
 	}
 
 	runtime.HandleError(fmt.Errorf("error processing service %v (will retry): %v", key, err))
-	c.queue.AddRateLimited(key)
+	c.serviceQueue.AddRateLimited(key)
 	return true
 }
 
@@ -675,13 +677,13 @@ func shouldSyncUpdatedNode(oldNode, newNode *v1.Node) bool {
 	return respectsPredicates(oldNode, allNodePredicates...) != respectsPredicates(newNode, allNodePredicates...)
 }
 
-// nodeSyncInternal handles updating the hosts pointed to by all load
+// syncNodes handles updating the hosts pointed to by all load
 // balancers whenever the set of nodes in the cluster changes.
-func (c *Controller) nodeSyncInternal(ctx context.Context, workers int) {
+func (c *Controller) syncNodes(ctx context.Context, workers int) sets.String {
 	startTime := time.Now()
 	defer func() {
 		latency := time.Since(startTime).Seconds()
-		klog.V(4).Infof("It took %v seconds to finish nodeSyncInternal", latency)
+		klog.V(4).Infof("It took %v seconds to finish syncNodes", latency)
 		nodeSyncLatency.Observe(latency)
 	}()
 
@@ -691,6 +693,7 @@ func (c *Controller) nodeSyncInternal(ctx context.Context, workers int) {
 	servicesToRetry := c.updateLoadBalancerHosts(ctx, servicesToUpdate, workers)
 	klog.V(2).Infof("Successfully updated %d out of %d load balancers to direct traffic to the updated set of nodes",
 		numServices-len(servicesToRetry), numServices)
+	return servicesToRetry
 }
 
 // nodeSyncService syncs the nodes for one load balancer type service. The return value

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,8 +47,6 @@ import (
 	servicehelper "k8s.io/cloud-provider/service/helpers"
 
 	utilpointer "k8s.io/utils/pointer"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const region = "us-central"
@@ -101,7 +100,6 @@ func newController() (*Controller, *fakecloud.Cloud, *fake.Clientset) {
 
 	controller := &Controller{
 		cloud:            cloud,
-		knownHosts:       []*v1.Node{},
 		kubeClient:       kubeClient,
 		clusterName:      "test-cluster",
 		cache:            &serviceCache{serviceMap: make(map[string]*cachedService)},
@@ -566,7 +564,6 @@ func TestUpdateNodesInExternalLoadBalancer(t *testing.T) {
 			defer cancel()
 			controller, cloud, _ := newController()
 			controller.nodeLister = newFakeNodeLister(nil, nodes...)
-
 			if servicesToRetry := controller.updateLoadBalancerHosts(ctx, item.services, item.workers); len(servicesToRetry) != 0 {
 				t.Errorf("for case %q, unexpected servicesToRetry: %v", item.desc, servicesToRetry)
 			}
@@ -1513,28 +1510,6 @@ func TestServiceCache(t *testing.T) {
 		if err := tc.checkCacheFn(); err != nil {
 			t.Errorf("%v returned %v", tc.testName, err)
 		}
-	}
-}
-
-// Test a utility functions as it's not easy to unit test nodeSyncInternal directly
-func TestNodeSlicesEqualForLB(t *testing.T) {
-	numNodes := 10
-	nArray := make([]*v1.Node, numNodes)
-	mArray := make([]*v1.Node, numNodes)
-	for i := 0; i < numNodes; i++ {
-		nArray[i] = &v1.Node{}
-		nArray[i].Name = fmt.Sprintf("node%d", i)
-	}
-	for i := 0; i < numNodes; i++ {
-		mArray[i] = &v1.Node{}
-		mArray[i].Name = fmt.Sprintf("node%d", i+1)
-	}
-
-	if !nodeSlicesEqualForLB(nArray, nArray) {
-		t.Errorf("nodeSlicesEqualForLB() Expected=true Obtained=false")
-	}
-	if nodeSlicesEqualForLB(nArray, mArray) {
-		t.Errorf("nodeSlicesEqualForLB() Expected=false Obtained=true")
 	}
 }
 
@@ -3225,32 +3200,6 @@ func TestTriggerNodeSync(t *testing.T) {
 	tryReadFromChannel(t, controller.nodeSyncCh, false)
 	tryReadFromChannel(t, controller.nodeSyncCh, false)
 	tryReadFromChannel(t, controller.nodeSyncCh, false)
-}
-
-func TestMarkAndUnmarkFullSync(t *testing.T) {
-	controller, _, _ := newController()
-	if controller.needFullSync != false {
-		t.Errorf("expect controller.needFullSync to be false, but got true")
-	}
-
-	ret := controller.needFullSyncAndUnmark()
-	if ret != false {
-		t.Errorf("expect ret == false, but got true")
-	}
-
-	ret = controller.needFullSyncAndUnmark()
-	if ret != false {
-		t.Errorf("expect ret == false, but got true")
-	}
-	controller.needFullSync = true
-	ret = controller.needFullSyncAndUnmark()
-	if ret != true {
-		t.Errorf("expect ret == true, but got false")
-	}
-	ret = controller.needFullSyncAndUnmark()
-	if ret != false {
-		t.Errorf("expect ret == false, but got true")
-	}
 }
 
 func tryReadFromChannel(t *testing.T, ch chan interface{}, expectValue bool) {


### PR DESCRIPTION
Cherry pick of #111663 on release-1.25.

#111663: Cleanup service sync path

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix sync for services of (type:LoadBalancer,ExternalTrafficPolicy=Local) and node events. This causes the load balancer backend set to be de-synced from the Kubernetes set of nodes which the service load balancer should reference   
```

Fixes https://github.com/kubernetes/kubernetes/issues/112793

In-depth explanation:

I didn't realize the full importance of #111663. The original PR that merged on 1.25 (https://github.com/kubernetes/kubernetes/pull/109706) introduced a change to how we sync load balancers, namely for ETP=Local we avoid looking at any nodes' readiness condition, i.e: nodes that are `NotReady` get added to the load balancer's set of nodes. This set constitutes the load balancers "backend pool" for traffic load balancing. This is not the case for ETP=Cluster. The set of nodes hence depends on the class of service, and the set of nodes will be larger for ETP=Local (since again, it also contains `NotReady` nodes which ETP=Cluster do not have). One can hence denote the set of nodes for ETP=Local to be the "superset", and the set of nodes for ETP=Cluster the "subset" when comparing both classes of services (i.e: all nodes in ETP=Cluster will always be in the set of nodes for ETP=Local, but not vice-versa). 

In the CCM's node sync loop we enqueue node changes by:

- Node ADD
- Node DELETE
- Node UPDATE (but only if the update is interesting to us, which is determined by `shouldSyncUpdatedNode`) 

A Node UPDATE is interesting to us if the following fields are modified on the Node object:

- Gets the label `node.kubernetes.io/exclude-from-external-load-balancers` added/removed
- Gets the taint `ToBeDeletedByClusterAutoscaler ` added/removed
- Gets the condition `Ready` changed to either `True` or `False`

Currently on 1.25: when the update is "enqueued" the node is processed in `triggerNodeSync` by means of[ listing all the nodes from the informer cache and applying `allNodePredicates` on the set](https://github.com/kubernetes/kubernetes/blob/release-1.25/staging/src/k8s.io/cloud-provider/controllers/service/controller.go#L264), which will filter all the nodes out that:

- Have the label `node.kubernetes.io/exclude-from-external-load-balancers`
- Have the taint `ToBeDeletedByClusterAutoscaler`
- Have the condition `Ready` equal to `False`

This is essentially the set of nodes that apply to the ETP=Cluster class of services. Again: the subset of nodes when considering the set per service class. 

[In `triggerNodeSync` we store the old set of nodes we processed last time (`knownHosts`) to be the subset corresponding to ETP=Cluster](https://github.com/kubernetes/kubernetes/blob/release-1.25/staging/src/k8s.io/cloud-provider/controllers/service/controller.go#L277). This field `knownHosts` is then used to compare to the current set of nodes matching the same predicates (again: predicates which correspond to the ETP=Cluster case)...and if the set is equal, we only perform a "partial sync". A "partial sync" here is defined as a sync which only syncs all _failed_ services which were synced in the last iteration. This is often empty. Once this happens we execute `updateLoadBalancerHosts` which will fetch all the nodes from the informer cache (denoted "new nodes") and store them as `lastSyncedNodes` (denoted "old nodes" since these are to be used in the next sync). Whenever we sync services (in `nodeSyncService`) we then use "new nodes" and "old nodes" and apply the predicates that correspond to that service type and check if there's an update to the set, that is interesting to that class of service.

Conclusion: we are trying to reduce the amount of cloud provider sync calls that the CCM performs (because syncing load balancers is somewhat "expensive"). We are trying to be smart about it by comparing the old vs. new set of nodes to detect if there is a change in the set that applies for that service class. If we do that: then we can't really be triggering the sync in `triggerNodeSync` by comparing the set of nodes that only correspond to ETP=Cluster. We will miss "essential" events for ETP=Local. "Essential" meaning: that is the moment the set of nodes change for the ETP=Local case and which will require updating all load balancers for ETP=Local services! 

#111663 performed some nice clean up in the CCM and reduced this logical complexity by quite a bit. 

Essentially, on master `triggerNodeSync` has been completely removed. So now when a node is enqueued from the event handlers we _always_ re-sync all services in the cache because we know this update is interesting _to at least some_ services, irrespective of their service class! On 1.25: this additional "comparison" in `triggerNodeSync` might "cancel" the enqueued update, as I mentioned above. This is why the bug does not happen on 1.26 but only on 1.25. 

The proper fix is thus backporting the PR to 1.25 and making sure we always sync all services in our cache whenever we receive an enqueued node event. 

We can also perform a smaller change on 1.25 and completely remove the partial vs. full sync logic in`triggerNodeSync`, but I think it's better to align the branches and "do it by the book", which is: cherry-pick and converge the branch logic instead of having the branch logic diverge.  

/assign @thockin 
/sig network
/sig cloud-provider
/cc @swetharepakula 
/cc @panslava   
/kind bug
/kind regression