### PR TITLE
kubectl: `apply --server-side` managed fields migration

### DIFF
--- a/staging/src/k8s.io/client-go/util/csaupgrade/OWNERS
+++ b/staging/src/k8s.io/client-go/util/csaupgrade/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+  - apelisse
+  - alexzielenski
+reviewers:
+  - apelisse
+  - alexzielenski
+  - KnVerey
+labels:
+  - sig/api-machinery

--- a/staging/src/k8s.io/client-go/util/csaupgrade/upgrade.go
+++ b/staging/src/k8s.io/client-go/util/csaupgrade/upgrade.go
@@ -26,9 +26,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
-const csaAnnotationName = "kubectl.kubernetes.io/last-applied-configuration"
 
-var csaAnnotationFieldSet = fieldpath.NewSet(fieldpath.MakePathOrDie("metadata", "annotations", csaAnnotationName))
 
 // Upgrades the Manager information for fields managed with client-side-apply (CSA)
 // Prepares fields owned by `csaManager` for 'Update' operations for use now
@@ -107,12 +105,8 @@ func UpgradeManagedFields(
 			entry.Subresource == "")
 	})
 
-	// Wipe out last-applied-configuration annotation if it exists
-	annotations := accessor.GetAnnotations()
-	delete(annotations, csaAnnotationName)
 
 	// Commit changes to object
-	accessor.SetAnnotations(annotations)
 	accessor.SetManagedFields(filteredManagers)
 
 	return nil
@@ -153,10 +147,6 @@ func unionManagerIntoIndex(entries []metav1.ManagedFieldsEntry, targetIndex int,
 
 		combinedFieldSet = combinedFieldSet.Union(&csaFieldSet)
 	}
-
-	// Ensure that the resultant fieldset does not include the
-	// last applied annotation
-	combinedFieldSet = combinedFieldSet.Difference(csaAnnotationFieldSet)
 
 	// Encode the fields back to the serialized format
 	err = encodeManagedFieldsEntrySet(&entries[targetIndex], *combinedFieldSet)

--- a/staging/src/k8s.io/client-go/util/csaupgrade/upgrade_test.go
+++ b/staging/src/k8s.io/client-go/util/csaupgrade/upgrade_test.go
@@ -17,11 +17,16 @@ limitations under the License.
 package csaupgrade_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/util/csaupgrade"
 )
