### PR TITLE
Update publishing-bot rules to Go 1.19.2 and 1.18.7

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -21,7 +21,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/code-generator
@@ -47,7 +47,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/apimachinery
@@ -86,7 +86,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/api
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -152,7 +152,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -216,7 +216,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-base
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -278,7 +278,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -357,7 +357,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/apiserver
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -447,7 +447,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -560,7 +560,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -660,7 +660,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -762,7 +762,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -839,7 +839,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/metrics
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -903,7 +903,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: api
       branch: release-1.25
@@ -973,7 +973,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1044,7 +1044,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1116,7 +1116,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubelet
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1188,7 +1188,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1270,7 +1270,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1370,7 +1370,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1482,7 +1482,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1546,7 +1546,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1598,7 +1598,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1630,7 +1630,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/mount-utils
@@ -1741,7 +1741,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1789,7 +1789,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/cri-api
@@ -1884,7 +1884,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubectl
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1974,7 +1974,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.25
-    go: 1.19
+    go: 1.19.2
     dependencies:
     - repository: api
       branch: release-1.25

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -16,7 +16,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/code-generator
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
@@ -42,7 +42,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
@@ -78,7 +78,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/api
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -138,7 +138,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -204,7 +204,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-base
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -266,7 +266,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -343,7 +343,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apiserver
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -429,7 +429,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -537,7 +537,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -641,7 +641,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -742,7 +742,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -825,7 +825,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/metrics
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -891,7 +891,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -959,7 +959,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1030,7 +1030,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1102,7 +1102,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubelet
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1174,7 +1174,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1254,7 +1254,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1350,7 +1350,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1460,7 +1460,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1536,7 +1536,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1588,7 +1588,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1625,7 +1625,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
@@ -1715,7 +1715,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1784,7 +1784,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cri-api
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
@@ -1862,7 +1862,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubectl
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1958,7 +1958,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.24
-    go: 1.18.6
+    go: 1.18.7
     dependencies:
     - repository: api
       branch: release-1.24


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

This PR updates publishing-bot branch rules to Go 1.19.2 and 1.18.7.

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2694

#### Special notes for your reviewer:

I'm not sure if https://github.com/kubernetes/kubernetes/commit/c7cd9c0a55e3fbd4caf9d9daab0755f6055e094b is needed at all. All other branches specify the full Go version (including the patch release) besides Go 1.19. I think this might have been forgotten when we updated to Go 1.19.1, so I added patch releases now. Please let me know if this is wrong and if this commit should be reverted.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/sig release
cc @kubernetes/release-engineering 