### PR TITLE
Add ability to pass format options in mount-utils

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount.go
+++ b/staging/src/k8s.io/mount-utils/mount.go
@@ -165,7 +165,15 @@ func (mounter *SafeFormatAndMount) FormatAndMount(source string, target string, 
 // be used by callers that pass sensitive material (like passwords) as mount
 // options.
 func (mounter *SafeFormatAndMount) FormatAndMountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
-	return mounter.formatAndMountSensitive(source, target, fstype, options, sensitiveOptions)
+	return mounter.FormatAndMountSensitiveWithFormatOptions(source, target, fstype, options, sensitiveOptions, nil /* formatOptions */)
+}
+
+// FormatAndMountSensitiveWithFormatOptions behaves exactly the same as
+// FormatAndMountSensitive, but allows for options to be passed when the disk
+// is formatted. These options are NOT validated in any way and should never
+// come directly from untrusted user input as that would be an injection risk.
+func (mounter *SafeFormatAndMount) FormatAndMountSensitiveWithFormatOptions(source string, target string, fstype string, options []string, sensitiveOptions []string, formatOptions []string) error {
+	return mounter.formatAndMountSensitive(source, target, fstype, options, sensitiveOptions, formatOptions)
 }
 
 // getMountRefsByDev finds all references to the device provided

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -469,7 +469,7 @@ func (mounter *SafeFormatAndMount) checkAndRepairFilesystem(source string) error
 }
 
 // formatAndMount uses unix utils to format and mount the given disk
-func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string, formatOptions []string) error {
 	readOnly := false
 	for _, option := range options {
 		if option == "ro" {
@@ -521,6 +521,7 @@ func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target
 				source,
 			}
 		}
+		args = append(formatOptions, args...)
 
 		klog.Infof("Disk %q appears to be unformatted, attempting to format as type: %q with options: %v", source, fstype, args)
 		output, err := mounter.Exec.Command("mkfs."+fstype, args...).CombinedOutput()

--- a/staging/src/k8s.io/mount-utils/mount_unsupported.go
+++ b/staging/src/k8s.io/mount-utils/mount_unsupported.go
@@ -90,7 +90,7 @@ func (mounter *Mounter) GetMountRefs(pathname string) ([]string, error) {
 	return nil, errUnsupported
 }
 
-func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string, formatOptions []string) error {
 	return mounter.Interface.Mount(source, target, fstype, options)
 }
 

--- a/staging/src/k8s.io/mount-utils/mount_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_windows.go
@@ -273,7 +273,7 @@ func (mounter *Mounter) GetMountRefs(pathname string) ([]string, error) {
 	return []string{pathname}, nil
 }
 
-func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string, formatOptions []string) error {
 	// Try to mount the disk
 	klog.V(4).Infof("Attempting to formatAndMount disk: %s %s %s", fstype, source, target)
 
@@ -288,8 +288,12 @@ func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target
 	}
 
 	// format disk if it is unformatted(raw)
+	formatOptionsUnwrapped := ""
+	if len(formatOptions) > 0 {
+		formatOptionsUnwrapped = " " + strings.Join(formatOptions, " ")
+	}
 	cmd := fmt.Sprintf("Get-Disk -Number %s | Where partitionstyle -eq 'raw' | Initialize-Disk -PartitionStyle GPT -PassThru"+
-		" | New-Partition -UseMaximumSize | Format-Volume -FileSystem %s -Confirm:$false", source, fstype)
+		" | New-Partition -UseMaximumSize | Format-Volume -FileSystem %s -Confirm:$false%s", source, fstype, formatOptionsUnwrapped)
 	if output, err := mounter.Exec.Command("powershell", "/c", cmd).CombinedOutput(); err != nil {
 		return fmt.Errorf("diskMount: format disk failed, error: %v, output: %q", err, string(output))
 	}

--- a/staging/src/k8s.io/mount-utils/safe_format_and_mount_test.go
+++ b/staging/src/k8s.io/mount-utils/safe_format_and_mount_test.go
@@ -68,6 +68,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 		fstype                string
 		mountOptions          []string
 		sensitiveMountOptions []string
+		formatOptions         []string
 		execScripts           []ExecArgs
 		mountErrs             []error
 		expErrorType          MountErrorType
@@ -213,6 +214,15 @@ func TestSafeFormatAndMount(t *testing.T) {
 			},
 			expErrorType: FormatFailed,
 		},
+		{
+			description:   "Test that 'blkid' is called and confirms unformatted disk, format passes, mount passes (with format options)",
+			fstype:        "ext4",
+			formatOptions: []string{"-b", "1024"},
+			execScripts: []ExecArgs{
+				{"blkid", []string{"-p", "-s", "TYPE", "-s", "PTTYPE", "-o", "export", "/dev/foo"}, "", &testingexec.FakeExitError{Status: 2}},
+				{"mkfs.ext4", []string{"-b", "1024", "-F", "-m0", "/dev/foo"}, "", nil},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -233,7 +243,9 @@ func TestSafeFormatAndMount(t *testing.T) {
 		device := "/dev/foo"
 		dest := mntDir
 		var err error
-		if len(test.sensitiveMountOptions) == 0 {
+		if len(test.formatOptions) > 0 {
+			err = mounter.FormatAndMountSensitiveWithFormatOptions(device, dest, test.fstype, test.mountOptions, test.sensitiveMountOptions, test.formatOptions)
+		} else if len(test.sensitiveMountOptions) == 0 {
 			err = mounter.FormatAndMount(device, dest, test.fstype, test.mountOptions)
 		} else {
 			err = mounter.FormatAndMountSensitive(device, dest, test.fstype, test.mountOptions, test.sensitiveMountOptions)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
/sig storage

#### What this PR does / why we need it:

We over at the [aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) have a user request to customize the block size of created volumes. We use `mount-utils` to mount/format volumes. `mount-utils` allows passing in custom mount options, but not custom format options. This PR adds that.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

I was torn between modifying the existing functions, or adding a new one with the ability to specify format options. I eventually opted for the latter, but I'm not particularly confident on my decision here so let me know if you think modifying the existing functions would be better.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
