### PR TITLE
Automated cherry pick of #112837: Fix winkernel proxier setting the wrong HNS loadbalancer ID

### DIFF
--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -1371,8 +1371,6 @@ func (proxier *Proxier) syncProxyRules() {
 			} else {
 				klog.V(3).InfoS("Skipped creating Hns LoadBalancer for loadBalancer Ingress resources", "lbIngressIP", lbIngressIP)
 			}
-			lbIngressIP.hnsID = hnsLoadBalancer.hnsID
-			klog.V(3).InfoS("Hns LoadBalancer resource created for loadBalancer Ingress resources", "lbIngressIP", lbIngressIP)
 
 			if proxier.forwardHealthCheckVip && gatewayHnsendpoint != nil {
 				nodeport := proxier.healthzPort


### PR DESCRIPTION
Cherry pick of #112837 on release-1.25.

#112837: Fix winkernel proxier setting the wrong HNS loadbalancer ID

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.24 regression in winkernel proxier that causes proxy rules to leak anytime service backends are modified.
```
