### PR TITLE
e2e storage: add Rename to PodIO

### DIFF
--- a/test/e2e/storage/drivers/csi-test/mock/service/service.go
+++ b/test/e2e/storage/drivers/csi-test/mock/service/service.go
@@ -71,6 +71,9 @@ type DirIO interface {
 	Mkdir(path string) error
 	// RemoveAll removes the path and everything contained inside it. It's not an error if the path does not exist.
 	RemoveAll(path string) error
+	// Rename changes the name of a file or directory. The parent directory
+	// of newPath must exist.
+	Rename(oldPath, newPath string) error
 }
 
 type OSDirIO struct{}
@@ -95,6 +98,10 @@ func (o OSDirIO) Mkdir(path string) error {
 
 func (o OSDirIO) RemoveAll(path string) error {
 	return os.RemoveAll(path)
+}
+
+func (o OSDirIO) Rename(oldPath, newPath string) error {
+	return os.Rename(oldPath, newPath)
 }
 
 // Service is the CSI Mock service provider.

--- a/test/e2e/storage/drivers/proxy/io.go
+++ b/test/e2e/storage/drivers/proxy/io.go
@@ -70,6 +70,14 @@ func (p PodDirIO) CreateFile(path string, content io.Reader) error {
 	return nil
 }
 
+func (p PodDirIO) Rename(oldPath, newPath string) error {
+	_, stderr, err := p.execute([]string{"mv", oldPath, newPath}, nil)
+	if err != nil {
+		return fmt.Errorf("rename %q -> %q: stderr=%q, %v", oldPath, newPath, stderr, err)
+	}
+	return nil
+}
+
 func (p PodDirIO) RemoveAll(path string) error {
 	_, stderr, err := p.execute([]string{"rm", "-rf", path}, nil)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is useful for atomic file creation: first create a temporary file, then rename it.

#### Special notes for your reviewer:

Will be needed for https://github.com/kubernetes/kubernetes/pull/111023

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
