### PR TITLE
test: demote service ClientIP affinity timeout tests from conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1597,38 +1597,6 @@
     named Kubernetes with the Namespace of default.
   release: v1.18
   file: test/e2e/network/service.go
-- testname: Service, NodePort type, session affinity to ClientIP with timeout
-  codename: '[sig-network] Services should have session affinity timeout work for
-    NodePort service [LinuxOnly] [Conformance]'
-  description: 'Create a service of type "NodePort" and provide service port and protocol.
-    Service''s sessionAffinity is set to "ClientIP" and session affinity timeout is
-    set. Service creation MUST be successful by assigning a "ClusterIP" to service
-    and allocating NodePort on all nodes. Create a Replication Controller to ensure
-    that 3 pods are running and are targeted by the service to serve hostname of the
-    pod when requests are sent to the service. Create another pod to make requests
-    to the service on node''s IP and NodePort. Service MUST serve the hostname from
-    the same pod of the replica for all consecutive requests until timeout. After
-    timeout, requests MUST be served from different pods of the replica. Service MUST
-    be reachable over serviceName and the ClusterIP on servicePort. Service MUST also
-    be reachable over node''s IP on NodePort. [LinuxOnly]: Windows does not support
-    session affinity.'
-  release: v1.19
-  file: test/e2e/network/service.go
-- testname: Service, ClusterIP type, session affinity to ClientIP with timeout
-  codename: '[sig-network] Services should have session affinity timeout work for
-    service with type clusterIP [LinuxOnly] [Conformance]'
-  description: 'Create a service of type "ClusterIP". Service''s sessionAffinity is
-    set to "ClientIP" and session affinity timeout is set. Service creation MUST be
-    successful by assigning "ClusterIP" to the service. Create a Replication Controller
-    to ensure that 3 pods are running and are targeted by the service to serve hostname
-    of the pod when requests are sent to the service. Create another pod to make requests
-    to the service. Service MUST serve the hostname from the same pod of the replica
-    for all consecutive requests until timeout expires. After timeout, requests MUST
-    be served from different pods of the replica. Service MUST be reachable over serviceName
-    and the ClusterIP on servicePort. [LinuxOnly]: Windows does not support session
-    affinity.'
-  release: v1.19
-  file: test/e2e/network/service.go
 - testname: Service, NodePort type, session affinity to ClientIP
   codename: '[sig-network] Services should have session affinity work for NodePort
     service [LinuxOnly] [Conformance]'

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2199,17 +2199,7 @@ var _ = common.SIGDescribe("Services", func() {
 		execAffinityTestForNonLBService(f, cs, svc)
 	})
 
-	/*
-		Release: v1.19
-		Testname: Service, ClusterIP type, session affinity to ClientIP with timeout
-		Description: Create a service of type "ClusterIP". Service's sessionAffinity is set to "ClientIP" and session affinity timeout is set. Service creation MUST be successful by assigning "ClusterIP" to the service.
-		Create a Replication Controller to ensure that 3 pods are running and are targeted by the service to serve hostname of the pod when requests are sent to the service.
-		Create another pod to make requests to the service. Service MUST serve the hostname from the same pod of the replica for all consecutive requests until timeout expires.
-		After timeout, requests MUST be served from different pods of the replica.
-		Service MUST be reachable over serviceName and the ClusterIP on servicePort.
-		[LinuxOnly]: Windows does not support session affinity.
-	*/
-	framework.ConformanceIt("should have session affinity timeout work for service with type clusterIP [LinuxOnly]", func() {
+	ginkgo.It("should have session affinity timeout work for service with type clusterIP [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-clusterip-timeout")
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		execAffinityTestForSessionAffinityTimeout(f, cs, svc)
@@ -2246,18 +2236,7 @@ var _ = common.SIGDescribe("Services", func() {
 		execAffinityTestForNonLBService(f, cs, svc)
 	})
 
-	/*
-		Release: v1.19
-		Testname: Service, NodePort type, session affinity to ClientIP with timeout
-		Description: Create a service of type "NodePort" and provide service port and protocol. Service's sessionAffinity is set to "ClientIP" and session affinity timeout is set.
-		Service creation MUST be successful by assigning a "ClusterIP" to service and allocating NodePort on all nodes.
-		Create a Replication Controller to ensure that 3 pods are running and are targeted by the service to serve hostname of the pod when requests are sent to the service.
-		Create another pod to make requests to the service on node's IP and NodePort. Service MUST serve the hostname from the same pod of the replica for all consecutive requests until timeout.
-		After timeout, requests MUST be served from different pods of the replica.
-		Service MUST be reachable over serviceName and the ClusterIP on servicePort. Service MUST also be reachable over node's IP on NodePort.
-		[LinuxOnly]: Windows does not support session affinity.
-	*/
-	framework.ConformanceIt("should have session affinity timeout work for NodePort service [LinuxOnly]", func() {
+	ginkgo.It("should have session affinity timeout work for NodePort service [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-nodeport-timeout")
 		svc.Spec.Type = v1.ServiceTypeNodePort
 		execAffinityTestForSessionAffinityTimeout(f, cs, svc)


### PR DESCRIPTION
During the September 29th, 2022 SIG-Network meeting we decided to demote the two affinity timeout conformance tests. This was because:

- there is no documented correct behavior for these tests other than "what kube-proxy does"
- even the kube-proxy behavior differs depending on the backend implementation of iptables, IPVS, or [win]userspace (and winkernel doesn't at all)
- iptables uses only srcip matching, while userspace and IPVS use srcip+srcport
- IPVS and iptables have different minimum timeouts and we had to hack up the test itself to make IPVS pass
- popular 3rd party network plugins also vary in their implementation

Our plan is to deprecate the current affinity options and re-add specific options for various behaviors so it's clear exactly what plugins support and which behavior (if any) we want to require for conformance in the future.

/kind cleanup

```release-note
Service session affinity timeout tests are no longer required for Kubernetes network plugin conformance due to variations in existing implementations. New conformance tests will be developed to better express conformance in future releases.
```

@thockin @danwinship @aojea @kubernetes/sig-network-misc 