### PR TITLE
Updating kube-proxy base impage to distroless-iptables:v0.1.2

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -90,7 +90,7 @@ readonly KUBE_RSYNC_PORT="${KUBE_RSYNC_PORT:-}"
 readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_distroless_iptables_version=v0.1.1
+readonly __default_distroless_iptables_version=v0.1.2
 readonly __default_go_runner_version=v2.3.1-go1.19.1-bullseye.0
 readonly __default_setcap_version=bullseye-v1.3.0
 

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -131,7 +131,7 @@ dependencies:
       match: BASE_IMAGE_VERSION\?=
 
   - name: "registry.k8s.io/distroless-iptables: dependents"
-    version: v0.1.1
+    version: v0.1.2
     refPaths:
     - path: build/common.sh
       match: __default_distroless_iptables_version=

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -240,7 +240,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.29-2"}
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.2"}
-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.1.1"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.1.2"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.5-0"}
 	configs[GlusterDynamicProvisioner] = Config{list.PromoterE2eRegistry, "glusterdynamic-provisioner", "v1.3"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-2"}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This bumps the version of distroless-iptables to patch CVEs. For more info, refer to https://github.com/kubernetes/release/pull/2667.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig network
/priority important-soon
/triage accepted