### PR TITLE
wire up feature-gate for component slis

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -169,7 +169,6 @@ func TestNewWithDelegate(t *testing.T) {
 		"/livez/poststarthook/storage-object-count-tracker-hook",
 		"/livez/poststarthook/wrapping-post-start-hook",
 		"/metrics",
-		"/metrics/slis",
 		"/readyz",
 		"/readyz/delegate-health",
 		"/readyz/informer-sync",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1973,6 +1973,7 @@ k8s.io/component-base/logs/klogflags
 k8s.io/component-base/logs/logreduction
 k8s.io/component-base/logs/testinit
 k8s.io/component-base/metrics
+k8s.io/component-base/metrics/features
 k8s.io/component-base/metrics/legacyregistry
 k8s.io/component-base/metrics/prometheus/clientgo
 k8s.io/component-base/metrics/prometheus/clientgo/leaderelection


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Puts `/metrics/slis` behind a feature gate. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Introduce `ComponentSLIs` alpha feature-gate for component SLIs metrics endpoint.
```

