### PR TITLE
Avoid tainting with NoSchedule when DisableCloudProviders feature is on

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -32,12 +32,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	cloudprovider "k8s.io/cloud-provider"
 	cloudproviderapi "k8s.io/cloud-provider/api"
 	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/klog/v2"
 	kubeletapis "k8s.io/kubelet/pkg/apis"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/nodestatus"
 	"k8s.io/kubernetes/pkg/kubelet/util"
@@ -328,7 +330,13 @@ func (kl *Kubelet) initialNode(ctx context.Context) (*v1.Node, error) {
 			Effect: v1.TaintEffectNoSchedule,
 		}
 
-		nodeTaints = append(nodeTaints, taint)
+		// Disable functionality in kubelet related to the `--cloud-provider` component flag.
+		if !utilfeature.DefaultFeatureGate.Enabled(features.DisableCloudProviders) {
+			klog.InfoS("feature DisableCloudProviders is on, disabling taint",
+				"taint", cloudproviderapi.TaintExternalCloudProvider,
+				"effect", v1.TaintEffectNoSchedule)
+			nodeTaints = append(nodeTaints, taint)
+		}
 	}
 	if len(nodeTaints) > 0 {
 		node.Spec.Taints = nodeTaints


### PR DESCRIPTION
Context:
We have a long standing enhancement here - [KEP-2395](https://github.com/kubernetes/enhancements/issues/2395). To make progress we have a feature gate named `DisableCloudProviders` and we have some CI jobs:
- presubmit : https://testgrid.k8s.io/google-gce#pull-e2e-gce-cloud-provider-disabled
- periodic : https://testgrid.k8s.io/google-gce#disable-cloud-provider

Unfortunately these jobs are currently failing because when we switch on the flag above and when `cloud-provider` is set to `external` we add taints`"node.cloudprovider.kubernetes.io/uninitialized"` with `effect: NoSchedule`.

since in these jobs, we do NOT have an external cloud provider running like we have in this job, there is no one to clear these taints as documented in:
https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager

So when this feature flag is on DisableCloudProviders, we need to ensure that the taints will not be applied so that pods can be scheduled and the test cases are run properly.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

NOTE: even with this PR, the CI jobs will not be green. With this patch at least a bunch of tests go green and we have to come up with a plan to deal with failures once we know which categories of tests do not pass.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