@@ -30,7 +35,7 @@ func TestUpgradeCSA(t *testing.T) {
 
 	cases := []struct {
 		Name           string
-		CSAManager     string
+		CSAManagers    []string
 		SSAManager     string
 		OriginalObject []byte
 		ExpectedObject []byte
@@ -39,14 +44,15 @@ func TestUpgradeCSA(t *testing.T) {
 			// Case where there is a CSA entry with the given name, but no SSA entry
 			// is found. Expect that the CSA entry is converted to an SSA entry
 			// and renamed.
-			Name:       "csa-basic-direct-conversion",
-			CSAManager: "kubectl-client-side-apply",
-			SSAManager: "kubectl",
+			Name:        "csa-basic-direct-conversion",
+			CSAManagers: []string{"kubectl-client-side-apply"},
+			SSAManager:  "kubectl",
 			OriginalObject: []byte(`
 apiVersion: v1
 data: {}
 kind: ConfigMap
 metadata:
+  resourceVersion: "1"
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
       {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
@@ -74,7 +80,10 @@ apiVersion: v1
 data: {}
 kind: ConfigMap
 metadata:
-  annotations: {}
+  resourceVersion: "1"
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
   creationTimestamp: "2022-08-22T23:08:23Z"
   managedFields:
   - apiVersion: v1
@@ -85,12 +94,14 @@ metadata:
         f:key: {}
         f:legacy: {}
       f:metadata:
-        f:annotations: {}
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
     manager: kubectl
     operation: Apply
     time: "2022-08-22T23:08:23Z"
   name: test
-  namespace: default  
+  namespace: default
 `),
 		},
 		{
@@ -98,14 +109,15 @@ metadata:
 			// Server creates duplicate managed fields entry - one for Update and another
 			// for Apply. Expect entries to be merged into one entry, which is unchanged
 			// from initial SSA.
-			Name:       "csa-combine-with-ssa-duplicate-keys",
-			CSAManager: "kubectl-client-side-apply",
-			SSAManager: "kubectl",
+			Name:        "csa-combine-with-ssa-duplicate-keys",
+			CSAManagers: []string{"kubectl-client-side-apply"},
+			SSAManager:  "kubectl",
 			OriginalObject: []byte(`
 apiVersion: v1
 data: {}
 kind: ConfigMap
 metadata:
+  resourceVersion: "1"
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
       {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
@@ -147,7 +159,10 @@ apiVersion: v1
 data: {}
 kind: ConfigMap
 metadata:
-  annotations: {}
+  resourceVersion: "1"
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
   creationTimestamp: "2022-08-22T23:08:23Z"
   managedFields:
   - apiVersion: v1
@@ -158,12 +173,14 @@ metadata:
         f:key: {}
         f:legacy: {}
       f:metadata:
-        f:annotations: {}
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
     manager: kubectl
     operation: Apply
     time: "2022-08-23T23:08:23Z"
   name: test
-  namespace: default  
+  namespace: default
 `),
 		},
 		{
@@ -173,14 +190,15 @@ metadata:
 			// This shows that upgrading such an object results in correct behavior next
 			// time SSA applier
 			// Expect final object to have unioned keys from both entries
-			Name:       "csa-combine-with-ssa-additional-keys",
-			CSAManager: "kubectl-client-side-apply",
-			SSAManager: "kubectl",
+			Name:        "csa-combine-with-ssa-additional-keys",
+			CSAManagers: []string{"kubectl-client-side-apply"},
+			SSAManager:  "kubectl",
 			OriginalObject: []byte(`
 apiVersion: v1
 data: {}
 kind: ConfigMap
 metadata:
+  resourceVersion: "1"
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
       {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
@@ -221,7 +239,10 @@ apiVersion: v1
 data: {}
 kind: ConfigMap
 metadata:
-  annotations: {}
+  resourceVersion: "1"
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
   creationTimestamp: "2022-08-22T23:08:23Z"
   managedFields:
   - apiVersion: v1
@@ -232,26 +253,29 @@ metadata:
         f:key: {}
         f:legacy: {}
       f:metadata:
-        f:annotations: {}
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
     manager: kubectl
     operation: Apply
     time: "2022-08-23T23:08:23Z"
   name: test
-  namespace: default  
+  namespace: default
 `),
 		},
 		{
 			// Case when there are multiple CSA versions on the object which do not
 			// match the version from the apply entry. Shows they are tossed away
 			// without being merged.
-			Name:       "csa-no-applicable-version",
-			CSAManager: "kubectl-client-side-apply",
-			SSAManager: "kubectl",
+			Name:        "csa-no-applicable-version",
+			CSAManagers: []string{"kubectl-client-side-apply"},
+			SSAManager:  "kubectl",
 			OriginalObject: []byte(`
 apiVersion: v1
 data: {}
 kind: ConfigMap
 metadata:
+  resourceVersion: "1"
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
       {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
@@ -323,7 +347,10 @@ apiVersion: v1
 data: {}
 kind: ConfigMap
 metadata:
-  annotations: {}
+  resourceVersion: "1"
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
   creationTimestamp: "2022-08-22T23:08:23Z"
   managedFields:
   - apiVersion: v5
@@ -334,26 +361,29 @@ metadata:
         f:key: {}
         f:legacy: {}
       f:metadata:
-        f:annotations: {}
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
     manager: kubectl
     operation: Apply
     time: "2022-08-23T23:08:23Z"
   name: test
-  namespace: default  
+  namespace: default
 `),
 		},
 		{
 			// Case when there are multiple CSA versions on the object which do not
 			// match the version from the apply entry, and one which does.
 			// Shows that CSA entry with matching version is unioned into the SSA entry.
-			Name:       "csa-single-applicable-version",
-			CSAManager: "kubectl-client-side-apply",
-			SSAManager: "kubectl",
+			Name:        "csa-single-applicable-version",
+			CSAManagers: []string{"kubectl-client-side-apply"},
+			SSAManager:  "kubectl",
 			OriginalObject: []byte(`
 apiVersion: v1
 data: {}
 kind: ConfigMap
 metadata:
+  resourceVersion: "1"
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
       {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
@@ -425,7 +455,10 @@ apiVersion: v1
 data: {}
 kind: ConfigMap
 metadata:
-  annotations: {}
+  resourceVersion: "1"
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
   creationTimestamp: "2022-08-22T23:08:23Z"
   managedFields:
   - apiVersion: v5
@@ -440,11 +473,355 @@ metadata:
         f:annotations:
           .: {}
           f:hello2: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
     manager: kubectl
     operation: Apply
     time: "2022-08-23T23:08:23Z"
   name: test
-  namespace: default  
+  namespace: default
+`),
+		},
+		{
+			// Do nothing to object with nothing to migrate and no existing SSA manager
+			Name:        "noop",
+			CSAManagers: []string{"kubectl-client-side-apply"},
+			SSAManager:  "not-already-in-object",
+			OriginalObject: []byte(`
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  resourceVersion: "1"
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
+  creationTimestamp: "2022-08-22T23:08:23Z"
+  managedFields:
+  - apiVersion: v5
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:data:
+        .: {}
+        f:key: {}
+        f:legacy: {}
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
+    manager: kubectl
+    operation: Apply
+    time: "2022-08-23T23:08:23Z"
+  name: test
+  namespace: default
+`),
+			ExpectedObject: []byte(`
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  resourceVersion: "1"
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
+  creationTimestamp: "2022-08-22T23:08:23Z"
+  managedFields:
+  - apiVersion: v5
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:data:
+        .: {}
+        f:key: {}
+        f:legacy: {}
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
+    manager: kubectl
+    operation: Apply
+    time: "2022-08-23T23:08:23Z"
+  name: test
+  namespace: default
+`),
+		},
+		{
+			// Expect multiple targets to be merged into existing ssa manager
+			Name:        "multipleTargetsExisting",
+			CSAManagers: []string{"kube-scheduler", "kubectl-client-side-apply"},
+			SSAManager:  "kubectl",
+			OriginalObject: []byte(`
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  resourceVersion: "1"
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
+  creationTimestamp: "2022-08-22T23:08:23Z"
+  managedFields:
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          f:name: {}
+      f:spec:
+        f:containers:
+          k:{"name":"kubernetes-pause"}:
+            .: {}
+            f:image: {}
+            f:name: {}
+    manager: kubectl
+    operation: Apply
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        f:conditions:
+          .: {}
+          k:{"type":"PodScheduled"}:
+            .: {}
+            f:lastProbeTime: {}
+            f:lastTransitionTime: {}
+            f:message: {}
+            f:reason: {}
+            f:status: {}
+            f:type: {}
+    manager: kube-scheduler
+    operation: Update
+    time: "2022-11-03T23:22:40Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
+        f:labels:
+          .: {}
+          f:name: {}
+      f:spec:
+        f:containers:
+          k:{"name":"kubernetes-pause"}:
+            .: {}
+            f:image: {}
+            f:imagePullPolicy: {}
+            f:name: {}
+            f:resources: {}
+            f:terminationMessagePath: {}
+            f:terminationMessagePolicy: {}
+        f:dnsPolicy: {}
+        f:enableServiceLinks: {}
+        f:restartPolicy: {}
+        f:schedulerName: {}
+        f:securityContext: {}
+        f:terminationGracePeriodSeconds: {}
+    manager: kubectl-client-side-apply
+    operation: Update
+    time: "2022-11-03T23:22:40Z"
+  name: test
+  namespace: default
+`),
+			ExpectedObject: []byte(`
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  resourceVersion: "1"
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
+  creationTimestamp: "2022-08-22T23:08:23Z"
+  managedFields:
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        f:conditions:
+          .: {}
+          k:{"type":"PodScheduled"}:
+            .: {}
+            f:lastProbeTime: {}
+            f:lastTransitionTime: {}
+            f:message: {}
+            f:reason: {}
+            f:status: {}
+            f:type: {}
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
+        f:labels:
+          .: {}
+          f:name: {}
+      f:spec:
+        f:containers:
+          k:{"name":"kubernetes-pause"}:
+            .: {}
+            f:image: {}
+            f:imagePullPolicy: {}
+            f:name: {}
+            f:resources: {}
+            f:terminationMessagePath: {}
+            f:terminationMessagePolicy: {}
+        f:dnsPolicy: {}
+        f:enableServiceLinks: {}
+        f:restartPolicy: {}
+        f:schedulerName: {}
+        f:securityContext: {}
+        f:terminationGracePeriodSeconds: {}
+    manager: kubectl
+    operation: Apply
+  name: test
+  namespace: default
+`),
+		},
+		{
+			// Expect multiple targets to be merged into a new ssa manager
+			Name:        "multipleTargetsNewInsertion",
+			CSAManagers: []string{"kubectl-client-side-apply", "kube-scheduler"},
+			SSAManager:  "newly-inserted-manager",
+			OriginalObject: []byte(`
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  resourceVersion: "1"
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
+  creationTimestamp: "2022-08-22T23:08:23Z"
+  managedFields:
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          f:name: {}
+      f:spec:
+        f:containers:
+          k:{"name":"kubernetes-pause"}:
+            .: {}
+            f:image: {}
+            f:name: {}
+    manager: kubectl
+    operation: Apply
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        f:conditions:
+          .: {}
+          k:{"type":"PodScheduled"}:
+            .: {}
+            f:lastProbeTime: {}
+            f:lastTransitionTime: {}
+            f:message: {}
+            f:reason: {}
+            f:status: {}
+            f:type: {}
+    manager: kube-scheduler
+    operation: Update
+    time: "2022-11-03T23:22:40Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
+        f:labels:
+          .: {}
+          f:name: {}
+      f:spec:
+        f:containers:
+          k:{"name":"kubernetes-pause"}:
+            .: {}
+            f:image: {}
+            f:imagePullPolicy: {}
+            f:name: {}
+            f:resources: {}
+            f:terminationMessagePath: {}
+            f:terminationMessagePolicy: {}
+        f:dnsPolicy: {}
+        f:enableServiceLinks: {}
+        f:restartPolicy: {}
+        f:schedulerName: {}
+        f:securityContext: {}
+        f:terminationGracePeriodSeconds: {}
+    manager: kubectl-client-side-apply
+    operation: Update
+    time: "2022-11-03T23:22:40Z"
+  name: test
+  namespace: default
+`),
+			ExpectedObject: []byte(`
+  apiVersion: v1
+  data: {}
+  kind: ConfigMap
+  metadata:
+    resourceVersion: "1"
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"v1","data":{"key":"value","legacy":"unused"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"test","namespace":"default"}}
+    creationTimestamp: "2022-08-22T23:08:23Z"
+    managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:labels:
+            f:name: {}
+        f:spec:
+          f:containers:
+            k:{"name":"kubernetes-pause"}:
+              .: {}
+              f:image: {}
+              f:name: {}
+      manager: kubectl
+      operation: Apply
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:kubectl.kubernetes.io/last-applied-configuration: {}
+          f:labels:
+            .: {}
+            f:name: {}
+        f:spec:
+          f:containers:
+            k:{"name":"kubernetes-pause"}:
+              .: {}
+              f:image: {}
+              f:imagePullPolicy: {}
+              f:name: {}
+              f:resources: {}
+              f:terminationMessagePath: {}
+              f:terminationMessagePolicy: {}
+          f:dnsPolicy: {}
+          f:enableServiceLinks: {}
+          f:restartPolicy: {}
+          f:schedulerName: {}
+          f:securityContext: {}
+          f:terminationGracePeriodSeconds: {}
+        f:status:
+          f:conditions:
+            .: {}
+            k:{"type":"PodScheduled"}:
+              .: {}
+              f:lastProbeTime: {}
+              f:lastTransitionTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+      manager: newly-inserted-manager
+      operation: Apply
+      time: "2022-11-03T23:22:40Z"
+    name: test
+    namespace: default
 `),
 		},
 	}
@@ -452,7 +829,7 @@ metadata:
 	for _, testCase := range cases {
 		t.Run(testCase.Name, func(t *testing.T) {
 			initialObject := unstructured.Unstructured{}
-			err := yaml.Unmarshal(testCase.OriginalObject, &initialObject)
+			err := yaml.Unmarshal(testCase.OriginalObject, &initialObject.Object)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -460,7 +837,7 @@ metadata:
 			upgraded := initialObject.DeepCopy()
 			err = csaupgrade.UpgradeManagedFields(
 				upgraded,
-				testCase.CSAManager,
+				sets.New(testCase.CSAManagers...),
 				testCase.SSAManager,
 			)
 
@@ -469,13 +846,49 @@ metadata:
 			}
 
 			expectedObject := unstructured.Unstructured{}
-			err = yaml.Unmarshal(testCase.ExpectedObject, &expectedObject)
+			err = yaml.Unmarshal(testCase.ExpectedObject, &expectedObject.Object)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			if !reflect.DeepEqual(&expectedObject, upgraded) {
 				t.Fatal(cmp.Diff(&expectedObject, upgraded))
+			}
+
+			// Show that the UpgradeManagedFieldsPatch yields a patch that does
+			// nothing more and nothing less than make the object equal to output
+			// of UpgradeManagedFields
+
+			initialCopy := initialObject.DeepCopyObject()
+			patchBytes, err := csaupgrade.UpgradeManagedFieldsPatch(
+				initialCopy, sets.New(testCase.CSAManagers...), testCase.SSAManager)
+
+			if err != nil {
+				t.Fatal(err)
+			} else if patchBytes != nil {
+				patch, err := jsonpatch.DecodePatch(patchBytes)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				initialJSON, err := json.Marshal(initialObject.Object)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				patchedBytes, err := patch.Apply(initialJSON)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				var patched unstructured.Unstructured
+				if err := json.Unmarshal(patchedBytes, &patched.Object); err != nil {
+					t.Fatal(err)
+				}
+
+				if !reflect.DeepEqual(&patched, upgraded) {
+					t.Fatalf("expected patch to produce an upgraded object: %v", cmp.Diff(patched, upgraded))
+				}
 			}
 		})
 	}

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -42,6 +42,7 @@ require (
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2
 	sigs.k8s.io/kustomize/kustomize/v4 v4.5.7
 	sigs.k8s.io/kustomize/kyaml v0.13.9
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.3
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -87,7 +88,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
 replace (

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -36,6 +37,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/csaupgrade"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/delete"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -163,6 +165,9 @@ var (
 
 	warningNoLastAppliedConfigAnnotation = "Warning: resource %[1]s is missing the %[2]s annotation which is required by %[3]s apply. %[3]s apply should only be used on resources created declaratively by either %[3]s create --save-config or %[3]s apply. The missing annotation will be patched automatically.\n"
 	warningChangesOnDeletingResource     = "Warning: Detected changes to resource %[1]s which is currently being deleted.\n"
+	warningMigrationLastAppliedFailed    = "Warning: failed to migrate kubectl.kubernetes.io/last-applied-configuration for Server-Side Apply. This is non-fatal and will be retried next time you apply. Error: %[1]s\n"
+	warningMigrationPatchFailed          = "Warning: server rejected managed fields migration to Server-Side Apply. This is non-fatal and will be retried next time you apply. Error: %[1]s\n"
+	warningMigrationReapplyFailed        = "Warning: failed to re-apply configuration after performing Server-Side Apply migration. This is non-fatal and will be retried next time you apply. Error: %[1]s\n"
 )
 
 // NewApplyFlags returns a default ApplyFlags
@@ -542,6 +547,40 @@ See https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts`
 
 		info.Refresh(obj, true)
 
+		// Migrate managed fields if necessary.
+		//
+		// By checking afterward instead of fetching the object beforehand and
+		// unconditionally fetching we can make 3 network requests in the rare
+		// case of migration and 1 request if migration is unnecessary.
+		//
+		// To check beforehand means 2 requests for most operations, and 3
+		// requests in worst case.
+		if err = o.saveLastApplyAnnotationIfNecessary(helper, info); err != nil {
+			fmt.Fprintf(o.ErrOut, warningMigrationLastAppliedFailed, err.Error())
+		} else if performedMigration, err := o.migrateToSSAIfNecessary(helper, info); err != nil {
+			// Print-error as a warning.
+			// This is a non-fatal error because object was successfully applied
+			// above, but it might have issues since migration failed.
+			//
+			// This migration will be re-attempted if necessary upon next
+			// apply.
+			fmt.Fprintf(o.ErrOut, warningMigrationPatchFailed, err.Error())
+		} else if performedMigration {
+			if obj, err = helper.Patch(
+				info.Namespace,
+				info.Name,
+				types.ApplyPatchType,
+				data,
+				&options,
+			); err != nil {
+				// Re-send original SSA patch (this will allow dropped fields to
+				// finally be removed)
+				fmt.Fprintf(o.ErrOut, warningMigrationReapplyFailed, err.Error())
+			} else {
+				info.Refresh(obj, false)
+			}
+		}
+
 		WarnIfDeleting(info.Object, o.ErrOut)
 
 		if err := o.MarkObjectVisited(info); err != nil {
@@ -660,6 +699,183 @@ See https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts`
 	return nil
 }
 
+// Saves the last-applied-configuration annotation in a separate SSA field manager
+// to prevent it from being dropped by users who have transitioned to SSA.
+//
+// If this operation is not performed, then the last-applied-configuration annotation
+// would be removed from the object upon the first SSA usage. We want to keep it
+// around for a few releases since it is required to downgrade to
+// SSA per [1] and [2]. This code should be removed once the annotation is
+// deprecated.
+//
+// - [1] https://kubernetes.io/docs/reference/using-api/server-side-apply/#downgrading-from-server-side-apply-to-client-side-apply
+// - [2] https://github.com/kubernetes/kubernetes/pull/90187
+//
+// If the annotation is not already present, or if it is already managed by the
+// separate SSA fieldmanager, this is a no-op.
+func (o *ApplyOptions) saveLastApplyAnnotationIfNecessary(
+	helper *resource.Helper,
+	info *resource.Info,
+) error {
+	if o.FieldManager != fieldManagerServerSideApply {
+		// There is no point in preserving the annotation if the field manager
+		// will not remain default. This is because the server will not keep
+		// the annotation up to date.
+		return nil
+	}
+
+	// Send an apply patch with the last-applied-annotation
+	// so that it is not orphaned by SSA in the following patch:
+	accessor, err := meta.Accessor(info.Object)
+	if err != nil {
+		return err
+	}
+
+	// Get the current annotations from the object.
+	annots := accessor.GetAnnotations()
+	if annots == nil {
+		annots = map[string]string{}
+	}
+
+	fieldManager := fieldManagerLastAppliedAnnotation
+	originalAnnotation, hasAnnotation := annots[corev1.LastAppliedConfigAnnotation]
+
+	// If the annotation does not already exist, we do not do anything
+	if !hasAnnotation {
+		return nil
+	}
+
+	// If there is already an SSA field manager which owns the field, then there
+	// is nothing to do here.
+	if owners := csaupgrade.FindFieldsOwners(
+		accessor.GetManagedFields(),
+		metav1.ManagedFieldsOperationApply,
+		lastAppliedAnnotationFieldPath,
+	); len(owners) > 0 {
+		return nil
+	}
+
+	justAnnotation := &unstructured.Unstructured{}
+	justAnnotation.SetGroupVersionKind(info.Mapping.GroupVersionKind)
+	justAnnotation.SetName(accessor.GetName())
+	justAnnotation.SetNamespace(accessor.GetNamespace())
+	justAnnotation.SetAnnotations(map[string]string{
+		corev1.LastAppliedConfigAnnotation: originalAnnotation,
+	})
+
+	modified, err := runtime.Encode(unstructured.UnstructuredJSONScheme, justAnnotation)
+	if err != nil {
+		return nil
+	}
+
+	helperCopy := *helper
+	newObj, err := helperCopy.WithFieldManager(fieldManager).Patch(
+		info.Namespace,
+		info.Name,
+		types.ApplyPatchType,
+		modified,
+		nil,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return info.Refresh(newObj, false)
+}
+
+// Check if the returned object needs to have its kubectl-client-side-apply
+// managed fields migrated server-side-apply.
+//
+// field ownership metadata is stored in three places:
+//   - server-side managed fields
+//   - client-side managed fields
+//   - and the last_applied_configuration annotation.
+//
+// The migration merges the client-side-managed fields into the
+// server-side-managed fields, leaving the last_applied_configuration
+// annotation in place. Server will keep the annotation up to date
+// after every server-side-apply where the following conditions are ment:
+//
+//  1. field manager is 'kubectl'
+//  2. annotation already exists
+func (o *ApplyOptions) migrateToSSAIfNecessary(
+	helper *resource.Helper,
+	info *resource.Info,
+) (migrated bool, err error) {
+	accessor, err := meta.Accessor(info.Object)
+	if err != nil {
+		return false, err
+	}
+
+	// To determine which field managers were used by kubectl for client-side-apply
+	// we search for a manager used in `Update` operations which owns the
+	// last-applied-annotation.
+	//
+	// This is the last client-side-apply manager which changed the field.
+	//
+	// There may be multiple owners if multiple managers wrote the same exact
+	// configuration. In this case there are multiple owners, we want to migrate
+	// them all.
+	csaManagers := csaupgrade.FindFieldsOwners(
+		accessor.GetManagedFields(),
+		metav1.ManagedFieldsOperationUpdate,
+		lastAppliedAnnotationFieldPath)
+
+	managerNames := sets.New[string]()
+	for _, entry := range csaManagers {
+		managerNames.Insert(entry.Manager)
+	}
+
+	// Re-attempt patch as many times as it is conflicting due to ResourceVersion
+	// test failing
+	for i := 0; i < maxPatchRetry; i++ {
+		var patchData []byte
+		var obj runtime.Object
+
+		patchData, err = csaupgrade.UpgradeManagedFieldsPatch(
+			info.Object, managerNames, o.FieldManager)
+
+		if err != nil {
+			// If patch generation failed there was likely a bug.
+			return false, err
+		} else if patchData == nil {
+			// nil patch data means nothing to do - object is already migrated
+			return false, nil
+		}
+
+		// Send the patch to upgrade the managed fields if it is non-nil
+		obj, err = helper.Patch(
+			info.Namespace,
+			info.Name,
+			types.JSONPatchType,
+			patchData,
+			nil,
+		)
+
+		if err == nil {
+			// Stop retrying upon success.
+			info.Refresh(obj, false)
+			return true, nil
+		} else if !errors.IsConflict(err) {
+			// Only retry if there was a conflict
+			return false, err
+		}
+
+		// Refresh the object for next iteration
+		err = info.Get()
+		if err != nil {
+			// If there was an error fetching, return error
+			return false, err
+		}
+	}
+
+	// Reaching this point with non-nil error means there was a conflict and
+	// max retries was hit
+	// Return the last error witnessed (which will be a conflict)
+	return false, err
+}
+
 func (o *ApplyOptions) shouldPrintObject() bool {
 	// Print object only if output format other than "name" is specified
 	shouldPrint := false
@@ -766,6 +982,16 @@ const (
 	// for backward compatibility to not conflict with old versions
 	// of kubectl server-side apply where `kubectl` has already been the field manager.
 	fieldManagerServerSideApply = "kubectl"
+
+	fieldManagerLastAppliedAnnotation = "kubectl-last-applied"
+)
+
+var (
+	lastAppliedAnnotationFieldPath = fieldpath.NewSet(
+		fieldpath.MakePathOrDie(
+			"metadata", "annotations",
+			corev1.LastAppliedConfigAnnotation),
+	)
 )
 
 // GetApplyFieldManagerFlag gets the field manager for kubectl apply

--- a/staging/src/k8s.io/kubectl/testdata/apply/rc-managedfields-lastapplied.yaml
+++ b/staging/src/k8s.io/kubectl/testdata/apply/rc-managedfields-lastapplied.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"ReplicationController","metadata":{"annotations":{},"labels":{"name":"test-rc"},"name":"test-rc","namespace":"test"},"spec":{"replicas":1,"template":{"metadata":{"labels":{"name":"test-rc"}},"spec":{"containers":[{"image":"nginx","name":"test-rc","ports":[{"containerPort":80}]}]}}}}
+  creationTimestamp: "2022-10-06T20:46:22Z"
+  generation: 1
+  labels:
+    name: test-rc
+  managedFields:
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        f:fullyLabeledReplicas: {}
+        f:observedGeneration: {}
+        f:replicas: {}
+    manager: kube-controller-manager
+    operation: Update
+    subresource: status
+    time: "2022-10-06T20:46:22Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
+        f:labels:
+          .: {}
+          f:name: {}
+      f:spec:
+        f:replicas: {}
+        f:selector: {}
+        f:template:
+          .: {}
+          f:metadata:
+            .: {}
+            f:creationTimestamp: {}
+            f:labels:
+              .: {}
+              f:name: {}
+          f:spec:
+            .: {}
+            f:containers:
+              .: {}
+              k:{"name":"test-rc"}:
+                .: {}
+                f:image: {}
+                f:imagePullPolicy: {}
+                f:name: {}
+                f:ports:
+                  .: {}
+                  k:{"containerPort":80,"protocol":"TCP"}:
+                    .: {}
+                    f:containerPort: {}
+                    f:protocol: {}
+                f:resources: {}
+                f:terminationMessagePath: {}
+                f:terminationMessagePolicy: {}
+            f:dnsPolicy: {}
+            f:restartPolicy: {}
+            f:schedulerName: {}
+            f:securityContext: {}
+            f:terminationGracePeriodSeconds: {}
+    manager: kubectl-client-side-apply
+    operation: Update
+    time: "2022-10-06T20:46:22Z"
+  name: test-rc
+  namespace: test
+  resourceVersion: "290"
+  uid: ad68b34c-d6c5-4d09-b50d-ef49c109778d
+spec:
+  replicas: 1
+  selector:
+    name: test-rc
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        name: test-rc
+    spec:
+      containers:
+      - image: nginx
+        imagePullPolicy: Always
+        name: test-rc
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  fullyLabeledReplicas: 1
+  observedGeneration: 1
+  replicas: 1

--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -438,6 +438,165 @@ run_kubectl_server_side_apply_tests() {
   # clean-up
   kubectl delete -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
 
+  # Test apply migration
+
+  # Create a configmap in the cluster with client-side apply:
+  output_message=$(kubectl "${kube_flags[@]:?}" apply --server-side=false -f - << __EOF__
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  key: value
+  legacy: unused
+__EOF__
+  )
+
+  kube::test::if_has_string "${output_message}" 'configmap/test created'
+
+  # Apply the same manifest with --server-side flag, as per server-side-apply migration instructions:
+  output_message=$(kubectl "${kube_flags[@]:?}" apply --server-side -f - << __EOF__
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  key: value
+  legacy: unused
+__EOF__
+  )
+
+  kube::test::if_has_string "${output_message}" 'configmap/test serverside-applied'
+
+  # Apply the object a third time using server-side-apply, but this time removing
+  # a field and adding a field. Old versions of kubectl would not allow the field 
+  # to be removed
+  output_message=$(kubectl "${kube_flags[@]:?}" apply --server-side -f - << __EOF__
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  key: value
+  ssaKey: ssaValue
+__EOF__
+  )
+
+  kube::test::if_has_string "${output_message}" 'configmap/test serverside-applied'
+
+  # Fetch the object and check to see that it does not have a field 'legacy'
+  kube::test::get_object_assert "configmap test" "{{ .data.key }}" 'value'
+  kube::test::get_object_assert "configmap test" "{{ .data.legacy }}" '<no value>'
+  kube::test::get_object_assert "configmap test" "{{ .data.ssaKey }}" 'ssaValue'
+
+  # CSA the object after it has been server-side-applied and had a field removed
+  # Add new key with client-side-apply. Also removes the field from server-side-apply
+  output_message=$(kubectl "${kube_flags[@]:?}" apply --server-side=false -f - << __EOF__
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  key: value
+  newKey: newValue
+__EOF__
+  )
+
+  kube::test::get_object_assert "configmap test" "{{ .data.key }}" 'value'
+  kube::test::get_object_assert "configmap test" "{{ .data.newKey }}" 'newValue'
+  kube::test::get_object_assert "configmap test" "{{ .data.ssaKey }}" '<no value>'
+
+  # SSA the object without the field added above by CSA. Show that the object
+  # on the server has had the field removed
+  output_message=$(kubectl "${kube_flags[@]:?}" apply --server-side -f - << __EOF__
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  key: value
+  ssaKey: ssaValue
+__EOF__
+  )
+
+  # Fetch the object and check to see that it does not have a field 'newKey'
+  kube::test::get_object_assert "configmap test" "{{ .data.key }}" 'value'
+  kube::test::get_object_assert "configmap test" "{{ .data.newKey }}" '<no value>'
+  kube::test::get_object_assert "configmap test" "{{ .data.ssaKey }}" 'ssaValue'
+
+  # Show that kubectl diff --server-side also functions after a migration
+  output_message=$(kubectl diff "${kube_flags[@]:?}" --server-side -f - << __EOF__ || test $? -eq 1
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  annotations:
+    newAnnotation: newValue
+data:
+  key: value
+  newKey: newValue
+__EOF__
+)
+  kube::test::if_has_string "${output_message}" '+  newKey: newValue'
+  kube::test::if_has_string "${output_message}" '+    newAnnotation: newValue'
+
+  # clean-up
+  kubectl "${kube_flags[@]:?}" delete configmap test
+
+  ## Test to show that supplying a custom field manager to kubectl apply
+  # does not prevent migration from client-side-apply to server-side-apply
+  output_message=$(kubectl "${kube_flags[@]:?}" apply --server-side=false --field-manager=myfm  -f - << __EOF__
+apiVersion: v1
+data:
+ key: value1
+ legacy: value2
+kind: ConfigMap
+metadata:
+ name: ssa-test
+__EOF__
+)
+  kube::test::if_has_string "$output_message" "configmap/ssa-test created"
+  kube::test::get_object_assert "configmap ssa-test" "{{ .data.key }}" 'value1'
+
+  # show that after client-side applying with a custom field manager, the
+  # last-applied-annotation is present
+  grep -q kubectl.kubernetes.io/last-applied-configuration <<< "$(kubectl get configmap ssa-test -o yaml "${kube_flags[@]:?}")"
+
+  # Migrate to server-side-apply by applying the same object
+  output_message=$(kubectl "${kube_flags[@]:?}" apply --server-side=true --field-manager=myfm  -f - << __EOF__
+apiVersion: v1
+data:
+ key: value1
+ legacy: value2
+kind: ConfigMap
+metadata:
+ name: ssa-test
+__EOF__
+)
+  kube::test::if_has_string "$output_message" "configmap/ssa-test serverside-applied"
+  kube::test::get_object_assert "configmap ssa-test" "{{ .data.key }}" 'value1'
+
+  # show that after migrating to SSA with a custom field manager, the 
+  # last-applied-annotation is dropped
+  ! grep -q kubectl.kubernetes.io/last-applied-configuration <<< "$(kubectl get configmap ssa-test -o yaml "${kube_flags[@]:?}")" || exit 1
+
+  # Change a field without having any conflict and also drop a field in the same patch
+  output_message=$(kubectl "${kube_flags[@]:?}" apply --server-side=true --field-manager=myfm  -f - << __EOF__
+apiVersion: v1
+data:
+ key: value2
+kind: ConfigMap
+metadata:
+ name: ssa-test
+__EOF__
+)
+  kube::test::if_has_string "$output_message" "configmap/ssa-test serverside-applied"
+  kube::test::get_object_assert "configmap ssa-test" "{{ .data.key }}" 'value2'
+  kube::test::get_object_assert "configmap ssa-test" "{{ .data.legacy }}" '<no value>'
+
+  # Clean up
+  kubectl delete configmap ssa-test
+
   ## kubectl apply dry-run on CR
   # Create CRD
   kubectl "${kube_flags_with_token[@]}" create -f - << __EOF__

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1908,6 +1908,7 @@ k8s.io/client-go/util/cert
 k8s.io/client-go/util/certificate
 k8s.io/client-go/util/certificate/csr
 k8s.io/client-go/util/connrotation
+k8s.io/client-go/util/csaupgrade
 k8s.io/client-go/util/exec
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR will transparently take ownership of any client-side-apply fields when `--server-side` apply is used. If this is not done, then it will not be possible to remove fields previously used by client-side-apply with server-side-apply (without manually patching managed fields yourself).

Previously this change was [proposed in a KEP](https://github.com/kubernetes/enhancements/pull/3518), but during discussion with the SIG we have [scoped it down to a bug fix](https://github.com/kubernetes/enhancements/pull/3518#discussion_r984724392).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

addresses issues brought up in the following and likely more bug reports

Fixes #107980
Fixes #108081
Fixes #107417
Fixes #112826
Fixed #99003

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
For `kubectl`, `--server-side` now migrates ownership of all fields used by client-side-apply to the specified `--fieldmanager`. This prevents fields previously specified using kubectl from being able to live outside of server-side-apply's management and become undeleteable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Discussion]: https://github.com/kubernetes/enhancements/pull/3518#discussion_r984724392
```

/sig cli
/cc @soltysh @KnVerey @apelisse 
