### PR TITLE
releng: Update images, dependencies and version to Go 1.19.2

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.25.0-go1.19.1-bullseye.0
+v1.25.0-go1.19.2-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -91,7 +91,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
 readonly __default_distroless_iptables_version=v0.1.2
-readonly __default_go_runner_version=v2.3.1-go1.19.1-bullseye.0
+readonly __default_go_runner_version=v2.3.1-go1.19.2-bullseye.0
 readonly __default_setcap_version=bullseye-v1.3.0
 
 # These are the base images for the Docker-wrapped binaries.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -88,7 +88,7 @@ dependencies:
 
   # Golang
   - name: "golang: upstream version"
-    version: 1.19.1
+    version: 1.19.2
     refPaths:
     - path: build/build-image/cross/VERSION
     - path: staging/publishing/rules.yaml
@@ -109,7 +109,7 @@ dependencies:
       match: minimum_go_version=go([0-9]+\.[0-9]+)
 
   - name: "registry.k8s.io/kube-cross: dependents"
-    version: v1.25.0-go1.19.1-bullseye.0
+    version: v1.25.0-go1.19.2-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -139,7 +139,7 @@ dependencies:
       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
 
   - name: "registry.k8s.io/go-runner: dependents"
-    version: v2.3.1-go1.19.1-bullseye.0
+    version: v2.3.1-go1.19.2-bullseye.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1992,4 +1992,4 @@ rules:
   library: true
 recursive-delete-patterns:
 - '*/.gitattributes'
-default-go-version: 1.19.1
+default-go-version: 1.19.2

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -16,7 +16,7 @@ REGISTRY ?= registry.k8s.io/e2e-test-images
 GOARM ?= 7
 DOCKER_CERT_BASE_PATH ?=
 QEMUVERSION=v5.1.0-2
-GOLANG_VERSION=1.19.1
+GOLANG_VERSION=1.19.2
 export
 
 ifndef WHAT


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- Bump kube-cross and go-runner images to Go 1.19.2 based ones
- Bump test Makefile to Go 1.19.2
- Bump default Go version for publishing bot to 1.19.2

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2694

#### Does this PR introduce a user-facing change?

```release-note
Kubernetes is now built with Go 1.19.2
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

cc @kubernetes/release-engineering 