### PR TITLE
Do not use variables named 'l', 'O', or 'I' Because it is confusing  with some variable like '1', '0'

### DIFF
--- a/hack/verify-flags-underscore.py
+++ b/hack/verify-flags-underscore.py
@@ -109,9 +109,9 @@ def check_underscore_in_flags(rootdir, files):
     if len(new_excluded_flags) != 0:
         print("Found a flag declared with an _ but which is not explicitly listed as a valid flag name in hack/verify-flags/excluded-flags.txt")
         print("Are you certain this flag should not have been declared with an - instead?")
-        l = list(new_excluded_flags)
-        l.sort()
-        print("%s" % "\n".join(l))
+        L = list(new_excluded_flags)
+        L.sort()
+        print("%s" % "\n".join(L))
         sys.exit(1)
 
 def main():


### PR DESCRIPTION
###Description
Variables named I, O, and l can be very hard to read. This is because the letter I and the letter l are easily confused, and the letter O and the number 0 can be easily confused.

-->

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Change the names of these variables to something more descriptive. Because it is confusing with some variable and number



