### PR TITLE
moved the downloading of the node_perf tensorflow test-data artifact …

### DIFF
--- a/test/images/node-perf/tf-wide-deep/Dockerfile
+++ b/test/images/node-perf/tf-wide-deep/Dockerfile
@@ -32,7 +32,9 @@ RUN wget https://github.com/tensorflow/models/archive/v1.9.0.tar.gz \
 && tar xzf v1.9.0.tar.gz \
 && rm -f v1.9.0.tar.gz
 
+RUN python /models-1.9.0/official/wide_deep/data_download.py
+
 WORKDIR $HOME/models-1.9.0/official/wide_deep
 ENV PYTHONPATH=$PYTHONPATH:$HOME/models-1.9.0
 
-ENTRYPOINT python ./data_download.py && python ./wide_deep.py
+ENTRYPOINT python ./wide_deep.py


### PR DESCRIPTION
…into the Dockerfile to be downloaded at image-build time 109295

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

one of the node perf tests has been failing

the test case is not able to download its required dataset due to the endpoint being inaccessible

this PR moves the dataset download into the docker file where it will be pulled at image-build time.

the theory is that the image build server might be able to access the endpoint

if this is true this PR should turn the test green

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #109295

#### Special notes for your reviewer:

lots of discussion in #109295 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
