### PR TITLE
Update_ineligible_endpoints.yaml : add createAuthorizationV1SelfSubjectRulesReview to the list

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -445,3 +445,6 @@
 - endpoint: createCoreV1NamespacedBinding
   reason: Endpoint was deprecated in 1.7
   link: https://github.com/kubernetes/kubernetes/pull/47041  
+- endpoint: createAuthorizationV1SelfSubjectRulesReview
+  reason: Endpoint likely to be deprected
+  link: https://github.com/kubernetes/kubernetes/issues/112657#issuecomment-1265441626  

--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -446,5 +446,5 @@
   reason: Endpoint was deprecated in 1.7
   link: https://github.com/kubernetes/kubernetes/pull/47041  
 - endpoint: createAuthorizationV1SelfSubjectRulesReview
-  reason: Endpoint likely to be deprected
+  reason: Endpoint likely to be deprecated
   link: https://github.com/kubernetes/kubernetes/issues/112657#issuecomment-1265441626  


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
As discussed in Issue #112657 the endpoint should likely be depricated.
The endpoint is moved to the Inelegible endpoint list. 
The list would be revisited in 2023 to check of all endpoints on the list are still ineligble.
- createAuthorizationV1SelfSubjectRulesReview

**Special notes for your reviewer:**

**Which issue(s) this PR fixes:**
#112657 

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig architecture
/area conformance
/sig api-machinery