### PR TITLE
Fix ClientNegotiator decode not being set

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/negotiate.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/negotiate.go
@@ -89,6 +89,7 @@ func NewClientNegotiator(serializer NegotiatedSerializer, gv schema.GroupVersion
 	return &clientNegotiator{
 		serializer: serializer,
 		encode:     gv,
+		decode:     gv,
 	}
 }
 


### PR DESCRIPTION
/kind bug


#### What this PR does / why we need it:
I couldn't get watching custom resources to work, without this change
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #112915

#### Special notes for your reviewer:
I'm not familiar with the kubernetes codebase, but it looks like setting decode was just forgotten. It's being used, but to my knowledge not set anywhere.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE - I guess
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
