### PR TITLE
kubelet/stats: Don't use cAdvisor CPU/Memory stats when not initialized

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -840,6 +840,20 @@ func removeTerminatedContainers(containers []*runtimeapi.Container) []*runtimeap
 	return result
 }
 
+func cpuStatsInitialized(cpu *statsapi.CPUStats) bool {
+	return cpu != nil &&
+		(*cpu.UsageCoreNanoSeconds != 0 || *cpu.UsageNanoCores != 0)
+}
+
+func memoryStatsInitialized(memory *statsapi.MemoryStats) bool {
+	return memory != nil &&
+		(*memory.UsageBytes != 0 ||
+			*memory.WorkingSetBytes != 0 ||
+			*memory.MajorPageFaults != 0 ||
+			*memory.PageFaults != 0 ||
+			*memory.RSSBytes != 0)
+}
+
 func (p *criStatsProvider) addCadvisorContainerStats(
 	cs *statsapi.ContainerStats,
 	caPodStats *cadvisorapiv2.ContainerInfo,
@@ -849,10 +863,10 @@ func (p *criStatsProvider) addCadvisorContainerStats(
 	}
 
 	cpu, memory := cadvisorInfoToCPUandMemoryStats(caPodStats)
-	if cpu != nil {
+	if cpuStatsInitialized(cpu) {
 		cs.CPU = cpu
 	}
-	if memory != nil {
+	if memoryStatsInitialized(memory) {
 		cs.Memory = memory
 	}
 }
@@ -866,10 +880,10 @@ func (p *criStatsProvider) addCadvisorContainerCPUAndMemoryStats(
 	}
 
 	cpu, memory := cadvisorInfoToCPUandMemoryStats(caPodStats)
-	if cpu != nil {
+	if cpuStatsInitialized(cpu) {
 		cs.CPU = cpu
 	}
-	if memory != nil {
+	if memoryStatsInitialized(memory) {
 		cs.Memory = memory
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
cAdvisor gets container stats from cgroupfs, but there are cases where this does not yield correct usage information. Namely, gVisor containers do not support cgroupfs, and these stats must be queried through CRI.

This does not change the default source of container stats from cAdvisor to CRI, but rather detects a case where it doesn't make sense to overwrite CRI stats. In the case of gVisor containers, cAdvisor will output CPU/Memory as all zeroes, hence we should prefer the stats queried from the CRI. Other container types that can be queried through cgroupfs will continue to prefer cAdvisor.

Another related issue is https://github.com/kubernetes/kubernetes/issues/107172, however this does not attempt to fix the case of arbitrary mock stats.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
