### PR TITLE
add meta-metrics for metrics framework

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -44,7 +44,7 @@ func NewCounter(opts *CounterOpts) *Counter {
 
 	kc := &Counter{
 		CounterOpts: opts,
-		lazyMetric:  lazyMetric{},
+		lazyMetric:  lazyMetric{stabilityLevel: opts.StabilityLevel},
 	}
 	kc.setPrometheusCounter(noop)
 	kc.lazyInit(kc, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
@@ -129,7 +129,7 @@ func NewCounterVec(opts *CounterOpts, labels []string) *CounterVec {
 		CounterVec:     noopCounterVec,
 		CounterOpts:    opts,
 		originalLabels: labels,
-		lazyMetric:     lazyMetric{},
+		lazyMetric:     lazyMetric{stabilityLevel: opts.StabilityLevel},
 	}
 	cv.lazyInit(cv, fqName)
 	return cv

--- a/staging/src/k8s.io/component-base/metrics/gauge.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge.go
@@ -46,7 +46,7 @@ func NewGauge(opts *GaugeOpts) *Gauge {
 
 	kc := &Gauge{
 		GaugeOpts:  opts,
-		lazyMetric: lazyMetric{},
+		lazyMetric: lazyMetric{stabilityLevel: opts.StabilityLevel},
 	}
 	kc.setPrometheusGauge(noop)
 	kc.lazyInit(kc, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
@@ -115,7 +115,7 @@ func NewGaugeVec(opts *GaugeOpts, labels []string) *GaugeVec {
 		GaugeVec:       noopGaugeVec,
 		GaugeOpts:      opts,
 		originalLabels: labels,
-		lazyMetric:     lazyMetric{},
+		lazyMetric:     lazyMetric{stabilityLevel: opts.StabilityLevel},
 	}
 	cv.lazyInit(cv, fqName)
 	return cv

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -52,7 +52,7 @@ func NewHistogram(opts *HistogramOpts) *Histogram {
 
 	h := &Histogram{
 		HistogramOpts: opts,
-		lazyMetric:    lazyMetric{},
+		lazyMetric:    lazyMetric{stabilityLevel: opts.StabilityLevel},
 	}
 	h.setPrometheusHistogram(noopMetric{})
 	h.lazyInit(h, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
@@ -119,7 +119,7 @@ func NewHistogramVec(opts *HistogramOpts, labels []string) *HistogramVec {
 		HistogramVec:   noopHistogramVec,
 		HistogramOpts:  opts,
 		originalLabels: labels,
-		lazyMetric:     lazyMetric{},
+		lazyMetric:     lazyMetric{stabilityLevel: opts.StabilityLevel},
 	}
 	v.lazyInit(v, fqName)
 	return v

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -47,6 +47,7 @@ var (
 func init() {
 	RawMustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	RawMustRegister(collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll)))
+	defaultRegistry.RegisterMetaMetrics()
 }
 
 // Handler returns an HTTP handler for the DefaultGatherer. It is

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -89,14 +89,6 @@ func (r *lazyMetric) lazyInit(self kubeCollector, fqName string) {
 	r.self = self
 }
 
-func stabilityLevelOrDefault(sl string) string {
-	if sl == "" {
-		return string(INTERNAL)
-	} else {
-		return sl
-	}
-}
-
 // preprocessMetric figures out whether the lazy metric should be hidden or not.
 // This method takes a Version argument which should be the version of the binary in which
 // this code is currently being executed. A metric can be hidden under two conditions:

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -167,7 +167,7 @@ func (r *lazyMetric) Create(version *semver.Version) bool {
 	if deprecatedV != nil {
 		dv = deprecatedV.String()
 	}
-	defer registeredMetrics.WithLabelValues(string(sl), dv).Inc()
+	registeredMetrics.WithLabelValues(string(sl), dv).Inc()
 	return r.IsCreated()
 }
 

--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -36,6 +36,31 @@ var (
 	registries          []*kubeRegistry // stores all registries created by NewKubeRegistry()
 	registriesLock      sync.RWMutex
 	disabledMetrics     = map[string]struct{}{}
+
+	registeredMetrics = NewCounterVec(
+		&CounterOpts{
+			Name:           "registered_metric_total",
+			Help:           "The count of registered metrics broken by stability level and deprecation version.",
+			StabilityLevel: ALPHA,
+		},
+		[]string{"stability_level", "deprecated_version"},
+	)
+
+	disabledMetricsTotal = NewCounter(
+		&CounterOpts{
+			Name:           "disabled_metric_total",
+			Help:           "The count of disabled metrics.",
+			StabilityLevel: ALPHA,
+		},
+	)
+
+	hiddenMetricsTotal = NewCounter(
+		&CounterOpts{
+			Name:           "hidden_metric_total",
+			Help:           "The count of hidden metrics.",
+			StabilityLevel: ALPHA,
+		},
+	)
 )
 
 // shouldHide be used to check if a specific metric with deprecated version should be hidden
@@ -67,6 +92,7 @@ func SetDisabledMetric(name string) {
 	disabledMetricsLock.Lock()
 	defer disabledMetricsLock.Unlock()
 	disabledMetrics[name] = struct{}{}
+	disabledMetricsTotal.Inc()
 }
 
 // SetShowHidden will enable showing hidden metrics. This will no-opt
@@ -250,6 +276,7 @@ func (kr *kubeRegistry) trackHiddenCollector(c Registerable) {
 	defer kr.hiddenCollectorsLock.Unlock()
 
 	kr.hiddenCollectors[c.FQName()] = c
+	hiddenMetricsTotal.Inc()
 }
 
 // trackStableCollectors stores all custom collectors.
@@ -329,9 +356,11 @@ func newKubeRegistry(v apimachineryversion.Info) *kubeRegistry {
 	return r
 }
 
-// NewKubeRegistry creates a new vanilla Registry without any Collectors
-// pre-registered.
+// NewKubeRegistry creates a new vanilla Registry
 func NewKubeRegistry() KubeRegistry {
 	r := newKubeRegistry(BuildVersion())
+	r.MustRegister(registeredMetrics)
+	r.MustRegister(disabledMetricsTotal)
+	r.MustRegister(hiddenMetricsTotal)
 	return r
 }

--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -155,6 +155,8 @@ type KubeRegistry interface {
 	// Reset invokes the Reset() function on all items in the registry
 	// which are added as resettables.
 	Reset()
+	// RegisterMetaMetrics registers metrics about the number of registered metrics.
+	RegisterMetaMetrics()
 }
 
 // kubeRegistry is a wrapper around a prometheus registry-type object. Upon initialization
@@ -359,8 +361,11 @@ func newKubeRegistry(v apimachineryversion.Info) *kubeRegistry {
 // NewKubeRegistry creates a new vanilla Registry
 func NewKubeRegistry() KubeRegistry {
 	r := newKubeRegistry(BuildVersion())
+	return r
+}
+
+func (r *kubeRegistry) RegisterMetaMetrics() {
 	r.MustRegister(registeredMetrics)
 	r.MustRegister(disabledMetricsTotal)
 	r.MustRegister(hiddenMetricsTotal)
-	return r
 }

--- a/staging/src/k8s.io/component-base/metrics/summary.go
+++ b/staging/src/k8s.io/component-base/metrics/summary.go
@@ -49,7 +49,7 @@ func NewSummary(opts *SummaryOpts) *Summary {
 
 	s := &Summary{
 		SummaryOpts: opts,
-		lazyMetric:  lazyMetric{},
+		lazyMetric:  lazyMetric{stabilityLevel: opts.StabilityLevel},
 	}
 	s.setPrometheusSummary(noopMetric{})
 	s.lazyInit(s, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
@@ -118,7 +118,7 @@ func NewSummaryVec(opts *SummaryOpts, labels []string) *SummaryVec {
 	v := &SummaryVec{
 		SummaryOpts:    opts,
 		originalLabels: labels,
-		lazyMetric:     lazyMetric{},
+		lazyMetric:     lazyMetric{stabilityLevel: opts.StabilityLevel},
 	}
 	v.lazyInit(v, fqName)
 	return v

--- a/staging/src/k8s.io/component-base/metrics/timing_histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/timing_histogram.go
@@ -57,7 +57,7 @@ func NewTestableTimingHistogram(nowFunc func() time.Time, opts *TimingHistogramO
 	h := &TimingHistogram{
 		TimingHistogramOpts: opts,
 		nowFunc:             nowFunc,
-		lazyMetric:          lazyMetric{},
+		lazyMetric:          lazyMetric{stabilityLevel: opts.StabilityLevel},
 	}
 	h.setPrometheusHistogram(noopMetric{})
 	h.lazyInit(h, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
@@ -136,7 +136,7 @@ func NewTestableTimingHistogramVec(nowFunc func() time.Time, opts *TimingHistogr
 		TimingHistogramOpts: opts,
 		nowFunc:             nowFunc,
 		originalLabels:      labels,
-		lazyMetric:          lazyMetric{},
+		lazyMetric:          lazyMetric{stabilityLevel: opts.StabilityLevel},
 	}
 	v.lazyInit(v, fqName)
 	return v


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a metric showing the number of metrics broken down by stability level and deprecated version. 

```
# HELP registered_metric_total [ALPHA] The count of registered metrics broken by stability level and deprecation version.
# TYPE registered_metric_total counter
registered_metric_total{deprecated_version="",stability_level="ALPHA"} 150
registered_metric_total{deprecated_version="",stability_level="STABLE"} 10
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`registered_metric_total` now reports the number of metrics broken down by stability level and deprecated version
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/3466
```
