### PR TITLE
e2e: ginkgo timeouts: use context provided by ginkgo

### DIFF
--- a/test/e2e/apimachinery/apply.go
+++ b/test/e2e/apimachinery/apply.go
@@ -56,11 +56,11 @@ var _ = SIGDescribe("ServerSideApply", func() {
 		ns = f.Namespace.Name
 	})
 
-	ginkgo.AfterEach(func() {
-		_ = client.AppsV1().Deployments(ns).Delete(context.TODO(), "deployment", metav1.DeleteOptions{})
-		_ = client.AppsV1().Deployments(ns).Delete(context.TODO(), "deployment-shared-unset", metav1.DeleteOptions{})
-		_ = client.AppsV1().Deployments(ns).Delete(context.TODO(), "deployment-shared-map-item-removal", metav1.DeleteOptions{})
-		_ = client.CoreV1().Pods(ns).Delete(context.TODO(), "test-pod", metav1.DeleteOptions{})
+	ginkgo.AfterEach(func(ctx context.Context) {
+		_ = client.AppsV1().Deployments(ns).Delete(ctx, "deployment", metav1.DeleteOptions{})
+		_ = client.AppsV1().Deployments(ns).Delete(ctx, "deployment-shared-unset", metav1.DeleteOptions{})
+		_ = client.AppsV1().Deployments(ns).Delete(ctx, "deployment-shared-map-item-removal", metav1.DeleteOptions{})
+		_ = client.CoreV1().Pods(ns).Delete(ctx, "test-pod", metav1.DeleteOptions{})
 	})
 
 	/*
@@ -119,13 +119,13 @@ var _ = SIGDescribe("ServerSideApply", func() {
 				Name(tc.name).
 				Param("fieldManager", "apply_test").
 				Body([]byte(tc.body)).
-				Do(context.TODO()).
+				Do(ctx).
 				Get()
 			if err != nil {
 				framework.Failf("Failed to create object using Apply patch: %v", err)
 			}
 
-			_, err = client.CoreV1().RESTClient().Get().Namespace(ns).Resource(tc.resource).Name(tc.name).Do(context.TODO()).Get()
+			_, err = client.CoreV1().RESTClient().Get().Namespace(ns).Resource(tc.resource).Name(tc.name).Do(ctx).Get()
 			if err != nil {
 				framework.Failf("Failed to retrieve object: %v", err)
 			}
@@ -137,7 +137,7 @@ var _ = SIGDescribe("ServerSideApply", func() {
 				Name(tc.name).
 				Param("fieldManager", "apply_test_2").
 				Body([]byte(tc.body)).
-				Do(context.TODO()).
+				Do(ctx).
 				Get()
 			if err != nil {
 				framework.Failf("Failed to re-apply object using Apply patch: %v", err)
@@ -203,13 +203,13 @@ var _ = SIGDescribe("ServerSideApply", func() {
 					Name(tc.name).
 					Param("fieldManager", "apply_test").
 					Body([]byte(tc.body)).
-					Do(context.TODO()).
+					Do(ctx).
 					Get()
 				if err != nil {
 					framework.Failf("Failed to create object using Apply patch: %v", err)
 				}
 
-				_, err = client.CoreV1().RESTClient().Get().Namespace(ns).Resource(tc.resource).Name(tc.name).Do(context.TODO()).Get()
+				_, err = client.CoreV1().RESTClient().Get().Namespace(ns).Resource(tc.resource).Name(tc.name).Do(ctx).Get()
 				if err != nil {
 					framework.Failf("Failed to retrieve object: %v", err)
 				}
@@ -221,12 +221,12 @@ var _ = SIGDescribe("ServerSideApply", func() {
 					Name(tc.name).
 					Param("fieldManager", "apply_test2").
 					Body([]byte(tc.statusPatch)).
-					Do(context.TODO()).
+					Do(ctx).
 					Get()
 				if err != nil {
 					framework.Failf("Failed to Apply Status using Apply patch: %v", err)
 				}
-				pod, err := client.CoreV1().Pods(ns).Get(context.TODO(), "test-pod", metav1.GetOptions{})
+				pod, err := client.CoreV1().Pods(ns).Get(ctx, "test-pod", metav1.GetOptions{})
 				framework.ExpectNoError(err, "retrieving test pod")
 				for _, c := range pod.Status.Conditions {
 					if c.Type == "MyStatus" {
@@ -242,13 +242,13 @@ var _ = SIGDescribe("ServerSideApply", func() {
 					Name(tc.name).
 					Param("fieldManager", "apply_test2").
 					Body([]byte(tc.statusPatch)).
-					Do(context.TODO()).
+					Do(ctx).
 					Get()
 				if err != nil {
 					framework.Failf("Failed to Apply Status using Apply patch: %v", err)
 				}
 
-				pod, err = client.CoreV1().Pods(ns).Get(context.TODO(), "test-pod", metav1.GetOptions{})
+				pod, err = client.CoreV1().Pods(ns).Get(ctx, "test-pod", metav1.GetOptions{})
 				framework.ExpectNoError(err, "retrieving test pod")
 
 				myStatusFound := false
@@ -311,7 +311,7 @@ var _ = SIGDescribe("ServerSideApply", func() {
 			Resource("deployments").
 			Name("deployment").
 			Param("fieldManager", "apply_test").
-			Body(obj).Do(context.TODO()).Get()
+			Body(obj).Do(ctx).Get()
 		if err != nil {
 			framework.Failf("Failed to create object using Apply patch: %v", err)
 		}
@@ -352,12 +352,12 @@ var _ = SIGDescribe("ServerSideApply", func() {
 			Resource("deployments").
 			Name("deployment").
 			Param("fieldManager", "apply_test").
-			Body(obj).Do(context.TODO()).Get()
+			Body(obj).Do(ctx).Get()
 		if err != nil {
 			framework.Failf("Failed to remove container port using Apply patch: %v", err)
 		}
 
-		deployment, err := client.AppsV1().Deployments(ns).Get(context.TODO(), "deployment", metav1.GetOptions{})
+		deployment, err := client.AppsV1().Deployments(ns).Get(ctx, "deployment", metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("Failed to retrieve object: %v", err)
 		}
@@ -415,7 +415,7 @@ var _ = SIGDescribe("ServerSideApply", func() {
 				Name("deployment-shared-unset").
 				Param("fieldManager", fieldManager).
 				Body(apply).
-				Do(context.TODO()).
+				Do(ctx).
 				Get()
 			if err != nil {
 				framework.Failf("Failed to create object using Apply patch: %v", err)
@@ -459,7 +459,7 @@ var _ = SIGDescribe("ServerSideApply", func() {
 			Name("deployment-shared-unset").
 			Param("fieldManager", "shared_owner_1").
 			Body(apply).
-			Do(context.TODO()).
+			Do(ctx).
 			Get()
 		if err != nil {
 			framework.Failf("Failed to create object using Apply patch: %v", err)
@@ -518,7 +518,7 @@ var _ = SIGDescribe("ServerSideApply", func() {
 			Resource("deployments").
 			Name("deployment").
 			Param("fieldManager", "apply_test").
-			Body(obj).Do(context.TODO()).Get()
+			Body(obj).Do(ctx).Get()
 		if err != nil {
 			framework.Failf("Failed to create object using Apply patch: %v", err)
 		}
@@ -528,7 +528,7 @@ var _ = SIGDescribe("ServerSideApply", func() {
 			Namespace(ns).
 			Resource("deployments").
 			Name("deployment").
-			Body([]byte(`{"spec":{"replicas": 5}}`)).Do(context.TODO()).Get()
+			Body([]byte(`{"spec":{"replicas": 5}}`)).Do(ctx).Get()
 		if err != nil {
 			framework.Failf("Failed to patch object: %v", err)
 		}
@@ -539,7 +539,7 @@ var _ = SIGDescribe("ServerSideApply", func() {
 			Resource("deployments").
 			Name("deployment").
 			Param("fieldManager", "apply_test").
-			Body(obj).Do(context.TODO()).Get()
+			Body(obj).Do(ctx).Get()
 		if err == nil {
 			framework.Failf("Expecting to get conflicts when applying object")
 		}
@@ -558,7 +558,7 @@ var _ = SIGDescribe("ServerSideApply", func() {
 			Name("deployment").
 			Param("force", "true").
 			Param("fieldManager", "apply_test").
-			Body(obj).Do(context.TODO()).Get()
+			Body(obj).Do(ctx).Get()
 		if err != nil {
 			framework.Failf("Failed to apply object with force: %v", err)
 		}
@@ -678,7 +678,7 @@ spec:
 			Name(name).
 			Param("fieldManager", "apply_test").
 			Body(yamlBody).
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if err != nil {
 			framework.Failf("failed to create custom resource with apply: %v:\n%v", err, string(result))
 		}
@@ -706,7 +706,7 @@ spec:
 			Name(name).
 			Param("fieldManager", "apply_test").
 			Body(yamlBodyBeta).
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if err != nil {
 			framework.Failf("failed to create custom resource with apply: %v:\n%v", err, string(result))
 		}
@@ -719,7 +719,7 @@ spec:
 				AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural).
 				Name(name).
 				Body([]byte(`{"metadata":{"finalizers":[]}}`)).
-				DoRaw(context.TODO())
+				DoRaw(ctx)
 			if err != nil {
 				framework.Failf("failed to reset finalizers: %v:\n%v", err, string(result))
 			}
@@ -730,7 +730,7 @@ spec:
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural).
 			Name(name).
 			Body([]byte(`{"metadata":{"finalizers":["test-finalizer","another-one"]}}`)).
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if err != nil {
 			framework.Failf("failed to add finalizer with merge patch: %v:\n%v", err, string(result))
 		}
@@ -745,7 +745,7 @@ spec:
 			Param("fieldManager", "apply_test").
 			SetHeader("Accept", "application/json").
 			Body(yamlBody).
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if err != nil {
 			framework.Failf("failed to apply same config after adding a finalizer: %v:\n%v", err, string(result))
 		}
@@ -758,7 +758,7 @@ spec:
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural).
 			Name(name).
 			Body([]byte(`{"spec":{"replicas": 5}}`)).
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if err != nil {
 			framework.Failf("failed to update number of replicas with merge patch: %v:\n%v", err, string(result))
 		}
@@ -770,7 +770,7 @@ spec:
 			Name(name).
 			Param("fieldManager", "apply_test").
 			Body(yamlBody).
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if err == nil {
 			framework.Failf("Expecting to get conflicts when applying object after updating replicas, got no error: %s", result)
 		}
@@ -789,7 +789,7 @@ spec:
 			Param("force", "true").
 			Param("fieldManager", "apply_test").
 			Body(yamlBody).
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if err != nil {
 			framework.Failf("failed to apply object with force after updating replicas: %v:\n%v", err, string(result))
 		}
@@ -810,7 +810,7 @@ spec:
   - name: "y"
     containerPort: 80
     protocol: TCP`, apiVersion, kind, name))).
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if err == nil {
 			framework.Failf("Expecting to get conflicts when a different applier updates existing list item, got no error: %s", result)
 		}
@@ -838,7 +838,7 @@ spec:
     containerPort: 8080
     protocol: TCP`, apiVersion, kind, name))).
 			SetHeader("Accept", "application/json").
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if err != nil {
 			framework.Failf("failed to add a new list item to the object as a different applier: %v:\n%v", err, string(result))
 		}
@@ -872,7 +872,7 @@ spec:
 			Name("should-not-exist").
 			Param("fieldManager", "apply_test").
 			Body(notExistingYAMLBody).
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if !apierrors.IsNotFound(err) {
 			framework.Failf("create on update should fail with notFound, got %v", err)
 		}
@@ -932,7 +932,7 @@ spec:
 			Name(name).
 			Param("fieldManager", "apply_test").
 			Body(crdYamlBody).
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if err != nil {
 			framework.Failf("failed to create custom resource with apply: %v:\n%v", err, string(result))
 		}
@@ -953,7 +953,7 @@ spec:
 			Param("fieldManager", "apply_test_2").
 			Param("force", "true").
 			Body(crdYamlBody).
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if err != nil {
 			framework.Failf("failed to create custom resource with apply: %v:\n%v", err, string(result))
 		}
@@ -1006,7 +1006,7 @@ spec:
 			Name("deployment-shared-map-item-removal").
 			Param("fieldManager", "test_applier").
 			Body(apply).
-			Do(context.TODO()).
+			Do(ctx).
 			Get()
 		if err != nil {
 			framework.Failf("Failed to create object using Apply patch: %v", err)
@@ -1055,7 +1055,7 @@ spec:
 			Name("deployment-shared-map-item-removal").
 			Param("fieldManager", "test_applier").
 			Body(apply).
-			Do(context.TODO()).
+			Do(ctx).
 			Get()
 		if err != nil {
 			framework.Failf("Failed to create object using Apply patch: %v", err)

--- a/test/e2e/apimachinery/chunking.go
+++ b/test/e2e/apimachinery/chunking.go
@@ -48,14 +48,14 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 	f := framework.NewDefaultFramework("chunking")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		ns := f.Namespace.Name
 		c := f.ClientSet
 		client := c.CoreV1().PodTemplates(ns)
 		ginkgo.By("creating a large number of resources")
-		workqueue.ParallelizeUntil(context.TODO(), 20, numberOfTotalResources, func(i int) {
+		workqueue.ParallelizeUntil(ctx, 20, numberOfTotalResources, func(i int) {
 			for tries := 3; tries >= 0; tries-- {
-				_, err := client.Create(context.TODO(), &v1.PodTemplate{
+				_, err := client.Create(ctx, &v1.PodTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: fmt.Sprintf("template-%04d", i),
 					},
@@ -87,7 +87,7 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 			var lastRV string
 			for {
 				opts.Limit = int64(rand.Int31n(numberOfTotalResources/10) + 1)
-				list, err := client.List(context.TODO(), opts)
+				list, err := client.List(ctx, opts)
 				framework.ExpectNoError(err, "failed to list pod templates in namespace: %s, given limit: %d", ns, opts.Limit)
 				framework.Logf("Retrieved %d/%d results with rv %s and continue %s", len(list.Items), opts.Limit, list.ResourceVersion, list.Continue)
 				gomega.Expect(len(list.Items)).To(gomega.BeNumerically("<=", opts.Limit))
@@ -118,7 +118,7 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 
 		ginkgo.By("retrieving those results all at once")
 		opts := metav1.ListOptions{Limit: numberOfTotalResources + 1}
-		list, err := client.List(context.TODO(), opts)
+		list, err := client.List(ctx, opts)
 		framework.ExpectNoError(err, "failed to list pod templates in namespace: %s, given limit: %d", ns, opts.Limit)
 		gomega.Expect(list.Items).To(gomega.HaveLen(numberOfTotalResources))
 	})
@@ -132,7 +132,7 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 		oneTenth := int64(numberOfTotalResources / 10)
 		opts := metav1.ListOptions{}
 		opts.Limit = oneTenth
-		list, err := client.List(context.TODO(), opts)
+		list, err := client.List(ctx, opts)
 		framework.ExpectNoError(err, "failed to list pod templates in namespace: %s, given limit: %d", ns, opts.Limit)
 		firstToken := list.Continue
 		firstRV := list.ResourceVersion
@@ -150,7 +150,7 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 		opts.Continue = firstToken
 		var inconsistentToken string
 		wait.Poll(20*time.Second, 2*storagebackend.DefaultCompactInterval, func() (bool, error) {
-			_, err := client.List(context.TODO(), opts)
+			_, err := client.List(ctx, opts)
 			if err == nil {
 				framework.Logf("Token %s has not expired yet", firstToken)
 				return false, nil
@@ -173,7 +173,7 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 
 		ginkgo.By("retrieving the second page again with the token received with the error message")
 		opts.Continue = inconsistentToken
-		list, err = client.List(context.TODO(), opts)
+		list, err = client.List(ctx, opts)
 		framework.ExpectNoError(err, "failed to list pod templates in namespace: %s, given inconsistent continue token %s and limit: %d", ns, opts.Continue, opts.Limit)
 		framework.ExpectNotEqual(list.ResourceVersion, firstRV)
 		gomega.Expect(len(list.Items)).To(gomega.BeNumerically("==", opts.Limit))
@@ -196,7 +196,7 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 		opts.Continue = list.Continue
 		lastRV := list.ResourceVersion
 		for {
-			list, err := client.List(context.TODO(), opts)
+			list, err := client.List(ctx, opts)
 			framework.ExpectNoError(err, "failed to list pod templates in namespace: %s, given limit: %d", ns, opts.Limit)
 			if shouldCheckRemainingItem() {
 				if list.GetContinue() == "" {

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -138,7 +138,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 			framework.Failf("unexpected no error when explaining property that doesn't exist: %v", err)
 		}
 
-		if err := cleanupCRD(f, crd); err != nil {
+		if err := cleanupCRD(ctx, f, crd); err != nil {
 			framework.Failf("%v", err)
 		}
 	})
@@ -179,7 +179,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 			framework.Failf("%v", err)
 		}
 
-		if err := cleanupCRD(f, crd); err != nil {
+		if err := cleanupCRD(ctx, f, crd); err != nil {
 			framework.Failf("%v", err)
 		}
 	})
@@ -220,7 +220,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 			framework.Failf("%v", err)
 		}
 
-		if err := cleanupCRD(f, crd); err != nil {
+		if err := cleanupCRD(ctx, f, crd); err != nil {
 			framework.Failf("%v", err)
 		}
 	})
@@ -262,7 +262,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 			framework.Failf("%v", err)
 		}
 
-		if err := cleanupCRD(f, crd); err != nil {
+		if err := cleanupCRD(ctx, f, crd); err != nil {
 			framework.Failf("%v", err)
 		}
 	})
@@ -292,10 +292,10 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		if err := waitForDefinition(f.ClientSet, definitionName(crdFoo, "v1"), schemaFoo); err != nil {
 			framework.Failf("%v", err)
 		}
-		if err := cleanupCRD(f, crdFoo); err != nil {
+		if err := cleanupCRD(ctx, f, crdFoo); err != nil {
 			framework.Failf("%v", err)
 		}
-		if err := cleanupCRD(f, crdWaldo); err != nil {
+		if err := cleanupCRD(ctx, f, crdWaldo); err != nil {
 			framework.Failf("%v", err)
 		}
 	})
@@ -318,7 +318,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		if err := waitForDefinition(f.ClientSet, definitionName(crdMultiVer, "v2"), schemaFoo); err != nil {
 			framework.Failf("%v", err)
 		}
-		if err := cleanupCRD(f, crdMultiVer); err != nil {
+		if err := cleanupCRD(ctx, f, crdMultiVer); err != nil {
 			framework.Failf("%v", err)
 		}
 
@@ -340,10 +340,10 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		if err := waitForDefinition(f.ClientSet, definitionName(crdFoo, "v4"), schemaFoo); err != nil {
 			framework.Failf("%v", err)
 		}
-		if err := cleanupCRD(f, crdFoo); err != nil {
+		if err := cleanupCRD(ctx, f, crdFoo); err != nil {
 			framework.Failf("%v", err)
 		}
-		if err := cleanupCRD(f, crdWaldo); err != nil {
+		if err := cleanupCRD(ctx, f, crdWaldo); err != nil {
 			framework.Failf("%v", err)
 		}
 	})
@@ -373,10 +373,10 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		if err := waitForDefinition(f.ClientSet, definitionName(crdFoo, "v6"), schemaFoo); err != nil {
 			framework.Failf("%v", err)
 		}
-		if err := cleanupCRD(f, crdFoo); err != nil {
+		if err := cleanupCRD(ctx, f, crdFoo); err != nil {
 			framework.Failf("%v", err)
 		}
-		if err := cleanupCRD(f, crdWaldo); err != nil {
+		if err := cleanupCRD(ctx, f, crdWaldo); err != nil {
 			framework.Failf("%v", err)
 		}
 	})
@@ -406,7 +406,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 			{"op":"test","path":"/spec/versions/1/name","value":"v3"},
 			{"op": "replace", "path": "/spec/versions/1/name", "value": "v4"}
 		]`)
-		crdMultiVer.Crd, err = crdMultiVer.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Patch(context.TODO(), crdMultiVer.Crd.Name, types.JSONPatchType, patch, metav1.PatchOptions{})
+		crdMultiVer.Crd, err = crdMultiVer.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Patch(ctx, crdMultiVer.Crd.Name, types.JSONPatchType, patch, metav1.PatchOptions{})
 		if err != nil {
 			framework.Failf("%v", err)
 		}
@@ -427,7 +427,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		// TestCrd.Versions is different from TestCrd.Crd.Versions, we have to manually
 		// update the name there. Used by cleanupCRD
 		crdMultiVer.Crd.Spec.Versions[1].Name = "v4"
-		if err := cleanupCRD(f, crdMultiVer); err != nil {
+		if err := cleanupCRD(ctx, f, crdMultiVer); err != nil {
 			framework.Failf("%v", err)
 		}
 	})
@@ -454,12 +454,12 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		}
 
 		ginkgo.By("mark a version not serverd")
-		crd.Crd, err = crd.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Crd.Name, metav1.GetOptions{})
+		crd.Crd, err = crd.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Crd.Name, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("%v", err)
 		}
 		crd.Crd.Spec.Versions[1].Served = false
-		crd.Crd, err = crd.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), crd.Crd, metav1.UpdateOptions{})
+		crd.Crd, err = crd.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, crd.Crd, metav1.UpdateOptions{})
 		if err != nil {
 			framework.Failf("%v", err)
 		}
@@ -473,7 +473,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 			framework.Failf("%v", err)
 		}
 
-		if err := cleanupCRD(f, crd); err != nil {
+		if err := cleanupCRD(ctx, f, crd); err != nil {
 			framework.Failf("%v", err)
 		}
 	})
@@ -497,11 +497,11 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		}
 
 		if err := verifyKubectlExplain(f.Namespace.Name, customServiceShortName+".spec", `(?s)DESCRIPTION:.*Specification of CustomService.*FIELDS:.*dummy.*<string>.*Dummy property`); err != nil {
-			_ = cleanupCRD(f, crdSvc) // need to remove the crd since its name is unchanged
+			_ = cleanupCRD(ctx, f, crdSvc) // need to remove the crd since its name is unchanged
 			framework.Failf("%v", err)
 		}
 
-		if err := cleanupCRD(f, crdSvc); err != nil {
+		if err := cleanupCRD(ctx, f, crdSvc); err != nil {
 			framework.Failf("%v", err)
 		}
 	})
@@ -572,8 +572,8 @@ func setupCRDAndVerifySchemaWithOptions(f *framework.Framework, schema, expect [
 	return crd, nil
 }
 
-func cleanupCRD(f *framework.Framework, crd *crd.TestCrd) error {
-	crd.CleanUp()
+func cleanupCRD(ctx context.Context, f *framework.Framework, crd *crd.TestCrd) error {
+	_ = crd.CleanUp(ctx)
 	for _, v := range crd.Crd.Spec.Versions {
 		name := definitionName(crd, v.Name)
 		if err := waitForDefinitionCleanup(f.ClientSet, name); err != nil {

--- a/test/e2e/apimachinery/crd_validation_rules.go
+++ b/test/e2e/apimachinery/crd_validation_rules.go
@@ -107,7 +107,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin]", f
 		ginkgo.By("Creating a custom resource with values that are allowed by the validation rules set on the custom resource definition")
 		crClient, gvr := customResourceClient(crd)
 		name1 := names.SimpleNameGenerator.GenerateName("cr-1")
-		_, err = crClient.Namespace(f.Namespace.Name).Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{
+		_, err = crClient.Namespace(f.Namespace.Name).Create(ctx, &unstructured.Unstructured{Object: map[string]interface{}{
 			"apiVersion": gvr.Group + "/" + gvr.Version,
 			"kind":       crd.Spec.Names.Kind,
 			"metadata": map[string]interface{}{
@@ -137,7 +137,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin]", f
 		ginkgo.By("Creating a custom resource with values that fail the validation rules set on the custom resource definition")
 		crClient, gvr := customResourceClient(crd)
 		name1 := names.SimpleNameGenerator.GenerateName("cr-1")
-		_, err = crClient.Namespace(f.Namespace.Name).Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{
+		_, err = crClient.Namespace(f.Namespace.Name).Create(ctx, &unstructured.Unstructured{Object: map[string]interface{}{
 			"apiVersion": gvr.Group + "/" + gvr.Version,
 			"kind":       crd.Spec.Names.Kind,
 			"metadata": map[string]interface{}{
@@ -248,7 +248,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin]", f
 		ginkgo.By("Attempting to create a custom resource that will exceed the runtime cost limit")
 		crClient, gvr := customResourceClient(crd)
 		name1 := names.SimpleNameGenerator.GenerateName("cr-1")
-		_, err = crClient.Namespace(f.Namespace.Name).Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{
+		_, err = crClient.Namespace(f.Namespace.Name).Create(ctx, &unstructured.Unstructured{Object: map[string]interface{}{
 			"apiVersion": gvr.Group + "/" + gvr.Version,
 			"kind":       crd.Spec.Names.Kind,
 			"metadata": map[string]interface{}{
@@ -294,7 +294,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin]", f
 		ginkgo.By("Attempting to create a custom resource")
 		crClient, gvr := customResourceClient(crd)
 		name1 := names.SimpleNameGenerator.GenerateName("cr-1")
-		unstruct, err := crClient.Namespace(f.Namespace.Name).Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{
+		unstruct, err := crClient.Namespace(f.Namespace.Name).Create(ctx, &unstructured.Unstructured{Object: map[string]interface{}{
 			"apiVersion": gvr.Group + "/" + gvr.Version,
 			"kind":       crd.Spec.Names.Kind,
 			"metadata": map[string]interface{}{
@@ -307,7 +307,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin]", f
 		}}, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "transition rules do not apply to create operations")
 		ginkgo.By("Updating a custom resource with a value that does not satisfy an x-kubernetes-validations transition rule")
-		_, err = crClient.Namespace(f.Namespace.Name).Update(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{
+		_, err = crClient.Namespace(f.Namespace.Name).Update(ctx, &unstructured.Unstructured{Object: map[string]interface{}{
 			"apiVersion": gvr.Group + "/" + gvr.Version,
 			"kind":       crd.Spec.Names.Kind,
 			"metadata": map[string]interface{}{

--- a/test/e2e/apimachinery/crd_watch.go
+++ b/test/e2e/apimachinery/crd_watch.go
@@ -82,47 +82,47 @@ var _ = SIGDescribe("CustomResourceDefinition Watch [Privileged:ClusterAdmin]", 
 			noxuResourceClient, err := newNamespacedCustomResourceClient(ns, f.DynamicClient, noxuDefinition)
 			framework.ExpectNoError(err, "creating custom resource client")
 
-			watchA, err := watchCRWithName(noxuResourceClient, watchCRNameA)
+			watchA, err := watchCRWithName(ctx, noxuResourceClient, watchCRNameA)
 			framework.ExpectNoError(err, "failed to watch custom resource: %s", watchCRNameA)
 
-			watchB, err := watchCRWithName(noxuResourceClient, watchCRNameB)
+			watchB, err := watchCRWithName(ctx, noxuResourceClient, watchCRNameB)
 			framework.ExpectNoError(err, "failed to watch custom resource: %s", watchCRNameB)
 
 			testCrA := fixtures.NewNoxuInstance(ns, watchCRNameA)
 			testCrB := fixtures.NewNoxuInstance(ns, watchCRNameB)
 
 			ginkgo.By("Creating first CR ")
-			testCrA, err = instantiateCustomResource(testCrA, noxuResourceClient, noxuDefinition)
+			testCrA, err = instantiateCustomResource(ctx, testCrA, noxuResourceClient, noxuDefinition)
 			framework.ExpectNoError(err, "failed to instantiate custom resource: %+v", testCrA)
 			expectEvent(watchA, watch.Added, testCrA)
 			expectNoEvent(watchB, watch.Added, testCrA)
 
 			ginkgo.By("Creating second CR")
-			testCrB, err = instantiateCustomResource(testCrB, noxuResourceClient, noxuDefinition)
+			testCrB, err = instantiateCustomResource(ctx, testCrB, noxuResourceClient, noxuDefinition)
 			framework.ExpectNoError(err, "failed to instantiate custom resource: %+v", testCrB)
 			expectEvent(watchB, watch.Added, testCrB)
 			expectNoEvent(watchA, watch.Added, testCrB)
 
 			ginkgo.By("Modifying first CR")
-			err = patchCustomResource(noxuResourceClient, watchCRNameA)
+			err = patchCustomResource(ctx, noxuResourceClient, watchCRNameA)
 			framework.ExpectNoError(err, "failed to patch custom resource: %s", watchCRNameA)
 			expectEvent(watchA, watch.Modified, nil)
 			expectNoEvent(watchB, watch.Modified, nil)
 
 			ginkgo.By("Modifying second CR")
-			err = patchCustomResource(noxuResourceClient, watchCRNameB)
+			err = patchCustomResource(ctx, noxuResourceClient, watchCRNameB)
 			framework.ExpectNoError(err, "failed to patch custom resource: %s", watchCRNameB)
 			expectEvent(watchB, watch.Modified, nil)
 			expectNoEvent(watchA, watch.Modified, nil)
 
 			ginkgo.By("Deleting first CR")
-			err = deleteCustomResource(noxuResourceClient, watchCRNameA)
+			err = deleteCustomResource(ctx, noxuResourceClient, watchCRNameA)
 			framework.ExpectNoError(err, "failed to delete custom resource: %s", watchCRNameA)
 			expectEvent(watchA, watch.Deleted, nil)
 			expectNoEvent(watchB, watch.Deleted, nil)
 
 			ginkgo.By("Deleting second CR")
-			err = deleteCustomResource(noxuResourceClient, watchCRNameB)
+			err = deleteCustomResource(ctx, noxuResourceClient, watchCRNameB)
 			framework.ExpectNoError(err, "failed to delete custom resource: %s", watchCRNameB)
 			expectEvent(watchB, watch.Deleted, nil)
 			expectNoEvent(watchA, watch.Deleted, nil)
@@ -130,9 +130,9 @@ var _ = SIGDescribe("CustomResourceDefinition Watch [Privileged:ClusterAdmin]", 
 	})
 })
 
-func watchCRWithName(crdResourceClient dynamic.ResourceInterface, name string) (watch.Interface, error) {
+func watchCRWithName(ctx context.Context, crdResourceClient dynamic.ResourceInterface, name string) (watch.Interface, error) {
 	return crdResourceClient.Watch(
-		context.TODO(),
+		ctx,
 		metav1.ListOptions{
 			FieldSelector:  "metadata.name=" + name,
 			TimeoutSeconds: int64ptr(600),
@@ -140,8 +140,8 @@ func watchCRWithName(crdResourceClient dynamic.ResourceInterface, name string) (
 	)
 }
 
-func instantiateCustomResource(instanceToCreate *unstructured.Unstructured, client dynamic.ResourceInterface, definition *apiextensionsv1.CustomResourceDefinition) (*unstructured.Unstructured, error) {
-	createdInstance, err := client.Create(context.TODO(), instanceToCreate, metav1.CreateOptions{})
+func instantiateCustomResource(ctx context.Context, instanceToCreate *unstructured.Unstructured, client dynamic.ResourceInterface, definition *apiextensionsv1.CustomResourceDefinition) (*unstructured.Unstructured, error) {
+	createdInstance, err := client.Create(ctx, instanceToCreate, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -169,9 +169,9 @@ func instantiateCustomResource(instanceToCreate *unstructured.Unstructured, clie
 	return createdInstance, nil
 }
 
-func patchCustomResource(client dynamic.ResourceInterface, name string) error {
+func patchCustomResource(ctx context.Context, client dynamic.ResourceInterface, name string) error {
 	_, err := client.Patch(
-		context.TODO(),
+		ctx,
 		name,
 		types.JSONPatchType,
 		[]byte(`[{ "op": "add", "path": "/dummy", "value": "test" }]`),
@@ -179,8 +179,8 @@ func patchCustomResource(client dynamic.ResourceInterface, name string) error {
 	return err
 }
 
-func deleteCustomResource(client dynamic.ResourceInterface, name string) error {
-	return client.Delete(context.TODO(), name, metav1.DeleteOptions{})
+func deleteCustomResource(ctx context.Context, client dynamic.ResourceInterface, name string) error {
+	return client.Delete(ctx, name, metav1.DeleteOptions{})
 }
 
 func newNamespacedCustomResourceClient(ns string, client dynamic.Interface, crd *apiextensionsv1.CustomResourceDefinition) (dynamic.ResourceInterface, error) {

--- a/test/e2e/apimachinery/discovery.go
+++ b/test/e2e/apimachinery/discovery.go
@@ -123,7 +123,7 @@ var _ = SIGDescribe("Discovery", func() {
 
 		// get list of APIGroup endpoints
 		list := &metav1.APIGroupList{}
-		err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/").Do(context.TODO()).Into(list)
+		err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/").Do(ctx).Into(list)
 		framework.ExpectNoError(err, "Failed to find /apis/")
 		framework.ExpectNotEqual(len(list.Groups), 0, "Missing APIGroups")
 
@@ -137,7 +137,7 @@ var _ = SIGDescribe("Discovery", func() {
 			// locate APIGroup endpoint
 			checkGroup := &metav1.APIGroup{}
 			apiPath := "/apis/" + group.Name + "/"
-			err = f.ClientSet.Discovery().RESTClient().Get().AbsPath(apiPath).Do(context.TODO()).Into(checkGroup)
+			err = f.ClientSet.Discovery().RESTClient().Get().AbsPath(apiPath).Do(ctx).Into(checkGroup)
 			framework.ExpectNoError(err, "Fail to access: %s", apiPath)
 			framework.ExpectNotEqual(len(checkGroup.Versions), 0, "No version found for %v", group.Name)
 			framework.Logf("PreferredVersion.GroupVersion: %s", checkGroup.PreferredVersion.GroupVersion)

--- a/test/e2e/apimachinery/flowcontrol.go
+++ b/test/e2e/apimachinery/flowcontrol.go
@@ -62,13 +62,13 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		nonMatchingUsername := "foo"
 
 		ginkgo.By("creating a testing PriorityLevelConfiguration object")
-		createdPriorityLevel := createPriorityLevel(f, testingPriorityLevelName, 1)
+		createdPriorityLevel := createPriorityLevel(ctx, f, testingPriorityLevelName, 1)
 
 		ginkgo.By("creating a testing FlowSchema object")
-		createdFlowSchema := createFlowSchema(f, testingFlowSchemaName, 1000, testingPriorityLevelName, []string{matchingUsername})
+		createdFlowSchema := createFlowSchema(ctx, f, testingFlowSchemaName, 1000, testingPriorityLevelName, []string{matchingUsername})
 
 		ginkgo.By("waiting for testing FlowSchema and PriorityLevelConfiguration to reach steady state")
-		waitForSteadyState(f, testingFlowSchemaName, testingPriorityLevelName)
+		waitForSteadyState(ctx, f, testingFlowSchemaName, testingPriorityLevelName)
 
 		var response *http.Response
 		ginkgo.By("response headers should contain the UID of the appropriate FlowSchema and PriorityLevelConfiguration for a matching user")
@@ -130,19 +130,19 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		for i := range clients {
 			clients[i].priorityLevelName = fmt.Sprintf("%s-%s", priorityLevelNamePrefix, clients[i].username)
 			framework.Logf("creating PriorityLevel %q", clients[i].priorityLevelName)
-			createPriorityLevel(f, clients[i].priorityLevelName, 1)
+			createPriorityLevel(ctx, f, clients[i].priorityLevelName, 1)
 
 			clients[i].flowSchemaName = fmt.Sprintf("%s-%s", flowSchemaNamePrefix, clients[i].username)
 			framework.Logf("creating FlowSchema %q", clients[i].flowSchemaName)
-			createFlowSchema(f, clients[i].flowSchemaName, clients[i].matchingPrecedence, clients[i].priorityLevelName, []string{clients[i].username})
+			createFlowSchema(ctx, f, clients[i].flowSchemaName, clients[i].matchingPrecedence, clients[i].priorityLevelName, []string{clients[i].username})
 
 			ginkgo.By("waiting for testing FlowSchema and PriorityLevelConfiguration to reach steady state")
-			waitForSteadyState(f, clients[i].flowSchemaName, clients[i].priorityLevelName)
+			waitForSteadyState(ctx, f, clients[i].flowSchemaName, clients[i].priorityLevelName)
 		}
 
 		ginkgo.By("getting request concurrency from metrics")
 		for i := range clients {
-			realConcurrency, err := getPriorityLevelNominalConcurrency(f.ClientSet, clients[i].priorityLevelName)
+			realConcurrency, err := getPriorityLevelNominalConcurrency(ctx, f.ClientSet, clients[i].priorityLevelName)
 			framework.ExpectNoError(err)
 			clients[i].concurrency = int32(float64(realConcurrency) * clients[i].concurrencyMultiplier)
 			if clients[i].concurrency < 1 {
@@ -189,15 +189,15 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		loadDuration := 10 * time.Second
 
 		framework.Logf("creating PriorityLevel %q", priorityLevelName)
-		createPriorityLevel(f, priorityLevelName, 1)
+		createPriorityLevel(ctx, f, priorityLevelName, 1)
 
 		highQPSClientName := "highqps-" + f.UniqueName
 		lowQPSClientName := "lowqps-" + f.UniqueName
 		framework.Logf("creating FlowSchema %q", flowSchemaName)
-		createFlowSchema(f, flowSchemaName, 1000, priorityLevelName, []string{highQPSClientName, lowQPSClientName})
+		createFlowSchema(ctx, f, flowSchemaName, 1000, priorityLevelName, []string{highQPSClientName, lowQPSClientName})
 
 		ginkgo.By("waiting for testing flow schema and priority level to reach steady state")
-		waitForSteadyState(f, flowSchemaName, priorityLevelName)
+		waitForSteadyState(ctx, f, flowSchemaName, priorityLevelName)
 
 		type client struct {
 			username                    string
@@ -213,7 +213,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		}
 
 		framework.Logf("getting real concurrency")
-		realConcurrency, err := getPriorityLevelNominalConcurrency(f.ClientSet, priorityLevelName)
+		realConcurrency, err := getPriorityLevelNominalConcurrency(ctx, f.ClientSet, priorityLevelName)
 		framework.ExpectNoError(err)
 		for i := range clients {
 			clients[i].concurrency = int32(float64(realConcurrency) * clients[i].concurrencyMultiplier)
@@ -250,9 +250,9 @@ var _ = SIGDescribe("API priority and fairness", func() {
 
 // createPriorityLevel creates a priority level with the provided assured
 // concurrency share.
-func createPriorityLevel(f *framework.Framework, priorityLevelName string, nominalConcurrencyShares int32) *flowcontrol.PriorityLevelConfiguration {
+func createPriorityLevel(ctx context.Context, f *framework.Framework, priorityLevelName string, nominalConcurrencyShares int32) *flowcontrol.PriorityLevelConfiguration {
 	createdPriorityLevel, err := f.ClientSet.FlowcontrolV1beta3().PriorityLevelConfigurations().Create(
-		context.TODO(),
+		ctx,
 		&flowcontrol.PriorityLevelConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: priorityLevelName,
@@ -273,8 +273,8 @@ func createPriorityLevel(f *framework.Framework, priorityLevelName string, nomin
 	return createdPriorityLevel
 }
 
-func getPriorityLevelNominalConcurrency(c clientset.Interface, priorityLevelName string) (int32, error) {
-	resp, err := c.CoreV1().RESTClient().Get().RequestURI("/metrics").DoRaw(context.TODO())
+func getPriorityLevelNominalConcurrency(ctx context.Context, c clientset.Interface, priorityLevelName string) (int32, error) {
+	resp, err := c.CoreV1().RESTClient().Get().RequestURI("/metrics").DoRaw(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -306,7 +306,7 @@ func getPriorityLevelNominalConcurrency(c clientset.Interface, priorityLevelName
 
 // createFlowSchema creates a flow schema referring to a particular priority
 // level and matching the username provided.
-func createFlowSchema(f *framework.Framework, flowSchemaName string, matchingPrecedence int32, priorityLevelName string, matchingUsernames []string) *flowcontrol.FlowSchema {
+func createFlowSchema(ctx context.Context, f *framework.Framework, flowSchemaName string, matchingPrecedence int32, priorityLevelName string, matchingUsernames []string) *flowcontrol.FlowSchema {
 	var subjects []flowcontrol.Subject
 	for _, matchingUsername := range matchingUsernames {
 		subjects = append(subjects, flowcontrol.Subject{
@@ -318,7 +318,7 @@ func createFlowSchema(f *framework.Framework, flowSchemaName string, matchingPre
 	}
 
 	createdFlowSchema, err := f.ClientSet.FlowcontrolV1beta3().FlowSchemas().Create(
-		context.TODO(),
+		ctx,
 		&flowcontrol.FlowSchema{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: flowSchemaName,
@@ -354,9 +354,9 @@ func createFlowSchema(f *framework.Framework, flowSchemaName string, matchingPre
 // created flow schema and priority level have been seen by the APF controller
 // by checking: (1) the dangling priority level reference condition in the flow
 // schema status, and (2) metrics. The function times out after 30 seconds.
-func waitForSteadyState(f *framework.Framework, flowSchemaName string, priorityLevelName string) {
-	framework.ExpectNoError(wait.Poll(time.Second, 30*time.Second, func() (bool, error) {
-		fs, err := f.ClientSet.FlowcontrolV1beta3().FlowSchemas().Get(context.TODO(), flowSchemaName, metav1.GetOptions{})
+func waitForSteadyState(ctx context.Context, f *framework.Framework, flowSchemaName string, priorityLevelName string) {
+	framework.ExpectNoError(wait.PollWithContext(ctx, time.Second, 30*time.Second, func(ctx context.Context) (bool, error) {
+		fs, err := f.ClientSet.FlowcontrolV1beta3().FlowSchemas().Get(ctx, flowSchemaName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -368,7 +368,7 @@ func waitForSteadyState(f *framework.Framework, flowSchemaName string, priorityL
 			// hasn't been achieved.
 			return false, nil
 		}
-		_, err = getPriorityLevelNominalConcurrency(f.ClientSet, priorityLevelName)
+		_, err = getPriorityLevelNominalConcurrency(ctx, f.ClientSet, priorityLevelName)
 		if err != nil {
 			if err == errPriorityLevelNotFound {
 				return false, nil

--- a/test/e2e/apimachinery/generated_clientset.go
+++ b/test/e2e/apimachinery/generated_clientset.go
@@ -112,7 +112,7 @@ var _ = SIGDescribe("Generated clientset", func() {
 		ginkgo.By("setting up watch")
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{"time": value})).String()
 		options := metav1.ListOptions{LabelSelector: selector}
-		pods, err := podClient.List(context.TODO(), options)
+		pods, err := podClient.List(ctx, options)
 		if err != nil {
 			framework.Failf("Failed to query for pods: %v", err)
 		}
@@ -121,13 +121,13 @@ var _ = SIGDescribe("Generated clientset", func() {
 			LabelSelector:   selector,
 			ResourceVersion: pods.ListMeta.ResourceVersion,
 		}
-		w, err := podClient.Watch(context.TODO(), options)
+		w, err := podClient.Watch(ctx, options)
 		if err != nil {
 			framework.Failf("Failed to set up watch: %v", err)
 		}
 
 		ginkgo.By("creating the pod")
-		pod, err = podClient.Create(context.TODO(), pod, metav1.CreateOptions{})
+		pod, err = podClient.Create(ctx, pod, metav1.CreateOptions{})
 		if err != nil {
 			framework.Failf("Failed to create pod: %v", err)
 		}
@@ -137,7 +137,7 @@ var _ = SIGDescribe("Generated clientset", func() {
 			LabelSelector:   selector,
 			ResourceVersion: pod.ResourceVersion,
 		}
-		pods, err = podClient.List(context.TODO(), options)
+		pods, err = podClient.List(ctx, options)
 		if err != nil {
 			framework.Failf("Failed to query for pods: %v", err)
 		}
@@ -148,11 +148,11 @@ var _ = SIGDescribe("Generated clientset", func() {
 
 		// We need to wait for the pod to be scheduled, otherwise the deletion
 		// will be carried out immediately rather than gracefully.
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
 
 		ginkgo.By("deleting the pod gracefully")
 		gracePeriod := int64(31)
-		if err := podClient.Delete(context.TODO(), pod.Name, *metav1.NewDeleteOptions(gracePeriod)); err != nil {
+		if err := podClient.Delete(ctx, pod.Name, *metav1.NewDeleteOptions(gracePeriod)); err != nil {
 			framework.Failf("Failed to delete pod: %v", err)
 		}
 
@@ -225,7 +225,7 @@ var _ = SIGDescribe("Generated clientset", func() {
 		ginkgo.By("setting up watch")
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{"time": value})).String()
 		options := metav1.ListOptions{LabelSelector: selector}
-		cronJobs, err := cronJobClient.List(context.TODO(), options)
+		cronJobs, err := cronJobClient.List(ctx, options)
 		if err != nil {
 			framework.Failf("Failed to query for cronJobs: %v", err)
 		}
@@ -234,13 +234,13 @@ var _ = SIGDescribe("Generated clientset", func() {
 			LabelSelector:   selector,
 			ResourceVersion: cronJobs.ListMeta.ResourceVersion,
 		}
-		w, err := cronJobClient.Watch(context.TODO(), options)
+		w, err := cronJobClient.Watch(ctx, options)
 		if err != nil {
 			framework.Failf("Failed to set up watch: %v", err)
 		}
 
 		ginkgo.By("creating the cronJob")
-		cronJob, err = cronJobClient.Create(context.TODO(), cronJob, metav1.CreateOptions{})
+		cronJob, err = cronJobClient.Create(ctx, cronJob, metav1.CreateOptions{})
 		if err != nil {
 			framework.Failf("Failed to create cronJob: %v", err)
 		}
@@ -250,7 +250,7 @@ var _ = SIGDescribe("Generated clientset", func() {
 			LabelSelector:   selector,
 			ResourceVersion: cronJob.ResourceVersion,
 		}
-		cronJobs, err = cronJobClient.List(context.TODO(), options)
+		cronJobs, err = cronJobClient.List(ctx, options)
 		if err != nil {
 			framework.Failf("Failed to query for cronJobs: %v", err)
 		}
@@ -262,12 +262,12 @@ var _ = SIGDescribe("Generated clientset", func() {
 		ginkgo.By("deleting the cronJob")
 		// Use DeletePropagationBackground so the CronJob is really gone when the call returns.
 		propagationPolicy := metav1.DeletePropagationBackground
-		if err := cronJobClient.Delete(context.TODO(), cronJob.Name, metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
+		if err := cronJobClient.Delete(ctx, cronJob.Name, metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
 			framework.Failf("Failed to delete cronJob: %v", err)
 		}
 
 		options = metav1.ListOptions{LabelSelector: selector}
-		cronJobs, err = cronJobClient.List(context.TODO(), options)
+		cronJobs, err = cronJobClient.List(ctx, options)
 		if err != nil {
 			framework.Failf("Failed to list cronJobs to verify deletion: %v", err)
 		}

--- a/test/e2e/apimachinery/health_handlers.go
+++ b/test/e2e/apimachinery/health_handlers.go
@@ -93,10 +93,10 @@ var (
 	)
 )
 
-func testPath(client clientset.Interface, path string, requiredChecks sets.String) error {
+func testPath(ctx context.Context, client clientset.Interface, path string, requiredChecks sets.String) error {
 	var result restclient.Result
 	err := wait.Poll(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-		result = client.CoreV1().RESTClient().Get().RequestURI(path).Do(context.TODO())
+		result = client.CoreV1().RESTClient().Get().RequestURI(path).Do(ctx)
 		status := 0
 		result.StatusCode(&status)
 		return status == 200, nil
@@ -121,15 +121,15 @@ var _ = SIGDescribe("health handlers", func() {
 
 	ginkgo.It("should contain necessary checks", func(ctx context.Context) {
 		ginkgo.By("/health")
-		err := testPath(f.ClientSet, "/healthz?verbose=1", requiredHealthzChecks)
+		err := testPath(ctx, f.ClientSet, "/healthz?verbose=1", requiredHealthzChecks)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("/livez")
-		err = testPath(f.ClientSet, "/livez?verbose=1", requiredLivezChecks)
+		err = testPath(ctx, f.ClientSet, "/livez?verbose=1", requiredLivezChecks)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("/readyz")
-		err = testPath(f.ClientSet, "/readyz?verbose=1", requiredReadyzChecks)
+		err = testPath(ctx, f.ClientSet, "/readyz?verbose=1", requiredReadyzChecks)
 		framework.ExpectNoError(err)
 	})
 })

--- a/test/e2e/apimachinery/storage_version.go
+++ b/test/e2e/apimachinery/storage_version.go
@@ -47,7 +47,7 @@ var _ = SIGDescribe("StorageVersion resources [Feature:StorageVersionAPI]", func
 				GenerateName: svName,
 			},
 		}
-		createdSV, err := client.InternalV1alpha1().StorageVersions().Create(context.TODO(), sv, metav1.CreateOptions{})
+		createdSV, err := client.InternalV1alpha1().StorageVersions().Create(ctx, sv, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "creating storage version")
 
 		// update the created sv with server storage version
@@ -63,14 +63,14 @@ var _ = SIGDescribe("StorageVersion resources [Feature:StorageVersionAPI]", func
 			CommonEncodingVersion: &version,
 		}
 		_, err = client.InternalV1alpha1().StorageVersions().UpdateStatus(
-			context.TODO(), createdSV, metav1.UpdateOptions{})
+			ctx, createdSV, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "updating storage version")
 
 		// wait for sv to be GC'ed
 		framework.Logf("Waiting for storage version %v to be garbage collected", createdSV.Name)
 		err = wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
 			_, err := client.InternalV1alpha1().StorageVersions().Get(
-				context.TODO(), createdSV.Name, metav1.GetOptions{})
+				ctx, createdSV.Name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
 				return true, nil
 			}

--- a/test/e2e/apimachinery/table_conversion.go
+++ b/test/e2e/apimachinery/table_conversion.go
@@ -57,11 +57,11 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		podName := "pod-1"
 		framework.Logf("Creating pod %s", podName)
 
-		_, err := c.CoreV1().Pods(ns).Create(context.TODO(), newTablePod(ns, podName), metav1.CreateOptions{})
+		_, err := c.CoreV1().Pods(ns).Create(ctx, newTablePod(ns, podName), metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create pod %s in namespace: %s", podName, ns)
 
 		table := &metav1beta1.Table{}
-		err = c.CoreV1().RESTClient().Get().Resource("pods").Namespace(ns).Name(podName).SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").Do(context.TODO()).Into(table)
+		err = c.CoreV1().RESTClient().Get().Resource("pods").Namespace(ns).Name(podName).SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").Do(ctx).Into(table)
 		framework.ExpectNoError(err, "failed to get pod %s in Table form in namespace: %s", podName, ns)
 		framework.Logf("Table: %#v", table)
 
@@ -83,9 +83,9 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		client := c.CoreV1().PodTemplates(ns)
 
 		ginkgo.By("creating a large number of resources")
-		workqueue.ParallelizeUntil(context.TODO(), 5, 20, func(i int) {
+		workqueue.ParallelizeUntil(ctx, 5, 20, func(i int) {
 			for tries := 3; tries >= 0; tries-- {
-				_, err := client.Create(context.TODO(), &v1.PodTemplate{
+				_, err := client.Create(ctx, &v1.PodTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: fmt.Sprintf("template-%04d", i),
 					},
@@ -109,7 +109,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		err := c.CoreV1().RESTClient().Get().Namespace(ns).Resource("podtemplates").
 			VersionedParams(&metav1.ListOptions{Limit: 2}, metav1.ParameterCodec).
 			SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").
-			Do(context.TODO()).Into(pagedTable)
+			Do(ctx).Into(pagedTable)
 		framework.ExpectNoError(err, "failed to get pod templates in Table form in namespace: %s", ns)
 		framework.ExpectEqual(len(pagedTable.Rows), 2)
 		framework.ExpectNotEqual(pagedTable.ResourceVersion, "")
@@ -120,7 +120,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		err = c.CoreV1().RESTClient().Get().Namespace(ns).Resource("podtemplates").
 			VersionedParams(&metav1.ListOptions{Continue: pagedTable.Continue}, metav1.ParameterCodec).
 			SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").
-			Do(context.TODO()).Into(pagedTable)
+			Do(ctx).Into(pagedTable)
 		framework.ExpectNoError(err, "failed to get pod templates in Table form in namespace: %s", ns)
 		gomega.Expect(len(pagedTable.Rows)).To(gomega.BeNumerically(">", 0))
 		framework.ExpectEqual(pagedTable.Rows[0].Cells[0], "template-0002")
@@ -130,7 +130,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		c := f.ClientSet
 
 		table := &metav1beta1.Table{}
-		err := c.CoreV1().RESTClient().Get().Resource("nodes").SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").Do(context.TODO()).Into(table)
+		err := c.CoreV1().RESTClient().Get().Resource("nodes").SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").Do(ctx).Into(table)
 		framework.ExpectNoError(err, "failed to get nodes in Table form across all namespaces")
 		framework.Logf("Table: %#v", table)
 
@@ -163,7 +163,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 				},
 			},
 		}
-		err := c.AuthorizationV1().RESTClient().Post().Resource("selfsubjectaccessreviews").SetHeader("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io").Body(sar).Do(context.TODO()).Into(table)
+		err := c.AuthorizationV1().RESTClient().Post().Resource("selfsubjectaccessreviews").SetHeader("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io").Body(sar).Do(ctx).Into(table)
 		framework.ExpectError(err, "failed to return error when posting self subject access review: %+v, to a backend that does not implement metadata", sar)
 		framework.ExpectEqual(err.(apierrors.APIStatus).Status().Code, int32(406))
 	})

--- a/test/e2e/apimachinery/watch.go
+++ b/test/e2e/apimachinery/watch.go
@@ -62,15 +62,15 @@ var _ = SIGDescribe("Watchers", func() {
 		ns := f.Namespace.Name
 
 		ginkgo.By("creating a watch on configmaps with label A")
-		watchA, err := watchConfigMaps(f, "", multipleWatchersLabelValueA)
+		watchA, err := watchConfigMaps(ctx, f, "", multipleWatchersLabelValueA)
 		framework.ExpectNoError(err, "failed to create a watch on configmaps with label: %s", multipleWatchersLabelValueA)
 
 		ginkgo.By("creating a watch on configmaps with label B")
-		watchB, err := watchConfigMaps(f, "", multipleWatchersLabelValueB)
+		watchB, err := watchConfigMaps(ctx, f, "", multipleWatchersLabelValueB)
 		framework.ExpectNoError(err, "failed to create a watch on configmaps with label: %s", multipleWatchersLabelValueB)
 
 		ginkgo.By("creating a watch on configmaps with label A or B")
-		watchAB, err := watchConfigMaps(f, "", multipleWatchersLabelValueA, multipleWatchersLabelValueB)
+		watchAB, err := watchConfigMaps(ctx, f, "", multipleWatchersLabelValueA, multipleWatchersLabelValueB)
 		framework.ExpectNoError(err, "failed to create a watch on configmaps with label %s or %s", multipleWatchersLabelValueA, multipleWatchersLabelValueB)
 
 		testConfigMapA := &v1.ConfigMap{
@@ -91,13 +91,13 @@ var _ = SIGDescribe("Watchers", func() {
 		}
 
 		ginkgo.By("creating a configmap with label A and ensuring the correct watchers observe the notification")
-		testConfigMapA, err = c.CoreV1().ConfigMaps(ns).Create(context.TODO(), testConfigMapA, metav1.CreateOptions{})
+		testConfigMapA, err = c.CoreV1().ConfigMaps(ns).Create(ctx, testConfigMapA, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create a configmap with label %s in namespace: %s", multipleWatchersLabelValueA, ns)
 		expectEvent(watchA, watch.Added, testConfigMapA)
 		expectEvent(watchAB, watch.Added, testConfigMapA)
 
 		ginkgo.By("modifying configmap A and ensuring the correct watchers observe the notification")
-		testConfigMapA, err = updateConfigMap(c, ns, testConfigMapA.GetName(), func(cm *v1.ConfigMap) {
+		testConfigMapA, err = updateConfigMap(ctx, c, ns, testConfigMapA.GetName(), func(cm *v1.ConfigMap) {
 			setConfigMapData(cm, "mutation", "1")
 		})
 		framework.ExpectNoError(err, "failed to update configmap %s in namespace: %s", testConfigMapA.GetName(), ns)
@@ -105,7 +105,7 @@ var _ = SIGDescribe("Watchers", func() {
 		expectEvent(watchAB, watch.Modified, testConfigMapA)
 
 		ginkgo.By("modifying configmap A again and ensuring the correct watchers observe the notification")
-		testConfigMapA, err = updateConfigMap(c, ns, testConfigMapA.GetName(), func(cm *v1.ConfigMap) {
+		testConfigMapA, err = updateConfigMap(ctx, c, ns, testConfigMapA.GetName(), func(cm *v1.ConfigMap) {
 			setConfigMapData(cm, "mutation", "2")
 		})
 		framework.ExpectNoError(err, "failed to update configmap %s in namespace: %s", testConfigMapA.GetName(), ns)
@@ -113,20 +113,20 @@ var _ = SIGDescribe("Watchers", func() {
 		expectEvent(watchAB, watch.Modified, testConfigMapA)
 
 		ginkgo.By("deleting configmap A and ensuring the correct watchers observe the notification")
-		err = c.CoreV1().ConfigMaps(ns).Delete(context.TODO(), testConfigMapA.GetName(), metav1.DeleteOptions{})
+		err = c.CoreV1().ConfigMaps(ns).Delete(ctx, testConfigMapA.GetName(), metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete configmap %s in namespace: %s", testConfigMapA.GetName(), ns)
 		expectEvent(watchA, watch.Deleted, nil)
 		expectEvent(watchAB, watch.Deleted, nil)
 
 		ginkgo.By("creating a configmap with label B and ensuring the correct watchers observe the notification")
-		testConfigMapB, err = c.CoreV1().ConfigMaps(ns).Create(context.TODO(), testConfigMapB, metav1.CreateOptions{})
+		testConfigMapB, err = c.CoreV1().ConfigMaps(ns).Create(ctx, testConfigMapB, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create configmap %s in namespace: %s", testConfigMapB, ns)
 		expectEvent(watchB, watch.Added, testConfigMapB)
 		expectEvent(watchAB, watch.Added, testConfigMapB)
 		expectNoEvent(watchA, watch.Added, testConfigMapB)
 
 		ginkgo.By("deleting configmap B and ensuring the correct watchers observe the notification")
-		err = c.CoreV1().ConfigMaps(ns).Delete(context.TODO(), testConfigMapB.GetName(), metav1.DeleteOptions{})
+		err = c.CoreV1().ConfigMaps(ns).Delete(ctx, testConfigMapB.GetName(), metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete configmap %s in namespace: %s", testConfigMapB.GetName(), ns)
 		expectEvent(watchB, watch.Deleted, nil)
 		expectEvent(watchAB, watch.Deleted, nil)
@@ -153,27 +153,27 @@ var _ = SIGDescribe("Watchers", func() {
 		}
 
 		ginkgo.By("creating a new configmap")
-		testConfigMap, err := c.CoreV1().ConfigMaps(ns).Create(context.TODO(), testConfigMap, metav1.CreateOptions{})
+		testConfigMap, err := c.CoreV1().ConfigMaps(ns).Create(ctx, testConfigMap, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create configmap %s in namespace: %s", testConfigMap.GetName(), ns)
 
 		ginkgo.By("modifying the configmap once")
-		testConfigMapFirstUpdate, err := updateConfigMap(c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
+		testConfigMapFirstUpdate, err := updateConfigMap(ctx, c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
 			setConfigMapData(cm, "mutation", "1")
 		})
 		framework.ExpectNoError(err, "failed to update configmap %s in namespace: %s", testConfigMap.GetName(), ns)
 
 		ginkgo.By("modifying the configmap a second time")
-		testConfigMapSecondUpdate, err := updateConfigMap(c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
+		testConfigMapSecondUpdate, err := updateConfigMap(ctx, c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
 			setConfigMapData(cm, "mutation", "2")
 		})
 		framework.ExpectNoError(err, "failed to update configmap %s in namespace %s a second time", testConfigMap.GetName(), ns)
 
 		ginkgo.By("deleting the configmap")
-		err = c.CoreV1().ConfigMaps(ns).Delete(context.TODO(), testConfigMap.GetName(), metav1.DeleteOptions{})
+		err = c.CoreV1().ConfigMaps(ns).Delete(ctx, testConfigMap.GetName(), metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete configmap %s in namespace: %s", testConfigMap.GetName(), ns)
 
 		ginkgo.By("creating a watch on configmaps from the resource version returned by the first update")
-		testWatch, err := watchConfigMaps(f, testConfigMapFirstUpdate.ObjectMeta.ResourceVersion, fromResourceVersionLabelValue)
+		testWatch, err := watchConfigMaps(ctx, f, testConfigMapFirstUpdate.ObjectMeta.ResourceVersion, fromResourceVersionLabelValue)
 		framework.ExpectNoError(err, "failed to create a watch on configmaps from the resource version %s returned by the first update", testConfigMapFirstUpdate.ObjectMeta.ResourceVersion)
 
 		ginkgo.By("Expecting to observe notifications for all changes to the configmap after the first update")
@@ -203,15 +203,15 @@ var _ = SIGDescribe("Watchers", func() {
 		}
 
 		ginkgo.By("creating a watch on configmaps")
-		testWatchBroken, err := watchConfigMaps(f, "", watchRestartedLabelValue)
+		testWatchBroken, err := watchConfigMaps(ctx, f, "", watchRestartedLabelValue)
 		framework.ExpectNoError(err, "failed to create a watch on configmap with label: %s", watchRestartedLabelValue)
 
 		ginkgo.By("creating a new configmap")
-		testConfigMap, err = c.CoreV1().ConfigMaps(ns).Create(context.TODO(), testConfigMap, metav1.CreateOptions{})
+		testConfigMap, err = c.CoreV1().ConfigMaps(ns).Create(ctx, testConfigMap, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create configmap %s in namespace: %s", configMapName, ns)
 
 		ginkgo.By("modifying the configmap once")
-		_, err = updateConfigMap(c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
+		_, err = updateConfigMap(ctx, c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
 			setConfigMapData(cm, "mutation", "1")
 		})
 		framework.ExpectNoError(err, "failed to update configmap %s in namespace: %s", configMapName, ns)
@@ -225,7 +225,7 @@ var _ = SIGDescribe("Watchers", func() {
 		testWatchBroken.Stop()
 
 		ginkgo.By("modifying the configmap a second time, while the watch is closed")
-		testConfigMapSecondUpdate, err := updateConfigMap(c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
+		testConfigMapSecondUpdate, err := updateConfigMap(ctx, c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
 			setConfigMapData(cm, "mutation", "2")
 		})
 		framework.ExpectNoError(err, "failed to update configmap %s in namespace %s a second time", configMapName, ns)
@@ -235,11 +235,11 @@ var _ = SIGDescribe("Watchers", func() {
 		if !ok {
 			framework.Failf("Expected last notification to refer to a configmap but got: %v", lastEvent)
 		}
-		testWatchRestarted, err := watchConfigMaps(f, lastEventConfigMap.ObjectMeta.ResourceVersion, watchRestartedLabelValue)
+		testWatchRestarted, err := watchConfigMaps(ctx, f, lastEventConfigMap.ObjectMeta.ResourceVersion, watchRestartedLabelValue)
 		framework.ExpectNoError(err, "failed to create a new watch on configmaps from the last resource version %s observed by the first watch", lastEventConfigMap.ObjectMeta.ResourceVersion)
 
 		ginkgo.By("deleting the configmap")
-		err = c.CoreV1().ConfigMaps(ns).Delete(context.TODO(), testConfigMap.GetName(), metav1.DeleteOptions{})
+		err = c.CoreV1().ConfigMaps(ns).Delete(ctx, testConfigMap.GetName(), metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete configmap %s in namespace: %s", configMapName, ns)
 
 		ginkgo.By("Expecting to observe notifications for all changes to the configmap since the first watch closed")
@@ -269,21 +269,21 @@ var _ = SIGDescribe("Watchers", func() {
 		}
 
 		ginkgo.By("creating a watch on configmaps with a certain label")
-		testWatch, err := watchConfigMaps(f, "", toBeChangedLabelValue)
+		testWatch, err := watchConfigMaps(ctx, f, "", toBeChangedLabelValue)
 		framework.ExpectNoError(err, "failed to create a watch on configmap with label: %s", toBeChangedLabelValue)
 
 		ginkgo.By("creating a new configmap")
-		testConfigMap, err = c.CoreV1().ConfigMaps(ns).Create(context.TODO(), testConfigMap, metav1.CreateOptions{})
+		testConfigMap, err = c.CoreV1().ConfigMaps(ns).Create(ctx, testConfigMap, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create configmap %s in namespace: %s", configMapName, ns)
 
 		ginkgo.By("modifying the configmap once")
-		testConfigMapFirstUpdate, err := updateConfigMap(c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
+		testConfigMapFirstUpdate, err := updateConfigMap(ctx, c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
 			setConfigMapData(cm, "mutation", "1")
 		})
 		framework.ExpectNoError(err, "failed to update configmap %s in namespace: %s", configMapName, ns)
 
 		ginkgo.By("changing the label value of the configmap")
-		_, err = updateConfigMap(c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
+		_, err = updateConfigMap(ctx, c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
 			cm.ObjectMeta.Labels[watchConfigMapLabelKey] = "wrong-value"
 		})
 		framework.ExpectNoError(err, "failed to update configmap %s in namespace %s by changing label value", configMapName, ns)
@@ -294,7 +294,7 @@ var _ = SIGDescribe("Watchers", func() {
 		expectEvent(testWatch, watch.Deleted, nil)
 
 		ginkgo.By("modifying the configmap a second time")
-		testConfigMapSecondUpdate, err := updateConfigMap(c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
+		testConfigMapSecondUpdate, err := updateConfigMap(ctx, c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
 			setConfigMapData(cm, "mutation", "2")
 		})
 		framework.ExpectNoError(err, "failed to update configmap %s in namespace %s a second time", configMapName, ns)
@@ -303,19 +303,19 @@ var _ = SIGDescribe("Watchers", func() {
 		expectNoEvent(testWatch, watch.Modified, testConfigMapSecondUpdate)
 
 		ginkgo.By("changing the label value of the configmap back")
-		testConfigMapLabelRestored, err := updateConfigMap(c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
+		testConfigMapLabelRestored, err := updateConfigMap(ctx, c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
 			cm.ObjectMeta.Labels[watchConfigMapLabelKey] = toBeChangedLabelValue
 		})
 		framework.ExpectNoError(err, "failed to update configmap %s in namespace %s by changing label value back", configMapName, ns)
 
 		ginkgo.By("modifying the configmap a third time")
-		testConfigMapThirdUpdate, err := updateConfigMap(c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
+		testConfigMapThirdUpdate, err := updateConfigMap(ctx, c, ns, testConfigMap.GetName(), func(cm *v1.ConfigMap) {
 			setConfigMapData(cm, "mutation", "3")
 		})
 		framework.ExpectNoError(err, "failed to update configmap %s in namespace %s a third time", configMapName, ns)
 
 		ginkgo.By("deleting the configmap")
-		err = c.CoreV1().ConfigMaps(ns).Delete(context.TODO(), testConfigMap.GetName(), metav1.DeleteOptions{})
+		err = c.CoreV1().ConfigMaps(ns).Delete(ctx, testConfigMap.GetName(), metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete configmap %s in namespace: %s", configMapName, ns)
 
 		ginkgo.By("Expecting to observe an add notification for the watched object when the label value was restored")
@@ -338,7 +338,7 @@ var _ = SIGDescribe("Watchers", func() {
 		iterations := 100
 
 		ginkgo.By("getting a starting resourceVersion")
-		configmaps, err := c.CoreV1().ConfigMaps(ns).List(context.TODO(), metav1.ListOptions{})
+		configmaps, err := c.CoreV1().ConfigMaps(ns).List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "Failed to list configmaps in the namespace %s", ns)
 		resourceVersion := configmaps.ResourceVersion
 
@@ -348,12 +348,12 @@ var _ = SIGDescribe("Watchers", func() {
 		go func() {
 			defer ginkgo.GinkgoRecover()
 			defer close(donec)
-			produceConfigMapEvents(f, stopc, 5*time.Millisecond)
+			produceConfigMapEvents(ctx, f, stopc, 5*time.Millisecond)
 		}()
 
 		listWatcher := &cachetools.ListWatch{
 			WatchFunc: func(listOptions metav1.ListOptions) (watch.Interface, error) {
-				return c.CoreV1().ConfigMaps(ns).Watch(context.TODO(), listOptions)
+				return c.CoreV1().ConfigMaps(ns).Watch(ctx, listOptions)
 			},
 		}
 
@@ -379,7 +379,7 @@ var _ = SIGDescribe("Watchers", func() {
 	})
 })
 
-func watchConfigMaps(f *framework.Framework, resourceVersion string, labels ...string) (watch.Interface, error) {
+func watchConfigMaps(ctx context.Context, f *framework.Framework, resourceVersion string, labels ...string) (watch.Interface, error) {
 	c := f.ClientSet
 	ns := f.Namespace.Name
 	opts := metav1.ListOptions{
@@ -394,7 +394,7 @@ func watchConfigMaps(f *framework.Framework, resourceVersion string, labels ...s
 			},
 		}),
 	}
-	return c.CoreV1().ConfigMaps(ns).Watch(context.TODO(), opts)
+	return c.CoreV1().ConfigMaps(ns).Watch(ctx, opts)
 }
 
 func int64ptr(i int) *int64 {
@@ -467,7 +467,7 @@ const (
 	deleteEvent
 )
 
-func produceConfigMapEvents(f *framework.Framework, stopc <-chan struct{}, minWaitBetweenEvents time.Duration) {
+func produceConfigMapEvents(ctx context.Context, f *framework.Framework, stopc <-chan struct{}, minWaitBetweenEvents time.Duration) {
 	c := f.ClientSet
 	ns := f.Namespace.Name
 
@@ -493,7 +493,7 @@ func produceConfigMapEvents(f *framework.Framework, stopc <-chan struct{}, minWa
 					Name: name(i),
 				},
 			}
-			_, err := c.CoreV1().ConfigMaps(ns).Create(context.TODO(), cm, metav1.CreateOptions{})
+			_, err := c.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "Failed to create configmap %s in namespace %s", cm.Name, ns)
 			existing = append(existing, i)
 			i++
@@ -507,12 +507,12 @@ func produceConfigMapEvents(f *framework.Framework, stopc <-chan struct{}, minWa
 					},
 				},
 			}
-			_, err := c.CoreV1().ConfigMaps(ns).Update(context.TODO(), cm, metav1.UpdateOptions{})
+			_, err := c.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
 			framework.ExpectNoError(err, "Failed to update configmap %s in namespace %s", cm.Name, ns)
 			updates++
 		case deleteEvent:
 			idx := rand.Intn(len(existing))
-			err := c.CoreV1().ConfigMaps(ns).Delete(context.TODO(), name(existing[idx]), metav1.DeleteOptions{})
+			err := c.CoreV1().ConfigMaps(ns).Delete(ctx, name(existing[idx]), metav1.DeleteOptions{})
 			framework.ExpectNoError(err, "Failed to delete configmap %s in namespace %s", name(existing[idx]), ns)
 			existing = append(existing[:idx], existing[idx+1:]...)
 		default:

--- a/test/e2e/apps/cronjob.go
+++ b/test/e2e/apps/cronjob.go
@@ -70,21 +70,21 @@ var _ = SIGDescribe("CronJob", func() {
 		ginkgo.By("Creating a cronjob")
 		cronJob := newTestCronJob("concurrent", "*/1 * * * ?", batchv1.AllowConcurrent,
 			sleepCommand, nil, nil)
-		cronJob, err := createCronJob(f.ClientSet, f.Namespace.Name, cronJob)
+		cronJob, err := createCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob)
 		framework.ExpectNoError(err, "Failed to create CronJob in namespace %s", f.Namespace.Name)
 
 		ginkgo.By("Ensuring more than one job is running at a time")
-		err = waitForActiveJobs(f.ClientSet, f.Namespace.Name, cronJob.Name, 2)
+		err = waitForActiveJobs(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name, 2)
 		framework.ExpectNoError(err, "Failed to wait for active jobs in CronJob %s in namespace %s", cronJob.Name, f.Namespace.Name)
 
 		ginkgo.By("Ensuring at least two running jobs exists by listing jobs explicitly")
-		jobs, err := f.ClientSet.BatchV1().Jobs(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
+		jobs, err := f.ClientSet.BatchV1().Jobs(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "Failed to list the CronJobs in namespace %s", f.Namespace.Name)
 		activeJobs, _ := filterActiveJobs(jobs)
 		gomega.Expect(len(activeJobs)).To(gomega.BeNumerically(">=", 2))
 
 		ginkgo.By("Removing cronjob")
-		err = deleteCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		err = deleteCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name)
 		framework.ExpectNoError(err, "Failed to delete CronJob %s in namespace %s", cronJob.Name, f.Namespace.Name)
 	})
 
@@ -99,20 +99,20 @@ var _ = SIGDescribe("CronJob", func() {
 			sleepCommand, nil, nil)
 		t := true
 		cronJob.Spec.Suspend = &t
-		cronJob, err := createCronJob(f.ClientSet, f.Namespace.Name, cronJob)
+		cronJob, err := createCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob)
 		framework.ExpectNoError(err, "Failed to create CronJob in namespace %s", f.Namespace.Name)
 
 		ginkgo.By("Ensuring no jobs are scheduled")
-		err = waitForNoJobs(f.ClientSet, f.Namespace.Name, cronJob.Name, false)
+		err = waitForNoJobs(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name, false)
 		framework.ExpectError(err)
 
 		ginkgo.By("Ensuring no job exists by listing jobs explicitly")
-		jobs, err := f.ClientSet.BatchV1().Jobs(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
+		jobs, err := f.ClientSet.BatchV1().Jobs(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "Failed to list the CronJobs in namespace %s", f.Namespace.Name)
 		gomega.Expect(jobs.Items).To(gomega.HaveLen(0))
 
 		ginkgo.By("Removing cronjob")
-		err = deleteCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		err = deleteCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name)
 		framework.ExpectNoError(err, "Failed to delete CronJob %s in namespace %s", cronJob.Name, f.Namespace.Name)
 	})
 
@@ -125,30 +125,30 @@ var _ = SIGDescribe("CronJob", func() {
 		ginkgo.By("Creating a ForbidConcurrent cronjob")
 		cronJob := newTestCronJob("forbid", "*/1 * * * ?", batchv1.ForbidConcurrent,
 			sleepCommand, nil, nil)
-		cronJob, err := createCronJob(f.ClientSet, f.Namespace.Name, cronJob)
+		cronJob, err := createCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob)
 		framework.ExpectNoError(err, "Failed to create CronJob in namespace %s", f.Namespace.Name)
 
 		ginkgo.By("Ensuring a job is scheduled")
-		err = waitForActiveJobs(f.ClientSet, f.Namespace.Name, cronJob.Name, 1)
+		err = waitForActiveJobs(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name, 1)
 		framework.ExpectNoError(err, "Failed to schedule CronJob %s", cronJob.Name)
 
 		ginkgo.By("Ensuring exactly one is scheduled")
-		cronJob, err = getCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		cronJob, err = getCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name)
 		framework.ExpectNoError(err, "Failed to get CronJob %s", cronJob.Name)
 		gomega.Expect(cronJob.Status.Active).Should(gomega.HaveLen(1))
 
 		ginkgo.By("Ensuring exactly one running job exists by listing jobs explicitly")
-		jobs, err := f.ClientSet.BatchV1().Jobs(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
+		jobs, err := f.ClientSet.BatchV1().Jobs(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "Failed to list the CronJobs in namespace %s", f.Namespace.Name)
 		activeJobs, _ := filterActiveJobs(jobs)
 		gomega.Expect(activeJobs).To(gomega.HaveLen(1))
 
 		ginkgo.By("Ensuring no more jobs are scheduled")
-		err = waitForActiveJobs(f.ClientSet, f.Namespace.Name, cronJob.Name, 2)
+		err = waitForActiveJobs(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name, 2)
 		framework.ExpectError(err)
 
 		ginkgo.By("Removing cronjob")
-		err = deleteCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		err = deleteCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name)
 		framework.ExpectNoError(err, "Failed to delete CronJob %s in namespace %s", cronJob.Name, f.Namespace.Name)
 	})
 
@@ -161,30 +161,30 @@ var _ = SIGDescribe("CronJob", func() {
 		ginkgo.By("Creating a ReplaceConcurrent cronjob")
 		cronJob := newTestCronJob("replace", "*/1 * * * ?", batchv1.ReplaceConcurrent,
 			sleepCommand, nil, nil)
-		cronJob, err := createCronJob(f.ClientSet, f.Namespace.Name, cronJob)
+		cronJob, err := createCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob)
 		framework.ExpectNoError(err, "Failed to create CronJob in namespace %s", f.Namespace.Name)
 
 		ginkgo.By("Ensuring a job is scheduled")
-		err = waitForActiveJobs(f.ClientSet, f.Namespace.Name, cronJob.Name, 1)
+		err = waitForActiveJobs(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name, 1)
 		framework.ExpectNoError(err, "Failed to schedule CronJob %s in namespace %s", cronJob.Name, f.Namespace.Name)
 
 		ginkgo.By("Ensuring exactly one is scheduled")
-		cronJob, err = getCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		cronJob, err = getCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name)
 		framework.ExpectNoError(err, "Failed to get CronJob %s", cronJob.Name)
 		gomega.Expect(cronJob.Status.Active).Should(gomega.HaveLen(1))
 
 		ginkgo.By("Ensuring exactly one running job exists by listing jobs explicitly")
-		jobs, err := f.ClientSet.BatchV1().Jobs(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
+		jobs, err := f.ClientSet.BatchV1().Jobs(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "Failed to list the jobs in namespace %s", f.Namespace.Name)
 		activeJobs, _ := filterActiveJobs(jobs)
 		gomega.Expect(activeJobs).To(gomega.HaveLen(1))
 
 		ginkgo.By("Ensuring the job is replaced with a new one")
-		err = waitForJobReplaced(f.ClientSet, f.Namespace.Name, jobs.Items[0].Name)
+		err = waitForJobReplaced(ctx, f.ClientSet, f.Namespace.Name, jobs.Items[0].Name)
 		framework.ExpectNoError(err, "Failed to replace CronJob %s in namespace %s", jobs.Items[0].Name, f.Namespace.Name)
 
 		ginkgo.By("Removing cronjob")
-		err = deleteCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		err = deleteCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name)
 		framework.ExpectNoError(err, "Failed to delete CronJob %s in namespace %s", cronJob.Name, f.Namespace.Name)
 	})
 
@@ -196,21 +196,21 @@ var _ = SIGDescribe("CronJob", func() {
 		lastScheduleTime := creationTime.Add(1 * 24 * time.Hour)
 		cronJob.CreationTimestamp = metav1.Time{Time: creationTime}
 		cronJob.Status.LastScheduleTime = &metav1.Time{Time: lastScheduleTime}
-		cronJob, err := createCronJob(f.ClientSet, f.Namespace.Name, cronJob)
+		cronJob, err := createCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob)
 		framework.ExpectNoError(err, "Failed to create CronJob in namespace %s", f.Namespace.Name)
 
 		ginkgo.By("Ensuring one job is running")
-		err = waitForActiveJobs(f.ClientSet, f.Namespace.Name, cronJob.Name, 1)
+		err = waitForActiveJobs(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name, 1)
 		framework.ExpectNoError(err, "Failed to wait for active jobs in CronJob %s in namespace %s", cronJob.Name, f.Namespace.Name)
 
 		ginkgo.By("Ensuring at least one running jobs exists by listing jobs explicitly")
-		jobs, err := f.ClientSet.BatchV1().Jobs(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
+		jobs, err := f.ClientSet.BatchV1().Jobs(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "Failed to list the CronJobs in namespace %s", f.Namespace.Name)
 		activeJobs, _ := filterActiveJobs(jobs)
 		gomega.Expect(len(activeJobs)).To(gomega.BeNumerically(">=", 1))
 
 		ginkgo.By("Removing cronjob")
-		err = deleteCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		err = deleteCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name)
 		framework.ExpectNoError(err, "Failed to delete CronJob %s in namespace %s", cronJob.Name, f.Namespace.Name)
 	})
 
@@ -219,21 +219,21 @@ var _ = SIGDescribe("CronJob", func() {
 		ginkgo.By("Creating a cronjob")
 		cronJob := newTestCronJob("concurrent", "*/1 * * * ?", batchv1.AllowConcurrent,
 			nil, nil, nil)
-		cronJob, err := createCronJob(f.ClientSet, f.Namespace.Name, cronJob)
+		cronJob, err := createCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob)
 		framework.ExpectNoError(err, "Failed to create CronJob in namespace %s", f.Namespace.Name)
 
 		ginkgo.By("Ensuring at least two jobs and at least one finished job exists by listing jobs explicitly")
-		err = waitForJobsAtLeast(f.ClientSet, f.Namespace.Name, 2)
+		err = waitForJobsAtLeast(ctx, f.ClientSet, f.Namespace.Name, 2)
 		framework.ExpectNoError(err, "Failed to ensure at least two job exists in namespace %s", f.Namespace.Name)
-		err = waitForAnyFinishedJob(f.ClientSet, f.Namespace.Name)
+		err = waitForAnyFinishedJob(ctx, f.ClientSet, f.Namespace.Name)
 		framework.ExpectNoError(err, "Failed to ensure at least on finished job exists in namespace %s", f.Namespace.Name)
 
 		ginkgo.By("Ensuring no unexpected event has happened")
-		err = waitForEventWithReason(f.ClientSet, f.Namespace.Name, cronJob.Name, []string{"MissingJob", "UnexpectedJob"})
+		err = waitForEventWithReason(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name, []string{"MissingJob", "UnexpectedJob"})
 		framework.ExpectError(err)
 
 		ginkgo.By("Removing cronjob")
-		err = deleteCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		err = deleteCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name)
 		framework.ExpectNoError(err, "Failed to delete CronJob %s in namespace %s", cronJob.Name, f.Namespace.Name)
 	})
 
@@ -242,37 +242,37 @@ var _ = SIGDescribe("CronJob", func() {
 		ginkgo.By("Creating a ForbidConcurrent cronjob")
 		cronJob := newTestCronJob("forbid", "*/1 * * * ?", batchv1.ForbidConcurrent,
 			sleepCommand, nil, nil)
-		cronJob, err := createCronJob(f.ClientSet, f.Namespace.Name, cronJob)
+		cronJob, err := createCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob)
 		framework.ExpectNoError(err, "Failed to create CronJob in namespace %s", f.Namespace.Name)
 
 		ginkgo.By("Ensuring a job is scheduled")
-		err = waitForActiveJobs(f.ClientSet, f.Namespace.Name, cronJob.Name, 1)
+		err = waitForActiveJobs(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name, 1)
 		framework.ExpectNoError(err, "Failed to ensure a %s cronjob is scheduled in namespace %s", cronJob.Name, f.Namespace.Name)
 
 		ginkgo.By("Ensuring exactly one is scheduled")
-		cronJob, err = getCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		cronJob, err = getCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name)
 		framework.ExpectNoError(err, "Failed to ensure exactly one %s cronjob is scheduled in namespace %s", cronJob.Name, f.Namespace.Name)
 		gomega.Expect(cronJob.Status.Active).Should(gomega.HaveLen(1))
 
 		ginkgo.By("Deleting the job")
 		job := cronJob.Status.Active[0]
-		framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(f.ClientSet, batchinternal.Kind("Job"), f.Namespace.Name, job.Name))
+		framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, batchinternal.Kind("Job"), f.Namespace.Name, job.Name))
 
 		ginkgo.By("Ensuring job was deleted")
-		_, err = e2ejob.GetJob(f.ClientSet, f.Namespace.Name, job.Name)
+		_, err = e2ejob.GetJob(ctx, f.ClientSet, f.Namespace.Name, job.Name)
 		framework.ExpectError(err)
 		framework.ExpectEqual(apierrors.IsNotFound(err), true)
 
 		ginkgo.By("Ensuring the job is not in the cronjob active list")
-		err = waitForJobNotActive(f.ClientSet, f.Namespace.Name, cronJob.Name, job.Name)
+		err = waitForJobNotActive(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name, job.Name)
 		framework.ExpectNoError(err, "Failed to ensure the %s cronjob is not in active list in namespace %s", cronJob.Name, f.Namespace.Name)
 
 		ginkgo.By("Ensuring MissingJob event has occurred")
-		err = waitForEventWithReason(f.ClientSet, f.Namespace.Name, cronJob.Name, []string{"MissingJob"})
+		err = waitForEventWithReason(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name, []string{"MissingJob"})
 		framework.ExpectNoError(err, "Failed to ensure missing job event has occurred for %s cronjob in namespace %s", cronJob.Name, f.Namespace.Name)
 
 		ginkgo.By("Removing cronjob")
-		err = deleteCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		err = deleteCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob.Name)
 		framework.ExpectNoError(err, "Failed to remove %s cronjob in namespace %s", cronJob.Name, f.Namespace.Name)
 	})
 
@@ -284,7 +284,7 @@ var _ = SIGDescribe("CronJob", func() {
 		cronJob := newTestCronJob("successful-jobs-history-limit", "*/1 * * * ?", batchv1.AllowConcurrent,
 			successCommand, &successLimit, &failedLimit)
 
-		ensureHistoryLimits(f.ClientSet, f.Namespace.Name, cronJob)
+		ensureHistoryLimits(ctx, f.ClientSet, f.Namespace.Name, cronJob)
 	})
 
 	// cleanup of failed finished jobs, with limit of one failed job
@@ -295,7 +295,7 @@ var _ = SIGDescribe("CronJob", func() {
 		cronJob := newTestCronJob("failed-jobs-history-limit", "*/1 * * * ?", batchv1.AllowConcurrent,
 			failureCommand, &successLimit, &failedLimit)
 
-		ensureHistoryLimits(f.ClientSet, f.Namespace.Name, cronJob)
+		ensureHistoryLimits(ctx, f.ClientSet, f.Namespace.Name, cronJob)
 	})
 
 	ginkgo.It("should support timezone", func(ctx context.Context) {
@@ -304,7 +304,7 @@ var _ = SIGDescribe("CronJob", func() {
 			failureCommand, nil, nil)
 		badTimeZone := "bad-time-zone"
 		cronJob.Spec.TimeZone = &badTimeZone
-		_, err := createCronJob(f.ClientSet, f.Namespace.Name, cronJob)
+		_, err := createCronJob(ctx, f.ClientSet, f.Namespace.Name, cronJob)
 		framework.ExpectError(err, "CronJob creation should fail with invalid time zone error")
 		framework.ExpectEqual(apierrors.IsInvalid(err), true, "CronJob creation should fail with invalid time zone error")
 	})
@@ -331,38 +331,38 @@ var _ = SIGDescribe("CronJob", func() {
 		cjClient := f.ClientSet.BatchV1().CronJobs(ns)
 
 		ginkgo.By("creating")
-		createdCronJob, err := cjClient.Create(context.TODO(), cjTemplate, metav1.CreateOptions{})
+		createdCronJob, err := cjClient.Create(ctx, cjTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("getting")
-		gottenCronJob, err := cjClient.Get(context.TODO(), createdCronJob.Name, metav1.GetOptions{})
+		gottenCronJob, err := cjClient.Get(ctx, createdCronJob.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(gottenCronJob.UID, createdCronJob.UID)
 
 		ginkgo.By("listing")
-		cjs, err := cjClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		cjs, err := cjClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(cjs.Items), 1, "filtered list should have 1 item")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
-		cjWatch, err := cjClient.Watch(context.TODO(), metav1.ListOptions{ResourceVersion: cjs.ResourceVersion, LabelSelector: "special-label=" + f.UniqueName})
+		cjWatch, err := cjClient.Watch(ctx, metav1.ListOptions{ResourceVersion: cjs.ResourceVersion, LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 
 		// Test cluster-wide list and watch
 		clusterCJClient := f.ClientSet.BatchV1().CronJobs("")
 		ginkgo.By("cluster-wide listing")
-		clusterCJs, err := clusterCJClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		clusterCJs, err := clusterCJClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(clusterCJs.Items), 1, "filtered list should have 1 items")
 
 		ginkgo.By("cluster-wide watching")
 		framework.Logf("starting watch")
-		_, err = clusterCJClient.Watch(context.TODO(), metav1.ListOptions{ResourceVersion: cjs.ResourceVersion, LabelSelector: "special-label=" + f.UniqueName})
+		_, err = clusterCJClient.Watch(ctx, metav1.ListOptions{ResourceVersion: cjs.ResourceVersion, LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("patching")
-		patchedCronJob, err := cjClient.Patch(context.TODO(), createdCronJob.Name, types.MergePatchType,
+		patchedCronJob, err := cjClient.Patch(ctx, createdCronJob.Name, types.MergePatchType,
 			[]byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(patchedCronJob.Annotations["patched"], "true", "patched object should have the applied annotation")
@@ -370,12 +370,12 @@ var _ = SIGDescribe("CronJob", func() {
 		ginkgo.By("updating")
 		var cjToUpdate, updatedCronJob *batchv1.CronJob
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			cjToUpdate, err = cjClient.Get(context.TODO(), createdCronJob.Name, metav1.GetOptions{})
+			cjToUpdate, err = cjClient.Get(ctx, createdCronJob.Name, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 			cjToUpdate.Annotations["updated"] = "true"
-			updatedCronJob, err = cjClient.Update(context.TODO(), cjToUpdate, metav1.UpdateOptions{})
+			updatedCronJob, err = cjClient.Update(ctx, cjToUpdate, metav1.UpdateOptions{})
 			return err
 		})
 		framework.ExpectNoError(err)
@@ -410,7 +410,7 @@ var _ = SIGDescribe("CronJob", func() {
 		}
 		cjStatusJSON, err := json.Marshal(cjStatus)
 		framework.ExpectNoError(err)
-		patchedStatus, err := cjClient.Patch(context.TODO(), createdCronJob.Name, types.MergePatchType,
+		patchedStatus, err := cjClient.Patch(ctx, createdCronJob.Name, types.MergePatchType,
 			[]byte(`{"metadata":{"annotations":{"patchedstatus":"true"}},"status":`+string(cjStatusJSON)+`}`),
 			metav1.PatchOptions{}, "status")
 		framework.ExpectNoError(err)
@@ -422,12 +422,12 @@ var _ = SIGDescribe("CronJob", func() {
 		now2 := metav1.Now().Rfc3339Copy()
 		var statusToUpdate, updatedStatus *batchv1.CronJob
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			statusToUpdate, err = cjClient.Get(context.TODO(), createdCronJob.Name, metav1.GetOptions{})
+			statusToUpdate, err = cjClient.Get(ctx, createdCronJob.Name, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 			statusToUpdate.Status.LastScheduleTime = &now2
-			updatedStatus, err = cjClient.UpdateStatus(context.TODO(), statusToUpdate, metav1.UpdateOptions{})
+			updatedStatus, err = cjClient.UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})
 			return err
 		})
 		framework.ExpectNoError(err)
@@ -435,7 +435,7 @@ var _ = SIGDescribe("CronJob", func() {
 
 		ginkgo.By("get /status")
 		cjResource := schema.GroupVersionResource{Group: "batch", Version: cjVersion, Resource: "cronjobs"}
-		gottenStatus, err := f.DynamicClient.Resource(cjResource).Namespace(ns).Get(context.TODO(), createdCronJob.Name, metav1.GetOptions{}, "status")
+		gottenStatus, err := f.DynamicClient.Resource(cjResource).Namespace(ns).Get(ctx, createdCronJob.Name, metav1.GetOptions{}, "status")
 		framework.ExpectNoError(err)
 		statusUID, _, err := unstructured.NestedFieldCopy(gottenStatus.Object, "metadata", "uid")
 		framework.ExpectNoError(err)
@@ -449,11 +449,11 @@ var _ = SIGDescribe("CronJob", func() {
 
 		ginkgo.By("deleting")
 		cjTemplate.Name = "for-removal"
-		forRemovalCronJob, err := cjClient.Create(context.TODO(), cjTemplate, metav1.CreateOptions{})
+		forRemovalCronJob, err := cjClient.Create(ctx, cjTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		err = cjClient.Delete(context.TODO(), forRemovalCronJob.Name, metav1.DeleteOptions{})
+		err = cjClient.Delete(ctx, forRemovalCronJob.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
-		cj, err := cjClient.Get(context.TODO(), forRemovalCronJob.Name, metav1.GetOptions{})
+		cj, err := cjClient.Get(ctx, forRemovalCronJob.Name, metav1.GetOptions{})
 		// If controller does not support finalizers, we expect a 404.  Otherwise we validate finalizer behavior.
 		if err == nil {
 			expectFinalizer(cj, "deleting cronjob")
@@ -462,9 +462,9 @@ var _ = SIGDescribe("CronJob", func() {
 		}
 
 		ginkgo.By("deleting a collection")
-		err = cjClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		err = cjClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
-		cjs, err = cjClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		cjs, err = cjClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		// Should have <= 2 items since some cronjobs might not have been deleted yet due to finalizers
 		framework.ExpectEqual(len(cjs.Items) <= 2, true, "filtered list should be <= 2")
@@ -476,19 +476,19 @@ var _ = SIGDescribe("CronJob", func() {
 
 })
 
-func ensureHistoryLimits(c clientset.Interface, ns string, cronJob *batchv1.CronJob) {
-	cronJob, err := createCronJob(c, ns, cronJob)
+func ensureHistoryLimits(ctx context.Context, c clientset.Interface, ns string, cronJob *batchv1.CronJob) {
+	cronJob, err := createCronJob(ctx, c, ns, cronJob)
 	framework.ExpectNoError(err, "Failed to create allowconcurrent cronjob with custom history limits in namespace %s", ns)
 
 	// Job is going to complete instantly: do not check for an active job
 	// as we are most likely to miss it
 
 	ginkgo.By("Ensuring a finished job exists")
-	err = waitForAnyFinishedJob(c, ns)
+	err = waitForAnyFinishedJob(ctx, c, ns)
 	framework.ExpectNoError(err, "Failed to ensure a finished cronjob exists in namespace %s", ns)
 
 	ginkgo.By("Ensuring a finished job exists by listing jobs explicitly")
-	jobs, err := c.BatchV1().Jobs(ns).List(context.TODO(), metav1.ListOptions{})
+	jobs, err := c.BatchV1().Jobs(ns).List(ctx, metav1.ListOptions{})
 	framework.ExpectNoError(err, "Failed to ensure a finished cronjob exists by listing jobs explicitly in namespace %s", ns)
 	activeJobs, finishedJobs := filterActiveJobs(jobs)
 	if len(finishedJobs) != 1 {
@@ -498,13 +498,13 @@ func ensureHistoryLimits(c clientset.Interface, ns string, cronJob *batchv1.Cron
 
 	// Job should get deleted when the next job finishes the next minute
 	ginkgo.By("Ensuring this job and its pods does not exist anymore")
-	err = waitForJobToDisappear(c, ns, finishedJobs[0])
+	err = waitForJobToDisappear(ctx, c, ns, finishedJobs[0])
 	framework.ExpectNoError(err, "Failed to ensure that job does not exists anymore in namespace %s", ns)
-	err = waitForJobsPodToDisappear(c, ns, finishedJobs[0])
+	err = waitForJobsPodToDisappear(ctx, c, ns, finishedJobs[0])
 	framework.ExpectNoError(err, "Failed to ensure that pods for job does not exists anymore in namespace %s", ns)
 
 	ginkgo.By("Ensuring there is 1 finished job by listing jobs explicitly")
-	jobs, err = c.BatchV1().Jobs(ns).List(context.TODO(), metav1.ListOptions{})
+	jobs, err = c.BatchV1().Jobs(ns).List(ctx, metav1.ListOptions{})
 	framework.ExpectNoError(err, "Failed to ensure there is one finished job by listing job explicitly in namespace %s", ns)
 	activeJobs, finishedJobs = filterActiveJobs(jobs)
 	if len(finishedJobs) != 1 {
@@ -513,7 +513,7 @@ func ensureHistoryLimits(c clientset.Interface, ns string, cronJob *batchv1.Cron
 	}
 
 	ginkgo.By("Removing cronjob")
-	err = deleteCronJob(c, ns, cronJob.Name)
+	err = deleteCronJob(ctx, c, ns, cronJob.Name)
 	framework.ExpectNoError(err, "Failed to remove the %s cronjob in namespace %s", cronJob.Name, ns)
 }
 
@@ -575,23 +575,23 @@ func newTestCronJob(name, schedule string, concurrencyPolicy batchv1.Concurrency
 	return sj
 }
 
-func createCronJob(c clientset.Interface, ns string, cronJob *batchv1.CronJob) (*batchv1.CronJob, error) {
-	return c.BatchV1().CronJobs(ns).Create(context.TODO(), cronJob, metav1.CreateOptions{})
+func createCronJob(ctx context.Context, c clientset.Interface, ns string, cronJob *batchv1.CronJob) (*batchv1.CronJob, error) {
+	return c.BatchV1().CronJobs(ns).Create(ctx, cronJob, metav1.CreateOptions{})
 }
 
-func getCronJob(c clientset.Interface, ns, name string) (*batchv1.CronJob, error) {
-	return c.BatchV1().CronJobs(ns).Get(context.TODO(), name, metav1.GetOptions{})
+func getCronJob(ctx context.Context, c clientset.Interface, ns, name string) (*batchv1.CronJob, error) {
+	return c.BatchV1().CronJobs(ns).Get(ctx, name, metav1.GetOptions{})
 }
 
-func deleteCronJob(c clientset.Interface, ns, name string) error {
+func deleteCronJob(ctx context.Context, c clientset.Interface, ns, name string) error {
 	propagationPolicy := metav1.DeletePropagationBackground // Also delete jobs and pods related to cronjob
-	return c.BatchV1().CronJobs(ns).Delete(context.TODO(), name, metav1.DeleteOptions{PropagationPolicy: &propagationPolicy})
+	return c.BatchV1().CronJobs(ns).Delete(ctx, name, metav1.DeleteOptions{PropagationPolicy: &propagationPolicy})
 }
 
 // Wait for at least given amount of active jobs.
-func waitForActiveJobs(c clientset.Interface, ns, cronJobName string, active int) error {
-	return wait.Poll(framework.Poll, cronJobTimeout, func() (bool, error) {
-		curr, err := getCronJob(c, ns, cronJobName)
+func waitForActiveJobs(ctx context.Context, c clientset.Interface, ns, cronJobName string, active int) error {
+	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+		curr, err := getCronJob(ctx, c, ns, cronJobName)
 		if err != nil {
 			return false, err
 		}
@@ -603,9 +603,9 @@ func waitForActiveJobs(c clientset.Interface, ns, cronJobName string, active int
 // When failIfNonEmpty is set, this fails if the active set of jobs is still non-empty after
 // the timeout. When failIfNonEmpty is not set, this fails if the active set of jobs is still
 // empty after the timeout.
-func waitForNoJobs(c clientset.Interface, ns, jobName string, failIfNonEmpty bool) error {
-	return wait.Poll(framework.Poll, cronJobTimeout, func() (bool, error) {
-		curr, err := getCronJob(c, ns, jobName)
+func waitForNoJobs(ctx context.Context, c clientset.Interface, ns, jobName string, failIfNonEmpty bool) error {
+	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+		curr, err := getCronJob(ctx, c, ns, jobName)
 		if err != nil {
 			return false, err
 		}
@@ -618,9 +618,9 @@ func waitForNoJobs(c clientset.Interface, ns, jobName string, failIfNonEmpty boo
 }
 
 // Wait till a given job actually goes away from the Active list for a given cronjob
-func waitForJobNotActive(c clientset.Interface, ns, cronJobName, jobName string) error {
-	return wait.Poll(framework.Poll, cronJobTimeout, func() (bool, error) {
-		curr, err := getCronJob(c, ns, cronJobName)
+func waitForJobNotActive(ctx context.Context, c clientset.Interface, ns, cronJobName, jobName string) error {
+	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+		curr, err := getCronJob(ctx, c, ns, cronJobName)
 		if err != nil {
 			return false, err
 		}
@@ -635,9 +635,9 @@ func waitForJobNotActive(c clientset.Interface, ns, cronJobName, jobName string)
 }
 
 // Wait for a job to disappear by listing them explicitly.
-func waitForJobToDisappear(c clientset.Interface, ns string, targetJob *batchv1.Job) error {
-	return wait.Poll(framework.Poll, cronJobTimeout, func() (bool, error) {
-		jobs, err := c.BatchV1().Jobs(ns).List(context.TODO(), metav1.ListOptions{})
+func waitForJobToDisappear(ctx context.Context, c clientset.Interface, ns string, targetJob *batchv1.Job) error {
+	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+		jobs, err := c.BatchV1().Jobs(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -652,10 +652,10 @@ func waitForJobToDisappear(c clientset.Interface, ns string, targetJob *batchv1.
 }
 
 // Wait for a pod to disappear by listing them explicitly.
-func waitForJobsPodToDisappear(c clientset.Interface, ns string, targetJob *batchv1.Job) error {
-	return wait.Poll(framework.Poll, cronJobTimeout, func() (bool, error) {
+func waitForJobsPodToDisappear(ctx context.Context, c clientset.Interface, ns string, targetJob *batchv1.Job) error {
+	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
 		options := metav1.ListOptions{LabelSelector: fmt.Sprintf("controller-uid=%s", targetJob.UID)}
-		pods, err := c.CoreV1().Pods(ns).List(context.TODO(), options)
+		pods, err := c.CoreV1().Pods(ns).List(ctx, options)
 		if err != nil {
 			return false, err
 		}
@@ -664,9 +664,9 @@ func waitForJobsPodToDisappear(c clientset.Interface, ns string, targetJob *batc
 }
 
 // Wait for a job to be replaced with a new one.
-func waitForJobReplaced(c clientset.Interface, ns, previousJobName string) error {
-	return wait.Poll(framework.Poll, cronJobTimeout, func() (bool, error) {
-		jobs, err := c.BatchV1().Jobs(ns).List(context.TODO(), metav1.ListOptions{})
+func waitForJobReplaced(ctx context.Context, c clientset.Interface, ns, previousJobName string) error {
+	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+		jobs, err := c.BatchV1().Jobs(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -683,9 +683,9 @@ func waitForJobReplaced(c clientset.Interface, ns, previousJobName string) error
 }
 
 // waitForJobsAtLeast waits for at least a number of jobs to appear.
-func waitForJobsAtLeast(c clientset.Interface, ns string, atLeast int) error {
-	return wait.Poll(framework.Poll, cronJobTimeout, func() (bool, error) {
-		jobs, err := c.BatchV1().Jobs(ns).List(context.TODO(), metav1.ListOptions{})
+func waitForJobsAtLeast(ctx context.Context, c clientset.Interface, ns string, atLeast int) error {
+	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+		jobs, err := c.BatchV1().Jobs(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -694,9 +694,9 @@ func waitForJobsAtLeast(c clientset.Interface, ns string, atLeast int) error {
 }
 
 // waitForAnyFinishedJob waits for any completed job to appear.
-func waitForAnyFinishedJob(c clientset.Interface, ns string) error {
-	return wait.Poll(framework.Poll, cronJobTimeout, func() (bool, error) {
-		jobs, err := c.BatchV1().Jobs(ns).List(context.TODO(), metav1.ListOptions{})
+func waitForAnyFinishedJob(ctx context.Context, c clientset.Interface, ns string) error {
+	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+		jobs, err := c.BatchV1().Jobs(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -710,9 +710,9 @@ func waitForAnyFinishedJob(c clientset.Interface, ns string) error {
 }
 
 // waitForEventWithReason waits for events with a reason within a list has occurred
-func waitForEventWithReason(c clientset.Interface, ns, cronJobName string, reasons []string) error {
-	return wait.Poll(framework.Poll, 30*time.Second, func() (bool, error) {
-		sj, err := getCronJob(c, ns, cronJobName)
+func waitForEventWithReason(ctx context.Context, c clientset.Interface, ns, cronJobName string, reasons []string) error {
+	return wait.PollWithContext(ctx, framework.Poll, 30*time.Second, func(ctx context.Context) (bool, error) {
+		sj, err := getCronJob(ctx, c, ns, cronJobName)
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -81,8 +81,8 @@ var _ = SIGDescribe("Deployment", func() {
 	var c clientset.Interface
 	var dc dynamic.Interface
 
-	ginkgo.AfterEach(func() {
-		failureTrap(c, ns)
+	ginkgo.AfterEach(func(ctx context.Context) {
+		failureTrap(ctx, c, ns)
 	})
 
 	f := framework.NewDefaultFramework("deployment")
@@ -95,7 +95,7 @@ var _ = SIGDescribe("Deployment", func() {
 	})
 
 	ginkgo.It("deployment reaping should cascade to its replica sets and pods", func(ctx context.Context) {
-		testDeleteDeployment(f)
+		testDeleteDeployment(ctx, f)
 	})
 	/*
 	  Release: v1.12
@@ -103,7 +103,7 @@ var _ = SIGDescribe("Deployment", func() {
 	  Description: A conformant Kubernetes distribution MUST support the Deployment with RollingUpdate strategy.
 	*/
 	framework.ConformanceIt("RollingUpdateDeployment should delete old pods and create new ones", func(ctx context.Context) {
-		testRollingUpdateDeployment(f)
+		testRollingUpdateDeployment(ctx, f)
 	})
 	/*
 	  Release: v1.12
@@ -111,7 +111,7 @@ var _ = SIGDescribe("Deployment", func() {
 	  Description: A conformant Kubernetes distribution MUST support the Deployment with Recreate strategy.
 	*/
 	framework.ConformanceIt("RecreateDeployment should delete old pods and create new ones", func(ctx context.Context) {
-		testRecreateDeployment(f)
+		testRecreateDeployment(ctx, f)
 	})
 	/*
 	  Release: v1.12
@@ -120,7 +120,7 @@ var _ = SIGDescribe("Deployment", func() {
 	  the Deployment's `.spec.revisionHistoryLimit`.
 	*/
 	framework.ConformanceIt("deployment should delete old replica sets", func(ctx context.Context) {
-		testDeploymentCleanUpPolicy(f)
+		testDeploymentCleanUpPolicy(ctx, f)
 	})
 	/*
 	  Release: v1.12
@@ -130,13 +130,13 @@ var _ = SIGDescribe("Deployment", func() {
 	    before the rollout finishes.
 	*/
 	framework.ConformanceIt("deployment should support rollover", func(ctx context.Context) {
-		testRolloverDeployment(f)
+		testRolloverDeployment(ctx, f)
 	})
 	ginkgo.It("iterative rollouts should eventually progress", func(ctx context.Context) {
-		testIterativeDeployments(f)
+		testIterativeDeployments(ctx, f)
 	})
 	ginkgo.It("test Deployment ReplicaSet orphaning and adoption regarding controllerRef", func(ctx context.Context) {
-		testDeploymentsControllerRef(f)
+		testDeploymentsControllerRef(ctx, f)
 	})
 
 	/*
@@ -148,7 +148,7 @@ var _ = SIGDescribe("Deployment", func() {
 	   a scale subresource.
 	*/
 	framework.ConformanceIt("Deployment should have a working scale subresource", func(ctx context.Context) {
-		testDeploymentSubresources(f)
+		testDeploymentSubresources(ctx, f)
 	})
 	/*
 	  Release: v1.12
@@ -158,15 +158,15 @@ var _ = SIGDescribe("Deployment", func() {
 	    when a Deployment is scaled.
 	*/
 	framework.ConformanceIt("deployment should support proportional scaling", func(ctx context.Context) {
-		testProportionalScalingDeployment(f)
+		testProportionalScalingDeployment(ctx, f)
 	})
 	ginkgo.It("should not disrupt a cloud load-balancer's connectivity during rollout", func(ctx context.Context) {
 		e2eskipper.SkipUnlessProviderIs("aws", "azure", "gce", "gke")
 		e2eskipper.SkipIfIPv6("aws")
-		nodes, err := e2enode.GetReadySchedulableNodes(c)
+		nodes, err := e2enode.GetReadySchedulableNodes(ctx, c)
 		framework.ExpectNoError(err)
 		e2eskipper.SkipUnlessAtLeast(len(nodes.Items), 3, "load-balancer test requires at least 3 schedulable nodes")
-		testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f)
+		testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(ctx, f)
 	})
 	// TODO: add tests that cover deployment.Spec.MinReadySeconds once we solved clock-skew issues
 	// See https://github.com/kubernetes/kubernetes/issues/29229
@@ -198,10 +198,10 @@ var _ = SIGDescribe("Deployment", func() {
 		w := &cache.ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = testDeploymentLabelsFlat
-				return f.ClientSet.AppsV1().Deployments(testNamespaceName).Watch(context.TODO(), options)
+				return f.ClientSet.AppsV1().Deployments(testNamespaceName).Watch(ctx, options)
 			},
 		}
-		deploymentsList, err := f.ClientSet.AppsV1().Deployments("").List(context.TODO(), metav1.ListOptions{LabelSelector: testDeploymentLabelsFlat})
+		deploymentsList, err := f.ClientSet.AppsV1().Deployments("").List(ctx, metav1.ListOptions{LabelSelector: testDeploymentLabelsFlat})
 		framework.ExpectNoError(err, "failed to list Deployments")
 
 		ginkgo.By("creating a Deployment")
@@ -211,13 +211,13 @@ var _ = SIGDescribe("Deployment", func() {
 		testDeployment.ObjectMeta.Labels = map[string]string{"test-deployment-static": "true"}
 		testDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds = &one
 
-		_, err = f.ClientSet.AppsV1().Deployments(testNamespaceName).Create(context.TODO(), testDeployment, metav1.CreateOptions{})
+		_, err = f.ClientSet.AppsV1().Deployments(testNamespaceName).Create(ctx, testDeployment, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create Deployment %v in namespace %v", testDeploymentName, testNamespaceName)
 
 		ginkgo.By("waiting for Deployment to be created")
-		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		ctxUntil, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		_, err = watchtools.Until(ctx, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Added:
 				if deployment, ok := event.Object.(*appsv1.Deployment); ok {
@@ -233,9 +233,9 @@ var _ = SIGDescribe("Deployment", func() {
 		framework.ExpectNoError(err, "failed to see %v event", watch.Added)
 
 		ginkgo.By("waiting for all Replicas to be Ready")
-		ctx, cancel = context.WithTimeout(context.Background(), f.Timeouts.PodStart)
+		ctxUntil, cancel = context.WithTimeout(ctx, f.Timeouts.PodStart)
 		defer cancel()
-		_, err = watchtools.Until(ctx, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			if deployment, ok := event.Object.(*appsv1.Deployment); ok {
 				found := deployment.ObjectMeta.Name == testDeployment.Name &&
 					deployment.ObjectMeta.Labels["test-deployment-static"] == "true" &&
@@ -269,11 +269,11 @@ var _ = SIGDescribe("Deployment", func() {
 			},
 		})
 		framework.ExpectNoError(err, "failed to Marshal Deployment JSON patch")
-		_, err = f.ClientSet.AppsV1().Deployments(testNamespaceName).Patch(context.TODO(), testDeploymentName, types.StrategicMergePatchType, []byte(deploymentPatch), metav1.PatchOptions{})
+		_, err = f.ClientSet.AppsV1().Deployments(testNamespaceName).Patch(ctx, testDeploymentName, types.StrategicMergePatchType, []byte(deploymentPatch), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch Deployment")
-		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		ctxUntil, cancel = context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		_, err = watchtools.Until(ctx, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Modified:
 				if deployment, ok := event.Object.(*appsv1.Deployment); ok {
@@ -292,9 +292,9 @@ var _ = SIGDescribe("Deployment", func() {
 		framework.ExpectNoError(err, "failed to see %v event", watch.Modified)
 
 		ginkgo.By("waiting for Replicas to scale")
-		ctx, cancel = context.WithTimeout(context.Background(), f.Timeouts.PodStart)
+		ctxUntil, cancel = context.WithTimeout(ctx, f.Timeouts.PodStart)
 		defer cancel()
-		_, err = watchtools.Until(ctx, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			if deployment, ok := event.Object.(*appsv1.Deployment); ok {
 				found := deployment.ObjectMeta.Name == testDeployment.Name &&
 					deployment.ObjectMeta.Labels["test-deployment-static"] == "true" &&
@@ -313,7 +313,7 @@ var _ = SIGDescribe("Deployment", func() {
 		framework.ExpectNoError(err, "failed to see replicas of %v in namespace %v scale to requested amount of %v", testDeployment.Name, testNamespaceName, testDeploymentMinimumReplicas)
 
 		ginkgo.By("listing Deployments")
-		deploymentsList, err = f.ClientSet.AppsV1().Deployments("").List(context.TODO(), metav1.ListOptions{LabelSelector: testDeploymentLabelsFlat})
+		deploymentsList, err = f.ClientSet.AppsV1().Deployments("").List(ctx, metav1.ListOptions{LabelSelector: testDeploymentLabelsFlat})
 		framework.ExpectNoError(err, "failed to list Deployments")
 		foundDeployment := false
 		for _, deploymentItem := range deploymentsList.Items {
@@ -339,11 +339,11 @@ var _ = SIGDescribe("Deployment", func() {
 			Object: testDeploymentUpdateUnstructuredMap,
 		}
 		// currently this hasn't been able to hit the endpoint replaceAppsV1NamespacedDeploymentStatus
-		_, err = dc.Resource(deploymentResource).Namespace(testNamespaceName).Update(context.TODO(), &testDeploymentUpdateUnstructured, metav1.UpdateOptions{}) //, "status")
+		_, err = dc.Resource(deploymentResource).Namespace(testNamespaceName).Update(ctx, &testDeploymentUpdateUnstructured, metav1.UpdateOptions{}) //, "status")
 		framework.ExpectNoError(err, "failed to update the DeploymentStatus")
-		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		ctxUntil, cancel = context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		_, err = watchtools.Until(ctx, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Modified:
 				if deployment, ok := event.Object.(*appsv1.Deployment); ok {
@@ -363,7 +363,7 @@ var _ = SIGDescribe("Deployment", func() {
 		framework.ExpectNoError(err, "failed to see %v event", watch.Modified)
 
 		ginkgo.By("fetching the DeploymentStatus")
-		deploymentGetUnstructured, err := dc.Resource(deploymentResource).Namespace(testNamespaceName).Get(context.TODO(), testDeploymentName, metav1.GetOptions{}, "status")
+		deploymentGetUnstructured, err := dc.Resource(deploymentResource).Namespace(testNamespaceName).Get(ctx, testDeploymentName, metav1.GetOptions{}, "status")
 		framework.ExpectNoError(err, "failed to fetch the Deployment")
 		deploymentGet := appsv1.Deployment{}
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(deploymentGetUnstructured.Object, &deploymentGet)
@@ -371,9 +371,9 @@ var _ = SIGDescribe("Deployment", func() {
 		framework.ExpectEqual(deploymentGet.Spec.Template.Spec.Containers[0].Image, testDeploymentUpdateImage, "failed to update image")
 		framework.ExpectEqual(deploymentGet.ObjectMeta.Labels["test-deployment"], "updated", "failed to update labels")
 
-		ctx, cancel = context.WithTimeout(context.Background(), f.Timeouts.PodStart)
+		ctxUntil, cancel = context.WithTimeout(ctx, f.Timeouts.PodStart)
 		defer cancel()
-		_, err = watchtools.Until(ctx, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			if deployment, ok := event.Object.(*appsv1.Deployment); ok {
 				found := deployment.ObjectMeta.Name == testDeployment.Name &&
 					deployment.ObjectMeta.Labels["test-deployment-static"] == "true" &&
@@ -399,10 +399,14 @@ var _ = SIGDescribe("Deployment", func() {
 			},
 		})
 		framework.ExpectNoError(err, "failed to Marshal Deployment JSON patch")
-		dc.Resource(deploymentResource).Namespace(testNamespaceName).Patch(context.TODO(), testDeploymentName, types.StrategicMergePatchType, []byte(deploymentStatusPatch), metav1.PatchOptions{}, "status")
-		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		// This test is broken, patching fails with:
+		// Deployment.apps "test-deployment" is invalid: status.availableReplicas: Invalid value: 2: cannot be greater than readyReplicas
+		// https://github.com/kubernetes/kubernetes/issues/113259
+		_, _ = dc.Resource(deploymentResource).Namespace(testNamespaceName).Patch(ctx, testDeploymentName, types.StrategicMergePatchType, []byte(deploymentStatusPatch), metav1.PatchOptions{}, "status")
+
+		ctxUntil, cancel = context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		_, err = watchtools.Until(ctx, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Modified:
 				if deployment, ok := event.Object.(*appsv1.Deployment); ok {
@@ -418,16 +422,16 @@ var _ = SIGDescribe("Deployment", func() {
 		framework.ExpectNoError(err, "failed to see %v event", watch.Modified)
 
 		ginkgo.By("fetching the DeploymentStatus")
-		deploymentGetUnstructured, err = dc.Resource(deploymentResource).Namespace(testNamespaceName).Get(context.TODO(), testDeploymentName, metav1.GetOptions{}, "status")
+		deploymentGetUnstructured, err = dc.Resource(deploymentResource).Namespace(testNamespaceName).Get(ctx, testDeploymentName, metav1.GetOptions{}, "status")
 		framework.ExpectNoError(err, "failed to fetch the DeploymentStatus")
 		deploymentGet = appsv1.Deployment{}
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(deploymentGetUnstructured.Object, &deploymentGet)
 		framework.ExpectNoError(err, "failed to convert the unstructured response to a Deployment")
 		framework.ExpectEqual(deploymentGet.Spec.Template.Spec.Containers[0].Image, testDeploymentUpdateImage, "failed to update image")
 		framework.ExpectEqual(deploymentGet.ObjectMeta.Labels["test-deployment"], "updated", "failed to update labels")
-		ctx, cancel = context.WithTimeout(context.Background(), f.Timeouts.PodStart)
+		ctxUntil, cancel = context.WithTimeout(ctx, f.Timeouts.PodStart)
 		defer cancel()
-		_, err = watchtools.Until(ctx, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			if deployment, ok := event.Object.(*appsv1.Deployment); ok {
 				found := deployment.ObjectMeta.Name == testDeployment.Name &&
 					deployment.ObjectMeta.Labels["test-deployment-static"] == "true" &&
@@ -445,12 +449,12 @@ var _ = SIGDescribe("Deployment", func() {
 		framework.ExpectNoError(err, "failed to see replicas of %v in namespace %v scale to requested amount of %v", testDeployment.Name, testNamespaceName, testDeploymentDefaultReplicas)
 
 		ginkgo.By("deleting the Deployment")
-		err = f.ClientSet.AppsV1().Deployments(testNamespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &one}, metav1.ListOptions{LabelSelector: testDeploymentLabelsFlat})
+		err = f.ClientSet.AppsV1().Deployments(testNamespaceName).DeleteCollection(ctx, metav1.DeleteOptions{GracePeriodSeconds: &one}, metav1.ListOptions{LabelSelector: testDeploymentLabelsFlat})
 		framework.ExpectNoError(err, "failed to delete Deployment via collection")
 
-		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Minute)
+		ctxUntil, cancel = context.WithTimeout(ctx, 1*time.Minute)
 		defer cancel()
-		_, err = watchtools.Until(ctx, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Deleted:
 				if deployment, ok := event.Object.(*appsv1.Deployment); ok {
@@ -484,10 +488,10 @@ var _ = SIGDescribe("Deployment", func() {
 		w := &cache.ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = labelSelector
-				return dClient.Watch(context.TODO(), options)
+				return dClient.Watch(ctx, options)
 			},
 		}
-		dList, err := c.AppsV1().Deployments("").List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+		dList, err := c.AppsV1().Deployments("").List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 		framework.ExpectNoError(err, "failed to list Deployments")
 
 		ginkgo.By("creating a Deployment")
@@ -496,7 +500,7 @@ var _ = SIGDescribe("Deployment", func() {
 		replicas := int32(1)
 		framework.Logf("Creating simple deployment %s", dName)
 		d := e2edeployment.NewDeployment(dName, replicas, podLabels, WebserverImageName, WebserverImage, appsv1.RollingUpdateDeploymentStrategyType)
-		deploy, err := c.AppsV1().Deployments(ns).Create(context.TODO(), d, metav1.CreateOptions{})
+		deploy, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		// Wait for it to be updated to revision 1
@@ -506,12 +510,12 @@ var _ = SIGDescribe("Deployment", func() {
 		err = e2edeployment.WaitForDeploymentComplete(c, deploy)
 		framework.ExpectNoError(err)
 
-		testDeployment, err := dClient.Get(context.TODO(), dName, metav1.GetOptions{})
+		testDeployment, err := dClient.Get(ctx, dName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Getting /status")
 		dResource := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
-		dStatusUnstructured, err := f.DynamicClient.Resource(dResource).Namespace(ns).Get(context.TODO(), dName, metav1.GetOptions{}, "status")
+		dStatusUnstructured, err := f.DynamicClient.Resource(dResource).Namespace(ns).Get(ctx, dName, metav1.GetOptions{}, "status")
 		framework.ExpectNoError(err, "Failed to fetch the status of deployment %s in namespace %s", dName, ns)
 		dStatusBytes, err := json.Marshal(dStatusUnstructured)
 		framework.ExpectNoError(err, "Failed to marshal unstructured response. %v", err)
@@ -525,7 +529,7 @@ var _ = SIGDescribe("Deployment", func() {
 		var statusToUpdate, updatedStatus *appsv1.Deployment
 
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			statusToUpdate, err = dClient.Get(context.TODO(), dName, metav1.GetOptions{})
+			statusToUpdate, err = dClient.Get(ctx, dName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Unable to retrieve deployment %s", dName)
 
 			statusToUpdate.Status.Conditions = append(statusToUpdate.Status.Conditions, appsv1.DeploymentCondition{
@@ -535,17 +539,17 @@ var _ = SIGDescribe("Deployment", func() {
 				Message: "Set from e2e test",
 			})
 
-			updatedStatus, err = dClient.UpdateStatus(context.TODO(), statusToUpdate, metav1.UpdateOptions{})
+			updatedStatus, err = dClient.UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})
 			return err
 		})
 		framework.ExpectNoError(err, "Failed to update status. %v", err)
 		framework.Logf("updatedStatus.Conditions: %#v", updatedStatus.Status.Conditions)
 
 		ginkgo.By("watching for the Deployment status to be updated")
-		ctx, cancel := context.WithTimeout(ctx, dRetryTimeout)
+		ctxUntil, cancel := context.WithTimeout(ctx, dRetryTimeout)
 		defer cancel()
 
-		_, err = watchtools.Until(ctx, dList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, dList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			if d, ok := event.Object.(*appsv1.Deployment); ok {
 				found := d.ObjectMeta.Name == testDeployment.ObjectMeta.Name &&
 					d.ObjectMeta.Namespace == testDeployment.ObjectMeta.Namespace &&
@@ -576,15 +580,15 @@ var _ = SIGDescribe("Deployment", func() {
 		payload := []byte(`{"status":{"conditions":[{"type":"StatusPatched","status":"True"}]}}`)
 		framework.Logf("Patch payload: %v", string(payload))
 
-		patchedDeployment, err := dClient.Patch(context.TODO(), dName, types.MergePatchType, payload, metav1.PatchOptions{}, "status")
+		patchedDeployment, err := dClient.Patch(ctx, dName, types.MergePatchType, payload, metav1.PatchOptions{}, "status")
 		framework.ExpectNoError(err, "Failed to patch status. %v", err)
 		framework.Logf("Patched status conditions: %#v", patchedDeployment.Status.Conditions)
 
 		ginkgo.By("watching for the Deployment status to be patched")
-		ctx, cancel = context.WithTimeout(context.Background(), dRetryTimeout)
+		ctxUntil, cancel = context.WithTimeout(ctx, dRetryTimeout)
 		defer cancel()
 
-		_, err = watchtools.Until(ctx, dList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, dList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 
 			if e, ok := event.Object.(*appsv1.Deployment); ok {
 				found := e.ObjectMeta.Name == testDeployment.ObjectMeta.Name &&
@@ -611,8 +615,8 @@ var _ = SIGDescribe("Deployment", func() {
 	})
 })
 
-func failureTrap(c clientset.Interface, ns string) {
-	deployments, err := c.AppsV1().Deployments(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Everything().String()})
+func failureTrap(ctx context.Context, c clientset.Interface, ns string) {
+	deployments, err := c.AppsV1().Deployments(ns).List(ctx, metav1.ListOptions{LabelSelector: labels.Everything().String()})
 	if err != nil {
 		framework.Logf("Could not list Deployments in namespace %q: %v", ns, err)
 		return
@@ -638,7 +642,7 @@ func failureTrap(c clientset.Interface, ns string) {
 		return
 	}
 	framework.Logf("Log out all the ReplicaSets if there is no deployment created")
-	rss, err := c.AppsV1().ReplicaSets(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Everything().String()})
+	rss, err := c.AppsV1().ReplicaSets(ns).List(ctx, metav1.ListOptions{LabelSelector: labels.Everything().String()})
 	if err != nil {
 		framework.Logf("Could not list ReplicaSets in namespace %q: %v", ns, err)
 		return
@@ -650,7 +654,7 @@ func failureTrap(c clientset.Interface, ns string) {
 			framework.Logf("failed to get selector of ReplicaSet %s: %v", rs.Name, err)
 		}
 		options := metav1.ListOptions{LabelSelector: selector.String()}
-		podList, err := c.CoreV1().Pods(rs.Namespace).List(context.TODO(), options)
+		podList, err := c.CoreV1().Pods(rs.Namespace).List(ctx, options)
 		if err != nil {
 			framework.Logf("Failed to list Pods in namespace %s: %v", rs.Namespace, err)
 			continue
@@ -666,29 +670,29 @@ func intOrStrP(num int) *intstr.IntOrString {
 	return &intstr
 }
 
-func stopDeployment(c clientset.Interface, ns, deploymentName string) {
-	deployment, err := c.AppsV1().Deployments(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+func stopDeployment(ctx context.Context, c clientset.Interface, ns, deploymentName string) {
+	deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 
 	framework.Logf("Deleting deployment %s", deploymentName)
-	err = e2eresource.DeleteResourceAndWaitForGC(c, appsinternal.Kind("Deployment"), ns, deployment.Name)
+	err = e2eresource.DeleteResourceAndWaitForGC(ctx, c, appsinternal.Kind("Deployment"), ns, deployment.Name)
 	framework.ExpectNoError(err)
 
 	framework.Logf("Ensuring deployment %s was deleted", deploymentName)
-	_, err = c.AppsV1().Deployments(ns).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
+	_, err = c.AppsV1().Deployments(ns).Get(ctx, deployment.Name, metav1.GetOptions{})
 	framework.ExpectError(err)
 	framework.ExpectEqual(apierrors.IsNotFound(err), true)
 	framework.Logf("Ensuring deployment %s's RSes were deleted", deploymentName)
 	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
 	framework.ExpectNoError(err)
 	options := metav1.ListOptions{LabelSelector: selector.String()}
-	rss, err := c.AppsV1().ReplicaSets(ns).List(context.TODO(), options)
+	rss, err := c.AppsV1().ReplicaSets(ns).List(ctx, options)
 	framework.ExpectNoError(err)
 	gomega.Expect(rss.Items).Should(gomega.HaveLen(0))
 	framework.Logf("Ensuring deployment %s's Pods were deleted", deploymentName)
 	var pods *v1.PodList
 	if err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
-		pods, err = c.CoreV1().Pods(ns).List(context.TODO(), options)
+		pods, err = c.CoreV1().Pods(ns).List(ctx, options)
 		if err != nil {
 			return false, err
 		}
@@ -702,7 +706,7 @@ func stopDeployment(c clientset.Interface, ns, deploymentName string) {
 	}
 }
 
-func testDeleteDeployment(f *framework.Framework) {
+func testDeleteDeployment(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 
@@ -712,7 +716,7 @@ func testDeleteDeployment(f *framework.Framework) {
 	framework.Logf("Creating simple deployment %s", deploymentName)
 	d := e2edeployment.NewDeployment(deploymentName, replicas, podLabels, WebserverImageName, WebserverImage, appsv1.RollingUpdateDeploymentStrategyType)
 	d.Annotations = map[string]string{"test": "should-copy-to-replica-set", v1.LastAppliedConfigAnnotation: "should-not-copy-to-replica-set"}
-	deploy, err := c.AppsV1().Deployments(ns).Create(context.TODO(), d, metav1.CreateOptions{})
+	deploy, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	// Wait for it to be updated to revision 1
@@ -722,15 +726,15 @@ func testDeleteDeployment(f *framework.Framework) {
 	err = e2edeployment.WaitForDeploymentComplete(c, deploy)
 	framework.ExpectNoError(err)
 
-	deployment, err := c.AppsV1().Deployments(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	newRS, err := testutil.GetNewReplicaSet(deployment, c)
 	framework.ExpectNoError(err)
 	framework.ExpectNotEqual(newRS, nilRs)
-	stopDeployment(c, ns, deploymentName)
+	stopDeployment(ctx, c, ns, deploymentName)
 }
 
-func testRollingUpdateDeployment(f *framework.Framework) {
+func testRollingUpdateDeployment(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 	// Create webserver pods.
@@ -748,17 +752,17 @@ func testRollingUpdateDeployment(f *framework.Framework) {
 	rs := newRS(rsName, replicas, rsPodLabels, WebserverImageName, WebserverImage, nil)
 	rs.Annotations = annotations
 	framework.Logf("Creating replica set %q (going to be adopted)", rs.Name)
-	_, err := c.AppsV1().ReplicaSets(ns).Create(context.TODO(), rs, metav1.CreateOptions{})
+	_, err := c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	// Verify that the required pods have come up.
-	err = e2epod.VerifyPodsRunning(c, ns, "sample-pod", false, replicas)
+	err = e2epod.VerifyPodsRunning(ctx, c, ns, "sample-pod", false, replicas)
 	framework.ExpectNoError(err, "error in waiting for pods to come up: %s", err)
 
 	// Create a deployment to delete webserver pods and instead bring up agnhost pods.
 	deploymentName := "test-rolling-update-deployment"
 	framework.Logf("Creating deployment %q", deploymentName)
 	d := e2edeployment.NewDeployment(deploymentName, replicas, deploymentPodLabels, AgnhostImageName, AgnhostImage, appsv1.RollingUpdateDeploymentStrategyType)
-	deploy, err := c.AppsV1().Deployments(ns).Create(context.TODO(), d, metav1.CreateOptions{})
+	deploy, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	// Wait for it to be updated to revision 3546343826724305833.
@@ -772,14 +776,14 @@ func testRollingUpdateDeployment(f *framework.Framework) {
 
 	// There should be 1 old RS (webserver-controller, which is adopted)
 	framework.Logf("Ensuring deployment %q has one old replica set (the one it adopted)", deploy.Name)
-	deployment, err := c.AppsV1().Deployments(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	_, allOldRSs, err := testutil.GetOldReplicaSets(deployment, c)
 	framework.ExpectNoError(err)
 	framework.ExpectEqual(len(allOldRSs), 1)
 }
 
-func testRecreateDeployment(f *framework.Framework) {
+func testRecreateDeployment(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 
@@ -787,7 +791,7 @@ func testRecreateDeployment(f *framework.Framework) {
 	deploymentName := "test-recreate-deployment"
 	framework.Logf("Creating deployment %q", deploymentName)
 	d := e2edeployment.NewDeployment(deploymentName, int32(1), map[string]string{"name": "sample-pod-3"}, AgnhostImageName, AgnhostImage, appsv1.RecreateDeploymentStrategyType)
-	deployment, err := c.AppsV1().Deployments(ns).Create(context.TODO(), d, metav1.CreateOptions{})
+	deployment, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	// Wait for it to be updated to revision 1
@@ -808,12 +812,12 @@ func testRecreateDeployment(f *framework.Framework) {
 	framework.ExpectNoError(err)
 
 	framework.Logf("Watching deployment %q to verify that new pods will not run with olds pods", deploymentName)
-	err = watchRecreateDeployment(c, deployment)
+	err = watchRecreateDeployment(ctx, c, deployment)
 	framework.ExpectNoError(err)
 }
 
 // testDeploymentCleanUpPolicy tests that deployment supports cleanup policy
-func testDeploymentCleanUpPolicy(f *framework.Framework) {
+func testDeploymentCleanUpPolicy(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 	// Create webserver pods.
@@ -825,18 +829,18 @@ func testDeploymentCleanUpPolicy(f *framework.Framework) {
 	rsName := "test-cleanup-controller"
 	replicas := int32(1)
 	revisionHistoryLimit := utilpointer.Int32Ptr(0)
-	_, err := c.AppsV1().ReplicaSets(ns).Create(context.TODO(), newRS(rsName, replicas, rsPodLabels, WebserverImageName, WebserverImage, nil), metav1.CreateOptions{})
+	_, err := c.AppsV1().ReplicaSets(ns).Create(ctx, newRS(rsName, replicas, rsPodLabels, WebserverImageName, WebserverImage, nil), metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	// Verify that the required pods have come up.
-	err = e2epod.VerifyPodsRunning(c, ns, "cleanup-pod", false, replicas)
+	err = e2epod.VerifyPodsRunning(ctx, c, ns, "cleanup-pod", false, replicas)
 	framework.ExpectNoError(err, "error in waiting for pods to come up: %v", err)
 
 	// Create a deployment to delete webserver pods and instead bring up agnhost pods.
 	deploymentName := "test-cleanup-deployment"
 	framework.Logf("Creating deployment %s", deploymentName)
 
-	pods, err := c.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Everything().String()})
+	pods, err := c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: labels.Everything().String()})
 	framework.ExpectNoError(err, "Failed to query for pods: %v", err)
 
 	options := metav1.ListOptions{
@@ -844,7 +848,7 @@ func testDeploymentCleanUpPolicy(f *framework.Framework) {
 	}
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	w, err := c.CoreV1().Pods(ns).Watch(context.TODO(), options)
+	w, err := c.CoreV1().Pods(ns).Watch(ctx, options)
 	framework.ExpectNoError(err)
 	go func() {
 		defer ginkgo.GinkgoRecover()
@@ -875,17 +879,17 @@ func testDeploymentCleanUpPolicy(f *framework.Framework) {
 	}()
 	d := e2edeployment.NewDeployment(deploymentName, replicas, deploymentPodLabels, AgnhostImageName, AgnhostImage, appsv1.RollingUpdateDeploymentStrategyType)
 	d.Spec.RevisionHistoryLimit = revisionHistoryLimit
-	_, err = c.AppsV1().Deployments(ns).Create(context.TODO(), d, metav1.CreateOptions{})
+	_, err = c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.By(fmt.Sprintf("Waiting for deployment %s history to be cleaned up", deploymentName))
-	err = waitForDeploymentOldRSsNum(c, ns, deploymentName, int(*revisionHistoryLimit))
+	err = waitForDeploymentOldRSsNum(ctx, c, ns, deploymentName, int(*revisionHistoryLimit))
 	framework.ExpectNoError(err)
 }
 
 // testRolloverDeployment tests that deployment supports rollover.
 // i.e. we can change desired state and kick off rolling update, then change desired state again before it finishes.
-func testRolloverDeployment(f *framework.Framework) {
+func testRolloverDeployment(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 	podName := "rollover-pod"
@@ -897,15 +901,15 @@ func testRolloverDeployment(f *framework.Framework) {
 
 	rsName := "test-rollover-controller"
 	rsReplicas := int32(1)
-	_, err := c.AppsV1().ReplicaSets(ns).Create(context.TODO(), newRS(rsName, rsReplicas, rsPodLabels, WebserverImageName, WebserverImage, nil), metav1.CreateOptions{})
+	_, err := c.AppsV1().ReplicaSets(ns).Create(ctx, newRS(rsName, rsReplicas, rsPodLabels, WebserverImageName, WebserverImage, nil), metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	// Verify that the required pods have come up.
-	err = e2epod.VerifyPodsRunning(c, ns, podName, false, rsReplicas)
+	err = e2epod.VerifyPodsRunning(ctx, c, ns, podName, false, rsReplicas)
 	framework.ExpectNoError(err, "error in waiting for pods to come up: %v", err)
 
 	// Wait for replica set to become ready before adopting it.
 	framework.Logf("Waiting for pods owned by replica set %q to become ready", rsName)
-	err = e2ereplicaset.WaitForReadyReplicaSet(c, ns, rsName)
+	err = e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName)
 	framework.ExpectNoError(err)
 
 	// Create a deployment to delete webserver pods and instead bring up redis-slave pods.
@@ -921,11 +925,11 @@ func testRolloverDeployment(f *framework.Framework) {
 		MaxSurge:       intOrStrP(1),
 	}
 	newDeployment.Spec.MinReadySeconds = int32(10)
-	_, err = c.AppsV1().Deployments(ns).Create(context.TODO(), newDeployment, metav1.CreateOptions{})
+	_, err = c.AppsV1().Deployments(ns).Create(ctx, newDeployment, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	// Verify that the pods were scaled up and down as expected.
-	deployment, err := c.AppsV1().Deployments(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	framework.Logf("Make sure deployment %q performs scaling operations", deploymentName)
 	// Make sure the deployment starts to scale up and down replica sets by checking if its updated replicas >= 1
@@ -937,7 +941,7 @@ func testRolloverDeployment(f *framework.Framework) {
 	framework.ExpectNoError(err)
 
 	framework.Logf("Ensure that both replica sets have 1 created replica")
-	oldRS, err := c.AppsV1().ReplicaSets(ns).Get(context.TODO(), rsName, metav1.GetOptions{})
+	oldRS, err := c.AppsV1().ReplicaSets(ns).Get(ctx, rsName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	ensureReplicas(oldRS, int32(1))
 	newRS, err := testutil.GetNewReplicaSet(deployment, c)
@@ -968,11 +972,11 @@ func testRolloverDeployment(f *framework.Framework) {
 	framework.ExpectNoError(err)
 
 	framework.Logf("Ensure that both old replica sets have no replicas")
-	oldRS, err = c.AppsV1().ReplicaSets(ns).Get(context.TODO(), rsName, metav1.GetOptions{})
+	oldRS, err = c.AppsV1().ReplicaSets(ns).Get(ctx, rsName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	ensureReplicas(oldRS, int32(0))
 	// Not really the new replica set anymore but we GET by name so that's fine.
-	newRS, err = c.AppsV1().ReplicaSets(ns).Get(context.TODO(), newRS.Name, metav1.GetOptions{})
+	newRS, err = c.AppsV1().ReplicaSets(ns).Get(ctx, newRS.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	ensureReplicas(newRS, int32(0))
 }
@@ -995,7 +999,7 @@ func randomScale(d *appsv1.Deployment, i int) {
 	}
 }
 
-func testIterativeDeployments(f *framework.Framework) {
+func testIterativeDeployments(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 
@@ -1012,7 +1016,7 @@ func testIterativeDeployments(f *framework.Framework) {
 	d.Spec.RevisionHistoryLimit = &two
 	d.Spec.Template.Spec.TerminationGracePeriodSeconds = &zero
 	framework.Logf("Creating deployment %q", deploymentName)
-	deployment, err := c.AppsV1().Deployments(ns).Create(context.TODO(), d, metav1.CreateOptions{})
+	deployment, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	iterations := 20
@@ -1075,7 +1079,7 @@ func testIterativeDeployments(f *framework.Framework) {
 			selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
 			framework.ExpectNoError(err)
 			opts := metav1.ListOptions{LabelSelector: selector.String()}
-			podList, err := c.CoreV1().Pods(ns).List(context.TODO(), opts)
+			podList, err := c.CoreV1().Pods(ns).List(ctx, opts)
 			framework.ExpectNoError(err)
 			if len(podList.Items) == 0 {
 				framework.Logf("%02d: no deployment pods to delete", i)
@@ -1087,7 +1091,7 @@ func testIterativeDeployments(f *framework.Framework) {
 				}
 				name := podList.Items[p].Name
 				framework.Logf("%02d: deleting deployment pod %q", i, name)
-				err := c.CoreV1().Pods(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+				err := c.CoreV1().Pods(ns).Delete(ctx, name, metav1.DeleteOptions{})
 				if err != nil && !apierrors.IsNotFound(err) {
 					framework.ExpectNoError(err)
 				}
@@ -1096,7 +1100,7 @@ func testIterativeDeployments(f *framework.Framework) {
 	}
 
 	// unpause the deployment if we end up pausing it
-	deployment, err = c.AppsV1().Deployments(ns).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
+	deployment, err = c.AppsV1().Deployments(ns).Get(ctx, deployment.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	if deployment.Spec.Paused {
 		framework.Logf("Resuming deployment %q", deployment.Name)
@@ -1119,7 +1123,7 @@ func testIterativeDeployments(f *framework.Framework) {
 	framework.ExpectNoError(err)
 }
 
-func testDeploymentsControllerRef(f *framework.Framework) {
+func testDeploymentsControllerRef(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 
@@ -1128,44 +1132,44 @@ func testDeploymentsControllerRef(f *framework.Framework) {
 	podLabels := map[string]string{"name": WebserverImageName}
 	replicas := int32(1)
 	d := e2edeployment.NewDeployment(deploymentName, replicas, podLabels, WebserverImageName, WebserverImage, appsv1.RollingUpdateDeploymentStrategyType)
-	deploy, err := c.AppsV1().Deployments(ns).Create(context.TODO(), d, metav1.CreateOptions{})
+	deploy, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	err = e2edeployment.WaitForDeploymentComplete(c, deploy)
 	framework.ExpectNoError(err)
 
 	framework.Logf("Verifying Deployment %q has only one ReplicaSet", deploymentName)
-	rsList := listDeploymentReplicaSets(c, ns, podLabels)
+	rsList := listDeploymentReplicaSets(ctx, c, ns, podLabels)
 	framework.ExpectEqual(len(rsList.Items), 1)
 
 	framework.Logf("Obtaining the ReplicaSet's UID")
 	orphanedRSUID := rsList.Items[0].UID
 
 	framework.Logf("Checking the ReplicaSet has the right controllerRef")
-	err = checkDeploymentReplicaSetsControllerRef(c, ns, deploy.UID, podLabels)
+	err = checkDeploymentReplicaSetsControllerRef(ctx, c, ns, deploy.UID, podLabels)
 	framework.ExpectNoError(err)
 
 	framework.Logf("Deleting Deployment %q and orphaning its ReplicaSet", deploymentName)
-	err = orphanDeploymentReplicaSets(c, deploy)
+	err = orphanDeploymentReplicaSets(ctx, c, deploy)
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Wait for the ReplicaSet to be orphaned")
-	err = wait.Poll(dRetryPeriod, dRetryTimeout, waitDeploymentReplicaSetsOrphaned(c, ns, podLabels))
+	err = wait.PollWithContext(ctx, dRetryPeriod, dRetryTimeout, waitDeploymentReplicaSetsOrphaned(c, ns, podLabels))
 	framework.ExpectNoError(err, "error waiting for Deployment ReplicaSet to be orphaned")
 
 	deploymentName = "test-adopt-deployment"
 	framework.Logf("Creating Deployment %q to adopt the ReplicaSet", deploymentName)
 	d = e2edeployment.NewDeployment(deploymentName, replicas, podLabels, WebserverImageName, WebserverImage, appsv1.RollingUpdateDeploymentStrategyType)
-	deploy, err = c.AppsV1().Deployments(ns).Create(context.TODO(), d, metav1.CreateOptions{})
+	deploy, err = c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	err = e2edeployment.WaitForDeploymentComplete(c, deploy)
 	framework.ExpectNoError(err)
 
 	framework.Logf("Waiting for the ReplicaSet to have the right controllerRef")
-	err = checkDeploymentReplicaSetsControllerRef(c, ns, deploy.UID, podLabels)
+	err = checkDeploymentReplicaSetsControllerRef(ctx, c, ns, deploy.UID, podLabels)
 	framework.ExpectNoError(err)
 
 	framework.Logf("Verifying no extra ReplicaSet is created (Deployment %q still has only one ReplicaSet after adoption)", deploymentName)
-	rsList = listDeploymentReplicaSets(c, ns, podLabels)
+	rsList = listDeploymentReplicaSets(ctx, c, ns, podLabels)
 	framework.ExpectEqual(len(rsList.Items), 1)
 
 	framework.Logf("Verifying the ReplicaSet has the same UID as the orphaned ReplicaSet")
@@ -1175,7 +1179,7 @@ func testDeploymentsControllerRef(f *framework.Framework) {
 // testProportionalScalingDeployment tests that when a RollingUpdate Deployment is scaled in the middle
 // of a rollout (either in progress or paused), then the Deployment will balance additional replicas
 // in existing active ReplicaSets (ReplicaSets with more than 0 replica) in order to mitigate risk.
-func testProportionalScalingDeployment(f *framework.Framework) {
+func testProportionalScalingDeployment(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 
@@ -1190,7 +1194,7 @@ func testProportionalScalingDeployment(f *framework.Framework) {
 	d.Spec.Strategy.RollingUpdate.MaxUnavailable = intOrStrP(2)
 
 	framework.Logf("Creating deployment %q", deploymentName)
-	deployment, err := c.AppsV1().Deployments(ns).Create(context.TODO(), d, metav1.CreateOptions{})
+	deployment, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	framework.Logf("Waiting for observed generation %d", deployment.Generation)
@@ -1199,7 +1203,7 @@ func testProportionalScalingDeployment(f *framework.Framework) {
 
 	// Verify that the required pods have come up.
 	framework.Logf("Waiting for all required pods to come up")
-	err = e2epod.VerifyPodsRunning(c, ns, WebserverImageName, false, *(deployment.Spec.Replicas))
+	err = e2epod.VerifyPodsRunning(ctx, c, ns, WebserverImageName, false, *(deployment.Spec.Replicas))
 	framework.ExpectNoError(err, "error in waiting for pods to come up: %v", err)
 
 	framework.Logf("Waiting for deployment %q to complete", deployment.Name)
@@ -1228,19 +1232,19 @@ func testProportionalScalingDeployment(f *framework.Framework) {
 	// First rollout's replicaset should have Deployment's (replicas - maxUnavailable) = 10 - 2 = 8 available replicas.
 	minAvailableReplicas := replicas - int32(maxUnavailable)
 	framework.Logf("Waiting for the first rollout's replicaset to have .status.availableReplicas = %d", minAvailableReplicas)
-	err = e2ereplicaset.WaitForReplicaSetTargetAvailableReplicas(c, firstRS, minAvailableReplicas)
+	err = e2ereplicaset.WaitForReplicaSetTargetAvailableReplicas(ctx, c, firstRS, minAvailableReplicas)
 	framework.ExpectNoError(err)
 
 	// First rollout's replicaset should have .spec.replicas = 8 too.
 	framework.Logf("Waiting for the first rollout's replicaset to have .spec.replicas = %d", minAvailableReplicas)
-	err = waitForReplicaSetTargetSpecReplicas(c, firstRS, minAvailableReplicas)
+	err = waitForReplicaSetTargetSpecReplicas(ctx, c, firstRS, minAvailableReplicas)
 	framework.ExpectNoError(err)
 
 	// The desired replicas wait makes sure that the RS controller has created expected number of pods.
 	framework.Logf("Waiting for the first rollout's replicaset of deployment %q to have desired number of replicas", deploymentName)
-	firstRS, err = c.AppsV1().ReplicaSets(ns).Get(context.TODO(), firstRS.Name, metav1.GetOptions{})
+	firstRS, err = c.AppsV1().ReplicaSets(ns).Get(ctx, firstRS.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	err = waitForReplicaSetDesiredReplicas(c.AppsV1(), firstRS)
+	err = waitForReplicaSetDesiredReplicas(ctx, c.AppsV1(), firstRS)
 	framework.ExpectNoError(err)
 
 	// Checking state of second rollout's replicaset.
@@ -1257,14 +1261,14 @@ func testProportionalScalingDeployment(f *framework.Framework) {
 	// Second rollout's replicaset should have Deployment's (replicas + maxSurge - first RS's replicas) = 10 + 3 - 8 = 5 for .spec.replicas.
 	newReplicas := replicas + int32(maxSurge) - minAvailableReplicas
 	framework.Logf("Waiting for the second rollout's replicaset to have .spec.replicas = %d", newReplicas)
-	err = waitForReplicaSetTargetSpecReplicas(c, secondRS, newReplicas)
+	err = waitForReplicaSetTargetSpecReplicas(ctx, c, secondRS, newReplicas)
 	framework.ExpectNoError(err)
 
 	// The desired replicas wait makes sure that the RS controller has created expected number of pods.
 	framework.Logf("Waiting for the second rollout's replicaset of deployment %q to have desired number of replicas", deploymentName)
-	secondRS, err = c.AppsV1().ReplicaSets(ns).Get(context.TODO(), secondRS.Name, metav1.GetOptions{})
+	secondRS, err = c.AppsV1().ReplicaSets(ns).Get(ctx, secondRS.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	err = waitForReplicaSetDesiredReplicas(c.AppsV1(), secondRS)
+	err = waitForReplicaSetDesiredReplicas(ctx, c.AppsV1(), secondRS)
 	framework.ExpectNoError(err)
 
 	// Check the deployment's minimum availability.
@@ -1283,26 +1287,26 @@ func testProportionalScalingDeployment(f *framework.Framework) {
 	framework.ExpectNoError(err)
 
 	framework.Logf("Waiting for the replicasets of deployment %q to have desired number of replicas", deploymentName)
-	firstRS, err = c.AppsV1().ReplicaSets(ns).Get(context.TODO(), firstRS.Name, metav1.GetOptions{})
+	firstRS, err = c.AppsV1().ReplicaSets(ns).Get(ctx, firstRS.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	secondRS, err = c.AppsV1().ReplicaSets(ns).Get(context.TODO(), secondRS.Name, metav1.GetOptions{})
+	secondRS, err = c.AppsV1().ReplicaSets(ns).Get(ctx, secondRS.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 
 	// First rollout's replicaset should have .spec.replicas = 8 + (30-10)*(8/13) = 8 + 12 = 20 replicas.
 	// Note that 12 comes from rounding (30-10)*(8/13) to nearest integer.
 	framework.Logf("Verifying that first rollout's replicaset has .spec.replicas = 20")
-	err = waitForReplicaSetTargetSpecReplicas(c, firstRS, 20)
+	err = waitForReplicaSetTargetSpecReplicas(ctx, c, firstRS, 20)
 	framework.ExpectNoError(err)
 
 	// Second rollout's replicaset should have .spec.replicas = 5 + (30-10)*(5/13) = 5 + 8 = 13 replicas.
 	// Note that 8 comes from rounding (30-10)*(5/13) to nearest integer.
 	framework.Logf("Verifying that second rollout's replicaset has .spec.replicas = 13")
-	err = waitForReplicaSetTargetSpecReplicas(c, secondRS, 13)
+	err = waitForReplicaSetTargetSpecReplicas(ctx, c, secondRS, 13)
 	framework.ExpectNoError(err)
 }
 
-func checkDeploymentReplicaSetsControllerRef(c clientset.Interface, ns string, uid types.UID, label map[string]string) error {
-	rsList := listDeploymentReplicaSets(c, ns, label)
+func checkDeploymentReplicaSetsControllerRef(ctx context.Context, c clientset.Interface, ns string, uid types.UID, label map[string]string) error {
+	rsList := listDeploymentReplicaSets(ctx, c, ns, label)
 	for _, rs := range rsList.Items {
 		// This rs is adopted only when its controller ref is update
 		if controllerRef := metav1.GetControllerOf(&rs); controllerRef == nil || controllerRef.UID != uid {
@@ -1312,9 +1316,9 @@ func checkDeploymentReplicaSetsControllerRef(c clientset.Interface, ns string, u
 	return nil
 }
 
-func waitDeploymentReplicaSetsOrphaned(c clientset.Interface, ns string, label map[string]string) func() (bool, error) {
-	return func() (bool, error) {
-		rsList := listDeploymentReplicaSets(c, ns, label)
+func waitDeploymentReplicaSetsOrphaned(c clientset.Interface, ns string, label map[string]string) func(ctx context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
+		rsList := listDeploymentReplicaSets(ctx, c, ns, label)
 		for _, rs := range rsList.Items {
 			// This rs is orphaned only when controller ref is cleared
 			if controllerRef := metav1.GetControllerOf(&rs); controllerRef != nil {
@@ -1325,23 +1329,23 @@ func waitDeploymentReplicaSetsOrphaned(c clientset.Interface, ns string, label m
 	}
 }
 
-func listDeploymentReplicaSets(c clientset.Interface, ns string, label map[string]string) *appsv1.ReplicaSetList {
+func listDeploymentReplicaSets(ctx context.Context, c clientset.Interface, ns string, label map[string]string) *appsv1.ReplicaSetList {
 	selector := labels.Set(label).AsSelector()
 	options := metav1.ListOptions{LabelSelector: selector.String()}
-	rsList, err := c.AppsV1().ReplicaSets(ns).List(context.TODO(), options)
+	rsList, err := c.AppsV1().ReplicaSets(ns).List(ctx, options)
 	framework.ExpectNoError(err)
 	gomega.Expect(len(rsList.Items)).To(gomega.BeNumerically(">", 0))
 	return rsList
 }
 
-func orphanDeploymentReplicaSets(c clientset.Interface, d *appsv1.Deployment) error {
+func orphanDeploymentReplicaSets(ctx context.Context, c clientset.Interface, d *appsv1.Deployment) error {
 	trueVar := true
 	deleteOptions := metav1.DeleteOptions{OrphanDependents: &trueVar}
 	deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(d.UID))
-	return c.AppsV1().Deployments(d.Namespace).Delete(context.TODO(), d.Name, deleteOptions)
+	return c.AppsV1().Deployments(d.Namespace).Delete(ctx, d.Name, deleteOptions)
 }
 
-func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framework) {
+func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 
@@ -1372,7 +1376,7 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 		MaxSurge:       intOrStrP(1),
 		MaxUnavailable: intOrStrP(0),
 	}
-	deployment, err := c.AppsV1().Deployments(ns).Create(context.TODO(), d, metav1.CreateOptions{})
+	deployment, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	err = e2edeployment.WaitForDeploymentComplete(c, deployment)
 	framework.ExpectNoError(err)
@@ -1380,7 +1384,7 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 	framework.Logf("Creating a service %s with type=LoadBalancer and externalTrafficPolicy=Local in namespace %s", name, ns)
 	jig := e2eservice.NewTestJig(c, ns, name)
 	jig.Labels = podLabels
-	service, err := jig.CreateLoadBalancerService(e2eservice.GetServiceLoadBalancerCreationTimeout(c), func(svc *v1.Service) {
+	service, err := jig.CreateLoadBalancerService(ctx, e2eservice.GetServiceLoadBalancerCreationTimeout(ctx, c), func(svc *v1.Service) {
 		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
 	})
 	framework.ExpectNoError(err)
@@ -1393,9 +1397,9 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 	if framework.ProviderIs("aws") {
 		timeout = e2eservice.LoadBalancerLagTimeoutAWS
 	}
-	e2eservice.TestReachableHTTP(lbNameOrAddress, svcPort, timeout)
+	e2eservice.TestReachableHTTP(ctx, lbNameOrAddress, svcPort, timeout)
 
-	expectedNodes, err := jig.GetEndpointNodeNames()
+	expectedNodes, err := jig.GetEndpointNodeNames(ctx)
 	framework.ExpectNoError(err)
 
 	framework.Logf("Starting a goroutine to watch the service's endpoints in the background")
@@ -1409,7 +1413,7 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 		// Thus the set of nodes with local endpoints for the service
 		// should remain unchanged.
 		wait.Until(func() {
-			actualNodes, err := jig.GetEndpointNodeNames()
+			actualNodes, err := jig.GetEndpointNodeNames(ctx)
 			if err != nil {
 				framework.Logf("The previous set of nodes with local endpoints was %v, now the lookup failed: %v", expectedNodes.List(), err)
 				failed <- struct{}{}
@@ -1505,7 +1509,7 @@ func setAffinities(d *appsv1.Deployment, setAffinity bool) {
 
 // watchRecreateDeployment watches Recreate deployments and ensures no new pods will run at the same time with
 // old pods.
-func watchRecreateDeployment(c clientset.Interface, d *appsv1.Deployment) error {
+func watchRecreateDeployment(ctx context.Context, c clientset.Interface, d *appsv1.Deployment) error {
 	if d.Spec.Strategy.Type != appsv1.RecreateDeploymentStrategyType {
 		return fmt.Errorf("deployment %q does not use a Recreate strategy: %s", d.Name, d.Spec.Strategy.Type)
 	}
@@ -1514,7 +1518,7 @@ func watchRecreateDeployment(c clientset.Interface, d *appsv1.Deployment) error 
 	w := &cache.ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
 			options.FieldSelector = fieldSelector
-			return c.AppsV1().Deployments(d.Namespace).Watch(context.TODO(), options)
+			return c.AppsV1().Deployments(d.Namespace).Watch(ctx, options)
 		},
 	}
 
@@ -1540,9 +1544,9 @@ func watchRecreateDeployment(c clientset.Interface, d *appsv1.Deployment) error 
 			d.Generation <= d.Status.ObservedGeneration, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctxUntil, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
-	_, err := watchtools.Until(ctx, d.ResourceVersion, w, condition)
+	_, err := watchtools.Until(ctxUntil, d.ResourceVersion, w, condition)
 	if err == wait.ErrWaitTimeout {
 		err = fmt.Errorf("deployment %q never completed: %#v", d.Name, status)
 	}
@@ -1550,12 +1554,12 @@ func watchRecreateDeployment(c clientset.Interface, d *appsv1.Deployment) error 
 }
 
 // waitForDeploymentOldRSsNum waits for the deployment to clean up old rcs.
-func waitForDeploymentOldRSsNum(c clientset.Interface, ns, deploymentName string, desiredRSNum int) error {
+func waitForDeploymentOldRSsNum(ctx context.Context, c clientset.Interface, ns, deploymentName string, desiredRSNum int) error {
 	var oldRSs []*appsv1.ReplicaSet
 	var d *appsv1.Deployment
 
 	pollErr := wait.PollImmediate(poll, 5*time.Minute, func() (bool, error) {
-		deployment, err := c.AppsV1().Deployments(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+		deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -1575,10 +1579,10 @@ func waitForDeploymentOldRSsNum(c clientset.Interface, ns, deploymentName string
 }
 
 // waitForReplicaSetDesiredReplicas waits until the replicaset has desired number of replicas.
-func waitForReplicaSetDesiredReplicas(rsClient appsclient.ReplicaSetsGetter, replicaSet *appsv1.ReplicaSet) error {
+func waitForReplicaSetDesiredReplicas(ctx context.Context, rsClient appsclient.ReplicaSetsGetter, replicaSet *appsv1.ReplicaSet) error {
 	desiredGeneration := replicaSet.Generation
-	err := wait.PollImmediate(framework.Poll, framework.PollShortTimeout, func() (bool, error) {
-		rs, err := rsClient.ReplicaSets(replicaSet.Namespace).Get(context.TODO(), replicaSet.Name, metav1.GetOptions{})
+	err := wait.PollImmediateWithContext(ctx, framework.Poll, framework.PollShortTimeout, func(ctx context.Context) (bool, error) {
+		rs, err := rsClient.ReplicaSets(replicaSet.Namespace).Get(ctx, replicaSet.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -1591,10 +1595,10 @@ func waitForReplicaSetDesiredReplicas(rsClient appsclient.ReplicaSetsGetter, rep
 }
 
 // waitForReplicaSetTargetSpecReplicas waits for .spec.replicas of a RS to equal targetReplicaNum
-func waitForReplicaSetTargetSpecReplicas(c clientset.Interface, replicaSet *appsv1.ReplicaSet, targetReplicaNum int32) error {
+func waitForReplicaSetTargetSpecReplicas(ctx context.Context, c clientset.Interface, replicaSet *appsv1.ReplicaSet, targetReplicaNum int32) error {
 	desiredGeneration := replicaSet.Generation
-	err := wait.PollImmediate(framework.Poll, framework.PollShortTimeout, func() (bool, error) {
-		rs, err := c.AppsV1().ReplicaSets(replicaSet.Namespace).Get(context.TODO(), replicaSet.Name, metav1.GetOptions{})
+	err := wait.PollImmediateWithContext(ctx, framework.Poll, framework.PollShortTimeout, func(ctx context.Context) (bool, error) {
+		rs, err := c.AppsV1().ReplicaSets(replicaSet.Namespace).Get(ctx, replicaSet.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -1633,14 +1637,14 @@ func waitForDeploymentUpdatedReplicasGTE(c clientset.Interface, ns, deploymentNa
 }
 
 // Deployment should have a working scale subresource
-func testDeploymentSubresources(f *framework.Framework) {
+func testDeploymentSubresources(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 
 	deploymentName := "test-new-deployment"
 	framework.Logf("Creating simple deployment %s", deploymentName)
 	d := e2edeployment.NewDeployment("test-new-deployment", int32(1), map[string]string{"name": WebserverImageName}, WebserverImageName, WebserverImage, appsv1.RollingUpdateDeploymentStrategyType)
-	deploy, err := c.AppsV1().Deployments(ns).Create(context.TODO(), d, metav1.CreateOptions{})
+	deploy, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	// Wait for it to be updated to revision 1
@@ -1650,11 +1654,11 @@ func testDeploymentSubresources(f *framework.Framework) {
 	err = e2edeployment.WaitForDeploymentComplete(c, deploy)
 	framework.ExpectNoError(err)
 
-	_, err = c.AppsV1().Deployments(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	_, err = c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("getting scale subresource")
-	scale, err := c.AppsV1().Deployments(ns).GetScale(context.TODO(), deploymentName, metav1.GetOptions{})
+	scale, err := c.AppsV1().Deployments(ns).GetScale(ctx, deploymentName, metav1.GetOptions{})
 	if err != nil {
 		framework.Failf("Failed to get scale subresource: %v", err)
 	}
@@ -1664,14 +1668,14 @@ func testDeploymentSubresources(f *framework.Framework) {
 	ginkgo.By("updating a scale subresource")
 	scale.ResourceVersion = "" // indicate the scale update should be unconditional
 	scale.Spec.Replicas = 2
-	scaleResult, err := c.AppsV1().Deployments(ns).UpdateScale(context.TODO(), deploymentName, scale, metav1.UpdateOptions{})
+	scaleResult, err := c.AppsV1().Deployments(ns).UpdateScale(ctx, deploymentName, scale, metav1.UpdateOptions{})
 	if err != nil {
 		framework.Failf("Failed to put scale subresource: %v", err)
 	}
 	framework.ExpectEqual(scaleResult.Spec.Replicas, int32(2))
 
 	ginkgo.By("verifying the deployment Spec.Replicas was modified")
-	deployment, err := c.AppsV1().Deployments(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 	if err != nil {
 		framework.Failf("Failed to get deployment resource: %v", err)
 	}
@@ -1687,10 +1691,10 @@ func testDeploymentSubresources(f *framework.Framework) {
 	})
 	framework.ExpectNoError(err, "Could not Marshal JSON for patch payload")
 
-	_, err = c.AppsV1().Deployments(ns).Patch(context.TODO(), deploymentName, types.StrategicMergePatchType, []byte(deploymentScalePatchPayload), metav1.PatchOptions{}, "scale")
+	_, err = c.AppsV1().Deployments(ns).Patch(ctx, deploymentName, types.StrategicMergePatchType, []byte(deploymentScalePatchPayload), metav1.PatchOptions{}, "scale")
 	framework.ExpectNoError(err, "Failed to patch deployment: %v", err)
 
-	deployment, err = c.AppsV1().Deployments(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	deployment, err = c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 	framework.ExpectNoError(err, "Failed to get deployment resource: %v", err)
 	framework.ExpectEqual(*(deployment.Spec.Replicas), int32(4), "deployment should have 4 replicas")
 }

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -87,16 +87,16 @@ var _ = SIGDescribe("DisruptionController", func() {
 		framework.ConformanceIt("should list and delete a collection of PodDisruptionBudgets", func(ctx context.Context) {
 			specialLabels := map[string]string{"foo_pdb": "bar_pdb"}
 			labelSelector := labels.SelectorFromSet(specialLabels).String()
-			createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromInt(2), specialLabels)
-			createPDBMinAvailableOrDie(cs, ns, "foo2", intstr.FromString("1%"), specialLabels)
-			createPDBMinAvailableOrDie(anotherFramework.ClientSet, anotherFramework.Namespace.Name, "foo3", intstr.FromInt(2), specialLabels)
+			createPDBMinAvailableOrDie(ctx, cs, ns, defaultName, intstr.FromInt(2), specialLabels)
+			createPDBMinAvailableOrDie(ctx, cs, ns, "foo2", intstr.FromString("1%"), specialLabels)
+			createPDBMinAvailableOrDie(ctx, anotherFramework.ClientSet, anotherFramework.Namespace.Name, "foo3", intstr.FromInt(2), specialLabels)
 
 			ginkgo.By("listing a collection of PDBs across all namespaces")
-			listPDBs(cs, metav1.NamespaceAll, labelSelector, 3, []string{defaultName, "foo2", "foo3"})
+			listPDBs(ctx, cs, metav1.NamespaceAll, labelSelector, 3, []string{defaultName, "foo2", "foo3"})
 
 			ginkgo.By("listing a collection of PDBs in namespace " + ns)
-			listPDBs(cs, ns, labelSelector, 2, []string{defaultName, "foo2"})
-			deletePDBCollection(cs, ns)
+			listPDBs(ctx, cs, ns, labelSelector, 2, []string{defaultName, "foo2"})
+			deletePDBCollection(ctx, cs, ns)
 		})
 	})
 
@@ -107,10 +107,10 @@ var _ = SIGDescribe("DisruptionController", func() {
 	*/
 	framework.ConformanceIt("should create a PodDisruptionBudget", func(ctx context.Context) {
 		ginkgo.By("creating the pdb")
-		createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromString("1%"), defaultLabels)
+		createPDBMinAvailableOrDie(ctx, cs, ns, defaultName, intstr.FromString("1%"), defaultLabels)
 
 		ginkgo.By("updating the pdb")
-		updatedPDB := updatePDBOrDie(cs, ns, defaultName, func(pdb *policyv1.PodDisruptionBudget) *policyv1.PodDisruptionBudget {
+		updatedPDB := updatePDBOrDie(ctx, cs, ns, defaultName, func(pdb *policyv1.PodDisruptionBudget) *policyv1.PodDisruptionBudget {
 			newMinAvailable := intstr.FromString("2%")
 			pdb.Spec.MinAvailable = &newMinAvailable
 			return pdb
@@ -118,7 +118,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 		framework.ExpectEqual(updatedPDB.Spec.MinAvailable.String(), "2%")
 
 		ginkgo.By("patching the pdb")
-		patchedPDB := patchPDBOrDie(cs, dc, ns, defaultName, func(old *policyv1.PodDisruptionBudget) (bytes []byte, err error) {
+		patchedPDB := patchPDBOrDie(ctx, cs, dc, ns, defaultName, func(old *policyv1.PodDisruptionBudget) (bytes []byte, err error) {
 			newBytes, err := json.Marshal(map[string]interface{}{
 				"spec": map[string]interface{}{
 					"minAvailable": "3%",
@@ -129,7 +129,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 		})
 		framework.ExpectEqual(patchedPDB.Spec.MinAvailable.String(), "3%")
 
-		deletePDBOrDie(cs, ns, defaultName)
+		deletePDBOrDie(ctx, cs, ns, defaultName)
 	})
 
 	/*
@@ -139,15 +139,15 @@ var _ = SIGDescribe("DisruptionController", func() {
 	   how many disruptions are allowed.
 	*/
 	framework.ConformanceIt("should observe PodDisruptionBudget status updated", func(ctx context.Context) {
-		createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromInt(1), defaultLabels)
+		createPDBMinAvailableOrDie(ctx, cs, ns, defaultName, intstr.FromInt(1), defaultLabels)
 
-		createPodsOrDie(cs, ns, 3)
-		waitForPodsOrDie(cs, ns, 3)
+		createPodsOrDie(ctx, cs, ns, 3)
+		waitForPodsOrDie(ctx, cs, ns, 3)
 
 		// Since disruptionAllowed starts out 0, if we see it ever become positive,
 		// that means the controller is working.
-		err := wait.PollImmediate(framework.Poll, timeout, func() (bool, error) {
-			pdb, err := cs.PolicyV1().PodDisruptionBudgets(ns).Get(context.TODO(), defaultName, metav1.GetOptions{})
+		err := wait.PollImmediateWithContext(ctx, framework.Poll, timeout, func(ctx context.Context) (bool, error) {
+			pdb, err := cs.PolicyV1().PodDisruptionBudgets(ns).Get(ctx, defaultName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -162,25 +162,25 @@ var _ = SIGDescribe("DisruptionController", func() {
 		Description: PodDisruptionBudget API must support update and patch operations on status subresource.
 	*/
 	framework.ConformanceIt("should update/patch PodDisruptionBudget status", func(ctx context.Context) {
-		createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromInt(1), defaultLabels)
+		createPDBMinAvailableOrDie(ctx, cs, ns, defaultName, intstr.FromInt(1), defaultLabels)
 
 		ginkgo.By("Updating PodDisruptionBudget status")
 		// PDB status can be updated by both PDB controller and the status API. The test selects `DisruptedPods` field to show immediate update via API.
 		// The pod has to exist, otherwise wil be removed by the controller. Other fields may not reflect the change from API.
-		createPodsOrDie(cs, ns, 1)
-		waitForPodsOrDie(cs, ns, 1)
-		pod, _ := locateRunningPod(cs, ns)
-		updatePDBOrDie(cs, ns, defaultName, func(old *policyv1.PodDisruptionBudget) *policyv1.PodDisruptionBudget {
+		createPodsOrDie(ctx, cs, ns, 1)
+		waitForPodsOrDie(ctx, cs, ns, 1)
+		pod, _ := locateRunningPod(ctx, cs, ns)
+		updatePDBOrDie(ctx, cs, ns, defaultName, func(old *policyv1.PodDisruptionBudget) *policyv1.PodDisruptionBudget {
 			old.Status.DisruptedPods = make(map[string]metav1.Time)
 			old.Status.DisruptedPods[pod.Name] = metav1.NewTime(time.Now())
 			return old
 		}, cs.PolicyV1().PodDisruptionBudgets(ns).UpdateStatus)
 		// fetch again to make sure the update from API was effective
-		updated := getPDBStatusOrDie(dc, ns, defaultName)
+		updated := getPDBStatusOrDie(ctx, dc, ns, defaultName)
 		framework.ExpectHaveKey(updated.Status.DisruptedPods, pod.Name, "Expecting the DisruptedPods have %s", pod.Name)
 
 		ginkgo.By("Patching PodDisruptionBudget status")
-		patched := patchPDBOrDie(cs, dc, ns, defaultName, func(old *policyv1.PodDisruptionBudget) (bytes []byte, err error) {
+		patched := patchPDBOrDie(ctx, cs, dc, ns, defaultName, func(old *policyv1.PodDisruptionBudget) (bytes []byte, err error) {
 			oldBytes, err := json.Marshal(old)
 			framework.ExpectNoError(err, "failed to marshal JSON for old data")
 			old.Status.DisruptedPods = make(map[string]metav1.Time)
@@ -193,15 +193,15 @@ var _ = SIGDescribe("DisruptionController", func() {
 
 	// PDB shouldn't error out when there are unmanaged pods
 	ginkgo.It("should observe that the PodDisruptionBudget status is not updated for unmanaged pods",
-		func() {
-			createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromInt(1), defaultLabels)
+		func(ctx context.Context) {
+			createPDBMinAvailableOrDie(ctx, cs, ns, defaultName, intstr.FromInt(1), defaultLabels)
 
-			createPodsOrDie(cs, ns, 3)
-			waitForPodsOrDie(cs, ns, 3)
+			createPodsOrDie(ctx, cs, ns, 3)
+			waitForPodsOrDie(ctx, cs, ns, 3)
 
 			// Since we allow unmanaged pods to be associated with a PDB, we should not see any error
-			gomega.Consistently(func() (bool, error) {
-				pdb, err := cs.PolicyV1().PodDisruptionBudgets(ns).Get(context.TODO(), defaultName, metav1.GetOptions{})
+			gomega.Consistently(ctx, func(ctx context.Context) (bool, error) {
+				pdb, err := cs.PolicyV1().PodDisruptionBudgets(ns).Get(ctx, defaultName, metav1.GetOptions{})
 				if err != nil {
 					return false, err
 				}
@@ -291,21 +291,21 @@ var _ = SIGDescribe("DisruptionController", func() {
 			if c.skipForBigClusters {
 				e2eskipper.SkipUnlessNodeCountIsAtMost(bigClusterSize - 1)
 			}
-			createPodsOrDie(cs, ns, c.podCount)
+			createPodsOrDie(ctx, cs, ns, c.podCount)
 			if c.replicaSetSize > 0 {
-				createReplicaSetOrDie(cs, ns, c.replicaSetSize, c.exclusive)
+				createReplicaSetOrDie(ctx, cs, ns, c.replicaSetSize, c.exclusive)
 			}
 
 			if c.minAvailable.String() != "" {
-				createPDBMinAvailableOrDie(cs, ns, defaultName, c.minAvailable, defaultLabels)
+				createPDBMinAvailableOrDie(ctx, cs, ns, defaultName, c.minAvailable, defaultLabels)
 			}
 
 			if c.maxUnavailable.String() != "" {
-				createPDBMaxUnavailableOrDie(cs, ns, defaultName, c.maxUnavailable)
+				createPDBMaxUnavailableOrDie(ctx, cs, ns, defaultName, c.maxUnavailable)
 			}
 
 			// Locate a running pod.
-			pod, err := locateRunningPod(cs, ns)
+			pod, err := locateRunningPod(ctx, cs, ns)
 			framework.ExpectNoError(err)
 
 			e := &policyv1.Eviction{
@@ -316,19 +316,19 @@ var _ = SIGDescribe("DisruptionController", func() {
 			}
 
 			if c.shouldDeny {
-				err = cs.CoreV1().Pods(ns).EvictV1(context.TODO(), e)
+				err = cs.CoreV1().Pods(ns).EvictV1(ctx, e)
 				framework.ExpectError(err, "pod eviction should fail")
 				framework.ExpectEqual(apierrors.HasStatusCause(err, policyv1.DisruptionBudgetCause), true, "pod eviction should fail with DisruptionBudget cause")
 			} else {
 				// Only wait for running pods in the "allow" case
 				// because one of shouldDeny cases relies on the
 				// replicaSet not fitting on the cluster.
-				waitForPodsOrDie(cs, ns, c.podCount+int(c.replicaSetSize))
+				waitForPodsOrDie(ctx, cs, ns, c.podCount+int(c.replicaSetSize))
 
 				// Since disruptionAllowed starts out false, if an eviction is ever allowed,
 				// that means the controller is working.
-				err = wait.PollImmediate(framework.Poll, timeout, func() (bool, error) {
-					err = cs.CoreV1().Pods(ns).EvictV1(context.TODO(), e)
+				err = wait.PollImmediateWithContext(ctx, framework.Poll, timeout, func(ctx context.Context) (bool, error) {
+					err = cs.CoreV1().Pods(ns).EvictV1(ctx, e)
 					if err != nil {
 						return false, nil
 					}
@@ -346,13 +346,13 @@ var _ = SIGDescribe("DisruptionController", func() {
 	*/
 	framework.ConformanceIt("should block an eviction until the PDB is updated to allow it", func(ctx context.Context) {
 		ginkgo.By("Creating a pdb that targets all three pods in a test replica set")
-		createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromInt(3), defaultLabels)
-		createReplicaSetOrDie(cs, ns, 3, false)
+		createPDBMinAvailableOrDie(ctx, cs, ns, defaultName, intstr.FromInt(3), defaultLabels)
+		createReplicaSetOrDie(ctx, cs, ns, 3, false)
 
 		ginkgo.By("First trying to evict a pod which shouldn't be evictable")
-		waitForPodsOrDie(cs, ns, 3) // make sure that they are running and so would be evictable with a different pdb
+		waitForPodsOrDie(ctx, cs, ns, 3) // make sure that they are running and so would be evictable with a different pdb
 
-		pod, err := locateRunningPod(cs, ns)
+		pod, err := locateRunningPod(ctx, cs, ns)
 		framework.ExpectNoError(err)
 		e := &policyv1.Eviction{
 			ObjectMeta: metav1.ObjectMeta{
@@ -360,25 +360,25 @@ var _ = SIGDescribe("DisruptionController", func() {
 				Namespace: ns,
 			},
 		}
-		err = cs.CoreV1().Pods(ns).EvictV1(context.TODO(), e)
+		err = cs.CoreV1().Pods(ns).EvictV1(ctx, e)
 		framework.ExpectError(err, "pod eviction should fail")
 		framework.ExpectEqual(apierrors.HasStatusCause(err, policyv1.DisruptionBudgetCause), true, "pod eviction should fail with DisruptionBudget cause")
 
 		ginkgo.By("Updating the pdb to allow a pod to be evicted")
-		updatePDBOrDie(cs, ns, defaultName, func(pdb *policyv1.PodDisruptionBudget) *policyv1.PodDisruptionBudget {
+		updatePDBOrDie(ctx, cs, ns, defaultName, func(pdb *policyv1.PodDisruptionBudget) *policyv1.PodDisruptionBudget {
 			newMinAvailable := intstr.FromInt(2)
 			pdb.Spec.MinAvailable = &newMinAvailable
 			return pdb
 		}, cs.PolicyV1().PodDisruptionBudgets(ns).Update)
 
 		ginkgo.By("Trying to evict the same pod we tried earlier which should now be evictable")
-		waitForPodsOrDie(cs, ns, 3)
-		waitForPdbToObserveHealthyPods(cs, ns, 3)
-		err = cs.CoreV1().Pods(ns).EvictV1(context.TODO(), e)
+		waitForPodsOrDie(ctx, cs, ns, 3)
+		waitForPdbToObserveHealthyPods(ctx, cs, ns, 3)
+		err = cs.CoreV1().Pods(ns).EvictV1(ctx, e)
 		framework.ExpectNoError(err) // the eviction is now allowed
 
 		ginkgo.By("Patching the pdb to disallow a pod to be evicted")
-		patchPDBOrDie(cs, dc, ns, defaultName, func(old *policyv1.PodDisruptionBudget) (bytes []byte, err error) {
+		patchPDBOrDie(ctx, cs, dc, ns, defaultName, func(old *policyv1.PodDisruptionBudget) (bytes []byte, err error) {
 			oldData, err := json.Marshal(old)
 			framework.ExpectNoError(err, "failed to marshal JSON for old data")
 			old.Spec.MinAvailable = nil
@@ -389,8 +389,8 @@ var _ = SIGDescribe("DisruptionController", func() {
 			return jsonpatch.CreateMergePatch(oldData, newData)
 		})
 
-		waitForPodsOrDie(cs, ns, 3)
-		pod, err = locateRunningPod(cs, ns) // locate a new running pod
+		waitForPodsOrDie(ctx, cs, ns, 3)
+		pod, err = locateRunningPod(ctx, cs, ns) // locate a new running pod
 		framework.ExpectNoError(err)
 		e = &policyv1.Eviction{
 			ObjectMeta: metav1.ObjectMeta{
@@ -398,22 +398,22 @@ var _ = SIGDescribe("DisruptionController", func() {
 				Namespace: ns,
 			},
 		}
-		err = cs.CoreV1().Pods(ns).EvictV1(context.TODO(), e)
+		err = cs.CoreV1().Pods(ns).EvictV1(ctx, e)
 		framework.ExpectError(err, "pod eviction should fail")
 		framework.ExpectEqual(apierrors.HasStatusCause(err, policyv1.DisruptionBudgetCause), true, "pod eviction should fail with DisruptionBudget cause")
 
 		ginkgo.By("Deleting the pdb to allow a pod to be evicted")
-		deletePDBOrDie(cs, ns, defaultName)
+		deletePDBOrDie(ctx, cs, ns, defaultName)
 
 		ginkgo.By("Trying to evict the same pod we tried earlier which should now be evictable")
-		waitForPodsOrDie(cs, ns, 3)
-		err = cs.CoreV1().Pods(ns).EvictV1(context.TODO(), e)
+		waitForPodsOrDie(ctx, cs, ns, 3)
+		err = cs.CoreV1().Pods(ns).EvictV1(ctx, e)
 		framework.ExpectNoError(err) // the eviction is now allowed
 	})
 
 })
 
-func createPDBMinAvailableOrDie(cs kubernetes.Interface, ns string, name string, minAvailable intstr.IntOrString, labels map[string]string) {
+func createPDBMinAvailableOrDie(ctx context.Context, cs kubernetes.Interface, ns string, name string, minAvailable intstr.IntOrString, labels map[string]string) {
 	pdb := policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -425,12 +425,12 @@ func createPDBMinAvailableOrDie(cs kubernetes.Interface, ns string, name string,
 			MinAvailable: &minAvailable,
 		},
 	}
-	_, err := cs.PolicyV1().PodDisruptionBudgets(ns).Create(context.TODO(), &pdb, metav1.CreateOptions{})
+	_, err := cs.PolicyV1().PodDisruptionBudgets(ns).Create(ctx, &pdb, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "Waiting for the pdb to be created with minAvailable %d in namespace %s", minAvailable.IntVal, ns)
-	waitForPdbToBeProcessed(cs, ns, name)
+	waitForPdbToBeProcessed(ctx, cs, ns, name)
 }
 
-func createPDBMaxUnavailableOrDie(cs kubernetes.Interface, ns string, name string, maxUnavailable intstr.IntOrString) {
+func createPDBMaxUnavailableOrDie(ctx context.Context, cs kubernetes.Interface, ns string, name string, maxUnavailable intstr.IntOrString) {
 	pdb := policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -441,39 +441,39 @@ func createPDBMaxUnavailableOrDie(cs kubernetes.Interface, ns string, name strin
 			MaxUnavailable: &maxUnavailable,
 		},
 	}
-	_, err := cs.PolicyV1().PodDisruptionBudgets(ns).Create(context.TODO(), &pdb, metav1.CreateOptions{})
+	_, err := cs.PolicyV1().PodDisruptionBudgets(ns).Create(ctx, &pdb, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "Waiting for the pdb to be created with maxUnavailable %d in namespace %s", maxUnavailable.IntVal, ns)
-	waitForPdbToBeProcessed(cs, ns, name)
+	waitForPdbToBeProcessed(ctx, cs, ns, name)
 }
 
 type updateFunc func(pdb *policyv1.PodDisruptionBudget) *policyv1.PodDisruptionBudget
 type updateRestAPI func(ctx context.Context, podDisruptionBudget *policyv1.PodDisruptionBudget, opts metav1.UpdateOptions) (*policyv1.PodDisruptionBudget, error)
 type patchFunc func(pdb *policyv1.PodDisruptionBudget) ([]byte, error)
 
-func updatePDBOrDie(cs kubernetes.Interface, ns string, name string, f updateFunc, api updateRestAPI) (updated *policyv1.PodDisruptionBudget) {
+func updatePDBOrDie(ctx context.Context, cs kubernetes.Interface, ns string, name string, f updateFunc, api updateRestAPI) (updated *policyv1.PodDisruptionBudget) {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		old, err := cs.PolicyV1().PodDisruptionBudgets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		old, err := cs.PolicyV1().PodDisruptionBudgets(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 		old = f(old)
-		if updated, err = api(context.TODO(), old, metav1.UpdateOptions{}); err != nil {
+		if updated, err = api(ctx, old, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
 		return nil
 	})
 
 	framework.ExpectNoError(err, "Waiting for the PDB update to be processed in namespace %s", ns)
-	waitForPdbToBeProcessed(cs, ns, name)
+	waitForPdbToBeProcessed(ctx, cs, ns, name)
 	return updated
 }
 
-func patchPDBOrDie(cs kubernetes.Interface, dc dynamic.Interface, ns string, name string, f patchFunc, subresources ...string) (updated *policyv1.PodDisruptionBudget) {
+func patchPDBOrDie(ctx context.Context, cs kubernetes.Interface, dc dynamic.Interface, ns string, name string, f patchFunc, subresources ...string) (updated *policyv1.PodDisruptionBudget) {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		old := getPDBStatusOrDie(dc, ns, name)
+		old := getPDBStatusOrDie(ctx, dc, ns, name)
 		patchBytes, err := f(old)
 		framework.ExpectNoError(err)
-		if updated, err = cs.PolicyV1().PodDisruptionBudgets(ns).Patch(context.TODO(), old.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, subresources...); err != nil {
+		if updated, err = cs.PolicyV1().PodDisruptionBudgets(ns).Patch(ctx, old.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, subresources...); err != nil {
 			return err
 		}
 		framework.ExpectNoError(err)
@@ -481,18 +481,18 @@ func patchPDBOrDie(cs kubernetes.Interface, dc dynamic.Interface, ns string, nam
 	})
 
 	framework.ExpectNoError(err, "Waiting for the pdb update to be processed in namespace %s", ns)
-	waitForPdbToBeProcessed(cs, ns, name)
+	waitForPdbToBeProcessed(ctx, cs, ns, name)
 	return updated
 }
 
-func deletePDBOrDie(cs kubernetes.Interface, ns string, name string) {
-	err := cs.PolicyV1().PodDisruptionBudgets(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+func deletePDBOrDie(ctx context.Context, cs kubernetes.Interface, ns string, name string) {
+	err := cs.PolicyV1().PodDisruptionBudgets(ns).Delete(ctx, name, metav1.DeleteOptions{})
 	framework.ExpectNoError(err, "Deleting pdb in namespace %s", ns)
-	waitForPdbToBeDeleted(cs, ns, name)
+	waitForPdbToBeDeleted(ctx, cs, ns, name)
 }
 
-func listPDBs(cs kubernetes.Interface, ns string, labelSelector string, count int, expectedPDBNames []string) {
-	pdbList, err := cs.PolicyV1().PodDisruptionBudgets(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+func listPDBs(ctx context.Context, cs kubernetes.Interface, ns string, labelSelector string, count int, expectedPDBNames []string) {
+	pdbList, err := cs.PolicyV1().PodDisruptionBudgets(ns).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	framework.ExpectNoError(err, "Listing PDB set in namespace %s", ns)
 	framework.ExpectEqual(len(pdbList.Items), count, "Expecting %d PDBs returned in namespace %s", count, ns)
 
@@ -503,18 +503,18 @@ func listPDBs(cs kubernetes.Interface, ns string, labelSelector string, count in
 	framework.ExpectConsistOf(pdbNames, expectedPDBNames, "Expecting returned PDBs '%s' in namespace %s", expectedPDBNames, ns)
 }
 
-func deletePDBCollection(cs kubernetes.Interface, ns string) {
+func deletePDBCollection(ctx context.Context, cs kubernetes.Interface, ns string) {
 	ginkgo.By("deleting a collection of PDBs")
-	err := cs.PolicyV1().PodDisruptionBudgets(ns).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
+	err := cs.PolicyV1().PodDisruptionBudgets(ns).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
 	framework.ExpectNoError(err, "Deleting PDB set in namespace %s", ns)
 
-	waitForPDBCollectionToBeDeleted(cs, ns)
+	waitForPDBCollectionToBeDeleted(ctx, cs, ns)
 }
 
-func waitForPDBCollectionToBeDeleted(cs kubernetes.Interface, ns string) {
+func waitForPDBCollectionToBeDeleted(ctx context.Context, cs kubernetes.Interface, ns string) {
 	ginkgo.By("Waiting for the PDB collection to be deleted")
-	err := wait.PollImmediate(framework.Poll, schedulingTimeout, func() (bool, error) {
-		pdbList, err := cs.PolicyV1().PodDisruptionBudgets(ns).List(context.TODO(), metav1.ListOptions{})
+	err := wait.PollImmediateWithContext(ctx, framework.Poll, schedulingTimeout, func(ctx context.Context) (bool, error) {
+		pdbList, err := cs.PolicyV1().PodDisruptionBudgets(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -526,7 +526,7 @@ func waitForPDBCollectionToBeDeleted(cs kubernetes.Interface, ns string) {
 	framework.ExpectNoError(err, "Waiting for the PDB collection to be deleted in namespace %s", ns)
 }
 
-func createPodsOrDie(cs kubernetes.Interface, ns string, n int) {
+func createPodsOrDie(ctx context.Context, cs kubernetes.Interface, ns string, n int) {
 	for i := 0; i < n; i++ {
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -545,15 +545,15 @@ func createPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 			},
 		}
 
-		_, err := cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		_, err := cs.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Creating pod %q in namespace %q", pod.Name, ns)
 	}
 }
 
-func waitForPodsOrDie(cs kubernetes.Interface, ns string, n int) {
+func waitForPodsOrDie(ctx context.Context, cs kubernetes.Interface, ns string, n int) {
 	ginkgo.By("Waiting for all pods to be running")
-	err := wait.PollImmediate(framework.Poll, schedulingTimeout, func() (bool, error) {
-		pods, err := cs.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: "foo=bar"})
+	err := wait.PollImmediateWithContext(ctx, framework.Poll, schedulingTimeout, func(ctx context.Context) (bool, error) {
+		pods, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: "foo=bar"})
 		if err != nil {
 			return false, err
 		}
@@ -580,7 +580,7 @@ func waitForPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 	framework.ExpectNoError(err, "Waiting for pods in namespace %q to be ready", ns)
 }
 
-func createReplicaSetOrDie(cs kubernetes.Interface, ns string, size int32, exclusive bool) {
+func createReplicaSetOrDie(ctx context.Context, cs kubernetes.Interface, ns string, size int32, exclusive bool) {
 	container := v1.Container{
 		Name:  "donothing",
 		Image: imageutils.GetPauseImageName(),
@@ -612,14 +612,14 @@ func createReplicaSetOrDie(cs kubernetes.Interface, ns string, size int32, exclu
 		},
 	}
 
-	_, err := cs.AppsV1().ReplicaSets(ns).Create(context.TODO(), rs, metav1.CreateOptions{})
+	_, err := cs.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "Creating replica set %q in namespace %q", rs.Name, ns)
 }
 
-func locateRunningPod(cs kubernetes.Interface, ns string) (pod *v1.Pod, err error) {
+func locateRunningPod(ctx context.Context, cs kubernetes.Interface, ns string) (pod *v1.Pod, err error) {
 	ginkgo.By("locating a running pod")
-	err = wait.PollImmediate(framework.Poll, schedulingTimeout, func() (bool, error) {
-		podList, err := cs.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{})
+	err = wait.PollImmediateWithContext(ctx, framework.Poll, schedulingTimeout, func(ctx context.Context) (bool, error) {
+		podList, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -637,10 +637,10 @@ func locateRunningPod(cs kubernetes.Interface, ns string) (pod *v1.Pod, err erro
 	return pod, err
 }
 
-func waitForPdbToBeProcessed(cs kubernetes.Interface, ns string, name string) {
+func waitForPdbToBeProcessed(ctx context.Context, cs kubernetes.Interface, ns string, name string) {
 	ginkgo.By("Waiting for the pdb to be processed")
-	err := wait.PollImmediate(framework.Poll, schedulingTimeout, func() (bool, error) {
-		pdb, err := cs.PolicyV1().PodDisruptionBudgets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	err := wait.PollImmediateWithContext(ctx, framework.Poll, schedulingTimeout, func(ctx context.Context) (bool, error) {
+		pdb, err := cs.PolicyV1().PodDisruptionBudgets(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -652,10 +652,10 @@ func waitForPdbToBeProcessed(cs kubernetes.Interface, ns string, name string) {
 	framework.ExpectNoError(err, "Waiting for the pdb to be processed in namespace %s", ns)
 }
 
-func waitForPdbToBeDeleted(cs kubernetes.Interface, ns string, name string) {
+func waitForPdbToBeDeleted(ctx context.Context, cs kubernetes.Interface, ns string, name string) {
 	ginkgo.By("Waiting for the pdb to be deleted")
-	err := wait.PollImmediate(framework.Poll, schedulingTimeout, func() (bool, error) {
-		_, err := cs.PolicyV1().PodDisruptionBudgets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	err := wait.PollImmediateWithContext(ctx, framework.Poll, schedulingTimeout, func(ctx context.Context) (bool, error) {
+		_, err := cs.PolicyV1().PodDisruptionBudgets(ns).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil // done
 		}
@@ -667,10 +667,10 @@ func waitForPdbToBeDeleted(cs kubernetes.Interface, ns string, name string) {
 	framework.ExpectNoError(err, "Waiting for the pdb to be deleted in namespace %s", ns)
 }
 
-func waitForPdbToObserveHealthyPods(cs kubernetes.Interface, ns string, healthyCount int32) {
+func waitForPdbToObserveHealthyPods(ctx context.Context, cs kubernetes.Interface, ns string, healthyCount int32) {
 	ginkgo.By("Waiting for the pdb to observed all healthy pods")
-	err := wait.PollImmediate(framework.Poll, wait.ForeverTestTimeout, func() (bool, error) {
-		pdb, err := cs.PolicyV1().PodDisruptionBudgets(ns).Get(context.TODO(), "foo", metav1.GetOptions{})
+	err := wait.PollImmediateWithContext(ctx, framework.Poll, wait.ForeverTestTimeout, func(ctx context.Context) (bool, error) {
+		pdb, err := cs.PolicyV1().PodDisruptionBudgets(ns).Get(ctx, "foo", metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -682,9 +682,9 @@ func waitForPdbToObserveHealthyPods(cs kubernetes.Interface, ns string, healthyC
 	framework.ExpectNoError(err, "Waiting for the pdb in namespace %s to observed %d healthy pods", ns, healthyCount)
 }
 
-func getPDBStatusOrDie(dc dynamic.Interface, ns string, name string) *policyv1.PodDisruptionBudget {
+func getPDBStatusOrDie(ctx context.Context, dc dynamic.Interface, ns string, name string) *policyv1.PodDisruptionBudget {
 	pdbStatusResource := policyv1.SchemeGroupVersion.WithResource("poddisruptionbudgets")
-	unstruct, err := dc.Resource(pdbStatusResource).Namespace(ns).Get(context.TODO(), name, metav1.GetOptions{}, "status")
+	unstruct, err := dc.Resource(pdbStatusResource).Namespace(ns).Get(ctx, name, metav1.GetOptions{}, "status")
 	framework.ExpectNoError(err)
 	pdb, err := unstructuredToPDB(unstruct)
 	framework.ExpectNoError(err, "Getting the status of the pdb %s in namespace %s", name, ns)

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -110,82 +110,82 @@ var _ = SIGDescribe("StatefulSet", func() {
 		var statefulPodMounts, podMounts []v1.VolumeMount
 		var ss *appsv1.StatefulSet
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			statefulPodMounts = []v1.VolumeMount{{Name: "datadir", MountPath: "/data/"}}
 			podMounts = []v1.VolumeMount{{Name: "home", MountPath: "/home"}}
 			ss = e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 2, statefulPodMounts, podMounts, labels)
 
 			ginkgo.By("Creating service " + headlessSvcName + " in namespace " + ns)
 			headlessService := e2eservice.CreateServiceSpec(headlessSvcName, "", true, labels)
-			_, err := c.CoreV1().Services(ns).Create(context.TODO(), headlessService, metav1.CreateOptions{})
+			_, err := c.CoreV1().Services(ns).Create(ctx, headlessService, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 		})
 
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			if ginkgo.CurrentSpecReport().Failed() {
-				e2eoutput.DumpDebugInfo(c, ns)
+				e2eoutput.DumpDebugInfo(ctx, c, ns)
 			}
 			framework.Logf("Deleting all statefulset in ns %v", ns)
-			e2estatefulset.DeleteAllStatefulSets(c, ns)
+			e2estatefulset.DeleteAllStatefulSets(ctx, c, ns)
 		})
 
 		// This can't be Conformance yet because it depends on a default
 		// StorageClass and a dynamic provisioner.
 		ginkgo.It("should provide basic identity", func(ctx context.Context) {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			*(ss.Spec.Replicas) = 3
 			e2estatefulset.PauseNewPods(ss)
 
-			_, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Saturating stateful set " + ss.Name)
-			e2estatefulset.Saturate(c, ss)
+			e2estatefulset.Saturate(ctx, c, ss)
 
 			ginkgo.By("Verifying statefulset mounted data directory is usable")
-			framework.ExpectNoError(e2estatefulset.CheckMount(c, ss, "/data"))
+			framework.ExpectNoError(e2estatefulset.CheckMount(ctx, c, ss, "/data"))
 
 			ginkgo.By("Verifying statefulset provides a stable hostname for each pod")
-			framework.ExpectNoError(e2estatefulset.CheckHostname(c, ss))
+			framework.ExpectNoError(e2estatefulset.CheckHostname(ctx, c, ss))
 
 			ginkgo.By("Verifying statefulset set proper service name")
 			framework.ExpectNoError(e2estatefulset.CheckServiceName(ss, headlessSvcName))
 
 			cmd := "echo $(hostname) | dd of=/data/hostname conv=fsync"
 			ginkgo.By("Running " + cmd + " in all stateful pods")
-			framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(c, ss, cmd))
+			framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd))
 
 			ginkgo.By("Restarting statefulset " + ss.Name)
-			e2estatefulset.Restart(c, ss)
-			e2estatefulset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
+			e2estatefulset.Restart(ctx, c, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 
 			ginkgo.By("Verifying statefulset mounted data directory is usable")
-			framework.ExpectNoError(e2estatefulset.CheckMount(c, ss, "/data"))
+			framework.ExpectNoError(e2estatefulset.CheckMount(ctx, c, ss, "/data"))
 
 			cmd = "if [ \"$(cat /data/hostname)\" = \"$(hostname)\" ]; then exit 0; else exit 1; fi"
 			ginkgo.By("Running " + cmd + " in all stateful pods")
-			framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(c, ss, cmd))
+			framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd))
 		})
 
 		// This can't be Conformance yet because it depends on a default
 		// StorageClass and a dynamic provisioner.
 		ginkgo.It("should adopt matching orphans and release non-matching pods", func(ctx context.Context) {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			*(ss.Spec.Replicas) = 1
 			e2estatefulset.PauseNewPods(ss)
 
 			// Replace ss with the one returned from Create() so it has the UID.
 			// Save Kind since it won't be populated in the returned ss.
 			kind := ss.Kind
-			ss, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			ss.Kind = kind
 
 			ginkgo.By("Saturating stateful set " + ss.Name)
-			e2estatefulset.Saturate(c, ss)
-			pods := e2estatefulset.GetPodList(c, ss)
+			e2estatefulset.Saturate(ctx, c, ss)
+			pods := e2estatefulset.GetPodList(ctx, c, ss)
 			gomega.Expect(pods.Items).To(gomega.HaveLen(int(*ss.Spec.Replicas)))
 
 			ginkgo.By("Checking that stateful set pods are created with ControllerRef")
@@ -197,12 +197,12 @@ var _ = SIGDescribe("StatefulSet", func() {
 			framework.ExpectEqual(controllerRef.UID, ss.UID)
 
 			ginkgo.By("Orphaning one of the stateful set's pods")
-			e2epod.NewPodClient(f).Update(pod.Name, func(pod *v1.Pod) {
+			e2epod.NewPodClient(f).Update(ctx, pod.Name, func(pod *v1.Pod) {
 				pod.OwnerReferences = nil
 			})
 
 			ginkgo.By("Checking that the stateful set readopts the pod")
-			gomega.Expect(e2epod.WaitForPodCondition(c, pod.Namespace, pod.Name, "adopted", statefulSetTimeout,
+			gomega.Expect(e2epod.WaitForPodCondition(ctx, c, pod.Namespace, pod.Name, "adopted", statefulSetTimeout,
 				func(pod *v1.Pod) (bool, error) {
 					controllerRef := metav1.GetControllerOf(pod)
 					if controllerRef == nil {
@@ -217,12 +217,12 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By("Removing the labels from one of the stateful set's pods")
 			prevLabels := pod.Labels
-			e2epod.NewPodClient(f).Update(pod.Name, func(pod *v1.Pod) {
+			e2epod.NewPodClient(f).Update(ctx, pod.Name, func(pod *v1.Pod) {
 				pod.Labels = nil
 			})
 
 			ginkgo.By("Checking that the stateful set releases the pod")
-			gomega.Expect(e2epod.WaitForPodCondition(c, pod.Namespace, pod.Name, "released", statefulSetTimeout,
+			gomega.Expect(e2epod.WaitForPodCondition(ctx, c, pod.Namespace, pod.Name, "released", statefulSetTimeout,
 				func(pod *v1.Pod) (bool, error) {
 					controllerRef := metav1.GetControllerOf(pod)
 					if controllerRef != nil {
@@ -234,12 +234,12 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			// If we don't do this, the test leaks the Pod and PVC.
 			ginkgo.By("Readding labels to the stateful set's pod")
-			e2epod.NewPodClient(f).Update(pod.Name, func(pod *v1.Pod) {
+			e2epod.NewPodClient(f).Update(ctx, pod.Name, func(pod *v1.Pod) {
 				pod.Labels = prevLabels
 			})
 
 			ginkgo.By("Checking that the stateful set readopts the pod")
-			gomega.Expect(e2epod.WaitForPodCondition(c, pod.Namespace, pod.Name, "adopted", statefulSetTimeout,
+			gomega.Expect(e2epod.WaitForPodCondition(ctx, c, pod.Namespace, pod.Name, "adopted", statefulSetTimeout,
 				func(pod *v1.Pod) (bool, error) {
 					controllerRef := metav1.GetControllerOf(pod)
 					if controllerRef == nil {
@@ -257,45 +257,45 @@ var _ = SIGDescribe("StatefulSet", func() {
 		// StorageClass and a dynamic provisioner.
 		ginkgo.It("should not deadlock when a pod's predecessor fails", func(ctx context.Context) {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			*(ss.Spec.Replicas) = 2
 			e2estatefulset.PauseNewPods(ss)
 
-			_, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 
-			e2estatefulset.WaitForRunning(c, 1, 0, ss)
+			e2estatefulset.WaitForRunning(ctx, c, 1, 0, ss)
 
 			ginkgo.By("Resuming stateful pod at index 0.")
-			e2estatefulset.ResumeNextPod(c, ss)
+			e2estatefulset.ResumeNextPod(ctx, c, ss)
 
 			ginkgo.By("Waiting for stateful pod at index 1 to enter running.")
-			e2estatefulset.WaitForRunning(c, 2, 1, ss)
+			e2estatefulset.WaitForRunning(ctx, c, 2, 1, ss)
 
 			// Now we have 1 healthy and 1 unhealthy stateful pod. Deleting the healthy stateful pod should *not*
 			// create a new stateful pod till the remaining stateful pod becomes healthy, which won't happen till
 			// we set the healthy bit.
 
 			ginkgo.By("Deleting healthy stateful pod at index 0.")
-			deleteStatefulPodAtIndex(c, 0, ss)
+			deleteStatefulPodAtIndex(ctx, c, 0, ss)
 
 			ginkgo.By("Confirming stateful pod at index 0 is recreated.")
-			e2estatefulset.WaitForRunning(c, 2, 1, ss)
+			e2estatefulset.WaitForRunning(ctx, c, 2, 1, ss)
 
 			ginkgo.By("Resuming stateful pod at index 1.")
-			e2estatefulset.ResumeNextPod(c, ss)
+			e2estatefulset.ResumeNextPod(ctx, c, ss)
 
 			ginkgo.By("Confirming all stateful pods in statefulset are created.")
-			e2estatefulset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 		})
 
 		// This can't be Conformance yet because it depends on a default
 		// StorageClass and a dynamic provisioner.
 		ginkgo.It("should perform rolling updates and roll backs of template modifications with PVCs", func(ctx context.Context) {
 			ginkgo.By("Creating a new StatefulSet with PVCs")
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			*(ss.Spec.Replicas) = 3
-			rollbackTest(c, ns, ss)
+			rollbackTest(ctx, c, ns, ss)
 		})
 
 		/*
@@ -306,7 +306,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		framework.ConformanceIt("should perform rolling updates and roll backs of template modifications", func(ctx context.Context) {
 			ginkgo.By("Creating a new StatefulSet")
 			ss := e2estatefulset.NewStatefulSet("ss2", ns, headlessSvcName, 3, nil, nil, labels)
-			rollbackTest(c, ns, ss)
+			rollbackTest(ctx, c, ns, ss)
 		})
 
 		/*
@@ -328,14 +328,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 						}()}
 				}(),
 			}
-			ss, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			e2estatefulset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
-			ss = waitForStatus(c, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
+			ss = waitForStatus(ctx, c, ss)
 			currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 			framework.ExpectEqual(currentRevision, updateRevision, fmt.Sprintf("StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 				ss.Namespace, ss.Name, updateRevision, currentRevision))
-			pods := e2estatefulset.GetPodList(c, ss)
+			pods := e2estatefulset.GetPodList(ctx, c, ss)
 			for i := range pods.Items {
 				framework.ExpectEqual(pods.Items[i].Labels[appsv1.StatefulSetRevisionLabel], currentRevision, fmt.Sprintf("Pod %s/%s revision %s is not equal to currentRevision %s",
 					pods.Items[i].Namespace,
@@ -348,13 +348,13 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By(fmt.Sprintf("Updating stateful set template: update image from %s to %s", oldImage, newImage))
 			framework.ExpectNotEqual(oldImage, newImage, "Incorrect test setup: should update to a different image")
-			ss, err = updateStatefulSetWithRetries(c, ns, ss.Name, func(update *appsv1.StatefulSet) {
+			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 				update.Spec.Template.Spec.Containers[0].Image = newImage
 			})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Creating a new revision")
-			ss = waitForStatus(c, ss)
+			ss = waitForStatus(ctx, c, ss)
 			currentRevision, updateRevision = ss.Status.CurrentRevision, ss.Status.UpdateRevision
 			framework.ExpectNotEqual(currentRevision, updateRevision, "Current revision should not equal update revision during rolling update")
 
@@ -383,7 +383,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 						}()}
 				}(),
 			}
-			ss, err = updateStatefulSetWithRetries(c, ns, ss.Name, func(update *appsv1.StatefulSet) {
+			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 				update.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
 					Type: appsv1.RollingUpdateStatefulSetStrategyType,
 					RollingUpdate: func() *appsv1.RollingUpdateStatefulSetStrategy {
@@ -396,7 +396,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				}
 			})
 			framework.ExpectNoError(err)
-			ss, pods = waitForPartitionedRollingUpdate(c, ss)
+			ss, pods = waitForPartitionedRollingUpdate(ctx, c, ss)
 			for i := range pods.Items {
 				if i < int(*ss.Spec.UpdateStrategy.RollingUpdate.Partition) {
 					framework.ExpectEqual(pods.Items[i].Spec.Containers[0].Image, oldImage, fmt.Sprintf("Pod %s/%s has image %s not equal to current image %s",
@@ -424,11 +424,11 @@ var _ = SIGDescribe("StatefulSet", func() {
 			}
 
 			ginkgo.By("Restoring Pods to the correct revision when they are deleted")
-			deleteStatefulPodAtIndex(c, 0, ss)
-			deleteStatefulPodAtIndex(c, 2, ss)
-			e2estatefulset.WaitForRunningAndReady(c, 3, ss)
-			ss = getStatefulSet(c, ss.Namespace, ss.Name)
-			pods = e2estatefulset.GetPodList(c, ss)
+			deleteStatefulPodAtIndex(ctx, c, 0, ss)
+			deleteStatefulPodAtIndex(ctx, c, 2, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, 3, ss)
+			ss = getStatefulSet(ctx, c, ss.Namespace, ss.Name)
+			pods = e2estatefulset.GetPodList(ctx, c, ss)
 			for i := range pods.Items {
 				if i < int(*ss.Spec.UpdateStrategy.RollingUpdate.Partition) {
 					framework.ExpectEqual(pods.Items[i].Spec.Containers[0].Image, oldImage, fmt.Sprintf("Pod %s/%s has image %s not equal to current image %s",
@@ -457,7 +457,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By("Performing a phased rolling update")
 			for i := int(*ss.Spec.UpdateStrategy.RollingUpdate.Partition) - 1; i >= 0; i-- {
-				ss, err = updateStatefulSetWithRetries(c, ns, ss.Name, func(update *appsv1.StatefulSet) {
+				ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 					update.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
 						Type: appsv1.RollingUpdateStatefulSetStrategyType,
 						RollingUpdate: func() *appsv1.RollingUpdateStatefulSetStrategy {
@@ -469,7 +469,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					}
 				})
 				framework.ExpectNoError(err)
-				ss, pods = waitForPartitionedRollingUpdate(c, ss)
+				ss, pods = waitForPartitionedRollingUpdate(ctx, c, ss)
 				for i := range pods.Items {
 					if i < int(*ss.Spec.UpdateStrategy.RollingUpdate.Partition) {
 						framework.ExpectEqual(pods.Items[i].Spec.Containers[0].Image, oldImage, fmt.Sprintf("Pod %s/%s has image %s not equal to current image %s",
@@ -513,14 +513,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.OnDeleteStatefulSetStrategyType,
 			}
-			ss, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			e2estatefulset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
-			ss = waitForStatus(c, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
+			ss = waitForStatus(ctx, c, ss)
 			currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 			framework.ExpectEqual(currentRevision, updateRevision, fmt.Sprintf("StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 				ss.Namespace, ss.Name, updateRevision, currentRevision))
-			pods := e2estatefulset.GetPodList(c, ss)
+			pods := e2estatefulset.GetPodList(ctx, c, ss)
 			for i := range pods.Items {
 				framework.ExpectEqual(pods.Items[i].Labels[appsv1.StatefulSetRevisionLabel], currentRevision, fmt.Sprintf("Pod %s/%s revision %s is not equal to current revision %s",
 					pods.Items[i].Namespace,
@@ -530,12 +530,12 @@ var _ = SIGDescribe("StatefulSet", func() {
 			}
 
 			ginkgo.By("Restoring Pods to the current revision")
-			deleteStatefulPodAtIndex(c, 0, ss)
-			deleteStatefulPodAtIndex(c, 1, ss)
-			deleteStatefulPodAtIndex(c, 2, ss)
-			e2estatefulset.WaitForRunningAndReady(c, 3, ss)
-			ss = getStatefulSet(c, ss.Namespace, ss.Name)
-			pods = e2estatefulset.GetPodList(c, ss)
+			deleteStatefulPodAtIndex(ctx, c, 0, ss)
+			deleteStatefulPodAtIndex(ctx, c, 1, ss)
+			deleteStatefulPodAtIndex(ctx, c, 2, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, 3, ss)
+			ss = getStatefulSet(ctx, c, ss.Namespace, ss.Name)
+			pods = e2estatefulset.GetPodList(ctx, c, ss)
 			for i := range pods.Items {
 				framework.ExpectEqual(pods.Items[i].Labels[appsv1.StatefulSetRevisionLabel], currentRevision, fmt.Sprintf("Pod %s/%s revision %s is not equal to current revision %s",
 					pods.Items[i].Namespace,
@@ -548,23 +548,23 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By(fmt.Sprintf("Updating stateful set template: update image from %s to %s", oldImage, newImage))
 			framework.ExpectNotEqual(oldImage, newImage, "Incorrect test setup: should update to a different image")
-			ss, err = updateStatefulSetWithRetries(c, ns, ss.Name, func(update *appsv1.StatefulSet) {
+			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 				update.Spec.Template.Spec.Containers[0].Image = newImage
 			})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Creating a new revision")
-			ss = waitForStatus(c, ss)
+			ss = waitForStatus(ctx, c, ss)
 			currentRevision, updateRevision = ss.Status.CurrentRevision, ss.Status.UpdateRevision
 			framework.ExpectNotEqual(currentRevision, updateRevision, "Current revision should not equal update revision during rolling update")
 
 			ginkgo.By("Recreating Pods at the new revision")
-			deleteStatefulPodAtIndex(c, 0, ss)
-			deleteStatefulPodAtIndex(c, 1, ss)
-			deleteStatefulPodAtIndex(c, 2, ss)
-			e2estatefulset.WaitForRunningAndReady(c, 3, ss)
-			ss = getStatefulSet(c, ss.Namespace, ss.Name)
-			pods = e2estatefulset.GetPodList(c, ss)
+			deleteStatefulPodAtIndex(ctx, c, 0, ss)
+			deleteStatefulPodAtIndex(ctx, c, 1, ss)
+			deleteStatefulPodAtIndex(ctx, c, 2, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, 3, ss)
+			ss = getStatefulSet(ctx, c, ss.Namespace, ss.Name)
+			pods = e2estatefulset.GetPodList(ctx, c, ss)
 			for i := range pods.Items {
 				framework.ExpectEqual(pods.Items[i].Spec.Containers[0].Image, newImage, fmt.Sprintf("Pod %s/%s has image %s not equal to new image %s",
 					pods.Items[i].Namespace,
@@ -589,11 +589,11 @@ var _ = SIGDescribe("StatefulSet", func() {
 			w := &cache.ListWatch{
 				WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
 					options.LabelSelector = psLabels.AsSelector().String()
-					return f.ClientSet.CoreV1().Pods(ns).Watch(context.TODO(), options)
+					return f.ClientSet.CoreV1().Pods(ns).Watch(ctx, options)
 				},
 			}
 			ginkgo.By("Initializing watcher for selector " + psLabels.String())
-			pl, err := f.ClientSet.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
+			pl, err := f.ClientSet.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 				LabelSelector: psLabels.AsSelector().String(),
 			})
 			framework.ExpectNoError(err)
@@ -607,7 +607,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				defer wg.Done()
 
 				expectedOrder := []string{ssName + "-0", ssName + "-1", ssName + "-2"}
-				ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), statefulSetTimeout)
+				ctx, cancel := watchtools.ContextWithOptionalTimeout(ctx, statefulSetTimeout)
 				defer cancel()
 
 				_, orderErr = watchtools.Until(ctx, pl.ResourceVersion, w, func(event watch.Event) (bool, error) {
@@ -625,29 +625,29 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ginkgo.By("Creating stateful set " + ssName + " in namespace " + ns)
 			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, psLabels)
 			setHTTPProbe(ss)
-			ss, err = c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			ss, err = c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Waiting until all stateful set " + ssName + " replicas will be running in namespace " + ns)
-			e2estatefulset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 
 			ginkgo.By("Confirming that stateful set scale up will halt with unhealthy stateful pod")
-			breakHTTPProbe(c, ss)
-			waitForRunningAndNotReady(c, *ss.Spec.Replicas, ss)
-			e2estatefulset.WaitForStatusReadyReplicas(c, ss, 0)
-			e2estatefulset.UpdateReplicas(c, ss, 3)
-			confirmStatefulPodCount(c, 1, ss, 10*time.Second, true)
+			breakHTTPProbe(ctx, c, ss)
+			waitForRunningAndNotReady(ctx, c, *ss.Spec.Replicas, ss)
+			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 0)
+			e2estatefulset.UpdateReplicas(ctx, c, ss, 3)
+			confirmStatefulPodCount(ctx, c, 1, ss, 10*time.Second, true)
 
 			ginkgo.By("Scaling up stateful set " + ssName + " to 3 replicas and waiting until all of them will be running in namespace " + ns)
-			restoreHTTPProbe(c, ss)
-			e2estatefulset.WaitForRunningAndReady(c, 3, ss)
+			restoreHTTPProbe(ctx, c, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, 3, ss)
 
 			ginkgo.By("Verifying that stateful set " + ssName + " was scaled up in order")
 			wg.Wait()
 			framework.ExpectNoError(orderErr)
 
 			ginkgo.By("Scale down will halt with unhealthy stateful pod")
-			pl, err = f.ClientSet.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
+			pl, err = f.ClientSet.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 				LabelSelector: psLabels.AsSelector().String(),
 			})
 			framework.ExpectNoError(err)
@@ -659,7 +659,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				defer wg.Done()
 
 				expectedOrder := []string{ssName + "-2", ssName + "-1", ssName + "-0"}
-				ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), statefulSetTimeout)
+				ctx, cancel := watchtools.ContextWithOptionalTimeout(ctx, statefulSetTimeout)
 				defer cancel()
 
 				_, orderErr = watchtools.Until(ctx, pl.ResourceVersion, w, func(event watch.Event) (bool, error) {
@@ -674,15 +674,15 @@ var _ = SIGDescribe("StatefulSet", func() {
 				})
 			}()
 
-			breakHTTPProbe(c, ss)
-			e2estatefulset.WaitForStatusReadyReplicas(c, ss, 0)
-			waitForRunningAndNotReady(c, 3, ss)
-			e2estatefulset.UpdateReplicas(c, ss, 0)
-			confirmStatefulPodCount(c, 3, ss, 10*time.Second, true)
+			breakHTTPProbe(ctx, c, ss)
+			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 0)
+			waitForRunningAndNotReady(ctx, c, 3, ss)
+			e2estatefulset.UpdateReplicas(ctx, c, ss, 0)
+			confirmStatefulPodCount(ctx, c, 3, ss, 10*time.Second, true)
 
 			ginkgo.By("Scaling down stateful set " + ssName + " to 0 replicas and waiting until none of pods will run in namespace" + ns)
-			restoreHTTPProbe(c, ss)
-			e2estatefulset.Scale(c, ss, 0)
+			restoreHTTPProbe(ctx, c, ss)
+			e2estatefulset.Scale(ctx, c, ss, 0)
 
 			ginkgo.By("Verifying that stateful set " + ssName + " was scaled down in reverse order")
 			wg.Wait()
@@ -701,34 +701,34 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, psLabels)
 			ss.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 			setHTTPProbe(ss)
-			ss, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Waiting until all stateful set " + ssName + " replicas will be running in namespace " + ns)
-			e2estatefulset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 
 			ginkgo.By("Confirming that stateful set scale up will not halt with unhealthy stateful pod")
-			breakHTTPProbe(c, ss)
-			waitForRunningAndNotReady(c, *ss.Spec.Replicas, ss)
-			e2estatefulset.WaitForStatusReadyReplicas(c, ss, 0)
-			e2estatefulset.UpdateReplicas(c, ss, 3)
-			confirmStatefulPodCount(c, 3, ss, 10*time.Second, false)
+			breakHTTPProbe(ctx, c, ss)
+			waitForRunningAndNotReady(ctx, c, *ss.Spec.Replicas, ss)
+			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 0)
+			e2estatefulset.UpdateReplicas(ctx, c, ss, 3)
+			confirmStatefulPodCount(ctx, c, 3, ss, 10*time.Second, false)
 
 			ginkgo.By("Scaling up stateful set " + ssName + " to 3 replicas and waiting until all of them will be running in namespace " + ns)
-			restoreHTTPProbe(c, ss)
-			e2estatefulset.WaitForRunningAndReady(c, 3, ss)
+			restoreHTTPProbe(ctx, c, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, 3, ss)
 
 			ginkgo.By("Scale down will not halt with unhealthy stateful pod")
-			breakHTTPProbe(c, ss)
-			e2estatefulset.WaitForStatusReadyReplicas(c, ss, 0)
-			waitForRunningAndNotReady(c, 3, ss)
-			e2estatefulset.UpdateReplicas(c, ss, 0)
-			confirmStatefulPodCount(c, 0, ss, 10*time.Second, false)
+			breakHTTPProbe(ctx, c, ss)
+			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 0)
+			waitForRunningAndNotReady(ctx, c, 3, ss)
+			e2estatefulset.UpdateReplicas(ctx, c, ss, 0)
+			confirmStatefulPodCount(ctx, c, 0, ss, 10*time.Second, false)
 
 			ginkgo.By("Scaling down stateful set " + ssName + " to 0 replicas and waiting until none of pods will run in namespace" + ns)
-			restoreHTTPProbe(c, ss)
-			e2estatefulset.Scale(c, ss, 0)
-			e2estatefulset.WaitForStatusReplicas(c, ss, 0)
+			restoreHTTPProbe(ctx, c, ss)
+			e2estatefulset.Scale(ctx, c, ss, 0)
+			e2estatefulset.WaitForStatusReplicas(ctx, c, ss, 0)
 		})
 
 		/*
@@ -740,7 +740,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			podName := "test-pod"
 			statefulPodName := ssName + "-0"
 			ginkgo.By("Looking for a node to schedule stateful set and pod")
-			node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+			node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Creating pod with conflicting port in namespace " + f.Namespace.Name)
@@ -760,10 +760,10 @@ var _ = SIGDescribe("StatefulSet", func() {
 					NodeName: node.Name,
 				},
 			}
-			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			ginkgo.By("Waiting until pod " + podName + " will start running in namespace " + f.Namespace.Name)
-			if err := e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, podName, f.Namespace.Name); err != nil {
+			if err := e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, podName, f.Namespace.Name); err != nil {
 				framework.Failf("Pod %v did not start running: %v", podName, err)
 			}
 
@@ -772,14 +772,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 			statefulPodContainer := &ss.Spec.Template.Spec.Containers[0]
 			statefulPodContainer.Ports = append(statefulPodContainer.Ports, conflictingPort)
 			ss.Spec.Template.Spec.NodeName = node.Name
-			_, err = f.ClientSet.AppsV1().StatefulSets(f.Namespace.Name).Create(context.TODO(), ss, metav1.CreateOptions{})
+			_, err = f.ClientSet.AppsV1().StatefulSets(f.Namespace.Name).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 
 			var initialStatefulPodUID types.UID
 			ginkgo.By("Waiting until stateful pod " + statefulPodName + " will be recreated and deleted at least once in namespace " + f.Namespace.Name)
 
 			fieldSelector := fields.OneTermEqualSelector("metadata.name", statefulPodName).String()
-			pl, err := f.ClientSet.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
+			pl, err := f.ClientSet.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 				FieldSelector: fieldSelector,
 			})
 			framework.ExpectNoError(err)
@@ -793,7 +793,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			lw := &cache.ListWatch{
 				WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
 					options.FieldSelector = fieldSelector
-					return f.ClientSet.CoreV1().Pods(f.Namespace.Name).Watch(context.TODO(), options)
+					return f.ClientSet.CoreV1().Pods(f.Namespace.Name).Watch(ctx, options)
 				},
 			}
 			ctx, cancel := watchtools.ContextWithOptionalTimeout(ctx, statefulPodTimeout)
@@ -819,13 +819,13 @@ var _ = SIGDescribe("StatefulSet", func() {
 			}
 
 			ginkgo.By("Removing pod with conflicting port in namespace " + f.Namespace.Name)
-			err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, *metav1.NewDeleteOptions(0))
+			err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Waiting when stateful pod " + statefulPodName + " will be recreated in namespace " + f.Namespace.Name + " and will be in running state")
 			// we may catch delete event, that's why we are waiting for running phase like this, and not with watchtools.UntilWithoutRetry
-			gomega.Eventually(func() error {
-				statefulPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), statefulPodName, metav1.GetOptions{})
+			gomega.Eventually(ctx, func() error {
+				statefulPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, statefulPodName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -849,13 +849,13 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, labels)
 			setHTTPProbe(ss)
-			ss, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			e2estatefulset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
-			waitForStatus(c, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
+			waitForStatus(ctx, c, ss)
 
 			ginkgo.By("getting scale subresource")
-			scale, err := c.AppsV1().StatefulSets(ns).GetScale(context.TODO(), ssName, metav1.GetOptions{})
+			scale, err := c.AppsV1().StatefulSets(ns).GetScale(ctx, ssName, metav1.GetOptions{})
 			if err != nil {
 				framework.Failf("Failed to get scale subresource: %v", err)
 			}
@@ -865,14 +865,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ginkgo.By("updating a scale subresource")
 			scale.ResourceVersion = "" // indicate the scale update should be unconditional
 			scale.Spec.Replicas = 2
-			scaleResult, err := c.AppsV1().StatefulSets(ns).UpdateScale(context.TODO(), ssName, scale, metav1.UpdateOptions{})
+			scaleResult, err := c.AppsV1().StatefulSets(ns).UpdateScale(ctx, ssName, scale, metav1.UpdateOptions{})
 			if err != nil {
 				framework.Failf("Failed to put scale subresource: %v", err)
 			}
 			framework.ExpectEqual(scaleResult.Spec.Replicas, int32(2))
 
 			ginkgo.By("verifying the statefulset Spec.Replicas was modified")
-			ss, err = c.AppsV1().StatefulSets(ns).Get(context.TODO(), ssName, metav1.GetOptions{})
+			ss, err = c.AppsV1().StatefulSets(ns).Get(ctx, ssName, metav1.GetOptions{})
 			if err != nil {
 				framework.Failf("Failed to get statefulset resource: %v", err)
 			}
@@ -888,11 +888,11 @@ var _ = SIGDescribe("StatefulSet", func() {
 			})
 			framework.ExpectNoError(err, "Could not Marshal JSON for patch payload")
 
-			_, err = c.AppsV1().StatefulSets(ns).Patch(context.TODO(), ssName, types.StrategicMergePatchType, []byte(ssScalePatchPayload), metav1.PatchOptions{}, "scale")
+			_, err = c.AppsV1().StatefulSets(ns).Patch(ctx, ssName, types.StrategicMergePatchType, []byte(ssScalePatchPayload), metav1.PatchOptions{}, "scale")
 			framework.ExpectNoError(err, "Failed to patch stateful set: %v", err)
 
 			ginkgo.By("verifying the statefulset Spec.Replicas was modified")
-			ss, err = c.AppsV1().StatefulSets(ns).Get(context.TODO(), ssName, metav1.GetOptions{})
+			ss, err = c.AppsV1().StatefulSets(ns).Get(ctx, ssName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Failed to get statefulset resource: %v", err)
 			framework.ExpectEqual(*(ss.Spec.Replicas), int32(4), "statefulset should have 4 replicas")
 		})
@@ -919,10 +919,10 @@ var _ = SIGDescribe("StatefulSet", func() {
 			}
 			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, ssPodLabels)
 			setHTTPProbe(ss)
-			ss, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			e2estatefulset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
-			waitForStatus(c, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
+			waitForStatus(ctx, c, ss)
 
 			ginkgo.By("patching the StatefulSet")
 			ssPatch, err := json.Marshal(map[string]interface{}{
@@ -943,26 +943,26 @@ var _ = SIGDescribe("StatefulSet", func() {
 				},
 			})
 			framework.ExpectNoError(err, "failed to Marshal StatefulSet JSON patch")
-			_, err = f.ClientSet.AppsV1().StatefulSets(ns).Patch(context.TODO(), ssName, types.StrategicMergePatchType, []byte(ssPatch), metav1.PatchOptions{})
+			_, err = f.ClientSet.AppsV1().StatefulSets(ns).Patch(ctx, ssName, types.StrategicMergePatchType, []byte(ssPatch), metav1.PatchOptions{})
 			framework.ExpectNoError(err, "failed to patch Set")
-			ss, err = c.AppsV1().StatefulSets(ns).Get(context.TODO(), ssName, metav1.GetOptions{})
+			ss, err = c.AppsV1().StatefulSets(ns).Get(ctx, ssName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Failed to get statefulset resource: %v", err)
 			framework.ExpectEqual(*(ss.Spec.Replicas), ssPatchReplicas, "statefulset should have 2 replicas")
 			framework.ExpectEqual(ss.Spec.Template.Spec.Containers[0].Image, ssPatchImage, "statefulset not using ssPatchImage. Is using %v", ss.Spec.Template.Spec.Containers[0].Image)
-			e2estatefulset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
-			waitForStatus(c, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
+			waitForStatus(ctx, c, ss)
 
 			ginkgo.By("Listing all StatefulSets")
-			ssList, err := c.AppsV1().StatefulSets("").List(context.TODO(), metav1.ListOptions{LabelSelector: "test-ss=patched"})
+			ssList, err := c.AppsV1().StatefulSets("").List(ctx, metav1.ListOptions{LabelSelector: "test-ss=patched"})
 			framework.ExpectNoError(err, "failed to list StatefulSets")
 			framework.ExpectEqual(len(ssList.Items), 1, "filtered list wasn't found")
 
 			ginkgo.By("Delete all of the StatefulSets")
-			err = c.AppsV1().StatefulSets(ns).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &one}, metav1.ListOptions{LabelSelector: "test-ss=patched"})
+			err = c.AppsV1().StatefulSets(ns).DeleteCollection(ctx, metav1.DeleteOptions{GracePeriodSeconds: &one}, metav1.ListOptions{LabelSelector: "test-ss=patched"})
 			framework.ExpectNoError(err, "failed to delete StatefulSets")
 
 			ginkgo.By("Verify that StatefulSets have been deleted")
-			ssList, err = c.AppsV1().StatefulSets("").List(context.TODO(), metav1.ListOptions{LabelSelector: "test-ss=patched"})
+			ssList, err = c.AppsV1().StatefulSets("").List(ctx, metav1.ListOptions{LabelSelector: "test-ss=patched"})
 			framework.ExpectNoError(err, "failed to list StatefulSets")
 			framework.ExpectEqual(len(ssList.Items), 0, "filtered list should have no Statefulsets")
 		})
@@ -981,28 +981,28 @@ var _ = SIGDescribe("StatefulSet", func() {
 			w := &cache.ListWatch{
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 					options.LabelSelector = labelSelector
-					return ssClient.Watch(context.TODO(), options)
+					return ssClient.Watch(ctx, options)
 				},
 			}
-			ssList, err := c.AppsV1().StatefulSets("").List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+			ssList, err := c.AppsV1().StatefulSets("").List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 			framework.ExpectNoError(err, "failed to list StatefulSets")
 
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, labels)
 			setHTTPProbe(ss)
-			ss, err = c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			ss, err = c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			e2estatefulset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
-			waitForStatus(c, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
+			waitForStatus(ctx, c, ss)
 
 			ginkgo.By("Patch Statefulset to include a label")
 			payload := []byte(`{"metadata":{"labels":{"e2e":"testing"}}}`)
-			ss, err = ssClient.Patch(context.TODO(), ssName, types.StrategicMergePatchType, payload, metav1.PatchOptions{})
+			ss, err = ssClient.Patch(ctx, ssName, types.StrategicMergePatchType, payload, metav1.PatchOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Getting /status")
 			ssResource := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
-			ssStatusUnstructured, err := f.DynamicClient.Resource(ssResource).Namespace(ns).Get(context.TODO(), ssName, metav1.GetOptions{}, "status")
+			ssStatusUnstructured, err := f.DynamicClient.Resource(ssResource).Namespace(ns).Get(ctx, ssName, metav1.GetOptions{}, "status")
 			framework.ExpectNoError(err, "Failed to fetch the status of replica set %s in namespace %s", ssName, ns)
 			ssStatusBytes, err := json.Marshal(ssStatusUnstructured)
 			framework.ExpectNoError(err, "Failed to marshal unstructured response. %v", err)
@@ -1016,7 +1016,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			var statusToUpdate, updatedStatus *appsv1.StatefulSet
 
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				statusToUpdate, err = ssClient.Get(context.TODO(), ssName, metav1.GetOptions{})
+				statusToUpdate, err = ssClient.Get(ctx, ssName, metav1.GetOptions{})
 				framework.ExpectNoError(err, "Unable to retrieve statefulset %s", ssName)
 
 				statusToUpdate.Status.Conditions = append(statusToUpdate.Status.Conditions, appsv1.StatefulSetCondition{
@@ -1026,7 +1026,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					Message: "Set from e2e test",
 				})
 
-				updatedStatus, err = ssClient.UpdateStatus(context.TODO(), statusToUpdate, metav1.UpdateOptions{})
+				updatedStatus, err = ssClient.UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})
 				return err
 			})
 			framework.ExpectNoError(err, "Failed to update status. %v", err)
@@ -1034,10 +1034,10 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By("watching for the statefulset status to be updated")
 
-			ctx, cancel := context.WithTimeout(ctx, statefulSetTimeout)
+			ctxUntil, cancel := context.WithTimeout(ctx, statefulSetTimeout)
 			defer cancel()
 
-			_, err = watchtools.Until(ctx, ssList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+			_, err = watchtools.Until(ctxUntil, ssList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 
 				if e, ok := event.Object.(*appsv1.StatefulSet); ok {
 					found := e.ObjectMeta.Name == ss.ObjectMeta.Name &&
@@ -1068,14 +1068,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 			payload = []byte(`{"status":{"conditions":[{"type":"StatusPatched","status":"True"}]}}`)
 			framework.Logf("Patch payload: %v", string(payload))
 
-			patchedStatefulSet, err := ssClient.Patch(context.TODO(), ssName, types.MergePatchType, payload, metav1.PatchOptions{}, "status")
+			patchedStatefulSet, err := ssClient.Patch(ctx, ssName, types.MergePatchType, payload, metav1.PatchOptions{}, "status")
 			framework.ExpectNoError(err, "Failed to patch status. %v", err)
 			framework.Logf("Patched status conditions: %#v", patchedStatefulSet.Status.Conditions)
 
 			ginkgo.By("watching for the Statefulset status to be patched")
-			ctx, cancel = context.WithTimeout(context.Background(), statefulSetTimeout)
+			ctxUntil, cancel = context.WithTimeout(ctx, statefulSetTimeout)
 
-			_, err = watchtools.Until(ctx, ssList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+			_, err = watchtools.Until(ctxUntil, ssList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 
 				defer cancel()
 				if e, ok := event.Object.(*appsv1.StatefulSet); ok {
@@ -1104,48 +1104,48 @@ var _ = SIGDescribe("StatefulSet", func() {
 	ginkgo.Describe("Deploy clustered applications [Feature:StatefulSet] [Slow]", func() {
 		var appTester *clusterAppTester
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			appTester = &clusterAppTester{client: c, ns: ns}
 		})
 
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			if ginkgo.CurrentSpecReport().Failed() {
-				e2eoutput.DumpDebugInfo(c, ns)
+				e2eoutput.DumpDebugInfo(ctx, c, ns)
 			}
 			framework.Logf("Deleting all statefulset in ns %v", ns)
-			e2estatefulset.DeleteAllStatefulSets(c, ns)
+			e2estatefulset.DeleteAllStatefulSets(ctx, c, ns)
 		})
 
 		// Do not mark this as Conformance.
 		// StatefulSet Conformance should not be dependent on specific applications.
 		ginkgo.It("should creating a working zookeeper cluster", func(ctx context.Context) {
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			appTester.statefulPod = &zookeeperTester{client: c}
-			appTester.run()
+			appTester.run(ctx)
 		})
 
 		// Do not mark this as Conformance.
 		// StatefulSet Conformance should not be dependent on specific applications.
 		ginkgo.It("should creating a working redis cluster", func(ctx context.Context) {
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			appTester.statefulPod = &redisTester{client: c}
-			appTester.run()
+			appTester.run(ctx)
 		})
 
 		// Do not mark this as Conformance.
 		// StatefulSet Conformance should not be dependent on specific applications.
 		ginkgo.It("should creating a working mysql cluster", func(ctx context.Context) {
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			appTester.statefulPod = &mysqlGaleraTester{client: c}
-			appTester.run()
+			appTester.run(ctx)
 		})
 
 		// Do not mark this as Conformance.
 		// StatefulSet Conformance should not be dependent on specific applications.
 		ginkgo.It("should creating a working CockroachDB cluster", func(ctx context.Context) {
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			appTester.statefulPod = &cockroachDBTester{client: c}
-			appTester.run()
+			appTester.run(ctx)
 		})
 	})
 
@@ -1161,9 +1161,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 		}
 		ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, ssPodLabels)
 		setHTTPProbe(ss)
-		ss, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+		ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		e2estatefulset.WaitForStatusAvailableReplicas(c, ss, 1)
+		e2estatefulset.WaitForStatusAvailableReplicas(ctx, c, ss, 1)
 	})
 
 	ginkgo.It("AvailableReplicas should get updated accordingly when MinReadySeconds is enabled", func(ctx context.Context) {
@@ -1177,30 +1177,30 @@ var _ = SIGDescribe("StatefulSet", func() {
 		ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 2, nil, nil, ssPodLabels)
 		ss.Spec.MinReadySeconds = 30
 		setHTTPProbe(ss)
-		ss, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+		ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		e2estatefulset.WaitForStatusAvailableReplicas(c, ss, 0)
+		e2estatefulset.WaitForStatusAvailableReplicas(ctx, c, ss, 0)
 		// let's check that the availableReplicas have still not updated
 		time.Sleep(5 * time.Second)
-		ss, err = c.AppsV1().StatefulSets(ns).Get(context.TODO(), ss.Name, metav1.GetOptions{})
+		ss, err = c.AppsV1().StatefulSets(ns).Get(ctx, ss.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		if ss.Status.AvailableReplicas != 0 {
 			framework.Failf("invalid number of availableReplicas: expected=%v received=%v", 0, ss.Status.AvailableReplicas)
 		}
-		e2estatefulset.WaitForStatusAvailableReplicas(c, ss, 2)
+		e2estatefulset.WaitForStatusAvailableReplicas(ctx, c, ss, 2)
 
-		ss, err = updateStatefulSetWithRetries(c, ns, ss.Name, func(update *appsv1.StatefulSet) {
+		ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 			update.Spec.MinReadySeconds = 3600
 		})
 		framework.ExpectNoError(err)
 		// We don't expect replicas to be updated till 1 hour, so the availableReplicas should be 0
-		e2estatefulset.WaitForStatusAvailableReplicas(c, ss, 0)
+		e2estatefulset.WaitForStatusAvailableReplicas(ctx, c, ss, 0)
 
-		ss, err = updateStatefulSetWithRetries(c, ns, ss.Name, func(update *appsv1.StatefulSet) {
+		ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 			update.Spec.MinReadySeconds = 0
 		})
 		framework.ExpectNoError(err)
-		e2estatefulset.WaitForStatusAvailableReplicas(c, ss, 2)
+		e2estatefulset.WaitForStatusAvailableReplicas(ctx, c, ss, 2)
 
 		ginkgo.By("check availableReplicas are shown in status")
 		out, err := e2ekubectl.RunKubectl(ns, "get", "statefulset", ss.Name, "-o=yaml")
@@ -1220,83 +1220,83 @@ var _ = SIGDescribe("StatefulSet", func() {
 		var statefulPodMounts, podMounts []v1.VolumeMount
 		var ss *appsv1.StatefulSet
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			statefulPodMounts = []v1.VolumeMount{{Name: "datadir", MountPath: "/data/"}}
 			podMounts = []v1.VolumeMount{{Name: "home", MountPath: "/home"}}
 			ss = e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 2, statefulPodMounts, podMounts, labels)
 
 			ginkgo.By("Creating service " + headlessSvcName + " in namespace " + ns)
 			headlessService := e2eservice.CreateServiceSpec(headlessSvcName, "", true, labels)
-			_, err := c.CoreV1().Services(ns).Create(context.TODO(), headlessService, metav1.CreateOptions{})
+			_, err := c.CoreV1().Services(ns).Create(ctx, headlessService, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 		})
 
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			if ginkgo.CurrentSpecReport().Failed() {
-				e2eoutput.DumpDebugInfo(c, ns)
+				e2eoutput.DumpDebugInfo(ctx, c, ns)
 			}
 			framework.Logf("Deleting all statefulset in ns %v", ns)
-			e2estatefulset.DeleteAllStatefulSets(c, ns)
+			e2estatefulset.DeleteAllStatefulSets(ctx, c, ns)
 		})
 
 		ginkgo.It("should delete PVCs with a WhenDeleted policy", func(ctx context.Context) {
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			*(ss.Spec.Replicas) = 3
 			ss.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
 				WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
 			}
-			_, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Confirming all 3 PVCs exist with their owner refs")
-			err = verifyStatefulSetPVCsExistWithOwnerRefs(c, ss, []int{0, 1, 2}, true, false)
+			err = verifyStatefulSetPVCsExistWithOwnerRefs(ctx, c, ss, []int{0, 1, 2}, true, false)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Deleting stateful set " + ss.Name)
-			err = c.AppsV1().StatefulSets(ns).Delete(context.TODO(), ss.Name, metav1.DeleteOptions{})
+			err = c.AppsV1().StatefulSets(ns).Delete(ctx, ss.Name, metav1.DeleteOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Verifying PVCs deleted")
-			err = verifyStatefulSetPVCsExist(c, ss, []int{})
+			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{})
 			framework.ExpectNoError(err)
 		})
 
 		ginkgo.It("should delete PVCs with a OnScaledown policy", func(ctx context.Context) {
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			*(ss.Spec.Replicas) = 3
 			ss.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
 				WhenScaled: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
 			}
-			_, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Confirming all 3 PVCs exist")
-			err = verifyStatefulSetPVCsExist(c, ss, []int{0, 1, 2})
+			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0, 1, 2})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Scaling stateful set " + ss.Name + " to one replica")
-			ss, err = e2estatefulset.Scale(c, ss, 1)
+			ss, err = e2estatefulset.Scale(ctx, c, ss, 1)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Verifying all but one PVC deleted")
-			err = verifyStatefulSetPVCsExist(c, ss, []int{0})
+			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})
 			framework.ExpectNoError(err)
 		})
 
 		ginkgo.It("should delete PVCs after adopting pod (WhenDeleted)", func(ctx context.Context) {
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			*(ss.Spec.Replicas) = 3
 			ss.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
 				WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
 			}
-			_, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Confirming all 3 PVCs exist with their owner refs")
-			err = verifyStatefulSetPVCsExistWithOwnerRefs(c, ss, []int{0, 1, 2}, true, false)
+			err = verifyStatefulSetPVCsExistWithOwnerRefs(ctx, c, ss, []int{0, 1, 2}, true, false)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Orphaning the 3rd pod")
@@ -1304,30 +1304,30 @@ var _ = SIGDescribe("StatefulSet", func() {
 				OwnerReferences: []metav1.OwnerReference{},
 			})
 			framework.ExpectNoError(err, "Could not Marshal JSON for patch payload")
-			_, err = c.CoreV1().Pods(ns).Patch(context.TODO(), fmt.Sprintf("%s-2", ss.Name), types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
+			_, err = c.CoreV1().Pods(ns).Patch(ctx, fmt.Sprintf("%s-2", ss.Name), types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
 			framework.ExpectNoError(err, "Could not patch payload")
 
 			ginkgo.By("Deleting stateful set " + ss.Name)
-			err = c.AppsV1().StatefulSets(ns).Delete(context.TODO(), ss.Name, metav1.DeleteOptions{})
+			err = c.AppsV1().StatefulSets(ns).Delete(ctx, ss.Name, metav1.DeleteOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Verifying PVCs deleted")
-			err = verifyStatefulSetPVCsExist(c, ss, []int{})
+			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{})
 			framework.ExpectNoError(err)
 		})
 
 		ginkgo.It("should delete PVCs after adopting pod (WhenScaled) [Feature:StatefulSetAutoDeletePVC]", func(ctx context.Context) {
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			*(ss.Spec.Replicas) = 3
 			ss.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
 				WhenScaled: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
 			}
-			_, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Confirming all 3 PVCs exist")
-			err = verifyStatefulSetPVCsExist(c, ss, []int{0, 1, 2})
+			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0, 1, 2})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Orphaning the 3rd pod")
@@ -1335,15 +1335,15 @@ var _ = SIGDescribe("StatefulSet", func() {
 				OwnerReferences: []metav1.OwnerReference{},
 			})
 			framework.ExpectNoError(err, "Could not Marshal JSON for patch payload")
-			_, err = c.CoreV1().Pods(ns).Patch(context.TODO(), fmt.Sprintf("%s-2", ss.Name), types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
+			_, err = c.CoreV1().Pods(ns).Patch(ctx, fmt.Sprintf("%s-2", ss.Name), types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
 			framework.ExpectNoError(err, "Could not patch payload")
 
 			ginkgo.By("Scaling stateful set " + ss.Name + " to one replica")
-			ss, err = e2estatefulset.Scale(c, ss, 1)
+			ss, err = e2estatefulset.Scale(ctx, c, ss, 1)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Verifying all but one PVC deleted")
-			err = verifyStatefulSetPVCsExist(c, ss, []int{0})
+			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})
 			framework.ExpectNoError(err)
 		})
 	})
@@ -1362,7 +1362,7 @@ func kubectlExecWithRetries(ns string, args ...string) (out string) {
 }
 
 type statefulPodTester interface {
-	deploy(ns string) *appsv1.StatefulSet
+	deploy(ctx context.Context, ns string) *appsv1.StatefulSet
 	write(statefulPodIndex int, kv map[string]string)
 	read(statefulPodIndex int, key string) string
 	name() string
@@ -1374,9 +1374,9 @@ type clusterAppTester struct {
 	client      clientset.Interface
 }
 
-func (c *clusterAppTester) run() {
+func (c *clusterAppTester) run(ctx context.Context) {
 	ginkgo.By("Deploying " + c.statefulPod.name())
-	ss := c.statefulPod.deploy(c.ns)
+	ss := c.statefulPod.deploy(ctx, c.ns)
 
 	ginkgo.By("Creating foo:bar in member with index 0")
 	c.statefulPod.write(0, map[string]string{"foo": "bar"})
@@ -1387,13 +1387,13 @@ func (c *clusterAppTester) run() {
 	default:
 		if restartCluster {
 			ginkgo.By("Restarting stateful set " + ss.Name)
-			e2estatefulset.Restart(c.client, ss)
-			e2estatefulset.WaitForRunningAndReady(c.client, *ss.Spec.Replicas, ss)
+			e2estatefulset.Restart(ctx, c.client, ss)
+			e2estatefulset.WaitForRunningAndReady(ctx, c.client, *ss.Spec.Replicas, ss)
 		}
 	}
 
 	ginkgo.By("Reading value under foo from member with index 2")
-	if err := pollReadWithTimeout(c.statefulPod, 2, "foo", "bar"); err != nil {
+	if err := pollReadWithTimeout(ctx, c.statefulPod, 2, "foo", "bar"); err != nil {
 		framework.Failf("%v", err)
 	}
 }
@@ -1407,8 +1407,8 @@ func (z *zookeeperTester) name() string {
 	return "zookeeper"
 }
 
-func (z *zookeeperTester) deploy(ns string) *appsv1.StatefulSet {
-	z.ss = e2estatefulset.CreateStatefulSet(z.client, zookeeperManifestPath, ns)
+func (z *zookeeperTester) deploy(ctx context.Context, ns string) *appsv1.StatefulSet {
+	z.ss = e2estatefulset.CreateStatefulSet(ctx, z.client, zookeeperManifestPath, ns)
 	return z.ss
 }
 
@@ -1443,8 +1443,8 @@ func (m *mysqlGaleraTester) mysqlExec(cmd, ns, podName string) string {
 	return kubectlExecWithRetries(ns, "exec", podName, "--", "/bin/sh", "-c", cmd)
 }
 
-func (m *mysqlGaleraTester) deploy(ns string) *appsv1.StatefulSet {
-	m.ss = e2estatefulset.CreateStatefulSet(m.client, mysqlGaleraManifestPath, ns)
+func (m *mysqlGaleraTester) deploy(ctx context.Context, ns string) *appsv1.StatefulSet {
+	m.ss = e2estatefulset.CreateStatefulSet(ctx, m.client, mysqlGaleraManifestPath, ns)
 
 	framework.Logf("Deployed statefulset %v, initializing database", m.ss.Name)
 	for _, cmd := range []string{
@@ -1483,8 +1483,8 @@ func (m *redisTester) redisExec(cmd, ns, podName string) string {
 	return e2ekubectl.RunKubectlOrDie(ns, "exec", podName, "--", "/bin/sh", "-c", cmd)
 }
 
-func (m *redisTester) deploy(ns string) *appsv1.StatefulSet {
-	m.ss = e2estatefulset.CreateStatefulSet(m.client, redisManifestPath, ns)
+func (m *redisTester) deploy(ctx context.Context, ns string) *appsv1.StatefulSet {
+	m.ss = e2estatefulset.CreateStatefulSet(ctx, m.client, redisManifestPath, ns)
 	return m.ss
 }
 
@@ -1514,8 +1514,8 @@ func (c *cockroachDBTester) cockroachDBExec(cmd, ns, podName string) string {
 	return e2ekubectl.RunKubectlOrDie(ns, "exec", podName, "--", "/bin/sh", "-c", cmd)
 }
 
-func (c *cockroachDBTester) deploy(ns string) *appsv1.StatefulSet {
-	c.ss = e2estatefulset.CreateStatefulSet(c.client, cockroachDBManifestPath, ns)
+func (c *cockroachDBTester) deploy(ctx context.Context, ns string) *appsv1.StatefulSet {
+	c.ss = e2estatefulset.CreateStatefulSet(ctx, c.client, cockroachDBManifestPath, ns)
 	framework.Logf("Deployed statefulset %v, initializing database", c.ss.Name)
 	for _, cmd := range []string{
 		"CREATE DATABASE IF NOT EXISTS foo;",
@@ -1543,8 +1543,8 @@ func lastLine(out string) string {
 	return outLines[len(outLines)-1]
 }
 
-func pollReadWithTimeout(statefulPod statefulPodTester, statefulPodNumber int, key, expectedVal string) error {
-	err := wait.PollImmediate(time.Second, readTimeout, func() (bool, error) {
+func pollReadWithTimeout(ctx context.Context, statefulPod statefulPodTester, statefulPodNumber int, key, expectedVal string) error {
+	err := wait.PollImmediateWithContext(ctx, time.Second, readTimeout, func(ctx context.Context) (bool, error) {
 		val := statefulPod.read(statefulPodNumber, key)
 		if val == "" {
 			return false, nil
@@ -1562,16 +1562,16 @@ func pollReadWithTimeout(statefulPod statefulPodTester, statefulPodNumber int, k
 
 // This function is used by two tests to test StatefulSet rollbacks: one using
 // PVCs and one using no storage.
-func rollbackTest(c clientset.Interface, ns string, ss *appsv1.StatefulSet) {
+func rollbackTest(ctx context.Context, c clientset.Interface, ns string, ss *appsv1.StatefulSet) {
 	setHTTPProbe(ss)
-	ss, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+	ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
-	e2estatefulset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
-	ss = waitForStatus(c, ss)
+	e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
+	ss = waitForStatus(ctx, c, ss)
 	currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 	framework.ExpectEqual(currentRevision, updateRevision, fmt.Sprintf("StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 		ss.Namespace, ss.Name, updateRevision, currentRevision))
-	pods := e2estatefulset.GetPodList(c, ss)
+	pods := e2estatefulset.GetPodList(ctx, c, ss)
 	for i := range pods.Items {
 		framework.ExpectEqual(pods.Items[i].Labels[appsv1.StatefulSetRevisionLabel], currentRevision, fmt.Sprintf("Pod %s/%s revision %s is not equal to current revision %s",
 			pods.Items[i].Namespace,
@@ -1582,29 +1582,29 @@ func rollbackTest(c clientset.Interface, ns string, ss *appsv1.StatefulSet) {
 	e2estatefulset.SortStatefulPods(pods)
 	err = breakPodHTTPProbe(ss, &pods.Items[1])
 	framework.ExpectNoError(err)
-	ss, _ = waitForPodNotReady(c, ss, pods.Items[1].Name)
+	ss, _ = waitForPodNotReady(ctx, c, ss, pods.Items[1].Name)
 	newImage := NewWebserverImage
 	oldImage := ss.Spec.Template.Spec.Containers[0].Image
 
 	ginkgo.By(fmt.Sprintf("Updating StatefulSet template: update image from %s to %s", oldImage, newImage))
 	framework.ExpectNotEqual(oldImage, newImage, "Incorrect test setup: should update to a different image")
-	ss, err = updateStatefulSetWithRetries(c, ns, ss.Name, func(update *appsv1.StatefulSet) {
+	ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 		update.Spec.Template.Spec.Containers[0].Image = newImage
 	})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Creating a new revision")
-	ss = waitForStatus(c, ss)
+	ss = waitForStatus(ctx, c, ss)
 	currentRevision, updateRevision = ss.Status.CurrentRevision, ss.Status.UpdateRevision
 	framework.ExpectNotEqual(currentRevision, updateRevision, "Current revision should not equal update revision during rolling update")
 
 	ginkgo.By("Updating Pods in reverse ordinal order")
-	pods = e2estatefulset.GetPodList(c, ss)
+	pods = e2estatefulset.GetPodList(ctx, c, ss)
 	e2estatefulset.SortStatefulPods(pods)
 	err = restorePodHTTPProbe(ss, &pods.Items[1])
 	framework.ExpectNoError(err)
-	ss, _ = e2estatefulset.WaitForPodReady(c, ss, pods.Items[1].Name)
-	ss, pods = waitForRollingUpdate(c, ss)
+	ss, _ = e2estatefulset.WaitForPodReady(ctx, c, ss, pods.Items[1].Name)
+	ss, pods = waitForRollingUpdate(ctx, c, ss)
 	framework.ExpectEqual(ss.Status.CurrentRevision, updateRevision, fmt.Sprintf("StatefulSet %s/%s current revision %s does not equal update revision %s on update completion",
 		ss.Namespace,
 		ss.Name,
@@ -1626,23 +1626,23 @@ func rollbackTest(c clientset.Interface, ns string, ss *appsv1.StatefulSet) {
 	ginkgo.By("Rolling back to a previous revision")
 	err = breakPodHTTPProbe(ss, &pods.Items[1])
 	framework.ExpectNoError(err)
-	ss, _ = waitForPodNotReady(c, ss, pods.Items[1].Name)
+	ss, _ = waitForPodNotReady(ctx, c, ss, pods.Items[1].Name)
 	priorRevision := currentRevision
-	ss, err = updateStatefulSetWithRetries(c, ns, ss.Name, func(update *appsv1.StatefulSet) {
+	ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 		update.Spec.Template.Spec.Containers[0].Image = oldImage
 	})
 	framework.ExpectNoError(err)
-	ss = waitForStatus(c, ss)
+	ss = waitForStatus(ctx, c, ss)
 	currentRevision, updateRevision = ss.Status.CurrentRevision, ss.Status.UpdateRevision
 	framework.ExpectEqual(priorRevision, updateRevision, "Prior revision should equal update revision during roll back")
 	framework.ExpectNotEqual(currentRevision, updateRevision, "Current revision should not equal update revision during roll back")
 
 	ginkgo.By("Rolling back update in reverse ordinal order")
-	pods = e2estatefulset.GetPodList(c, ss)
+	pods = e2estatefulset.GetPodList(ctx, c, ss)
 	e2estatefulset.SortStatefulPods(pods)
 	restorePodHTTPProbe(ss, &pods.Items[1])
-	ss, _ = e2estatefulset.WaitForPodReady(c, ss, pods.Items[1].Name)
-	ss, pods = waitForRollingUpdate(c, ss)
+	ss, _ = e2estatefulset.WaitForPodReady(ctx, c, ss, pods.Items[1].Name)
+	ss, pods = waitForRollingUpdate(ctx, c, ss)
 	framework.ExpectEqual(ss.Status.CurrentRevision, priorRevision, fmt.Sprintf("StatefulSet %s/%s current revision %s does not equal prior revision %s on rollback completion",
 		ss.Namespace,
 		ss.Name,
@@ -1665,11 +1665,11 @@ func rollbackTest(c clientset.Interface, ns string, ss *appsv1.StatefulSet) {
 
 // confirmStatefulPodCount asserts that the current number of Pods in ss is count, waiting up to timeout for ss to
 // to scale to count.
-func confirmStatefulPodCount(c clientset.Interface, count int, ss *appsv1.StatefulSet, timeout time.Duration, hard bool) {
+func confirmStatefulPodCount(ctx context.Context, c clientset.Interface, count int, ss *appsv1.StatefulSet, timeout time.Duration, hard bool) {
 	start := time.Now()
 	deadline := start.Add(timeout)
-	for t := time.Now(); t.Before(deadline); t = time.Now() {
-		podList := e2estatefulset.GetPodList(c, ss)
+	for t := time.Now(); t.Before(deadline) && ctx.Err() == nil; t = time.Now() {
+		podList := e2estatefulset.GetPodList(ctx, c, ss)
 		statefulPodCount := len(podList.Items)
 		if statefulPodCount != count {
 			e2epod.LogPodStates(podList.Items)
@@ -1694,14 +1694,14 @@ func setHTTPProbe(ss *appsv1.StatefulSet) {
 }
 
 // breakHTTPProbe breaks the readiness probe for Nginx StatefulSet containers in ss.
-func breakHTTPProbe(c clientset.Interface, ss *appsv1.StatefulSet) error {
+func breakHTTPProbe(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet) error {
 	path := httpProbe.HTTPGet.Path
 	if path == "" {
 		return fmt.Errorf("path expected to be not empty: %v", path)
 	}
 	// Ignore 'mv' errors to make this idempotent.
 	cmd := fmt.Sprintf("mv -v /usr/local/apache2/htdocs%v /tmp/ || true", path)
-	return e2estatefulset.ExecInStatefulPods(c, ss, cmd)
+	return e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd)
 }
 
 // breakPodHTTPProbe breaks the readiness probe for Nginx StatefulSet containers in one pod.
@@ -1718,14 +1718,14 @@ func breakPodHTTPProbe(ss *appsv1.StatefulSet, pod *v1.Pod) error {
 }
 
 // restoreHTTPProbe restores the readiness probe for Nginx StatefulSet containers in ss.
-func restoreHTTPProbe(c clientset.Interface, ss *appsv1.StatefulSet) error {
+func restoreHTTPProbe(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet) error {
 	path := httpProbe.HTTPGet.Path
 	if path == "" {
 		return fmt.Errorf("path expected to be not empty: %v", path)
 	}
 	// Ignore 'mv' errors to make this idempotent.
 	cmd := fmt.Sprintf("mv -v /tmp%v /usr/local/apache2/htdocs/ || true", path)
-	return e2estatefulset.ExecInStatefulPods(c, ss, cmd)
+	return e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd)
 }
 
 // restorePodHTTPProbe restores the readiness probe for Nginx StatefulSet containers in pod.
@@ -1742,10 +1742,10 @@ func restorePodHTTPProbe(ss *appsv1.StatefulSet, pod *v1.Pod) error {
 }
 
 // deleteStatefulPodAtIndex deletes the Pod with ordinal index in ss.
-func deleteStatefulPodAtIndex(c clientset.Interface, index int, ss *appsv1.StatefulSet) {
+func deleteStatefulPodAtIndex(ctx context.Context, c clientset.Interface, index int, ss *appsv1.StatefulSet) {
 	name := getStatefulSetPodNameAtIndex(index, ss)
 	noGrace := int64(0)
-	if err := c.CoreV1().Pods(ss.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{GracePeriodSeconds: &noGrace}); err != nil {
+	if err := c.CoreV1().Pods(ss.Namespace).Delete(ctx, name, metav1.DeleteOptions{GracePeriodSeconds: &noGrace}); err != nil {
 		framework.Failf("Failed to delete stateful pod %v for StatefulSet %v/%v: %v", name, ss.Namespace, ss.Name, err)
 	}
 }
@@ -1760,16 +1760,16 @@ func getStatefulSetPodNameAtIndex(index int, ss *appsv1.StatefulSet) string {
 type updateStatefulSetFunc func(*appsv1.StatefulSet)
 
 // updateStatefulSetWithRetries updates statfulset template with retries.
-func updateStatefulSetWithRetries(c clientset.Interface, namespace, name string, applyUpdate updateStatefulSetFunc) (statefulSet *appsv1.StatefulSet, err error) {
+func updateStatefulSetWithRetries(ctx context.Context, c clientset.Interface, namespace, name string, applyUpdate updateStatefulSetFunc) (statefulSet *appsv1.StatefulSet, err error) {
 	statefulSets := c.AppsV1().StatefulSets(namespace)
 	var updateErr error
-	pollErr := wait.Poll(10*time.Millisecond, 1*time.Minute, func() (bool, error) {
-		if statefulSet, err = statefulSets.Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
+	pollErr := wait.PollWithContext(ctx, 10*time.Millisecond, 1*time.Minute, func(ctx context.Context) (bool, error) {
+		if statefulSet, err = statefulSets.Get(ctx, name, metav1.GetOptions{}); err != nil {
 			return false, err
 		}
 		// Apply the update, then attempt to push it to the apiserver.
 		applyUpdate(statefulSet)
-		if statefulSet, err = statefulSets.Update(context.TODO(), statefulSet, metav1.UpdateOptions{}); err == nil {
+		if statefulSet, err = statefulSets.Update(ctx, statefulSet, metav1.UpdateOptions{}); err == nil {
 			framework.Logf("Updating stateful set %s", name)
 			return true, nil
 		}
@@ -1783,8 +1783,8 @@ func updateStatefulSetWithRetries(c clientset.Interface, namespace, name string,
 }
 
 // getStatefulSet gets the StatefulSet named name in namespace.
-func getStatefulSet(c clientset.Interface, namespace, name string) *appsv1.StatefulSet {
-	ss, err := c.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func getStatefulSet(ctx context.Context, c clientset.Interface, namespace, name string) *appsv1.StatefulSet {
+	ss, err := c.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		framework.Failf("Failed to get StatefulSet %s/%s: %v", namespace, name, err)
 	}
@@ -1792,13 +1792,13 @@ func getStatefulSet(c clientset.Interface, namespace, name string) *appsv1.State
 }
 
 // verifyStatefulSetPVCsExist confirms that exactly the PVCs for ss with the specified ids exist. This polls until the situation occurs, an error happens, or until timeout (in the latter case an error is also returned). Beware that this cannot tell if a PVC will be deleted at some point in the future, so if used to confirm that no PVCs are deleted, the caller should wait for some event giving the PVCs a reasonable chance to be deleted, before calling this function.
-func verifyStatefulSetPVCsExist(c clientset.Interface, ss *appsv1.StatefulSet, claimIds []int) error {
+func verifyStatefulSetPVCsExist(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, claimIds []int) error {
 	idSet := map[int]struct{}{}
 	for _, id := range claimIds {
 		idSet[id] = struct{}{}
 	}
 	return wait.PollImmediate(e2estatefulset.StatefulSetPoll, e2estatefulset.StatefulSetTimeout, func() (bool, error) {
-		pvcList, err := c.CoreV1().PersistentVolumeClaims(ss.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: klabels.Everything().String()})
+		pvcList, err := c.CoreV1().PersistentVolumeClaims(ss.Namespace).List(ctx, metav1.ListOptions{LabelSelector: klabels.Everything().String()})
 		if err != nil {
 			framework.Logf("WARNING: Failed to list pvcs for verification, retrying: %v", err)
 			return false, nil
@@ -1832,18 +1832,18 @@ func verifyStatefulSetPVCsExist(c clientset.Interface, ss *appsv1.StatefulSet, c
 }
 
 // verifyStatefulSetPVCsExistWithOwnerRefs works as verifyStatefulSetPVCsExist, but also waits for the ownerRefs to match.
-func verifyStatefulSetPVCsExistWithOwnerRefs(c clientset.Interface, ss *appsv1.StatefulSet, claimIndicies []int, wantSetRef, wantPodRef bool) error {
+func verifyStatefulSetPVCsExistWithOwnerRefs(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, claimIndicies []int, wantSetRef, wantPodRef bool) error {
 	indexSet := map[int]struct{}{}
 	for _, id := range claimIndicies {
 		indexSet[id] = struct{}{}
 	}
-	set := getStatefulSet(c, ss.Namespace, ss.Name)
+	set := getStatefulSet(ctx, c, ss.Namespace, ss.Name)
 	setUID := set.GetUID()
 	if setUID == "" {
 		framework.Failf("Statefulset %s missing UID", ss.Name)
 	}
 	return wait.PollImmediate(e2estatefulset.StatefulSetPoll, e2estatefulset.StatefulSetTimeout, func() (bool, error) {
-		pvcList, err := c.CoreV1().PersistentVolumeClaims(ss.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: klabels.Everything().String()})
+		pvcList, err := c.CoreV1().PersistentVolumeClaims(ss.Namespace).List(ctx, metav1.ListOptions{LabelSelector: klabels.Everything().String()})
 		if err != nil {
 			framework.Logf("WARNING: Failed to list pvcs for verification, retrying: %v", err)
 			return false, nil
@@ -1872,7 +1872,7 @@ func verifyStatefulSetPVCsExistWithOwnerRefs(c clientset.Interface, ss *appsv1.S
 					}
 					if ref.Kind == "Pod" {
 						podName := fmt.Sprintf("%s-%d", ss.Name, ordinal)
-						pod, err := c.CoreV1().Pods(ss.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+						pod, err := c.CoreV1().Pods(ss.Namespace).Get(ctx, podName, metav1.GetOptions{})
 						if err != nil {
 							framework.Logf("Pod %s not found, retrying (%v)", podName, err)
 							return false, nil

--- a/test/e2e/apps/ttl_after_finished.go
+++ b/test/e2e/apps/ttl_after_finished.go
@@ -46,11 +46,11 @@ var _ = SIGDescribe("TTLAfterFinished", func() {
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 
 	ginkgo.It("job should be deleted once it finishes after TTL seconds", func(ctx context.Context) {
-		testFinishedJob(f)
+		testFinishedJob(ctx, f)
 	})
 })
 
-func cleanupJob(f *framework.Framework, job *batchv1.Job) {
+func cleanupJob(ctx context.Context, f *framework.Framework, job *batchv1.Job) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 
@@ -58,15 +58,15 @@ func cleanupJob(f *framework.Framework, job *batchv1.Job) {
 	removeFinalizerFunc := func(j *batchv1.Job) {
 		j.ObjectMeta.Finalizers = slice.RemoveString(j.ObjectMeta.Finalizers, dummyFinalizer, nil)
 	}
-	_, err := updateJobWithRetries(c, ns, job.Name, removeFinalizerFunc)
+	_, err := updateJobWithRetries(ctx, c, ns, job.Name, removeFinalizerFunc)
 	framework.ExpectNoError(err)
-	e2ejob.WaitForJobGone(c, ns, job.Name, wait.ForeverTestTimeout)
+	e2ejob.WaitForJobGone(ctx, c, ns, job.Name, wait.ForeverTestTimeout)
 
-	err = e2ejob.WaitForAllJobPodsGone(c, ns, job.Name)
+	err = e2ejob.WaitForAllJobPodsGone(ctx, c, ns, job.Name)
 	framework.ExpectNoError(err)
 }
 
-func testFinishedJob(f *framework.Framework) {
+func testFinishedJob(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 
@@ -81,19 +81,19 @@ func testFinishedJob(f *framework.Framework) {
 	ginkgo.DeferCleanup(cleanupJob, f, job)
 
 	framework.Logf("Create a Job %s/%s with TTL", ns, job.Name)
-	job, err := e2ejob.CreateJob(c, ns, job)
+	job, err := e2ejob.CreateJob(ctx, c, ns, job)
 	framework.ExpectNoError(err)
 
 	framework.Logf("Wait for the Job to finish")
-	err = e2ejob.WaitForJobFinish(c, ns, job.Name)
+	err = e2ejob.WaitForJobFinish(ctx, c, ns, job.Name)
 	framework.ExpectNoError(err)
 
 	framework.Logf("Wait for TTL after finished controller to delete the Job")
-	err = waitForJobDeleting(c, ns, job.Name)
+	err = waitForJobDeleting(ctx, c, ns, job.Name)
 	framework.ExpectNoError(err)
 
 	framework.Logf("Check Job's deletionTimestamp and compare with the time when the Job finished")
-	job, err = e2ejob.GetJob(c, ns, job.Name)
+	job, err = e2ejob.GetJob(ctx, c, ns, job.Name)
 	framework.ExpectNoError(err)
 	jobFinishTime := finishTime(job)
 	finishTimeUTC := jobFinishTime.UTC()
@@ -118,16 +118,16 @@ func finishTime(finishedJob *batchv1.Job) metav1.Time {
 }
 
 // updateJobWithRetries updates job with retries.
-func updateJobWithRetries(c clientset.Interface, namespace, name string, applyUpdate func(*batchv1.Job)) (job *batchv1.Job, err error) {
+func updateJobWithRetries(ctx context.Context, c clientset.Interface, namespace, name string, applyUpdate func(*batchv1.Job)) (job *batchv1.Job, err error) {
 	jobs := c.BatchV1().Jobs(namespace)
 	var updateErr error
-	pollErr := wait.PollImmediate(framework.Poll, JobTimeout, func() (bool, error) {
-		if job, err = jobs.Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
+	pollErr := wait.PollImmediateWithContext(ctx, framework.Poll, JobTimeout, func(ctx context.Context) (bool, error) {
+		if job, err = jobs.Get(ctx, name, metav1.GetOptions{}); err != nil {
 			return false, err
 		}
 		// Apply the update, then attempt to push it to the apiserver.
 		applyUpdate(job)
-		if job, err = jobs.Update(context.TODO(), job, metav1.UpdateOptions{}); err == nil {
+		if job, err = jobs.Update(ctx, job, metav1.UpdateOptions{}); err == nil {
 			framework.Logf("Updating job %s", name)
 			return true, nil
 		}
@@ -142,9 +142,9 @@ func updateJobWithRetries(c clientset.Interface, namespace, name string, applyUp
 
 // waitForJobDeleting uses c to wait for the Job jobName in namespace ns to have
 // a non-nil deletionTimestamp (i.e. being deleted).
-func waitForJobDeleting(c clientset.Interface, ns, jobName string) error {
-	return wait.PollImmediate(framework.Poll, JobTimeout, func() (bool, error) {
-		curr, err := c.BatchV1().Jobs(ns).Get(context.TODO(), jobName, metav1.GetOptions{})
+func waitForJobDeleting(ctx context.Context, c clientset.Interface, ns, jobName string) error {
+	return wait.PollImmediateWithContext(ctx, framework.Poll, JobTimeout, func(ctx context.Context) (bool, error) {
+		curr, err := c.BatchV1().Jobs(ns).Get(ctx, jobName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/apps/wait.go
+++ b/test/e2e/apps/wait.go
@@ -17,6 +17,8 @@ limitations under the License.
 package apps
 
 import (
+	"context"
+
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -30,7 +32,7 @@ import (
 // a RollingUpdateStatefulSetStrategyType with a non-nil RollingUpdate and Partition. All Pods with ordinals less
 // than or equal to the Partition are expected to be at set's current revision. All other Pods are expected to be
 // at its update revision.
-func waitForPartitionedRollingUpdate(c clientset.Interface, set *appsv1.StatefulSet) (*appsv1.StatefulSet, *v1.PodList) {
+func waitForPartitionedRollingUpdate(ctx context.Context, c clientset.Interface, set *appsv1.StatefulSet) (*appsv1.StatefulSet, *v1.PodList) {
 	var pods *v1.PodList
 	if set.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
 		framework.Failf("StatefulSet %s/%s attempt to wait for partitioned update with updateStrategy %s",
@@ -43,7 +45,7 @@ func waitForPartitionedRollingUpdate(c clientset.Interface, set *appsv1.Stateful
 			set.Namespace,
 			set.Name)
 	}
-	e2estatefulset.WaitForState(c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
+	e2estatefulset.WaitForState(ctx, c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
 		set = set2
 		pods = pods2
 		partition := int(*set.Spec.UpdateStrategy.RollingUpdate.Partition)
@@ -84,8 +86,8 @@ func waitForPartitionedRollingUpdate(c clientset.Interface, set *appsv1.Stateful
 
 // waitForStatus waits for the StatefulSetStatus's ObservedGeneration to be greater than or equal to set's Generation.
 // The returned StatefulSet contains such a StatefulSetStatus
-func waitForStatus(c clientset.Interface, set *appsv1.StatefulSet) *appsv1.StatefulSet {
-	e2estatefulset.WaitForState(c, set, func(set2 *appsv1.StatefulSet, pods *v1.PodList) (bool, error) {
+func waitForStatus(ctx context.Context, c clientset.Interface, set *appsv1.StatefulSet) *appsv1.StatefulSet {
+	e2estatefulset.WaitForState(ctx, c, set, func(set2 *appsv1.StatefulSet, pods *v1.PodList) (bool, error) {
 		if set2.Status.ObservedGeneration >= set.Generation {
 			set = set2
 			return true, nil
@@ -96,9 +98,9 @@ func waitForStatus(c clientset.Interface, set *appsv1.StatefulSet) *appsv1.State
 }
 
 // waitForPodNotReady waits for the Pod named podName in set to exist and to not have a Ready condition.
-func waitForPodNotReady(c clientset.Interface, set *appsv1.StatefulSet, podName string) (*appsv1.StatefulSet, *v1.PodList) {
+func waitForPodNotReady(ctx context.Context, c clientset.Interface, set *appsv1.StatefulSet, podName string) (*appsv1.StatefulSet, *v1.PodList) {
 	var pods *v1.PodList
-	e2estatefulset.WaitForState(c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
+	e2estatefulset.WaitForState(ctx, c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
 		set = set2
 		pods = pods2
 		for i := range pods.Items {
@@ -113,7 +115,7 @@ func waitForPodNotReady(c clientset.Interface, set *appsv1.StatefulSet, podName 
 
 // waitForRollingUpdate waits for all Pods in set to exist and have the correct revision and for the RollingUpdate to
 // complete. set must have a RollingUpdateStatefulSetStrategyType.
-func waitForRollingUpdate(c clientset.Interface, set *appsv1.StatefulSet) (*appsv1.StatefulSet, *v1.PodList) {
+func waitForRollingUpdate(ctx context.Context, c clientset.Interface, set *appsv1.StatefulSet) (*appsv1.StatefulSet, *v1.PodList) {
 	var pods *v1.PodList
 	if set.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
 		framework.Failf("StatefulSet %s/%s attempt to wait for rolling update with updateStrategy %s",
@@ -121,7 +123,7 @@ func waitForRollingUpdate(c clientset.Interface, set *appsv1.StatefulSet) (*apps
 			set.Name,
 			set.Spec.UpdateStrategy.Type)
 	}
-	e2estatefulset.WaitForState(c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
+	e2estatefulset.WaitForState(ctx, c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
 		set = set2
 		pods = pods2
 		if len(pods.Items) < int(*set.Spec.Replicas) {
@@ -150,6 +152,6 @@ func waitForRollingUpdate(c clientset.Interface, set *appsv1.StatefulSet) (*apps
 }
 
 // waitForRunningAndNotReady waits for numStatefulPods in ss to be Running and not Ready.
-func waitForRunningAndNotReady(c clientset.Interface, numStatefulPods int32, ss *appsv1.StatefulSet) {
-	e2estatefulset.WaitForRunning(c, numStatefulPods, 0, ss)
+func waitForRunningAndNotReady(ctx context.Context, c clientset.Interface, numStatefulPods int32, ss *appsv1.StatefulSet) {
+	e2estatefulset.WaitForRunning(ctx, c, numStatefulPods, 0, ss)
 }

--- a/test/e2e/architecture/conformance.go
+++ b/test/e2e/architecture/conformance.go
@@ -38,8 +38,8 @@ var _ = SIGDescribe("Conformance Tests", func() {
 	*/
 	framework.ConformanceIt("should have at least two untainted nodes", func(ctx context.Context) {
 		ginkgo.By("Getting node addresses")
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(f.ClientSet, 10*time.Minute))
-		nodeList, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 10*time.Minute))
+		nodeList, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 		if len(nodeList.Items) < 2 {
 			framework.Failf("Conformance requires at least two nodes")

--- a/test/e2e/auth/certificates.go
+++ b/test/e2e/auth/certificates.go
@@ -90,7 +90,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		}
 
 		// Grant permissions to the new user
-		clusterRole, err := f.ClientSet.RbacV1().ClusterRoles().Create(context.TODO(), &rbacv1.ClusterRole{
+		clusterRole, err := f.ClientSet.RbacV1().ClusterRoles().Create(ctx, &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: commonName + "-"},
 			Rules:      []rbacv1.PolicyRule{{Verbs: []string{"create"}, APIGroups: []string{"certificates.k8s.io"}, Resources: []string{"certificatesigningrequests"}}},
 		}, metav1.CreateOptions{})
@@ -99,11 +99,11 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 			framework.Logf("error granting permissions to %s, create certificatesigningrequests permissions must be granted out of band: %v", commonName, err)
 		} else {
 			defer func() {
-				framework.ExpectNoError(f.ClientSet.RbacV1().ClusterRoles().Delete(context.TODO(), clusterRole.Name, metav1.DeleteOptions{}))
+				framework.ExpectNoError(f.ClientSet.RbacV1().ClusterRoles().Delete(ctx, clusterRole.Name, metav1.DeleteOptions{}))
 			}()
 		}
 
-		clusterRoleBinding, err := f.ClientSet.RbacV1().ClusterRoleBindings().Create(context.TODO(), &rbacv1.ClusterRoleBinding{
+		clusterRoleBinding, err := f.ClientSet.RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: commonName + "-"},
 			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: clusterRole.Name},
 			Subjects:   []rbacv1.Subject{{APIGroup: "rbac.authorization.k8s.io", Kind: "User", Name: commonName}},
@@ -113,15 +113,15 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 			framework.Logf("error granting permissions to %s, create certificatesigningrequests permissions must be granted out of band: %v", commonName, err)
 		} else {
 			defer func() {
-				framework.ExpectNoError(f.ClientSet.RbacV1().ClusterRoleBindings().Delete(context.TODO(), clusterRoleBinding.Name, metav1.DeleteOptions{}))
+				framework.ExpectNoError(f.ClientSet.RbacV1().ClusterRoleBindings().Delete(ctx, clusterRoleBinding.Name, metav1.DeleteOptions{}))
 			}()
 		}
 
 		framework.Logf("creating CSR")
-		csr, err := csrClient.Create(context.TODO(), csrTemplate, metav1.CreateOptions{})
+		csr, err := csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		defer func() {
-			framework.ExpectNoError(csrClient.Delete(context.TODO(), csr.Name, metav1.DeleteOptions{}))
+			framework.ExpectNoError(csrClient.Delete(ctx, csr.Name, metav1.DeleteOptions{}))
 		}()
 
 		framework.Logf("approving CSR")
@@ -134,9 +134,9 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 					Message: "Set from an e2e test",
 				},
 			}
-			csr, err = csrClient.UpdateApproval(context.TODO(), csr.Name, csr, metav1.UpdateOptions{})
+			csr, err = csrClient.UpdateApproval(ctx, csr.Name, csr, metav1.UpdateOptions{})
 			if err != nil {
-				csr, _ = csrClient.Get(context.TODO(), csr.Name, metav1.GetOptions{})
+				csr, _ = csrClient.Get(ctx, csr.Name, metav1.GetOptions{})
 				framework.Logf("err updating approval: %v", err)
 				return false, nil
 			}
@@ -145,7 +145,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 
 		framework.Logf("waiting for CSR to be signed")
 		framework.ExpectNoError(wait.Poll(5*time.Second, time.Minute, func() (bool, error) {
-			csr, err = csrClient.Get(context.TODO(), csr.Name, metav1.GetOptions{})
+			csr, err = csrClient.Get(ctx, csr.Name, metav1.GetOptions{})
 			if err != nil {
 				framework.Logf("error getting csr: %v", err)
 				return false, nil
@@ -177,10 +177,10 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err)
 
 		framework.Logf("creating CSR as new client")
-		newCSR, err := newClient.CertificateSigningRequests().Create(context.TODO(), csrTemplate, metav1.CreateOptions{})
+		newCSR, err := newClient.CertificateSigningRequests().Create(ctx, csrTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		defer func() {
-			framework.ExpectNoError(csrClient.Delete(context.TODO(), newCSR.Name, metav1.DeleteOptions{}))
+			framework.ExpectNoError(csrClient.Delete(ctx, newCSR.Name, metav1.DeleteOptions{}))
 		}()
 		framework.ExpectEqual(newCSR.Spec.Username, commonName)
 	})
@@ -251,7 +251,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		ginkgo.By("getting /apis/certificates.k8s.io")
 		{
 			group := &metav1.APIGroup{}
-			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/certificates.k8s.io").Do(context.TODO()).Into(group)
+			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/certificates.k8s.io").Do(ctx).Into(group)
 			framework.ExpectNoError(err)
 			found := false
 			for _, version := range group.Versions {
@@ -294,38 +294,38 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		// Main resource create/read/update/watch operations
 
 		ginkgo.By("creating")
-		_, err = csrClient.Create(context.TODO(), csrTemplate, metav1.CreateOptions{})
+		_, err = csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		_, err = csrClient.Create(context.TODO(), csrTemplate, metav1.CreateOptions{})
+		_, err = csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		createdCSR, err := csrClient.Create(context.TODO(), csrTemplate, metav1.CreateOptions{})
+		createdCSR, err := csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("getting")
-		gottenCSR, err := csrClient.Get(context.TODO(), createdCSR.Name, metav1.GetOptions{})
+		gottenCSR, err := csrClient.Get(ctx, createdCSR.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(gottenCSR.UID, createdCSR.UID)
 		framework.ExpectEqual(gottenCSR.Spec.ExpirationSeconds, csr.DurationToExpirationSeconds(time.Hour))
 
 		ginkgo.By("listing")
-		csrs, err := csrClient.List(context.TODO(), metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})
+		csrs, err := csrClient.List(ctx, metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(csrs.Items), 3, "filtered list should have 3 items")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
-		csrWatch, err := csrClient.Watch(context.TODO(), metav1.ListOptions{ResourceVersion: csrs.ResourceVersion, FieldSelector: "metadata.name=" + createdCSR.Name})
+		csrWatch, err := csrClient.Watch(ctx, metav1.ListOptions{ResourceVersion: csrs.ResourceVersion, FieldSelector: "metadata.name=" + createdCSR.Name})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("patching")
-		patchedCSR, err := csrClient.Patch(context.TODO(), createdCSR.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
+		patchedCSR, err := csrClient.Patch(ctx, createdCSR.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(patchedCSR.Annotations["patched"], "true", "patched object should have the applied annotation")
 
 		ginkgo.By("updating")
 		csrToUpdate := patchedCSR.DeepCopy()
 		csrToUpdate.Annotations["updated"] = "true"
-		updatedCSR, err := csrClient.Update(context.TODO(), csrToUpdate, metav1.UpdateOptions{})
+		updatedCSR, err := csrClient.Update(ctx, csrToUpdate, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(updatedCSR.Annotations["updated"], "true", "updated object should have the applied annotation")
 
@@ -356,13 +356,13 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		// /approval subresource operations
 
 		ginkgo.By("getting /approval")
-		gottenApproval, err := f.DynamicClient.Resource(csrResource).Get(context.TODO(), createdCSR.Name, metav1.GetOptions{}, "approval")
+		gottenApproval, err := f.DynamicClient.Resource(csrResource).Get(ctx, createdCSR.Name, metav1.GetOptions{}, "approval")
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(gottenApproval.GetObjectKind().GroupVersionKind(), certificatesv1.SchemeGroupVersion.WithKind("CertificateSigningRequest"))
 		framework.ExpectEqual(gottenApproval.GetUID(), createdCSR.UID)
 
 		ginkgo.By("patching /approval")
-		patchedApproval, err := csrClient.Patch(context.TODO(), createdCSR.Name, types.MergePatchType,
+		patchedApproval, err := csrClient.Patch(ctx, createdCSR.Name, types.MergePatchType,
 			[]byte(`{"metadata":{"annotations":{"patchedapproval":"true"}},"status":{"conditions":[{"type":"ApprovalPatch","status":"True","reason":"e2e"}]}}`),
 			metav1.PatchOptions{}, "approval")
 		framework.ExpectNoError(err)
@@ -378,7 +378,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 			Reason:  "E2E",
 			Message: "Set from an e2e test",
 		})
-		updatedApproval, err := csrClient.UpdateApproval(context.TODO(), approvalToUpdate.Name, approvalToUpdate, metav1.UpdateOptions{})
+		updatedApproval, err := csrClient.UpdateApproval(ctx, approvalToUpdate.Name, approvalToUpdate, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(updatedApproval.Status.Conditions), 2, fmt.Sprintf("updated object should have the applied condition, got %#v", updatedApproval.Status.Conditions))
 		framework.ExpectEqual(updatedApproval.Status.Conditions[1].Type, certificatesv1.CertificateApproved, fmt.Sprintf("updated object should have the approved condition, got %#v", updatedApproval.Status.Conditions))
@@ -386,13 +386,13 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		// /status subresource operations
 
 		ginkgo.By("getting /status")
-		gottenStatus, err := f.DynamicClient.Resource(csrResource).Get(context.TODO(), createdCSR.Name, metav1.GetOptions{}, "status")
+		gottenStatus, err := f.DynamicClient.Resource(csrResource).Get(ctx, createdCSR.Name, metav1.GetOptions{}, "status")
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(gottenStatus.GetObjectKind().GroupVersionKind(), certificatesv1.SchemeGroupVersion.WithKind("CertificateSigningRequest"))
 		framework.ExpectEqual(gottenStatus.GetUID(), createdCSR.UID)
 
 		ginkgo.By("patching /status")
-		patchedStatus, err := csrClient.Patch(context.TODO(), createdCSR.Name, types.MergePatchType,
+		patchedStatus, err := csrClient.Patch(ctx, createdCSR.Name, types.MergePatchType,
 			[]byte(`{"metadata":{"annotations":{"patchedstatus":"true"}},"status":{"certificate":`+string(certificateDataJSON)+`}}`),
 			metav1.PatchOptions{}, "status")
 		framework.ExpectNoError(err)
@@ -407,7 +407,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 			Reason:  "E2E",
 			Message: "Set from an e2e test",
 		})
-		updatedStatus, err := csrClient.UpdateStatus(context.TODO(), statusToUpdate, metav1.UpdateOptions{})
+		updatedStatus, err := csrClient.UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(updatedStatus.Status.Conditions), len(statusToUpdate.Status.Conditions), fmt.Sprintf("updated object should have the applied condition, got %#v", updatedStatus.Status.Conditions))
 		framework.ExpectEqual(string(updatedStatus.Status.Conditions[len(updatedStatus.Status.Conditions)-1].Type), "StatusUpdate", fmt.Sprintf("updated object should have the approved condition, got %#v", updatedStatus.Status.Conditions))
@@ -415,20 +415,20 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		// main resource delete operations
 
 		ginkgo.By("deleting")
-		err = csrClient.Delete(context.TODO(), createdCSR.Name, metav1.DeleteOptions{})
+		err = csrClient.Delete(ctx, createdCSR.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
-		_, err = csrClient.Get(context.TODO(), createdCSR.Name, metav1.GetOptions{})
+		_, err = csrClient.Get(ctx, createdCSR.Name, metav1.GetOptions{})
 		if !apierrors.IsNotFound(err) {
 			framework.Failf("expected 404, got %#v", err)
 		}
-		csrs, err = csrClient.List(context.TODO(), metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})
+		csrs, err = csrClient.List(ctx, metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(csrs.Items), 2, "filtered list should have 2 items")
 
 		ginkgo.By("deleting a collection")
-		err = csrClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})
+		err = csrClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})
 		framework.ExpectNoError(err)
-		csrs, err = csrClient.List(context.TODO(), metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})
+		csrs, err = csrClient.List(ctx, metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(csrs.Items), 0, "filtered list should have 0 items")
 	})

--- a/test/e2e/auth/selfsubjectreviews.go
+++ b/test/e2e/auth/selfsubjectreviews.go
@@ -69,7 +69,7 @@ var _ = SIGDescribe("SelfSubjectReview [Feature:APISelfSubjectReview]", func() {
 		ginkgo.By("getting /apis/authentication.k8s.io")
 		{
 			group := &metav1.APIGroup{}
-			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/authentication.k8s.io").Do(context.TODO()).Into(group)
+			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/authentication.k8s.io").Do(ctx).Into(group)
 			framework.ExpectNoError(err)
 			found := false
 			for _, version := range group.Versions {
@@ -112,7 +112,7 @@ var _ = SIGDescribe("SelfSubjectReview [Feature:APISelfSubjectReview]", func() {
 			}
 
 			ssrClient := kubernetes.NewForConfigOrDie(config).AuthenticationV1alpha1().SelfSubjectReviews()
-			res, err := ssrClient.Create(context.TODO(), &authenticationv1alpha1.SelfSubjectReview{}, metav1.CreateOptions{})
+			res, err := ssrClient.Create(ctx, &authenticationv1alpha1.SelfSubjectReview{}, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 
 			framework.ExpectEqual(config.Impersonate.UserName, res.Status.UserInfo.Username)

--- a/test/e2e/autoscaling/autoscaling_timer.go
+++ b/test/e2e/autoscaling/autoscaling_timer.go
@@ -39,9 +39,9 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 	var experiment *gmeasure.Experiment
 
 	ginkgo.Describe("Autoscaling a service", func() {
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			// Check if Cloud Autoscaler is enabled by trying to get its ConfigMap.
-			_, err := f.ClientSet.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "cluster-autoscaler-status", metav1.GetOptions{})
+			_, err := f.ClientSet.CoreV1().ConfigMaps("kube-system").Get(ctx, "cluster-autoscaler-status", metav1.GetOptions{})
 			if err != nil {
 				e2eskipper.Skipf("test expects Cluster Autoscaler to be enabled")
 			}
@@ -54,7 +54,7 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 			var nodeGroupName string // Set by BeforeEach, used by AfterEach to scale this node group down after the test.
 			var nodes *v1.NodeList   // Set by BeforeEach, used by Measure to calculate CPU request based on node's sizes.
 
-			ginkgo.BeforeEach(func() {
+			ginkgo.BeforeEach(func(ctx context.Context) {
 				// Make sure there is only 1 node group, otherwise this test becomes useless.
 				nodeGroups := strings.Split(framework.TestContext.CloudConfig.NodeInstanceGroup, ",")
 				if len(nodeGroups) != 1 {
@@ -70,19 +70,19 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 				}
 
 				// Make sure all nodes are schedulable, otherwise we are in some kind of a problem state.
-				nodes, err = e2enode.GetReadySchedulableNodes(f.ClientSet)
+				nodes, err = e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
 				framework.ExpectNoError(err)
 				schedulableCount := len(nodes.Items)
 				framework.ExpectEqual(schedulableCount, nodeGroupSize, "not all nodes are schedulable")
 			})
 
-			ginkgo.AfterEach(func() {
+			ginkgo.AfterEach(func(ctx context.Context) {
 				// Attempt cleanup only if a node group was targeted for scale up.
 				// Otherwise the test was probably skipped and we'll get a gcloud error due to invalid parameters.
 				if len(nodeGroupName) > 0 {
 					// Scale down back to only 'nodesNum' nodes, as expected at the start of the test.
 					framework.ExpectNoError(framework.ResizeGroup(nodeGroupName, nodesNum))
-					framework.ExpectNoError(e2enode.WaitForReadyNodes(f.ClientSet, nodesNum, 15*time.Minute))
+					framework.ExpectNoError(e2enode.WaitForReadyNodes(ctx, f.ClientSet, nodesNum, 15*time.Minute))
 				}
 			})
 
@@ -102,21 +102,21 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 				nodeMemoryMB := (&nodeMemoryBytes).Value() / 1024 / 1024
 				memRequestMB := nodeMemoryMB / 10 // Ensure each pod takes not more than 10% of node's allocatable memory.
 				replicas := 1
-				resourceConsumer := e2eautoscaling.NewDynamicResourceConsumer("resource-consumer", f.Namespace.Name, e2eautoscaling.KindDeployment, replicas, 0, 0, 0, cpuRequestMillis, memRequestMB, f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle)
+				resourceConsumer := e2eautoscaling.NewDynamicResourceConsumer(ctx, "resource-consumer", f.Namespace.Name, e2eautoscaling.KindDeployment, replicas, 0, 0, 0, cpuRequestMillis, memRequestMB, f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle)
 				ginkgo.DeferCleanup(resourceConsumer.CleanUp)
-				resourceConsumer.WaitForReplicas(replicas, 1*time.Minute) // Should finish ~immediately, so 1 minute is more than enough.
+				resourceConsumer.WaitForReplicas(ctx, replicas, 1*time.Minute) // Should finish ~immediately, so 1 minute is more than enough.
 
 				// Enable Horizontal Pod Autoscaler with 50% target utilization and
 				// scale up the CPU usage to trigger autoscaling to 8 pods for target to be satisfied.
 				targetCPUUtilizationPercent := int32(50)
-				hpa := e2eautoscaling.CreateCPUResourceHorizontalPodAutoscaler(resourceConsumer, targetCPUUtilizationPercent, 1, 10)
+				hpa := e2eautoscaling.CreateCPUResourceHorizontalPodAutoscaler(ctx, resourceConsumer, targetCPUUtilizationPercent, 1, 10)
 				ginkgo.DeferCleanup(e2eautoscaling.DeleteHorizontalPodAutoscaler, resourceConsumer, hpa.Name)
 				cpuLoad := 8 * cpuRequestMillis * int64(targetCPUUtilizationPercent) / 100 // 8 pods utilized to the target level
 				resourceConsumer.ConsumeCPU(int(cpuLoad))
 
 				// Measure the time it takes for the service to scale to 8 pods with 50% CPU utilization each.
 				experiment.SampleDuration("total scale-up time", func(idx int) {
-					resourceConsumer.WaitForReplicas(8, timeToWait)
+					resourceConsumer.WaitForReplicas(ctx, 8, timeToWait)
 				}, gmeasure.SamplingConfig{N: 1})
 			}) // Increase to run the test more than once.
 		})

--- a/test/e2e/autoscaling/cluster_autoscaler_scalability.go
+++ b/test/e2e/autoscaling/cluster_autoscaler_scalability.go
@@ -70,11 +70,11 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 	var originalSizes map[string]int
 	var sum int
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		e2eskipper.SkipUnlessProviderIs("gce", "gke", "kubemark")
 
 		// Check if Cloud Autoscaler is enabled by trying to get its ConfigMap.
-		_, err := f.ClientSet.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "cluster-autoscaler-status", metav1.GetOptions{})
+		_, err := f.ClientSet.CoreV1().ConfigMaps("kube-system").Get(ctx, "cluster-autoscaler-status", metav1.GetOptions{})
 		if err != nil {
 			e2eskipper.Skipf("test expects Cluster Autoscaler to be enabled")
 		}
@@ -92,9 +92,9 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 			}
 		}
 
-		framework.ExpectNoError(e2enode.WaitForReadyNodes(c, sum, scaleUpTimeout))
+		framework.ExpectNoError(e2enode.WaitForReadyNodes(ctx, c, sum, scaleUpTimeout))
 
-		nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+		nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 		nodeCount = len(nodes.Items)
 		cpu := nodes.Items[0].Status.Capacity[v1.ResourceCPU]
@@ -114,17 +114,17 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 		}
 	})
 
-	ginkgo.AfterEach(func() {
+	ginkgo.AfterEach(func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Restoring initial size of the cluster"))
 		setMigSizes(originalSizes)
-		framework.ExpectNoError(e2enode.WaitForReadyNodes(c, nodeCount, scaleDownTimeout))
-		nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		framework.ExpectNoError(e2enode.WaitForReadyNodes(ctx, c, nodeCount, scaleDownTimeout))
+		nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err)
 		s := time.Now()
 	makeSchedulableLoop:
 		for start := time.Now(); time.Since(start) < makeSchedulableTimeout; time.Sleep(makeSchedulableDelay) {
 			for _, n := range nodes.Items {
-				err = makeNodeSchedulable(c, &n, true)
+				err = makeNodeSchedulable(ctx, c, &n, true)
 				switch err.(type) {
 				case CriticalAddonsOnlyError:
 					continue makeSchedulableLoop
@@ -146,9 +146,9 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 		additionalReservation := additionalNodes * perNodeReservation
 
 		// saturate cluster
-		reservationCleanup := ReserveMemory(f, "some-pod", nodeCount*2, nodeCount*perNodeReservation, true, memoryReservationTimeout)
+		reservationCleanup := ReserveMemory(ctx, f, "some-pod", nodeCount*2, nodeCount*perNodeReservation, true, memoryReservationTimeout)
 		defer reservationCleanup()
-		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(f, c))
+		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
 
 		// configure pending pods & expected scale up
 		rcConfig := reserveMemoryRCConfig(f, "extra-pod-1", replicas, additionalReservation, largeScaleUpTimeout)
@@ -156,7 +156,7 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 		config := createScaleUpTestConfig(nodeCount, nodeCount, rcConfig, expectedResult)
 
 		// run test
-		testCleanup := simpleScaleUpTest(f, config)
+		testCleanup := simpleScaleUpTest(ctx, f, config)
 		defer testCleanup()
 	})
 
@@ -176,9 +176,9 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 
 		// saturate cluster
 		initialReplicas := nodeCount
-		reservationCleanup := ReserveMemory(f, "some-pod", initialReplicas, nodeCount*perNodeReservation, true, memoryReservationTimeout)
+		reservationCleanup := ReserveMemory(ctx, f, "some-pod", initialReplicas, nodeCount*perNodeReservation, true, memoryReservationTimeout)
 		defer reservationCleanup()
-		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(f, c))
+		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
 
 		klog.Infof("Reserved successfully")
 
@@ -190,7 +190,7 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 		// run test #1
 		tolerateUnreadyNodes := additionalNodes1 / 20
 		tolerateUnreadyPods := (initialReplicas + replicas1) / 20
-		testCleanup1 := simpleScaleUpTestWithTolerance(f, config, tolerateUnreadyNodes, tolerateUnreadyPods)
+		testCleanup1 := simpleScaleUpTestWithTolerance(ctx, f, config, tolerateUnreadyNodes, tolerateUnreadyPods)
 		defer testCleanup1()
 
 		klog.Infof("Scaled up once")
@@ -203,7 +203,7 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 		// run test #2
 		tolerateUnreadyNodes = maxNodes / 20
 		tolerateUnreadyPods = (initialReplicas + replicas1 + replicas2) / 20
-		testCleanup2 := simpleScaleUpTestWithTolerance(f, config2, tolerateUnreadyNodes, tolerateUnreadyPods)
+		testCleanup2 := simpleScaleUpTestWithTolerance(ctx, f, config2, tolerateUnreadyNodes, tolerateUnreadyPods)
 		defer testCleanup2()
 
 		klog.Infof("Scaled up twice")
@@ -219,7 +219,7 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 			anyKey(originalSizes): totalNodes,
 		}
 		setMigSizes(newSizes)
-		framework.ExpectNoError(e2enode.WaitForReadyNodes(f.ClientSet, totalNodes, largeResizeTimeout))
+		framework.ExpectNoError(e2enode.WaitForReadyNodes(ctx, f.ClientSet, totalNodes, largeResizeTimeout))
 
 		// run replicas
 		rcConfig := reserveMemoryRCConfig(f, "some-pod", replicas, replicas*perNodeReservation, largeScaleUpTimeout)
@@ -227,11 +227,11 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 		config := createScaleUpTestConfig(totalNodes, totalNodes, rcConfig, expectedResult)
 		tolerateUnreadyNodes := totalNodes / 10
 		tolerateUnreadyPods := replicas / 10
-		testCleanup := simpleScaleUpTestWithTolerance(f, config, tolerateUnreadyNodes, tolerateUnreadyPods)
+		testCleanup := simpleScaleUpTestWithTolerance(ctx, f, config, tolerateUnreadyNodes, tolerateUnreadyPods)
 		defer testCleanup()
 
 		// check if empty nodes are scaled down
-		framework.ExpectNoError(WaitForClusterSizeFunc(f.ClientSet,
+		framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
 			func(size int) bool {
 				return size <= replicas+3 // leaving space for non-evictable kube-system pods
 			}, scaleDownTimeout))
@@ -253,19 +253,19 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 		}
 		setMigSizes(newSizes)
 
-		framework.ExpectNoError(e2enode.WaitForReadyNodes(f.ClientSet, totalNodes, largeResizeTimeout))
+		framework.ExpectNoError(e2enode.WaitForReadyNodes(ctx, f.ClientSet, totalNodes, largeResizeTimeout))
 
 		// annotate all nodes with no-scale-down
 		ScaleDownDisabledKey := "cluster-autoscaler.kubernetes.io/scale-down-disabled"
 
-		nodes, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+		nodes, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{
 			FieldSelector: fields.Set{
 				"spec.unschedulable": "false",
 			}.AsSelector().String(),
 		})
 
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(addAnnotation(f, nodes.Items, ScaleDownDisabledKey, "true"))
+		framework.ExpectNoError(addAnnotation(ctx, f, nodes.Items, ScaleDownDisabledKey, "true"))
 
 		// distribute pods using replication controllers taking up space that should
 		// be empty after pods are distributed
@@ -276,11 +276,11 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 			{numNodes: fullNodesNum, podsPerNode: fullPerNodeReplicas},
 			{numNodes: underutilizedNodesNum, podsPerNode: underutilizedPerNodeReplicas}}
 
-		distributeLoad(f, f.Namespace.Name, "10-70", podDistribution, perPodReservation,
+		distributeLoad(ctx, f, f.Namespace.Name, "10-70", podDistribution, perPodReservation,
 			int(0.95*float64(memCapacityMb)), map[string]string{}, largeScaleUpTimeout)
 
 		// enable scale down again
-		framework.ExpectNoError(addAnnotation(f, nodes.Items, ScaleDownDisabledKey, "false"))
+		framework.ExpectNoError(addAnnotation(ctx, f, nodes.Items, ScaleDownDisabledKey, "false"))
 
 		// wait for scale down to start. Node deletion takes a long time, so we just
 		// wait for maximum of 30 nodes deleted
@@ -290,7 +290,7 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 		}
 		expectedSize := totalNodes - nodesToScaleDownCount
 		timeout := time.Duration(nodesToScaleDownCount)*time.Minute + scaleDownTimeout
-		framework.ExpectNoError(WaitForClusterSizeFunc(f.ClientSet, func(size int) bool {
+		framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet, func(size int) bool {
 			return size <= expectedSize
 		}, timeout))
 	})
@@ -306,41 +306,41 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 			anyKey(originalSizes): totalNodes,
 		}
 		setMigSizes(newSizes)
-		framework.ExpectNoError(e2enode.WaitForReadyNodes(f.ClientSet, totalNodes, largeResizeTimeout))
+		framework.ExpectNoError(e2enode.WaitForReadyNodes(ctx, f.ClientSet, totalNodes, largeResizeTimeout))
 		divider := int(float64(totalNodes) * 0.7)
 		fullNodesCount := divider
 		underutilizedNodesCount := totalNodes - fullNodesCount
 
 		ginkgo.By("Reserving full nodes")
 		// run RC1 w/o host port
-		cleanup := ReserveMemory(f, "filling-pod", fullNodesCount, fullNodesCount*fullReservation, true, largeScaleUpTimeout*2)
+		cleanup := ReserveMemory(ctx, f, "filling-pod", fullNodesCount, fullNodesCount*fullReservation, true, largeScaleUpTimeout*2)
 		defer cleanup()
 
 		ginkgo.By("Reserving host ports on remaining nodes")
 		// run RC2 w/ host port
 		ginkgo.DeferCleanup(createHostPortPodsWithMemory, f, "underutilizing-host-port-pod", underutilizedNodesCount, reservedPort, underutilizedNodesCount*hostPortPodReservation, largeScaleUpTimeout)
 
-		waitForAllCaPodsReadyInNamespace(f, c)
+		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
 		// wait and check scale down doesn't occur
 		ginkgo.By(fmt.Sprintf("Sleeping %v minutes...", scaleDownTimeout.Minutes()))
 		time.Sleep(scaleDownTimeout)
 
 		ginkgo.By("Checking if the number of nodes is as expected")
-		nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+		nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 		klog.Infof("Nodes: %v, expected: %v", len(nodes.Items), totalNodes)
 		framework.ExpectEqual(len(nodes.Items), totalNodes)
 	})
 
-	ginkgo.Specify("CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]", func() {
+	ginkgo.It("CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]", func(ctx context.Context) {
 		// Start a number of pods saturating existing nodes.
 		perNodeReservation := int(float64(memCapacityMb) * 0.80)
 		replicasPerNode := 10
 		initialPodReplicas := nodeCount * replicasPerNode
 		initialPodsTotalMemory := nodeCount * perNodeReservation
-		reservationCleanup := ReserveMemory(f, "initial-pod", initialPodReplicas, initialPodsTotalMemory, true /* wait for pods to run */, memoryReservationTimeout)
+		reservationCleanup := ReserveMemory(ctx, f, "initial-pod", initialPodReplicas, initialPodsTotalMemory, true /* wait for pods to run */, memoryReservationTimeout)
 		ginkgo.DeferCleanup(reservationCleanup)
-		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(f, c))
+		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
 
 		// Configure a number of unschedulable pods.
 		unschedulableMemReservation := memCapacityMb * 2
@@ -348,11 +348,11 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 		totalMemReservation := unschedulableMemReservation * unschedulablePodReplicas
 		timeToWait := 5 * time.Minute
 		podsConfig := reserveMemoryRCConfig(f, "unschedulable-pod", unschedulablePodReplicas, totalMemReservation, timeToWait)
-		_ = e2erc.RunRC(*podsConfig) // Ignore error (it will occur because pods are unschedulable)
+		_ = e2erc.RunRC(ctx, *podsConfig) // Ignore error (it will occur because pods are unschedulable)
 		ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, podsConfig.Name)
 
 		// Ensure that no new nodes have been added so far.
-		readyNodeCount, _ := e2enode.TotalReady(f.ClientSet)
+		readyNodeCount, _ := e2enode.TotalReady(ctx, f.ClientSet)
 		framework.ExpectEqual(readyNodeCount, nodeCount)
 
 		// Start a number of schedulable pods to ensure CA reacts.
@@ -364,7 +364,7 @@ var _ = SIGDescribe("Cluster size autoscaler scalability [Slow]", func() {
 		config := createScaleUpTestConfig(nodeCount, initialPodReplicas, rcConfig, expectedResult)
 
 		// Test that scale up happens, allowing 1000 unschedulable pods not to be scheduled.
-		testCleanup := simpleScaleUpTestWithTolerance(f, config, 0, unschedulablePodReplicas)
+		testCleanup := simpleScaleUpTestWithTolerance(ctx, f, config, 0, unschedulablePodReplicas)
 		ginkgo.DeferCleanup(testCleanup)
 	})
 
@@ -377,35 +377,35 @@ func anyKey(input map[string]int) string {
 	return ""
 }
 
-func simpleScaleUpTestWithTolerance(f *framework.Framework, config *scaleUpTestConfig, tolerateMissingNodeCount int, tolerateMissingPodCount int) func() error {
+func simpleScaleUpTestWithTolerance(ctx context.Context, f *framework.Framework, config *scaleUpTestConfig, tolerateMissingNodeCount int, tolerateMissingPodCount int) func() error {
 	// resize cluster to start size
 	// run rc based on config
 	ginkgo.By(fmt.Sprintf("Running RC %v from config", config.extraPods.Name))
 	start := time.Now()
-	framework.ExpectNoError(e2erc.RunRC(*config.extraPods))
+	framework.ExpectNoError(e2erc.RunRC(ctx, *config.extraPods))
 	// check results
 	if tolerateMissingNodeCount > 0 {
 		// Tolerate some number of nodes not to be created.
 		minExpectedNodeCount := config.expectedResult.nodes - tolerateMissingNodeCount
-		framework.ExpectNoError(WaitForClusterSizeFunc(f.ClientSet,
+		framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
 			func(size int) bool { return size >= minExpectedNodeCount }, scaleUpTimeout))
 	} else {
-		framework.ExpectNoError(e2enode.WaitForReadyNodes(f.ClientSet, config.expectedResult.nodes, scaleUpTimeout))
+		framework.ExpectNoError(e2enode.WaitForReadyNodes(ctx, f.ClientSet, config.expectedResult.nodes, scaleUpTimeout))
 	}
 	klog.Infof("cluster is increased")
 	if tolerateMissingPodCount > 0 {
-		framework.ExpectNoError(waitForCaPodsReadyInNamespace(f, f.ClientSet, tolerateMissingPodCount))
+		framework.ExpectNoError(waitForCaPodsReadyInNamespace(ctx, f, f.ClientSet, tolerateMissingPodCount))
 	} else {
-		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(f, f.ClientSet))
+		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, f.ClientSet))
 	}
 	timeTrack(start, fmt.Sprintf("Scale up to %v", config.expectedResult.nodes))
 	return func() error {
-		return e2erc.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, config.extraPods.Name)
+		return e2erc.DeleteRCAndWaitForGC(ctx, f.ClientSet, f.Namespace.Name, config.extraPods.Name)
 	}
 }
 
-func simpleScaleUpTest(f *framework.Framework, config *scaleUpTestConfig) func() error {
-	return simpleScaleUpTestWithTolerance(f, config, 0, 0)
+func simpleScaleUpTest(ctx context.Context, f *framework.Framework, config *scaleUpTestConfig) func() error {
+	return simpleScaleUpTestWithTolerance(ctx, f, config, 0, 0)
 }
 
 func reserveMemoryRCConfig(f *framework.Framework, id string, replicas, megabytes int, timeout time.Duration) *testutils.RCConfig {
@@ -435,7 +435,7 @@ func createClusterPredicates(nodes int) *clusterPredicates {
 	}
 }
 
-func addAnnotation(f *framework.Framework, nodes []v1.Node, key, value string) error {
+func addAnnotation(ctx context.Context, f *framework.Framework, nodes []v1.Node, key, value string) error {
 	for _, node := range nodes {
 		oldData, err := json.Marshal(node)
 		if err != nil {
@@ -457,7 +457,7 @@ func addAnnotation(f *framework.Framework, nodes []v1.Node, key, value string) e
 			return err
 		}
 
-		_, err = f.ClientSet.CoreV1().Nodes().Patch(context.TODO(), string(node.Name), types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+		_, err = f.ClientSet.CoreV1().Nodes().Patch(ctx, string(node.Name), types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
 		if err != nil {
 			return err
 		}
@@ -465,7 +465,7 @@ func addAnnotation(f *framework.Framework, nodes []v1.Node, key, value string) e
 	return nil
 }
 
-func createHostPortPodsWithMemory(f *framework.Framework, id string, replicas, port, megabytes int, timeout time.Duration) func() error {
+func createHostPortPodsWithMemory(ctx context.Context, f *framework.Framework, id string, replicas, port, megabytes int, timeout time.Duration) func() error {
 	ginkgo.By(fmt.Sprintf("Running RC which reserves host port and memory"))
 	request := int64(1024 * 1024 * megabytes / replicas)
 	config := &testutils.RCConfig{
@@ -478,10 +478,10 @@ func createHostPortPodsWithMemory(f *framework.Framework, id string, replicas, p
 		HostPorts:  map[string]int{"port1": port},
 		MemRequest: request,
 	}
-	err := e2erc.RunRC(*config)
+	err := e2erc.RunRC(ctx, *config)
 	framework.ExpectNoError(err)
 	return func() error {
-		return e2erc.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, id)
+		return e2erc.DeleteRCAndWaitForGC(ctx, f.ClientSet, f.Namespace.Name, id)
 	}
 }
 
@@ -501,7 +501,7 @@ type podBatch struct {
 // conflicting host port
 // 2. Create target RC that will generate the load on the cluster
 // 3. Remove the rcs created in 1.
-func distributeLoad(f *framework.Framework, namespace string, id string, podDistribution []podBatch,
+func distributeLoad(ctx context.Context, f *framework.Framework, namespace string, id string, podDistribution []podBatch,
 	podMemRequestMegabytes int, nodeMemCapacity int, labels map[string]string, timeout time.Duration) {
 	port := 8013
 	// Create load-distribution RCs with one pod per node, reserving all remaining
@@ -512,14 +512,14 @@ func distributeLoad(f *framework.Framework, namespace string, id string, podDist
 		totalPods += podBatch.numNodes * podBatch.podsPerNode
 		remainingMem := nodeMemCapacity - podBatch.podsPerNode*podMemRequestMegabytes
 		replicas := podBatch.numNodes
-		cleanup := createHostPortPodsWithMemory(f, fmt.Sprintf("load-distribution%d", i), replicas, port, remainingMem*replicas, timeout)
+		cleanup := createHostPortPodsWithMemory(ctx, f, fmt.Sprintf("load-distribution%d", i), replicas, port, remainingMem*replicas, timeout)
 		defer cleanup()
 	}
-	framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(f, f.ClientSet))
+	framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, f.ClientSet))
 	// Create the target RC
 	rcConfig := reserveMemoryRCConfig(f, id, totalPods, totalPods*podMemRequestMegabytes, timeout)
-	framework.ExpectNoError(e2erc.RunRC(*rcConfig))
-	framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(f, f.ClientSet))
+	framework.ExpectNoError(e2erc.RunRC(ctx, *rcConfig))
+	framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, f.ClientSet))
 	ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, id)
 }
 

--- a/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
+++ b/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
@@ -77,7 +77,7 @@ var _ = SIGDescribe("[HPA] [Feature:CustomMetricsAutoscaling] Horizontal pod aut
 				deployment:      monitoring.SimpleStackdriverExporterDeployment(stackdriverExporterDeployment, f.Namespace.ObjectMeta.Name, int32(initialReplicas), metricValue),
 				hpa:             hpa("custom-metrics-pods-hpa", f.Namespace.ObjectMeta.Name, stackdriverExporterDeployment, 1, 3, metricSpecs),
 			}
-			tc.Run()
+			tc.Run(ctx)
 		})
 
 		ginkgo.It("should scale up with two metrics", func(ctx context.Context) {
@@ -112,7 +112,7 @@ var _ = SIGDescribe("[HPA] [Feature:CustomMetricsAutoscaling] Horizontal pod aut
 				deployment:      monitoring.StackdriverExporterDeployment(stackdriverExporterDeployment, f.Namespace.ObjectMeta.Name, int32(initialReplicas), containers),
 				hpa:             hpa("custom-metrics-pods-hpa", f.Namespace.ObjectMeta.Name, stackdriverExporterDeployment, 1, 3, metricSpecs),
 			}
-			tc.Run()
+			tc.Run(ctx)
 		})
 
 		ginkgo.It("should scale down with Prometheus", func(ctx context.Context) {
@@ -131,7 +131,7 @@ var _ = SIGDescribe("[HPA] [Feature:CustomMetricsAutoscaling] Horizontal pod aut
 				deployment:      monitoring.PrometheusExporterDeployment(stackdriverExporterDeployment, f.Namespace.ObjectMeta.Name, int32(initialReplicas), metricValue),
 				hpa:             hpa("custom-metrics-pods-hpa", f.Namespace.ObjectMeta.Name, stackdriverExporterDeployment, 1, 3, metricSpecs),
 			}
-			tc.Run()
+			tc.Run(ctx)
 		})
 	})
 
@@ -154,7 +154,7 @@ var _ = SIGDescribe("[HPA] [Feature:CustomMetricsAutoscaling] Horizontal pod aut
 				pod:        monitoring.StackdriverExporterPod(stackdriverExporterPod, f.Namespace.Name, stackdriverExporterPod, monitoring.CustomMetricName, metricValue),
 				hpa:        hpa("custom-metrics-objects-hpa", f.Namespace.ObjectMeta.Name, dummyDeploymentName, 1, 3, metricSpecs),
 			}
-			tc.Run()
+			tc.Run(ctx)
 		})
 
 		ginkgo.It("should scale down to 0", func(ctx context.Context) {
@@ -175,7 +175,7 @@ var _ = SIGDescribe("[HPA] [Feature:CustomMetricsAutoscaling] Horizontal pod aut
 				pod:        monitoring.StackdriverExporterPod(stackdriverExporterPod, f.Namespace.Name, stackdriverExporterPod, monitoring.CustomMetricName, metricValue),
 				hpa:        hpa("custom-metrics-objects-hpa", f.Namespace.ObjectMeta.Name, dummyDeploymentName, 0, 3, metricSpecs),
 			}
-			tc.Run()
+			tc.Run(ctx)
 		})
 	})
 
@@ -201,7 +201,7 @@ var _ = SIGDescribe("[HPA] [Feature:CustomMetricsAutoscaling] Horizontal pod aut
 				pod:        monitoring.StackdriverExporterPod(stackdriverExporterPod, f.Namespace.Name, stackdriverExporterPod, "target", metricValue),
 				hpa:        hpa("custom-metrics-external-hpa", f.Namespace.ObjectMeta.Name, dummyDeploymentName, 1, 3, metricSpecs),
 			}
-			tc.Run()
+			tc.Run(ctx)
 		})
 
 		ginkgo.It("should scale down with target average value", func(ctx context.Context) {
@@ -225,7 +225,7 @@ var _ = SIGDescribe("[HPA] [Feature:CustomMetricsAutoscaling] Horizontal pod aut
 				pod:        monitoring.StackdriverExporterPod(stackdriverExporterPod, f.Namespace.Name, stackdriverExporterPod, "target_average", externalMetricValue),
 				hpa:        hpa("custom-metrics-external-hpa", f.Namespace.ObjectMeta.Name, dummyDeploymentName, 1, 3, metricSpecs),
 			}
-			tc.Run()
+			tc.Run(ctx)
 		})
 
 		ginkgo.It("should scale up with two metrics", func(ctx context.Context) {
@@ -266,7 +266,7 @@ var _ = SIGDescribe("[HPA] [Feature:CustomMetricsAutoscaling] Horizontal pod aut
 				deployment:      monitoring.StackdriverExporterDeployment(dummyDeploymentName, f.Namespace.ObjectMeta.Name, int32(initialReplicas), containers),
 				hpa:             hpa("custom-metrics-external-hpa", f.Namespace.ObjectMeta.Name, dummyDeploymentName, 1, 3, metricSpecs),
 			}
-			tc.Run()
+			tc.Run(ctx)
 		})
 	})
 
@@ -297,7 +297,7 @@ var _ = SIGDescribe("[HPA] [Feature:CustomMetricsAutoscaling] Horizontal pod aut
 				scaledReplicas:  3,
 				deployment:      monitoring.StackdriverExporterDeployment(dummyDeploymentName, f.Namespace.ObjectMeta.Name, int32(initialReplicas), containers),
 				hpa:             hpa("multiple-metrics", f.Namespace.ObjectMeta.Name, dummyDeploymentName, 1, 3, metricSpecs)}
-			tc.Run()
+			tc.Run(ctx)
 		})
 
 		ginkgo.It("should scale up when one metric is missing (Resource and Object metrics)", func(ctx context.Context) {
@@ -317,7 +317,7 @@ var _ = SIGDescribe("[HPA] [Feature:CustomMetricsAutoscaling] Horizontal pod aut
 				deployment:      monitoring.SimpleStackdriverExporterDeployment(dummyDeploymentName, f.Namespace.ObjectMeta.Name, int32(initialReplicas), 0),
 				pod:             monitoring.StackdriverExporterPod(stackdriverExporterPod, f.Namespace.Name, stackdriverExporterPod, monitoring.CustomMetricName, metricValue),
 				hpa:             hpa("multiple-metrics", f.Namespace.ObjectMeta.Name, dummyDeploymentName, 1, 3, metricSpecs)}
-			tc.Run()
+			tc.Run(ctx)
 		})
 
 		ginkgo.It("should not scale down when one metric is missing (Container Resource and External Metrics)", func(ctx context.Context) {
@@ -347,7 +347,7 @@ var _ = SIGDescribe("[HPA] [Feature:CustomMetricsAutoscaling] Horizontal pod aut
 				verifyStability: true,
 				deployment:      monitoring.StackdriverExporterDeployment(dummyDeploymentName, f.Namespace.ObjectMeta.Name, int32(initialReplicas), containers),
 				hpa:             hpa("multiple-metrics", f.Namespace.ObjectMeta.Name, dummyDeploymentName, 1, 3, metricSpecs)}
-			tc.Run()
+			tc.Run(ctx)
 		})
 
 		ginkgo.It("should not scale down when one metric is missing (Pod and Object Metrics)", func(ctx context.Context) {
@@ -374,7 +374,7 @@ var _ = SIGDescribe("[HPA] [Feature:CustomMetricsAutoscaling] Horizontal pod aut
 				verifyStability: true,
 				deployment:      monitoring.StackdriverExporterDeployment(dummyDeploymentName, f.Namespace.ObjectMeta.Name, int32(initialReplicas), containers),
 				hpa:             hpa("multiple-metrics", f.Namespace.ObjectMeta.Name, dummyDeploymentName, 1, 3, metricSpecs)}
-			tc.Run()
+			tc.Run(ctx)
 		})
 	})
 
@@ -393,10 +393,9 @@ type CustomMetricTestCase struct {
 }
 
 // Run starts test case.
-func (tc *CustomMetricTestCase) Run() {
+func (tc *CustomMetricTestCase) Run(ctx context.Context) {
 	projectID := framework.TestContext.CloudConfig.ProjectID
 
-	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, gcm.CloudPlatformScope)
 	if err != nil {
 		framework.Failf("Failed to initialize gcm default client, %v", err)
@@ -433,38 +432,38 @@ func (tc *CustomMetricTestCase) Run() {
 	}
 
 	// Run application that exports the metric
-	err = createDeploymentToScale(tc.framework, tc.kubeClient, tc.deployment, tc.pod)
+	err = createDeploymentToScale(ctx, tc.framework, tc.kubeClient, tc.deployment, tc.pod)
 	if err != nil {
 		framework.Failf("Failed to create stackdriver-exporter pod: %v", err)
 	}
 	ginkgo.DeferCleanup(cleanupDeploymentsToScale, tc.framework, tc.kubeClient, tc.deployment, tc.pod)
 
 	// Wait for the deployment to run
-	waitForReplicas(tc.deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, tc.initialReplicas)
+	waitForReplicas(ctx, tc.deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, tc.initialReplicas)
 
 	// Autoscale the deployment
-	_, err = tc.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(tc.framework.Namespace.ObjectMeta.Name).Create(context.TODO(), tc.hpa, metav1.CreateOptions{})
+	_, err = tc.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(tc.framework.Namespace.ObjectMeta.Name).Create(ctx, tc.hpa, metav1.CreateOptions{})
 	if err != nil {
 		framework.Failf("Failed to create HPA: %v", err)
 	}
 	ginkgo.DeferCleanup(framework.IgnoreNotFound(tc.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(tc.framework.Namespace.ObjectMeta.Name).Delete), tc.hpa.ObjectMeta.Name, metav1.DeleteOptions{})
 
-	waitForReplicas(tc.deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, tc.scaledReplicas)
+	waitForReplicas(ctx, tc.deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, tc.scaledReplicas)
 
 	if tc.verifyStability {
-		ensureDesiredReplicasInRange(tc.deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, tc.scaledReplicas, tc.scaledReplicas, 10*time.Minute)
+		ensureDesiredReplicasInRange(ctx, tc.deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, tc.scaledReplicas, tc.scaledReplicas, 10*time.Minute)
 	}
 }
 
-func createDeploymentToScale(f *framework.Framework, cs clientset.Interface, deployment *appsv1.Deployment, pod *v1.Pod) error {
+func createDeploymentToScale(ctx context.Context, f *framework.Framework, cs clientset.Interface, deployment *appsv1.Deployment, pod *v1.Pod) error {
 	if deployment != nil {
-		_, err := cs.AppsV1().Deployments(f.Namespace.ObjectMeta.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+		_, err := cs.AppsV1().Deployments(f.Namespace.ObjectMeta.Name).Create(ctx, deployment, metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
 	}
 	if pod != nil {
-		_, err := cs.CoreV1().Pods(f.Namespace.ObjectMeta.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+		_, err := cs.CoreV1().Pods(f.Namespace.ObjectMeta.Name).Create(ctx, pod, metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
@@ -472,12 +471,12 @@ func createDeploymentToScale(f *framework.Framework, cs clientset.Interface, dep
 	return nil
 }
 
-func cleanupDeploymentsToScale(f *framework.Framework, cs clientset.Interface, deployment *appsv1.Deployment, pod *v1.Pod) {
+func cleanupDeploymentsToScale(ctx context.Context, f *framework.Framework, cs clientset.Interface, deployment *appsv1.Deployment, pod *v1.Pod) {
 	if deployment != nil {
-		_ = cs.AppsV1().Deployments(f.Namespace.ObjectMeta.Name).Delete(context.TODO(), deployment.ObjectMeta.Name, metav1.DeleteOptions{})
+		_ = cs.AppsV1().Deployments(f.Namespace.ObjectMeta.Name).Delete(ctx, deployment.ObjectMeta.Name, metav1.DeleteOptions{})
 	}
 	if pod != nil {
-		_ = cs.CoreV1().Pods(f.Namespace.ObjectMeta.Name).Delete(context.TODO(), pod.ObjectMeta.Name, metav1.DeleteOptions{})
+		_ = cs.CoreV1().Pods(f.Namespace.ObjectMeta.Name).Delete(ctx, pod.ObjectMeta.Name, metav1.DeleteOptions{})
 	}
 }
 
@@ -598,10 +597,10 @@ func hpa(name, namespace, deploymentName string, minReplicas, maxReplicas int32,
 	}
 }
 
-func waitForReplicas(deploymentName, namespace string, cs clientset.Interface, timeout time.Duration, desiredReplicas int) {
+func waitForReplicas(ctx context.Context, deploymentName, namespace string, cs clientset.Interface, timeout time.Duration, desiredReplicas int) {
 	interval := 20 * time.Second
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		deployment, err := cs.AppsV1().Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	err := wait.PollImmediateWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
+		deployment, err := cs.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("Failed to get replication controller %s: %v", deployment, err)
 		}
@@ -614,10 +613,10 @@ func waitForReplicas(deploymentName, namespace string, cs clientset.Interface, t
 	}
 }
 
-func ensureDesiredReplicasInRange(deploymentName, namespace string, cs clientset.Interface, minDesiredReplicas, maxDesiredReplicas int, timeout time.Duration) {
+func ensureDesiredReplicasInRange(ctx context.Context, deploymentName, namespace string, cs clientset.Interface, minDesiredReplicas, maxDesiredReplicas int, timeout time.Duration) {
 	interval := 60 * time.Second
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		deployment, err := cs.AppsV1().Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	err := wait.PollImmediateWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
+		deployment, err := cs.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("Failed to get replication controller %s: %v", deployment, err)
 		}

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -48,41 +48,41 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: C
 
 	ginkgo.Describe("[Serial] [Slow] Deployment (Pod Resource)", func() {
 		ginkgo.It(titleUp+titleAverageUtilization, func(ctx context.Context) {
-			scaleUp("test-deployment", e2eautoscaling.KindDeployment, cpuResource, utilizationMetricType, false, f)
+			scaleUp(ctx, "test-deployment", e2eautoscaling.KindDeployment, cpuResource, utilizationMetricType, false, f)
 		})
 		ginkgo.It(titleDown+titleAverageUtilization, func(ctx context.Context) {
-			scaleDown("test-deployment", e2eautoscaling.KindDeployment, cpuResource, utilizationMetricType, false, f)
+			scaleDown(ctx, "test-deployment", e2eautoscaling.KindDeployment, cpuResource, utilizationMetricType, false, f)
 		})
 		ginkgo.It(titleUp+titleAverageValue, func(ctx context.Context) {
-			scaleUp("test-deployment", e2eautoscaling.KindDeployment, cpuResource, valueMetricType, false, f)
+			scaleUp(ctx, "test-deployment", e2eautoscaling.KindDeployment, cpuResource, valueMetricType, false, f)
 		})
 	})
 
 	ginkgo.Describe("[Serial] [Slow] Deployment (Container Resource)", func() {
 		ginkgo.It(titleUp+titleAverageUtilization, func(ctx context.Context) {
-			scaleUpContainerResource("test-deployment", e2eautoscaling.KindDeployment, cpuResource, utilizationMetricType, f)
+			scaleUpContainerResource(ctx, "test-deployment", e2eautoscaling.KindDeployment, cpuResource, utilizationMetricType, f)
 		})
 		ginkgo.It(titleUp+titleAverageValue, func(ctx context.Context) {
-			scaleUpContainerResource("test-deployment", e2eautoscaling.KindDeployment, cpuResource, valueMetricType, f)
+			scaleUpContainerResource(ctx, "test-deployment", e2eautoscaling.KindDeployment, cpuResource, valueMetricType, f)
 		})
 	})
 
 	ginkgo.Describe("[Serial] [Slow] ReplicaSet", func() {
 		ginkgo.It(titleUp, func(ctx context.Context) {
-			scaleUp("rs", e2eautoscaling.KindReplicaSet, cpuResource, utilizationMetricType, false, f)
+			scaleUp(ctx, "rs", e2eautoscaling.KindReplicaSet, cpuResource, utilizationMetricType, false, f)
 		})
 		ginkgo.It(titleDown, func(ctx context.Context) {
-			scaleDown("rs", e2eautoscaling.KindReplicaSet, cpuResource, utilizationMetricType, false, f)
+			scaleDown(ctx, "rs", e2eautoscaling.KindReplicaSet, cpuResource, utilizationMetricType, false, f)
 		})
 	})
 
 	// These tests take ~20 minutes each.
 	ginkgo.Describe("[Serial] [Slow] ReplicationController", func() {
 		ginkgo.It(titleUp+" and verify decision stability", func(ctx context.Context) {
-			scaleUp("rc", e2eautoscaling.KindRC, cpuResource, utilizationMetricType, true, f)
+			scaleUp(ctx, "rc", e2eautoscaling.KindRC, cpuResource, utilizationMetricType, true, f)
 		})
 		ginkgo.It(titleDown+" and verify decision stability", func(ctx context.Context) {
-			scaleDown("rc", e2eautoscaling.KindRC, cpuResource, utilizationMetricType, true, f)
+			scaleDown(ctx, "rc", e2eautoscaling.KindRC, cpuResource, utilizationMetricType, true, f)
 		})
 	})
 
@@ -99,7 +99,7 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: C
 				resourceType:     cpuResource,
 				metricTargetType: utilizationMetricType,
 			}
-			st.run("rc-light", e2eautoscaling.KindRC, f)
+			st.run(ctx, "rc-light", e2eautoscaling.KindRC, f)
 		})
 		ginkgo.It("[Slow] Should scale from 2 pods to 1 pod", func(ctx context.Context) {
 			st := &HPAScaleTest{
@@ -113,19 +113,19 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: C
 				resourceType:     cpuResource,
 				metricTargetType: utilizationMetricType,
 			}
-			st.run("rc-light", e2eautoscaling.KindRC, f)
+			st.run(ctx, "rc-light", e2eautoscaling.KindRC, f)
 		})
 	})
 
 	ginkgo.Describe("[Serial] [Slow] ReplicaSet with idle sidecar (ContainerResource use case)", func() {
 		// ContainerResource CPU autoscaling on idle sidecar
 		ginkgo.It(titleUp+" on a busy application with an idle sidecar container", func(ctx context.Context) {
-			scaleOnIdleSideCar("rs", e2eautoscaling.KindReplicaSet, cpuResource, utilizationMetricType, false, f)
+			scaleOnIdleSideCar(ctx, "rs", e2eautoscaling.KindReplicaSet, cpuResource, utilizationMetricType, false, f)
 		})
 
 		// ContainerResource CPU autoscaling on busy sidecar
 		ginkgo.It("Should not scale up on a busy sidecar with an idle application", func(ctx context.Context) {
-			doNotScaleOnBusySidecar("rs", e2eautoscaling.KindReplicaSet, cpuResource, utilizationMetricType, true, f)
+			doNotScaleOnBusySidecar(ctx, "rs", e2eautoscaling.KindReplicaSet, cpuResource, utilizationMetricType, true, f)
 		})
 	})
 
@@ -142,7 +142,7 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: C
 				resourceType:     cpuResource,
 				metricTargetType: utilizationMetricType,
 			}
-			scaleTest.run("foo-crd", e2eautoscaling.KindCRD, f)
+			scaleTest.run(ctx, "foo-crd", e2eautoscaling.KindCRD, f)
 		})
 	})
 })
@@ -153,19 +153,19 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: M
 
 	ginkgo.Describe("[Serial] [Slow] Deployment (Pod Resource)", func() {
 		ginkgo.It(titleUp+titleAverageUtilization, func(ctx context.Context) {
-			scaleUp("test-deployment", e2eautoscaling.KindDeployment, memResource, utilizationMetricType, false, f)
+			scaleUp(ctx, "test-deployment", e2eautoscaling.KindDeployment, memResource, utilizationMetricType, false, f)
 		})
 		ginkgo.It(titleUp+titleAverageValue, func(ctx context.Context) {
-			scaleUp("test-deployment", e2eautoscaling.KindDeployment, memResource, valueMetricType, false, f)
+			scaleUp(ctx, "test-deployment", e2eautoscaling.KindDeployment, memResource, valueMetricType, false, f)
 		})
 	})
 
 	ginkgo.Describe("[Serial] [Slow] Deployment (Container Resource)", func() {
 		ginkgo.It(titleUp+titleAverageUtilization, func(ctx context.Context) {
-			scaleUpContainerResource("test-deployment", e2eautoscaling.KindDeployment, memResource, utilizationMetricType, f)
+			scaleUpContainerResource(ctx, "test-deployment", e2eautoscaling.KindDeployment, memResource, utilizationMetricType, f)
 		})
 		ginkgo.It(titleUp+titleAverageValue, func(ctx context.Context) {
-			scaleUpContainerResource("test-deployment", e2eautoscaling.KindDeployment, memResource, valueMetricType, f)
+			scaleUpContainerResource(ctx, "test-deployment", e2eautoscaling.KindDeployment, memResource, valueMetricType, f)
 		})
 	})
 })
@@ -194,7 +194,7 @@ type HPAScaleTest struct {
 // The first state change is due to the CPU being consumed initially, which HPA responds to by changing pod counts.
 // The second state change (optional) is due to the CPU burst parameter, which HPA again responds to.
 // TODO The use of 3 states is arbitrary, we could eventually make this test handle "n" states once this test stabilizes.
-func (st *HPAScaleTest) run(name string, kind schema.GroupVersionKind, f *framework.Framework) {
+func (st *HPAScaleTest) run(ctx context.Context, name string, kind schema.GroupVersionKind, f *framework.Framework) {
 	const timeToWait = 15 * time.Minute
 	initCPUTotal, initMemTotal := 0, 0
 	if st.resourceType == cpuResource {
@@ -202,26 +202,26 @@ func (st *HPAScaleTest) run(name string, kind schema.GroupVersionKind, f *framew
 	} else if st.resourceType == memResource {
 		initMemTotal = st.initMemTotal
 	}
-	rc := e2eautoscaling.NewDynamicResourceConsumer(name, f.Namespace.Name, kind, st.initPods, initCPUTotal, initMemTotal, 0, st.perPodCPURequest, st.perPodMemRequest, f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle)
+	rc := e2eautoscaling.NewDynamicResourceConsumer(ctx, name, f.Namespace.Name, kind, st.initPods, initCPUTotal, initMemTotal, 0, st.perPodCPURequest, st.perPodMemRequest, f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle)
 	ginkgo.DeferCleanup(rc.CleanUp)
-	hpa := e2eautoscaling.CreateResourceHorizontalPodAutoscaler(rc, st.resourceType, st.metricTargetType, st.targetValue, st.minPods, st.maxPods)
+	hpa := e2eautoscaling.CreateResourceHorizontalPodAutoscaler(ctx, rc, st.resourceType, st.metricTargetType, st.targetValue, st.minPods, st.maxPods)
 	ginkgo.DeferCleanup(e2eautoscaling.DeleteHorizontalPodAutoscaler, rc, hpa.Name)
 
-	rc.WaitForReplicas(st.firstScale, timeToWait)
+	rc.WaitForReplicas(ctx, st.firstScale, timeToWait)
 	if st.firstScaleStasis > 0 {
-		rc.EnsureDesiredReplicasInRange(st.firstScale, st.firstScale+1, st.firstScaleStasis, hpa.Name)
+		rc.EnsureDesiredReplicasInRange(ctx, st.firstScale, st.firstScale+1, st.firstScaleStasis, hpa.Name)
 	}
 	if st.resourceType == cpuResource && st.cpuBurst > 0 && st.secondScale > 0 {
 		rc.ConsumeCPU(st.cpuBurst)
-		rc.WaitForReplicas(int(st.secondScale), timeToWait)
+		rc.WaitForReplicas(ctx, int(st.secondScale), timeToWait)
 	}
 	if st.resourceType == memResource && st.memBurst > 0 && st.secondScale > 0 {
 		rc.ConsumeMem(st.memBurst)
-		rc.WaitForReplicas(int(st.secondScale), timeToWait)
+		rc.WaitForReplicas(ctx, int(st.secondScale), timeToWait)
 	}
 }
 
-func scaleUp(name string, kind schema.GroupVersionKind, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, checkStability bool, f *framework.Framework) {
+func scaleUp(ctx context.Context, name string, kind schema.GroupVersionKind, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, checkStability bool, f *framework.Framework) {
 	stasis := 0 * time.Minute
 	if checkStability {
 		stasis = 10 * time.Minute
@@ -247,10 +247,10 @@ func scaleUp(name string, kind schema.GroupVersionKind, resourceType v1.Resource
 		st.initMemTotal = 250
 		st.memBurst = 700
 	}
-	st.run(name, kind, f)
+	st.run(ctx, name, kind, f)
 }
 
-func scaleDown(name string, kind schema.GroupVersionKind, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, checkStability bool, f *framework.Framework) {
+func scaleDown(ctx context.Context, name string, kind schema.GroupVersionKind, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, checkStability bool, f *framework.Framework) {
 	stasis := 0 * time.Minute
 	if checkStability {
 		stasis = 10 * time.Minute
@@ -277,7 +277,7 @@ func scaleDown(name string, kind schema.GroupVersionKind, resourceType v1.Resour
 		st.initMemTotal = 325
 		st.memBurst = 10
 	}
-	st.run(name, kind, f)
+	st.run(ctx, name, kind, f)
 }
 
 type HPAContainerResourceScaleTest struct {
@@ -302,7 +302,7 @@ type HPAContainerResourceScaleTest struct {
 	metricTargetType       autoscalingv2.MetricTargetType
 }
 
-func (st *HPAContainerResourceScaleTest) run(name string, kind schema.GroupVersionKind, f *framework.Framework) {
+func (st *HPAContainerResourceScaleTest) run(ctx context.Context, name string, kind schema.GroupVersionKind, f *framework.Framework) {
 	const timeToWait = 15 * time.Minute
 	initCPUTotal, initMemTotal := 0, 0
 	if st.resourceType == cpuResource {
@@ -310,32 +310,32 @@ func (st *HPAContainerResourceScaleTest) run(name string, kind schema.GroupVersi
 	} else if st.resourceType == memResource {
 		initMemTotal = st.initMemTotal
 	}
-	rc := e2eautoscaling.NewDynamicResourceConsumer(name, f.Namespace.Name, kind, st.initPods, initCPUTotal, initMemTotal, 0, st.perContainerCPURequest, st.perContainerMemRequest, f.ClientSet, f.ScalesGetter, st.sidecarStatus, st.sidecarType)
+	rc := e2eautoscaling.NewDynamicResourceConsumer(ctx, name, f.Namespace.Name, kind, st.initPods, initCPUTotal, initMemTotal, 0, st.perContainerCPURequest, st.perContainerMemRequest, f.ClientSet, f.ScalesGetter, st.sidecarStatus, st.sidecarType)
 	ginkgo.DeferCleanup(rc.CleanUp)
-	hpa := e2eautoscaling.CreateContainerResourceHorizontalPodAutoscaler(rc, st.resourceType, st.metricTargetType, st.targetValue, st.minPods, st.maxPods)
+	hpa := e2eautoscaling.CreateContainerResourceHorizontalPodAutoscaler(ctx, rc, st.resourceType, st.metricTargetType, st.targetValue, st.minPods, st.maxPods)
 	ginkgo.DeferCleanup(e2eautoscaling.DeleteContainerResourceHPA, rc, hpa.Name)
 
 	if st.noScale {
 		if st.noScaleStasis > 0 {
-			rc.EnsureDesiredReplicasInRange(st.initPods, st.initPods, st.noScaleStasis, hpa.Name)
+			rc.EnsureDesiredReplicasInRange(ctx, st.initPods, st.initPods, st.noScaleStasis, hpa.Name)
 		}
 	} else {
-		rc.WaitForReplicas(st.firstScale, timeToWait)
+		rc.WaitForReplicas(ctx, st.firstScale, timeToWait)
 		if st.firstScaleStasis > 0 {
-			rc.EnsureDesiredReplicasInRange(st.firstScale, st.firstScale+1, st.firstScaleStasis, hpa.Name)
+			rc.EnsureDesiredReplicasInRange(ctx, st.firstScale, st.firstScale+1, st.firstScaleStasis, hpa.Name)
 		}
 		if st.resourceType == cpuResource && st.cpuBurst > 0 && st.secondScale > 0 {
 			rc.ConsumeCPU(st.cpuBurst)
-			rc.WaitForReplicas(int(st.secondScale), timeToWait)
+			rc.WaitForReplicas(ctx, int(st.secondScale), timeToWait)
 		}
 		if st.resourceType == memResource && st.memBurst > 0 && st.secondScale > 0 {
 			rc.ConsumeMem(st.memBurst)
-			rc.WaitForReplicas(int(st.secondScale), timeToWait)
+			rc.WaitForReplicas(ctx, int(st.secondScale), timeToWait)
 		}
 	}
 }
 
-func scaleUpContainerResource(name string, kind schema.GroupVersionKind, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, f *framework.Framework) {
+func scaleUpContainerResource(ctx context.Context, name string, kind schema.GroupVersionKind, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, f *framework.Framework) {
 	st := &HPAContainerResourceScaleTest{
 		initPods:               1,
 		perContainerCPURequest: 500,
@@ -359,10 +359,10 @@ func scaleUpContainerResource(name string, kind schema.GroupVersionKind, resourc
 		st.initMemTotal = 250
 		st.memBurst = 700
 	}
-	st.run(name, kind, f)
+	st.run(ctx, name, kind, f)
 }
 
-func scaleOnIdleSideCar(name string, kind schema.GroupVersionKind, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, checkStability bool, f *framework.Framework) {
+func scaleOnIdleSideCar(ctx context.Context, name string, kind schema.GroupVersionKind, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, checkStability bool, f *framework.Framework) {
 	// Scale up on a busy application with an idle sidecar container
 	stasis := 0 * time.Minute
 	if checkStability {
@@ -384,10 +384,10 @@ func scaleOnIdleSideCar(name string, kind schema.GroupVersionKind, resourceType 
 		sidecarStatus:          e2eautoscaling.Enable,
 		sidecarType:            e2eautoscaling.Idle,
 	}
-	st.run(name, kind, f)
+	st.run(ctx, name, kind, f)
 }
 
-func doNotScaleOnBusySidecar(name string, kind schema.GroupVersionKind, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, checkStability bool, f *framework.Framework) {
+func doNotScaleOnBusySidecar(ctx context.Context, name string, kind schema.GroupVersionKind, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, checkStability bool, f *framework.Framework) {
 	// Do not scale up on a busy sidecar with an idle application
 	stasis := 0 * time.Minute
 	if checkStability {
@@ -408,7 +408,7 @@ func doNotScaleOnBusySidecar(name string, kind schema.GroupVersionKind, resource
 		noScale:                true,
 		noScaleStasis:          stasis,
 	}
-	st.run(name, kind, f)
+	st.run(ctx, name, kind, f)
 }
 
 func getTargetValueByType(averageValueTarget, averageUtilizationTarget int, targetType autoscalingv2.MetricTargetType) int32 {

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -61,14 +61,14 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			upScaleStabilization := 0 * time.Minute
 			downScaleStabilization := 1 * time.Minute
 
-			rc := e2eautoscaling.NewDynamicResourceConsumer(
+			rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
 				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
 			ginkgo.DeferCleanup(rc.CleanUp)
 
-			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(ctx,
 				rc, int32(targetCPUUtilizationPercent), 1, 5,
 				e2eautoscaling.HPABehaviorWithStabilizationWindows(upScaleStabilization, downScaleStabilization),
 			)
@@ -78,12 +78,12 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			// for stabilization logic before lowering the consumption
 			ginkgo.By("triggering scale up to record a recommendation")
 			rc.ConsumeCPU(3 * usageForSingleReplica)
-			rc.WaitForReplicas(3, maxHPAReactionTime+maxResourceConsumerDelay+waitBuffer)
+			rc.WaitForReplicas(ctx, 3, maxHPAReactionTime+maxResourceConsumerDelay+waitBuffer)
 
 			ginkgo.By("triggering scale down by lowering consumption")
 			rc.ConsumeCPU(2 * usageForSingleReplica)
 			waitStart := time.Now()
-			rc.WaitForReplicas(2, downScaleStabilization+maxHPAReactionTime+maxResourceConsumerDelay+waitBuffer)
+			rc.WaitForReplicas(ctx, 2, downScaleStabilization+maxHPAReactionTime+maxResourceConsumerDelay+waitBuffer)
 			timeWaited := time.Now().Sub(waitStart)
 
 			ginkgo.By("verifying time waited for a scale down")
@@ -102,14 +102,14 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			upScaleStabilization := 3 * time.Minute
 			downScaleStabilization := 0 * time.Minute
 
-			rc := e2eautoscaling.NewDynamicResourceConsumer(
+			rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
 				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
 			ginkgo.DeferCleanup(rc.CleanUp)
 
-			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(ctx,
 				rc, int32(targetCPUUtilizationPercent), 1, 10,
 				e2eautoscaling.HPABehaviorWithStabilizationWindows(upScaleStabilization, downScaleStabilization),
 			)
@@ -119,12 +119,12 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			// for stabilization logic before increasing the consumption
 			ginkgo.By("triggering scale down to record a recommendation")
 			rc.ConsumeCPU(1 * usageForSingleReplica)
-			rc.WaitForReplicas(1, maxHPAReactionTime+maxResourceConsumerDelay+waitBuffer)
+			rc.WaitForReplicas(ctx, 1, maxHPAReactionTime+maxResourceConsumerDelay+waitBuffer)
 
 			ginkgo.By("triggering scale up by increasing consumption")
 			rc.ConsumeCPU(3 * usageForSingleReplica)
 			waitStart := time.Now()
-			rc.WaitForReplicas(3, upScaleStabilization+maxHPAReactionTime+maxResourceConsumerDelay+waitBuffer)
+			rc.WaitForReplicas(ctx, 3, upScaleStabilization+maxHPAReactionTime+maxResourceConsumerDelay+waitBuffer)
 			timeWaited := time.Now().Sub(waitStart)
 
 			ginkgo.By("verifying time waited for a scale up")
@@ -141,14 +141,14 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			initPods := 1
 			initCPUUsageTotal := initPods * usageForSingleReplica
 
-			rc := e2eautoscaling.NewDynamicResourceConsumer(
+			rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
 				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
 			ginkgo.DeferCleanup(rc.CleanUp)
 
-			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(ctx,
 				rc, int32(targetCPUUtilizationPercent), 1, 10, e2eautoscaling.HPABehaviorWithScaleDisabled(e2eautoscaling.ScaleUpDirection),
 			)
 			ginkgo.DeferCleanup(e2eautoscaling.DeleteHPAWithBehavior, rc, hpa.Name)
@@ -159,7 +159,7 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			rc.ConsumeCPU(8 * usageForSingleReplica)
 			waitStart := time.Now()
 
-			rc.EnsureDesiredReplicasInRange(initPods, initPods, waitDeadline, hpa.Name)
+			rc.EnsureDesiredReplicasInRange(ctx, initPods, initPods, waitDeadline, hpa.Name)
 			timeWaited := time.Now().Sub(waitStart)
 
 			ginkgo.By("verifying time waited for a scale up")
@@ -167,7 +167,7 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			framework.ExpectEqual(timeWaited > waitDeadline, true, "waited %s, wanted to wait more than %s", timeWaited, waitDeadline)
 
 			ginkgo.By("verifying number of replicas")
-			replicas := rc.GetReplicas()
+			replicas := rc.GetReplicas(ctx)
 			framework.ExpectEqual(replicas == initPods, true, "had %s replicas, still have %s replicas after time deadline", initPods, replicas)
 		})
 
@@ -176,14 +176,14 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			initPods := 3
 			initCPUUsageTotal := initPods * usageForSingleReplica
 
-			rc := e2eautoscaling.NewDynamicResourceConsumer(
+			rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
 				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
 			ginkgo.DeferCleanup(rc.CleanUp)
 
-			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(ctx,
 				rc, int32(targetCPUUtilizationPercent), 1, 10, e2eautoscaling.HPABehaviorWithScaleDisabled(e2eautoscaling.ScaleDownDirection),
 			)
 			ginkgo.DeferCleanup(e2eautoscaling.DeleteHPAWithBehavior, rc, hpa.Name)
@@ -195,7 +195,7 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			rc.ConsumeCPU(1 * usageForSingleReplica)
 			waitStart := time.Now()
 
-			rc.EnsureDesiredReplicasInRange(initPods, initPods, waitDeadline, hpa.Name)
+			rc.EnsureDesiredReplicasInRange(ctx, initPods, initPods, waitDeadline, hpa.Name)
 			timeWaited := time.Now().Sub(waitStart)
 
 			ginkgo.By("verifying time waited for a scale down")
@@ -203,7 +203,7 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			framework.ExpectEqual(timeWaited > waitDeadline, true, "waited %s, wanted to wait more than %s", timeWaited, waitDeadline)
 
 			ginkgo.By("verifying number of replicas")
-			replicas := rc.GetReplicas()
+			replicas := rc.GetReplicas(ctx)
 			framework.ExpectEqual(replicas == initPods, true, "had %s replicas, still have %s replicas after time deadline", initPods, replicas)
 		})
 
@@ -221,14 +221,14 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			limitWindowLength := 1 * time.Minute
 			podsLimitPerMinute := 1
 
-			rc := e2eautoscaling.NewDynamicResourceConsumer(
+			rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
 				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
 			ginkgo.DeferCleanup(rc.CleanUp)
 
-			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(ctx,
 				rc, int32(targetCPUUtilizationPercent), 1, 10,
 				e2eautoscaling.HPABehaviorWithScaleLimitedByNumberOfPods(e2eautoscaling.ScaleUpDirection, int32(podsLimitPerMinute), int32(limitWindowLength.Seconds())),
 			)
@@ -238,11 +238,11 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			rc.ConsumeCPU(3 * usageForSingleReplica)
 
 			waitStart := time.Now()
-			rc.WaitForReplicas(2, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			rc.WaitForReplicas(ctx, 2, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
 			timeWaitedFor2 := time.Now().Sub(waitStart)
 
 			waitStart = time.Now()
-			rc.WaitForReplicas(3, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			rc.WaitForReplicas(ctx, 3, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
 			timeWaitedFor3 := time.Now().Sub(waitStart)
 
 			ginkgo.By("verifying time waited for a scale up to 2 replicas")
@@ -263,14 +263,14 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			limitWindowLength := 1 * time.Minute
 			podsLimitPerMinute := 1
 
-			rc := e2eautoscaling.NewDynamicResourceConsumer(
+			rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
 				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
 			ginkgo.DeferCleanup(rc.CleanUp)
 
-			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(ctx,
 				rc, int32(targetCPUUtilizationPercent), 1, 10,
 				e2eautoscaling.HPABehaviorWithScaleLimitedByNumberOfPods(e2eautoscaling.ScaleDownDirection, int32(podsLimitPerMinute), int32(limitWindowLength.Seconds())),
 			)
@@ -280,11 +280,11 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			rc.ConsumeCPU(1 * usageForSingleReplica)
 
 			waitStart := time.Now()
-			rc.WaitForReplicas(2, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			rc.WaitForReplicas(ctx, 2, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
 			timeWaitedFor2 := time.Now().Sub(waitStart)
 
 			waitStart = time.Now()
-			rc.WaitForReplicas(1, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			rc.WaitForReplicas(ctx, 1, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
 			timeWaitedFor1 := time.Now().Sub(waitStart)
 
 			ginkgo.By("verifying time waited for a scale down to 2 replicas")
@@ -311,14 +311,14 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			limitWindowLength := 1 * time.Minute
 			percentageLimitPerMinute := 50
 
-			rc := e2eautoscaling.NewDynamicResourceConsumer(
+			rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
 				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
 			ginkgo.DeferCleanup(rc.CleanUp)
 
-			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(ctx,
 				rc, int32(targetCPUUtilizationPercent), 1, 10,
 				e2eautoscaling.HPABehaviorWithScaleLimitedByPercentage(e2eautoscaling.ScaleUpDirection, int32(percentageLimitPerMinute), int32(limitWindowLength.Seconds())),
 			)
@@ -328,12 +328,12 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			rc.ConsumeCPU(8 * usageForSingleReplica)
 
 			waitStart := time.Now()
-			rc.WaitForReplicas(3, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			rc.WaitForReplicas(ctx, 3, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
 			timeWaitedFor3 := time.Now().Sub(waitStart)
 
 			waitStart = time.Now()
 			// Scale up limited by percentage takes ceiling, so new replicas number is ceil(3 * 1.5) = ceil(4.5) = 5
-			rc.WaitForReplicas(5, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			rc.WaitForReplicas(ctx, 5, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
 			timeWaitedFor5 := time.Now().Sub(waitStart)
 
 			ginkgo.By("verifying time waited for a scale up to 3 replicas")
@@ -354,14 +354,14 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			limitWindowLength := 1 * time.Minute
 			percentageLimitPerMinute := 25
 
-			rc := e2eautoscaling.NewDynamicResourceConsumer(
+			rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
 				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
 			ginkgo.DeferCleanup(rc.CleanUp)
 
-			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(ctx,
 				rc, int32(targetCPUUtilizationPercent), 1, 10,
 				e2eautoscaling.HPABehaviorWithScaleLimitedByPercentage(e2eautoscaling.ScaleDownDirection, int32(percentageLimitPerMinute), int32(limitWindowLength.Seconds())),
 			)
@@ -371,12 +371,12 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			rc.ConsumeCPU(1 * usageForSingleReplica)
 
 			waitStart := time.Now()
-			rc.WaitForReplicas(5, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			rc.WaitForReplicas(ctx, 5, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
 			timeWaitedFor5 := time.Now().Sub(waitStart)
 
 			waitStart = time.Now()
 			// Scale down limited by percentage takes floor, so new replicas number is floor(5 * 0.75) = floor(3.75) = 3
-			rc.WaitForReplicas(3, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
+			rc.WaitForReplicas(ctx, 3, maxHPAReactionTime+maxResourceConsumerDelay+limitWindowLength)
 			timeWaitedFor3 := time.Now().Sub(waitStart)
 
 			ginkgo.By("verifying time waited for a scale down to 5 replicas")
@@ -401,14 +401,14 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			upScaleStabilization := 3 * time.Minute
 			downScaleStabilization := 3 * time.Minute
 
-			rc := e2eautoscaling.NewDynamicResourceConsumer(
+			rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
 				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 			)
 			ginkgo.DeferCleanup(rc.CleanUp)
 
-			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(ctx,
 				rc, int32(targetCPUUtilizationPercent), 2, 5,
 				e2eautoscaling.HPABehaviorWithStabilizationWindows(upScaleStabilization, downScaleStabilization),
 			)
@@ -419,12 +419,12 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			waitDeadline := upScaleStabilization
 
 			ginkgo.By("verifying number of replicas stay in desired range within stabilisation window")
-			rc.EnsureDesiredReplicasInRange(2, 2, waitDeadline, hpa.Name)
+			rc.EnsureDesiredReplicasInRange(ctx, 2, 2, waitDeadline, hpa.Name)
 
 			ginkgo.By("waiting for replicas to scale up after stabilisation window passed")
 			waitStart := time.Now()
 			waitDeadline = maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer
-			rc.WaitForReplicas(4, waitDeadline)
+			rc.WaitForReplicas(ctx, 4, waitDeadline)
 			timeWaited := time.Now().Sub(waitStart)
 			framework.Logf("time waited for scale up: %s", timeWaited)
 			framework.ExpectEqual(timeWaited < waitDeadline, true, "waited %s, wanted less than %s", timeWaited, waitDeadline)
@@ -434,12 +434,12 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			waitDeadline = downScaleStabilization
 
 			ginkgo.By("verifying number of replicas stay in desired range within stabilisation window")
-			rc.EnsureDesiredReplicasInRange(4, 4, waitDeadline, hpa.Name)
+			rc.EnsureDesiredReplicasInRange(ctx, 4, 4, waitDeadline, hpa.Name)
 
 			ginkgo.By("waiting for replicas to scale down after stabilisation window passed")
 			waitStart = time.Now()
 			waitDeadline = maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer
-			rc.WaitForReplicas(2, waitDeadline)
+			rc.WaitForReplicas(ctx, 2, waitDeadline)
 			timeWaited = time.Now().Sub(waitStart)
 			framework.Logf("time waited for scale down: %s", timeWaited)
 			framework.ExpectEqual(timeWaited < waitDeadline, true, "waited %s, wanted less than %s", timeWaited, waitDeadline)
@@ -453,7 +453,7 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			limitWindowLength := 2 * time.Minute
 			podsLimitPerMinute := 1
 
-			rc := e2eautoscaling.NewDynamicResourceConsumer(
+			rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
 				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
 				initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
 				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
@@ -462,7 +462,7 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 
 			scaleUpRule := e2eautoscaling.HPAScalingRuleWithScalingPolicy(autoscalingv2.PodsScalingPolicy, int32(podsLimitPerMinute), int32(limitWindowLength.Seconds()))
 			scaleDownRule := e2eautoscaling.HPAScalingRuleWithStabilizationWindow(int32(downScaleStabilization.Seconds()))
-			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(
+			hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(ctx,
 				rc, int32(targetCPUUtilizationPercent), 2, 5,
 				e2eautoscaling.HPABehaviorWithScaleUpAndDownRules(scaleUpRule, scaleDownRule),
 			)
@@ -473,12 +473,12 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 			waitDeadline := limitWindowLength
 
 			ginkgo.By("verifying number of replicas stay in desired range with pod limit rate")
-			rc.EnsureDesiredReplicasInRange(2, 3, waitDeadline, hpa.Name)
+			rc.EnsureDesiredReplicasInRange(ctx, 2, 3, waitDeadline, hpa.Name)
 
 			ginkgo.By("waiting for replicas to scale up")
 			waitStart := time.Now()
 			waitDeadline = limitWindowLength + maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer
-			rc.WaitForReplicas(4, waitDeadline)
+			rc.WaitForReplicas(ctx, 4, waitDeadline)
 			timeWaited := time.Now().Sub(waitStart)
 			framework.Logf("time waited for scale up: %s", timeWaited)
 			framework.ExpectEqual(timeWaited < waitDeadline, true, "waited %s, wanted less than %s", timeWaited, waitDeadline)
@@ -488,12 +488,12 @@ var _ = SIGDescribe("[Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (n
 
 			ginkgo.By("verifying number of replicas stay in desired range within stabilisation window")
 			waitDeadline = downScaleStabilization
-			rc.EnsureDesiredReplicasInRange(4, 4, waitDeadline, hpa.Name)
+			rc.EnsureDesiredReplicasInRange(ctx, 4, 4, waitDeadline, hpa.Name)
 
 			ginkgo.By("waiting for replicas to scale down after stabilisation window passed")
 			waitStart = time.Now()
 			waitDeadline = maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer
-			rc.WaitForReplicas(2, waitDeadline)
+			rc.WaitForReplicas(ctx, 2, waitDeadline)
 			timeWaited = time.Now().Sub(waitStart)
 			framework.Logf("time waited for scale down: %s", timeWaited)
 			framework.ExpectEqual(timeWaited < waitDeadline, true, "waited %s, wanted less than %s", timeWaited, waitDeadline)

--- a/test/e2e/cloud/gcp/apps/stateful_apps.go
+++ b/test/e2e/cloud/gcp/apps/stateful_apps.go
@@ -43,7 +43,7 @@ var _ = SIGDescribe("stateful Upgrade [Feature:StatefulUpgrade]", func() {
 
 	ginkgo.Describe("stateful upgrade", func() {
 		ginkgo.It("should maintain a functioning cluster", func(ctx context.Context) {
-			e2epv.SkipIfNoDefaultStorageClass(f.ClientSet)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, f.ClientSet)
 			upgCtx, err := common.GetUpgradeContext(f.ClientSet.Discovery())
 			framework.ExpectNoError(err)
 
@@ -52,7 +52,7 @@ var _ = SIGDescribe("stateful Upgrade [Feature:StatefulUpgrade]", func() {
 			testSuite.TestCases = append(testSuite.TestCases, statefulUpgradeTest)
 
 			upgradeFunc := common.ClusterUpgradeFunc(f, upgCtx, statefulUpgradeTest, nil, nil)
-			upgrades.RunUpgradeSuite(upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
+			upgrades.RunUpgradeSuite(ctx, upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
 		})
 	})
 })

--- a/test/e2e/cloud/gcp/auth/service_account_admission_controller_migration.go
+++ b/test/e2e/cloud/gcp/auth/service_account_admission_controller_migration.go
@@ -51,7 +51,7 @@ var _ = SIGDescribe("ServiceAccount admission controller migration [Feature:Boun
 			testSuite.TestCases = append(testSuite.TestCases, serviceaccountAdmissionControllerMigrationTest)
 
 			upgradeFunc := common.ControlPlaneUpgradeFunc(f, upgCtx, serviceaccountAdmissionControllerMigrationTest, nil)
-			upgrades.RunUpgradeSuite(upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.MasterUpgrade, upgradeFunc)
+			upgrades.RunUpgradeSuite(ctx, upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.MasterUpgrade, upgradeFunc)
 		})
 	})
 })

--- a/test/e2e/cloud/gcp/cluster_upgrade.go
+++ b/test/e2e/cloud/gcp/cluster_upgrade.go
@@ -72,7 +72,7 @@ var _ = SIGDescribe("Upgrade [Feature:Upgrade]", func() {
 			testSuite.TestCases = append(testSuite.TestCases, masterUpgradeTest)
 
 			upgradeFunc := common.ControlPlaneUpgradeFunc(f, upgCtx, masterUpgradeTest, nil)
-			upgrades.RunUpgradeSuite(upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.MasterUpgrade, upgradeFunc)
+			upgrades.RunUpgradeSuite(ctx, upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.MasterUpgrade, upgradeFunc)
 		})
 	})
 
@@ -86,7 +86,7 @@ var _ = SIGDescribe("Upgrade [Feature:Upgrade]", func() {
 			testSuite.TestCases = append(testSuite.TestCases, clusterUpgradeTest)
 
 			upgradeFunc := common.ClusterUpgradeFunc(f, upgCtx, clusterUpgradeTest, nil, nil)
-			upgrades.RunUpgradeSuite(upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
+			upgrades.RunUpgradeSuite(ctx, upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
 		})
 	})
 })
@@ -106,7 +106,7 @@ var _ = SIGDescribe("Downgrade [Feature:Downgrade]", func() {
 			testSuite.TestCases = append(testSuite.TestCases, clusterDowngradeTest)
 
 			upgradeFunc := common.ClusterDowngradeFunc(f, upgCtx, clusterDowngradeTest, nil, nil)
-			upgrades.RunUpgradeSuite(upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
+			upgrades.RunUpgradeSuite(ctx, upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
 		})
 	})
 })

--- a/test/e2e/cloud/gcp/common/upgrade_mechanics.go
+++ b/test/e2e/cloud/gcp/common/upgrade_mechanics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -34,48 +35,48 @@ import (
 )
 
 // ControlPlaneUpgradeFunc returns a function that performs control plane upgrade.
-func ControlPlaneUpgradeFunc(f *framework.Framework, upgCtx *upgrades.UpgradeContext, testCase *junit.TestCase, controlPlaneExtraEnvs []string) func() {
-	return func() {
+func ControlPlaneUpgradeFunc(f *framework.Framework, upgCtx *upgrades.UpgradeContext, testCase *junit.TestCase, controlPlaneExtraEnvs []string) func(ctx context.Context) {
+	return func(ctx context.Context) {
 		target := upgCtx.Versions[1].Version.String()
-		framework.ExpectNoError(controlPlaneUpgrade(f, target, controlPlaneExtraEnvs))
-		framework.ExpectNoError(checkControlPlaneVersion(f.ClientSet, target))
+		framework.ExpectNoError(controlPlaneUpgrade(ctx, f, target, controlPlaneExtraEnvs))
+		framework.ExpectNoError(checkControlPlaneVersion(ctx, f.ClientSet, target))
 	}
 }
 
 // ClusterUpgradeFunc returns a function that performs full cluster upgrade (both control plane and nodes).
-func ClusterUpgradeFunc(f *framework.Framework, upgCtx *upgrades.UpgradeContext, testCase *junit.TestCase, controlPlaneExtraEnvs, nodeExtraEnvs []string) func() {
-	return func() {
+func ClusterUpgradeFunc(f *framework.Framework, upgCtx *upgrades.UpgradeContext, testCase *junit.TestCase, controlPlaneExtraEnvs, nodeExtraEnvs []string) func(ctx context.Context) {
+	return func(ctx context.Context) {
 		target := upgCtx.Versions[1].Version.String()
 		image := upgCtx.Versions[1].NodeImage
-		framework.ExpectNoError(controlPlaneUpgrade(f, target, controlPlaneExtraEnvs))
-		framework.ExpectNoError(checkControlPlaneVersion(f.ClientSet, target))
-		framework.ExpectNoError(nodeUpgrade(f, target, image, nodeExtraEnvs))
-		framework.ExpectNoError(checkNodesVersions(f.ClientSet, target))
+		framework.ExpectNoError(controlPlaneUpgrade(ctx, f, target, controlPlaneExtraEnvs))
+		framework.ExpectNoError(checkControlPlaneVersion(ctx, f.ClientSet, target))
+		framework.ExpectNoError(nodeUpgrade(ctx, f, target, image, nodeExtraEnvs))
+		framework.ExpectNoError(checkNodesVersions(ctx, f.ClientSet, target))
 	}
 }
 
 // ClusterDowngradeFunc returns a function that performs full cluster downgrade (both nodes and control plane).
-func ClusterDowngradeFunc(f *framework.Framework, upgCtx *upgrades.UpgradeContext, testCase *junit.TestCase, controlPlaneExtraEnvs, nodeExtraEnvs []string) func() {
-	return func() {
+func ClusterDowngradeFunc(f *framework.Framework, upgCtx *upgrades.UpgradeContext, testCase *junit.TestCase, controlPlaneExtraEnvs, nodeExtraEnvs []string) func(ctx context.Context) {
+	return func(ctx context.Context) {
 		target := upgCtx.Versions[1].Version.String()
 		image := upgCtx.Versions[1].NodeImage
 		// Yes this really is a downgrade. And nodes must downgrade first.
-		framework.ExpectNoError(nodeUpgrade(f, target, image, nodeExtraEnvs))
-		framework.ExpectNoError(checkNodesVersions(f.ClientSet, target))
-		framework.ExpectNoError(controlPlaneUpgrade(f, target, controlPlaneExtraEnvs))
-		framework.ExpectNoError(checkControlPlaneVersion(f.ClientSet, target))
+		framework.ExpectNoError(nodeUpgrade(ctx, f, target, image, nodeExtraEnvs))
+		framework.ExpectNoError(checkNodesVersions(ctx, f.ClientSet, target))
+		framework.ExpectNoError(controlPlaneUpgrade(ctx, f, target, controlPlaneExtraEnvs))
+		framework.ExpectNoError(checkControlPlaneVersion(ctx, f.ClientSet, target))
 	}
 }
 
 const etcdImage = "3.4.9-1"
 
 // controlPlaneUpgrade upgrades control plane node on GCE/GKE.
-func controlPlaneUpgrade(f *framework.Framework, v string, extraEnvs []string) error {
+func controlPlaneUpgrade(ctx context.Context, f *framework.Framework, v string, extraEnvs []string) error {
 	switch framework.TestContext.Provider {
 	case "gce":
 		return controlPlaneUpgradeGCE(v, extraEnvs)
 	case "gke":
-		return e2eproviders.MasterUpgradeGKE(f.Namespace.Name, v)
+		return e2eproviders.MasterUpgradeGKE(ctx, f.Namespace.Name, v)
 	default:
 		return fmt.Errorf("controlPlaneUpgrade() is not implemented for provider %s", framework.TestContext.Provider)
 	}
@@ -117,11 +118,11 @@ func traceRouteToControlPlane() {
 }
 
 // checkControlPlaneVersion validates the control plane version
-func checkControlPlaneVersion(c clientset.Interface, want string) error {
+func checkControlPlaneVersion(ctx context.Context, c clientset.Interface, want string) error {
 	framework.Logf("Checking control plane version")
 	var err error
 	var v *version.Info
-	waitErr := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+	waitErr := wait.PollImmediateWithContext(ctx, 5*time.Second, 2*time.Minute, func(ctx context.Context) (bool, error) {
 		v, err = c.Discovery().ServerVersion()
 		if err != nil {
 			traceRouteToControlPlane()
@@ -144,21 +145,21 @@ func checkControlPlaneVersion(c clientset.Interface, want string) error {
 }
 
 // nodeUpgrade upgrades nodes on GCE/GKE.
-func nodeUpgrade(f *framework.Framework, v string, img string, extraEnvs []string) error {
+func nodeUpgrade(ctx context.Context, f *framework.Framework, v string, img string, extraEnvs []string) error {
 	// Perform the upgrade.
 	var err error
 	switch framework.TestContext.Provider {
 	case "gce":
 		err = nodeUpgradeGCE(v, img, extraEnvs)
 	case "gke":
-		err = nodeUpgradeGKE(f.Namespace.Name, v, img)
+		err = nodeUpgradeGKE(ctx, f.Namespace.Name, v, img)
 	default:
 		err = fmt.Errorf("nodeUpgrade() is not implemented for provider %s", framework.TestContext.Provider)
 	}
 	if err != nil {
 		return err
 	}
-	return waitForNodesReadyAfterUpgrade(f)
+	return waitForNodesReadyAfterUpgrade(ctx, f)
 }
 
 // TODO(mrhohn): Remove 'enableKubeProxyDaemonSet' when kube-proxy is run as a DaemonSet by default.
@@ -174,7 +175,7 @@ func nodeUpgradeGCE(rawV, img string, extraEnvs []string) error {
 	return err
 }
 
-func nodeUpgradeGKE(namespace string, v string, img string) error {
+func nodeUpgradeGKE(ctx context.Context, namespace string, v string, img string) error {
 	framework.Logf("Upgrading nodes to version %q and image %q", v, img)
 	nps, err := nodePoolsGKE()
 	if err != nil {
@@ -202,7 +203,7 @@ func nodeUpgradeGKE(namespace string, v string, img string) error {
 			return err
 		}
 
-		e2enode.WaitForSSHTunnels(namespace)
+		e2enode.WaitForSSHTunnels(ctx, namespace)
 	}
 	return nil
 }
@@ -227,25 +228,25 @@ func nodePoolsGKE() ([]string, error) {
 	return strings.Fields(stdout), nil
 }
 
-func waitForNodesReadyAfterUpgrade(f *framework.Framework) error {
+func waitForNodesReadyAfterUpgrade(ctx context.Context, f *framework.Framework) error {
 	// Wait for it to complete and validate nodes are healthy.
 	//
 	// TODO(ihmccreery) We shouldn't have to wait for nodes to be ready in
 	// GKE; the operation shouldn't return until they all are.
-	numNodes, err := e2enode.TotalRegistered(f.ClientSet)
+	numNodes, err := e2enode.TotalRegistered(ctx, f.ClientSet)
 	if err != nil {
 		return fmt.Errorf("couldn't detect number of nodes")
 	}
 	framework.Logf("Waiting up to %v for all %d nodes to be ready after the upgrade", framework.RestartNodeReadyAgainTimeout, numNodes)
-	if _, err := e2enode.CheckReady(f.ClientSet, numNodes, framework.RestartNodeReadyAgainTimeout); err != nil {
+	if _, err := e2enode.CheckReady(ctx, f.ClientSet, numNodes, framework.RestartNodeReadyAgainTimeout); err != nil {
 		return err
 	}
 	return nil
 }
 
 // checkNodesVersions validates the nodes versions
-func checkNodesVersions(cs clientset.Interface, want string) error {
-	l, err := e2enode.GetReadySchedulableNodes(cs)
+func checkNodesVersions(ctx context.Context, cs clientset.Interface, want string) error {
+	l, err := e2enode.GetReadySchedulableNodes(ctx, cs)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/cloud/gcp/gke_node_pools.go
+++ b/test/e2e/cloud/gcp/gke_node_pools.go
@@ -40,11 +40,11 @@ var _ = SIGDescribe("GKE node pools [Feature:GKENodePool]", func() {
 
 	ginkgo.It("should create a cluster with multiple node pools [Feature:GKENodePool]", func(ctx context.Context) {
 		framework.Logf("Start create node pool test")
-		testCreateDeleteNodePool(f, "test-pool")
+		testCreateDeleteNodePool(ctx, f, "test-pool")
 	})
 })
 
-func testCreateDeleteNodePool(f *framework.Framework, poolName string) {
+func testCreateDeleteNodePool(ctx context.Context, f *framework.Framework, poolName string) {
 	framework.Logf("Create node pool: %q in cluster: %q", poolName, framework.TestContext.CloudConfig.Cluster)
 
 	clusterStr := fmt.Sprintf("--cluster=%s", framework.TestContext.CloudConfig.Cluster)
@@ -67,7 +67,7 @@ func testCreateDeleteNodePool(f *framework.Framework, poolName string) {
 	framework.Logf("Node pools:\n%s", string(out))
 
 	framework.Logf("Checking that 2 nodes have the correct node pool label.")
-	nodeCount := nodesWithPoolLabel(f, poolName)
+	nodeCount := nodesWithPoolLabel(ctx, f, poolName)
 	if nodeCount != 2 {
 		framework.Failf("Wanted 2 nodes with node pool label, got: %v", nodeCount)
 	}
@@ -92,7 +92,7 @@ func testCreateDeleteNodePool(f *framework.Framework, poolName string) {
 	framework.Logf("\nNode pools:\n%s", string(out))
 
 	framework.Logf("Checking that no nodes have the deleted node pool's label.")
-	nodeCount = nodesWithPoolLabel(f, poolName)
+	nodeCount = nodesWithPoolLabel(ctx, f, poolName)
 	if nodeCount != 0 {
 		framework.Failf("Wanted 0 nodes with node pool label, got: %v", nodeCount)
 	}
@@ -101,9 +101,9 @@ func testCreateDeleteNodePool(f *framework.Framework, poolName string) {
 
 // nodesWithPoolLabel returns the number of nodes that have the "gke-nodepool"
 // label with the given node pool name.
-func nodesWithPoolLabel(f *framework.Framework, poolName string) int {
+func nodesWithPoolLabel(ctx context.Context, f *framework.Framework, poolName string) int {
 	nodeCount := 0
-	nodeList, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+	nodeList, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
 	framework.ExpectNoError(err)
 	for _, node := range nodeList.Items {
 		if poolLabel := node.Labels["cloud.google.com/gke-nodepool"]; poolLabel == poolName {

--- a/test/e2e/cloud/gcp/kubelet_security.go
+++ b/test/e2e/cloud/gcp/kubelet_security.go
@@ -40,16 +40,16 @@ var _ = SIGDescribe("Ports Security Check [Feature:KubeletSecurity]", func() {
 	var node *v1.Node
 	var nodeName string
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		var err error
-		node, err = e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		node, err = e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 		nodeName = node.Name
 	})
 
 	// make sure kubelet readonly (10255) and cadvisor (4194) ports are disabled via API server proxy
 	ginkgo.It(fmt.Sprintf("should not be able to proxy to the readonly kubelet port %v using proxy subresource", ports.KubeletReadOnlyPort), func(ctx context.Context) {
-		result, err := e2ekubelet.ProxyRequest(f.ClientSet, nodeName, "pods/", ports.KubeletReadOnlyPort)
+		result, err := e2ekubelet.ProxyRequest(ctx, f.ClientSet, nodeName, "pods/", ports.KubeletReadOnlyPort)
 		framework.ExpectNoError(err)
 
 		var statusCode int
@@ -57,7 +57,7 @@ var _ = SIGDescribe("Ports Security Check [Feature:KubeletSecurity]", func() {
 		framework.ExpectNotEqual(statusCode, http.StatusOK)
 	})
 	ginkgo.It("should not be able to proxy to cadvisor port 4194 using proxy subresource", func(ctx context.Context) {
-		result, err := e2ekubelet.ProxyRequest(f.ClientSet, nodeName, "containers/", 4194)
+		result, err := e2ekubelet.ProxyRequest(ctx, f.ClientSet, nodeName, "containers/", 4194)
 		framework.ExpectNoError(err)
 
 		var statusCode int

--- a/test/e2e/cloud/gcp/network/kube_proxy_migration.go
+++ b/test/e2e/cloud/gcp/network/kube_proxy_migration.go
@@ -69,7 +69,7 @@ var _ = SIGDescribe("kube-proxy migration [Feature:KubeProxyDaemonSetMigration]"
 
 			extraEnvs := kubeProxyDaemonSetExtraEnvs(true)
 			upgradeFunc := common.ClusterUpgradeFunc(f, upgCtx, kubeProxyUpgradeTest, extraEnvs, extraEnvs)
-			upgrades.RunUpgradeSuite(upgCtx, upgradeTests, upgradeTestFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
+			upgrades.RunUpgradeSuite(ctx, upgCtx, upgradeTests, upgradeTestFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
 		})
 	})
 
@@ -87,7 +87,7 @@ var _ = SIGDescribe("kube-proxy migration [Feature:KubeProxyDaemonSetMigration]"
 
 			extraEnvs := kubeProxyDaemonSetExtraEnvs(false)
 			upgradeFunc := common.ClusterDowngradeFunc(f, upgCtx, kubeProxyDowngradeTest, extraEnvs, extraEnvs)
-			upgrades.RunUpgradeSuite(upgCtx, downgradeTests, downgradeTestsFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
+			upgrades.RunUpgradeSuite(ctx, upgCtx, downgradeTests, downgradeTestsFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
 		})
 	})
 })

--- a/test/e2e/cloud/gcp/node/gpu.go
+++ b/test/e2e/cloud/gcp/node/gpu.go
@@ -48,7 +48,7 @@ var _ = SIGDescribe("gpu Upgrade [Feature:GPUUpgrade]", func() {
 			testSuite.TestCases = append(testSuite.TestCases, gpuUpgradeTest)
 
 			upgradeFunc := common.ControlPlaneUpgradeFunc(f, upgCtx, gpuUpgradeTest, nil)
-			upgrades.RunUpgradeSuite(upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.MasterUpgrade, upgradeFunc)
+			upgrades.RunUpgradeSuite(ctx, upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.MasterUpgrade, upgradeFunc)
 		})
 	})
 	ginkgo.Describe("cluster upgrade", func() {
@@ -61,7 +61,7 @@ var _ = SIGDescribe("gpu Upgrade [Feature:GPUUpgrade]", func() {
 			testSuite.TestCases = append(testSuite.TestCases, gpuUpgradeTest)
 
 			upgradeFunc := common.ClusterUpgradeFunc(f, upgCtx, gpuUpgradeTest, nil, nil)
-			upgrades.RunUpgradeSuite(upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
+			upgrades.RunUpgradeSuite(ctx, upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
 		})
 	})
 	ginkgo.Describe("cluster downgrade", func() {
@@ -74,7 +74,7 @@ var _ = SIGDescribe("gpu Upgrade [Feature:GPUUpgrade]", func() {
 			testSuite.TestCases = append(testSuite.TestCases, gpuDowngradeTest)
 
 			upgradeFunc := common.ClusterDowngradeFunc(f, upgCtx, gpuDowngradeTest, nil, nil)
-			upgrades.RunUpgradeSuite(upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
+			upgrades.RunUpgradeSuite(ctx, upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.ClusterUpgrade, upgradeFunc)
 		})
 	})
 })

--- a/test/e2e/cloud/gcp/reboot.go
+++ b/test/e2e/cloud/gcp/reboot.go
@@ -65,13 +65,13 @@ var _ = SIGDescribe("Reboot [Disruptive] [Feature:Reboot]", func() {
 		e2eskipper.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
 	})
 
-	ginkgo.AfterEach(func() {
+	ginkgo.AfterEach(func(ctx context.Context) {
 		if ginkgo.CurrentSpecReport().Failed() {
 			// Most of the reboot tests just make sure that addon/system pods are running, so dump
 			// events for the kube-system namespace on failures
 			namespaceName := metav1.NamespaceSystem
 			ginkgo.By(fmt.Sprintf("Collecting events from namespace %q.", namespaceName))
-			events, err := f.ClientSet.CoreV1().Events(namespaceName).List(context.TODO(), metav1.ListOptions{})
+			events, err := f.ClientSet.CoreV1().Events(namespaceName).List(ctx, metav1.ListOptions{})
 			framework.ExpectNoError(err)
 
 			for _, e := range events.Items {
@@ -97,19 +97,19 @@ var _ = SIGDescribe("Reboot [Disruptive] [Feature:Reboot]", func() {
 	ginkgo.It("each node by ordering clean reboot and ensure they function upon restart", func(ctx context.Context) {
 		// clean shutdown and restart
 		// We sleep 10 seconds to give some time for ssh command to cleanly finish before the node is rebooted.
-		testReboot(f.ClientSet, "nohup sh -c 'sleep 10 && sudo reboot' >/dev/null 2>&1 &", nil)
+		testReboot(ctx, f.ClientSet, "nohup sh -c 'sleep 10 && sudo reboot' >/dev/null 2>&1 &", nil)
 	})
 
 	ginkgo.It("each node by ordering unclean reboot and ensure they function upon restart", func(ctx context.Context) {
 		// unclean shutdown and restart
 		// We sleep 10 seconds to give some time for ssh command to cleanly finish before the node is shutdown.
-		testReboot(f.ClientSet, "nohup sh -c 'echo 1 | sudo tee /proc/sys/kernel/sysrq && sleep 10 && echo b | sudo tee /proc/sysrq-trigger' >/dev/null 2>&1 &", nil)
+		testReboot(ctx, f.ClientSet, "nohup sh -c 'echo 1 | sudo tee /proc/sys/kernel/sysrq && sleep 10 && echo b | sudo tee /proc/sysrq-trigger' >/dev/null 2>&1 &", nil)
 	})
 
 	ginkgo.It("each node by triggering kernel panic and ensure they function upon restart", func(ctx context.Context) {
 		// kernel panic
 		// We sleep 10 seconds to give some time for ssh command to cleanly finish before kernel panic is triggered.
-		testReboot(f.ClientSet, "nohup sh -c 'echo 1 | sudo tee /proc/sys/kernel/sysrq && sleep 10 && echo c | sudo tee /proc/sysrq-trigger' >/dev/null 2>&1 &", nil)
+		testReboot(ctx, f.ClientSet, "nohup sh -c 'echo 1 | sudo tee /proc/sys/kernel/sysrq && sleep 10 && echo c | sudo tee /proc/sysrq-trigger' >/dev/null 2>&1 &", nil)
 	})
 
 	ginkgo.It("each node by switching off the network interface and ensure they function upon switch on", func(ctx context.Context) {
@@ -130,7 +130,7 @@ var _ = SIGDescribe("Reboot [Disruptive] [Feature:Reboot]", func() {
 			"echo Starting systemd-networkd | sudo tee /dev/kmsg; " +
 			"sudo systemctl restart systemd-networkd | sudo tee /dev/kmsg" +
 			"' >/dev/null 2>&1 &"
-		testReboot(f.ClientSet, cmd, nil)
+		testReboot(ctx, f.ClientSet, cmd, nil)
 	})
 
 	ginkgo.It("each node by dropping all inbound packets for a while and ensure they function afterwards", func(ctx context.Context) {
@@ -138,7 +138,7 @@ var _ = SIGDescribe("Reboot [Disruptive] [Feature:Reboot]", func() {
 		// We sleep 10 seconds to give some time for ssh command to cleanly finish before starting dropping inbound packets.
 		// We still accept packages send from localhost to prevent monit from restarting kubelet.
 		tmpLogPath := "/tmp/drop-inbound.log"
-		testReboot(f.ClientSet, dropPacketsScript("INPUT", tmpLogPath), catLogHook(tmpLogPath))
+		testReboot(ctx, f.ClientSet, dropPacketsScript("INPUT", tmpLogPath), catLogHook(ctx, tmpLogPath))
 	})
 
 	ginkgo.It("each node by dropping all outbound packets for a while and ensure they function afterwards", func(ctx context.Context) {
@@ -146,13 +146,13 @@ var _ = SIGDescribe("Reboot [Disruptive] [Feature:Reboot]", func() {
 		// We sleep 10 seconds to give some time for ssh command to cleanly finish before starting dropping outbound packets.
 		// We still accept packages send to localhost to prevent monit from restarting kubelet.
 		tmpLogPath := "/tmp/drop-outbound.log"
-		testReboot(f.ClientSet, dropPacketsScript("OUTPUT", tmpLogPath), catLogHook(tmpLogPath))
+		testReboot(ctx, f.ClientSet, dropPacketsScript("OUTPUT", tmpLogPath), catLogHook(ctx, tmpLogPath))
 	})
 })
 
-func testReboot(c clientset.Interface, rebootCmd string, hook terminationHook) {
+func testReboot(ctx context.Context, c clientset.Interface, rebootCmd string, hook terminationHook) {
 	// Get all nodes, and kick off the test on each.
-	nodelist, err := e2enode.GetReadySchedulableNodes(c)
+	nodelist, err := e2enode.GetReadySchedulableNodes(ctx, c)
 	framework.ExpectNoError(err, "failed to list nodes")
 	if hook != nil {
 		defer func() {
@@ -170,7 +170,7 @@ func testReboot(c clientset.Interface, rebootCmd string, hook terminationHook) {
 			defer ginkgo.GinkgoRecover()
 			defer wg.Done()
 			n := nodelist.Items[ix]
-			result[ix] = rebootNode(c, framework.TestContext.Provider, n.ObjectMeta.Name, rebootCmd)
+			result[ix] = rebootNode(ctx, c, framework.TestContext.Provider, n.ObjectMeta.Name, rebootCmd)
 			if !result[ix] {
 				failed = true
 			}
@@ -191,7 +191,7 @@ func testReboot(c clientset.Interface, rebootCmd string, hook terminationHook) {
 	}
 }
 
-func printStatusAndLogsForNotReadyPods(c clientset.Interface, ns string, podNames []string, pods []*v1.Pod) {
+func printStatusAndLogsForNotReadyPods(ctx context.Context, c clientset.Interface, ns string, podNames []string, pods []*v1.Pod) {
 	printFn := func(id, log string, err error, previous bool) {
 		prefix := "Retrieving log for container"
 		if previous {
@@ -218,7 +218,7 @@ func printStatusAndLogsForNotReadyPods(c clientset.Interface, ns string, podName
 		// Print the log of the containers if pod is not running and ready.
 		for _, container := range p.Status.ContainerStatuses {
 			cIdentifer := fmt.Sprintf("%s/%s/%s", p.Namespace, p.Name, container.Name)
-			log, err := e2epod.GetPodLogs(c, p.Namespace, p.Name, container.Name)
+			log, err := e2epod.GetPodLogs(ctx, c, p.Namespace, p.Name, container.Name)
 			printFn(cIdentifer, log, err, false)
 			// Get log from the previous container.
 			if container.RestartCount > 0 {
@@ -238,7 +238,7 @@ func printStatusAndLogsForNotReadyPods(c clientset.Interface, ns string, podName
 //
 // It returns true through result only if all of the steps pass; at the first
 // failed step, it will return false through result and not run the rest.
-func rebootNode(c clientset.Interface, provider, name, rebootCmd string) bool {
+func rebootNode(ctx context.Context, c clientset.Interface, provider, name, rebootCmd string) bool {
 	// Setup
 	ns := metav1.NamespaceSystem
 	ps, err := testutils.NewPodStore(c, ns, labels.Everything(), fields.OneTermEqualSelector("spec.nodeName", name))
@@ -250,14 +250,14 @@ func rebootNode(c clientset.Interface, provider, name, rebootCmd string) bool {
 
 	// Get the node initially.
 	framework.Logf("Getting %s", name)
-	node, err := c.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+	node, err := c.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		framework.Logf("Couldn't get node %s", name)
 		return false
 	}
 
 	// Node sanity check: ensure it is "ready".
-	if !e2enode.WaitForNodeToBeReady(c, name, framework.NodeReadyInitialTimeout) {
+	if !e2enode.WaitForNodeToBeReady(ctx, c, name, framework.NodeReadyInitialTimeout) {
 		return false
 	}
 
@@ -281,32 +281,32 @@ func rebootNode(c clientset.Interface, provider, name, rebootCmd string) bool {
 
 	// For each pod, we do a sanity check to ensure it's running / healthy
 	// or succeeded now, as that's what we'll be checking later.
-	if !e2epod.CheckPodsRunningReadyOrSucceeded(c, ns, podNames, framework.PodReadyBeforeTimeout) {
-		printStatusAndLogsForNotReadyPods(c, ns, podNames, pods)
+	if !e2epod.CheckPodsRunningReadyOrSucceeded(ctx, c, ns, podNames, framework.PodReadyBeforeTimeout) {
+		printStatusAndLogsForNotReadyPods(ctx, c, ns, podNames, pods)
 		return false
 	}
 
 	// Reboot the node.
-	if err = e2essh.IssueSSHCommand(rebootCmd, provider, node); err != nil {
+	if err = e2essh.IssueSSHCommand(ctx, rebootCmd, provider, node); err != nil {
 		framework.Logf("Error while issuing ssh command: %v", err)
 		return false
 	}
 
 	// Wait for some kind of "not ready" status.
-	if !e2enode.WaitForNodeToBeNotReady(c, name, rebootNodeNotReadyTimeout) {
+	if !e2enode.WaitForNodeToBeNotReady(ctx, c, name, rebootNodeNotReadyTimeout) {
 		return false
 	}
 
 	// Wait for some kind of "ready" status.
-	if !e2enode.WaitForNodeToBeReady(c, name, rebootNodeReadyAgainTimeout) {
+	if !e2enode.WaitForNodeToBeReady(ctx, c, name, rebootNodeReadyAgainTimeout) {
 		return false
 	}
 
 	// Ensure all of the pods that we found on this node before the reboot are
 	// running / healthy, or succeeded.
-	if !e2epod.CheckPodsRunningReadyOrSucceeded(c, ns, podNames, rebootPodReadyAgainTimeout) {
+	if !e2epod.CheckPodsRunningReadyOrSucceeded(ctx, c, ns, podNames, rebootPodReadyAgainTimeout) {
 		newPods := ps.List()
-		printStatusAndLogsForNotReadyPods(c, ns, podNames, newPods)
+		printStatusAndLogsForNotReadyPods(ctx, c, ns, podNames, newPods)
 		return false
 	}
 
@@ -316,11 +316,11 @@ func rebootNode(c clientset.Interface, provider, name, rebootCmd string) bool {
 
 type terminationHook func(provider string, nodes *v1.NodeList)
 
-func catLogHook(logPath string) terminationHook {
+func catLogHook(ctx context.Context, logPath string) terminationHook {
 	return func(provider string, nodes *v1.NodeList) {
 		for _, n := range nodes.Items {
 			cmd := fmt.Sprintf("cat %v && rm %v", logPath, logPath)
-			if _, err := e2essh.IssueSSHCommandWithResult(cmd, provider, &n); err != nil {
+			if _, err := e2essh.IssueSSHCommandWithResult(ctx, cmd, provider, &n); err != nil {
 				framework.Logf("Error while issuing ssh command: %v", err)
 			}
 		}

--- a/test/e2e/cloud/nodes.go
+++ b/test/e2e/cloud/nodes.go
@@ -47,10 +47,10 @@ var _ = SIGDescribe("[Feature:CloudProvider][Disruptive] Nodes", func() {
 	ginkgo.It("should be deleted on API server if it doesn't exist in the cloud provider", func(ctx context.Context) {
 		ginkgo.By("deleting a node on the cloud provider")
 
-		nodeToDelete, err := e2enode.GetRandomReadySchedulableNode(c)
+		nodeToDelete, err := e2enode.GetRandomReadySchedulableNode(ctx, c)
 		framework.ExpectNoError(err)
 
-		origNodes, err := e2enode.GetReadyNodesIncludingTainted(c)
+		origNodes, err := e2enode.GetReadyNodesIncludingTainted(ctx, c)
 		if err != nil {
 			framework.Logf("Unexpected error occurred: %v", err)
 		}
@@ -63,11 +63,11 @@ var _ = SIGDescribe("[Feature:CloudProvider][Disruptive] Nodes", func() {
 			framework.Failf("failed to delete node %q, err: %q", nodeToDelete.Name, err)
 		}
 
-		newNodes, err := e2enode.CheckReady(c, len(origNodes.Items)-1, 5*time.Minute)
+		newNodes, err := e2enode.CheckReady(ctx, c, len(origNodes.Items)-1, 5*time.Minute)
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(newNodes), len(origNodes.Items)-1)
 
-		_, err = c.CoreV1().Nodes().Get(context.TODO(), nodeToDelete.Name, metav1.GetOptions{})
+		_, err = c.CoreV1().Nodes().Get(ctx, nodeToDelete.Name, metav1.GetOptions{})
 		if err == nil {
 			framework.Failf("node %q still exists when it should be deleted", nodeToDelete.Name)
 		} else if !apierrors.IsNotFound(err) {

--- a/test/e2e/common/network/networking.go
+++ b/test/e2e/common/network/networking.go
@@ -33,13 +33,13 @@ var _ = SIGDescribe("Networking", func() {
 
 	ginkgo.Describe("Granular Checks: Pods", func() {
 
-		checkPodToPodConnectivity := func(config *e2enetwork.NetworkingTestConfig, protocol string, port int) {
+		checkPodToPodConnectivity := func(ctx context.Context, config *e2enetwork.NetworkingTestConfig, protocol string, port int) {
 			// breadth first poll to quickly estimate failure.
 			failedPodsByHost := map[string][]*v1.Pod{}
 			// First time, we'll quickly try all pods, breadth first.
 			for _, endpointPod := range config.EndpointPods {
 				framework.Logf("Breadth first check of %v on host %v...", endpointPod.Status.PodIP, endpointPod.Status.HostIP)
-				if err := config.DialFromTestContainer(protocol, endpointPod.Status.PodIP, port, 1, 0, sets.NewString(endpointPod.Name)); err != nil {
+				if err := config.DialFromTestContainer(ctx, protocol, endpointPod.Status.PodIP, port, 1, 0, sets.NewString(endpointPod.Name)); err != nil {
 					if _, ok := failedPodsByHost[endpointPod.Status.HostIP]; !ok {
 						failedPodsByHost[endpointPod.Status.HostIP] = []*v1.Pod{}
 					}
@@ -54,7 +54,7 @@ var _ = SIGDescribe("Networking", func() {
 				framework.Logf("Doublechecking %v pods in host %v which weren't seen the first time.", len(failedPods), host)
 				for _, endpointPod := range failedPods {
 					framework.Logf("Now attempting to probe pod [[[ %v ]]]", endpointPod.Status.PodIP)
-					if err := config.DialFromTestContainer(protocol, endpointPod.Status.PodIP, port, config.MaxTries, 0, sets.NewString(endpointPod.Name)); err != nil {
+					if err := config.DialFromTestContainer(ctx, protocol, endpointPod.Status.PodIP, port, config.MaxTries, 0, sets.NewString(endpointPod.Name)); err != nil {
 						errors = append(errors, err)
 					} else {
 						framework.Logf("Was able to reach %v on %v ", endpointPod.Status.PodIP, endpointPod.Status.HostIP)
@@ -82,8 +82,8 @@ var _ = SIGDescribe("Networking", func() {
 			The kubectl exec on the webserver container MUST reach a http port on the each of service proxy endpoints in the cluster and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
 		*/
 		framework.ConformanceIt("should function for intra-pod communication: http [NodeConformance]", func(ctx context.Context) {
-			config := e2enetwork.NewCoreNetworkingTestConfig(f, false)
-			checkPodToPodConnectivity(config, "http", e2enetwork.EndpointHTTPPort)
+			config := e2enetwork.NewCoreNetworkingTestConfig(ctx, f, false)
+			checkPodToPodConnectivity(ctx, config, "http", e2enetwork.EndpointHTTPPort)
 		})
 
 		/*
@@ -93,8 +93,8 @@ var _ = SIGDescribe("Networking", func() {
 			The kubectl exec on the webserver container MUST reach a udp port on the each of service proxy endpoints in the cluster and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
 		*/
 		framework.ConformanceIt("should function for intra-pod communication: udp [NodeConformance]", func(ctx context.Context) {
-			config := e2enetwork.NewCoreNetworkingTestConfig(f, false)
-			checkPodToPodConnectivity(config, "udp", e2enetwork.EndpointUDPPort)
+			config := e2enetwork.NewCoreNetworkingTestConfig(ctx, f, false)
+			checkPodToPodConnectivity(ctx, config, "udp", e2enetwork.EndpointUDPPort)
 		})
 
 		/*
@@ -105,9 +105,9 @@ var _ = SIGDescribe("Networking", func() {
 			This test is marked LinuxOnly it breaks when using Overlay networking with Windows.
 		*/
 		framework.ConformanceIt("should function for node-pod communication: http [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-			config := e2enetwork.NewCoreNetworkingTestConfig(f, true)
+			config := e2enetwork.NewCoreNetworkingTestConfig(ctx, f, true)
 			for _, endpointPod := range config.EndpointPods {
-				err := config.DialFromNode("http", endpointPod.Status.PodIP, e2enetwork.EndpointHTTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+				err := config.DialFromNode(ctx, "http", endpointPod.Status.PodIP, e2enetwork.EndpointHTTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
 				if err != nil {
 					framework.Failf("Error dialing HTTP node to pod %v", err)
 				}
@@ -122,9 +122,9 @@ var _ = SIGDescribe("Networking", func() {
 			This test is marked LinuxOnly it breaks when using Overlay networking with Windows.
 		*/
 		framework.ConformanceIt("should function for node-pod communication: udp [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-			config := e2enetwork.NewCoreNetworkingTestConfig(f, true)
+			config := e2enetwork.NewCoreNetworkingTestConfig(ctx, f, true)
 			for _, endpointPod := range config.EndpointPods {
-				err := config.DialFromNode("udp", endpointPod.Status.PodIP, e2enetwork.EndpointUDPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+				err := config.DialFromNode(ctx, "udp", endpointPod.Status.PodIP, e2enetwork.EndpointUDPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
 				if err != nil {
 					framework.Failf("Error dialing UDP from node to pod: %v", err)
 				}
@@ -132,15 +132,15 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		ginkgo.It("should function for intra-pod communication: sctp [LinuxOnly][Feature:SCTPConnectivity]", func(ctx context.Context) {
-			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.EnableSCTP)
-			checkPodToPodConnectivity(config, "sctp", e2enetwork.EndpointSCTPPort)
+			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.EnableSCTP)
+			checkPodToPodConnectivity(ctx, config, "sctp", e2enetwork.EndpointSCTPPort)
 		})
 
 		ginkgo.It("should function for node-pod communication: sctp [LinuxOnly][Feature:SCTPConnectivity]", func(ctx context.Context) {
 			ginkgo.Skip("Skipping SCTP node to pod test until DialFromNode supports SCTP #96482")
-			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.EnableSCTP)
+			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.EnableSCTP)
 			for _, endpointPod := range config.EndpointPods {
-				err := config.DialFromNode("sctp", endpointPod.Status.PodIP, e2enetwork.EndpointSCTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+				err := config.DialFromNode(ctx, "sctp", endpointPod.Status.PodIP, e2enetwork.EndpointSCTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
 				if err != nil {
 					framework.Failf("Error dialing SCTP from node to pod: %v", err)
 				}

--- a/test/e2e/common/node/configmap.go
+++ b/test/e2e/common/node/configmap.go
@@ -47,7 +47,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		configMap := newConfigMap(f, name)
 		ginkgo.By(fmt.Sprintf("Creating configMap %v/%v", f.Namespace.Name, configMap.Name))
 		var err error
-		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 		}
 
@@ -80,7 +80,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 			},
 		}
 
-		e2epodoutput.TestContainerOutput(f, "consume configMaps", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "consume configMaps", pod, 0, []string{
 			"CONFIG_DATA_1=value-1",
 		})
 	})
@@ -95,7 +95,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		configMap := newConfigMap(f, name)
 		ginkgo.By(fmt.Sprintf("Creating configMap %v/%v", f.Namespace.Name, configMap.Name))
 		var err error
-		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 		}
 
@@ -124,7 +124,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 			},
 		}
 
-		e2epodoutput.TestContainerOutput(f, "consume configMaps", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "consume configMaps", pod, 0, []string{
 			"data-1=value-1", "data-2=value-2", "data-3=value-3",
 			"p-data-1=value-1", "p-data-2=value-2", "p-data-3=value-3",
 		})
@@ -136,7 +136,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 	   Description: Attempt to create a ConfigMap with an empty key. The creation MUST fail.
 	*/
 	framework.ConformanceIt("should fail to create ConfigMap with empty key", func(ctx context.Context) {
-		configMap, err := newConfigMapWithEmptyKey(f)
+		configMap, err := newConfigMapWithEmptyKey(ctx, f)
 		framework.ExpectError(err, "created configMap %q with empty key in namespace %q", configMap.Name, f.Namespace.Name)
 	})
 
@@ -144,17 +144,17 @@ var _ = SIGDescribe("ConfigMap", func() {
 		name := "configmap-test-" + string(uuid.NewUUID())
 		configMap := newConfigMap(f, name)
 		ginkgo.By(fmt.Sprintf("Creating ConfigMap %v/%v", f.Namespace.Name, configMap.Name))
-		_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create ConfigMap")
 
 		configMap.Data = map[string]string{
 			"data": "value",
 		}
 		ginkgo.By(fmt.Sprintf("Updating configMap %v/%v", f.Namespace.Name, configMap.Name))
-		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, configMap, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "failed to update ConfigMap")
 
-		configMapFromUpdate, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(context.TODO(), name, metav1.GetOptions{})
+		configMapFromUpdate, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx, name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get ConfigMap")
 		ginkgo.By(fmt.Sprintf("Verifying update of ConfigMap %v/%v", f.Namespace.Name, configMap.Name))
 		framework.ExpectEqual(configMapFromUpdate.Data, configMap.Data)
@@ -183,11 +183,11 @@ var _ = SIGDescribe("ConfigMap", func() {
 		}
 
 		ginkgo.By("creating a ConfigMap")
-		_, err := f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).Create(context.TODO(), &testConfigMap, metav1.CreateOptions{})
+		_, err := f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).Create(ctx, &testConfigMap, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create ConfigMap")
 
 		ginkgo.By("fetching the ConfigMap")
-		configMap, err := f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).Get(context.TODO(), testConfigMapName, metav1.GetOptions{})
+		configMap, err := f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).Get(ctx, testConfigMapName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get ConfigMap")
 		framework.ExpectEqual(configMap.Data["valueName"], testConfigMap.Data["valueName"])
 		framework.ExpectEqual(configMap.Labels["test-configmap-static"], testConfigMap.Labels["test-configmap-static"])
@@ -205,11 +205,11 @@ var _ = SIGDescribe("ConfigMap", func() {
 		framework.ExpectNoError(err, "failed to marshal patch data")
 
 		ginkgo.By("patching the ConfigMap")
-		_, err = f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).Patch(context.TODO(), testConfigMapName, types.StrategicMergePatchType, []byte(configMapPatchPayload), metav1.PatchOptions{})
+		_, err = f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).Patch(ctx, testConfigMapName, types.StrategicMergePatchType, []byte(configMapPatchPayload), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch ConfigMap")
 
 		ginkgo.By("listing all ConfigMaps in all namespaces with a label selector")
-		configMapList, err := f.ClientSet.CoreV1().ConfigMaps("").List(context.TODO(), metav1.ListOptions{
+		configMapList, err := f.ClientSet.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{
 			LabelSelector: "test-configmap=patched",
 		})
 		framework.ExpectNoError(err, "failed to list ConfigMaps with LabelSelector")
@@ -229,13 +229,13 @@ var _ = SIGDescribe("ConfigMap", func() {
 		}
 
 		ginkgo.By("deleting the ConfigMap by collection with a label selector")
-		err = f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
+		err = f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
 			LabelSelector: "test-configmap-static=true",
 		})
 		framework.ExpectNoError(err, "failed to delete ConfigMap collection with LabelSelector")
 
 		ginkgo.By("listing all ConfigMaps in test namespace")
-		configMapList, err = f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).List(context.TODO(), metav1.ListOptions{
+		configMapList, err = f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).List(ctx, metav1.ListOptions{
 			LabelSelector: "test-configmap-static=true",
 		})
 		framework.ExpectNoError(err, "failed to list ConfigMap by LabelSelector")
@@ -257,7 +257,7 @@ func newConfigMap(f *framework.Framework, name string) *v1.ConfigMap {
 	}
 }
 
-func newConfigMapWithEmptyKey(f *framework.Framework) (*v1.ConfigMap, error) {
+func newConfigMapWithEmptyKey(ctx context.Context, f *framework.Framework) (*v1.ConfigMap, error) {
 	name := "configmap-test-emptyKey-" + string(uuid.NewUUID())
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -270,5 +270,5 @@ func newConfigMapWithEmptyKey(f *framework.Framework) (*v1.ConfigMap, error) {
 	}
 
 	ginkgo.By(fmt.Sprintf("Creating configMap that has name %s", configMap.Name))
-	return f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{})
+	return f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{})
 }

--- a/test/e2e/common/node/container.go
+++ b/test/e2e/common/node/container.go
@@ -50,7 +50,7 @@ type ConformanceContainer struct {
 }
 
 // Create creates the defined conformance container
-func (cc *ConformanceContainer) Create() {
+func (cc *ConformanceContainer) Create(ctx context.Context) {
 	cc.podName = cc.Container.Name + string(uuid.NewUUID())
 	imagePullSecrets := []v1.LocalObjectReference{}
 	for _, s := range cc.ImagePullSecrets {
@@ -70,17 +70,17 @@ func (cc *ConformanceContainer) Create() {
 			ImagePullSecrets: imagePullSecrets,
 		},
 	}
-	cc.PodClient.Create(pod)
+	cc.PodClient.Create(ctx, pod)
 }
 
 // Delete deletes the defined conformance container
-func (cc *ConformanceContainer) Delete() error {
-	return cc.PodClient.Delete(context.TODO(), cc.podName, *metav1.NewDeleteOptions(0))
+func (cc *ConformanceContainer) Delete(ctx context.Context) error {
+	return cc.PodClient.Delete(ctx, cc.podName, *metav1.NewDeleteOptions(0))
 }
 
 // IsReady returns whether this container is ready and error if any
-func (cc *ConformanceContainer) IsReady() (bool, error) {
-	pod, err := cc.PodClient.Get(context.TODO(), cc.podName, metav1.GetOptions{})
+func (cc *ConformanceContainer) IsReady(ctx context.Context) (bool, error) {
+	pod, err := cc.PodClient.Get(ctx, cc.podName, metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -88,8 +88,8 @@ func (cc *ConformanceContainer) IsReady() (bool, error) {
 }
 
 // GetPhase returns the phase of the pod lifecycle and error if any
-func (cc *ConformanceContainer) GetPhase() (v1.PodPhase, error) {
-	pod, err := cc.PodClient.Get(context.TODO(), cc.podName, metav1.GetOptions{})
+func (cc *ConformanceContainer) GetPhase(ctx context.Context) (v1.PodPhase, error) {
+	pod, err := cc.PodClient.Get(ctx, cc.podName, metav1.GetOptions{})
 	if err != nil {
 		// it doesn't matter what phase to return as error would not be nil
 		return v1.PodSucceeded, err
@@ -98,8 +98,8 @@ func (cc *ConformanceContainer) GetPhase() (v1.PodPhase, error) {
 }
 
 // GetStatus returns the details of the current status of this container and error if any
-func (cc *ConformanceContainer) GetStatus() (v1.ContainerStatus, error) {
-	pod, err := cc.PodClient.Get(context.TODO(), cc.podName, metav1.GetOptions{})
+func (cc *ConformanceContainer) GetStatus(ctx context.Context) (v1.ContainerStatus, error) {
+	pod, err := cc.PodClient.Get(ctx, cc.podName, metav1.GetOptions{})
 	if err != nil {
 		return v1.ContainerStatus{}, err
 	}
@@ -111,8 +111,8 @@ func (cc *ConformanceContainer) GetStatus() (v1.ContainerStatus, error) {
 }
 
 // Present returns whether this pod is present and error if any
-func (cc *ConformanceContainer) Present() (bool, error) {
-	_, err := cc.PodClient.Get(context.TODO(), cc.podName, metav1.GetOptions{})
+func (cc *ConformanceContainer) Present(ctx context.Context) (bool, error) {
+	_, err := cc.PodClient.Get(ctx, cc.podName, metav1.GetOptions{})
 	if err == nil {
 		return true, nil
 	}

--- a/test/e2e/common/node/containers.go
+++ b/test/e2e/common/node/containers.go
@@ -41,16 +41,16 @@ var _ = SIGDescribe("Containers", func() {
 	framework.ConformanceIt("should use the image defaults if command and args are blank [NodeConformance]", func(ctx context.Context) {
 		pod := entrypointTestPod(f.Namespace.Name)
 		pod.Spec.Containers[0].Args = nil
-		pod = e2epod.NewPodClient(f).Create(pod)
-		err := e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+		pod = e2epod.NewPodClient(f).Create(ctx, pod)
+		err := e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 		framework.ExpectNoError(err, "Expected pod %q to be running, got error: %v", pod.Name, err)
 		pollLogs := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
 		}
 
 		// The agnhost's image default entrypoint / args are: "/agnhost pause"
 		// which will print out "Paused".
-		gomega.Eventually(pollLogs, 3, framework.Poll).Should(gomega.ContainSubstring("Paused"))
+		gomega.Eventually(ctx, pollLogs, 3, framework.Poll).Should(gomega.ContainSubstring("Paused"))
 	})
 
 	/*
@@ -60,7 +60,7 @@ var _ = SIGDescribe("Containers", func() {
 	*/
 	framework.ConformanceIt("should be able to override the image's default arguments (container cmd) [NodeConformance]", func(ctx context.Context) {
 		pod := entrypointTestPod(f.Namespace.Name, "entrypoint-tester", "override", "arguments")
-		e2epodoutput.TestContainerOutput(f, "override arguments", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "override arguments", pod, 0, []string{
 			"[/agnhost entrypoint-tester override arguments]",
 		})
 	})
@@ -76,7 +76,7 @@ var _ = SIGDescribe("Containers", func() {
 		pod := entrypointTestPod(f.Namespace.Name, "entrypoint-tester")
 		pod.Spec.Containers[0].Command = []string{"/agnhost-2"}
 
-		e2epodoutput.TestContainerOutput(f, "override command", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "override command", pod, 0, []string{
 			"[/agnhost-2 entrypoint-tester]",
 		})
 	})
@@ -90,7 +90,7 @@ var _ = SIGDescribe("Containers", func() {
 		pod := entrypointTestPod(f.Namespace.Name, "entrypoint-tester", "override", "arguments")
 		pod.Spec.Containers[0].Command = []string{"/agnhost-2"}
 
-		e2epodoutput.TestContainerOutput(f, "override all", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "override all", pod, 0, []string{
 			"[/agnhost-2 entrypoint-tester override arguments]",
 		})
 	})

--- a/test/e2e/common/node/downwardapi.go
+++ b/test/e2e/common/node/downwardapi.go
@@ -80,7 +80,7 @@ var _ = SIGDescribe("Downward API", func() {
 			fmt.Sprintf("POD_IP=%v|%v", e2enetwork.RegexIPv4, e2enetwork.RegexIPv6),
 		}
 
-		testDownwardAPI(f, podName, env, expectations)
+		testDownwardAPI(ctx, f, podName, env, expectations)
 	})
 
 	/*
@@ -106,7 +106,7 @@ var _ = SIGDescribe("Downward API", func() {
 			fmt.Sprintf("HOST_IP=%v|%v", e2enetwork.RegexIPv4, e2enetwork.RegexIPv6),
 		}
 
-		testDownwardAPI(f, podName, env, expectations)
+		testDownwardAPI(ctx, f, podName, env, expectations)
 	})
 
 	ginkgo.It("should provide host IP and pod IP as an env var if pod uses host network [LinuxOnly]", func(ctx context.Context) {
@@ -155,7 +155,7 @@ var _ = SIGDescribe("Downward API", func() {
 			},
 		}
 
-		testDownwardAPIUsingPod(f, pod, env, expectations)
+		testDownwardAPIUsingPod(ctx, f, pod, env, expectations)
 
 	})
 
@@ -207,7 +207,7 @@ var _ = SIGDescribe("Downward API", func() {
 			"MEMORY_REQUEST=33554432",
 		}
 
-		testDownwardAPI(f, podName, env, expectations)
+		testDownwardAPI(ctx, f, podName, env, expectations)
 	})
 
 	/*
@@ -257,7 +257,7 @@ var _ = SIGDescribe("Downward API", func() {
 			},
 		}
 
-		testDownwardAPIUsingPod(f, pod, env, expectations)
+		testDownwardAPIUsingPod(ctx, f, pod, env, expectations)
 	})
 
 	/*
@@ -283,7 +283,7 @@ var _ = SIGDescribe("Downward API", func() {
 			"POD_UID=[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}",
 		}
 
-		testDownwardAPI(f, podName, env, expectations)
+		testDownwardAPI(ctx, f, podName, env, expectations)
 	})
 })
 
@@ -344,7 +344,7 @@ var _ = SIGDescribe("Downward API [Serial] [Disruptive] [NodeFeature:DownwardAPI
 					RestartPolicy: v1.RestartPolicyNever,
 				},
 			}
-			testDownwardAPIUsingPod(f, pod, env, expectations)
+			testDownwardAPIUsingPod(ctx, f, pod, env, expectations)
 		})
 
 		ginkgo.It("should provide default limits.hugepages-<pagesize> from node allocatable", func(ctx context.Context) {
@@ -381,13 +381,13 @@ var _ = SIGDescribe("Downward API [Serial] [Disruptive] [NodeFeature:DownwardAPI
 				},
 			}
 
-			testDownwardAPIUsingPod(f, pod, env, expectations)
+			testDownwardAPIUsingPod(ctx, f, pod, env, expectations)
 		})
 	})
 
 })
 
-func testDownwardAPI(f *framework.Framework, podName string, env []v1.EnvVar, expectations []string) {
+func testDownwardAPI(ctx context.Context, f *framework.Framework, podName string, env []v1.EnvVar, expectations []string) {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   podName,
@@ -416,9 +416,9 @@ func testDownwardAPI(f *framework.Framework, podName string, env []v1.EnvVar, ex
 		},
 	}
 
-	testDownwardAPIUsingPod(f, pod, env, expectations)
+	testDownwardAPIUsingPod(ctx, f, pod, env, expectations)
 }
 
-func testDownwardAPIUsingPod(f *framework.Framework, pod *v1.Pod, env []v1.EnvVar, expectations []string) {
-	e2epodoutput.TestContainerOutputRegexp(f, "downward api env vars", pod, 0, expectations)
+func testDownwardAPIUsingPod(ctx context.Context, f *framework.Framework, pod *v1.Pod, env []v1.EnvVar, expectations []string) {
+	e2epodoutput.TestContainerOutputRegexp(ctx, f, "downward api env vars", pod, 0, expectations)
 }

--- a/test/e2e/common/node/ephemeral_containers.go
+++ b/test/e2e/common/node/ephemeral_containers.go
@@ -45,7 +45,7 @@ var _ = SIGDescribe("Ephemeral Containers [NodeConformance]", func() {
 	// Description: Adding an ephemeral container to pod.spec MUST result in the container running.
 	framework.ConformanceIt("will start an ephemeral container in an existing pod", func(ctx context.Context) {
 		ginkgo.By("creating a target pod")
-		pod := podClient.CreateSync(&v1.Pod{
+		pod := podClient.CreateSync(ctx, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "ephemeral-containers-target-pod"},
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
@@ -70,14 +70,14 @@ var _ = SIGDescribe("Ephemeral Containers [NodeConformance]", func() {
 				TTY:     true,
 			},
 		}
-		err := podClient.AddEphemeralContainerSync(pod, ec, time.Minute)
+		err := podClient.AddEphemeralContainerSync(ctx, pod, ec, time.Minute)
 		framework.ExpectNoError(err, "Failed to patch ephemeral containers in pod %q", format.Pod(pod))
 
 		ginkgo.By("checking pod container endpoints")
 		// Can't use anything depending on kubectl here because it's not available in the node test environment
 		output := e2epod.ExecCommandInContainer(f, pod.Name, ecName, "/bin/echo", "marco")
 		gomega.Expect(output).To(gomega.ContainSubstring("marco"))
-		log, err := e2epod.GetPodLogs(f.ClientSet, pod.Namespace, pod.Name, ecName)
+		log, err := e2epod.GetPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, ecName)
 		framework.ExpectNoError(err, "Failed to get logs for pod %q ephemeral container %q", format.Pod(pod), ecName)
 		gomega.Expect(log).To(gomega.ContainSubstring("polo"))
 	})

--- a/test/e2e/common/node/init_container.go
+++ b/test/e2e/common/node/init_container.go
@@ -210,13 +210,13 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 			},
 		}
 		framework.Logf("PodSpec: initContainers in spec.initContainers")
-		startedPod := podClient.Create(pod)
+		startedPod := podClient.Create(ctx, pod)
 
 		fieldSelector := fields.OneTermEqualSelector("metadata.name", startedPod.Name).String()
 		w := &cache.ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
 				options.FieldSelector = fieldSelector
-				return podClient.Watch(context.TODO(), options)
+				return podClient.Watch(ctx, options)
 			},
 		}
 		var events []watch.Event
@@ -291,13 +291,13 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 			},
 		}
 		framework.Logf("PodSpec: initContainers in spec.initContainers")
-		startedPod := podClient.Create(pod)
+		startedPod := podClient.Create(ctx, pod)
 
 		fieldSelector := fields.OneTermEqualSelector("metadata.name", startedPod.Name).String()
 		w := &cache.ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
 				options.FieldSelector = fieldSelector
-				return podClient.Watch(context.TODO(), options)
+				return podClient.Watch(ctx, options)
 			},
 		}
 		var events []watch.Event
@@ -371,13 +371,13 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 			},
 		}
 		framework.Logf("PodSpec: initContainers in spec.initContainers")
-		startedPod := podClient.Create(pod)
+		startedPod := podClient.Create(ctx, pod)
 
 		fieldSelector := fields.OneTermEqualSelector("metadata.name", startedPod.Name).String()
 		w := &cache.ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
 				options.FieldSelector = fieldSelector
-				return podClient.Watch(context.TODO(), options)
+				return podClient.Watch(ctx, options)
 			},
 		}
 
@@ -496,13 +496,13 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 			},
 		}
 		framework.Logf("PodSpec: initContainers in spec.initContainers")
-		startedPod := podClient.Create(pod)
+		startedPod := podClient.Create(ctx, pod)
 
 		fieldSelector := fields.OneTermEqualSelector("metadata.name", startedPod.Name).String()
 		w := &cache.ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
 				options.FieldSelector = fieldSelector
-				return podClient.Watch(context.TODO(), options)
+				return podClient.Watch(ctx, options)
 			},
 		}
 

--- a/test/e2e/common/node/kubelet.go
+++ b/test/e2e/common/node/kubelet.go
@@ -50,7 +50,7 @@ var _ = SIGDescribe("Kubelet", func() {
 			Description: By default the stdout and stderr from the process being executed in a pod MUST be sent to the pod's logs.
 		*/
 		framework.ConformanceIt("should print the output to logs [NodeConformance]", func(ctx context.Context) {
-			podClient.CreateSync(&v1.Pod{
+			podClient.CreateSync(ctx, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: podName,
 				},
@@ -66,9 +66,9 @@ var _ = SIGDescribe("Kubelet", func() {
 					},
 				},
 			})
-			gomega.Eventually(func() string {
+			gomega.Eventually(ctx, func() string {
 				sinceTime := metav1.NewTime(time.Now().Add(time.Duration(-1 * time.Hour)))
-				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{SinceTime: &sinceTime}).Stream(context.TODO())
+				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{SinceTime: &sinceTime}).Stream(ctx)
 				if err != nil {
 					return ""
 				}
@@ -82,9 +82,9 @@ var _ = SIGDescribe("Kubelet", func() {
 	ginkgo.Context("when scheduling a busybox command that always fails in a pod", func() {
 		var podName string
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			podName = "bin-false" + string(uuid.NewUUID())
-			podClient.Create(&v1.Pod{
+			podClient.Create(ctx, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: podName,
 				},
@@ -108,8 +108,8 @@ var _ = SIGDescribe("Kubelet", func() {
 			Description: Create a Pod with terminated state. Pod MUST have only one container. Container MUST be in terminated state and MUST have an terminated reason.
 		*/
 		framework.ConformanceIt("should have an terminated reason [NodeConformance]", func(ctx context.Context) {
-			gomega.Eventually(func() error {
-				podData, err := podClient.Get(context.TODO(), podName, metav1.GetOptions{})
+			gomega.Eventually(ctx, func() error {
+				podData, err := podClient.Get(ctx, podName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -133,7 +133,7 @@ var _ = SIGDescribe("Kubelet", func() {
 			Description: Create a Pod with terminated state. This terminated pod MUST be able to be deleted.
 		*/
 		framework.ConformanceIt("should be possible to delete [NodeConformance]", func(ctx context.Context) {
-			err := podClient.Delete(context.TODO(), podName, metav1.DeleteOptions{})
+			err := podClient.Delete(ctx, podName, metav1.DeleteOptions{})
 			gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("Error deleting Pod %v", err))
 		})
 	})
@@ -156,12 +156,12 @@ var _ = SIGDescribe("Kubelet", func() {
 				},
 			}
 
-			pod = podClient.Create(pod)
+			pod = podClient.Create(ctx, pod)
 			ginkgo.By("Waiting for pod completion")
-			err := e2epod.WaitForPodNoLongerRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+			err := e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 			framework.ExpectNoError(err)
 
-			rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(context.TODO())
+			rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(ctx)
 			framework.ExpectNoError(err)
 			defer rc.Close()
 			buf := new(bytes.Buffer)
@@ -183,7 +183,7 @@ var _ = SIGDescribe("Kubelet", func() {
 		*/
 		framework.ConformanceIt("should not write to root filesystem [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
 			isReadOnly := true
-			podClient.CreateSync(&v1.Pod{
+			podClient.CreateSync(ctx, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: podName,
 				},
@@ -202,8 +202,8 @@ var _ = SIGDescribe("Kubelet", func() {
 					},
 				},
 			})
-			gomega.Eventually(func() string {
-				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(context.TODO())
+			gomega.Eventually(ctx, func() string {
+				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(ctx)
 				if err != nil {
 					return ""
 				}

--- a/test/e2e/common/node/kubelet_etc_hosts.go
+++ b/test/e2e/common/node/kubelet_etc_hosts.go
@@ -63,7 +63,7 @@ var _ = SIGDescribe("KubeletManagedEtcHosts", func() {
 	*/
 	framework.ConformanceIt("should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
 		ginkgo.By("Setting up the test")
-		config.setup()
+		config.setup(ctx)
 
 		ginkgo.By("Running the test")
 		config.verifyEtcHosts()
@@ -83,22 +83,22 @@ func (config *KubeletManagedHostConfig) verifyEtcHosts() {
 	assertManagedStatus(config, etcHostsHostNetworkPodName, false, "busybox-2")
 }
 
-func (config *KubeletManagedHostConfig) setup() {
+func (config *KubeletManagedHostConfig) setup(ctx context.Context) {
 	ginkgo.By("Creating hostNetwork=false pod")
-	config.createPodWithoutHostNetwork()
+	config.createPodWithoutHostNetwork(ctx)
 
 	ginkgo.By("Creating hostNetwork=true pod")
-	config.createPodWithHostNetwork()
+	config.createPodWithHostNetwork(ctx)
 }
 
-func (config *KubeletManagedHostConfig) createPodWithoutHostNetwork() {
+func (config *KubeletManagedHostConfig) createPodWithoutHostNetwork(ctx context.Context) {
 	podSpec := config.createPodSpec(etcHostsPodName)
-	config.pod = e2epod.NewPodClient(config.f).CreateSync(podSpec)
+	config.pod = e2epod.NewPodClient(config.f).CreateSync(ctx, podSpec)
 }
 
-func (config *KubeletManagedHostConfig) createPodWithHostNetwork() {
+func (config *KubeletManagedHostConfig) createPodWithHostNetwork(ctx context.Context) {
 	podSpec := config.createPodSpecWithHostNetwork(etcHostsHostNetworkPodName)
-	config.hostNetworkPod = e2epod.NewPodClient(config.f).CreateSync(podSpec)
+	config.hostNetworkPod = e2epod.NewPodClient(config.f).CreateSync(ctx, podSpec)
 }
 
 func assertManagedStatus(

--- a/test/e2e/common/node/lease.go
+++ b/test/e2e/common/node/lease.go
@@ -86,10 +86,10 @@ var _ = SIGDescribe("Lease", func() {
 			},
 		}
 
-		createdLease, err := leaseClient.Create(context.TODO(), lease, metav1.CreateOptions{})
+		createdLease, err := leaseClient.Create(ctx, lease, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "creating Lease failed")
 
-		readLease, err := leaseClient.Get(context.TODO(), name, metav1.GetOptions{})
+		readLease, err := leaseClient.Get(ctx, name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "couldn't read Lease")
 		if !apiequality.Semantic.DeepEqual(lease.Spec, readLease.Spec) {
 			framework.Failf("Leases don't match. Diff (- for expected, + for actual):\n%s", cmp.Diff(lease.Spec, readLease.Spec))
@@ -103,10 +103,10 @@ var _ = SIGDescribe("Lease", func() {
 			LeaseTransitions:     pointer.Int32Ptr(1),
 		}
 
-		_, err = leaseClient.Update(context.TODO(), createdLease, metav1.UpdateOptions{})
+		_, err = leaseClient.Update(ctx, createdLease, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "updating Lease failed")
 
-		readLease, err = leaseClient.Get(context.TODO(), name, metav1.GetOptions{})
+		readLease, err = leaseClient.Get(ctx, name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "couldn't read Lease")
 		if !apiequality.Semantic.DeepEqual(createdLease.Spec, readLease.Spec) {
 			framework.Failf("Leases don't match. Diff (- for expected, + for actual):\n%s", cmp.Diff(createdLease.Spec, readLease.Spec))
@@ -123,10 +123,10 @@ var _ = SIGDescribe("Lease", func() {
 		patchBytes, err := getPatchBytes(readLease, patchedLease)
 		framework.ExpectNoError(err, "creating patch failed")
 
-		_, err = leaseClient.Patch(context.TODO(), name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+		_, err = leaseClient.Patch(ctx, name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
 		framework.ExpectNoError(err, "patching Lease failed")
 
-		readLease, err = leaseClient.Get(context.TODO(), name, metav1.GetOptions{})
+		readLease, err = leaseClient.Get(ctx, name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "couldn't read Lease")
 		if !apiequality.Semantic.DeepEqual(patchedLease.Spec, readLease.Spec) {
 			framework.Failf("Leases don't match. Diff (- for expected, + for actual):\n%s", cmp.Diff(patchedLease.Spec, readLease.Spec))
@@ -146,25 +146,25 @@ var _ = SIGDescribe("Lease", func() {
 				LeaseTransitions:     pointer.Int32Ptr(0),
 			},
 		}
-		_, err = leaseClient.Create(context.TODO(), lease2, metav1.CreateOptions{})
+		_, err = leaseClient.Create(ctx, lease2, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "creating Lease failed")
 
-		leases, err := leaseClient.List(context.TODO(), metav1.ListOptions{})
+		leases, err := leaseClient.List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "couldn't list Leases")
 		framework.ExpectEqual(len(leases.Items), 2)
 
 		selector := labels.Set(map[string]string{"deletecollection": "true"}).AsSelector()
-		err = leaseClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector.String()})
+		err = leaseClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector.String()})
 		framework.ExpectNoError(err, "couldn't delete collection")
 
-		leases, err = leaseClient.List(context.TODO(), metav1.ListOptions{})
+		leases, err = leaseClient.List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "couldn't list Leases")
 		framework.ExpectEqual(len(leases.Items), 1)
 
-		err = leaseClient.Delete(context.TODO(), name, metav1.DeleteOptions{})
+		err = leaseClient.Delete(ctx, name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "deleting Lease failed")
 
-		_, err = leaseClient.Get(context.TODO(), name, metav1.GetOptions{})
+		_, err = leaseClient.Get(ctx, name, metav1.GetOptions{})
 		if !apierrors.IsNotFound(err) {
 			framework.Failf("expected IsNotFound error, got %#v", err)
 		}
@@ -174,7 +174,7 @@ var _ = SIGDescribe("Lease", func() {
 		// created for every node by the corresponding Kubelet.
 		// That said, the objects themselves are small (~300B), so even with 5000
 		// of them, that gives ~1.5MB, which is acceptable.
-		_, err = leaseClient.List(context.TODO(), metav1.ListOptions{})
+		_, err = leaseClient.List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "couldn't list Leases from all namespace")
 	})
 })

--- a/test/e2e/common/node/lifecycle_hook.go
+++ b/test/e2e/common/node/lifecycle_hook.go
@@ -75,8 +75,8 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 			e2epod.NewAgnhostContainer("container-handle-https-request", nil, httpsPorts, httpsArgs...),
 		)
 
-		ginkgo.BeforeEach(func() {
-			node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 			framework.ExpectNoError(err)
 			targetNode = node.Name
 			nodeSelection := e2epod.NodeSelection{}
@@ -85,16 +85,16 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 
 			podClient = e2epod.NewPodClient(f)
 			ginkgo.By("create the container to handle the HTTPGet hook request.")
-			newPod := podClient.CreateSync(podHandleHookRequest)
+			newPod := podClient.CreateSync(ctx, podHandleHookRequest)
 			targetIP = newPod.Status.PodIP
 			targetURL = targetIP
 			if strings.Contains(targetIP, ":") {
 				targetURL = fmt.Sprintf("[%s]", targetIP)
 			}
 		})
-		testPodWithHook := func(podWithHook *v1.Pod) {
+		testPodWithHook := func(ctx context.Context, podWithHook *v1.Pod) {
 			ginkgo.By("create the pod with lifecycle hook")
-			podClient.CreateSync(podWithHook)
+			podClient.CreateSync(ctx, podWithHook)
 			const (
 				defaultHandler = iota
 				httpsHandler
@@ -107,13 +107,13 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 						handlerContainer = httpsHandler
 					}
 				}
-				gomega.Eventually(func() error {
-					return podClient.MatchContainerOutput(podHandleHookRequest.Name, podHandleHookRequest.Spec.Containers[handlerContainer].Name,
+				gomega.Eventually(ctx, func(ctx context.Context) error {
+					return podClient.MatchContainerOutput(ctx, podHandleHookRequest.Name, podHandleHookRequest.Spec.Containers[handlerContainer].Name,
 						`GET /echo\?msg=poststart`)
 				}, postStartWaitTimeout, podCheckInterval).Should(gomega.BeNil())
 			}
 			ginkgo.By("delete the pod with lifecycle hook")
-			podClient.DeleteSync(podWithHook.Name, *metav1.NewDeleteOptions(15), e2epod.DefaultPodDeletionTimeout)
+			podClient.DeleteSync(ctx, podWithHook.Name, *metav1.NewDeleteOptions(15), e2epod.DefaultPodDeletionTimeout)
 			if podWithHook.Spec.Containers[0].Lifecycle.PreStop != nil {
 				ginkgo.By("check prestop hook")
 				if podWithHook.Spec.Containers[0].Lifecycle.PreStop.HTTPGet != nil {
@@ -121,8 +121,8 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 						handlerContainer = httpsHandler
 					}
 				}
-				gomega.Eventually(func() error {
-					return podClient.MatchContainerOutput(podHandleHookRequest.Name, podHandleHookRequest.Spec.Containers[handlerContainer].Name,
+				gomega.Eventually(ctx, func(ctx context.Context) error {
+					return podClient.MatchContainerOutput(ctx, podHandleHookRequest.Name, podHandleHookRequest.Spec.Containers[handlerContainer].Name,
 						`GET /echo\?msg=prestop`)
 				}, preStopWaitTimeout, podCheckInterval).Should(gomega.BeNil())
 			}
@@ -142,7 +142,7 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 			}
 			podWithHook := getPodWithHook("pod-with-poststart-exec-hook", imageutils.GetE2EImage(imageutils.Agnhost), lifecycle)
 
-			testPodWithHook(podWithHook)
+			testPodWithHook(ctx, podWithHook)
 		})
 		/*
 			Release: v1.9
@@ -158,7 +158,7 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 				},
 			}
 			podWithHook := getPodWithHook("pod-with-prestop-exec-hook", imageutils.GetE2EImage(imageutils.Agnhost), lifecycle)
-			testPodWithHook(podWithHook)
+			testPodWithHook(ctx, podWithHook)
 		})
 		/*
 			Release: v1.9
@@ -180,7 +180,7 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 			nodeSelection := e2epod.NodeSelection{}
 			e2epod.SetAffinity(&nodeSelection, targetNode)
 			e2epod.SetNodeSelection(&podWithHook.Spec, nodeSelection)
-			testPodWithHook(podWithHook)
+			testPodWithHook(ctx, podWithHook)
 		})
 		/*
 			Release : v1.23
@@ -203,7 +203,7 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 			nodeSelection := e2epod.NodeSelection{}
 			e2epod.SetAffinity(&nodeSelection, targetNode)
 			e2epod.SetNodeSelection(&podWithHook.Spec, nodeSelection)
-			testPodWithHook(podWithHook)
+			testPodWithHook(ctx, podWithHook)
 		})
 		/*
 			Release : v1.9
@@ -225,7 +225,7 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 			nodeSelection := e2epod.NodeSelection{}
 			e2epod.SetAffinity(&nodeSelection, targetNode)
 			e2epod.SetNodeSelection(&podWithHook.Spec, nodeSelection)
-			testPodWithHook(podWithHook)
+			testPodWithHook(ctx, podWithHook)
 		})
 		/*
 			Release : v1.23
@@ -248,7 +248,7 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 			nodeSelection := e2epod.NodeSelection{}
 			e2epod.SetAffinity(&nodeSelection, targetNode)
 			e2epod.SetNodeSelection(&podWithHook.Spec, nodeSelection)
-			testPodWithHook(podWithHook)
+			testPodWithHook(ctx, podWithHook)
 		})
 	})
 })

--- a/test/e2e/common/node/pod_admission.go
+++ b/test/e2e/common/node/pod_admission.go
@@ -37,7 +37,7 @@ var _ = SIGDescribe("PodOSRejection [NodeConformance]", func() {
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 	ginkgo.Context("Kubelet", func() {
 		ginkgo.It("should reject pod when the node OS doesn't match pod's OS", func(ctx context.Context) {
-			linuxNode, err := findLinuxNode(f)
+			linuxNode, err := findLinuxNode(ctx, f)
 			framework.ExpectNoError(err)
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -57,18 +57,18 @@ var _ = SIGDescribe("PodOSRejection [NodeConformance]", func() {
 					NodeName: linuxNode.Name, // Set the node to an node which doesn't support
 				},
 			}
-			pod = e2epod.NewPodClient(f).Create(pod)
+			pod = e2epod.NewPodClient(f).Create(ctx, pod)
 			// Check the pod is still not running
-			err = e2epod.WaitForPodFailedReason(f.ClientSet, pod, "PodOSNotSupported", f.Timeouts.PodStartShort)
+			err = e2epod.WaitForPodFailedReason(ctx, f.ClientSet, pod, "PodOSNotSupported", f.Timeouts.PodStartShort)
 			framework.ExpectNoError(err)
 		})
 	})
 })
 
 // findLinuxNode finds a Linux node that is Ready and Schedulable
-func findLinuxNode(f *framework.Framework) (v1.Node, error) {
+func findLinuxNode(ctx context.Context, f *framework.Framework) (v1.Node, error) {
 	selector := labels.Set{"kubernetes.io/os": "linux"}.AsSelector()
-	nodeList, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	nodeList, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 
 	if err != nil {
 		return v1.Node{}, err

--- a/test/e2e/common/node/podtemplates.go
+++ b/test/e2e/common/node/podtemplates.go
@@ -55,14 +55,14 @@ var _ = SIGDescribe("PodTemplates", func() {
 		podTemplateName := "nginx-pod-template-" + string(uuid.NewUUID())
 
 		// get a list of PodTemplates (in all namespaces to hit endpoint)
-		podTemplateList, err := f.ClientSet.CoreV1().PodTemplates("").List(context.TODO(), metav1.ListOptions{
+		podTemplateList, err := f.ClientSet.CoreV1().PodTemplates("").List(ctx, metav1.ListOptions{
 			LabelSelector: "podtemplate-static=true",
 		})
 		framework.ExpectNoError(err, "failed to list all PodTemplates")
 		framework.ExpectEqual(len(podTemplateList.Items), 0, "unable to find templates")
 
 		// create a PodTemplate
-		_, err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Create(context.TODO(), &v1.PodTemplate{
+		_, err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Create(ctx, &v1.PodTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: podTemplateName,
 				Labels: map[string]string{
@@ -80,7 +80,7 @@ var _ = SIGDescribe("PodTemplates", func() {
 		framework.ExpectNoError(err, "failed to create PodTemplate")
 
 		// get template
-		podTemplateRead, err := f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Get(context.TODO(), podTemplateName, metav1.GetOptions{})
+		podTemplateRead, err := f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Get(ctx, podTemplateName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get created PodTemplate")
 		framework.ExpectEqual(podTemplateRead.ObjectMeta.Name, podTemplateName)
 
@@ -93,20 +93,20 @@ var _ = SIGDescribe("PodTemplates", func() {
 			},
 		})
 		framework.ExpectNoError(err, "failed to marshal patch data")
-		_, err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Patch(context.TODO(), podTemplateName, types.StrategicMergePatchType, []byte(podTemplatePatch), metav1.PatchOptions{})
+		_, err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Patch(ctx, podTemplateName, types.StrategicMergePatchType, []byte(podTemplatePatch), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch PodTemplate")
 
 		// get template (ensure label is there)
-		podTemplateRead, err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Get(context.TODO(), podTemplateName, metav1.GetOptions{})
+		podTemplateRead, err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Get(ctx, podTemplateName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get PodTemplate")
 		framework.ExpectEqual(podTemplateRead.ObjectMeta.Labels["podtemplate"], "patched", "failed to patch template, new label not found")
 
 		// delete the PodTemplate
-		err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Delete(context.TODO(), podTemplateName, metav1.DeleteOptions{})
+		err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Delete(ctx, podTemplateName, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete PodTemplate")
 
 		// list the PodTemplates
-		podTemplateList, err = f.ClientSet.CoreV1().PodTemplates("").List(context.TODO(), metav1.ListOptions{
+		podTemplateList, err = f.ClientSet.CoreV1().PodTemplates("").List(ctx, metav1.ListOptions{
 			LabelSelector: "podtemplate-static=true",
 		})
 		framework.ExpectNoError(err, "failed to list PodTemplate")
@@ -125,7 +125,7 @@ var _ = SIGDescribe("PodTemplates", func() {
 		ginkgo.By("Create set of pod templates")
 		// create a set of pod templates in test namespace
 		for _, podTemplateName := range podTemplateNames {
-			_, err := f.ClientSet.CoreV1().PodTemplates(f.Namespace.Name).Create(context.TODO(), &v1.PodTemplate{
+			_, err := f.ClientSet.CoreV1().PodTemplates(f.Namespace.Name).Create(ctx, &v1.PodTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   podTemplateName,
 					Labels: map[string]string{"podtemplate-set": "true"},
@@ -144,7 +144,7 @@ var _ = SIGDescribe("PodTemplates", func() {
 
 		ginkgo.By("get a list of pod templates with a label in the current namespace")
 		// get a list of pod templates
-		podTemplateList, err := f.ClientSet.CoreV1().PodTemplates(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{
+		podTemplateList, err := f.ClientSet.CoreV1().PodTemplates(f.Namespace.Name).List(ctx, metav1.ListOptions{
 			LabelSelector: "podtemplate-set=true",
 		})
 		framework.ExpectNoError(err, "failed to get a list of pod templates")
@@ -155,13 +155,13 @@ var _ = SIGDescribe("PodTemplates", func() {
 		// delete collection
 
 		framework.Logf("requesting DeleteCollection of pod templates")
-		err = f.ClientSet.CoreV1().PodTemplates(f.Namespace.Name).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
+		err = f.ClientSet.CoreV1().PodTemplates(f.Namespace.Name).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
 			LabelSelector: "podtemplate-set=true"})
 		framework.ExpectNoError(err, "failed to delete all pod templates")
 
 		ginkgo.By("check that the list of pod templates matches the requested quantity")
 
-		err = wait.PollImmediate(podTemplateRetryPeriod, podTemplateRetryTimeout, checkPodTemplateListQuantity(f, "podtemplate-set=true", 0))
+		err = wait.PollImmediate(podTemplateRetryPeriod, podTemplateRetryTimeout, checkPodTemplateListQuantity(ctx, f, "podtemplate-set=true", 0))
 		framework.ExpectNoError(err, "failed to count required pod templates")
 
 	})
@@ -178,7 +178,7 @@ var _ = SIGDescribe("PodTemplates", func() {
 		ptName := "podtemplate-" + utilrand.String(5)
 
 		ginkgo.By("Create a pod template")
-		ptResource, err := ptClient.Create(context.TODO(), &v1.PodTemplate{
+		ptResource, err := ptClient.Create(ctx, &v1.PodTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: ptName,
 			},
@@ -196,12 +196,12 @@ var _ = SIGDescribe("PodTemplates", func() {
 		var updatedPT *v1.PodTemplate
 
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			ptResource, err = ptClient.Get(context.TODO(), ptName, metav1.GetOptions{})
+			ptResource, err = ptClient.Get(ctx, ptName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Unable to get pod template %s", ptName)
 			ptResource.Annotations = map[string]string{
 				"updated": "true",
 			}
-			updatedPT, err = ptClient.Update(context.TODO(), ptResource, metav1.UpdateOptions{})
+			updatedPT, err = ptClient.Update(ctx, ptResource, metav1.UpdateOptions{})
 			return err
 		})
 		framework.ExpectNoError(err)
@@ -211,13 +211,13 @@ var _ = SIGDescribe("PodTemplates", func() {
 
 })
 
-func checkPodTemplateListQuantity(f *framework.Framework, label string, quantity int) func() (bool, error) {
+func checkPodTemplateListQuantity(ctx context.Context, f *framework.Framework, label string, quantity int) func() (bool, error) {
 	return func() (bool, error) {
 		var err error
 
 		framework.Logf("requesting list of pod templates to confirm quantity")
 
-		list, err := f.ClientSet.CoreV1().PodTemplates(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{
+		list, err := f.ClientSet.CoreV1().PodTemplates(f.Namespace.Name).List(ctx, metav1.ListOptions{
 			LabelSelector: label})
 
 		if err != nil {

--- a/test/e2e/common/node/privileged.go
+++ b/test/e2e/common/node/privileged.go
@@ -54,7 +54,7 @@ var _ = SIGDescribe("PrivilegedPod [NodeConformance]", func() {
 	ginkgo.It("should enable privileged commands [LinuxOnly]", func(ctx context.Context) {
 		// Windows does not support privileged containers.
 		ginkgo.By("Creating a pod with a privileged container")
-		config.createPods()
+		config.createPods(ctx)
 
 		ginkgo.By("Executing in the privileged container")
 		config.run(config.privilegedContainer, true)
@@ -115,7 +115,7 @@ func (c *PrivilegedPodTestConfig) createPodsSpec() *v1.Pod {
 	}
 }
 
-func (c *PrivilegedPodTestConfig) createPods() {
+func (c *PrivilegedPodTestConfig) createPods(ctx context.Context) {
 	podSpec := c.createPodsSpec()
-	c.pod = e2epod.NewPodClient(c.f).CreateSync(podSpec)
+	c.pod = e2epod.NewPodClient(c.f).CreateSync(ctx, podSpec)
 }

--- a/test/e2e/common/node/runtimeclass.go
+++ b/test/e2e/common/node/runtimeclass.go
@@ -54,15 +54,15 @@ var _ = SIGDescribe("RuntimeClass", func() {
 	*/
 	framework.ConformanceIt("should reject a Pod requesting a non-existent RuntimeClass [NodeConformance]", func(ctx context.Context) {
 		rcName := f.Namespace.Name + "-nonexistent"
-		expectPodRejection(f, e2enode.NewRuntimeClassPod(rcName))
+		expectPodRejection(ctx, f, e2enode.NewRuntimeClassPod(rcName))
 	})
 
 	// The test CANNOT be made a Conformance as it depends on a container runtime to have a specific handler not being installed.
 	ginkgo.It("should reject a Pod requesting a RuntimeClass with an unconfigured handler [NodeFeature:RuntimeHandler]", func(ctx context.Context) {
 		handler := f.Namespace.Name + "-handler"
-		rcName := createRuntimeClass(f, "unconfigured-handler", handler, nil)
+		rcName := createRuntimeClass(ctx, f, "unconfigured-handler", handler, nil)
 		ginkgo.DeferCleanup(deleteRuntimeClass, f, rcName)
-		pod := e2epod.NewPodClient(f).Create(e2enode.NewRuntimeClassPod(rcName))
+		pod := e2epod.NewPodClient(f).Create(ctx, e2enode.NewRuntimeClassPod(rcName))
 		eventSelector := fields.Set{
 			"involvedObject.kind":      "Pod",
 			"involvedObject.name":      pod.Name,
@@ -70,12 +70,12 @@ var _ = SIGDescribe("RuntimeClass", func() {
 			"reason":                   events.FailedCreatePodSandBox,
 		}.AsSelector().String()
 		// Events are unreliable, don't depend on the event. It's used only to speed up the test.
-		err := e2eevents.WaitTimeoutForEvent(f.ClientSet, f.Namespace.Name, eventSelector, handler, framework.PodEventTimeout)
+		err := e2eevents.WaitTimeoutForEvent(ctx, f.ClientSet, f.Namespace.Name, eventSelector, handler, framework.PodEventTimeout)
 		if err != nil {
 			framework.Logf("Warning: did not get event about FailedCreatePodSandBox. Err: %v", err)
 		}
 		// Check the pod is still not running
-		p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "could not re-read the pod after event (or timeout)")
 		framework.ExpectEqual(p.Status.Phase, v1.PodPending, "Pod phase isn't pending")
 	})
@@ -87,10 +87,10 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		// see https://github.com/kubernetes/kubernetes/blob/eb729620c522753bc7ae61fc2c7b7ea19d4aad2f/cluster/gce/gci/configure-helper.sh#L3069-L3076
 		e2eskipper.SkipUnlessProviderIs("gce")
 
-		rcName := createRuntimeClass(f, "preconfigured-handler", e2enode.PreconfiguredRuntimeClassHandler, nil)
+		rcName := createRuntimeClass(ctx, f, "preconfigured-handler", e2enode.PreconfiguredRuntimeClassHandler, nil)
 		ginkgo.DeferCleanup(deleteRuntimeClass, f, rcName)
-		pod := e2epod.NewPodClient(f).Create(e2enode.NewRuntimeClassPod(rcName))
-		expectPodSuccess(f, pod)
+		pod := e2epod.NewPodClient(f).Create(ctx, e2enode.NewRuntimeClassPod(rcName))
+		expectPodSuccess(ctx, f, pod)
 	})
 
 	/*
@@ -102,12 +102,12 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		is not being tested here.
 	*/
 	framework.ConformanceIt("should schedule a Pod requesting a RuntimeClass without PodOverhead [NodeConformance]", func(ctx context.Context) {
-		rcName := createRuntimeClass(f, "preconfigured-handler", e2enode.PreconfiguredRuntimeClassHandler, nil)
+		rcName := createRuntimeClass(ctx, f, "preconfigured-handler", e2enode.PreconfiguredRuntimeClassHandler, nil)
 		ginkgo.DeferCleanup(deleteRuntimeClass, f, rcName)
-		pod := e2epod.NewPodClient(f).Create(e2enode.NewRuntimeClassPod(rcName))
+		pod := e2epod.NewPodClient(f).Create(ctx, e2enode.NewRuntimeClassPod(rcName))
 		// there is only one pod in the namespace
 		label := labels.SelectorFromSet(labels.Set(map[string]string{}))
-		pods, err := e2epod.WaitForPodsWithLabelScheduled(f.ClientSet, f.Namespace.Name, label)
+		pods, err := e2epod.WaitForPodsWithLabelScheduled(ctx, f.ClientSet, f.Namespace.Name, label)
 		framework.ExpectNoError(err, "Failed to schedule Pod with the RuntimeClass")
 
 		framework.ExpectEqual(len(pods.Items), 1)
@@ -127,17 +127,17 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		is not being tested here.
 	*/
 	framework.ConformanceIt("should schedule a Pod requesting a RuntimeClass and initialize its Overhead [NodeConformance]", func(ctx context.Context) {
-		rcName := createRuntimeClass(f, "preconfigured-handler", e2enode.PreconfiguredRuntimeClassHandler, &nodev1.Overhead{
+		rcName := createRuntimeClass(ctx, f, "preconfigured-handler", e2enode.PreconfiguredRuntimeClassHandler, &nodev1.Overhead{
 			PodFixed: v1.ResourceList{
 				v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10m"),
 				v1.ResourceName(v1.ResourceMemory): resource.MustParse("1Mi"),
 			},
 		})
 		ginkgo.DeferCleanup(deleteRuntimeClass, f, rcName)
-		pod := e2epod.NewPodClient(f).Create(e2enode.NewRuntimeClassPod(rcName))
+		pod := e2epod.NewPodClient(f).Create(ctx, e2enode.NewRuntimeClassPod(rcName))
 		// there is only one pod in the namespace
 		label := labels.SelectorFromSet(labels.Set(map[string]string{}))
-		pods, err := e2epod.WaitForPodsWithLabelScheduled(f.ClientSet, f.Namespace.Name, label)
+		pods, err := e2epod.WaitForPodsWithLabelScheduled(ctx, f.ClientSet, f.Namespace.Name, label)
 		framework.ExpectNoError(err, "Failed to schedule Pod with the RuntimeClass")
 
 		framework.ExpectEqual(len(pods.Items), 1)
@@ -154,16 +154,16 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		Description: Pod requesting the deleted RuntimeClass must be rejected.
 	*/
 	framework.ConformanceIt("should reject a Pod requesting a deleted RuntimeClass [NodeConformance]", func(ctx context.Context) {
-		rcName := createRuntimeClass(f, "delete-me", "runc", nil)
+		rcName := createRuntimeClass(ctx, f, "delete-me", "runc", nil)
 		rcClient := f.ClientSet.NodeV1().RuntimeClasses()
 
 		ginkgo.By("Deleting RuntimeClass "+rcName, func() {
-			err := rcClient.Delete(context.TODO(), rcName, metav1.DeleteOptions{})
+			err := rcClient.Delete(ctx, rcName, metav1.DeleteOptions{})
 			framework.ExpectNoError(err, "failed to delete RuntimeClass %s", rcName)
 
 			ginkgo.By("Waiting for the RuntimeClass to disappear")
 			framework.ExpectNoError(wait.PollImmediate(framework.Poll, time.Minute, func() (bool, error) {
-				_, err := rcClient.Get(context.TODO(), rcName, metav1.GetOptions{})
+				_, err := rcClient.Get(ctx, rcName, metav1.GetOptions{})
 				if apierrors.IsNotFound(err) {
 					return true, nil // done
 				}
@@ -174,7 +174,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 			}))
 		})
 
-		expectPodRejection(f, e2enode.NewRuntimeClassPod(rcName))
+		expectPodRejection(ctx, f, e2enode.NewRuntimeClassPod(rcName))
 	})
 
 	/*
@@ -227,7 +227,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		ginkgo.By("getting /apis/node.k8s.io")
 		{
 			group := &metav1.APIGroup{}
-			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/node.k8s.io").Do(context.TODO()).Into(group)
+			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/node.k8s.io").Do(ctx).Into(group)
 			framework.ExpectNoError(err)
 			found := false
 			for _, version := range group.Versions {
@@ -260,43 +260,43 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		// Main resource create/read/update/watch operations
 
 		ginkgo.By("creating")
-		createdRC, err := rcClient.Create(context.TODO(), rc, metav1.CreateOptions{})
+		createdRC, err := rcClient.Create(ctx, rc, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		_, err = rcClient.Create(context.TODO(), rc, metav1.CreateOptions{})
+		_, err = rcClient.Create(ctx, rc, metav1.CreateOptions{})
 		if !apierrors.IsAlreadyExists(err) {
 			framework.Failf("expected 409, got %#v", err)
 		}
-		_, err = rcClient.Create(context.TODO(), rc2, metav1.CreateOptions{})
+		_, err = rcClient.Create(ctx, rc2, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
-		rcWatch, err := rcClient.Watch(context.TODO(), metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		rcWatch, err := rcClient.Watch(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
 
 		// added for a watch
-		_, err = rcClient.Create(context.TODO(), rc3, metav1.CreateOptions{})
+		_, err = rcClient.Create(ctx, rc3, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("getting")
-		gottenRC, err := rcClient.Get(context.TODO(), rc.Name, metav1.GetOptions{})
+		gottenRC, err := rcClient.Get(ctx, rc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(gottenRC.UID, createdRC.UID)
 
 		ginkgo.By("listing")
-		rcs, err := rcClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		rcs, err := rcClient.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(rcs.Items), 3, "filtered list should have 3 items")
 
 		ginkgo.By("patching")
-		patchedRC, err := rcClient.Patch(context.TODO(), createdRC.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
+		patchedRC, err := rcClient.Patch(ctx, createdRC.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(patchedRC.Annotations["patched"], "true", "patched object should have the applied annotation")
 
 		ginkgo.By("updating")
 		csrToUpdate := patchedRC.DeepCopy()
 		csrToUpdate.Annotations["updated"] = "true"
-		updatedRC, err := rcClient.Update(context.TODO(), csrToUpdate, metav1.UpdateOptions{})
+		updatedRC, err := rcClient.Update(ctx, csrToUpdate, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(updatedRC.Annotations["updated"], "true", "updated object should have the applied annotation")
 
@@ -338,43 +338,43 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		// main resource delete operations
 
 		ginkgo.By("deleting")
-		err = rcClient.Delete(context.TODO(), createdRC.Name, metav1.DeleteOptions{})
+		err = rcClient.Delete(ctx, createdRC.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
-		_, err = rcClient.Get(context.TODO(), createdRC.Name, metav1.GetOptions{})
+		_, err = rcClient.Get(ctx, createdRC.Name, metav1.GetOptions{})
 		if !apierrors.IsNotFound(err) {
 			framework.Failf("expected 404, got %#v", err)
 		}
-		rcs, err = rcClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		rcs, err = rcClient.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(rcs.Items), 2, "filtered list should have 2 items")
 
 		ginkgo.By("deleting a collection")
-		err = rcClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		err = rcClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
-		rcs, err = rcClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		rcs, err = rcClient.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(rcs.Items), 0, "filtered list should have 0 items")
 	})
 })
 
-func deleteRuntimeClass(f *framework.Framework, name string) {
-	err := f.ClientSet.NodeV1().RuntimeClasses().Delete(context.TODO(), name, metav1.DeleteOptions{})
+func deleteRuntimeClass(ctx context.Context, f *framework.Framework, name string) {
+	err := f.ClientSet.NodeV1().RuntimeClasses().Delete(ctx, name, metav1.DeleteOptions{})
 	framework.ExpectNoError(err, "failed to delete RuntimeClass resource")
 }
 
 // createRuntimeClass generates a RuntimeClass with the desired handler and a "namespaced" name,
 // synchronously creates it, and returns the generated name.
-func createRuntimeClass(f *framework.Framework, name, handler string, overhead *nodev1.Overhead) string {
+func createRuntimeClass(ctx context.Context, f *framework.Framework, name, handler string, overhead *nodev1.Overhead) string {
 	uniqueName := fmt.Sprintf("%s-%s", f.Namespace.Name, name)
 	rc := runtimeclasstest.NewRuntimeClass(uniqueName, handler)
 	rc.Overhead = overhead
-	rc, err := f.ClientSet.NodeV1().RuntimeClasses().Create(context.TODO(), rc, metav1.CreateOptions{})
+	rc, err := f.ClientSet.NodeV1().RuntimeClasses().Create(ctx, rc, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "failed to create RuntimeClass resource")
 	return rc.GetName()
 }
 
-func expectPodRejection(f *framework.Framework, pod *v1.Pod) {
-	_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+func expectPodRejection(ctx context.Context, f *framework.Framework, pod *v1.Pod) {
+	_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 	framework.ExpectError(err, "should be forbidden")
 	if !apierrors.IsForbidden(err) {
 		framework.Failf("expected forbidden error, got %#v", err)
@@ -382,7 +382,7 @@ func expectPodRejection(f *framework.Framework, pod *v1.Pod) {
 }
 
 // expectPodSuccess waits for the given pod to terminate successfully.
-func expectPodSuccess(f *framework.Framework, pod *v1.Pod) {
+func expectPodSuccess(ctx context.Context, f *framework.Framework, pod *v1.Pod) {
 	framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(
-		f.ClientSet, pod.Name, f.Namespace.Name))
+		ctx, f.ClientSet, pod.Name, f.Namespace.Name))
 }

--- a/test/e2e/common/node/secrets.go
+++ b/test/e2e/common/node/secrets.go
@@ -49,7 +49,7 @@ var _ = SIGDescribe("Secrets", func() {
 
 		ginkgo.By(fmt.Sprintf("Creating secret with name %s", secret.Name))
 		var err error
-		if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+		if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
 		}
 
@@ -82,7 +82,7 @@ var _ = SIGDescribe("Secrets", func() {
 			},
 		}
 
-		e2epodoutput.TestContainerOutput(f, "consume secrets", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "consume secrets", pod, 0, []string{
 			"SECRET_DATA=value-1",
 		})
 	})
@@ -97,7 +97,7 @@ var _ = SIGDescribe("Secrets", func() {
 		secret := secretForTest(f.Namespace.Name, name)
 		ginkgo.By(fmt.Sprintf("creating secret %v/%v", f.Namespace.Name, secret.Name))
 		var err error
-		if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+		if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
 		}
 
@@ -126,7 +126,7 @@ var _ = SIGDescribe("Secrets", func() {
 			},
 		}
 
-		e2epodoutput.TestContainerOutput(f, "consume secrets", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "consume secrets", pod, 0, []string{
 			"data-1=value-1", "data-2=value-2", "data-3=value-3",
 			"p-data-1=value-1", "p-data-2=value-2", "p-data-3=value-3",
 		})
@@ -138,7 +138,7 @@ var _ = SIGDescribe("Secrets", func() {
 	   Description: Attempt to create a Secret with an empty key. The creation MUST fail.
 	*/
 	framework.ConformanceIt("should fail to create secret due to empty secret key", func(ctx context.Context) {
-		secret, err := createEmptyKeySecretForTest(f)
+		secret, err := createEmptyKeySecretForTest(ctx, f)
 		framework.ExpectError(err, "created secret %q with empty key in namespace %q", secret.Name, f.Namespace.Name)
 	})
 
@@ -157,7 +157,7 @@ var _ = SIGDescribe("Secrets", func() {
 		secretTestName := "test-secret-" + string(uuid.NewUUID())
 
 		// create a secret in the test namespace
-		_, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), &v1.Secret{
+		_, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: secretTestName,
 				Labels: map[string]string{
@@ -173,7 +173,7 @@ var _ = SIGDescribe("Secrets", func() {
 
 		ginkgo.By("listing secrets in all namespaces to ensure that there are more than zero")
 		// list all secrets in all namespaces to ensure endpoint coverage
-		secretsList, err := f.ClientSet.CoreV1().Secrets("").List(context.TODO(), metav1.ListOptions{
+		secretsList, err := f.ClientSet.CoreV1().Secrets("").List(ctx, metav1.ListOptions{
 			LabelSelector: "testsecret-constant=true",
 		})
 		framework.ExpectNoError(err, "failed to list secrets")
@@ -202,10 +202,10 @@ var _ = SIGDescribe("Secrets", func() {
 			"data": map[string][]byte{"key": []byte(secretPatchNewData)},
 		})
 		framework.ExpectNoError(err, "failed to marshal JSON")
-		_, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Patch(context.TODO(), secretCreatedName, types.StrategicMergePatchType, []byte(secretPatch), metav1.PatchOptions{})
+		_, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Patch(ctx, secretCreatedName, types.StrategicMergePatchType, []byte(secretPatch), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch secret")
 
-		secret, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), secretCreatedName, metav1.GetOptions{})
+		secret, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Get(ctx, secretCreatedName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get secret")
 
 		secretDecodedstring, err := base64.StdEncoding.DecodeString(string(secret.Data["key"]))
@@ -214,14 +214,14 @@ var _ = SIGDescribe("Secrets", func() {
 		framework.ExpectEqual(string(secretDecodedstring), "value1", "found secret, but the data wasn't updated from the patch")
 
 		ginkgo.By("deleting the secret using a LabelSelector")
-		err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
+		err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
 			LabelSelector: "testsecret=true",
 		})
 		framework.ExpectNoError(err, "failed to delete patched secret")
 
 		ginkgo.By("listing secrets in all namespaces, searching for label name and value in patch")
 		// list all secrets in all namespaces
-		secretsList, err = f.ClientSet.CoreV1().Secrets("").List(context.TODO(), metav1.ListOptions{
+		secretsList, err = f.ClientSet.CoreV1().Secrets("").List(ctx, metav1.ListOptions{
 			LabelSelector: "testsecret-constant=true",
 		})
 		framework.ExpectNoError(err, "failed to list secrets")
@@ -253,7 +253,7 @@ func secretForTest(namespace, name string) *v1.Secret {
 	}
 }
 
-func createEmptyKeySecretForTest(f *framework.Framework) (*v1.Secret, error) {
+func createEmptyKeySecretForTest(ctx context.Context, f *framework.Framework) (*v1.Secret, error) {
 	secretName := "secret-emptykey-test-" + string(uuid.NewUUID())
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -265,5 +265,5 @@ func createEmptyKeySecretForTest(f *framework.Framework) (*v1.Secret, error) {
 		},
 	}
 	ginkgo.By(fmt.Sprintf("Creating projection with secret that has name %s", secret.Name))
-	return f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{})
+	return f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{})
 }

--- a/test/e2e/common/node/sysctl.go
+++ b/test/e2e/common/node/sysctl.go
@@ -87,27 +87,27 @@ var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeConformance]", func() {
 		pod.Spec.Containers[0].Command = []string{"/bin/sysctl", "kernel.shm_rmid_forced"}
 
 		ginkgo.By("Creating a pod with the kernel.shm_rmid_forced sysctl")
-		pod = podClient.Create(pod)
+		pod = podClient.Create(ctx, pod)
 
 		ginkgo.By("Watching for error events or started pod")
 		// watch for events instead of termination of pod because the kubelet deletes
 		// failed pods without running containers. This would create a race as the pod
 		// might have already been deleted here.
-		ev, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(pod)
+		ev, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(ctx, pod)
 		framework.ExpectNoError(err)
 		gomega.Expect(ev).To(gomega.BeNil())
 
 		ginkgo.By("Waiting for pod completion")
-		err = e2epod.WaitForPodNoLongerRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+		err = e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 		framework.ExpectNoError(err)
-		pod, err = podClient.Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Checking that the pod succeeded")
 		framework.ExpectEqual(pod.Status.Phase, v1.PodSucceeded)
 
 		ginkgo.By("Getting logs from the pod")
-		log, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
+		log, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Checking that the sysctl is actually updated")
@@ -146,7 +146,7 @@ var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeConformance]", func() {
 
 		ginkgo.By("Creating a pod with one valid and two invalid sysctls")
 		client := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
-		_, err := client.Create(context.TODO(), pod, metav1.CreateOptions{})
+		_, err := client.Create(ctx, pod, metav1.CreateOptions{})
 
 		gomega.Expect(err).NotTo(gomega.BeNil())
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring(`Invalid value: "foo-"`))
@@ -168,11 +168,11 @@ var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeConformance]", func() {
 		}
 
 		ginkgo.By("Creating a pod with an ignorelisted, but not allowlisted sysctl on the node")
-		pod = podClient.Create(pod)
+		pod = podClient.Create(ctx, pod)
 
 		ginkgo.By("Wait for pod failed reason")
 		// watch for pod failed reason instead of termination of pod
-		err := e2epod.WaitForPodFailedReason(f.ClientSet, pod, "SysctlForbidden", f.Timeouts.PodStart)
+		err := e2epod.WaitForPodFailedReason(ctx, f.ClientSet, pod, "SysctlForbidden", f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
 	})
 
@@ -195,27 +195,27 @@ var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeConformance]", func() {
 		pod.Spec.Containers[0].Command = []string{"/bin/sysctl", "kernel/shm_rmid_forced"}
 
 		ginkgo.By("Creating a pod with the kernel/shm_rmid_forced sysctl")
-		pod = podClient.Create(pod)
+		pod = podClient.Create(ctx, pod)
 
 		ginkgo.By("Watching for error events or started pod")
 		// watch for events instead of termination of pod because the kubelet deletes
 		// failed pods without running containers. This would create a race as the pod
 		// might have already been deleted here.
-		ev, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(pod)
+		ev, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(ctx, pod)
 		framework.ExpectNoError(err)
 		gomega.Expect(ev).To(gomega.BeNil())
 
 		ginkgo.By("Waiting for pod completion")
-		err = e2epod.WaitForPodNoLongerRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+		err = e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 		framework.ExpectNoError(err)
-		pod, err = podClient.Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Checking that the pod succeeded")
 		framework.ExpectEqual(pod.Status.Phase, v1.PodSucceeded)
 
 		ginkgo.By("Getting logs from the pod")
-		log, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
+		log, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Checking that the sysctl is actually updated")

--- a/test/e2e/common/storage/configmap_volume.go
+++ b/test/e2e/common/storage/configmap_volume.go
@@ -45,7 +45,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST default to 0x644.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func(ctx context.Context) {
-		doConfigMapE2EWithoutMappings(f, false, 0, nil)
+		doConfigMapE2EWithoutMappings(ctx, f, false, 0, nil)
 	})
 
 	/*
@@ -56,14 +56,14 @@ var _ = SIGDescribe("ConfigMap", func() {
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
 		defaultMode := int32(0400)
-		doConfigMapE2EWithoutMappings(f, false, 0, &defaultMode)
+		doConfigMapE2EWithoutMappings(ctx, f, false, 0, &defaultMode)
 	})
 
 	ginkgo.It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [LinuxOnly] [NodeFeature:FSGroup]", func(ctx context.Context) {
 		// Windows does not support RunAsUser / FSGroup SecurityContext options, and it does not support setting file permissions.
 		e2eskipper.SkipIfNodeOSDistroIs("windows")
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
-		doConfigMapE2EWithoutMappings(f, true, 1001, &defaultMode)
+		doConfigMapE2EWithoutMappings(ctx, f, true, 1001, &defaultMode)
 	})
 
 	/*
@@ -72,13 +72,13 @@ var _ = SIGDescribe("ConfigMap", func() {
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Pod is run as a non-root user with uid=1000. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The file on the volume MUST have file mode set to default value of 0x644.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume as non-root [NodeConformance]", func(ctx context.Context) {
-		doConfigMapE2EWithoutMappings(f, true, 0, nil)
+		doConfigMapE2EWithoutMappings(ctx, f, true, 0, nil)
 	})
 
 	ginkgo.It("should be consumable from pods in volume as non-root with FSGroup [LinuxOnly] [NodeFeature:FSGroup]", func(ctx context.Context) {
 		// Windows does not support RunAsUser / FSGroup SecurityContext options.
 		e2eskipper.SkipIfNodeOSDistroIs("windows")
-		doConfigMapE2EWithoutMappings(f, true, 1001, nil)
+		doConfigMapE2EWithoutMappings(ctx, f, true, 1001, nil)
 	})
 
 	/*
@@ -87,7 +87,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Files are mapped to a path in the volume. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST default to 0x644.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func(ctx context.Context) {
-		doConfigMapE2EWithMappings(f, false, 0, nil)
+		doConfigMapE2EWithMappings(ctx, f, false, 0, nil)
 	})
 
 	/*
@@ -98,7 +98,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
 		mode := int32(0400)
-		doConfigMapE2EWithMappings(f, false, 0, &mode)
+		doConfigMapE2EWithMappings(ctx, f, false, 0, &mode)
 	})
 
 	/*
@@ -107,13 +107,13 @@ var _ = SIGDescribe("ConfigMap", func() {
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Files are mapped to a path in the volume. Pod is run as a non-root user with uid=1000. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The file on the volume MUST have file mode set to default value of 0x644.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [NodeConformance]", func(ctx context.Context) {
-		doConfigMapE2EWithMappings(f, true, 0, nil)
+		doConfigMapE2EWithMappings(ctx, f, true, 0, nil)
 	})
 
 	ginkgo.It("should be consumable from pods in volume with mappings as non-root with FSGroup [LinuxOnly] [NodeFeature:FSGroup]", func(ctx context.Context) {
 		// Windows does not support RunAsUser / FSGroup SecurityContext options.
 		e2eskipper.SkipIfNodeOSDistroIs("windows")
-		doConfigMapE2EWithMappings(f, true, 1001, nil)
+		doConfigMapE2EWithMappings(ctx, f, true, 1001, nil)
 	})
 
 	/*
@@ -122,7 +122,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		Description: The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount that is mapped to custom path in the Pod. When the ConfigMap is updated the change to the config map MUST be verified by reading the content from the mounted file in the Pod.
 	*/
 	framework.ConformanceIt("updates should be reflected in volume [NodeConformance]", func(ctx context.Context) {
-		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
+		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(ctx, f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
 		name := "configmap-test-upd-" + string(uuid.NewUUID())
@@ -141,7 +141,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 
 		ginkgo.By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
 		var err error
-		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 		}
 
@@ -149,22 +149,22 @@ var _ = SIGDescribe("ConfigMap", func() {
 			"--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volume/data-1")
 
 		ginkgo.By("Creating the pod")
-		e2epod.NewPodClient(f).CreateSync(pod)
+		e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 		pollLogs := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
 		}
 
-		gomega.Eventually(pollLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
+		gomega.Eventually(ctx, pollLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
 
 		ginkgo.By(fmt.Sprintf("Updating configmap %v", configMap.Name))
 		configMap.ResourceVersion = "" // to force update
 		configMap.Data["data-1"] = "value-2"
-		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, configMap, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "Failed to update configmap %q in namespace %q", configMap.Name, f.Namespace.Name)
 
 		ginkgo.By("waiting to observe update in volume")
-		gomega.Eventually(pollLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-2"))
+		gomega.Eventually(ctx, pollLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-2"))
 	})
 
 	/*
@@ -173,7 +173,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		Description: The ConfigMap that is created with text data and binary data MUST be accessible to read from the newly created Pod using the volume mount that is mapped to custom path in the Pod. ConfigMap's text data and binary data MUST be verified by reading the content from the mounted files in the Pod.
 	*/
 	framework.ConformanceIt("binary data should be reflected in volume [NodeConformance]", func(ctx context.Context) {
-		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
+		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(ctx, f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
 		name := "configmap-test-upd-" + string(uuid.NewUUID())
@@ -196,7 +196,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 
 		ginkgo.By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
 		var err error
-		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 		}
 
@@ -216,20 +216,20 @@ var _ = SIGDescribe("ConfigMap", func() {
 		})
 
 		ginkgo.By("Creating the pod")
-		e2epod.NewPodClient(f).Create(pod)
-		e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+		e2epod.NewPodClient(f).Create(ctx, pod)
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
 
 		pollLogs1 := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
 		}
 		pollLogs2 := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[1].Name)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[1].Name)
 		}
 
 		ginkgo.By("Waiting for pod with text data")
-		gomega.Eventually(pollLogs1, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
+		gomega.Eventually(ctx, pollLogs1, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
 		ginkgo.By("Waiting for pod with binary data")
-		gomega.Eventually(pollLogs2, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("de ca fe ba d0 fe ff"))
+		gomega.Eventually(ctx, pollLogs2, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("de ca fe ba d0 fe ff"))
 	})
 
 	/*
@@ -238,7 +238,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		Description: The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount that is mapped to custom path in the Pod. When the config map is updated the change to the config map MUST be verified by reading the content from the mounted file in the Pod. Also when the item(file) is deleted from the map that MUST result in a error reading that item(file).
 	*/
 	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func(ctx context.Context) {
-		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
+		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(ctx, f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true
 		volumeMountPath := "/etc/configmap-volumes"
@@ -284,12 +284,12 @@ var _ = SIGDescribe("ConfigMap", func() {
 
 		ginkgo.By(fmt.Sprintf("Creating configMap with name %s", deleteConfigMap.Name))
 		var err error
-		if deleteConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), deleteConfigMap, metav1.CreateOptions{}); err != nil {
+		if deleteConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, deleteConfigMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", deleteConfigMap.Name, err)
 		}
 
 		ginkgo.By(fmt.Sprintf("Creating configMap with name %s", updateConfigMap.Name))
-		if updateConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), updateConfigMap, metav1.CreateOptions{}); err != nil {
+		if updateConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, updateConfigMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", updateConfigMap.Name, err)
 		}
 
@@ -375,44 +375,44 @@ var _ = SIGDescribe("ConfigMap", func() {
 			},
 		}
 		ginkgo.By("Creating the pod")
-		e2epod.NewPodClient(f).CreateSync(pod)
+		e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 		pollCreateLogs := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, createContainerName)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, createContainerName)
 		}
-		gomega.Eventually(pollCreateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/configmap-volumes/create/data-1"))
+		gomega.Eventually(ctx, pollCreateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/configmap-volumes/create/data-1"))
 
 		pollUpdateLogs := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, updateContainerName)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, updateContainerName)
 		}
-		gomega.Eventually(pollUpdateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/configmap-volumes/update/data-3"))
+		gomega.Eventually(ctx, pollUpdateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/configmap-volumes/update/data-3"))
 
 		pollDeleteLogs := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, deleteContainerName)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, deleteContainerName)
 		}
-		gomega.Eventually(pollDeleteLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
+		gomega.Eventually(ctx, pollDeleteLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
 
 		ginkgo.By(fmt.Sprintf("Deleting configmap %v", deleteConfigMap.Name))
-		err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(context.TODO(), deleteConfigMap.Name, metav1.DeleteOptions{})
+		err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, deleteConfigMap.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "Failed to delete configmap %q in namespace %q", deleteConfigMap.Name, f.Namespace.Name)
 
 		ginkgo.By(fmt.Sprintf("Updating configmap %v", updateConfigMap.Name))
 		updateConfigMap.ResourceVersion = "" // to force update
 		delete(updateConfigMap.Data, "data-1")
 		updateConfigMap.Data["data-3"] = "value-3"
-		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), updateConfigMap, metav1.UpdateOptions{})
+		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, updateConfigMap, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "Failed to update configmap %q in namespace %q", updateConfigMap.Name, f.Namespace.Name)
 
 		ginkgo.By(fmt.Sprintf("Creating configMap with name %s", createConfigMap.Name))
-		if createConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), createConfigMap, metav1.CreateOptions{}); err != nil {
+		if createConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, createConfigMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", createConfigMap.Name, err)
 		}
 
 		ginkgo.By("waiting to observe update in volume")
 
-		gomega.Eventually(pollCreateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
-		gomega.Eventually(pollUpdateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-3"))
-		gomega.Eventually(pollDeleteLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/configmap-volumes/delete/data-1"))
+		gomega.Eventually(ctx, pollCreateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
+		gomega.Eventually(ctx, pollUpdateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-3"))
+		gomega.Eventually(ctx, pollDeleteLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/configmap-volumes/delete/data-1"))
 	})
 
 	/*
@@ -432,7 +432,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 
 		ginkgo.By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
 		var err error
-		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 		}
 
@@ -486,7 +486,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 			},
 		}
 
-		e2epodoutput.TestContainerOutput(f, "consume configMaps", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "consume configMaps", pod, 0, []string{
 			"content of file \"/etc/configmap-volume/data-1\": value-1",
 		})
 
@@ -505,28 +505,28 @@ var _ = SIGDescribe("ConfigMap", func() {
 		name := "immutable"
 		configMap := newConfigMap(f, name)
 
-		currentConfigMap, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		currentConfigMap, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Failed to create config map %q in namespace %q", configMap.Name, configMap.Namespace)
 
 		currentConfigMap.Data["data-4"] = "value-4"
-		currentConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), currentConfigMap, metav1.UpdateOptions{})
+		currentConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, currentConfigMap, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "Failed to update config map %q in namespace %q", configMap.Name, configMap.Namespace)
 
 		// Mark config map as immutable.
 		trueVal := true
 		currentConfigMap.Immutable = &trueVal
-		currentConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), currentConfigMap, metav1.UpdateOptions{})
+		currentConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, currentConfigMap, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "Failed to mark config map %q in namespace %q as immutable", configMap.Name, configMap.Namespace)
 
 		// Ensure data can't be changed now.
 		currentConfigMap.Data["data-5"] = "value-5"
-		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), currentConfigMap, metav1.UpdateOptions{})
+		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, currentConfigMap, metav1.UpdateOptions{})
 		if !apierrors.IsInvalid(err) {
 			framework.Failf("expected 'invalid' as error, got instead: %v", err)
 		}
 
 		// Ensure config map can't be switched from immutable to mutable.
-		currentConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(context.TODO(), name, metav1.GetOptions{})
+		currentConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx, name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "Failed to get config map %q in namespace %q", configMap.Name, configMap.Namespace)
 		if !*currentConfigMap.Immutable {
 			framework.Failf("currentConfigMap %s can be switched from immutable to mutable", currentConfigMap.Name)
@@ -534,20 +534,20 @@ var _ = SIGDescribe("ConfigMap", func() {
 
 		falseVal := false
 		currentConfigMap.Immutable = &falseVal
-		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), currentConfigMap, metav1.UpdateOptions{})
+		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, currentConfigMap, metav1.UpdateOptions{})
 		if !apierrors.IsInvalid(err) {
 			framework.Failf("expected 'invalid' as error, got instead: %v", err)
 		}
 
 		// Ensure that metadata can be changed.
-		currentConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(context.TODO(), name, metav1.GetOptions{})
+		currentConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx, name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "Failed to get config map %q in namespace %q", configMap.Name, configMap.Namespace)
 		currentConfigMap.Labels = map[string]string{"label1": "value1"}
-		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), currentConfigMap, metav1.UpdateOptions{})
+		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, currentConfigMap, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "Failed to update config map %q in namespace %q", configMap.Name, configMap.Namespace)
 
 		// Ensure that immutable config map can be deleted.
-		err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "Failed to delete config map %q in namespace %q", configMap.Name, configMap.Namespace)
 	})
 
@@ -556,7 +556,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 	// Slow (~5 mins)
 	ginkgo.It("Should fail non-optional pod creation due to configMap object does not exist [Slow]", func(ctx context.Context) {
 		volumeMountPath := "/etc/configmap-volumes"
-		pod, err := createNonOptionalConfigMapPod(f, volumeMountPath)
+		pod, err := createNonOptionalConfigMapPod(ctx, f, volumeMountPath)
 		framework.ExpectError(err, "created pod %q with non-optional configMap in namespace %q", pod.Name, f.Namespace.Name)
 	})
 
@@ -565,7 +565,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 	// Slow (~5 mins)
 	ginkgo.It("Should fail non-optional pod creation due to the key in the configMap object does not exist [Slow]", func(ctx context.Context) {
 		volumeMountPath := "/etc/configmap-volumes"
-		pod, err := createNonOptionalConfigMapPodWithConfig(f, volumeMountPath)
+		pod, err := createNonOptionalConfigMapPodWithConfig(ctx, f, volumeMountPath)
 		framework.ExpectError(err, "created pod %q with non-optional configMap in namespace %q", pod.Name, f.Namespace.Name)
 	})
 })
@@ -584,7 +584,7 @@ func newConfigMap(f *framework.Framework, name string) *v1.ConfigMap {
 	}
 }
 
-func doConfigMapE2EWithoutMappings(f *framework.Framework, asUser bool, fsGroup int64, defaultMode *int32) {
+func doConfigMapE2EWithoutMappings(ctx context.Context, f *framework.Framework, asUser bool, fsGroup int64, defaultMode *int32) {
 	groupID := int64(fsGroup)
 
 	var (
@@ -596,7 +596,7 @@ func doConfigMapE2EWithoutMappings(f *framework.Framework, asUser bool, fsGroup 
 
 	ginkgo.By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
 	var err error
-	if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+	if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 	}
 
@@ -622,10 +622,10 @@ func doConfigMapE2EWithoutMappings(f *framework.Framework, asUser bool, fsGroup 
 		"content of file \"/etc/configmap-volume/data-1\": value-1",
 		fileModeRegexp,
 	}
-	e2epodoutput.TestContainerOutputRegexp(f, "consume configMaps", pod, 0, output)
+	e2epodoutput.TestContainerOutputRegexp(ctx, f, "consume configMaps", pod, 0, output)
 }
 
-func doConfigMapE2EWithMappings(f *framework.Framework, asUser bool, fsGroup int64, itemMode *int32) {
+func doConfigMapE2EWithMappings(ctx context.Context, f *framework.Framework, asUser bool, fsGroup int64, itemMode *int32) {
 	groupID := int64(fsGroup)
 
 	var (
@@ -638,7 +638,7 @@ func doConfigMapE2EWithMappings(f *framework.Framework, asUser bool, fsGroup int
 	ginkgo.By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
 
 	var err error
-	if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+	if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 	}
 
@@ -674,11 +674,11 @@ func doConfigMapE2EWithMappings(f *framework.Framework, asUser bool, fsGroup int
 		fileModeRegexp := getFileModeRegex("/etc/configmap-volume/path/to/data-2", itemMode)
 		output = append(output, fileModeRegexp)
 	}
-	e2epodoutput.TestContainerOutputRegexp(f, "consume configMaps", pod, 0, output)
+	e2epodoutput.TestContainerOutputRegexp(ctx, f, "consume configMaps", pod, 0, output)
 }
 
-func createNonOptionalConfigMapPod(f *framework.Framework, volumeMountPath string) (*v1.Pod, error) {
-	podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
+func createNonOptionalConfigMapPod(ctx context.Context, f *framework.Framework, volumeMountPath string) (*v1.Pod, error) {
+	podLogTimeout := e2epod.GetPodSecretUpdateTimeout(ctx, f.ClientSet)
 	containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 	falseValue := false
 
@@ -691,12 +691,12 @@ func createNonOptionalConfigMapPod(f *framework.Framework, volumeMountPath strin
 	pod.Spec.Volumes[0].VolumeSource.ConfigMap.Optional = &falseValue
 
 	ginkgo.By("Creating the pod")
-	pod = e2epod.NewPodClient(f).Create(pod)
-	return pod, e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+	pod = e2epod.NewPodClient(f).Create(ctx, pod)
+	return pod, e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 }
 
-func createNonOptionalConfigMapPodWithConfig(f *framework.Framework, volumeMountPath string) (*v1.Pod, error) {
-	podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
+func createNonOptionalConfigMapPodWithConfig(ctx context.Context, f *framework.Framework, volumeMountPath string) (*v1.Pod, error) {
+	podLogTimeout := e2epod.GetPodSecretUpdateTimeout(ctx, f.ClientSet)
 	containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 	falseValue := false
 
@@ -706,7 +706,7 @@ func createNonOptionalConfigMapPodWithConfig(f *framework.Framework, volumeMount
 
 	ginkgo.By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
 	var err error
-	if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+	if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 	}
 	// creating a pod with configMap object, but with different key which is not present in configMap object.
@@ -721,8 +721,8 @@ func createNonOptionalConfigMapPodWithConfig(f *framework.Framework, volumeMount
 	}
 
 	ginkgo.By("Creating the pod")
-	pod = e2epod.NewPodClient(f).Create(pod)
-	return pod, e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+	pod = e2epod.NewPodClient(f).Create(ctx, pod)
+	return pod, e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 }
 
 func createConfigMapVolumeMounttestPod(namespace, volumeName, referenceName, mountPath string, mounttestArgs ...string) *v1.Pod {

--- a/test/e2e/common/storage/downwardapi.go
+++ b/test/e2e/common/storage/downwardapi.go
@@ -62,7 +62,7 @@ var _ = SIGDescribe("Downward API [Serial] [Disruptive] [Feature:EphemeralStorag
 				fmt.Sprintf("EPHEMERAL_STORAGE_REQUEST=%d", 32*1024*1024),
 			}
 
-			testDownwardAPIForEphemeralStorage(f, podName, env, expectations)
+			testDownwardAPIForEphemeralStorage(ctx, f, podName, env, expectations)
 		})
 
 		ginkgo.It("should provide default limits.ephemeral-storage from node allocatable", func(ctx context.Context) {
@@ -98,13 +98,13 @@ var _ = SIGDescribe("Downward API [Serial] [Disruptive] [Feature:EphemeralStorag
 				},
 			}
 
-			testDownwardAPIUsingPod(f, pod, env, expectations)
+			testDownwardAPIUsingPod(ctx, f, pod, env, expectations)
 		})
 	})
 
 })
 
-func testDownwardAPIForEphemeralStorage(f *framework.Framework, podName string, env []v1.EnvVar, expectations []string) {
+func testDownwardAPIForEphemeralStorage(ctx context.Context, f *framework.Framework, podName string, env []v1.EnvVar, expectations []string) {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   podName,
@@ -131,9 +131,9 @@ func testDownwardAPIForEphemeralStorage(f *framework.Framework, podName string, 
 		},
 	}
 
-	testDownwardAPIUsingPod(f, pod, env, expectations)
+	testDownwardAPIUsingPod(ctx, f, pod, env, expectations)
 }
 
-func testDownwardAPIUsingPod(f *framework.Framework, pod *v1.Pod, env []v1.EnvVar, expectations []string) {
-	e2epodoutput.TestContainerOutputRegexp(f, "downward api env vars", pod, 0, expectations)
+func testDownwardAPIUsingPod(ctx context.Context, f *framework.Framework, pod *v1.Pod, env []v1.EnvVar, expectations []string) {
+	e2epodoutput.TestContainerOutputRegexp(ctx, f, "downward api env vars", pod, 0, expectations)
 }

--- a/test/e2e/common/storage/downwardapi_volume.go
+++ b/test/e2e/common/storage/downwardapi_volume.go
@@ -55,7 +55,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("%s\n", podName),
 		})
 	})
@@ -71,7 +71,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		defaultMode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			"mode of file \"/etc/podinfo/podname\": -r--------",
 		})
 	})
@@ -87,7 +87,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		mode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			"mode of file \"/etc/podinfo/podname\": -r--------",
 		})
 	})
@@ -102,7 +102,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 			FSGroup: &gid,
 		}
 		setPodNonRootUser(pod)
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("%s\n", podName),
 		})
 	})
@@ -118,7 +118,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 			FSGroup: &gid,
 		}
 		setPodNonRootUser(pod)
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			"mode of file \"/etc/podinfo/podname\": -r--r-----",
 		})
 	})
@@ -137,20 +137,20 @@ var _ = SIGDescribe("Downward API volume", func() {
 		pod := downwardAPIVolumePodForUpdateTest(podName, labels, map[string]string{}, "/etc/podinfo/labels")
 		containerName := "client-container"
 		ginkgo.By("Creating the pod")
-		podClient.CreateSync(pod)
+		podClient.CreateSync(ctx, pod)
 
-		gomega.Eventually(func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, containerName)
+		gomega.Eventually(ctx, func() (string, error) {
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, podName, containerName)
 		},
 			podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("key1=\"value1\"\n"))
 
 		//modify labels
-		podClient.Update(podName, func(pod *v1.Pod) {
+		podClient.Update(ctx, podName, func(pod *v1.Pod) {
 			pod.Labels["key3"] = "value3"
 		})
 
-		gomega.Eventually(func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, containerName)
+		gomega.Eventually(ctx, func() (string, error) {
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, containerName)
 		},
 			podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("key3=\"value3\"\n"))
 	})
@@ -168,20 +168,20 @@ var _ = SIGDescribe("Downward API volume", func() {
 
 		containerName := "client-container"
 		ginkgo.By("Creating the pod")
-		pod = podClient.CreateSync(pod)
+		pod = podClient.CreateSync(ctx, pod)
 
-		gomega.Eventually(func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, containerName)
+		gomega.Eventually(ctx, func() (string, error) {
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, containerName)
 		},
 			podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("builder=\"bar\"\n"))
 
 		//modify annotations
-		podClient.Update(podName, func(pod *v1.Pod) {
+		podClient.Update(ctx, podName, func(pod *v1.Pod) {
 			pod.Annotations["builder"] = "foo"
 		})
 
-		gomega.Eventually(func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, containerName)
+		gomega.Eventually(ctx, func() (string, error) {
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, containerName)
 		},
 			podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("builder=\"foo\"\n"))
 	})
@@ -195,7 +195,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_limit")
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("2\n"),
 		})
 	})
@@ -209,7 +209,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("67108864\n"),
 		})
 	})
@@ -223,7 +223,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_request")
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("1\n"),
 		})
 	})
@@ -237,7 +237,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_request")
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("33554432\n"),
 		})
 	})
@@ -251,7 +251,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/cpu_limit")
 
-		e2epodoutput.TestContainerOutputRegexp(f, "downward API volume plugin", pod, 0, []string{"[1-9]"})
+		e2epodoutput.TestContainerOutputRegexp(ctx, f, "downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
 
 	/*
@@ -263,7 +263,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/memory_limit")
 
-		e2epodoutput.TestContainerOutputRegexp(f, "downward API volume plugin", pod, 0, []string{"[1-9]"})
+		e2epodoutput.TestContainerOutputRegexp(ctx, f, "downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
 })
 

--- a/test/e2e/common/storage/empty_dir.go
+++ b/test/e2e/common/storage/empty_dir.go
@@ -54,27 +54,27 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		})
 
 		ginkgo.It("new files should be created with FSGroup ownership when container is root", func(ctx context.Context) {
-			doTestSetgidFSGroup(f, 0, v1.StorageMediumMemory)
+			doTestSetgidFSGroup(ctx, f, 0, v1.StorageMediumMemory)
 		})
 
 		ginkgo.It("new files should be created with FSGroup ownership when container is non-root", func(ctx context.Context) {
-			doTestSetgidFSGroup(f, nonRootUID, v1.StorageMediumMemory)
+			doTestSetgidFSGroup(ctx, f, nonRootUID, v1.StorageMediumMemory)
 		})
 
 		ginkgo.It("nonexistent volume subPath should have the correct mode and owner using FSGroup", func(ctx context.Context) {
-			doTestSubPathFSGroup(f, nonRootUID, v1.StorageMediumMemory)
+			doTestSubPathFSGroup(ctx, f, nonRootUID, v1.StorageMediumMemory)
 		})
 
 		ginkgo.It("files with FSGroup ownership should support (root,0644,tmpfs)", func(ctx context.Context) {
-			doTest0644FSGroup(f, 0, v1.StorageMediumMemory)
+			doTest0644FSGroup(ctx, f, 0, v1.StorageMediumMemory)
 		})
 
 		ginkgo.It("volume on default medium should have the correct mode using FSGroup", func(ctx context.Context) {
-			doTestVolumeModeFSGroup(f, 0, v1.StorageMediumDefault)
+			doTestVolumeModeFSGroup(ctx, f, 0, v1.StorageMediumDefault)
 		})
 
 		ginkgo.It("volume on tmpfs should have the correct mode using FSGroup", func(ctx context.Context) {
-			doTestVolumeModeFSGroup(f, 0, v1.StorageMediumMemory)
+			doTestVolumeModeFSGroup(ctx, f, 0, v1.StorageMediumMemory)
 		})
 	})
 
@@ -85,7 +85,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("volume on tmpfs should have the correct mode [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTestVolumeMode(f, 0, v1.StorageMediumMemory)
+		doTestVolumeMode(ctx, f, 0, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -95,7 +95,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("should support (root,0644,tmpfs) [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTest0644(f, 0, v1.StorageMediumMemory)
+		doTest0644(ctx, f, 0, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -105,7 +105,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("should support (root,0666,tmpfs) [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTest0666(f, 0, v1.StorageMediumMemory)
+		doTest0666(ctx, f, 0, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -115,7 +115,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("should support (root,0777,tmpfs) [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTest0777(f, 0, v1.StorageMediumMemory)
+		doTest0777(ctx, f, 0, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -125,7 +125,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("should support (non-root,0644,tmpfs) [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTest0644(f, nonRootUID, v1.StorageMediumMemory)
+		doTest0644(ctx, f, nonRootUID, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -135,7 +135,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("should support (non-root,0666,tmpfs) [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTest0666(f, nonRootUID, v1.StorageMediumMemory)
+		doTest0666(ctx, f, nonRootUID, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -145,7 +145,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("should support (non-root,0777,tmpfs) [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTest0777(f, nonRootUID, v1.StorageMediumMemory)
+		doTest0777(ctx, f, nonRootUID, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -155,7 +155,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
 	framework.ConformanceIt("volume on default medium should have the correct mode [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTestVolumeMode(f, 0, v1.StorageMediumDefault)
+		doTestVolumeMode(ctx, f, 0, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -165,7 +165,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
 	framework.ConformanceIt("should support (root,0644,default) [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTest0644(f, 0, v1.StorageMediumDefault)
+		doTest0644(ctx, f, 0, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -175,7 +175,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
 	framework.ConformanceIt("should support (root,0666,default) [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTest0666(f, 0, v1.StorageMediumDefault)
+		doTest0666(ctx, f, 0, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -185,7 +185,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
 	framework.ConformanceIt("should support (root,0777,default) [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTest0777(f, 0, v1.StorageMediumDefault)
+		doTest0777(ctx, f, 0, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -195,7 +195,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
 	framework.ConformanceIt("should support (non-root,0644,default) [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTest0644(f, nonRootUID, v1.StorageMediumDefault)
+		doTest0644(ctx, f, nonRootUID, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -205,7 +205,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
 	framework.ConformanceIt("should support (non-root,0666,default) [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTest0666(f, nonRootUID, v1.StorageMediumDefault)
+		doTest0666(ctx, f, nonRootUID, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -215,7 +215,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
 	framework.ConformanceIt("should support (non-root,0777,default) [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
-		doTest0777(f, nonRootUID, v1.StorageMediumDefault)
+		doTest0777(ctx, f, nonRootUID, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -283,8 +283,8 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 		}
 
 		ginkgo.By("Creating Pod")
-		e2epod.NewPodClient(f).Create(pod)
-		e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+		e2epod.NewPodClient(f).Create(ctx, pod)
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
 
 		ginkgo.By("Reading file content from the nginx-container")
 		result := e2epod.ExecShellInContainer(f, pod.Name, busyBoxMainContainerName, fmt.Sprintf("cat %s", busyBoxMainVolumeFilePath))
@@ -343,14 +343,14 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 
 		var err error
 		ginkgo.By("Creating Pod")
-		pod = e2epod.NewPodClient(f).CreateSync(pod)
+		pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 		ginkgo.By("Waiting for the pod running")
-		err = e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+		err = e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 		framework.ExpectNoError(err, "failed to deploy pod %s", pod.Name)
 
 		ginkgo.By("Getting the pod")
-		pod, err = e2epod.NewPodClient(f).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		pod, err = e2epod.NewPodClient(f).Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get pod %s", pod.Name)
 
 		ginkgo.By("Reading empty dir size")
@@ -364,7 +364,7 @@ const (
 	volumeName    = "test-volume"
 )
 
-func doTestSetgidFSGroup(f *framework.Framework, uid int64, medium v1.StorageMedium) {
+func doTestSetgidFSGroup(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
@@ -391,10 +391,10 @@ func doTestSetgidFSGroup(f *framework.Framework, uid int64, medium v1.StorageMed
 	if medium == v1.StorageMediumMemory {
 		out = append(out, "mount type of \"/test-volume\": tmpfs")
 	}
-	e2epodoutput.TestContainerOutput(f, msg, pod, 0, out)
+	e2epodoutput.TestContainerOutput(ctx, f, msg, pod, 0, out)
 }
 
-func doTestSubPathFSGroup(f *framework.Framework, uid int64, medium v1.StorageMedium) {
+func doTestSubPathFSGroup(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		subPath = "test-sub"
 		source  = &v1.EmptyDirVolumeSource{Medium: medium}
@@ -424,10 +424,10 @@ func doTestSubPathFSGroup(f *framework.Framework, uid int64, medium v1.StorageMe
 	if medium == v1.StorageMediumMemory {
 		out = append(out, "mount type of \"/test-volume\": tmpfs")
 	}
-	e2epodoutput.TestContainerOutput(f, msg, pod, 0, out)
+	e2epodoutput.TestContainerOutput(ctx, f, msg, pod, 0, out)
 }
 
-func doTestVolumeModeFSGroup(f *framework.Framework, uid int64, medium v1.StorageMedium) {
+func doTestVolumeModeFSGroup(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		source = &v1.EmptyDirVolumeSource{Medium: medium}
 		pod    = testPodWithVolume(uid, volumePath, source)
@@ -449,10 +449,10 @@ func doTestVolumeModeFSGroup(f *framework.Framework, uid int64, medium v1.Storag
 	if medium == v1.StorageMediumMemory {
 		out = append(out, "mount type of \"/test-volume\": tmpfs")
 	}
-	e2epodoutput.TestContainerOutput(f, msg, pod, 0, out)
+	e2epodoutput.TestContainerOutput(ctx, f, msg, pod, 0, out)
 }
 
-func doTest0644FSGroup(f *framework.Framework, uid int64, medium v1.StorageMedium) {
+func doTest0644FSGroup(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
@@ -477,10 +477,10 @@ func doTest0644FSGroup(f *framework.Framework, uid int64, medium v1.StorageMediu
 	if medium == v1.StorageMediumMemory {
 		out = append(out, "mount type of \"/test-volume\": tmpfs")
 	}
-	e2epodoutput.TestContainerOutput(f, msg, pod, 0, out)
+	e2epodoutput.TestContainerOutput(ctx, f, msg, pod, 0, out)
 }
 
-func doTestVolumeMode(f *framework.Framework, uid int64, medium v1.StorageMedium) {
+func doTestVolumeMode(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		source = &v1.EmptyDirVolumeSource{Medium: medium}
 		pod    = testPodWithVolume(uid, volumePath, source)
@@ -499,10 +499,10 @@ func doTestVolumeMode(f *framework.Framework, uid int64, medium v1.StorageMedium
 	if medium == v1.StorageMediumMemory {
 		out = append(out, "mount type of \"/test-volume\": tmpfs")
 	}
-	e2epodoutput.TestContainerOutput(f, msg, pod, 0, out)
+	e2epodoutput.TestContainerOutput(ctx, f, msg, pod, 0, out)
 }
 
-func doTest0644(f *framework.Framework, uid int64, medium v1.StorageMedium) {
+func doTest0644(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
@@ -524,10 +524,10 @@ func doTest0644(f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	if medium == v1.StorageMediumMemory {
 		out = append(out, "mount type of \"/test-volume\": tmpfs")
 	}
-	e2epodoutput.TestContainerOutput(f, msg, pod, 0, out)
+	e2epodoutput.TestContainerOutput(ctx, f, msg, pod, 0, out)
 }
 
-func doTest0666(f *framework.Framework, uid int64, medium v1.StorageMedium) {
+func doTest0666(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
@@ -549,10 +549,10 @@ func doTest0666(f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	if medium == v1.StorageMediumMemory {
 		out = append(out, "mount type of \"/test-volume\": tmpfs")
 	}
-	e2epodoutput.TestContainerOutput(f, msg, pod, 0, out)
+	e2epodoutput.TestContainerOutput(ctx, f, msg, pod, 0, out)
 }
 
-func doTest0777(f *framework.Framework, uid int64, medium v1.StorageMedium) {
+func doTest0777(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
@@ -574,7 +574,7 @@ func doTest0777(f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	if medium == v1.StorageMediumMemory {
 		out = append(out, "mount type of \"/test-volume\": tmpfs")
 	}
-	e2epodoutput.TestContainerOutput(f, msg, pod, 0, out)
+	e2epodoutput.TestContainerOutput(ctx, f, msg, pod, 0, out)
 }
 
 func formatMedium(medium v1.StorageMedium) string {

--- a/test/e2e/common/storage/host_path.go
+++ b/test/e2e/common/storage/host_path.go
@@ -60,7 +60,7 @@ var _ = SIGDescribe("HostPath", func() {
 			fmt.Sprintf("--fs_type=%v", volumePath),
 			fmt.Sprintf("--file_mode=%v", volumePath),
 		}
-		e2epodoutput.TestContainerOutputRegexp(f, "hostPath mode", pod, 0, []string{
+		e2epodoutput.TestContainerOutputRegexp(ctx, f, "hostPath mode", pod, 0, []string{
 			"mode of file \"/test-volume\": dg?trwxrwx", // we expect the sticky bit (mode flag t) to be set for the dir
 		})
 	})
@@ -89,7 +89,7 @@ var _ = SIGDescribe("HostPath", func() {
 		}
 		//Read the content of the file with the second container to
 		//verify volumes  being shared properly among containers within the pod.
-		e2epodoutput.TestContainerOutput(f, "hostPath r/w", pod, 1, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "hostPath r/w", pod, 1, []string{
 			"content of file \"/test-volume/test-file\": mount-tester new file",
 		})
 	})
@@ -126,7 +126,7 @@ var _ = SIGDescribe("HostPath", func() {
 			fmt.Sprintf("--retry_time=%d", retryDuration),
 		}
 
-		e2epodoutput.TestContainerOutput(f, "hostPath subPath", pod, 1, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "hostPath subPath", pod, 1, []string{
 			"content of file \"" + filePathInReader + "\": mount-tester new file",
 		})
 	})

--- a/test/e2e/common/storage/projected_combined.go
+++ b/test/e2e/common/storage/projected_combined.go
@@ -66,11 +66,11 @@ var _ = SIGDescribe("Projected combined", func() {
 		}
 
 		ginkgo.By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
-		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 		}
 		ginkgo.By(fmt.Sprintf("Creating secret with name %s", secret.Name))
-		if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+		if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
 		}
 
@@ -89,7 +89,7 @@ var _ = SIGDescribe("Projected combined", func() {
 				},
 			},
 		}
-		e2epodoutput.TestContainerOutput(f, "Check all projections for projected volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "Check all projections for projected volume plugin", pod, 0, []string{
 			podName,
 			"secret-value-1",
 			"configmap-value-1",

--- a/test/e2e/common/storage/projected_configmap.go
+++ b/test/e2e/common/storage/projected_configmap.go
@@ -45,7 +45,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap with default permission mode. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -rw-r--r--.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func(ctx context.Context) {
-		doProjectedConfigMapE2EWithoutMappings(f, false, 0, nil)
+		doProjectedConfigMapE2EWithoutMappings(ctx, f, false, 0, nil)
 	})
 
 	/*
@@ -56,14 +56,14 @@ var _ = SIGDescribe("Projected configMap", func() {
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
 		defaultMode := int32(0400)
-		doProjectedConfigMapE2EWithoutMappings(f, false, 0, &defaultMode)
+		doProjectedConfigMapE2EWithoutMappings(ctx, f, false, 0, &defaultMode)
 	})
 
 	ginkgo.It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [LinuxOnly] [NodeFeature:FSGroup]", func(ctx context.Context) {
 		// Windows does not support RunAsUser / FSGroup SecurityContext options, and it does not support setting file permissions.
 		e2eskipper.SkipIfNodeOSDistroIs("windows")
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
-		doProjectedConfigMapE2EWithoutMappings(f, true, 1001, &defaultMode)
+		doProjectedConfigMapE2EWithoutMappings(ctx, f, true, 1001, &defaultMode)
 	})
 
 	/*
@@ -72,13 +72,13 @@ var _ = SIGDescribe("Projected configMap", func() {
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap as non-root user with uid 1000. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -rw-r--r--.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume as non-root [NodeConformance]", func(ctx context.Context) {
-		doProjectedConfigMapE2EWithoutMappings(f, true, 0, nil)
+		doProjectedConfigMapE2EWithoutMappings(ctx, f, true, 0, nil)
 	})
 
 	ginkgo.It("should be consumable from pods in volume as non-root with FSGroup [LinuxOnly] [NodeFeature:FSGroup]", func(ctx context.Context) {
 		// Windows does not support RunAsUser / FSGroup SecurityContext options.
 		e2eskipper.SkipIfNodeOSDistroIs("windows")
-		doProjectedConfigMapE2EWithoutMappings(f, true, 1001, nil)
+		doProjectedConfigMapE2EWithoutMappings(ctx, f, true, 1001, nil)
 	})
 
 	/*
@@ -87,7 +87,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap with default permission mode. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -rw-r--r--.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func(ctx context.Context) {
-		doProjectedConfigMapE2EWithMappings(f, false, 0, nil)
+		doProjectedConfigMapE2EWithMappings(ctx, f, false, 0, nil)
 	})
 
 	/*
@@ -98,7 +98,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
 		mode := int32(0400)
-		doProjectedConfigMapE2EWithMappings(f, false, 0, &mode)
+		doProjectedConfigMapE2EWithMappings(ctx, f, false, 0, &mode)
 	})
 
 	/*
@@ -107,13 +107,13 @@ var _ = SIGDescribe("Projected configMap", func() {
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap as non-root user with uid 1000. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -r--r--r--.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [NodeConformance]", func(ctx context.Context) {
-		doProjectedConfigMapE2EWithMappings(f, true, 0, nil)
+		doProjectedConfigMapE2EWithMappings(ctx, f, true, 0, nil)
 	})
 
 	ginkgo.It("should be consumable from pods in volume with mappings as non-root with FSGroup [LinuxOnly] [NodeFeature:FSGroup]", func(ctx context.Context) {
 		// Windows does not support RunAsUser / FSGroup SecurityContext options.
 		e2eskipper.SkipIfNodeOSDistroIs("windows")
-		doProjectedConfigMapE2EWithMappings(f, true, 1001, nil)
+		doProjectedConfigMapE2EWithMappings(ctx, f, true, 1001, nil)
 	})
 
 	/*
@@ -122,7 +122,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap and performs a create and update to new value. Pod MUST be able to create the configMap with value-1. Pod MUST be able to update the value in the confgiMap to value-2.
 	*/
 	framework.ConformanceIt("updates should be reflected in volume [NodeConformance]", func(ctx context.Context) {
-		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
+		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(ctx, f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
 		name := "projected-configmap-test-upd-" + string(uuid.NewUUID())
@@ -140,7 +140,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 
 		ginkgo.By(fmt.Sprintf("Creating projection with configMap that has name %s", configMap.Name))
 		var err error
-		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 		}
 
@@ -148,22 +148,22 @@ var _ = SIGDescribe("Projected configMap", func() {
 			"--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-configmap-volume/data-1")
 
 		ginkgo.By("Creating the pod")
-		e2epod.NewPodClient(f).CreateSync(pod)
+		e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 		pollLogs := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
 		}
 
-		gomega.Eventually(pollLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
+		gomega.Eventually(ctx, pollLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
 
 		ginkgo.By(fmt.Sprintf("Updating configmap %v", configMap.Name))
 		configMap.ResourceVersion = "" // to force update
 		configMap.Data["data-1"] = "value-2"
-		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, configMap, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "Failed to update configmap %q in namespace %q", configMap.Name, f.Namespace.Name)
 
 		ginkgo.By("waiting to observe update in volume")
-		gomega.Eventually(pollLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-2"))
+		gomega.Eventually(ctx, pollLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-2"))
 	})
 
 	/*
@@ -172,7 +172,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 	   Description: Create a Pod with three containers with ConfigMaps namely a create, update and delete container. Create Container when started MUST not have configMap, update and delete containers MUST be created with a ConfigMap value as 'value-1'. Create a configMap in the create container, the Pod MUST be able to read the configMap from the create container. Update the configMap in the update container, Pod MUST be able to read the updated configMap value. Delete the configMap in the delete container. Pod MUST fail to read the configMap from the delete container.
 	*/
 	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func(ctx context.Context) {
-		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
+		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(ctx, f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true
 		volumeMountPath := "/etc/projected-configmap-volumes"
@@ -218,12 +218,12 @@ var _ = SIGDescribe("Projected configMap", func() {
 
 		ginkgo.By(fmt.Sprintf("Creating configMap with name %s", deleteConfigMap.Name))
 		var err error
-		if deleteConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), deleteConfigMap, metav1.CreateOptions{}); err != nil {
+		if deleteConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, deleteConfigMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", deleteConfigMap.Name, err)
 		}
 
 		ginkgo.By(fmt.Sprintf("Creating configMap with name %s", updateConfigMap.Name))
-		if updateConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), updateConfigMap, metav1.CreateOptions{}); err != nil {
+		if updateConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, updateConfigMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", updateConfigMap.Name, err)
 		}
 
@@ -327,44 +327,44 @@ var _ = SIGDescribe("Projected configMap", func() {
 			},
 		}
 		ginkgo.By("Creating the pod")
-		e2epod.NewPodClient(f).CreateSync(pod)
+		e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 		pollCreateLogs := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, createContainerName)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, createContainerName)
 		}
-		gomega.Eventually(pollCreateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/projected-configmap-volumes/create/data-1"))
+		gomega.Eventually(ctx, pollCreateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/projected-configmap-volumes/create/data-1"))
 
 		pollUpdateLogs := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, updateContainerName)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, updateContainerName)
 		}
-		gomega.Eventually(pollUpdateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/projected-configmap-volumes/update/data-3"))
+		gomega.Eventually(ctx, pollUpdateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/projected-configmap-volumes/update/data-3"))
 
 		pollDeleteLogs := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, deleteContainerName)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, deleteContainerName)
 		}
-		gomega.Eventually(pollDeleteLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
+		gomega.Eventually(ctx, pollDeleteLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
 
 		ginkgo.By(fmt.Sprintf("Deleting configmap %v", deleteConfigMap.Name))
-		err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(context.TODO(), deleteConfigMap.Name, metav1.DeleteOptions{})
+		err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, deleteConfigMap.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "Failed to delete configmap %q in namespace %q", deleteConfigMap.Name, f.Namespace.Name)
 
 		ginkgo.By(fmt.Sprintf("Updating configmap %v", updateConfigMap.Name))
 		updateConfigMap.ResourceVersion = "" // to force update
 		delete(updateConfigMap.Data, "data-1")
 		updateConfigMap.Data["data-3"] = "value-3"
-		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), updateConfigMap, metav1.UpdateOptions{})
+		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, updateConfigMap, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "Failed to update configmap %q in namespace %q", updateConfigMap.Name, f.Namespace.Name)
 
 		ginkgo.By(fmt.Sprintf("Creating configMap with name %s", createConfigMap.Name))
-		if createConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), createConfigMap, metav1.CreateOptions{}); err != nil {
+		if createConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, createConfigMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", createConfigMap.Name, err)
 		}
 
 		ginkgo.By("waiting to observe update in volume")
 
-		gomega.Eventually(pollCreateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
-		gomega.Eventually(pollUpdateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-3"))
-		gomega.Eventually(pollDeleteLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/projected-configmap-volumes/delete/data-1"))
+		gomega.Eventually(ctx, pollCreateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
+		gomega.Eventually(ctx, pollUpdateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-3"))
+		gomega.Eventually(ctx, pollDeleteLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/projected-configmap-volumes/delete/data-1"))
 	})
 
 	/*
@@ -384,7 +384,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 
 		ginkgo.By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
 		var err error
-		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 		}
 
@@ -451,7 +451,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 			},
 		}
 
-		e2epodoutput.TestContainerOutput(f, "consume configMaps", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "consume configMaps", pod, 0, []string{
 			"content of file \"/etc/projected-configmap-volume/data-1\": value-1",
 		})
 
@@ -462,7 +462,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 	//Slow (~5 mins)
 	ginkgo.It("Should fail non-optional pod creation due to configMap object does not exist [Slow]", func(ctx context.Context) {
 		volumeMountPath := "/etc/projected-configmap-volumes"
-		pod, err := createNonOptionalConfigMapPod(f, volumeMountPath)
+		pod, err := createNonOptionalConfigMapPod(ctx, f, volumeMountPath)
 		framework.ExpectError(err, "created pod %q with non-optional configMap in namespace %q", pod.Name, f.Namespace.Name)
 	})
 
@@ -471,12 +471,12 @@ var _ = SIGDescribe("Projected configMap", func() {
 	//Slow (~5 mins)
 	ginkgo.It("Should fail non-optional pod creation due to the key in the configMap object does not exist [Slow]", func(ctx context.Context) {
 		volumeMountPath := "/etc/configmap-volumes"
-		pod, err := createNonOptionalConfigMapPodWithConfig(f, volumeMountPath)
+		pod, err := createNonOptionalConfigMapPodWithConfig(ctx, f, volumeMountPath)
 		framework.ExpectError(err, "created pod %q with non-optional configMap in namespace %q", pod.Name, f.Namespace.Name)
 	})
 })
 
-func doProjectedConfigMapE2EWithoutMappings(f *framework.Framework, asUser bool, fsGroup int64, defaultMode *int32) {
+func doProjectedConfigMapE2EWithoutMappings(ctx context.Context, f *framework.Framework, asUser bool, fsGroup int64, defaultMode *int32) {
 	groupID := int64(fsGroup)
 
 	var (
@@ -488,7 +488,7 @@ func doProjectedConfigMapE2EWithoutMappings(f *framework.Framework, asUser bool,
 
 	ginkgo.By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
 	var err error
-	if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+	if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 	}
 
@@ -513,10 +513,10 @@ func doProjectedConfigMapE2EWithoutMappings(f *framework.Framework, asUser bool,
 		"content of file \"/etc/projected-configmap-volume/data-1\": value-1",
 		fileModeRegexp,
 	}
-	e2epodoutput.TestContainerOutputRegexp(f, "consume configMaps", pod, 0, output)
+	e2epodoutput.TestContainerOutputRegexp(ctx, f, "consume configMaps", pod, 0, output)
 }
 
-func doProjectedConfigMapE2EWithMappings(f *framework.Framework, asUser bool, fsGroup int64, itemMode *int32) {
+func doProjectedConfigMapE2EWithMappings(ctx context.Context, f *framework.Framework, asUser bool, fsGroup int64, itemMode *int32) {
 	groupID := int64(fsGroup)
 
 	var (
@@ -529,7 +529,7 @@ func doProjectedConfigMapE2EWithMappings(f *framework.Framework, asUser bool, fs
 	ginkgo.By(fmt.Sprintf("Creating configMap with name %s", configMap.Name))
 
 	var err error
-	if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+	if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 	}
 
@@ -564,7 +564,7 @@ func doProjectedConfigMapE2EWithMappings(f *framework.Framework, asUser bool, fs
 		fileModeRegexp := getFileModeRegex("/etc/projected-configmap-volume/path/to/data-2", itemMode)
 		output = append(output, fileModeRegexp)
 	}
-	e2epodoutput.TestContainerOutputRegexp(f, "consume configMaps", pod, 0, output)
+	e2epodoutput.TestContainerOutputRegexp(ctx, f, "consume configMaps", pod, 0, output)
 }
 
 func createProjectedConfigMapMounttestPod(namespace, volumeName, referenceName, mountPath string, mounttestArgs ...string) *v1.Pod {

--- a/test/e2e/common/storage/projected_downwardapi.go
+++ b/test/e2e/common/storage/projected_downwardapi.go
@@ -55,7 +55,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("%s\n", podName),
 		})
 	})
@@ -71,7 +71,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 		defaultMode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			"mode of file \"/etc/podinfo/podname\": -r--------",
 		})
 	})
@@ -87,7 +87,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 		mode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			"mode of file \"/etc/podinfo/podname\": -r--------",
 		})
 	})
@@ -102,7 +102,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 			FSGroup: &gid,
 		}
 		setPodNonRootUser(pod)
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("%s\n", podName),
 		})
 	})
@@ -118,7 +118,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 			FSGroup: &gid,
 		}
 		setPodNonRootUser(pod)
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			"mode of file \"/etc/podinfo/podname\": -r--r-----",
 		})
 	})
@@ -137,20 +137,20 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 		pod := projectedDownwardAPIVolumePodForUpdateTest(podName, labels, map[string]string{}, "/etc/podinfo/labels")
 		containerName := "client-container"
 		ginkgo.By("Creating the pod")
-		podClient.CreateSync(pod)
+		podClient.CreateSync(ctx, pod)
 
-		gomega.Eventually(func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, containerName)
+		gomega.Eventually(ctx, func() (string, error) {
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, podName, containerName)
 		},
 			podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("key1=\"value1\"\n"))
 
 		//modify labels
-		podClient.Update(podName, func(pod *v1.Pod) {
+		podClient.Update(ctx, podName, func(pod *v1.Pod) {
 			pod.Labels["key3"] = "value3"
 		})
 
-		gomega.Eventually(func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, containerName)
+		gomega.Eventually(ctx, func() (string, error) {
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, containerName)
 		},
 			podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("key3=\"value3\"\n"))
 	})
@@ -168,20 +168,20 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 
 		containerName := "client-container"
 		ginkgo.By("Creating the pod")
-		pod = podClient.CreateSync(pod)
+		pod = podClient.CreateSync(ctx, pod)
 
-		gomega.Eventually(func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, containerName)
+		gomega.Eventually(ctx, func() (string, error) {
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, containerName)
 		},
 			podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("builder=\"bar\"\n"))
 
 		//modify annotations
-		podClient.Update(podName, func(pod *v1.Pod) {
+		podClient.Update(ctx, podName, func(pod *v1.Pod) {
 			pod.Annotations["builder"] = "foo"
 		})
 
-		gomega.Eventually(func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, containerName)
+		gomega.Eventually(ctx, func() (string, error) {
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, containerName)
 		},
 			podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("builder=\"foo\"\n"))
 	})
@@ -195,7 +195,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_limit")
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("2\n"),
 		})
 	})
@@ -209,7 +209,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("67108864\n"),
 		})
 	})
@@ -223,7 +223,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_request")
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("1\n"),
 		})
 	})
@@ -237,7 +237,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_request")
 
-		e2epodoutput.TestContainerOutput(f, "downward API volume plugin", pod, 0, []string{
+		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("33554432\n"),
 		})
 	})
@@ -251,7 +251,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/cpu_limit")
 
-		e2epodoutput.TestContainerOutputRegexp(f, "downward API volume plugin", pod, 0, []string{"[1-9]"})
+		e2epodoutput.TestContainerOutputRegexp(ctx, f, "downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
 
 	/*
@@ -263,7 +263,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/memory_limit")
 
-		e2epodoutput.TestContainerOutputRegexp(f, "downward API volume plugin", pod, 0, []string{"[1-9]"})
+		e2epodoutput.TestContainerOutputRegexp(ctx, f, "downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
 })
 

--- a/test/e2e/common/storage/projected_secret.go
+++ b/test/e2e/common/storage/projected_secret.go
@@ -44,7 +44,7 @@ var _ = SIGDescribe("Projected secret", func() {
 	   Description: A Pod is created with a projected volume source 'secret' to store a secret with a specified key with default permission mode. Pod MUST be able to read the content of the key successfully and the mode MUST be -rw-r--r-- by default.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func(ctx context.Context) {
-		doProjectedSecretE2EWithoutMapping(f, nil /* default mode */, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
+		doProjectedSecretE2EWithoutMapping(ctx, f, nil /* default mode */, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
 	/*
@@ -55,7 +55,7 @@ var _ = SIGDescribe("Projected secret", func() {
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
 		defaultMode := int32(0400)
-		doProjectedSecretE2EWithoutMapping(f, &defaultMode, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
+		doProjectedSecretE2EWithoutMapping(ctx, f, &defaultMode, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
 	/*
@@ -67,7 +67,7 @@ var _ = SIGDescribe("Projected secret", func() {
 	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		fsGroup := int64(1001)
-		doProjectedSecretE2EWithoutMapping(f, &defaultMode, "projected-secret-test-"+string(uuid.NewUUID()), &fsGroup, &nonRootTestUserID)
+		doProjectedSecretE2EWithoutMapping(ctx, f, &defaultMode, "projected-secret-test-"+string(uuid.NewUUID()), &fsGroup, &nonRootTestUserID)
 	})
 
 	/*
@@ -76,7 +76,7 @@ var _ = SIGDescribe("Projected secret", func() {
 	   Description: A Pod is created with a projected volume source 'secret' to store a secret with a specified key with default permission mode. The secret is also mapped to a custom path. Pod MUST be able to read the content of the key successfully and the mode MUST be -r--------on the mapped volume.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func(ctx context.Context) {
-		doProjectedSecretE2EWithMapping(f, nil)
+		doProjectedSecretE2EWithMapping(ctx, f, nil)
 	})
 
 	/*
@@ -87,7 +87,7 @@ var _ = SIGDescribe("Projected secret", func() {
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set [LinuxOnly] [NodeConformance]", func(ctx context.Context) {
 		mode := int32(0400)
-		doProjectedSecretE2EWithMapping(f, &mode)
+		doProjectedSecretE2EWithMapping(ctx, f, &mode)
 	})
 
 	ginkgo.It("should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]", func(ctx context.Context) {
@@ -97,7 +97,7 @@ var _ = SIGDescribe("Projected secret", func() {
 			secret2Name = "projected-secret-test-" + string(uuid.NewUUID())
 		)
 
-		if namespace2, err = f.CreateNamespace("secret-namespace", nil); err != nil {
+		if namespace2, err = f.CreateNamespace(ctx, "secret-namespace", nil); err != nil {
 			framework.Failf("unable to create new namespace %s: %v", namespace2.Name, err)
 		}
 
@@ -105,10 +105,10 @@ var _ = SIGDescribe("Projected secret", func() {
 		secret2.Data = map[string][]byte{
 			"this_should_not_match_content_of_other_secret": []byte("similarly_this_should_not_match_content_of_other_secret\n"),
 		}
-		if secret2, err = f.ClientSet.CoreV1().Secrets(namespace2.Name).Create(context.TODO(), secret2, metav1.CreateOptions{}); err != nil {
+		if secret2, err = f.ClientSet.CoreV1().Secrets(namespace2.Name).Create(ctx, secret2, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test secret %s: %v", secret2.Name, err)
 		}
-		doProjectedSecretE2EWithoutMapping(f, nil /* default mode */, secret2.Name, nil, nil)
+		doProjectedSecretE2EWithoutMapping(ctx, f, nil /* default mode */, secret2.Name, nil, nil)
 	})
 
 	/*
@@ -131,7 +131,7 @@ var _ = SIGDescribe("Projected secret", func() {
 
 		ginkgo.By(fmt.Sprintf("Creating secret with name %s", secret.Name))
 		var err error
-		if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+		if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
 		}
 
@@ -201,7 +201,7 @@ var _ = SIGDescribe("Projected secret", func() {
 		}
 
 		fileModeRegexp := getFileModeRegex("/etc/projected-secret-volume/data-1", nil)
-		e2epodoutput.TestContainerOutputRegexp(f, "consume secrets", pod, 0, []string{
+		e2epodoutput.TestContainerOutputRegexp(ctx, f, "consume secrets", pod, 0, []string{
 			"content of file \"/etc/projected-secret-volume/data-1\": value-1",
 			fileModeRegexp,
 		})
@@ -213,7 +213,7 @@ var _ = SIGDescribe("Projected secret", func() {
 	   Description: Create a Pod with three containers with secrets namely a create, update and delete container. Create Container when started MUST no have a secret, update and delete containers MUST be created with a secret value. Create a secret in the create container, the Pod MUST be able to read the secret from the create container. Update the secret in the update container, Pod MUST be able to read the updated secret value. Delete the secret in the delete container. Pod MUST fail to read the secret from the delete container.
 	*/
 	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func(ctx context.Context) {
-		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
+		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(ctx, f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true
 		volumeMountPath := "/etc/projected-secret-volumes"
@@ -259,12 +259,12 @@ var _ = SIGDescribe("Projected secret", func() {
 
 		ginkgo.By(fmt.Sprintf("Creating secret with name %s", deleteSecret.Name))
 		var err error
-		if deleteSecret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), deleteSecret, metav1.CreateOptions{}); err != nil {
+		if deleteSecret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, deleteSecret, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test secret %s: %v", deleteSecret.Name, err)
 		}
 
 		ginkgo.By(fmt.Sprintf("Creating secret with name %s", updateSecret.Name))
-		if updateSecret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), updateSecret, metav1.CreateOptions{}); err != nil {
+		if updateSecret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, updateSecret, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test secret %s: %v", updateSecret.Name, err)
 		}
 
@@ -368,44 +368,44 @@ var _ = SIGDescribe("Projected secret", func() {
 			},
 		}
 		ginkgo.By("Creating the pod")
-		e2epod.NewPodClient(f).CreateSync(pod)
+		e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 		pollCreateLogs := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, createContainerName)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, createContainerName)
 		}
-		gomega.Eventually(pollCreateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/projected-secret-volumes/create/data-1"))
+		gomega.Eventually(ctx, pollCreateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/projected-secret-volumes/create/data-1"))
 
 		pollUpdateLogs := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, updateContainerName)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, updateContainerName)
 		}
-		gomega.Eventually(pollUpdateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/projected-secret-volumes/update/data-3"))
+		gomega.Eventually(ctx, pollUpdateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/projected-secret-volumes/update/data-3"))
 
 		pollDeleteLogs := func() (string, error) {
-			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, deleteContainerName)
+			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, deleteContainerName)
 		}
-		gomega.Eventually(pollDeleteLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
+		gomega.Eventually(ctx, pollDeleteLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
 
 		ginkgo.By(fmt.Sprintf("Deleting secret %v", deleteSecret.Name))
-		err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), deleteSecret.Name, metav1.DeleteOptions{})
+		err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, deleteSecret.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "Failed to delete secret %q in namespace %q", deleteSecret.Name, f.Namespace.Name)
 
 		ginkgo.By(fmt.Sprintf("Updating secret %v", updateSecret.Name))
 		updateSecret.ResourceVersion = "" // to force update
 		delete(updateSecret.Data, "data-1")
 		updateSecret.Data["data-3"] = []byte("value-3")
-		_, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.TODO(), updateSecret, metav1.UpdateOptions{})
+		_, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Update(ctx, updateSecret, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "Failed to update secret %q in namespace %q", updateSecret.Name, f.Namespace.Name)
 
 		ginkgo.By(fmt.Sprintf("Creating secret with name %s", createSecret.Name))
-		if createSecret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), createSecret, metav1.CreateOptions{}); err != nil {
+		if createSecret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, createSecret, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test secret %s: %v", createSecret.Name, err)
 		}
 
 		ginkgo.By("waiting to observe update in volume")
 
-		gomega.Eventually(pollCreateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
-		gomega.Eventually(pollUpdateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-3"))
-		gomega.Eventually(pollDeleteLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/projected-secret-volumes/delete/data-1"))
+		gomega.Eventually(ctx, pollCreateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-1"))
+		gomega.Eventually(ctx, pollUpdateLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("value-3"))
+		gomega.Eventually(ctx, pollDeleteLogs, podLogTimeout, framework.Poll).Should(gomega.ContainSubstring("Error reading file /etc/projected-secret-volumes/delete/data-1"))
 	})
 
 	//The secret is in pending during volume creation until the secret objects are available
@@ -414,7 +414,7 @@ var _ = SIGDescribe("Projected secret", func() {
 	ginkgo.It("Should fail non-optional pod creation due to secret object does not exist [Slow]", func(ctx context.Context) {
 		volumeMountPath := "/etc/projected-secret-volumes"
 		podName := "pod-secrets-" + string(uuid.NewUUID())
-		err := createNonOptionalSecretPod(f, volumeMountPath, podName)
+		err := createNonOptionalSecretPod(ctx, f, volumeMountPath, podName)
 		framework.ExpectError(err, "created pod %q with non-optional secret in namespace %q", podName, f.Namespace.Name)
 	})
 
@@ -424,12 +424,12 @@ var _ = SIGDescribe("Projected secret", func() {
 	ginkgo.It("Should fail non-optional pod creation due to the key in the secret object does not exist [Slow]", func(ctx context.Context) {
 		volumeMountPath := "/etc/secret-volumes"
 		podName := "pod-secrets-" + string(uuid.NewUUID())
-		err := createNonOptionalSecretPodWithSecret(f, volumeMountPath, podName)
+		err := createNonOptionalSecretPodWithSecret(ctx, f, volumeMountPath, podName)
 		framework.ExpectError(err, "created pod %q with non-optional secret in namespace %q", podName, f.Namespace.Name)
 	})
 })
 
-func doProjectedSecretE2EWithoutMapping(f *framework.Framework, defaultMode *int32,
+func doProjectedSecretE2EWithoutMapping(ctx context.Context, f *framework.Framework, defaultMode *int32,
 	secretName string, fsGroup *int64, uid *int64) {
 	var (
 		volumeName      = "projected-secret-volume"
@@ -439,7 +439,7 @@ func doProjectedSecretE2EWithoutMapping(f *framework.Framework, defaultMode *int
 
 	ginkgo.By(fmt.Sprintf("Creating projection with secret that has name %s", secret.Name))
 	var err error
-	if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+	if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create test secret %s: %v", secret.Name, err)
 	}
 
@@ -505,10 +505,10 @@ func doProjectedSecretE2EWithoutMapping(f *framework.Framework, defaultMode *int
 		fileModeRegexp,
 	}
 
-	e2epodoutput.TestContainerOutputRegexp(f, "consume secrets", pod, 0, expectedOutput)
+	e2epodoutput.TestContainerOutputRegexp(ctx, f, "consume secrets", pod, 0, expectedOutput)
 }
 
-func doProjectedSecretE2EWithMapping(f *framework.Framework, mode *int32) {
+func doProjectedSecretE2EWithMapping(ctx context.Context, f *framework.Framework, mode *int32) {
 	var (
 		name            = "projected-secret-test-map-" + string(uuid.NewUUID())
 		volumeName      = "projected-secret-volume"
@@ -518,7 +518,7 @@ func doProjectedSecretE2EWithMapping(f *framework.Framework, mode *int32) {
 
 	ginkgo.By(fmt.Sprintf("Creating projection with secret that has name %s", secret.Name))
 	var err error
-	if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+	if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create test secret %s: %v", secret.Name, err)
 	}
 
@@ -582,5 +582,5 @@ func doProjectedSecretE2EWithMapping(f *framework.Framework, mode *int32) {
 		fileModeRegexp,
 	}
 
-	e2epodoutput.TestContainerOutputRegexp(f, "consume secrets", pod, 0, expectedOutput)
+	e2epodoutput.TestContainerOutputRegexp(ctx, f, "consume secrets", pod, 0, expectedOutput)
 }

--- a/test/e2e/common/storage/volumes.go
+++ b/test/e2e/common/storage/volumes.go
@@ -77,7 +77,7 @@ var _ = SIGDescribe("Volumes", func() {
 	////////////////////////////////////////////////////////////////////////
 	ginkgo.Describe("NFSv4", func() {
 		ginkgo.It("should be mountable for NFSv4", func(ctx context.Context) {
-			config, _, serverHost := e2evolume.NewNFSServer(c, namespace.Name, []string{})
+			config, _, serverHost := e2evolume.NewNFSServer(ctx, c, namespace.Name, []string{})
 			ginkgo.DeferCleanup(e2evolume.TestServerCleanup, f, config)
 
 			tests := []e2evolume.Test{
@@ -95,13 +95,13 @@ var _ = SIGDescribe("Volumes", func() {
 			}
 
 			// Must match content of test/images/volumes-tester/nfs/index.html
-			e2evolume.TestVolumeClient(f, config, nil, "" /* fsType */, tests)
+			e2evolume.TestVolumeClient(ctx, f, config, nil, "" /* fsType */, tests)
 		})
 	})
 
 	ginkgo.Describe("NFSv3", func() {
 		ginkgo.It("should be mountable for NFSv3", func(ctx context.Context) {
-			config, _, serverHost := e2evolume.NewNFSServer(c, namespace.Name, []string{})
+			config, _, serverHost := e2evolume.NewNFSServer(ctx, c, namespace.Name, []string{})
 			ginkgo.DeferCleanup(e2evolume.TestServerCleanup, f, config)
 
 			tests := []e2evolume.Test{
@@ -118,7 +118,7 @@ var _ = SIGDescribe("Volumes", func() {
 				},
 			}
 			// Must match content of test/images/volume-tester/nfs/index.html
-			e2evolume.TestVolumeClient(f, config, nil, "" /* fsType */, tests)
+			e2evolume.TestVolumeClient(ctx, f, config, nil, "" /* fsType */, tests)
 		})
 	})
 })

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -139,8 +139,8 @@ type ResourceConsumer struct {
 }
 
 // NewDynamicResourceConsumer is a wrapper to create a new dynamic ResourceConsumer
-func NewDynamicResourceConsumer(name, nsName string, kind schema.GroupVersionKind, replicas, initCPUTotal, initMemoryTotal, initCustomMetric int, cpuLimit, memLimit int64, clientset clientset.Interface, scaleClient scaleclient.ScalesGetter, enableSidecar SidecarStatusType, sidecarType SidecarWorkloadType) *ResourceConsumer {
-	return newResourceConsumer(name, nsName, kind, replicas, initCPUTotal, initMemoryTotal, initCustomMetric, dynamicConsumptionTimeInSeconds,
+func NewDynamicResourceConsumer(ctx context.Context, name, nsName string, kind schema.GroupVersionKind, replicas, initCPUTotal, initMemoryTotal, initCustomMetric int, cpuLimit, memLimit int64, clientset clientset.Interface, scaleClient scaleclient.ScalesGetter, enableSidecar SidecarStatusType, sidecarType SidecarWorkloadType) *ResourceConsumer {
+	return newResourceConsumer(ctx, name, nsName, kind, replicas, initCPUTotal, initMemoryTotal, initCustomMetric, dynamicConsumptionTimeInSeconds,
 		dynamicRequestSizeInMillicores, dynamicRequestSizeInMegabytes, dynamicRequestSizeCustomMetric, cpuLimit, memLimit, clientset, scaleClient, nil, nil, enableSidecar, sidecarType)
 }
 
@@ -178,7 +178,7 @@ initMemoryTotal argument is in megabytes
 memLimit argument is in megabytes, memLimit is a maximum amount of memory that can be consumed by a single pod
 cpuLimit argument is in millicores, cpuLimit is a maximum amount of cpu that can be consumed by a single pod
 */
-func newResourceConsumer(name, nsName string, kind schema.GroupVersionKind, replicas, initCPUTotal, initMemoryTotal, initCustomMetric, consumptionTimeInSeconds, requestSizeInMillicores,
+func newResourceConsumer(ctx context.Context, name, nsName string, kind schema.GroupVersionKind, replicas, initCPUTotal, initMemoryTotal, initCustomMetric, consumptionTimeInSeconds, requestSizeInMillicores,
 	requestSizeInMegabytes int, requestSizeCustomMetric int, cpuLimit, memLimit int64, clientset clientset.Interface, scaleClient scaleclient.ScalesGetter, podAnnotations, serviceAnnotations map[string]string, sidecarStatus SidecarStatusType, sidecarType SidecarWorkloadType) *ResourceConsumer {
 	if podAnnotations == nil {
 		podAnnotations = make(map[string]string)
@@ -202,11 +202,11 @@ func newResourceConsumer(name, nsName string, kind schema.GroupVersionKind, repl
 	framework.ExpectNoError(err)
 	resourceClient := dynamicClient.Resource(schema.GroupVersionResource{Group: crdGroup, Version: crdVersion, Resource: crdNamePlural}).Namespace(nsName)
 
-	runServiceAndWorkloadForResourceConsumer(clientset, resourceClient, apiExtensionClient, nsName, name, kind, replicas, cpuLimit, memLimit, podAnnotations, serviceAnnotations, additionalContainers)
+	runServiceAndWorkloadForResourceConsumer(ctx, clientset, resourceClient, apiExtensionClient, nsName, name, kind, replicas, cpuLimit, memLimit, podAnnotations, serviceAnnotations, additionalContainers)
 	controllerName := name + "-ctrl"
 	// If sidecar is enabled and busy, run service and consumer for sidecar
 	if sidecarStatus == Enable && sidecarType == Busy {
-		runServiceAndSidecarForResourceConsumer(clientset, nsName, name, kind, replicas, serviceAnnotations)
+		runServiceAndSidecarForResourceConsumer(ctx, clientset, nsName, name, kind, replicas, serviceAnnotations)
 		controllerName = name + "-sidecar-ctrl"
 	}
 
@@ -235,11 +235,11 @@ func newResourceConsumer(name, nsName string, kind schema.GroupVersionKind, repl
 		sidecarStatus:            sidecarStatus,
 	}
 
-	go rc.makeConsumeCPURequests()
+	go rc.makeConsumeCPURequests(ctx)
 	rc.ConsumeCPU(initCPUTotal)
-	go rc.makeConsumeMemRequests()
+	go rc.makeConsumeMemRequests(ctx)
 	rc.ConsumeMem(initMemoryTotal)
-	go rc.makeConsumeCustomMetric()
+	go rc.makeConsumeCustomMetric(ctx)
 	rc.ConsumeCustomMetric(initCustomMetric)
 	return rc
 }
@@ -262,7 +262,7 @@ func (rc *ResourceConsumer) ConsumeCustomMetric(amount int) {
 	rc.customMetric <- amount
 }
 
-func (rc *ResourceConsumer) makeConsumeCPURequests() {
+func (rc *ResourceConsumer) makeConsumeCPURequests(ctx context.Context) {
 	defer ginkgo.GinkgoRecover()
 	rc.stopWaitGroup.Add(1)
 	defer rc.stopWaitGroup.Done()
@@ -279,9 +279,12 @@ func (rc *ResourceConsumer) makeConsumeCPURequests() {
 		case <-tick:
 			if millicores != 0 {
 				framework.Logf("RC %s: sending request to consume %d millicores", rc.name, millicores)
-				rc.sendConsumeCPURequest(millicores)
+				rc.sendConsumeCPURequest(ctx, millicores)
 			}
 			tick = time.After(rc.sleepTime)
+		case <-ctx.Done():
+			framework.Logf("RC %s: stopping CPU consumer: %v", rc.name, ctx.Err())
+			return
 		case <-rc.stopCPU:
 			framework.Logf("RC %s: stopping CPU consumer", rc.name)
 			return
@@ -289,7 +292,7 @@ func (rc *ResourceConsumer) makeConsumeCPURequests() {
 	}
 }
 
-func (rc *ResourceConsumer) makeConsumeMemRequests() {
+func (rc *ResourceConsumer) makeConsumeMemRequests(ctx context.Context) {
 	defer ginkgo.GinkgoRecover()
 	rc.stopWaitGroup.Add(1)
 	defer rc.stopWaitGroup.Done()
@@ -306,9 +309,12 @@ func (rc *ResourceConsumer) makeConsumeMemRequests() {
 		case <-tick:
 			if megabytes != 0 {
 				framework.Logf("RC %s: sending request to consume %d MB", rc.name, megabytes)
-				rc.sendConsumeMemRequest(megabytes)
+				rc.sendConsumeMemRequest(ctx, megabytes)
 			}
 			tick = time.After(rc.sleepTime)
+		case <-ctx.Done():
+			framework.Logf("RC %s: stopping mem consumer: %v", rc.name, ctx.Err())
+			return
 		case <-rc.stopMem:
 			framework.Logf("RC %s: stopping mem consumer", rc.name)
 			return
@@ -316,7 +322,7 @@ func (rc *ResourceConsumer) makeConsumeMemRequests() {
 	}
 }
 
-func (rc *ResourceConsumer) makeConsumeCustomMetric() {
+func (rc *ResourceConsumer) makeConsumeCustomMetric(ctx context.Context) {
 	defer ginkgo.GinkgoRecover()
 	rc.stopWaitGroup.Add(1)
 	defer rc.stopWaitGroup.Done()
@@ -333,9 +339,12 @@ func (rc *ResourceConsumer) makeConsumeCustomMetric() {
 		case <-tick:
 			if delta != 0 {
 				framework.Logf("RC %s: sending request to consume %d of custom metric %s", rc.name, delta, customMetricName)
-				rc.sendConsumeCustomMetric(delta)
+				rc.sendConsumeCustomMetric(ctx, delta)
 			}
 			tick = time.After(rc.sleepTime)
+		case <-ctx.Done():
+			framework.Logf("RC %s: stopping metric consumer: %v", rc.name, ctx.Err())
+			return
 		case <-rc.stopCustomMetric:
 			framework.Logf("RC %s: stopping metric consumer", rc.name)
 			return
@@ -343,11 +352,11 @@ func (rc *ResourceConsumer) makeConsumeCustomMetric() {
 	}
 }
 
-func (rc *ResourceConsumer) sendConsumeCPURequest(millicores int) {
-	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
+func (rc *ResourceConsumer) sendConsumeCPURequest(ctx context.Context, millicores int) {
+	ctx, cancel := context.WithTimeout(ctx, framework.SingleCallTimeout)
 	defer cancel()
 
-	err := wait.PollImmediate(serviceInitializationInterval, serviceInitializationTimeout, func() (bool, error) {
+	err := wait.PollImmediateWithContext(ctx, serviceInitializationInterval, serviceInitializationTimeout, func(ctx context.Context) (bool, error) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
@@ -369,11 +378,11 @@ func (rc *ResourceConsumer) sendConsumeCPURequest(millicores int) {
 }
 
 // sendConsumeMemRequest sends POST request for memory consumption
-func (rc *ResourceConsumer) sendConsumeMemRequest(megabytes int) {
-	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
+func (rc *ResourceConsumer) sendConsumeMemRequest(ctx context.Context, megabytes int) {
+	ctx, cancel := context.WithTimeout(ctx, framework.SingleCallTimeout)
 	defer cancel()
 
-	err := wait.PollImmediate(serviceInitializationInterval, serviceInitializationTimeout, func() (bool, error) {
+	err := wait.PollImmediateWithContext(ctx, serviceInitializationInterval, serviceInitializationTimeout, func(ctx context.Context) (bool, error) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
@@ -395,11 +404,11 @@ func (rc *ResourceConsumer) sendConsumeMemRequest(megabytes int) {
 }
 
 // sendConsumeCustomMetric sends POST request for custom metric consumption
-func (rc *ResourceConsumer) sendConsumeCustomMetric(delta int) {
-	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
+func (rc *ResourceConsumer) sendConsumeCustomMetric(ctx context.Context, delta int) {
+	ctx, cancel := context.WithTimeout(ctx, framework.SingleCallTimeout)
 	defer cancel()
 
-	err := wait.PollImmediate(serviceInitializationInterval, serviceInitializationTimeout, func() (bool, error) {
+	err := wait.PollImmediateWithContext(ctx, serviceInitializationInterval, serviceInitializationTimeout, func(ctx context.Context) (bool, error) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
@@ -421,44 +430,44 @@ func (rc *ResourceConsumer) sendConsumeCustomMetric(delta int) {
 }
 
 // GetReplicas get the replicas
-func (rc *ResourceConsumer) GetReplicas() int {
+func (rc *ResourceConsumer) GetReplicas(ctx context.Context) int {
 	switch rc.kind {
 	case KindRC:
-		replicationController, err := rc.clientSet.CoreV1().ReplicationControllers(rc.nsName).Get(context.TODO(), rc.name, metav1.GetOptions{})
+		replicationController, err := rc.clientSet.CoreV1().ReplicationControllers(rc.nsName).Get(ctx, rc.name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		if replicationController == nil {
 			framework.Failf(rcIsNil)
 		}
 		return int(replicationController.Status.ReadyReplicas)
 	case KindDeployment:
-		deployment, err := rc.clientSet.AppsV1().Deployments(rc.nsName).Get(context.TODO(), rc.name, metav1.GetOptions{})
+		deployment, err := rc.clientSet.AppsV1().Deployments(rc.nsName).Get(ctx, rc.name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		if deployment == nil {
 			framework.Failf(deploymentIsNil)
 		}
 		return int(deployment.Status.ReadyReplicas)
 	case KindReplicaSet:
-		rs, err := rc.clientSet.AppsV1().ReplicaSets(rc.nsName).Get(context.TODO(), rc.name, metav1.GetOptions{})
+		rs, err := rc.clientSet.AppsV1().ReplicaSets(rc.nsName).Get(ctx, rc.name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		if rs == nil {
 			framework.Failf(rsIsNil)
 		}
 		return int(rs.Status.ReadyReplicas)
 	case KindCRD:
-		deployment, err := rc.clientSet.AppsV1().Deployments(rc.nsName).Get(context.TODO(), rc.name, metav1.GetOptions{})
+		deployment, err := rc.clientSet.AppsV1().Deployments(rc.nsName).Get(ctx, rc.name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		if deployment == nil {
 			framework.Failf(deploymentIsNil)
 		}
 		deploymentReplicas := int64(deployment.Status.ReadyReplicas)
 
-		scale, err := rc.scaleClient.Scales(rc.nsName).Get(context.TODO(), schema.GroupResource{Group: crdGroup, Resource: crdNamePlural}, rc.name, metav1.GetOptions{})
+		scale, err := rc.scaleClient.Scales(rc.nsName).Get(ctx, schema.GroupResource{Group: crdGroup, Resource: crdNamePlural}, rc.name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
-		crdInstance, err := rc.resourceClient.Get(context.TODO(), rc.name, metav1.GetOptions{})
+		crdInstance, err := rc.resourceClient.Get(ctx, rc.name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		// Update custom resource's status.replicas with child Deployment's current number of ready replicas.
 		framework.ExpectNoError(unstructured.SetNestedField(crdInstance.Object, deploymentReplicas, "status", "replicas"))
-		_, err = rc.resourceClient.Update(context.TODO(), crdInstance, metav1.UpdateOptions{})
+		_, err = rc.resourceClient.Update(ctx, crdInstance, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 		return int(scale.Spec.Replicas)
 	default:
@@ -468,15 +477,15 @@ func (rc *ResourceConsumer) GetReplicas() int {
 }
 
 // GetHpa get the corresponding horizontalPodAutoscaler object
-func (rc *ResourceConsumer) GetHpa(name string) (*autoscalingv1.HorizontalPodAutoscaler, error) {
-	return rc.clientSet.AutoscalingV1().HorizontalPodAutoscalers(rc.nsName).Get(context.TODO(), name, metav1.GetOptions{})
+func (rc *ResourceConsumer) GetHpa(ctx context.Context, name string) (*autoscalingv1.HorizontalPodAutoscaler, error) {
+	return rc.clientSet.AutoscalingV1().HorizontalPodAutoscalers(rc.nsName).Get(ctx, name, metav1.GetOptions{})
 }
 
 // WaitForReplicas wait for the desired replicas
-func (rc *ResourceConsumer) WaitForReplicas(desiredReplicas int, duration time.Duration) {
+func (rc *ResourceConsumer) WaitForReplicas(ctx context.Context, desiredReplicas int, duration time.Duration) {
 	interval := 20 * time.Second
-	err := wait.PollImmediate(interval, duration, func() (bool, error) {
-		replicas := rc.GetReplicas()
+	err := wait.PollImmediateWithContext(ctx, interval, duration, func(ctx context.Context) (bool, error) {
+		replicas := rc.GetReplicas(ctx)
 		framework.Logf("waiting for %d replicas (current: %d)", desiredReplicas, replicas)
 		return replicas == desiredReplicas, nil // Expected number of replicas found. Exit.
 	})
@@ -484,12 +493,12 @@ func (rc *ResourceConsumer) WaitForReplicas(desiredReplicas int, duration time.D
 }
 
 // EnsureDesiredReplicasInRange ensure the replicas is in a desired range
-func (rc *ResourceConsumer) EnsureDesiredReplicasInRange(minDesiredReplicas, maxDesiredReplicas int, duration time.Duration, hpaName string) {
+func (rc *ResourceConsumer) EnsureDesiredReplicasInRange(ctx context.Context, minDesiredReplicas, maxDesiredReplicas int, duration time.Duration, hpaName string) {
 	interval := 10 * time.Second
-	err := wait.PollImmediate(interval, duration, func() (bool, error) {
-		replicas := rc.GetReplicas()
+	err := wait.PollImmediateWithContext(ctx, interval, duration, func(ctx context.Context) (bool, error) {
+		replicas := rc.GetReplicas(ctx)
 		framework.Logf("expecting there to be in [%d, %d] replicas (are: %d)", minDesiredReplicas, maxDesiredReplicas, replicas)
-		as, err := rc.GetHpa(hpaName)
+		as, err := rc.GetHpa(ctx, hpaName)
 		if err != nil {
 			framework.Logf("Error getting HPA: %s", err)
 		} else {
@@ -521,15 +530,15 @@ func (rc *ResourceConsumer) Pause() {
 }
 
 // Resume starts background goroutines responsible for consuming resources.
-func (rc *ResourceConsumer) Resume() {
+func (rc *ResourceConsumer) Resume(ctx context.Context) {
 	ginkgo.By(fmt.Sprintf("HPA resuming RC %s", rc.name))
-	go rc.makeConsumeCPURequests()
-	go rc.makeConsumeMemRequests()
-	go rc.makeConsumeCustomMetric()
+	go rc.makeConsumeCPURequests(ctx)
+	go rc.makeConsumeMemRequests(ctx)
+	go rc.makeConsumeCustomMetric(ctx)
 }
 
 // CleanUp clean up the background goroutines responsible for consuming resources.
-func (rc *ResourceConsumer) CleanUp() {
+func (rc *ResourceConsumer) CleanUp(ctx context.Context) {
 	ginkgo.By(fmt.Sprintf("Removing consuming RC %s", rc.name))
 	close(rc.stopCPU)
 	close(rc.stopMem)
@@ -540,24 +549,24 @@ func (rc *ResourceConsumer) CleanUp() {
 	kind := rc.kind.GroupKind()
 	if kind.Kind == crdKind {
 		gvr := schema.GroupVersionResource{Group: crdGroup, Version: crdVersion, Resource: crdNamePlural}
-		framework.ExpectNoError(e2eresource.DeleteCustomResourceAndWaitForGC(rc.clientSet, rc.dynamicClient, rc.scaleClient, gvr, rc.nsName, rc.name))
+		framework.ExpectNoError(e2eresource.DeleteCustomResourceAndWaitForGC(ctx, rc.clientSet, rc.dynamicClient, rc.scaleClient, gvr, rc.nsName, rc.name))
 
 	} else {
-		framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(rc.clientSet, kind, rc.nsName, rc.name))
+		framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, rc.clientSet, kind, rc.nsName, rc.name))
 	}
 
-	framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(context.TODO(), rc.name, metav1.DeleteOptions{}))
-	framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(rc.clientSet, schema.GroupKind{Kind: "ReplicationController"}, rc.nsName, rc.controllerName))
-	framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(context.TODO(), rc.name+"-ctrl", metav1.DeleteOptions{}))
+	framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(ctx, rc.name, metav1.DeleteOptions{}))
+	framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, rc.clientSet, schema.GroupKind{Kind: "ReplicationController"}, rc.nsName, rc.controllerName))
+	framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(ctx, rc.name+"-ctrl", metav1.DeleteOptions{}))
 	// Cleanup sidecar related resources
 	if rc.sidecarStatus == Enable && rc.sidecarType == Busy {
-		framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(context.TODO(), rc.name+"-sidecar", metav1.DeleteOptions{}))
-		framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(context.TODO(), rc.name+"-sidecar-ctrl", metav1.DeleteOptions{}))
+		framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(ctx, rc.name+"-sidecar", metav1.DeleteOptions{}))
+		framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(ctx, rc.name+"-sidecar-ctrl", metav1.DeleteOptions{}))
 	}
 }
 
-func createService(c clientset.Interface, name, ns string, annotations, selectors map[string]string, port int32, targetPort int) (*v1.Service, error) {
-	return c.CoreV1().Services(ns).Create(context.TODO(), &v1.Service{
+func createService(ctx context.Context, c clientset.Interface, name, ns string, annotations, selectors map[string]string, port int32, targetPort int) (*v1.Service, error) {
+	return c.CoreV1().Services(ns).Create(ctx, &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Annotations: annotations,
@@ -573,19 +582,19 @@ func createService(c clientset.Interface, name, ns string, annotations, selector
 }
 
 // runServiceAndSidecarForResourceConsumer creates service and runs resource consumer for sidecar container
-func runServiceAndSidecarForResourceConsumer(c clientset.Interface, ns, name string, kind schema.GroupVersionKind, replicas int, serviceAnnotations map[string]string) {
+func runServiceAndSidecarForResourceConsumer(ctx context.Context, c clientset.Interface, ns, name string, kind schema.GroupVersionKind, replicas int, serviceAnnotations map[string]string) {
 	ginkgo.By(fmt.Sprintf("Running consuming RC sidecar %s via %s with %v replicas", name, kind, replicas))
 
 	sidecarName := name + "-sidecar"
 	serviceSelectors := map[string]string{
 		"name": name,
 	}
-	_, err := createService(c, sidecarName, ns, serviceAnnotations, serviceSelectors, port, sidecarTargetPort)
+	_, err := createService(ctx, c, sidecarName, ns, serviceAnnotations, serviceSelectors, port, sidecarTargetPort)
 	framework.ExpectNoError(err)
 
 	ginkgo.By(fmt.Sprintf("Running controller for sidecar"))
 	controllerName := sidecarName + "-ctrl"
-	_, err = createService(c, controllerName, ns, map[string]string{}, map[string]string{"name": controllerName}, port, targetPort)
+	_, err = createService(ctx, c, controllerName, ns, map[string]string{}, map[string]string{"name": controllerName}, port, targetPort)
 	framework.ExpectNoError(err)
 
 	dnsClusterFirst := v1.DNSClusterFirst
@@ -600,15 +609,15 @@ func runServiceAndSidecarForResourceConsumer(c clientset.Interface, ns, name str
 		DNSPolicy: &dnsClusterFirst,
 	}
 
-	framework.ExpectNoError(e2erc.RunRC(controllerRcConfig))
+	framework.ExpectNoError(e2erc.RunRC(ctx, controllerRcConfig))
 	// Wait for endpoints to propagate for the controller service.
 	framework.ExpectNoError(framework.WaitForServiceEndpointsNum(
-		c, ns, controllerName, 1, startServiceInterval, startServiceTimeout))
+		ctx, c, ns, controllerName, 1, startServiceInterval, startServiceTimeout))
 }
 
-func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, resourceClient dynamic.ResourceInterface, apiExtensionClient crdclientset.Interface, ns, name string, kind schema.GroupVersionKind, replicas int, cpuLimitMillis, memLimitMb int64, podAnnotations, serviceAnnotations map[string]string, additionalContainers []v1.Container) {
+func runServiceAndWorkloadForResourceConsumer(ctx context.Context, c clientset.Interface, resourceClient dynamic.ResourceInterface, apiExtensionClient crdclientset.Interface, ns, name string, kind schema.GroupVersionKind, replicas int, cpuLimitMillis, memLimitMb int64, podAnnotations, serviceAnnotations map[string]string, additionalContainers []v1.Container) {
 	ginkgo.By(fmt.Sprintf("Running consuming RC %s via %s with %v replicas", name, kind, replicas))
-	_, err := createService(c, name, ns, serviceAnnotations, map[string]string{"name": name}, port, targetPort)
+	_, err := createService(ctx, c, name, ns, serviceAnnotations, map[string]string{"name": name}, port, targetPort)
 	framework.ExpectNoError(err)
 
 	rcConfig := testutils.RCConfig{
@@ -634,25 +643,25 @@ func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, resourceCli
 
 	switch kind {
 	case KindRC:
-		framework.ExpectNoError(e2erc.RunRC(rcConfig))
+		framework.ExpectNoError(e2erc.RunRC(ctx, rcConfig))
 	case KindDeployment:
 		ginkgo.By(fmt.Sprintf("Creating deployment %s in namespace %s", dpConfig.Name, dpConfig.Namespace))
-		framework.ExpectNoError(testutils.RunDeployment(dpConfig))
+		framework.ExpectNoError(testutils.RunDeployment(ctx, dpConfig))
 	case KindReplicaSet:
 		rsConfig := testutils.ReplicaSetConfig{
 			RCConfig: rcConfig,
 		}
 		ginkgo.By(fmt.Sprintf("Creating replicaset %s in namespace %s", rsConfig.Name, rsConfig.Namespace))
-		framework.ExpectNoError(runReplicaSet(rsConfig))
+		framework.ExpectNoError(runReplicaSet(ctx, rsConfig))
 	case KindCRD:
-		crd := CreateCustomResourceDefinition(apiExtensionClient)
-		crdInstance, err := CreateCustomSubresourceInstance(ns, name, resourceClient, crd)
+		crd := CreateCustomResourceDefinition(ctx, apiExtensionClient)
+		crdInstance, err := CreateCustomSubresourceInstance(ctx, ns, name, resourceClient, crd)
 		framework.ExpectNoError(err)
 
 		ginkgo.By(fmt.Sprintf("Creating deployment %s backing CRD in namespace %s", dpConfig.Name, dpConfig.Namespace))
-		framework.ExpectNoError(testutils.RunDeployment(dpConfig))
+		framework.ExpectNoError(testutils.RunDeployment(ctx, dpConfig))
 
-		deployment, err := c.AppsV1().Deployments(dpConfig.Namespace).Get(context.TODO(), dpConfig.Name, metav1.GetOptions{})
+		deployment, err := c.AppsV1().Deployments(dpConfig.Namespace).Get(ctx, dpConfig.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		deployment.SetOwnerReferences([]metav1.OwnerReference{{
 			APIVersion: kind.GroupVersion().String(),
@@ -660,7 +669,7 @@ func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, resourceCli
 			Name:       name,
 			UID:        crdInstance.GetUID(),
 		}})
-		_, err = c.AppsV1().Deployments(dpConfig.Namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+		_, err = c.AppsV1().Deployments(dpConfig.Namespace).Update(ctx, deployment, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 	default:
 		framework.Failf(invalidKind)
@@ -668,7 +677,7 @@ func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, resourceCli
 
 	ginkgo.By(fmt.Sprintf("Running controller"))
 	controllerName := name + "-ctrl"
-	_, err = createService(c, controllerName, ns, map[string]string{}, map[string]string{"name": controllerName}, port, targetPort)
+	_, err = createService(ctx, c, controllerName, ns, map[string]string{}, map[string]string{"name": controllerName}, port, targetPort)
 	framework.ExpectNoError(err)
 
 	dnsClusterFirst := v1.DNSClusterFirst
@@ -683,13 +692,13 @@ func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, resourceCli
 		DNSPolicy: &dnsClusterFirst,
 	}
 
-	framework.ExpectNoError(e2erc.RunRC(controllerRcConfig))
+	framework.ExpectNoError(e2erc.RunRC(ctx, controllerRcConfig))
 	// Wait for endpoints to propagate for the controller service.
 	framework.ExpectNoError(framework.WaitForServiceEndpointsNum(
-		c, ns, controllerName, 1, startServiceInterval, startServiceTimeout))
+		ctx, c, ns, controllerName, 1, startServiceInterval, startServiceTimeout))
 }
 
-func CreateHorizontalPodAutoscaler(rc *ResourceConsumer, targetRef autoscalingv2.CrossVersionObjectReference, namespace string, metrics []autoscalingv2.MetricSpec, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, metricTargetValue, minReplicas, maxReplicas int32) *autoscalingv2.HorizontalPodAutoscaler {
+func CreateHorizontalPodAutoscaler(ctx context.Context, rc *ResourceConsumer, targetRef autoscalingv2.CrossVersionObjectReference, namespace string, metrics []autoscalingv2.MetricSpec, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, metricTargetValue, minReplicas, maxReplicas int32) *autoscalingv2.HorizontalPodAutoscaler {
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      targetRef.Name,
@@ -702,12 +711,12 @@ func CreateHorizontalPodAutoscaler(rc *ResourceConsumer, targetRef autoscalingv2
 			Metrics:        metrics,
 		},
 	}
-	hpa, errHPA := rc.clientSet.AutoscalingV2().HorizontalPodAutoscalers(namespace).Create(context.TODO(), hpa, metav1.CreateOptions{})
+	hpa, errHPA := rc.clientSet.AutoscalingV2().HorizontalPodAutoscalers(namespace).Create(ctx, hpa, metav1.CreateOptions{})
 	framework.ExpectNoError(errHPA)
 	return hpa
 }
 
-func CreateResourceHorizontalPodAutoscaler(rc *ResourceConsumer, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, metricTargetValue, minReplicas, maxReplicas int32) *autoscalingv2.HorizontalPodAutoscaler {
+func CreateResourceHorizontalPodAutoscaler(ctx context.Context, rc *ResourceConsumer, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, metricTargetValue, minReplicas, maxReplicas int32) *autoscalingv2.HorizontalPodAutoscaler {
 	targetRef := autoscalingv2.CrossVersionObjectReference{
 		APIVersion: rc.kind.GroupVersion().String(),
 		Kind:       rc.kind.Kind,
@@ -722,27 +731,27 @@ func CreateResourceHorizontalPodAutoscaler(rc *ResourceConsumer, resourceType v1
 			},
 		},
 	}
-	return CreateHorizontalPodAutoscaler(rc, targetRef, rc.nsName, metrics, resourceType, metricTargetType, metricTargetValue, minReplicas, maxReplicas)
+	return CreateHorizontalPodAutoscaler(ctx, rc, targetRef, rc.nsName, metrics, resourceType, metricTargetType, metricTargetValue, minReplicas, maxReplicas)
 }
 
-func CreateCPUResourceHorizontalPodAutoscaler(rc *ResourceConsumer, cpu, minReplicas, maxReplicas int32) *autoscalingv2.HorizontalPodAutoscaler {
-	return CreateResourceHorizontalPodAutoscaler(rc, v1.ResourceCPU, autoscalingv2.UtilizationMetricType, cpu, minReplicas, maxReplicas)
+func CreateCPUResourceHorizontalPodAutoscaler(ctx context.Context, rc *ResourceConsumer, cpu, minReplicas, maxReplicas int32) *autoscalingv2.HorizontalPodAutoscaler {
+	return CreateResourceHorizontalPodAutoscaler(ctx, rc, v1.ResourceCPU, autoscalingv2.UtilizationMetricType, cpu, minReplicas, maxReplicas)
 }
 
 // DeleteHorizontalPodAutoscaler delete the horizontalPodAutoscaler for consuming resources.
-func DeleteHorizontalPodAutoscaler(rc *ResourceConsumer, autoscalerName string) {
-	rc.clientSet.AutoscalingV1().HorizontalPodAutoscalers(rc.nsName).Delete(context.TODO(), autoscalerName, metav1.DeleteOptions{})
+func DeleteHorizontalPodAutoscaler(ctx context.Context, rc *ResourceConsumer, autoscalerName string) {
+	framework.ExpectNoError(rc.clientSet.AutoscalingV1().HorizontalPodAutoscalers(rc.nsName).Delete(ctx, autoscalerName, metav1.DeleteOptions{}))
 }
 
 // runReplicaSet launches (and verifies correctness) of a replicaset.
-func runReplicaSet(config testutils.ReplicaSetConfig) error {
+func runReplicaSet(ctx context.Context, config testutils.ReplicaSetConfig) error {
 	ginkgo.By(fmt.Sprintf("creating replicaset %s in namespace %s", config.Name, config.Namespace))
 	config.NodeDumpFunc = e2edebug.DumpNodeDebugInfo
 	config.ContainerDumpFunc = e2ekubectl.LogFailedContainers
-	return testutils.RunReplicaSet(config)
+	return testutils.RunReplicaSet(ctx, config)
 }
 
-func CreateContainerResourceHorizontalPodAutoscaler(rc *ResourceConsumer, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, metricTargetValue, minReplicas, maxReplicas int32) *autoscalingv2.HorizontalPodAutoscaler {
+func CreateContainerResourceHorizontalPodAutoscaler(ctx context.Context, rc *ResourceConsumer, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, metricTargetValue, minReplicas, maxReplicas int32) *autoscalingv2.HorizontalPodAutoscaler {
 	targetRef := autoscalingv2.CrossVersionObjectReference{
 		APIVersion: rc.kind.GroupVersion().String(),
 		Kind:       rc.kind.Kind,
@@ -758,12 +767,12 @@ func CreateContainerResourceHorizontalPodAutoscaler(rc *ResourceConsumer, resour
 			},
 		},
 	}
-	return CreateHorizontalPodAutoscaler(rc, targetRef, rc.nsName, metrics, resourceType, metricTargetType, metricTargetValue, minReplicas, maxReplicas)
+	return CreateHorizontalPodAutoscaler(ctx, rc, targetRef, rc.nsName, metrics, resourceType, metricTargetType, metricTargetValue, minReplicas, maxReplicas)
 }
 
 // DeleteContainerResourceHPA delete the horizontalPodAutoscaler for consuming resources.
-func DeleteContainerResourceHPA(rc *ResourceConsumer, autoscalerName string) {
-	rc.clientSet.AutoscalingV2().HorizontalPodAutoscalers(rc.nsName).Delete(context.TODO(), autoscalerName, metav1.DeleteOptions{})
+func DeleteContainerResourceHPA(ctx context.Context, rc *ResourceConsumer, autoscalerName string) {
+	framework.ExpectNoError(rc.clientSet.AutoscalingV2().HorizontalPodAutoscalers(rc.nsName).Delete(ctx, autoscalerName, metav1.DeleteOptions{}))
 }
 
 func CreateMetricTargetWithType(resourceType v1.ResourceName, targetType autoscalingv2.MetricTargetType, targetValue int32) autoscalingv2.MetricTarget {
@@ -788,7 +797,7 @@ func CreateMetricTargetWithType(resourceType v1.ResourceName, targetType autosca
 	return metricTarget
 }
 
-func CreateCPUHorizontalPodAutoscalerWithBehavior(rc *ResourceConsumer, cpu int32, minReplicas int32, maxRepl int32, behavior *autoscalingv2.HorizontalPodAutoscalerBehavior) *autoscalingv2.HorizontalPodAutoscaler {
+func CreateCPUHorizontalPodAutoscalerWithBehavior(ctx context.Context, rc *ResourceConsumer, cpu int32, minReplicas int32, maxRepl int32, behavior *autoscalingv2.HorizontalPodAutoscalerBehavior) *autoscalingv2.HorizontalPodAutoscaler {
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rc.name,
@@ -817,7 +826,7 @@ func CreateCPUHorizontalPodAutoscalerWithBehavior(rc *ResourceConsumer, cpu int3
 			Behavior: behavior,
 		},
 	}
-	hpa, errHPA := rc.clientSet.AutoscalingV2().HorizontalPodAutoscalers(rc.nsName).Create(context.TODO(), hpa, metav1.CreateOptions{})
+	hpa, errHPA := rc.clientSet.AutoscalingV2().HorizontalPodAutoscalers(rc.nsName).Create(ctx, hpa, metav1.CreateOptions{})
 	framework.ExpectNoError(errHPA)
 	return hpa
 }
@@ -890,8 +899,8 @@ func HPABehaviorWithScaleLimitedByPercentage(scalingDirection ScalingDirection, 
 	return HPABehaviorWithScalingRuleInDirection(scalingDirection, scalingRule)
 }
 
-func DeleteHPAWithBehavior(rc *ResourceConsumer, autoscalerName string) {
-	rc.clientSet.AutoscalingV2().HorizontalPodAutoscalers(rc.nsName).Delete(context.TODO(), autoscalerName, metav1.DeleteOptions{})
+func DeleteHPAWithBehavior(ctx context.Context, rc *ResourceConsumer, autoscalerName string) {
+	framework.ExpectNoError(rc.clientSet.AutoscalingV2().HorizontalPodAutoscalers(rc.nsName).Delete(ctx, autoscalerName, metav1.DeleteOptions{}))
 }
 
 // SidecarStatusType type for sidecar status
@@ -910,7 +919,7 @@ const (
 	Idle SidecarWorkloadType = "Idle"
 )
 
-func CreateCustomResourceDefinition(c crdclientset.Interface) *apiextensionsv1.CustomResourceDefinition {
+func CreateCustomResourceDefinition(ctx context.Context, c crdclientset.Interface) *apiextensionsv1.CustomResourceDefinition {
 	crdSchema := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: crdNamePlural + "." + crdGroup},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
@@ -939,12 +948,12 @@ func CreateCustomResourceDefinition(c crdclientset.Interface) *apiextensionsv1.C
 		Status: apiextensionsv1.CustomResourceDefinitionStatus{},
 	}
 	// Create Custom Resource Definition if it's not present.
-	crd, err := c.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crdSchema.Name, metav1.GetOptions{})
+	crd, err := c.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdSchema.Name, metav1.GetOptions{})
 	if err != nil {
-		crd, err = c.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), crdSchema, metav1.CreateOptions{})
+		crd, err = c.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, crdSchema, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		// Wait until just created CRD appears in discovery.
-		err = wait.PollImmediate(500*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollImmediateWithContext(ctx, 500*time.Millisecond, 30*time.Second, func(ctx context.Context) (bool, error) {
 			return ExistsInDiscovery(crd, c, "v1")
 		})
 		framework.ExpectNoError(err)
@@ -966,7 +975,7 @@ func ExistsInDiscovery(crd *apiextensionsv1.CustomResourceDefinition, apiExtensi
 	return false, nil
 }
 
-func CreateCustomSubresourceInstance(namespace, name string, client dynamic.ResourceInterface, definition *apiextensionsv1.CustomResourceDefinition) (*unstructured.Unstructured, error) {
+func CreateCustomSubresourceInstance(ctx context.Context, namespace, name string, client dynamic.ResourceInterface, definition *apiextensionsv1.CustomResourceDefinition) (*unstructured.Unstructured, error) {
 	instance := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": crdGroup + "/" + crdVersion,
@@ -985,7 +994,7 @@ func CreateCustomSubresourceInstance(namespace, name string, client dynamic.Reso
 			},
 		},
 	}
-	instance, err := client.Create(context.TODO(), instance, metav1.CreateOptions{})
+	instance, err := client.Create(ctx, instance, metav1.CreateOptions{})
 	if err != nil {
 		framework.Logf("%#v", instance)
 		return nil, err

--- a/test/e2e/framework/daemonset/fixtures.go
+++ b/test/e2e/framework/daemonset/fixtures.go
@@ -62,25 +62,25 @@ func NewDaemonSet(dsName, image string, labels map[string]string, volumes []v1.V
 	}
 }
 
-func CheckRunningOnAllNodes(f *framework.Framework, ds *appsv1.DaemonSet) (bool, error) {
-	nodeNames := SchedulableNodes(f.ClientSet, ds)
-	return CheckDaemonPodOnNodes(f, ds, nodeNames)()
+func CheckRunningOnAllNodes(ctx context.Context, f *framework.Framework, ds *appsv1.DaemonSet) (bool, error) {
+	nodeNames := SchedulableNodes(ctx, f.ClientSet, ds)
+	return CheckDaemonPodOnNodes(f, ds, nodeNames)(ctx)
 }
 
 // CheckPresentOnNodes will check that the daemonset will be present on at least the given number of
 // schedulable nodes.
-func CheckPresentOnNodes(c clientset.Interface, ds *appsv1.DaemonSet, ns string, numNodes int) (bool, error) {
-	nodeNames := SchedulableNodes(c, ds)
+func CheckPresentOnNodes(ctx context.Context, c clientset.Interface, ds *appsv1.DaemonSet, ns string, numNodes int) (bool, error) {
+	nodeNames := SchedulableNodes(ctx, c, ds)
 	if len(nodeNames) < numNodes {
 		return false, nil
 	}
-	return checkDaemonPodStateOnNodes(c, ds, ns, nodeNames, func(pod *v1.Pod) bool {
+	return checkDaemonPodStateOnNodes(ctx, c, ds, ns, nodeNames, func(pod *v1.Pod) bool {
 		return pod.Status.Phase != v1.PodPending
 	})
 }
 
-func SchedulableNodes(c clientset.Interface, ds *appsv1.DaemonSet) []string {
-	nodeList, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+func SchedulableNodes(ctx context.Context, c clientset.Interface, ds *appsv1.DaemonSet) []string {
+	nodeList, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	framework.ExpectNoError(err)
 	nodeNames := make([]string, 0)
 	for _, node := range nodeList.Items {
@@ -94,16 +94,16 @@ func SchedulableNodes(c clientset.Interface, ds *appsv1.DaemonSet) []string {
 	return nodeNames
 }
 
-func CheckDaemonPodOnNodes(f *framework.Framework, ds *appsv1.DaemonSet, nodeNames []string) func() (bool, error) {
-	return func() (bool, error) {
-		return checkDaemonPodStateOnNodes(f.ClientSet, ds, f.Namespace.Name, nodeNames, func(pod *v1.Pod) bool {
+func CheckDaemonPodOnNodes(f *framework.Framework, ds *appsv1.DaemonSet, nodeNames []string) func(ctx context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
+		return checkDaemonPodStateOnNodes(ctx, f.ClientSet, ds, f.Namespace.Name, nodeNames, func(pod *v1.Pod) bool {
 			return podutil.IsPodAvailable(pod, ds.Spec.MinReadySeconds, metav1.Now())
 		})
 	}
 }
 
-func checkDaemonPodStateOnNodes(c clientset.Interface, ds *appsv1.DaemonSet, ns string, nodeNames []string, stateChecker func(*v1.Pod) bool) (bool, error) {
-	podList, err := c.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{})
+func checkDaemonPodStateOnNodes(ctx context.Context, c clientset.Interface, ds *appsv1.DaemonSet, ns string, nodeNames []string, stateChecker func(*v1.Pod) bool) (bool, error) {
+	podList, err := c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		framework.Logf("could not get the pod list: %v", err)
 		return false, nil
@@ -139,8 +139,8 @@ func checkDaemonPodStateOnNodes(c clientset.Interface, ds *appsv1.DaemonSet, ns 
 	return len(nodesToPodCount) == len(nodeNames), nil
 }
 
-func CheckDaemonStatus(f *framework.Framework, dsName string) error {
-	ds, err := f.ClientSet.AppsV1().DaemonSets(f.Namespace.Name).Get(context.TODO(), dsName, metav1.GetOptions{})
+func CheckDaemonStatus(ctx context.Context, f *framework.Framework, dsName string) error {
+	ds, err := f.ClientSet.AppsV1().DaemonSets(f.Namespace.Name).Get(ctx, dsName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/e2e/framework/debug/resource_usage_gatherer.go
+++ b/test/e2e/framework/debug/resource_usage_gatherer.go
@@ -181,10 +181,10 @@ type resourceGatherWorker struct {
 	printVerboseLogs            bool
 }
 
-func (w *resourceGatherWorker) singleProbe() {
+func (w *resourceGatherWorker) singleProbe(ctx context.Context) {
 	data := make(ResourceUsagePerContainer)
 	if w.inKubemark {
-		kubemarkData := getKubemarkMasterComponentsResourceUsage()
+		kubemarkData := getKubemarkMasterComponentsResourceUsage(ctx)
 		if kubemarkData == nil {
 			return
 		}
@@ -319,22 +319,26 @@ func removeUint64Ptr(ptr *uint64) uint64 {
 	return *ptr
 }
 
-func (w *resourceGatherWorker) gather(initialSleep time.Duration) {
+func (w *resourceGatherWorker) gather(ctx context.Context, initialSleep time.Duration) {
 	defer utilruntime.HandleCrash()
 	defer w.wg.Done()
 	defer framework.Logf("Closing worker for %v", w.nodeName)
 	defer func() { w.finished = true }()
 	select {
 	case <-time.After(initialSleep):
-		w.singleProbe()
+		w.singleProbe(ctx)
 		for {
 			select {
 			case <-time.After(w.resourceDataGatheringPeriod):
-				w.singleProbe()
+				w.singleProbe(ctx)
+			case <-ctx.Done():
+				return
 			case <-w.stopCh:
 				return
 			}
 		}
+	case <-ctx.Done():
+		return
 	case <-w.stopCh:
 		return
 	}
@@ -373,11 +377,11 @@ const (
 
 // nodeHasControlPlanePods returns true if specified node has control plane pods
 // (kube-scheduler and/or kube-controller-manager).
-func nodeHasControlPlanePods(c clientset.Interface, nodeName string) (bool, error) {
+func nodeHasControlPlanePods(ctx context.Context, c clientset.Interface, nodeName string) (bool, error) {
 	regKubeScheduler := regexp.MustCompile("kube-scheduler-.*")
 	regKubeControllerManager := regexp.MustCompile("kube-controller-manager-.*")
 
-	podList, err := c.CoreV1().Pods(metav1.NamespaceSystem).List(context.TODO(), metav1.ListOptions{
+	podList, err := c.CoreV1().Pods(metav1.NamespaceSystem).List(ctx, metav1.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
 	})
 	if err != nil {
@@ -395,7 +399,7 @@ func nodeHasControlPlanePods(c clientset.Interface, nodeName string) (bool, erro
 }
 
 // NewResourceUsageGatherer returns a new ContainerResourceGatherer.
-func NewResourceUsageGatherer(c clientset.Interface, options ResourceGathererOptions, pods *v1.PodList) (*ContainerResourceGatherer, error) {
+func NewResourceUsageGatherer(ctx context.Context, c clientset.Interface, options ResourceGathererOptions, pods *v1.PodList) (*ContainerResourceGatherer, error) {
 	g := ContainerResourceGatherer{
 		client:       c,
 		stopCh:       make(chan struct{}),
@@ -420,7 +424,7 @@ func NewResourceUsageGatherer(c clientset.Interface, options ResourceGathererOpt
 	// Tracks kube-system pods if no valid PodList is passed in.
 	var err error
 	if pods == nil {
-		pods, err = c.CoreV1().Pods("kube-system").List(context.TODO(), metav1.ListOptions{})
+		pods, err = c.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{})
 		if err != nil {
 			framework.Logf("Error while listing Pods: %v", err)
 			return nil, err
@@ -429,7 +433,7 @@ func NewResourceUsageGatherer(c clientset.Interface, options ResourceGathererOpt
 	dnsNodes := make(map[string]bool)
 	for _, pod := range pods.Items {
 		if options.Nodes == MasterNodes {
-			isControlPlane, err := nodeHasControlPlanePods(c, pod.Spec.NodeName)
+			isControlPlane, err := nodeHasControlPlanePods(ctx, c, pod.Spec.NodeName)
 			if err != nil {
 				return nil, err
 			}
@@ -438,7 +442,7 @@ func NewResourceUsageGatherer(c clientset.Interface, options ResourceGathererOpt
 			}
 		}
 		if options.Nodes == MasterAndDNSNodes {
-			isControlPlane, err := nodeHasControlPlanePods(c, pod.Spec.NodeName)
+			isControlPlane, err := nodeHasControlPlanePods(ctx, c, pod.Spec.NodeName)
 			if err != nil {
 				return nil, err
 			}
@@ -456,14 +460,14 @@ func NewResourceUsageGatherer(c clientset.Interface, options ResourceGathererOpt
 			dnsNodes[pod.Spec.NodeName] = true
 		}
 	}
-	nodeList, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodeList, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		framework.Logf("Error while listing Nodes: %v", err)
 		return nil, err
 	}
 
 	for _, node := range nodeList.Items {
-		isControlPlane, err := nodeHasControlPlanePods(c, node.Name)
+		isControlPlane, err := nodeHasControlPlanePods(ctx, c, node.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -491,14 +495,14 @@ func NewResourceUsageGatherer(c clientset.Interface, options ResourceGathererOpt
 
 // StartGatheringData starts a stat gathering worker blocks for each node to track,
 // and blocks until StopAndSummarize is called.
-func (g *ContainerResourceGatherer) StartGatheringData() {
+func (g *ContainerResourceGatherer) StartGatheringData(ctx context.Context) {
 	if len(g.workers) == 0 {
 		return
 	}
 	delayPeriod := g.options.ResourceDataGatheringPeriod / time.Duration(len(g.workers))
 	delay := time.Duration(0)
 	for i := range g.workers {
-		go g.workers[i].gather(delay)
+		go g.workers[i].gather(ctx, delay)
 		delay += delayPeriod
 	}
 	g.workerWg.Wait()
@@ -603,8 +607,8 @@ type kubemarkResourceUsage struct {
 	CPUUsageInCores         float64
 }
 
-func getMasterUsageByPrefix(prefix string) (string, error) {
-	sshResult, err := e2essh.SSH(fmt.Sprintf("ps ax -o %%cpu,rss,command | tail -n +2 | grep %v | sed 's/\\s+/ /g'", prefix), framework.APIAddress()+":22", framework.TestContext.Provider)
+func getMasterUsageByPrefix(ctx context.Context, prefix string) (string, error) {
+	sshResult, err := e2essh.SSH(ctx, fmt.Sprintf("ps ax -o %%cpu,rss,command | tail -n +2 | grep %v | sed 's/\\s+/ /g'", prefix), framework.APIAddress()+":22", framework.TestContext.Provider)
 	if err != nil {
 		return "", err
 	}
@@ -612,10 +616,10 @@ func getMasterUsageByPrefix(prefix string) (string, error) {
 }
 
 // getKubemarkMasterComponentsResourceUsage returns the resource usage of kubemark which contains multiple combinations of cpu and memory usage for each pod name.
-func getKubemarkMasterComponentsResourceUsage() map[string]*kubemarkResourceUsage {
+func getKubemarkMasterComponentsResourceUsage(ctx context.Context) map[string]*kubemarkResourceUsage {
 	result := make(map[string]*kubemarkResourceUsage)
 	// Get kubernetes component resource usage
-	sshResult, err := getMasterUsageByPrefix("kube")
+	sshResult, err := getMasterUsageByPrefix(ctx, "kube")
 	if err != nil {
 		framework.Logf("Error when trying to SSH to master machine. Skipping probe. %v", err)
 		return nil
@@ -633,7 +637,7 @@ func getKubemarkMasterComponentsResourceUsage() map[string]*kubemarkResourceUsag
 		}
 	}
 	// Get etcd resource usage
-	sshResult, err = getMasterUsageByPrefix("bin/etcd")
+	sshResult, err = getMasterUsageByPrefix(ctx, "bin/etcd")
 	if err != nil {
 		framework.Logf("Error when trying to SSH to master machine. Skipping probe")
 		return nil

--- a/test/e2e/framework/deployment/fixtures.go
+++ b/test/e2e/framework/deployment/fixtures.go
@@ -71,9 +71,9 @@ func NewDeployment(deploymentName string, replicas int32, podLabels map[string]s
 }
 
 // CreateDeployment creates a deployment.
-func CreateDeployment(client clientset.Interface, replicas int32, podLabels map[string]string, nodeSelector map[string]string, namespace string, pvclaims []*v1.PersistentVolumeClaim, command string) (*appsv1.Deployment, error) {
+func CreateDeployment(ctx context.Context, client clientset.Interface, replicas int32, podLabels map[string]string, nodeSelector map[string]string, namespace string, pvclaims []*v1.PersistentVolumeClaim, command string) (*appsv1.Deployment, error) {
 	deploymentSpec := testDeployment(replicas, podLabels, nodeSelector, namespace, pvclaims, false, command)
-	deployment, err := client.AppsV1().Deployments(namespace).Create(context.TODO(), deploymentSpec, metav1.CreateOptions{})
+	deployment, err := client.AppsV1().Deployments(namespace).Create(ctx, deploymentSpec, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("deployment %q Create API error: %v", deploymentSpec.Name, err)
 	}
@@ -86,14 +86,14 @@ func CreateDeployment(client clientset.Interface, replicas int32, podLabels map[
 }
 
 // GetPodsForDeployment gets pods for the given deployment
-func GetPodsForDeployment(client clientset.Interface, deployment *appsv1.Deployment) (*v1.PodList, error) {
+func GetPodsForDeployment(ctx context.Context, client clientset.Interface, deployment *appsv1.Deployment) (*v1.PodList, error) {
 	replicaSetSelector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
 	if err != nil {
 		return nil, err
 	}
 
 	replicaSetListOptions := metav1.ListOptions{LabelSelector: replicaSetSelector.String()}
-	allReplicaSets, err := client.AppsV1().ReplicaSets(deployment.Namespace).List(context.TODO(), replicaSetListOptions)
+	allReplicaSets, err := client.AppsV1().ReplicaSets(deployment.Namespace).List(ctx, replicaSetListOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func GetPodsForDeployment(client clientset.Interface, deployment *appsv1.Deploym
 		return nil, err
 	}
 	podListOptions := metav1.ListOptions{LabelSelector: podSelector.String()}
-	allPods, err := client.CoreV1().Pods(deployment.Namespace).List(context.TODO(), podListOptions)
+	allPods, err := client.CoreV1().Pods(deployment.Namespace).List(ctx, podListOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/framework/events/events.go
+++ b/test/e2e/framework/events/events.go
@@ -32,15 +32,15 @@ type Action func() error
 
 // WaitTimeoutForEvent waits the given timeout duration for an event to occur.
 // Please note delivery of events is not guaranteed. Asserting on events can lead to flaky tests.
-func WaitTimeoutForEvent(c clientset.Interface, namespace, eventSelector, msg string, timeout time.Duration) error {
+func WaitTimeoutForEvent(ctx context.Context, c clientset.Interface, namespace, eventSelector, msg string, timeout time.Duration) error {
 	interval := 2 * time.Second
-	return wait.PollImmediate(interval, timeout, eventOccurred(c, namespace, eventSelector, msg))
+	return wait.PollImmediateWithContext(ctx, interval, timeout, eventOccurred(c, namespace, eventSelector, msg))
 }
 
-func eventOccurred(c clientset.Interface, namespace, eventSelector, msg string) wait.ConditionFunc {
+func eventOccurred(c clientset.Interface, namespace, eventSelector, msg string) wait.ConditionWithContextFunc {
 	options := metav1.ListOptions{FieldSelector: eventSelector}
-	return func() (bool, error) {
-		events, err := c.CoreV1().Events(namespace).List(context.TODO(), options)
+	return func(ctx context.Context) (bool, error) {
+		events, err := c.CoreV1().Events(namespace).List(ctx, options)
 		if err != nil {
 			return false, fmt.Errorf("got error while getting events: %v", err)
 		}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -128,7 +128,7 @@ type Framework struct {
 
 // DumpAllNamespaceInfoAction is called after each failed test for namespaces
 // created for the test.
-type DumpAllNamespaceInfoAction func(f *Framework, namespace string)
+type DumpAllNamespaceInfoAction func(ctx context.Context, f *Framework, namespace string)
 
 // TestDataSummary is an interface for managing test data.
 type TestDataSummary interface {
@@ -184,7 +184,7 @@ func NewFramework(baseName string, options Options, client clientset.Interface) 
 }
 
 // BeforeEach gets a client and makes a namespace.
-func (f *Framework) BeforeEach() {
+func (f *Framework) BeforeEach(ctx context.Context) {
 	// DeferCleanup, in contrast to AfterEach, triggers execution in
 	// first-in-last-out order. This ensures that the framework instance
 	// remains valid as long as possible.
@@ -235,7 +235,7 @@ func (f *Framework) BeforeEach() {
 
 	if !f.SkipNamespaceCreation {
 		ginkgo.By(fmt.Sprintf("Building a namespace api object, basename %s", f.BaseName))
-		namespace, err := f.CreateNamespace(f.BaseName, map[string]string{
+		namespace, err := f.CreateNamespace(ctx, f.BaseName, map[string]string{
 			"e2e-framework": f.BaseName,
 		})
 		ExpectNoError(err)
@@ -244,10 +244,10 @@ func (f *Framework) BeforeEach() {
 
 		if TestContext.VerifyServiceAccount {
 			ginkgo.By("Waiting for a default service account to be provisioned in namespace")
-			err = WaitForDefaultServiceAccountInNamespace(f.ClientSet, namespace.Name)
+			err = WaitForDefaultServiceAccountInNamespace(ctx, f.ClientSet, namespace.Name)
 			ExpectNoError(err)
 			ginkgo.By("Waiting for kube-root-ca.crt to be provisioned in namespace")
-			err = WaitForKubeRootCAInNamespace(f.ClientSet, namespace.Name)
+			err = WaitForKubeRootCAInNamespace(ctx, f.ClientSet, namespace.Name)
 			ExpectNoError(err)
 		} else {
 			Logf("Skipping waiting for service account")
@@ -261,7 +261,7 @@ func (f *Framework) BeforeEach() {
 	f.flakeReport = NewFlakeReport()
 }
 
-func (f *Framework) dumpNamespaceInfo() {
+func (f *Framework) dumpNamespaceInfo(ctx context.Context) {
 	if !ginkgo.CurrentSpecReport().Failed() {
 		return
 	}
@@ -274,7 +274,7 @@ func (f *Framework) dumpNamespaceInfo() {
 	ginkgo.By("dump namespace information after failure", func() {
 		if !f.SkipNamespaceCreation {
 			for _, ns := range f.namespacesToDelete {
-				f.DumpAllNamespaceInfo(f, ns.Name)
+				f.DumpAllNamespaceInfo(ctx, f, ns.Name)
 			}
 		}
 	})
@@ -318,7 +318,7 @@ func printSummaries(summaries []TestDataSummary, testBaseName string) {
 }
 
 // AfterEach deletes the namespace, after reading its events.
-func (f *Framework) AfterEach() {
+func (f *Framework) AfterEach(ctx context.Context) {
 	// This should not happen. Given ClientSet is a public field a test must have updated it!
 	// Error out early before any API calls during cleanup.
 	if f.ClientSet == nil {
@@ -335,13 +335,13 @@ func (f *Framework) AfterEach() {
 		if TestContext.DeleteNamespace && (TestContext.DeleteNamespaceOnFailure || !ginkgo.CurrentSpecReport().Failed()) {
 			for _, ns := range f.namespacesToDelete {
 				ginkgo.By(fmt.Sprintf("Destroying namespace %q for this suite.", ns.Name))
-				if err := f.ClientSet.CoreV1().Namespaces().Delete(context.TODO(), ns.Name, metav1.DeleteOptions{}); err != nil {
+				if err := f.ClientSet.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}); err != nil {
 					if !apierrors.IsNotFound(err) {
 						nsDeletionErrors[ns.Name] = err
 
 						// Dump namespace if we are unable to delete the namespace and the dump was not already performed.
 						if !ginkgo.CurrentSpecReport().Failed() && TestContext.DumpLogsOnFailure && f.DumpAllNamespaceInfo != nil {
-							f.DumpAllNamespaceInfo(f, ns.Name)
+							f.DumpAllNamespaceInfo(ctx, f, ns.Name)
 						}
 					} else {
 						Logf("Namespace %v was already deleted", ns.Name)
@@ -388,14 +388,14 @@ func (f *Framework) AfterEach() {
 // DeleteNamespace can be used to delete a namespace. Additionally it can be used to
 // dump namespace information so as it can be used as an alternative of framework
 // deleting the namespace towards the end.
-func (f *Framework) DeleteNamespace(name string) {
+func (f *Framework) DeleteNamespace(ctx context.Context, name string) {
 	defer func() {
-		err := f.ClientSet.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
+		err := f.ClientSet.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			Logf("error deleting namespace %s: %v", name, err)
 			return
 		}
-		err = WaitForNamespacesDeleted(f.ClientSet, []string{name}, DefaultNamespaceDeletionTimeout)
+		err = WaitForNamespacesDeleted(ctx, f.ClientSet, []string{name}, DefaultNamespaceDeletionTimeout)
 		if err != nil {
 			Logf("error deleting namespace %s: %v", name, err)
 			return
@@ -412,13 +412,13 @@ func (f *Framework) DeleteNamespace(name string) {
 	}()
 	// if current test failed then we should dump namespace information
 	if !f.SkipNamespaceCreation && ginkgo.CurrentSpecReport().Failed() && TestContext.DumpLogsOnFailure && f.DumpAllNamespaceInfo != nil {
-		f.DumpAllNamespaceInfo(f, name)
+		f.DumpAllNamespaceInfo(ctx, f, name)
 	}
 
 }
 
 // CreateNamespace creates a namespace for e2e testing.
-func (f *Framework) CreateNamespace(baseName string, labels map[string]string) (*v1.Namespace, error) {
+func (f *Framework) CreateNamespace(ctx context.Context, baseName string, labels map[string]string) (*v1.Namespace, error) {
 	createTestingNS := TestContext.CreateTestingNS
 	if createTestingNS == nil {
 		createTestingNS = CreateTestingNS
@@ -440,7 +440,7 @@ func (f *Framework) CreateNamespace(baseName string, labels map[string]string) (
 	}
 	labels[admissionapi.EnforceLevelLabel] = string(enforceLevel)
 
-	ns, err := createTestingNS(baseName, f.ClientSet, labels)
+	ns, err := createTestingNS(ctx, baseName, f.ClientSet, labels)
 	// check ns instead of err to see if it's nil as we may
 	// fail to create serviceAccount in it.
 	f.AddNamespacesToDelete(ns)
@@ -599,7 +599,7 @@ func passesPhasesFilter(pod v1.Pod, validPhases []v1.PodPhase) bool {
 }
 
 // filterLabels returns a list of pods which have labels.
-func filterLabels(selectors map[string]string, cli clientset.Interface, ns string) (*v1.PodList, error) {
+func filterLabels(ctx context.Context, selectors map[string]string, cli clientset.Interface, ns string) (*v1.PodList, error) {
 	var err error
 	var selector labels.Selector
 	var pl *v1.PodList
@@ -608,9 +608,9 @@ func filterLabels(selectors map[string]string, cli clientset.Interface, ns strin
 	if len(selectors) > 0 {
 		selector = labels.SelectorFromSet(labels.Set(selectors))
 		options := metav1.ListOptions{LabelSelector: selector.String()}
-		pl, err = cli.CoreV1().Pods(ns).List(context.TODO(), options)
+		pl, err = cli.CoreV1().Pods(ns).List(ctx, options)
 	} else {
-		pl, err = cli.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{})
+		pl, err = cli.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
 	}
 	return pl, err
 }
@@ -618,13 +618,13 @@ func filterLabels(selectors map[string]string, cli clientset.Interface, ns strin
 // filter filters pods which pass a filter.  It can be used to compose
 // the more useful abstractions like ForEach, WaitFor, and so on, which
 // can be used directly by tests.
-func (p *PodStateVerification) filter(c clientset.Interface, namespace *v1.Namespace) ([]v1.Pod, error) {
+func (p *PodStateVerification) filter(ctx context.Context, c clientset.Interface, namespace *v1.Namespace) ([]v1.Pod, error) {
 	if len(p.ValidPhases) == 0 || namespace == nil {
 		panic(fmt.Errorf("Need to specify a valid pod phases (%v) and namespace (%v). ", p.ValidPhases, namespace))
 	}
 
 	ns := namespace.Name
-	pl, err := filterLabels(p.Selectors, c, ns) // Build an v1.PodList to operate against.
+	pl, err := filterLabels(ctx, p.Selectors, c, ns) // Build an v1.PodList to operate against.
 	Logf("Selector matched %v pods for %v", len(pl.Items), p.Selectors)
 	if len(pl.Items) == 0 || err != nil {
 		return pl.Items, err
@@ -652,12 +652,12 @@ ReturnPodsSoFar:
 
 // WaitFor waits for some minimum number of pods to be verified, according to the PodStateVerification
 // definition.
-func (cl *ClusterVerification) WaitFor(atLeast int, timeout time.Duration) ([]v1.Pod, error) {
+func (cl *ClusterVerification) WaitFor(ctx context.Context, atLeast int, timeout time.Duration) ([]v1.Pod, error) {
 	pods := []v1.Pod{}
 	var returnedErr error
 
-	err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
-		pods, returnedErr = cl.podState.filter(cl.client, cl.namespace)
+	err := wait.PollWithContext(ctx, 1*time.Second, timeout, func(ctx context.Context) (bool, error) {
+		pods, returnedErr = cl.podState.filter(ctx, cl.client, cl.namespace)
 
 		// Failure
 		if returnedErr != nil {
@@ -680,8 +680,8 @@ func (cl *ClusterVerification) WaitFor(atLeast int, timeout time.Duration) ([]v1
 }
 
 // WaitForOrFail provides a shorthand WaitFor with failure as an option if anything goes wrong.
-func (cl *ClusterVerification) WaitForOrFail(atLeast int, timeout time.Duration) {
-	pods, err := cl.WaitFor(atLeast, timeout)
+func (cl *ClusterVerification) WaitForOrFail(ctx context.Context, atLeast int, timeout time.Duration) {
+	pods, err := cl.WaitFor(ctx, atLeast, timeout)
 	if err != nil || len(pods) < atLeast {
 		Failf("Verified %v of %v pods , error : %v", len(pods), atLeast, err)
 	}
@@ -692,8 +692,8 @@ func (cl *ClusterVerification) WaitForOrFail(atLeast int, timeout time.Duration)
 //
 // For example, if you require at least 5 pods to be running before your test will pass,
 // its smart to first call "clusterVerification.WaitFor(5)" before you call clusterVerification.ForEach.
-func (cl *ClusterVerification) ForEach(podFunc func(v1.Pod)) error {
-	pods, err := cl.podState.filter(cl.client, cl.namespace)
+func (cl *ClusterVerification) ForEach(ctx context.Context, podFunc func(v1.Pod)) error {
+	pods, err := cl.podState.filter(ctx, cl.client, cl.namespace)
 	if err == nil {
 		if len(pods) == 0 {
 			Failf("No pods matched the filter.")

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -169,8 +169,8 @@ type NegStatus struct {
 }
 
 // SimpleGET executes a get on the given url, returns error if non-200 returned.
-func SimpleGET(c *http.Client, url, host string) (string, error) {
-	req, err := http.NewRequest("GET", url, nil)
+func SimpleGET(ctx context.Context, c *http.Client, url, host string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return "", err
 	}
@@ -194,11 +194,11 @@ func SimpleGET(c *http.Client, url, host string) (string, error) {
 
 // PollURL polls till the url responds with a healthy http code. If
 // expectUnreachable is true, it breaks on first non-healthy http code instead.
-func PollURL(route, host string, timeout time.Duration, interval time.Duration, httpClient *http.Client, expectUnreachable bool) error {
+func PollURL(ctx context.Context, route, host string, timeout time.Duration, interval time.Duration, httpClient *http.Client, expectUnreachable bool) error {
 	var lastBody string
-	pollErr := wait.PollImmediate(interval, timeout, func() (bool, error) {
+	pollErr := wait.PollImmediateWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
 		var err error
-		lastBody, err = SimpleGET(httpClient, route, host)
+		lastBody, err = SimpleGET(ctx, httpClient, route, host)
 		if err != nil {
 			framework.Logf("host %v path %v: %v unreachable", host, route, err)
 			return expectUnreachable, nil
@@ -216,7 +216,7 @@ func PollURL(route, host string, timeout time.Duration, interval time.Duration, 
 // CreateIngressComformanceTests generates an slice of sequential test cases:
 // a simple http ingress, ingress with HTTPS, ingress HTTPS with a modified hostname,
 // ingress https with a modified URLMap
-func CreateIngressComformanceTests(jig *TestJig, ns string, annotations map[string]string) []ConformanceTests {
+func CreateIngressComformanceTests(ctx context.Context, jig *TestJig, ns string, annotations map[string]string) []ConformanceTests {
 	manifestPath := filepath.Join(IngressManifestPath, "http")
 	// These constants match the manifests used in IngressManifestPath
 	tlsHost := "foo.bar.com"
@@ -229,19 +229,19 @@ func CreateIngressComformanceTests(jig *TestJig, ns string, annotations map[stri
 	tests := []ConformanceTests{
 		{
 			fmt.Sprintf("should create a basic HTTP ingress"),
-			func() { jig.CreateIngress(manifestPath, ns, annotations, annotations) },
+			func() { jig.CreateIngress(ctx, manifestPath, ns, annotations, annotations) },
 			fmt.Sprintf("waiting for urls on basic HTTP ingress"),
 		},
 		{
 			fmt.Sprintf("should terminate TLS for host %v", tlsHost),
-			func() { jig.SetHTTPS(tlsSecretName, tlsHost) },
+			func() { jig.SetHTTPS(ctx, tlsSecretName, tlsHost) },
 			fmt.Sprintf("waiting for HTTPS updates to reflect in ingress"),
 		},
 		{
 			fmt.Sprintf("should update url map for host %v to expose a single url: %v", updateURLMapHost, updateURLMapPath),
 			func() {
 				var pathToFail string
-				jig.Update(func(ing *networkingv1.Ingress) {
+				jig.Update(ctx, func(ing *networkingv1.Ingress) {
 					newRules := []networkingv1.IngressRule{}
 					for _, rule := range ing.Spec.Rules {
 						if rule.Host != updateURLMapHost {
@@ -269,7 +269,7 @@ func CreateIngressComformanceTests(jig *TestJig, ns string, annotations map[stri
 				})
 				ginkgo.By("Checking that " + pathToFail + " is not exposed by polling for failure")
 				route := fmt.Sprintf("http://%v%v", jig.Address, pathToFail)
-				framework.ExpectNoError(PollURL(route, updateURLMapHost, e2eservice.LoadBalancerCleanupTimeout, jig.PollInterval, &http.Client{Timeout: IngressReqTimeout}, true))
+				framework.ExpectNoError(PollURL(ctx, route, updateURLMapHost, e2eservice.LoadBalancerCleanupTimeout, jig.PollInterval, &http.Client{Timeout: IngressReqTimeout}, true))
 			},
 			fmt.Sprintf("Waiting for path updates to reflect in L7"),
 		},
@@ -279,7 +279,7 @@ func CreateIngressComformanceTests(jig *TestJig, ns string, annotations map[stri
 		tests = append(tests, ConformanceTests{
 			fmt.Sprintf("should update SSL certificate with modified hostname %v", updatedTLSHost),
 			func() {
-				jig.Update(func(ing *networkingv1.Ingress) {
+				jig.Update(ctx, func(ing *networkingv1.Ingress) {
 					newRules := []networkingv1.IngressRule{}
 					for _, rule := range ing.Spec.Rules {
 						if rule.Host != tlsHost {
@@ -293,7 +293,7 @@ func CreateIngressComformanceTests(jig *TestJig, ns string, annotations map[stri
 					}
 					ing.Spec.Rules = newRules
 				})
-				jig.SetHTTPS(tlsSecretName, updatedTLSHost)
+				jig.SetHTTPS(ctx, tlsSecretName, updatedTLSHost)
 			},
 			fmt.Sprintf("Waiting for updated certificates to accept requests for host %v", updatedTLSHost),
 		})
@@ -388,7 +388,7 @@ func BuildInsecureClient(timeout time.Duration) *http.Client {
 // createTLSSecret creates a secret containing TLS certificates.
 // If a secret with the same name already pathExists in the namespace of the
 // Ingress, it's updated.
-func createTLSSecret(kubeClient clientset.Interface, namespace, secretName string, hosts ...string) (host string, rootCA, privKey []byte, err error) {
+func createTLSSecret(ctx context.Context, kubeClient clientset.Interface, namespace, secretName string, hosts ...string) (host string, rootCA, privKey []byte, err error) {
 	host = strings.Join(hosts, ",")
 	framework.Logf("Generating RSA cert for host %v", host)
 	cert, key, err := GenerateRSACerts(host, true)
@@ -405,13 +405,13 @@ func createTLSSecret(kubeClient clientset.Interface, namespace, secretName strin
 		},
 	}
 	var s *v1.Secret
-	if s, err = kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{}); err == nil {
+	if s, err = kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{}); err == nil {
 		framework.Logf("Updating secret %v in ns %v with hosts %v", secret.Name, namespace, host)
 		s.Data = secret.Data
-		_, err = kubeClient.CoreV1().Secrets(namespace).Update(context.TODO(), s, metav1.UpdateOptions{})
+		_, err = kubeClient.CoreV1().Secrets(namespace).Update(ctx, s, metav1.UpdateOptions{})
 	} else {
 		framework.Logf("Creating secret %v in ns %v with hosts %v", secret.Name, namespace, host)
-		_, err = kubeClient.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+		_, err = kubeClient.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
 	}
 	return host, cert, key, err
 }
@@ -448,7 +448,7 @@ func NewIngressTestJig(c clientset.Interface) *TestJig {
 // Optional: secret.yaml, ingAnnotations
 // If ingAnnotations is specified it will overwrite any annotations in ing.yaml
 // If svcAnnotations is specified it will overwrite any annotations in svc.yaml
-func (j *TestJig) CreateIngress(manifestPath, ns string, ingAnnotations map[string]string, svcAnnotations map[string]string) {
+func (j *TestJig) CreateIngress(ctx context.Context, manifestPath, ns string, ingAnnotations map[string]string, svcAnnotations map[string]string) {
 	var err error
 	read := func(file string) string {
 		data, err := e2etestfiles.Read(filepath.Join(manifestPath, file))
@@ -471,11 +471,11 @@ func (j *TestJig) CreateIngress(manifestPath, ns string, ingAnnotations map[stri
 	j.Logger.Infof("creating service")
 	e2ekubectl.RunKubectlOrDieInput(ns, read("svc.yaml"), "create", "-f", "-")
 	if len(svcAnnotations) > 0 {
-		svcList, err := j.Client.CoreV1().Services(ns).List(context.TODO(), metav1.ListOptions{})
+		svcList, err := j.Client.CoreV1().Services(ns).List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err)
 		for _, svc := range svcList.Items {
 			svc.Annotations = svcAnnotations
-			_, err = j.Client.CoreV1().Services(ns).Update(context.TODO(), &svc, metav1.UpdateOptions{})
+			_, err = j.Client.CoreV1().Services(ns).Update(ctx, &svc, metav1.UpdateOptions{})
 			framework.ExpectNoError(err)
 		}
 	}
@@ -493,7 +493,7 @@ func (j *TestJig) CreateIngress(manifestPath, ns string, ingAnnotations map[stri
 		j.Ingress.Spec.IngressClassName = &j.Class
 	}
 	j.Logger.Infof("creating %v ingress", j.Ingress.Name)
-	j.Ingress, err = j.runCreate(j.Ingress)
+	j.Ingress, err = j.runCreate(ctx, j.Ingress)
 	framework.ExpectNoError(err)
 }
 
@@ -542,9 +542,9 @@ func ingressToManifest(ing *networkingv1.Ingress, path string) error {
 }
 
 // runCreate runs the required command to create the given ingress.
-func (j *TestJig) runCreate(ing *networkingv1.Ingress) (*networkingv1.Ingress, error) {
+func (j *TestJig) runCreate(ctx context.Context, ing *networkingv1.Ingress) (*networkingv1.Ingress, error) {
 	if j.Class != MulticlusterIngressClassValue {
-		return j.Client.NetworkingV1().Ingresses(ing.Namespace).Create(context.TODO(), ing, metav1.CreateOptions{})
+		return j.Client.NetworkingV1().Ingresses(ing.Namespace).Create(ctx, ing, metav1.CreateOptions{})
 	}
 	// Use kubemci to create a multicluster ingress.
 	filePath := framework.TestContext.OutputDir + "/mci.yaml"
@@ -556,9 +556,9 @@ func (j *TestJig) runCreate(ing *networkingv1.Ingress) (*networkingv1.Ingress, e
 }
 
 // runUpdate runs the required command to update the given ingress.
-func (j *TestJig) runUpdate(ing *networkingv1.Ingress) (*networkingv1.Ingress, error) {
+func (j *TestJig) runUpdate(ctx context.Context, ing *networkingv1.Ingress) (*networkingv1.Ingress, error) {
 	if j.Class != MulticlusterIngressClassValue {
-		return j.Client.NetworkingV1().Ingresses(ing.Namespace).Update(context.TODO(), ing, metav1.UpdateOptions{})
+		return j.Client.NetworkingV1().Ingresses(ing.Namespace).Update(ctx, ing, metav1.UpdateOptions{})
 	}
 	// Use kubemci to update a multicluster ingress.
 	// kubemci does not have an update command. We use "create --force" to update an existing ingress.
@@ -579,16 +579,16 @@ func DescribeIng(ns string) {
 }
 
 // Update retrieves the ingress, performs the passed function, and then updates it.
-func (j *TestJig) Update(update func(ing *networkingv1.Ingress)) {
+func (j *TestJig) Update(ctx context.Context, update func(ing *networkingv1.Ingress)) {
 	var err error
 	ns, name := j.Ingress.Namespace, j.Ingress.Name
 	for i := 0; i < 3; i++ {
-		j.Ingress, err = j.Client.NetworkingV1().Ingresses(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		j.Ingress, err = j.Client.NetworkingV1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("failed to get ingress %s/%s: %v", ns, name, err)
 		}
 		update(j.Ingress)
-		j.Ingress, err = j.runUpdate(j.Ingress)
+		j.Ingress, err = j.runUpdate(ctx, j.Ingress)
 		if err == nil {
 			DescribeIng(j.Ingress.Namespace)
 			return
@@ -601,24 +601,24 @@ func (j *TestJig) Update(update func(ing *networkingv1.Ingress)) {
 }
 
 // AddHTTPS updates the ingress to add this secret for these hosts.
-func (j *TestJig) AddHTTPS(secretName string, hosts ...string) {
+func (j *TestJig) AddHTTPS(ctx context.Context, secretName string, hosts ...string) {
 	// TODO: Just create the secret in GetRootCAs once we're watching secrets in
 	// the ingress controller.
-	_, cert, _, err := createTLSSecret(j.Client, j.Ingress.Namespace, secretName, hosts...)
+	_, cert, _, err := createTLSSecret(ctx, j.Client, j.Ingress.Namespace, secretName, hosts...)
 	framework.ExpectNoError(err)
 	j.Logger.Infof("Updating ingress %v to also use secret %v for TLS termination", j.Ingress.Name, secretName)
-	j.Update(func(ing *networkingv1.Ingress) {
+	j.Update(ctx, func(ing *networkingv1.Ingress) {
 		ing.Spec.TLS = append(ing.Spec.TLS, networkingv1.IngressTLS{Hosts: hosts, SecretName: secretName})
 	})
 	j.RootCAs[secretName] = cert
 }
 
 // SetHTTPS updates the ingress to use only this secret for these hosts.
-func (j *TestJig) SetHTTPS(secretName string, hosts ...string) {
-	_, cert, _, err := createTLSSecret(j.Client, j.Ingress.Namespace, secretName, hosts...)
+func (j *TestJig) SetHTTPS(ctx context.Context, secretName string, hosts ...string) {
+	_, cert, _, err := createTLSSecret(ctx, j.Client, j.Ingress.Namespace, secretName, hosts...)
 	framework.ExpectNoError(err)
 	j.Logger.Infof("Updating ingress %v to only use secret %v for TLS termination", j.Ingress.Name, secretName)
-	j.Update(func(ing *networkingv1.Ingress) {
+	j.Update(ctx, func(ing *networkingv1.Ingress) {
 		ing.Spec.TLS = []networkingv1.IngressTLS{{Hosts: hosts, SecretName: secretName}}
 	})
 	j.RootCAs = map[string][]byte{secretName: cert}
@@ -626,7 +626,7 @@ func (j *TestJig) SetHTTPS(secretName string, hosts ...string) {
 
 // RemoveHTTPS updates the ingress to not use this secret for TLS.
 // Note: Does not delete the secret.
-func (j *TestJig) RemoveHTTPS(secretName string) {
+func (j *TestJig) RemoveHTTPS(ctx context.Context, secretName string) {
 	newTLS := []networkingv1.IngressTLS{}
 	for _, ingressTLS := range j.Ingress.Spec.TLS {
 		if secretName != ingressTLS.SecretName {
@@ -634,15 +634,15 @@ func (j *TestJig) RemoveHTTPS(secretName string) {
 		}
 	}
 	j.Logger.Infof("Updating ingress %v to not use secret %v for TLS termination", j.Ingress.Name, secretName)
-	j.Update(func(ing *networkingv1.Ingress) {
+	j.Update(ctx, func(ing *networkingv1.Ingress) {
 		ing.Spec.TLS = newTLS
 	})
 	delete(j.RootCAs, secretName)
 }
 
 // PrepareTLSSecret creates a TLS secret and caches the cert.
-func (j *TestJig) PrepareTLSSecret(namespace, secretName string, hosts ...string) error {
-	_, cert, _, err := createTLSSecret(j.Client, namespace, secretName, hosts...)
+func (j *TestJig) PrepareTLSSecret(ctx context.Context, namespace, secretName string, hosts ...string) error {
+	_, cert, _, err := createTLSSecret(ctx, j.Client, namespace, secretName, hosts...)
 	if err != nil {
 		return err
 	}
@@ -661,20 +661,20 @@ func (j *TestJig) GetRootCA(secretName string) (rootCA []byte) {
 }
 
 // TryDeleteIngress attempts to delete the ingress resource and logs errors if they occur.
-func (j *TestJig) TryDeleteIngress() {
-	j.tryDeleteGivenIngress(j.Ingress)
+func (j *TestJig) TryDeleteIngress(ctx context.Context) {
+	j.tryDeleteGivenIngress(ctx, j.Ingress)
 }
 
-func (j *TestJig) tryDeleteGivenIngress(ing *networkingv1.Ingress) {
-	if err := j.runDelete(ing); err != nil {
+func (j *TestJig) tryDeleteGivenIngress(ctx context.Context, ing *networkingv1.Ingress) {
+	if err := j.runDelete(ctx, ing); err != nil {
 		j.Logger.Infof("Error while deleting the ingress %v/%v with class %s: %v", ing.Namespace, ing.Name, j.Class, err)
 	}
 }
 
 // runDelete runs the required command to delete the given ingress.
-func (j *TestJig) runDelete(ing *networkingv1.Ingress) error {
+func (j *TestJig) runDelete(ctx context.Context, ing *networkingv1.Ingress) error {
 	if j.Class != MulticlusterIngressClassValue {
-		return j.Client.NetworkingV1().Ingresses(ing.Namespace).Delete(context.TODO(), ing.Name, metav1.DeleteOptions{})
+		return j.Client.NetworkingV1().Ingresses(ing.Namespace).Delete(ctx, ing.Name, metav1.DeleteOptions{})
 	}
 	// Use kubemci to delete a multicluster ingress.
 	filePath := framework.TestContext.OutputDir + "/mci.yaml"
@@ -710,11 +710,11 @@ func findIPv4(input string) string {
 }
 
 // getIngressAddress returns the ips/hostnames associated with the Ingress.
-func getIngressAddress(client clientset.Interface, ns, name, class string) ([]string, error) {
+func getIngressAddress(ctx context.Context, client clientset.Interface, ns, name, class string) ([]string, error) {
 	if class == MulticlusterIngressClassValue {
 		return getIngressAddressFromKubemci(name)
 	}
-	ing, err := client.NetworkingV1().Ingresses(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	ing, err := client.NetworkingV1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -731,10 +731,10 @@ func getIngressAddress(client clientset.Interface, ns, name, class string) ([]st
 }
 
 // WaitForIngressAddress waits for the Ingress to acquire an address.
-func (j *TestJig) WaitForIngressAddress(c clientset.Interface, ns, ingName string, timeout time.Duration) (string, error) {
+func (j *TestJig) WaitForIngressAddress(ctx context.Context, c clientset.Interface, ns, ingName string, timeout time.Duration) (string, error) {
 	var address string
-	err := wait.PollImmediate(10*time.Second, timeout, func() (bool, error) {
-		ipOrNameList, err := getIngressAddress(c, ns, ingName, j.Class)
+	err := wait.PollImmediateWithContext(ctx, 10*time.Second, timeout, func(ctx context.Context) (bool, error) {
+		ipOrNameList, err := getIngressAddress(ctx, c, ns, ingName, j.Class)
 		if err != nil || len(ipOrNameList) == 0 {
 			j.Logger.Errorf("Waiting for Ingress %s/%s to acquire IP, error: %v, ipOrNameList: %v", ns, ingName, err, ipOrNameList)
 			return false, err
@@ -746,7 +746,7 @@ func (j *TestJig) WaitForIngressAddress(c clientset.Interface, ns, ingName strin
 	return address, err
 }
 
-func (j *TestJig) pollIngressWithCert(ing *networkingv1.Ingress, address string, knownHosts []string, cert []byte, waitForNodePort bool, timeout time.Duration) error {
+func (j *TestJig) pollIngressWithCert(ctx context.Context, ing *networkingv1.Ingress, address string, knownHosts []string, cert []byte, waitForNodePort bool, timeout time.Duration) error {
 	// Check that all rules respond to a simple GET.
 	knownHostsSet := sets.NewString(knownHosts...)
 	for _, rules := range ing.Spec.Rules {
@@ -764,14 +764,14 @@ func (j *TestJig) pollIngressWithCert(ing *networkingv1.Ingress, address string,
 		for _, p := range rules.IngressRuleValue.HTTP.Paths {
 			if waitForNodePort {
 				nodePort := int(p.Backend.Service.Port.Number)
-				if err := j.pollServiceNodePort(ing.Namespace, p.Backend.Service.Name, nodePort); err != nil {
+				if err := j.pollServiceNodePort(ctx, ing.Namespace, p.Backend.Service.Name, nodePort); err != nil {
 					j.Logger.Infof("Error in waiting for nodeport %d on service %v/%v: %s", nodePort, ing.Namespace, p.Backend.Service.Name, err)
 					return err
 				}
 			}
 			route := fmt.Sprintf("%v://%v%v", proto, address, p.Path)
 			j.Logger.Infof("Testing route %v host %v with simple GET", route, rules.Host)
-			if err := PollURL(route, rules.Host, timeout, j.PollInterval, timeoutClient, false); err != nil {
+			if err := PollURL(ctx, route, rules.Host, timeout, j.PollInterval, timeoutClient, false); err != nil {
 				return err
 			}
 		}
@@ -782,16 +782,16 @@ func (j *TestJig) pollIngressWithCert(ing *networkingv1.Ingress, address string,
 
 // WaitForIngress waits for the Ingress to get an address.
 // WaitForIngress returns when it gets the first 200 response
-func (j *TestJig) WaitForIngress(waitForNodePort bool) {
-	if err := j.WaitForGivenIngressWithTimeout(j.Ingress, waitForNodePort, e2eservice.GetServiceLoadBalancerPropagationTimeout(j.Client)); err != nil {
+func (j *TestJig) WaitForIngress(ctx context.Context, waitForNodePort bool) {
+	if err := j.WaitForGivenIngressWithTimeout(ctx, j.Ingress, waitForNodePort, e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, j.Client)); err != nil {
 		framework.Failf("error in waiting for ingress to get an address: %s", err)
 	}
 }
 
 // WaitForIngressToStable waits for the LB return 100 consecutive 200 responses.
-func (j *TestJig) WaitForIngressToStable() {
-	if err := wait.Poll(10*time.Second, e2eservice.GetServiceLoadBalancerPropagationTimeout(j.Client), func() (bool, error) {
-		_, err := j.GetDistinctResponseFromIngress()
+func (j *TestJig) WaitForIngressToStable(ctx context.Context) {
+	if err := wait.PollWithContext(ctx, 10*time.Second, e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, j.Client), func(ctx context.Context) (bool, error) {
+		_, err := j.GetDistinctResponseFromIngress(ctx)
 		if err != nil {
 			return false, nil
 		}
@@ -806,9 +806,9 @@ func (j *TestJig) WaitForIngressToStable() {
 // http or https). If waitForNodePort is true, the NodePort of the Service
 // is verified before verifying the Ingress. NodePort is currently a
 // requirement for cloudprovider Ingress.
-func (j *TestJig) WaitForGivenIngressWithTimeout(ing *networkingv1.Ingress, waitForNodePort bool, timeout time.Duration) error {
+func (j *TestJig) WaitForGivenIngressWithTimeout(ctx context.Context, ing *networkingv1.Ingress, waitForNodePort bool, timeout time.Duration) error {
 	// Wait for the loadbalancer IP.
-	address, err := j.WaitForIngressAddress(j.Client, ing.Namespace, ing.Name, timeout)
+	address, err := j.WaitForIngressAddress(ctx, j.Client, ing.Namespace, ing.Name, timeout)
 	if err != nil {
 		return fmt.Errorf("Ingress failed to acquire an IP address within %v", timeout)
 	}
@@ -819,7 +819,7 @@ func (j *TestJig) WaitForGivenIngressWithTimeout(ing *networkingv1.Ingress, wait
 		knownHosts = ing.Spec.TLS[0].Hosts
 		cert = j.GetRootCA(ing.Spec.TLS[0].SecretName)
 	}
-	return j.pollIngressWithCert(ing, address, knownHosts, cert, waitForNodePort, timeout)
+	return j.pollIngressWithCert(ctx, ing, address, knownHosts, cert, waitForNodePort, timeout)
 }
 
 // WaitForIngressWithCert waits till the ingress acquires an IP, then waits for its
@@ -827,22 +827,22 @@ func (j *TestJig) WaitForGivenIngressWithTimeout(ing *networkingv1.Ingress, wait
 // waitForNodePort is true, the NodePort of the Service is verified before
 // verifying the Ingress. NodePort is currently a requirement for cloudprovider
 // Ingress. Hostnames and certificate need to be explicitly passed in.
-func (j *TestJig) WaitForIngressWithCert(waitForNodePort bool, knownHosts []string, cert []byte) error {
+func (j *TestJig) WaitForIngressWithCert(ctx context.Context, waitForNodePort bool, knownHosts []string, cert []byte) error {
 	// Wait for the loadbalancer IP.
-	propagationTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(j.Client)
-	address, err := j.WaitForIngressAddress(j.Client, j.Ingress.Namespace, j.Ingress.Name, propagationTimeout)
+	propagationTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, j.Client)
+	address, err := j.WaitForIngressAddress(ctx, j.Client, j.Ingress.Namespace, j.Ingress.Name, propagationTimeout)
 	if err != nil {
 		return fmt.Errorf("Ingress failed to acquire an IP address within %v", propagationTimeout)
 	}
 
-	return j.pollIngressWithCert(j.Ingress, address, knownHosts, cert, waitForNodePort, propagationTimeout)
+	return j.pollIngressWithCert(ctx, j.Ingress, address, knownHosts, cert, waitForNodePort, propagationTimeout)
 }
 
 // VerifyURL polls for the given iterations, in intervals, and fails if the
 // given url returns a non-healthy http code even once.
-func (j *TestJig) VerifyURL(route, host string, iterations int, interval time.Duration, httpClient *http.Client) error {
+func (j *TestJig) VerifyURL(ctx context.Context, route, host string, iterations int, interval time.Duration, httpClient *http.Client) error {
 	for i := 0; i < iterations; i++ {
-		b, err := SimpleGET(httpClient, route, host)
+		b, err := SimpleGET(ctx, httpClient, route, host)
 		if err != nil {
 			framework.Logf(b)
 			return err
@@ -853,18 +853,18 @@ func (j *TestJig) VerifyURL(route, host string, iterations int, interval time.Du
 	return nil
 }
 
-func (j *TestJig) pollServiceNodePort(ns, name string, port int) error {
+func (j *TestJig) pollServiceNodePort(ctx context.Context, ns, name string, port int) error {
 	// TODO: Curl all nodes?
-	u, err := getPortURL(j.Client, ns, name, port)
+	u, err := getPortURL(ctx, j.Client, ns, name, port)
 	if err != nil {
 		return err
 	}
-	return PollURL(u, "", 30*time.Second, j.PollInterval, &http.Client{Timeout: IngressReqTimeout}, false)
+	return PollURL(ctx, u, "", 30*time.Second, j.PollInterval, &http.Client{Timeout: IngressReqTimeout}, false)
 }
 
 // getSvcNodePort returns the node port for the given service:port.
-func getSvcNodePort(client clientset.Interface, ns, name string, svcPort int) (int, error) {
-	svc, err := client.CoreV1().Services(ns).Get(context.TODO(), name, metav1.GetOptions{})
+func getSvcNodePort(ctx context.Context, client clientset.Interface, ns, name string, svcPort int) (int, error) {
+	svc, err := client.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return 0, err
 	}
@@ -880,8 +880,8 @@ func getSvcNodePort(client clientset.Interface, ns, name string, svcPort int) (i
 }
 
 // getPortURL returns the url to a nodeport Service.
-func getPortURL(client clientset.Interface, ns, name string, svcPort int) (string, error) {
-	nodePort, err := getSvcNodePort(client, ns, name, svcPort)
+func getPortURL(ctx context.Context, client clientset.Interface, ns, name string, svcPort int) (string, error) {
+	nodePort, err := getSvcNodePort(ctx, client, ns, name, svcPort)
 	if err != nil {
 		return "", err
 	}
@@ -889,8 +889,8 @@ func getPortURL(client clientset.Interface, ns, name string, svcPort int) (strin
 	// unschedulable, since control plane nodes don't run kube-proxy. Without
 	// kube-proxy NodePorts won't work.
 	var nodes *v1.NodeList
-	if wait.PollImmediate(poll, framework.SingleCallTimeout, func() (bool, error) {
-		nodes, err = client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{FieldSelector: fields.Set{
+	if wait.PollImmediateWithContext(ctx, poll, framework.SingleCallTimeout, func(ctx context.Context) (bool, error) {
+		nodes, err = client.CoreV1().Nodes().List(ctx, metav1.ListOptions{FieldSelector: fields.Set{
 			"spec.unschedulable": "false",
 		}.AsSelector().String()})
 		if err != nil {
@@ -919,9 +919,9 @@ func getPortURL(client clientset.Interface, ns, name string, svcPort int) (strin
 // GetIngressNodePorts returns related backend services' nodePorts.
 // Current GCE ingress controller allows traffic to the default HTTP backend
 // by default, so retrieve its nodePort if includeDefaultBackend is true.
-func (j *TestJig) GetIngressNodePorts(includeDefaultBackend bool) []string {
+func (j *TestJig) GetIngressNodePorts(ctx context.Context, includeDefaultBackend bool) []string {
 	nodePorts := []string{}
-	svcPorts := j.GetServicePorts(includeDefaultBackend)
+	svcPorts := j.GetServicePorts(ctx, includeDefaultBackend)
 	for _, svcPort := range svcPorts {
 		nodePorts = append(nodePorts, strconv.Itoa(int(svcPort.NodePort)))
 	}
@@ -931,10 +931,10 @@ func (j *TestJig) GetIngressNodePorts(includeDefaultBackend bool) []string {
 // GetServicePorts returns related backend services' svcPorts.
 // Current GCE ingress controller allows traffic to the default HTTP backend
 // by default, so retrieve its nodePort if includeDefaultBackend is true.
-func (j *TestJig) GetServicePorts(includeDefaultBackend bool) map[string]v1.ServicePort {
+func (j *TestJig) GetServicePorts(ctx context.Context, includeDefaultBackend bool) map[string]v1.ServicePort {
 	svcPorts := make(map[string]v1.ServicePort)
 	if includeDefaultBackend {
-		defaultSvc, err := j.Client.CoreV1().Services(metav1.NamespaceSystem).Get(context.TODO(), defaultBackendName, metav1.GetOptions{})
+		defaultSvc, err := j.Client.CoreV1().Services(metav1.NamespaceSystem).Get(ctx, defaultBackendName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		svcPorts[defaultBackendName] = defaultSvc.Spec.Ports[0]
 	}
@@ -949,7 +949,7 @@ func (j *TestJig) GetServicePorts(includeDefaultBackend bool) map[string]v1.Serv
 		}
 	}
 	for _, svcName := range backendSvcs {
-		svc, err := j.Client.CoreV1().Services(j.Ingress.Namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
+		svc, err := j.Client.CoreV1().Services(j.Ingress.Namespace).Get(ctx, svcName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		svcPorts[svcName] = svc.Spec.Ports[0]
 	}
@@ -957,8 +957,8 @@ func (j *TestJig) GetServicePorts(includeDefaultBackend bool) map[string]v1.Serv
 }
 
 // ConstructFirewallForIngress returns the expected GCE firewall rule for the ingress resource
-func (j *TestJig) ConstructFirewallForIngress(firewallRuleName string, nodeTags []string) *compute.Firewall {
-	nodePorts := j.GetIngressNodePorts(true)
+func (j *TestJig) ConstructFirewallForIngress(ctx context.Context, firewallRuleName string, nodeTags []string) *compute.Firewall {
+	nodePorts := j.GetIngressNodePorts(ctx, true)
 
 	fw := compute.Firewall{}
 	fw.Name = firewallRuleName
@@ -974,10 +974,10 @@ func (j *TestJig) ConstructFirewallForIngress(firewallRuleName string, nodeTags 
 }
 
 // GetDistinctResponseFromIngress tries GET call to the ingress VIP and return all distinct responses.
-func (j *TestJig) GetDistinctResponseFromIngress() (sets.String, error) {
+func (j *TestJig) GetDistinctResponseFromIngress(ctx context.Context) (sets.String, error) {
 	// Wait for the loadbalancer IP.
-	propagationTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(j.Client)
-	address, err := j.WaitForIngressAddress(j.Client, j.Ingress.Namespace, j.Ingress.Name, propagationTimeout)
+	propagationTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, j.Client)
+	address, err := j.WaitForIngressAddress(ctx, j.Client, j.Ingress.Namespace, j.Ingress.Name, propagationTimeout)
 	if err != nil {
 		framework.Failf("Ingress failed to acquire an IP address within %v", propagationTimeout)
 	}
@@ -986,7 +986,7 @@ func (j *TestJig) GetDistinctResponseFromIngress() (sets.String, error) {
 
 	for i := 0; i < 100; i++ {
 		url := fmt.Sprintf("http://%v", address)
-		res, err := SimpleGET(timeoutClient, url, "")
+		res, err := SimpleGET(ctx, timeoutClient, url, "")
 		if err != nil {
 			j.Logger.Errorf("Failed to GET %q. Got responses: %q: %v", url, res, err)
 			return responses, err
@@ -1006,13 +1006,13 @@ type NginxIngressController struct {
 }
 
 // Init initializes the NginxIngressController
-func (cont *NginxIngressController) Init() {
+func (cont *NginxIngressController) Init(ctx context.Context) {
 	// Set up a LoadBalancer service in front of nginx ingress controller and pass it via
 	// --publish-service flag (see <IngressManifestPath>/nginx/rc.yaml) to make it work in private
 	// clusters, i.e. clusters where nodes don't have public IPs.
 	framework.Logf("Creating load balancer service for nginx ingress controller")
 	serviceJig := e2eservice.NewTestJig(cont.Client, cont.Ns, "nginx-ingress-lb")
-	_, err := serviceJig.CreateTCPService(func(svc *v1.Service) {
+	_, err := serviceJig.CreateTCPService(ctx, func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeLoadBalancer
 		svc.Spec.Selector = map[string]string{"k8s-app": "nginx-ingress-lb"}
 		svc.Spec.Ports = []v1.ServicePort{
@@ -1021,7 +1021,7 @@ func (cont *NginxIngressController) Init() {
 			{Name: "stats", Port: 18080}}
 	})
 	framework.ExpectNoError(err)
-	cont.lbSvc, err = serviceJig.WaitForLoadBalancer(e2eservice.GetServiceLoadBalancerCreationTimeout(cont.Client))
+	cont.lbSvc, err = serviceJig.WaitForLoadBalancer(ctx, e2eservice.GetServiceLoadBalancerCreationTimeout(ctx, cont.Client))
 	framework.ExpectNoError(err)
 
 	read := func(file string) string {
@@ -1035,14 +1035,14 @@ func (cont *NginxIngressController) Init() {
 	framework.Logf("initializing nginx ingress controller")
 	e2ekubectl.RunKubectlOrDieInput(cont.Ns, read("rc.yaml"), "create", "-f", "-")
 
-	rc, err := cont.Client.CoreV1().ReplicationControllers(cont.Ns).Get(context.TODO(), "nginx-ingress-controller", metav1.GetOptions{})
+	rc, err := cont.Client.CoreV1().ReplicationControllers(cont.Ns).Get(ctx, "nginx-ingress-controller", metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	cont.rc = rc
 
 	framework.Logf("waiting for pods with label %v", rc.Spec.Selector)
 	sel := labels.SelectorFromSet(labels.Set(rc.Spec.Selector))
 	framework.ExpectNoError(testutils.WaitForPodsWithLabelRunning(cont.Client, cont.Ns, sel))
-	pods, err := cont.Client.CoreV1().Pods(cont.Ns).List(context.TODO(), metav1.ListOptions{LabelSelector: sel.String()})
+	pods, err := cont.Client.CoreV1().Pods(cont.Ns).List(ctx, metav1.ListOptions{LabelSelector: sel.String()})
 	framework.ExpectNoError(err)
 	if len(pods.Items) == 0 {
 		framework.Failf("Failed to find nginx ingress controller pods with selector %v", sel)
@@ -1052,12 +1052,12 @@ func (cont *NginxIngressController) Init() {
 }
 
 // TearDown cleans up the NginxIngressController.
-func (cont *NginxIngressController) TearDown() {
+func (cont *NginxIngressController) TearDown(ctx context.Context) {
 	if cont.lbSvc == nil {
 		framework.Logf("No LoadBalancer service created, no cleanup necessary")
 		return
 	}
-	e2eservice.WaitForServiceDeletedWithFinalizer(cont.Client, cont.Ns, cont.lbSvc.Name)
+	e2eservice.WaitForServiceDeletedWithFinalizer(ctx, cont.Client, cont.Ns, cont.lbSvc.Name)
 }
 
 func generateBacksideHTTPSIngressSpec(ns string) *networkingv1.Ingress {
@@ -1122,12 +1122,12 @@ func generateBacksideHTTPSDeploymentSpec() *appsv1.Deployment {
 }
 
 // SetUpBacksideHTTPSIngress sets up deployment, service and ingress with backside HTTPS configured.
-func (j *TestJig) SetUpBacksideHTTPSIngress(cs clientset.Interface, namespace string, staticIPName string) (*appsv1.Deployment, *v1.Service, *networkingv1.Ingress, error) {
-	deployCreated, err := cs.AppsV1().Deployments(namespace).Create(context.TODO(), generateBacksideHTTPSDeploymentSpec(), metav1.CreateOptions{})
+func (j *TestJig) SetUpBacksideHTTPSIngress(ctx context.Context, cs clientset.Interface, namespace string, staticIPName string) (*appsv1.Deployment, *v1.Service, *networkingv1.Ingress, error) {
+	deployCreated, err := cs.AppsV1().Deployments(namespace).Create(ctx, generateBacksideHTTPSDeploymentSpec(), metav1.CreateOptions{})
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	svcCreated, err := cs.CoreV1().Services(namespace).Create(context.TODO(), generateBacksideHTTPSServiceSpec(), metav1.CreateOptions{})
+	svcCreated, err := cs.CoreV1().Services(namespace).Create(ctx, generateBacksideHTTPSServiceSpec(), metav1.CreateOptions{})
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1138,7 +1138,7 @@ func (j *TestJig) SetUpBacksideHTTPSIngress(cs clientset.Interface, namespace st
 		}
 		ingToCreate.Annotations[IngressStaticIPKey] = staticIPName
 	}
-	ingCreated, err := j.runCreate(ingToCreate)
+	ingCreated, err := j.runCreate(ctx, ingToCreate)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1146,20 +1146,20 @@ func (j *TestJig) SetUpBacksideHTTPSIngress(cs clientset.Interface, namespace st
 }
 
 // DeleteTestResource deletes given deployment, service and ingress.
-func (j *TestJig) DeleteTestResource(cs clientset.Interface, deploy *appsv1.Deployment, svc *v1.Service, ing *networkingv1.Ingress) []error {
+func (j *TestJig) DeleteTestResource(ctx context.Context, cs clientset.Interface, deploy *appsv1.Deployment, svc *v1.Service, ing *networkingv1.Ingress) []error {
 	var errs []error
 	if ing != nil {
-		if err := j.runDelete(ing); err != nil {
+		if err := j.runDelete(ctx, ing); err != nil {
 			errs = append(errs, fmt.Errorf("error while deleting ingress %s/%s: %v", ing.Namespace, ing.Name, err))
 		}
 	}
 	if svc != nil {
-		if err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{}); err != nil {
+		if err := cs.CoreV1().Services(svc.Namespace).Delete(ctx, svc.Name, metav1.DeleteOptions{}); err != nil {
 			errs = append(errs, fmt.Errorf("error while deleting service %s/%s: %v", svc.Namespace, svc.Name, err))
 		}
 	}
 	if deploy != nil {
-		if err := cs.AppsV1().Deployments(deploy.Namespace).Delete(context.TODO(), deploy.Name, metav1.DeleteOptions{}); err != nil {
+		if err := cs.AppsV1().Deployments(deploy.Namespace).Delete(ctx, deploy.Name, metav1.DeleteOptions{}); err != nil {
 			errs = append(errs, fmt.Errorf("error while deleting deployment %s/%s: %v", deploy.Namespace, deploy.Name, err))
 		}
 	}

--- a/test/e2e/framework/job/rest.go
+++ b/test/e2e/framework/job/rest.go
@@ -27,13 +27,13 @@ import (
 )
 
 // GetJob uses c to get the Job in namespace ns named name. If the returned error is nil, the returned Job is valid.
-func GetJob(c clientset.Interface, ns, name string) (*batchv1.Job, error) {
-	return c.BatchV1().Jobs(ns).Get(context.TODO(), name, metav1.GetOptions{})
+func GetJob(ctx context.Context, c clientset.Interface, ns, name string) (*batchv1.Job, error) {
+	return c.BatchV1().Jobs(ns).Get(ctx, name, metav1.GetOptions{})
 }
 
 // GetAllRunningJobPods returns a list of all running Pods belonging to a Job.
-func GetAllRunningJobPods(c clientset.Interface, ns, jobName string) ([]v1.Pod, error) {
-	if podList, err := GetJobPods(c, ns, jobName); err != nil {
+func GetAllRunningJobPods(ctx context.Context, c clientset.Interface, ns, jobName string) ([]v1.Pod, error) {
+	if podList, err := GetJobPods(ctx, c, ns, jobName); err != nil {
 		return nil, err
 	} else {
 		pods := []v1.Pod{}
@@ -47,20 +47,20 @@ func GetAllRunningJobPods(c clientset.Interface, ns, jobName string) ([]v1.Pod, 
 }
 
 // GetJobPods returns a list of Pods belonging to a Job.
-func GetJobPods(c clientset.Interface, ns, jobName string) (*v1.PodList, error) {
+func GetJobPods(ctx context.Context, c clientset.Interface, ns, jobName string) (*v1.PodList, error) {
 	label := labels.SelectorFromSet(labels.Set(map[string]string{JobSelectorKey: jobName}))
 	options := metav1.ListOptions{LabelSelector: label.String()}
-	return c.CoreV1().Pods(ns).List(context.TODO(), options)
+	return c.CoreV1().Pods(ns).List(ctx, options)
 }
 
 // CreateJob uses c to create job in namespace ns. If the returned error is nil, the returned Job is valid and has
 // been created.
-func CreateJob(c clientset.Interface, ns string, job *batchv1.Job) (*batchv1.Job, error) {
-	return c.BatchV1().Jobs(ns).Create(context.TODO(), job, metav1.CreateOptions{})
+func CreateJob(ctx context.Context, c clientset.Interface, ns string, job *batchv1.Job) (*batchv1.Job, error) {
+	return c.BatchV1().Jobs(ns).Create(ctx, job, metav1.CreateOptions{})
 }
 
 // CreateJob uses c to update a job in namespace ns. If the returned error is
 // nil, the returned Job is valid and has been updated.
-func UpdateJob(c clientset.Interface, ns string, job *batchv1.Job) (*batchv1.Job, error) {
-	return c.BatchV1().Jobs(ns).Update(context.TODO(), job, metav1.UpdateOptions{})
+func UpdateJob(ctx context.Context, c clientset.Interface, ns string, job *batchv1.Job) (*batchv1.Job, error) {
+	return c.BatchV1().Jobs(ns).Update(ctx, job, metav1.UpdateOptions{})
 }

--- a/test/e2e/framework/job/wait.go
+++ b/test/e2e/framework/job/wait.go
@@ -31,19 +31,19 @@ import (
 
 // WaitForJobPodsRunning wait for all pods for the Job named JobName in namespace ns to become Running.  Only use
 // when pods will run for a long time, or it will be racy.
-func WaitForJobPodsRunning(c clientset.Interface, ns, jobName string, expectedCount int32) error {
-	return waitForJobPodsInPhase(c, ns, jobName, expectedCount, v1.PodRunning)
+func WaitForJobPodsRunning(ctx context.Context, c clientset.Interface, ns, jobName string, expectedCount int32) error {
+	return waitForJobPodsInPhase(ctx, c, ns, jobName, expectedCount, v1.PodRunning)
 }
 
 // WaitForJobPodsSucceeded wait for all pods for the Job named JobName in namespace ns to become Succeeded.
-func WaitForJobPodsSucceeded(c clientset.Interface, ns, jobName string, expectedCount int32) error {
-	return waitForJobPodsInPhase(c, ns, jobName, expectedCount, v1.PodSucceeded)
+func WaitForJobPodsSucceeded(ctx context.Context, c clientset.Interface, ns, jobName string, expectedCount int32) error {
+	return waitForJobPodsInPhase(ctx, c, ns, jobName, expectedCount, v1.PodSucceeded)
 }
 
 // waitForJobPodsInPhase wait for all pods for the Job named JobName in namespace ns to be in a given phase.
-func waitForJobPodsInPhase(c clientset.Interface, ns, jobName string, expectedCount int32, phase v1.PodPhase) error {
-	return wait.Poll(framework.Poll, JobTimeout, func() (bool, error) {
-		pods, err := GetJobPods(c, ns, jobName)
+func waitForJobPodsInPhase(ctx context.Context, c clientset.Interface, ns, jobName string, expectedCount int32, phase v1.PodPhase) error {
+	return wait.PollWithContext(ctx, framework.Poll, JobTimeout, func(ctx context.Context) (bool, error) {
+		pods, err := GetJobPods(ctx, c, ns, jobName)
 		if err != nil {
 			return false, err
 		}
@@ -58,9 +58,9 @@ func waitForJobPodsInPhase(c clientset.Interface, ns, jobName string, expectedCo
 }
 
 // WaitForJobComplete uses c to wait for completions to complete for the Job jobName in namespace ns.
-func WaitForJobComplete(c clientset.Interface, ns, jobName string, completions int32) error {
-	return wait.Poll(framework.Poll, JobTimeout, func() (bool, error) {
-		curr, err := c.BatchV1().Jobs(ns).Get(context.TODO(), jobName, metav1.GetOptions{})
+func WaitForJobComplete(ctx context.Context, c clientset.Interface, ns, jobName string, completions int32) error {
+	return wait.PollWithContext(ctx, framework.Poll, JobTimeout, func(ctx context.Context) (bool, error) {
+		curr, err := c.BatchV1().Jobs(ns).Get(ctx, jobName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -90,9 +90,9 @@ func isJobFailed(j *batchv1.Job) bool {
 }
 
 // WaitForJobFinish uses c to wait for the Job jobName in namespace ns to finish (either Failed or Complete).
-func WaitForJobFinish(c clientset.Interface, ns, jobName string) error {
-	return wait.PollImmediate(framework.Poll, JobTimeout, func() (bool, error) {
-		curr, err := c.BatchV1().Jobs(ns).Get(context.TODO(), jobName, metav1.GetOptions{})
+func WaitForJobFinish(ctx context.Context, c clientset.Interface, ns, jobName string) error {
+	return wait.PollImmediateWithContext(ctx, framework.Poll, JobTimeout, func(ctx context.Context) (bool, error) {
+		curr, err := c.BatchV1().Jobs(ns).Get(ctx, jobName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -112,9 +112,9 @@ func isJobFinished(j *batchv1.Job) bool {
 }
 
 // WaitForJobGone uses c to wait for up to timeout for the Job named jobName in namespace ns to be removed.
-func WaitForJobGone(c clientset.Interface, ns, jobName string, timeout time.Duration) error {
-	return wait.Poll(framework.Poll, timeout, func() (bool, error) {
-		_, err := c.BatchV1().Jobs(ns).Get(context.TODO(), jobName, metav1.GetOptions{})
+func WaitForJobGone(ctx context.Context, c clientset.Interface, ns, jobName string, timeout time.Duration) error {
+	return wait.PollWithContext(ctx, framework.Poll, timeout, func(ctx context.Context) (bool, error) {
+		_, err := c.BatchV1().Jobs(ns).Get(ctx, jobName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
@@ -124,9 +124,9 @@ func WaitForJobGone(c clientset.Interface, ns, jobName string, timeout time.Dura
 
 // WaitForAllJobPodsGone waits for all pods for the Job named jobName in namespace ns
 // to be deleted.
-func WaitForAllJobPodsGone(c clientset.Interface, ns, jobName string) error {
-	return wait.PollImmediate(framework.Poll, JobTimeout, func() (bool, error) {
-		pods, err := GetJobPods(c, ns, jobName)
+func WaitForAllJobPodsGone(ctx context.Context, c clientset.Interface, ns, jobName string) error {
+	return wait.PollImmediateWithContext(ctx, framework.Poll, JobTimeout, func(ctx context.Context) (bool, error) {
+		pods, err := GetJobPods(ctx, c, ns, jobName)
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/framework/kubelet/kubelet_pods.go
+++ b/test/e2e/framework/kubelet/kubelet_pods.go
@@ -17,26 +17,28 @@ limitations under the License.
 package kubelet
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 // GetKubeletPods retrieves the list of pods on the kubelet.
-func GetKubeletPods(c clientset.Interface, node string) (*v1.PodList, error) {
-	return getKubeletPods(c, node, "pods")
+func GetKubeletPods(ctx context.Context, c clientset.Interface, node string) (*v1.PodList, error) {
+	return getKubeletPods(ctx, c, node, "pods")
 }
 
 // GetKubeletRunningPods retrieves the list of running pods on the kubelet. The pods
 // includes necessary information (e.g., UID, name, namespace for
 // pods/containers), but do not contain the full spec.
-func GetKubeletRunningPods(c clientset.Interface, node string) (*v1.PodList, error) {
-	return getKubeletPods(c, node, "runningpods")
+func GetKubeletRunningPods(ctx context.Context, c clientset.Interface, node string) (*v1.PodList, error) {
+	return getKubeletPods(ctx, c, node, "runningpods")
 }
 
-func getKubeletPods(c clientset.Interface, node, resource string) (*v1.PodList, error) {
+func getKubeletPods(ctx context.Context, c clientset.Interface, node, resource string) (*v1.PodList, error) {
 	result := &v1.PodList{}
-	client, err := ProxyRequest(c, node, resource, framework.KubeletPort)
+	client, err := ProxyRequest(ctx, c, node, resource, framework.KubeletPort)
 	if err != nil {
 		return &v1.PodList{}, err
 	}

--- a/test/e2e/framework/kubelet/stats.go
+++ b/test/e2e/framework/kubelet/stats.go
@@ -98,7 +98,7 @@ type RuntimeOperationErrorRate struct {
 }
 
 // ProxyRequest performs a get on a node proxy endpoint given the nodename and rest client.
-func ProxyRequest(c clientset.Interface, node, endpoint string, port int) (restclient.Result, error) {
+func ProxyRequest(ctx context.Context, c clientset.Interface, node, endpoint string, port int) (restclient.Result, error) {
 	// proxy tends to hang in some cases when Node is not ready. Add an artificial timeout for this call. #22165
 	var result restclient.Result
 	finished := make(chan struct{}, 1)
@@ -108,7 +108,7 @@ func ProxyRequest(c clientset.Interface, node, endpoint string, port int) (restc
 			SubResource("proxy").
 			Name(fmt.Sprintf("%v:%v", node, port)).
 			Suffix(endpoint).
-			Do(context.TODO())
+			Do(ctx)
 
 		finished <- struct{}{}
 	}()
@@ -121,12 +121,12 @@ func ProxyRequest(c clientset.Interface, node, endpoint string, port int) (restc
 }
 
 // NewRuntimeOperationMonitor returns a new RuntimeOperationMonitor.
-func NewRuntimeOperationMonitor(c clientset.Interface) *RuntimeOperationMonitor {
+func NewRuntimeOperationMonitor(ctx context.Context, c clientset.Interface) *RuntimeOperationMonitor {
 	m := &RuntimeOperationMonitor{
 		client:          c,
 		nodesRuntimeOps: make(map[string]NodeRuntimeOperationErrorRate),
 	}
-	nodes, err := m.client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodes, err := m.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		framework.Failf("RuntimeOperationMonitor: unable to get list of nodes: %v", err)
 	}
@@ -134,15 +134,15 @@ func NewRuntimeOperationMonitor(c clientset.Interface) *RuntimeOperationMonitor 
 		m.nodesRuntimeOps[node.Name] = make(NodeRuntimeOperationErrorRate)
 	}
 	// Initialize the runtime operation error rate
-	m.GetRuntimeOperationErrorRate()
+	m.GetRuntimeOperationErrorRate(ctx)
 	return m
 }
 
 // GetRuntimeOperationErrorRate gets runtime operation records from kubelet metrics and calculate
 // error rates of all runtime operations.
-func (m *RuntimeOperationMonitor) GetRuntimeOperationErrorRate() map[string]NodeRuntimeOperationErrorRate {
+func (m *RuntimeOperationMonitor) GetRuntimeOperationErrorRate(ctx context.Context) map[string]NodeRuntimeOperationErrorRate {
 	for node := range m.nodesRuntimeOps {
-		nodeResult, err := getNodeRuntimeOperationErrorRate(m.client, node)
+		nodeResult, err := getNodeRuntimeOperationErrorRate(ctx, m.client, node)
 		if err != nil {
 			framework.Logf("GetRuntimeOperationErrorRate: unable to get kubelet metrics from node %q: %v", node, err)
 			continue
@@ -153,12 +153,12 @@ func (m *RuntimeOperationMonitor) GetRuntimeOperationErrorRate() map[string]Node
 }
 
 // GetLatestRuntimeOperationErrorRate gets latest error rate and timeout rate from last observed RuntimeOperationErrorRate.
-func (m *RuntimeOperationMonitor) GetLatestRuntimeOperationErrorRate() map[string]NodeRuntimeOperationErrorRate {
+func (m *RuntimeOperationMonitor) GetLatestRuntimeOperationErrorRate(ctx context.Context) map[string]NodeRuntimeOperationErrorRate {
 	result := make(map[string]NodeRuntimeOperationErrorRate)
 	for node := range m.nodesRuntimeOps {
 		result[node] = make(NodeRuntimeOperationErrorRate)
 		oldNodeResult := m.nodesRuntimeOps[node]
-		curNodeResult, err := getNodeRuntimeOperationErrorRate(m.client, node)
+		curNodeResult, err := getNodeRuntimeOperationErrorRate(ctx, m.client, node)
 		if err != nil {
 			framework.Logf("GetLatestRuntimeOperationErrorRate: unable to get kubelet metrics from node %q: %v", node, err)
 			continue
@@ -193,9 +193,9 @@ func FormatRuntimeOperationErrorRate(nodesResult map[string]NodeRuntimeOperation
 }
 
 // getNodeRuntimeOperationErrorRate gets runtime operation error rate from specified node.
-func getNodeRuntimeOperationErrorRate(c clientset.Interface, node string) (NodeRuntimeOperationErrorRate, error) {
+func getNodeRuntimeOperationErrorRate(ctx context.Context, c clientset.Interface, node string) (NodeRuntimeOperationErrorRate, error) {
 	result := make(NodeRuntimeOperationErrorRate)
-	ms, err := e2emetrics.GetKubeletMetrics(c, node)
+	ms, err := e2emetrics.GetKubeletMetrics(ctx, c, node)
 	if err != nil {
 		return result, err
 	}
@@ -225,8 +225,8 @@ func getNodeRuntimeOperationErrorRate(c clientset.Interface, node string) (NodeR
 }
 
 // GetStatsSummary contacts kubelet for the container information.
-func GetStatsSummary(c clientset.Interface, nodeName string) (*kubeletstatsv1alpha1.Summary, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
+func GetStatsSummary(ctx context.Context, c clientset.Interface, nodeName string) (*kubeletstatsv1alpha1.Summary, error) {
+	ctx, cancel := context.WithTimeout(ctx, framework.SingleCallTimeout)
 	defer cancel()
 
 	data, err := c.CoreV1().RESTClient().Get().
@@ -248,14 +248,14 @@ func GetStatsSummary(c clientset.Interface, nodeName string) (*kubeletstatsv1alp
 	return &summary, nil
 }
 
-func getNodeStatsSummary(c clientset.Interface, nodeName string) (*kubeletstatsv1alpha1.Summary, error) {
+func getNodeStatsSummary(ctx context.Context, c clientset.Interface, nodeName string) (*kubeletstatsv1alpha1.Summary, error) {
 	data, err := c.CoreV1().RESTClient().Get().
 		Resource("nodes").
 		SubResource("proxy").
 		Name(fmt.Sprintf("%v:%v", nodeName, framework.KubeletPort)).
 		Suffix("stats/summary").
 		SetHeader("Content-Type", "application/json").
-		Do(context.TODO()).Raw()
+		Do(ctx).Raw()
 
 	if err != nil {
 		return nil, err
@@ -318,8 +318,8 @@ func formatResourceUsageStats(nodeName string, containerStats ResourceUsagePerCo
 }
 
 // GetKubeletHeapStats returns stats of kubelet heap.
-func GetKubeletHeapStats(c clientset.Interface, nodeName string) (string, error) {
-	client, err := ProxyRequest(c, nodeName, "debug/pprof/heap", framework.KubeletPort)
+func GetKubeletHeapStats(ctx context.Context, c clientset.Interface, nodeName string) (string, error) {
+	client, err := ProxyRequest(ctx, c, nodeName, "debug/pprof/heap", framework.KubeletPort)
 	if err != nil {
 		return "", err
 	}
@@ -356,7 +356,7 @@ type resourceCollector struct {
 	client          clientset.Interface
 	buffers         map[string][]*ContainerResourceUsage
 	pollingInterval time.Duration
-	stopCh          chan struct{}
+	stop            func()
 }
 
 func newResourceCollector(c clientset.Interface, nodeName string, containerNames []string, pollingInterval time.Duration) *resourceCollector {
@@ -371,22 +371,23 @@ func newResourceCollector(c clientset.Interface, nodeName string, containerNames
 }
 
 // Start starts a goroutine to Poll the node every pollingInterval.
-func (r *resourceCollector) Start() {
-	r.stopCh = make(chan struct{}, 1)
+func (r *resourceCollector) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	r.stop = cancel
 	// Keep the last observed stats for comparison.
 	oldStats := make(map[string]*kubeletstatsv1alpha1.ContainerStats)
-	go wait.Until(func() { r.collectStats(oldStats) }, r.pollingInterval, r.stopCh)
+	go wait.UntilWithContext(ctx, func(ctx context.Context) { r.collectStats(ctx, oldStats) }, r.pollingInterval)
 }
 
 // Stop sends a signal to terminate the stats collecting goroutine.
 func (r *resourceCollector) Stop() {
-	close(r.stopCh)
+	r.stop()
 }
 
 // collectStats gets the latest stats from kubelet stats summary API, computes
 // the resource usage, and pushes it to the buffer.
-func (r *resourceCollector) collectStats(oldStatsMap map[string]*kubeletstatsv1alpha1.ContainerStats) {
-	summary, err := getNodeStatsSummary(r.client, r.node)
+func (r *resourceCollector) collectStats(ctx context.Context, oldStatsMap map[string]*kubeletstatsv1alpha1.ContainerStats) {
+	summary, err := getNodeStatsSummary(ctx, r.client, r.node)
 	if err != nil {
 		framework.Logf("Error getting node stats summary on %q, err: %v", r.node, err)
 		return
@@ -486,9 +487,9 @@ func NewResourceMonitor(c clientset.Interface, containerNames []string, pollingI
 }
 
 // Start starts collectors.
-func (r *ResourceMonitor) Start() {
+func (r *ResourceMonitor) Start(ctx context.Context) {
 	// It should be OK to monitor unschedulable Nodes
-	nodes, err := r.client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodes, err := r.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		framework.Failf("ResourceMonitor: unable to get list of nodes: %v", err)
 	}
@@ -496,7 +497,7 @@ func (r *ResourceMonitor) Start() {
 	for _, node := range nodes.Items {
 		collector := newResourceCollector(r.client, node.Name, r.containers, r.pollingInterval)
 		r.collectors[node.Name] = collector
-		collector.Start()
+		collector.Start(ctx)
 	}
 }
 

--- a/test/e2e/framework/metrics/api_server_metrics.go
+++ b/test/e2e/framework/metrics/api_server_metrics.go
@@ -43,8 +43,8 @@ func parseAPIServerMetrics(data string) (APIServerMetrics, error) {
 	return result, nil
 }
 
-func (g *Grabber) getMetricsFromAPIServer() (string, error) {
-	rawOutput, err := g.client.CoreV1().RESTClient().Get().RequestURI("/metrics").Do(context.TODO()).Raw()
+func (g *Grabber) getMetricsFromAPIServer(ctx context.Context) (string, error) {
+	rawOutput, err := g.client.CoreV1().RESTClient().Get().RequestURI("/metrics").Do(ctx).Raw()
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/framework/metrics/init/init.go
+++ b/test/e2e/framework/metrics/init/init.go
@@ -19,6 +19,8 @@ limitations under the License.
 package init
 
 import (
+	"context"
+
 	"github.com/onsi/ginkgo/v2"
 
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -28,8 +30,8 @@ import (
 func init() {
 	framework.NewFrameworkExtensions = append(framework.NewFrameworkExtensions,
 		func(f *framework.Framework) {
-			ginkgo.BeforeEach(func() {
-				metrics := e2emetrics.GrabBeforeEach(f)
+			ginkgo.BeforeEach(func(ctx context.Context) {
+				metrics := e2emetrics.GrabBeforeEach(ctx, f)
 				ginkgo.DeferCleanup(e2emetrics.GrabAfterEach, f, metrics)
 			})
 		},

--- a/test/e2e/framework/node/helper.go
+++ b/test/e2e/framework/node/helper.go
@@ -39,16 +39,17 @@ const (
 
 // WaitForAllNodesSchedulable waits up to timeout for all
 // (but TestContext.AllowedNotReadyNodes) to become schedulable.
-func WaitForAllNodesSchedulable(c clientset.Interface, timeout time.Duration) error {
+func WaitForAllNodesSchedulable(ctx context.Context, c clientset.Interface, timeout time.Duration) error {
 	if framework.TestContext.AllowedNotReadyNodes == -1 {
 		return nil
 	}
 
 	framework.Logf("Waiting up to %v for all (but %d) nodes to be schedulable", timeout, framework.TestContext.AllowedNotReadyNodes)
-	return wait.PollImmediate(
+	return wait.PollImmediateWithContext(
+		ctx,
 		30*time.Second,
 		timeout,
-		CheckReadyForTests(c, framework.TestContext.NonblockingTaints, framework.TestContext.AllowedNotReadyNodes, largeClusterThreshold),
+		CheckReadyForTests(ctx, c, framework.TestContext.NonblockingTaints, framework.TestContext.AllowedNotReadyNodes, largeClusterThreshold),
 	)
 }
 
@@ -58,9 +59,9 @@ func AddOrUpdateLabelOnNode(c clientset.Interface, nodeName string, labelKey, la
 }
 
 // ExpectNodeHasLabel expects that the given node has the given label pair.
-func ExpectNodeHasLabel(c clientset.Interface, nodeName string, labelKey string, labelValue string) {
+func ExpectNodeHasLabel(ctx context.Context, c clientset.Interface, nodeName string, labelKey string, labelValue string) {
 	ginkgo.By("verifying the node has the label " + labelKey + " " + labelValue)
-	node, err := c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	node, err := c.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	framework.ExpectEqual(node.Labels[labelKey], labelValue)
 }
@@ -76,17 +77,17 @@ func RemoveLabelOffNode(c clientset.Interface, nodeName string, labelKey string)
 }
 
 // ExpectNodeHasTaint expects that the node has the given taint.
-func ExpectNodeHasTaint(c clientset.Interface, nodeName string, taint *v1.Taint) {
+func ExpectNodeHasTaint(ctx context.Context, c clientset.Interface, nodeName string, taint *v1.Taint) {
 	ginkgo.By("verifying the node has the taint " + taint.ToString())
-	if has, err := NodeHasTaint(c, nodeName, taint); !has {
+	if has, err := NodeHasTaint(ctx, c, nodeName, taint); !has {
 		framework.ExpectNoError(err)
 		framework.Failf("Failed to find taint %s on node %s", taint.ToString(), nodeName)
 	}
 }
 
 // NodeHasTaint returns true if the node has the given taint, else returns false.
-func NodeHasTaint(c clientset.Interface, nodeName string, taint *v1.Taint) (bool, error) {
-	node, err := c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+func NodeHasTaint(ctx context.Context, c clientset.Interface, nodeName string, taint *v1.Taint) (bool, error) {
+	node, err := c.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -104,14 +105,14 @@ func NodeHasTaint(c clientset.Interface, nodeName string, taint *v1.Taint) (bool
 // TODO: we should change the AllNodesReady call in AfterEach to WaitForAllNodesHealthy,
 // and figure out how to do it in a configurable way, as we can't expect all setups to run
 // default test add-ons.
-func AllNodesReady(c clientset.Interface, timeout time.Duration) error {
-	if err := allNodesReady(c, timeout); err != nil {
+func AllNodesReady(ctx context.Context, c clientset.Interface, timeout time.Duration) error {
+	if err := allNodesReady(ctx, c, timeout); err != nil {
 		return fmt.Errorf("checking for ready nodes: %v", err)
 	}
 	return nil
 }
 
-func allNodesReady(c clientset.Interface, timeout time.Duration) error {
+func allNodesReady(ctx context.Context, c clientset.Interface, timeout time.Duration) error {
 	if framework.TestContext.AllowedNotReadyNodes == -1 {
 		return nil
 	}
@@ -119,10 +120,10 @@ func allNodesReady(c clientset.Interface, timeout time.Duration) error {
 	framework.Logf("Waiting up to %v for all (but %d) nodes to be ready", timeout, framework.TestContext.AllowedNotReadyNodes)
 
 	var notReady []*v1.Node
-	err := wait.PollImmediate(framework.Poll, timeout, func() (bool, error) {
+	err := wait.PollImmediateWithContext(ctx, framework.Poll, timeout, func(ctx context.Context) (bool, error) {
 		notReady = nil
 		// It should be OK to list unschedulable Nodes here.
-		nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/framework/node/init/init.go
+++ b/test/e2e/framework/node/init/init.go
@@ -18,6 +18,7 @@ limitations under the License.
 package init
 
 import (
+	"context"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -29,14 +30,14 @@ import (
 func init() {
 	framework.NewFrameworkExtensions = append(framework.NewFrameworkExtensions,
 		func(f *framework.Framework) {
-			ginkgo.AfterEach(func() {
+			ginkgo.AfterEach(func(ctx context.Context) {
 				if f.ClientSet == nil {
 					// Test didn't reach f.BeforeEach, most
 					// likely because the test got
 					// skipped. Nothing to check...
 					return
 				}
-				e2enode.AllNodesReady(f.ClientSet, 3*time.Minute)
+				e2enode.AllNodesReady(ctx, f.ClientSet, 3*time.Minute)
 			})
 		},
 	)

--- a/test/e2e/framework/node/ssh.go
+++ b/test/e2e/framework/node/ssh.go
@@ -17,6 +17,7 @@ limitations under the License.
 package node
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -25,7 +26,7 @@ import (
 )
 
 // WaitForSSHTunnels waits for establishing SSH tunnel to busybox pod.
-func WaitForSSHTunnels(namespace string) {
+func WaitForSSHTunnels(ctx context.Context, namespace string) {
 	framework.Logf("Waiting for SSH tunnels to establish")
 	e2ekubectl.RunKubectl(namespace, "run", "ssh-tunnel-test",
 		"--image=busybox",
@@ -35,7 +36,7 @@ func WaitForSSHTunnels(namespace string) {
 	defer e2ekubectl.RunKubectl(namespace, "delete", "pod", "ssh-tunnel-test")
 
 	// allow up to a minute for new ssh tunnels to establish
-	wait.PollImmediate(5*time.Second, time.Minute, func() (bool, error) {
+	wait.PollImmediateWithContext(ctx, 5*time.Second, time.Minute, func(ctx context.Context) (bool, error) {
 		_, err := e2ekubectl.RunKubectl(namespace, "logs", "ssh-tunnel-test")
 		return err == nil, nil
 	})

--- a/test/e2e/framework/node/wait.go
+++ b/test/e2e/framework/node/wait.go
@@ -40,21 +40,21 @@ var requiredPerNodePods = []*regexp.Regexp{
 
 // WaitForReadyNodes waits up to timeout for cluster to has desired size and
 // there is no not-ready nodes in it. By cluster size we mean number of schedulable Nodes.
-func WaitForReadyNodes(c clientset.Interface, size int, timeout time.Duration) error {
-	_, err := CheckReady(c, size, timeout)
+func WaitForReadyNodes(ctx context.Context, c clientset.Interface, size int, timeout time.Duration) error {
+	_, err := CheckReady(ctx, c, size, timeout)
 	return err
 }
 
 // WaitForTotalHealthy checks whether all registered nodes are ready and all required Pods are running on them.
-func WaitForTotalHealthy(c clientset.Interface, timeout time.Duration) error {
+func WaitForTotalHealthy(ctx context.Context, c clientset.Interface, timeout time.Duration) error {
 	framework.Logf("Waiting up to %v for all nodes to be ready", timeout)
 
 	var notReady []v1.Node
 	var missingPodsPerNode map[string][]string
-	err := wait.PollImmediate(poll, timeout, func() (bool, error) {
+	err := wait.PollImmediateWithContext(ctx, poll, timeout, func(ctx context.Context) (bool, error) {
 		notReady = nil
 		// It should be OK to list unschedulable Nodes here.
-		nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
+		nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return false, err
 		}
@@ -63,7 +63,7 @@ func WaitForTotalHealthy(c clientset.Interface, timeout time.Duration) error {
 				notReady = append(notReady, node)
 			}
 		}
-		pods, err := c.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
+		pods, err := c.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return false, err
 		}
@@ -114,10 +114,10 @@ func WaitForTotalHealthy(c clientset.Interface, timeout time.Duration) error {
 // within timeout. If wantTrue is true, it will ensure the node condition status
 // is ConditionTrue; if it's false, it ensures the node condition is in any state
 // other than ConditionTrue (e.g. not true or unknown).
-func WaitConditionToBe(c clientset.Interface, name string, conditionType v1.NodeConditionType, wantTrue bool, timeout time.Duration) bool {
+func WaitConditionToBe(ctx context.Context, c clientset.Interface, name string, conditionType v1.NodeConditionType, wantTrue bool, timeout time.Duration) bool {
 	framework.Logf("Waiting up to %v for node %s condition %s to be %t", timeout, name, conditionType, wantTrue)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
-		node, err := c.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+		node, err := c.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			framework.Logf("Couldn't get node %s", name)
 			continue
@@ -134,20 +134,20 @@ func WaitConditionToBe(c clientset.Interface, name string, conditionType v1.Node
 // WaitForNodeToBeNotReady returns whether node name is not ready (i.e. the
 // readiness condition is anything but ready, e.g false or unknown) within
 // timeout.
-func WaitForNodeToBeNotReady(c clientset.Interface, name string, timeout time.Duration) bool {
-	return WaitConditionToBe(c, name, v1.NodeReady, false, timeout)
+func WaitForNodeToBeNotReady(ctx context.Context, c clientset.Interface, name string, timeout time.Duration) bool {
+	return WaitConditionToBe(ctx, c, name, v1.NodeReady, false, timeout)
 }
 
 // WaitForNodeToBeReady returns whether node name is ready within timeout.
-func WaitForNodeToBeReady(c clientset.Interface, name string, timeout time.Duration) bool {
-	return WaitConditionToBe(c, name, v1.NodeReady, true, timeout)
+func WaitForNodeToBeReady(ctx context.Context, c clientset.Interface, name string, timeout time.Duration) bool {
+	return WaitConditionToBe(ctx, c, name, v1.NodeReady, true, timeout)
 }
 
 // CheckReady waits up to timeout for cluster to has desired size and
 // there is no not-ready nodes in it. By cluster size we mean number of schedulable Nodes.
-func CheckReady(c clientset.Interface, size int, timeout time.Duration) ([]v1.Node, error) {
+func CheckReady(ctx context.Context, c clientset.Interface, size int, timeout time.Duration) ([]v1.Node, error) {
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(sleepTime) {
-		nodes, err := waitListSchedulableNodes(c)
+		nodes, err := waitListSchedulableNodes(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to list nodes: %v", err)
 			continue
@@ -172,11 +172,11 @@ func CheckReady(c clientset.Interface, size int, timeout time.Duration) ([]v1.No
 }
 
 // waitListSchedulableNodes is a wrapper around listing nodes supporting retries.
-func waitListSchedulableNodes(c clientset.Interface) (*v1.NodeList, error) {
+func waitListSchedulableNodes(ctx context.Context, c clientset.Interface) (*v1.NodeList, error) {
 	var nodes *v1.NodeList
 	var err error
-	if wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
-		nodes, err = c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{FieldSelector: fields.Set{
+	if wait.PollImmediateWithContext(ctx, poll, singleCallTimeout, func(ctx context.Context) (bool, error) {
+		nodes, err = c.CoreV1().Nodes().List(ctx, metav1.ListOptions{FieldSelector: fields.Set{
 			"spec.unschedulable": "false",
 		}.AsSelector().String()})
 		if err != nil {
@@ -190,8 +190,8 @@ func waitListSchedulableNodes(c clientset.Interface) (*v1.NodeList, error) {
 }
 
 // checkWaitListSchedulableNodes is a wrapper around listing nodes supporting retries.
-func checkWaitListSchedulableNodes(c clientset.Interface) (*v1.NodeList, error) {
-	nodes, err := waitListSchedulableNodes(c)
+func checkWaitListSchedulableNodes(ctx context.Context, c clientset.Interface) (*v1.NodeList, error) {
+	nodes, err := waitListSchedulableNodes(ctx, c)
 	if err != nil {
 		return nil, fmt.Errorf("error: %s. Non-retryable failure or timed out while listing nodes for e2e cluster", err)
 	}
@@ -199,9 +199,9 @@ func checkWaitListSchedulableNodes(c clientset.Interface) (*v1.NodeList, error) 
 }
 
 // CheckReadyForTests returns a function which will return 'true' once the number of ready nodes is above the allowedNotReadyNodes threshold (i.e. to be used as a global gate for starting the tests).
-func CheckReadyForTests(c clientset.Interface, nonblockingTaints string, allowedNotReadyNodes, largeClusterThreshold int) func() (bool, error) {
+func CheckReadyForTests(ctx context.Context, c clientset.Interface, nonblockingTaints string, allowedNotReadyNodes, largeClusterThreshold int) func(ctx context.Context) (bool, error) {
 	attempt := 0
-	return func() (bool, error) {
+	return func(ctx context.Context) (bool, error) {
 		if allowedNotReadyNodes == -1 {
 			return true, nil
 		}
@@ -212,7 +212,7 @@ func CheckReadyForTests(c clientset.Interface, nonblockingTaints string, allowed
 			// remove uncordoned nodes from our calculation, TODO refactor if node v2 API removes that semantic.
 			FieldSelector: fields.Set{"spec.unschedulable": "false"}.AsSelector().String(),
 		}
-		allNodes, err := c.CoreV1().Nodes().List(context.TODO(), opts)
+		allNodes, err := c.CoreV1().Nodes().List(ctx, opts)
 		if err != nil {
 			var terminalListNodesErr error
 			framework.Logf("Unexpected error listing nodes: %v", err)

--- a/test/e2e/framework/node/wait_test.go
+++ b/test/e2e/framework/node/wait_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package node
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -167,12 +168,12 @@ func TestCheckReadyForTests(t *testing.T) {
 				nodeList := &v1.NodeList{Items: tc.nodes}
 				return true, nodeList, tc.nodeListErr
 			})
-			checkFunc := CheckReadyForTests(c, tc.nonblockingTaints, tc.allowedNotReadyNodes, testLargeClusterThreshold)
+			checkFunc := CheckReadyForTests(context.Background(), c, tc.nonblockingTaints, tc.allowedNotReadyNodes, testLargeClusterThreshold)
 			// The check function returns "false, nil" during its
 			// first two calls, therefore we have to try several
 			// times until we get the expected error.
 			for attempt := 0; attempt <= 3; attempt++ {
-				out, err := checkFunc()
+				out, err := checkFunc(context.Background())
 				expected := tc.expected
 				expectedErr := tc.expectedErr
 				if tc.nodeListErr != nil && attempt < 2 {

--- a/test/e2e/framework/pod/create.go
+++ b/test/e2e/framework/pod/create.go
@@ -52,19 +52,19 @@ type Config struct {
 }
 
 // CreateUnschedulablePod with given claims based on node selector
-func CreateUnschedulablePod(client clientset.Interface, namespace string, nodeSelector map[string]string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bool, command string) (*v1.Pod, error) {
+func CreateUnschedulablePod(ctx context.Context, client clientset.Interface, namespace string, nodeSelector map[string]string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bool, command string) (*v1.Pod, error) {
 	pod := MakePod(namespace, nodeSelector, pvclaims, isPrivileged, command)
-	pod, err := client.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	pod, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("pod Create API error: %v", err)
 	}
 	// Waiting for pod to become Unschedulable
-	err = WaitForPodNameUnschedulableInNamespace(client, pod.Name, namespace)
+	err = WaitForPodNameUnschedulableInNamespace(ctx, client, pod.Name, namespace)
 	if err != nil {
 		return pod, fmt.Errorf("pod %q is not Unschedulable: %v", pod.Name, err)
 	}
 	// get fresh pod info
-	pod, err = client.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+	pod, err = client.CoreV1().Pods(namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	if err != nil {
 		return pod, fmt.Errorf("pod Get API error: %v", err)
 	}
@@ -72,24 +72,24 @@ func CreateUnschedulablePod(client clientset.Interface, namespace string, nodeSe
 }
 
 // CreateClientPod defines and creates a pod with a mounted PV. Pod runs infinite loop until killed.
-func CreateClientPod(c clientset.Interface, ns string, pvc *v1.PersistentVolumeClaim) (*v1.Pod, error) {
-	return CreatePod(c, ns, nil, []*v1.PersistentVolumeClaim{pvc}, true, "")
+func CreateClientPod(ctx context.Context, c clientset.Interface, ns string, pvc *v1.PersistentVolumeClaim) (*v1.Pod, error) {
+	return CreatePod(ctx, c, ns, nil, []*v1.PersistentVolumeClaim{pvc}, true, "")
 }
 
 // CreatePod with given claims based on node selector
-func CreatePod(client clientset.Interface, namespace string, nodeSelector map[string]string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bool, command string) (*v1.Pod, error) {
+func CreatePod(ctx context.Context, client clientset.Interface, namespace string, nodeSelector map[string]string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bool, command string) (*v1.Pod, error) {
 	pod := MakePod(namespace, nodeSelector, pvclaims, isPrivileged, command)
-	pod, err := client.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	pod, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("pod Create API error: %v", err)
 	}
 	// Waiting for pod to be running
-	err = WaitForPodNameRunningInNamespace(client, pod.Name, namespace)
+	err = WaitForPodNameRunningInNamespace(ctx, client, pod.Name, namespace)
 	if err != nil {
 		return pod, fmt.Errorf("pod %q is not Running: %v", pod.Name, err)
 	}
 	// get fresh pod info
-	pod, err = client.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+	pod, err = client.CoreV1().Pods(namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	if err != nil {
 		return pod, fmt.Errorf("pod Get API error: %v", err)
 	}
@@ -97,29 +97,29 @@ func CreatePod(client clientset.Interface, namespace string, nodeSelector map[st
 }
 
 // CreateSecPod creates security pod with given claims
-func CreateSecPod(client clientset.Interface, podConfig *Config, timeout time.Duration) (*v1.Pod, error) {
-	return CreateSecPodWithNodeSelection(client, podConfig, timeout)
+func CreateSecPod(ctx context.Context, client clientset.Interface, podConfig *Config, timeout time.Duration) (*v1.Pod, error) {
+	return CreateSecPodWithNodeSelection(ctx, client, podConfig, timeout)
 }
 
 // CreateSecPodWithNodeSelection creates security pod with given claims
-func CreateSecPodWithNodeSelection(client clientset.Interface, podConfig *Config, timeout time.Duration) (*v1.Pod, error) {
+func CreateSecPodWithNodeSelection(ctx context.Context, client clientset.Interface, podConfig *Config, timeout time.Duration) (*v1.Pod, error) {
 	pod, err := MakeSecPod(podConfig)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to create pod: %v", err)
 	}
 
-	pod, err = client.CoreV1().Pods(podConfig.NS).Create(context.TODO(), pod, metav1.CreateOptions{})
+	pod, err = client.CoreV1().Pods(podConfig.NS).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("pod Create API error: %v", err)
 	}
 
 	// Waiting for pod to be running
-	err = WaitTimeoutForPodRunningInNamespace(client, pod.Name, podConfig.NS, timeout)
+	err = WaitTimeoutForPodRunningInNamespace(ctx, client, pod.Name, podConfig.NS, timeout)
 	if err != nil {
 		return pod, fmt.Errorf("pod %q is not Running: %v", pod.Name, err)
 	}
 	// get fresh pod info
-	pod, err = client.CoreV1().Pods(podConfig.NS).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+	pod, err = client.CoreV1().Pods(podConfig.NS).Get(ctx, pod.Name, metav1.GetOptions{})
 	if err != nil {
 		return pod, fmt.Errorf("pod Get API error: %v", err)
 	}

--- a/test/e2e/framework/pod/delete.go
+++ b/test/e2e/framework/pod/delete.go
@@ -37,9 +37,9 @@ const (
 
 // DeletePodOrFail deletes the pod of the specified namespace and name. Resilient to the pod
 // not existing.
-func DeletePodOrFail(c clientset.Interface, ns, name string) {
+func DeletePodOrFail(ctx context.Context, c clientset.Interface, ns, name string) {
 	ginkgo.By(fmt.Sprintf("Deleting pod %s in namespace %s", name, ns))
-	err := c.CoreV1().Pods(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	err := c.CoreV1().Pods(ns).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil && apierrors.IsNotFound(err) {
 		return
 	}
@@ -49,18 +49,18 @@ func DeletePodOrFail(c clientset.Interface, ns, name string) {
 
 // DeletePodWithWait deletes the passed-in pod and waits for the pod to be terminated. Resilient to the pod
 // not existing.
-func DeletePodWithWait(c clientset.Interface, pod *v1.Pod) error {
+func DeletePodWithWait(ctx context.Context, c clientset.Interface, pod *v1.Pod) error {
 	if pod == nil {
 		return nil
 	}
-	return DeletePodWithWaitByName(c, pod.GetName(), pod.GetNamespace())
+	return DeletePodWithWaitByName(ctx, c, pod.GetName(), pod.GetNamespace())
 }
 
 // DeletePodWithWaitByName deletes the named and namespaced pod and waits for the pod to be terminated. Resilient to the pod
 // not existing.
-func DeletePodWithWaitByName(c clientset.Interface, podName, podNamespace string) error {
+func DeletePodWithWaitByName(ctx context.Context, c clientset.Interface, podName, podNamespace string) error {
 	framework.Logf("Deleting pod %q in namespace %q", podName, podNamespace)
-	err := c.CoreV1().Pods(podNamespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+	err := c.CoreV1().Pods(podNamespace).Delete(ctx, podName, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil // assume pod was already deleted
@@ -68,7 +68,7 @@ func DeletePodWithWaitByName(c clientset.Interface, podName, podNamespace string
 		return fmt.Errorf("pod Delete API error: %v", err)
 	}
 	framework.Logf("Wait up to %v for pod %q to be fully deleted", PodDeleteTimeout, podName)
-	err = WaitForPodNotFoundInNamespace(c, podName, podNamespace, PodDeleteTimeout)
+	err = WaitForPodNotFoundInNamespace(ctx, c, podName, podNamespace, PodDeleteTimeout)
 	if err != nil {
 		return fmt.Errorf("pod %q was not deleted: %v", podName, err)
 	}
@@ -76,14 +76,14 @@ func DeletePodWithWaitByName(c clientset.Interface, podName, podNamespace string
 }
 
 // DeletePodWithGracePeriod deletes the passed-in pod. Resilient to the pod not existing.
-func DeletePodWithGracePeriod(c clientset.Interface, pod *v1.Pod, grace int64) error {
-	return DeletePodWithGracePeriodByName(c, pod.GetName(), pod.GetNamespace(), grace)
+func DeletePodWithGracePeriod(ctx context.Context, c clientset.Interface, pod *v1.Pod, grace int64) error {
+	return DeletePodWithGracePeriodByName(ctx, c, pod.GetName(), pod.GetNamespace(), grace)
 }
 
 // DeletePodsWithGracePeriod deletes the passed-in pods. Resilient to the pods not existing.
-func DeletePodsWithGracePeriod(c clientset.Interface, pods []v1.Pod, grace int64) error {
+func DeletePodsWithGracePeriod(ctx context.Context, c clientset.Interface, pods []v1.Pod, grace int64) error {
 	for _, pod := range pods {
-		if err := DeletePodWithGracePeriod(c, &pod, grace); err != nil {
+		if err := DeletePodWithGracePeriod(ctx, c, &pod, grace); err != nil {
 			return err
 		}
 	}
@@ -91,9 +91,9 @@ func DeletePodsWithGracePeriod(c clientset.Interface, pods []v1.Pod, grace int64
 }
 
 // DeletePodWithGracePeriodByName deletes a pod by name and namespace. Resilient to the pod not existing.
-func DeletePodWithGracePeriodByName(c clientset.Interface, podName, podNamespace string, grace int64) error {
+func DeletePodWithGracePeriodByName(ctx context.Context, c clientset.Interface, podName, podNamespace string, grace int64) error {
 	framework.Logf("Deleting pod %q in namespace %q", podName, podNamespace)
-	err := c.CoreV1().Pods(podNamespace).Delete(context.TODO(), podName, *metav1.NewDeleteOptions(grace))
+	err := c.CoreV1().Pods(podNamespace).Delete(ctx, podName, *metav1.NewDeleteOptions(grace))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil // assume pod was already deleted

--- a/test/e2e/framework/pod/exec_util.go
+++ b/test/e2e/framework/pod/exec_util.go
@@ -87,6 +87,7 @@ func ExecWithOptions(f *framework.Framework, options ExecOptions) (string, strin
 // ExecCommandInContainerWithFullOutput executes a command in the
 // specified container and return stdout, stderr and error
 func ExecCommandInContainerWithFullOutput(f *framework.Framework, podName, containerName string, cmd ...string) (string, string, error) {
+	// TODO (pohly): add context support
 	return ExecWithOptions(f, ExecOptions{
 		Command:            cmd,
 		Namespace:          f.Namespace.Name,
@@ -114,28 +115,28 @@ func ExecShellInContainer(f *framework.Framework, podName, containerName string,
 	return ExecCommandInContainer(f, podName, containerName, "/bin/sh", "-c", cmd)
 }
 
-func execCommandInPod(f *framework.Framework, podName string, cmd ...string) string {
-	pod, err := NewPodClient(f).Get(context.TODO(), podName, metav1.GetOptions{})
+func execCommandInPod(ctx context.Context, f *framework.Framework, podName string, cmd ...string) string {
+	pod, err := NewPodClient(f).Get(ctx, podName, metav1.GetOptions{})
 	framework.ExpectNoError(err, "failed to get pod %v", podName)
 	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
 	return ExecCommandInContainer(f, podName, pod.Spec.Containers[0].Name, cmd...)
 }
 
-func execCommandInPodWithFullOutput(f *framework.Framework, podName string, cmd ...string) (string, string, error) {
-	pod, err := NewPodClient(f).Get(context.TODO(), podName, metav1.GetOptions{})
+func execCommandInPodWithFullOutput(ctx context.Context, f *framework.Framework, podName string, cmd ...string) (string, string, error) {
+	pod, err := NewPodClient(f).Get(ctx, podName, metav1.GetOptions{})
 	framework.ExpectNoError(err, "failed to get pod %v", podName)
 	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
 	return ExecCommandInContainerWithFullOutput(f, podName, pod.Spec.Containers[0].Name, cmd...)
 }
 
 // ExecShellInPod executes the specified command on the pod.
-func ExecShellInPod(f *framework.Framework, podName string, cmd string) string {
-	return execCommandInPod(f, podName, "/bin/sh", "-c", cmd)
+func ExecShellInPod(ctx context.Context, f *framework.Framework, podName string, cmd string) string {
+	return execCommandInPod(ctx, f, podName, "/bin/sh", "-c", cmd)
 }
 
 // ExecShellInPodWithFullOutput executes the specified command on the Pod and returns stdout, stderr and error.
-func ExecShellInPodWithFullOutput(f *framework.Framework, podName string, cmd string) (string, string, error) {
-	return execCommandInPodWithFullOutput(f, podName, "/bin/sh", "-c", cmd)
+func ExecShellInPodWithFullOutput(ctx context.Context, f *framework.Framework, podName string, cmd string) (string, string, error) {
+	return execCommandInPodWithFullOutput(ctx, f, podName, "/bin/sh", "-c", cmd)
 }
 
 func execute(method string, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {

--- a/test/e2e/framework/pod/output/output.go
+++ b/test/e2e/framework/pod/output/output.go
@@ -128,8 +128,8 @@ func CreateEmptyFileOnPod(namespace string, podName string, filePath string) err
 }
 
 // DumpDebugInfo dumps debug info of tests.
-func DumpDebugInfo(c clientset.Interface, ns string) {
-	sl, _ := c.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Everything().String()})
+func DumpDebugInfo(ctx context.Context, c clientset.Interface, ns string) {
+	sl, _ := c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: labels.Everything().String()})
 	for _, s := range sl.Items {
 		desc, _ := e2ekubectl.RunKubectl(ns, "describe", "po", s.Name)
 		framework.Logf("\nOutput of kubectl describe %v:\n%v", s.Name, desc)
@@ -142,6 +142,7 @@ func DumpDebugInfo(c clientset.Interface, ns string) {
 // MatchContainerOutput creates a pod and waits for all it's containers to exit with success.
 // It then tests that the matcher with each expectedOutput matches the output of the specified container.
 func MatchContainerOutput(
+	ctx context.Context,
 	f *framework.Framework,
 	pod *v1.Pod,
 	containerName string,
@@ -153,17 +154,17 @@ func MatchContainerOutput(
 	}
 	podClient := e2epod.PodClientNS(f, ns)
 
-	createdPod := podClient.Create(pod)
+	createdPod := podClient.Create(ctx, pod)
 	defer func() {
 		ginkgo.By("delete the pod")
-		podClient.DeleteSync(createdPod.Name, metav1.DeleteOptions{}, e2epod.DefaultPodDeletionTimeout)
+		podClient.DeleteSync(ctx, createdPod.Name, metav1.DeleteOptions{}, e2epod.DefaultPodDeletionTimeout)
 	}()
 
 	// Wait for client pod to complete.
-	podErr := e2epod.WaitForPodSuccessInNamespaceTimeout(f.ClientSet, createdPod.Name, ns, f.Timeouts.PodStart)
+	podErr := e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, createdPod.Name, ns, f.Timeouts.PodStart)
 
 	// Grab its logs.  Get host first.
-	podStatus, err := podClient.Get(context.TODO(), createdPod.Name, metav1.GetOptions{})
+	podStatus, err := podClient.Get(ctx, createdPod.Name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get pod status: %v", err)
 	}
@@ -171,7 +172,7 @@ func MatchContainerOutput(
 	if podErr != nil {
 		// Pod failed. Dump all logs from all containers to see what's wrong
 		_ = apiv1pod.VisitContainers(&podStatus.Spec, apiv1pod.AllFeatureEnabledContainers(), func(c *v1.Container, containerType apiv1pod.ContainerType) bool {
-			logs, err := e2epod.GetPodLogs(f.ClientSet, ns, podStatus.Name, c.Name)
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, ns, podStatus.Name, c.Name)
 			if err != nil {
 				framework.Logf("Failed to get logs from node %q pod %q container %q: %v",
 					podStatus.Spec.NodeName, podStatus.Name, c.Name, err)
@@ -187,7 +188,7 @@ func MatchContainerOutput(
 		podStatus.Spec.NodeName, podStatus.Name, containerName, err)
 
 	// Sometimes the actual containers take a second to get started, try to get logs for 60s
-	logs, err := e2epod.GetPodLogs(f.ClientSet, ns, podStatus.Name, containerName)
+	logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, ns, podStatus.Name, containerName)
 	if err != nil {
 		framework.Logf("Failed to get logs from node %q pod %q container %q. %v",
 			podStatus.Spec.NodeName, podStatus.Name, containerName, err)
@@ -210,21 +211,21 @@ func MatchContainerOutput(
 // TestContainerOutput runs the given pod in the given namespace and waits
 // for all of the containers in the podSpec to move into the 'Success' status, and tests
 // the specified container log against the given expected output using a substring matcher.
-func TestContainerOutput(f *framework.Framework, scenarioName string, pod *v1.Pod, containerIndex int, expectedOutput []string) {
-	TestContainerOutputMatcher(f, scenarioName, pod, containerIndex, expectedOutput, gomega.ContainSubstring)
+func TestContainerOutput(ctx context.Context, f *framework.Framework, scenarioName string, pod *v1.Pod, containerIndex int, expectedOutput []string) {
+	TestContainerOutputMatcher(ctx, f, scenarioName, pod, containerIndex, expectedOutput, gomega.ContainSubstring)
 }
 
 // TestContainerOutputRegexp runs the given pod in the given namespace and waits
 // for all of the containers in the podSpec to move into the 'Success' status, and tests
 // the specified container log against the given expected output using a regexp matcher.
-func TestContainerOutputRegexp(f *framework.Framework, scenarioName string, pod *v1.Pod, containerIndex int, expectedOutput []string) {
-	TestContainerOutputMatcher(f, scenarioName, pod, containerIndex, expectedOutput, gomega.MatchRegexp)
+func TestContainerOutputRegexp(ctx context.Context, f *framework.Framework, scenarioName string, pod *v1.Pod, containerIndex int, expectedOutput []string) {
+	TestContainerOutputMatcher(ctx, f, scenarioName, pod, containerIndex, expectedOutput, gomega.MatchRegexp)
 }
 
 // TestContainerOutputMatcher runs the given pod in the given namespace and waits
 // for all of the containers in the podSpec to move into the 'Success' status, and tests
 // the specified container log against the given expected output using the given matcher.
-func TestContainerOutputMatcher(f *framework.Framework,
+func TestContainerOutputMatcher(ctx context.Context, f *framework.Framework,
 	scenarioName string,
 	pod *v1.Pod,
 	containerIndex int,
@@ -234,5 +235,5 @@ func TestContainerOutputMatcher(f *framework.Framework,
 	if containerIndex < 0 || containerIndex >= len(pod.Spec.Containers) {
 		framework.Failf("Invalid container index: %d", containerIndex)
 	}
-	framework.ExpectNoError(MatchContainerOutput(f, pod, pod.Spec.Containers[containerIndex].Name, expectedOutput, matcher))
+	framework.ExpectNoError(MatchContainerOutput(ctx, f, pod, pod.Spec.Containers[containerIndex].Name, expectedOutput, matcher))
 }

--- a/test/e2e/framework/pod/pod_client.go
+++ b/test/e2e/framework/pod/pod_client.go
@@ -93,26 +93,26 @@ type PodClient struct {
 }
 
 // Create creates a new pod according to the framework specifications (don't wait for it to start).
-func (c *PodClient) Create(pod *v1.Pod) *v1.Pod {
+func (c *PodClient) Create(ctx context.Context, pod *v1.Pod) *v1.Pod {
 	c.mungeSpec(pod)
-	p, err := c.PodInterface.Create(context.TODO(), pod, metav1.CreateOptions{})
+	p, err := c.PodInterface.Create(ctx, pod, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "Error creating Pod")
 	return p
 }
 
 // CreateSync creates a new pod according to the framework specifications, and wait for it to start and be running and ready.
-func (c *PodClient) CreateSync(pod *v1.Pod) *v1.Pod {
+func (c *PodClient) CreateSync(ctx context.Context, pod *v1.Pod) *v1.Pod {
 	namespace := c.f.Namespace.Name
-	p := c.Create(pod)
-	framework.ExpectNoError(WaitTimeoutForPodReadyInNamespace(c.f.ClientSet, p.Name, namespace, framework.PodStartTimeout))
+	p := c.Create(ctx, pod)
+	framework.ExpectNoError(WaitTimeoutForPodReadyInNamespace(ctx, c.f.ClientSet, p.Name, namespace, framework.PodStartTimeout))
 	// Get the newest pod after it becomes running and ready, some status may change after pod created, such as pod ip.
-	p, err := c.Get(context.TODO(), p.Name, metav1.GetOptions{})
+	p, err := c.Get(ctx, p.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	return p
 }
 
 // CreateBatch create a batch of pods. All pods are created before waiting.
-func (c *PodClient) CreateBatch(pods []*v1.Pod) []*v1.Pod {
+func (c *PodClient) CreateBatch(ctx context.Context, pods []*v1.Pod) []*v1.Pod {
 	ps := make([]*v1.Pod, len(pods))
 	var wg sync.WaitGroup
 	for i, pod := range pods {
@@ -120,7 +120,7 @@ func (c *PodClient) CreateBatch(pods []*v1.Pod) []*v1.Pod {
 		go func(i int, pod *v1.Pod) {
 			defer wg.Done()
 			defer ginkgo.GinkgoRecover()
-			ps[i] = c.CreateSync(pod)
+			ps[i] = c.CreateSync(ctx, pod)
 		}(i, pod)
 	}
 	wg.Wait()
@@ -130,14 +130,14 @@ func (c *PodClient) CreateBatch(pods []*v1.Pod) []*v1.Pod {
 // Update updates the pod object. It retries if there is a conflict, throw out error if
 // there is any other apierrors. name is the pod name, updateFn is the function updating the
 // pod object.
-func (c *PodClient) Update(name string, updateFn func(pod *v1.Pod)) {
-	framework.ExpectNoError(wait.Poll(time.Millisecond*500, time.Second*30, func() (bool, error) {
-		pod, err := c.PodInterface.Get(context.TODO(), name, metav1.GetOptions{})
+func (c *PodClient) Update(ctx context.Context, name string, updateFn func(pod *v1.Pod)) {
+	framework.ExpectNoError(wait.PollWithContext(ctx, time.Millisecond*500, time.Second*30, func(ctx context.Context) (bool, error) {
+		pod, err := c.PodInterface.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("failed to get pod %q: %v", name, err)
 		}
 		updateFn(pod)
-		_, err = c.PodInterface.Update(context.TODO(), pod, metav1.UpdateOptions{})
+		_, err = c.PodInterface.Update(ctx, pod, metav1.UpdateOptions{})
 		if err == nil {
 			framework.Logf("Successfully updated pod %q", name)
 			return true, nil
@@ -151,7 +151,7 @@ func (c *PodClient) Update(name string, updateFn func(pod *v1.Pod)) {
 }
 
 // AddEphemeralContainerSync adds an EphemeralContainer to a pod and waits for it to be running.
-func (c *PodClient) AddEphemeralContainerSync(pod *v1.Pod, ec *v1.EphemeralContainer, timeout time.Duration) error {
+func (c *PodClient) AddEphemeralContainerSync(ctx context.Context, pod *v1.Pod, ec *v1.EphemeralContainer, timeout time.Duration) error {
 	namespace := c.f.Namespace.Name
 
 	podJS, err := json.Marshal(pod)
@@ -166,23 +166,23 @@ func (c *PodClient) AddEphemeralContainerSync(pod *v1.Pod, ec *v1.EphemeralConta
 	framework.ExpectNoError(err, "error creating patch to add ephemeral container %q", format.Pod(pod))
 
 	// Clients may optimistically attempt to add an ephemeral container to determine whether the EphemeralContainers feature is enabled.
-	if _, err := c.Patch(context.TODO(), pod.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "ephemeralcontainers"); err != nil {
+	if _, err := c.Patch(ctx, pod.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "ephemeralcontainers"); err != nil {
 		return err
 	}
 
-	framework.ExpectNoError(WaitForContainerRunning(c.f.ClientSet, namespace, pod.Name, ec.Name, timeout))
+	framework.ExpectNoError(WaitForContainerRunning(ctx, c.f.ClientSet, namespace, pod.Name, ec.Name, timeout))
 	return nil
 }
 
 // DeleteSync deletes the pod and wait for the pod to disappear for `timeout`. If the pod doesn't
 // disappear before the timeout, it will fail the test.
-func (c *PodClient) DeleteSync(name string, options metav1.DeleteOptions, timeout time.Duration) {
+func (c *PodClient) DeleteSync(ctx context.Context, name string, options metav1.DeleteOptions, timeout time.Duration) {
 	namespace := c.f.Namespace.Name
-	err := c.Delete(context.TODO(), name, options)
+	err := c.Delete(ctx, name, options)
 	if err != nil && !apierrors.IsNotFound(err) {
 		framework.Failf("Failed to delete pod %q: %v", name, err)
 	}
-	gomega.Expect(WaitForPodToDisappear(c.f.ClientSet, namespace, name, labels.Everything(),
+	gomega.Expect(WaitForPodToDisappear(ctx, c.f.ClientSet, namespace, name, labels.Everything(),
 		2*time.Second, timeout)).To(gomega.Succeed(), "wait for pod %q to disappear", name)
 }
 
@@ -224,9 +224,9 @@ func (c *PodClient) mungeSpec(pod *v1.Pod) {
 
 // WaitForSuccess waits for pod to succeed.
 // TODO(random-liu): Move pod wait function into this file
-func (c *PodClient) WaitForSuccess(name string, timeout time.Duration) {
+func (c *PodClient) WaitForSuccess(ctx context.Context, name string, timeout time.Duration) {
 	f := c.f
-	gomega.Expect(WaitForPodCondition(f.ClientSet, f.Namespace.Name, name, fmt.Sprintf("%s or %s", v1.PodSucceeded, v1.PodFailed), timeout,
+	gomega.Expect(WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, name, fmt.Sprintf("%s or %s", v1.PodSucceeded, v1.PodFailed), timeout,
 		func(pod *v1.Pod) (bool, error) {
 			switch pod.Status.Phase {
 			case v1.PodFailed:
@@ -241,9 +241,9 @@ func (c *PodClient) WaitForSuccess(name string, timeout time.Duration) {
 }
 
 // WaitForFinish waits for pod to finish running, regardless of success or failure.
-func (c *PodClient) WaitForFinish(name string, timeout time.Duration) {
+func (c *PodClient) WaitForFinish(ctx context.Context, name string, timeout time.Duration) {
 	f := c.f
-	gomega.Expect(WaitForPodCondition(f.ClientSet, f.Namespace.Name, name, fmt.Sprintf("%s or %s", v1.PodSucceeded, v1.PodFailed), timeout,
+	gomega.Expect(WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, name, fmt.Sprintf("%s or %s", v1.PodSucceeded, v1.PodFailed), timeout,
 		func(pod *v1.Pod) (bool, error) {
 			switch pod.Status.Phase {
 			case v1.PodFailed:
@@ -258,9 +258,9 @@ func (c *PodClient) WaitForFinish(name string, timeout time.Duration) {
 }
 
 // WaitForErrorEventOrSuccess waits for pod to succeed or an error event for that pod.
-func (c *PodClient) WaitForErrorEventOrSuccess(pod *v1.Pod) (*v1.Event, error) {
+func (c *PodClient) WaitForErrorEventOrSuccess(ctx context.Context, pod *v1.Pod) (*v1.Event, error) {
 	var ev *v1.Event
-	err := wait.Poll(framework.Poll, framework.PodStartTimeout, func() (bool, error) {
+	err := wait.PollWithContext(ctx, framework.Poll, framework.PodStartTimeout, func(ctx context.Context) (bool, error) {
 		evnts, err := c.f.ClientSet.CoreV1().Events(pod.Namespace).Search(scheme.Scheme, pod)
 		if err != nil {
 			return false, fmt.Errorf("error in listing events: %s", err)
@@ -282,9 +282,9 @@ func (c *PodClient) WaitForErrorEventOrSuccess(pod *v1.Pod) (*v1.Event, error) {
 }
 
 // MatchContainerOutput gets output of a container and match expected regexp in the output.
-func (c *PodClient) MatchContainerOutput(name string, containerName string, expectedRegexp string) error {
+func (c *PodClient) MatchContainerOutput(ctx context.Context, name string, containerName string, expectedRegexp string) error {
 	f := c.f
-	output, err := GetPodLogs(f.ClientSet, f.Namespace.Name, name, containerName)
+	output, err := GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, name, containerName)
 	if err != nil {
 		return fmt.Errorf("failed to get output for container %q of pod %q", containerName, name)
 	}
@@ -299,16 +299,16 @@ func (c *PodClient) MatchContainerOutput(name string, containerName string, expe
 }
 
 // PodIsReady returns true if the specified pod is ready. Otherwise false.
-func (c *PodClient) PodIsReady(name string) bool {
-	pod, err := c.Get(context.TODO(), name, metav1.GetOptions{})
+func (c *PodClient) PodIsReady(ctx context.Context, name string) bool {
+	pod, err := c.Get(ctx, name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	return podutils.IsPodReady(pod)
 }
 
 // RemovePodFinalizer removes the pod's finalizer
-func (c *PodClient) RemoveFinalizer(podName string, finalizerName string) {
+func (c *PodClient) RemoveFinalizer(ctx context.Context, podName string, finalizerName string) {
 	framework.Logf("Removing pod's %q finalizer: %q", podName, finalizerName)
-	c.Update(podName, func(pod *v1.Pod) {
+	c.Update(ctx, podName, func(pod *v1.Pod) {
 		pod.ObjectMeta.Finalizers = slice.RemoveString(pod.ObjectMeta.Finalizers, finalizerName, nil)
 	})
 }

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -96,10 +96,10 @@ func NewProxyResponseChecker(c clientset.Interface, ns string, label labels.Sele
 
 // CheckAllResponses issues GETs to all pods in the context and verify they
 // reply with their own pod name.
-func (r ProxyResponseChecker) CheckAllResponses() (done bool, err error) {
+func (r ProxyResponseChecker) CheckAllResponses(ctx context.Context) (done bool, err error) {
 	successes := 0
 	options := metav1.ListOptions{LabelSelector: r.label.String()}
-	currentPods, err := r.c.CoreV1().Pods(r.ns).List(context.TODO(), options)
+	currentPods, err := r.c.CoreV1().Pods(r.ns).List(ctx, options)
 	expectNoError(err, "Failed to get list of currentPods in namespace: %s", r.ns)
 	for i, pod := range r.pods.Items {
 		// Check that the replica list remains unchanged, otherwise we have problems.
@@ -107,7 +107,7 @@ func (r ProxyResponseChecker) CheckAllResponses() (done bool, err error) {
 			return false, fmt.Errorf("pod with UID %s is no longer a member of the replica set.  Must have been restarted for some reason.  Current replica set: %v", pod.UID, currentPods)
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), singleCallTimeout)
+		ctxUntil, cancel := context.WithTimeout(ctx, singleCallTimeout)
 		defer cancel()
 
 		body, err := r.c.CoreV1().RESTClient().Get().
@@ -115,11 +115,11 @@ func (r ProxyResponseChecker) CheckAllResponses() (done bool, err error) {
 			Resource("pods").
 			SubResource("proxy").
 			Name(string(pod.Name)).
-			Do(ctx).
+			Do(ctxUntil).
 			Raw()
 
 		if err != nil {
-			if ctx.Err() != nil {
+			if ctxUntil.Err() != nil {
 				// We may encounter errors here because of a race between the pod readiness and apiserver
 				// proxy. So, we log the error and retry if this occurs.
 				framework.Logf("Controller %s: Failed to Get from replica %d [%s]: %v\n pod status: %#v", r.controllerName, i+1, pod.Name, err, pod.Status)
@@ -159,19 +159,19 @@ func (r ProxyResponseChecker) CheckAllResponses() (done bool, err error) {
 }
 
 // PodsCreated returns a pod list matched by the given name.
-func PodsCreated(c clientset.Interface, ns, name string, replicas int32) (*v1.PodList, error) {
+func PodsCreated(ctx context.Context, c clientset.Interface, ns, name string, replicas int32) (*v1.PodList, error) {
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
-	return PodsCreatedByLabel(c, ns, name, replicas, label)
+	return PodsCreatedByLabel(ctx, c, ns, name, replicas, label)
 }
 
 // PodsCreatedByLabel returns a created pod list matched by the given label.
-func PodsCreatedByLabel(c clientset.Interface, ns, name string, replicas int32, label labels.Selector) (*v1.PodList, error) {
+func PodsCreatedByLabel(ctx context.Context, c clientset.Interface, ns, name string, replicas int32, label labels.Selector) (*v1.PodList, error) {
 	timeout := 2 * time.Minute
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(5 * time.Second) {
 		options := metav1.ListOptions{LabelSelector: label.String()}
 
 		// List the pods, making sure we observe all the replicas.
-		pods, err := c.CoreV1().Pods(ns).List(context.TODO(), options)
+		pods, err := c.CoreV1().Pods(ns).List(ctx, options)
 		if err != nil {
 			return nil, err
 		}
@@ -194,26 +194,26 @@ func PodsCreatedByLabel(c clientset.Interface, ns, name string, replicas int32, 
 }
 
 // VerifyPods checks if the specified pod is responding.
-func VerifyPods(c clientset.Interface, ns, name string, wantName bool, replicas int32) error {
-	return podRunningMaybeResponding(c, ns, name, wantName, replicas, true)
+func VerifyPods(ctx context.Context, c clientset.Interface, ns, name string, wantName bool, replicas int32) error {
+	return podRunningMaybeResponding(ctx, c, ns, name, wantName, replicas, true)
 }
 
 // VerifyPodsRunning checks if the specified pod is running.
-func VerifyPodsRunning(c clientset.Interface, ns, name string, wantName bool, replicas int32) error {
-	return podRunningMaybeResponding(c, ns, name, wantName, replicas, false)
+func VerifyPodsRunning(ctx context.Context, c clientset.Interface, ns, name string, wantName bool, replicas int32) error {
+	return podRunningMaybeResponding(ctx, c, ns, name, wantName, replicas, false)
 }
 
-func podRunningMaybeResponding(c clientset.Interface, ns, name string, wantName bool, replicas int32, checkResponding bool) error {
-	pods, err := PodsCreated(c, ns, name, replicas)
+func podRunningMaybeResponding(ctx context.Context, c clientset.Interface, ns, name string, wantName bool, replicas int32, checkResponding bool) error {
+	pods, err := PodsCreated(ctx, c, ns, name, replicas)
 	if err != nil {
 		return err
 	}
-	e := podsRunning(c, pods)
+	e := podsRunning(ctx, c, pods)
 	if len(e) > 0 {
 		return fmt.Errorf("failed to wait for pods running: %v", e)
 	}
 	if checkResponding {
-		err = PodsResponding(c, ns, name, wantName, pods)
+		err = PodsResponding(ctx, c, ns, name, wantName, pods)
 		if err != nil {
 			return fmt.Errorf("failed to wait for pods responding: %v", err)
 		}
@@ -221,7 +221,7 @@ func podRunningMaybeResponding(c clientset.Interface, ns, name string, wantName 
 	return nil
 }
 
-func podsRunning(c clientset.Interface, pods *v1.PodList) []error {
+func podsRunning(ctx context.Context, c clientset.Interface, pods *v1.PodList) []error {
 	// Wait for the pods to enter the running state. Waiting loops until the pods
 	// are running so non-running pods cause a timeout for this test.
 	ginkgo.By("ensuring each pod is running")
@@ -230,7 +230,7 @@ func podsRunning(c clientset.Interface, pods *v1.PodList) []error {
 
 	for _, pod := range pods.Items {
 		go func(p v1.Pod) {
-			errorChan <- WaitForPodRunningInNamespace(c, &p)
+			errorChan <- WaitForPodRunningInNamespace(ctx, c, &p)
 		}(pod)
 	}
 
@@ -302,7 +302,7 @@ func logPodTerminationMessages(pods []v1.Pod) {
 // We will log the Pods that have the LabelLogOnPodFailure label. If there aren't any, we default to
 // logging only the first 5 Pods. This requires the reportDir to be set, and the pods are logged into:
 // {report_dir}/pods/{namespace}/{pod}/{container_name}/logs.txt
-func logPodLogs(c clientset.Interface, namespace string, pods []v1.Pod, reportDir string) {
+func logPodLogs(ctx context.Context, c clientset.Interface, namespace string, pods []v1.Pod, reportDir string) {
 	if reportDir == "" {
 		return
 	}
@@ -328,7 +328,7 @@ func logPodLogs(c clientset.Interface, namespace string, pods []v1.Pod, reportDi
 	for i := 0; i < maxPods; i++ {
 		pod := logPods[i]
 		for _, container := range pod.Spec.Containers {
-			logs, err := getPodLogsInternal(c, namespace, pod.Name, container.Name, false, nil, &tailLen)
+			logs, err := getPodLogsInternal(ctx, c, namespace, pod.Name, container.Name, false, nil, &tailLen)
 			if err != nil {
 				framework.Logf("Unable to fetch %s/%s/%s logs: %v", pod.Namespace, pod.Name, container.Name, err)
 				continue
@@ -351,14 +351,14 @@ func logPodLogs(c clientset.Interface, namespace string, pods []v1.Pod, reportDi
 }
 
 // DumpAllPodInfoForNamespace logs all pod information for a given namespace.
-func DumpAllPodInfoForNamespace(c clientset.Interface, namespace, reportDir string) {
-	pods, err := c.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+func DumpAllPodInfoForNamespace(ctx context.Context, c clientset.Interface, namespace, reportDir string) {
+	pods, err := c.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		framework.Logf("unable to fetch pod debug info: %v", err)
 	}
 	LogPodStates(pods.Items)
 	logPodTerminationMessages(pods.Items)
-	logPodLogs(c, namespace, pods.Items, reportDir)
+	logPodLogs(ctx, c, namespace, pods.Items, reportDir)
 }
 
 // FilterNonRestartablePods filters out pods that will never get recreated if
@@ -459,15 +459,15 @@ func newExecPodSpec(ns, generateName string) *v1.Pod {
 
 // CreateExecPodOrFail creates a agnhost pause pod used as a vessel for kubectl exec commands.
 // Pod name is uniquely generated.
-func CreateExecPodOrFail(client clientset.Interface, ns, generateName string, tweak func(*v1.Pod)) *v1.Pod {
+func CreateExecPodOrFail(ctx context.Context, client clientset.Interface, ns, generateName string, tweak func(*v1.Pod)) *v1.Pod {
 	framework.Logf("Creating new exec pod")
 	pod := newExecPodSpec(ns, generateName)
 	if tweak != nil {
 		tweak(pod)
 	}
-	execPod, err := client.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+	execPod, err := client.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 	expectNoError(err, "failed to create new exec pod in namespace: %s", ns)
-	err = WaitForPodNameRunningInNamespace(client, execPod.Name, execPod.Namespace)
+	err = WaitForPodNameRunningInNamespace(ctx, client, execPod.Name, execPod.Namespace)
 	expectNoError(err, "failed to create new exec pod in namespace: %s", ns)
 	return execPod
 }
@@ -497,20 +497,20 @@ func WithWindowsHostProcess(pod *v1.Pod, username string) {
 // CheckPodsRunningReady returns whether all pods whose names are listed in
 // podNames in namespace ns are running and ready, using c and waiting at most
 // timeout.
-func CheckPodsRunningReady(c clientset.Interface, ns string, podNames []string, timeout time.Duration) bool {
-	return checkPodsCondition(c, ns, podNames, timeout, testutils.PodRunningReady, "running and ready")
+func CheckPodsRunningReady(ctx context.Context, c clientset.Interface, ns string, podNames []string, timeout time.Duration) bool {
+	return checkPodsCondition(ctx, c, ns, podNames, timeout, testutils.PodRunningReady, "running and ready")
 }
 
 // CheckPodsRunningReadyOrSucceeded returns whether all pods whose names are
 // listed in podNames in namespace ns are running and ready, or succeeded; use
 // c and waiting at most timeout.
-func CheckPodsRunningReadyOrSucceeded(c clientset.Interface, ns string, podNames []string, timeout time.Duration) bool {
-	return checkPodsCondition(c, ns, podNames, timeout, testutils.PodRunningReadyOrSucceeded, "running and ready, or succeeded")
+func CheckPodsRunningReadyOrSucceeded(ctx context.Context, c clientset.Interface, ns string, podNames []string, timeout time.Duration) bool {
+	return checkPodsCondition(ctx, c, ns, podNames, timeout, testutils.PodRunningReadyOrSucceeded, "running and ready, or succeeded")
 }
 
 // checkPodsCondition returns whether all pods whose names are listed in podNames
 // in namespace ns are in the condition, using c and waiting at most timeout.
-func checkPodsCondition(c clientset.Interface, ns string, podNames []string, timeout time.Duration, condition podCondition, desc string) bool {
+func checkPodsCondition(ctx context.Context, c clientset.Interface, ns string, podNames []string, timeout time.Duration, condition podCondition, desc string) bool {
 	np := len(podNames)
 	framework.Logf("Waiting up to %v for %d pods to be %s: %s", timeout, np, desc, podNames)
 	type waitPodResult struct {
@@ -521,7 +521,7 @@ func checkPodsCondition(c clientset.Interface, ns string, podNames []string, tim
 	for _, podName := range podNames {
 		// Launch off pod readiness checkers.
 		go func(name string) {
-			err := WaitForPodCondition(c, ns, name, desc, timeout, condition)
+			err := WaitForPodCondition(ctx, c, ns, name, desc, timeout, condition)
 			result <- waitPodResult{err == nil, name}
 		}(podName)
 	}
@@ -539,24 +539,24 @@ func checkPodsCondition(c clientset.Interface, ns string, podNames []string, tim
 }
 
 // GetPodLogs returns the logs of the specified container (namespace/pod/container).
-func GetPodLogs(c clientset.Interface, namespace, podName, containerName string) (string, error) {
-	return getPodLogsInternal(c, namespace, podName, containerName, false, nil, nil)
+func GetPodLogs(ctx context.Context, c clientset.Interface, namespace, podName, containerName string) (string, error) {
+	return getPodLogsInternal(ctx, c, namespace, podName, containerName, false, nil, nil)
 }
 
 // GetPodLogsSince returns the logs of the specified container (namespace/pod/container) since a timestamp.
-func GetPodLogsSince(c clientset.Interface, namespace, podName, containerName string, since time.Time) (string, error) {
+func GetPodLogsSince(ctx context.Context, c clientset.Interface, namespace, podName, containerName string, since time.Time) (string, error) {
 	sinceTime := metav1.NewTime(since)
-	return getPodLogsInternal(c, namespace, podName, containerName, false, &sinceTime, nil)
+	return getPodLogsInternal(ctx, c, namespace, podName, containerName, false, &sinceTime, nil)
 }
 
 // GetPreviousPodLogs returns the logs of the previous instance of the
 // specified container (namespace/pod/container).
-func GetPreviousPodLogs(c clientset.Interface, namespace, podName, containerName string) (string, error) {
-	return getPodLogsInternal(c, namespace, podName, containerName, true, nil, nil)
+func GetPreviousPodLogs(ctx context.Context, c clientset.Interface, namespace, podName, containerName string) (string, error) {
+	return getPodLogsInternal(ctx, c, namespace, podName, containerName, true, nil, nil)
 }
 
 // utility function for gomega Eventually
-func getPodLogsInternal(c clientset.Interface, namespace, podName, containerName string, previous bool, sinceTime *metav1.Time, tailLines *int) (string, error) {
+func getPodLogsInternal(ctx context.Context, c clientset.Interface, namespace, podName, containerName string, previous bool, sinceTime *metav1.Time, tailLines *int) (string, error) {
 	request := c.CoreV1().RESTClient().Get().
 		Resource("pods").
 		Namespace(namespace).
@@ -569,7 +569,7 @@ func getPodLogsInternal(c clientset.Interface, namespace, podName, containerName
 	if tailLines != nil {
 		request.Param("tailLines", strconv.Itoa(*tailLines))
 	}
-	logs, err := request.Do(context.TODO()).Raw()
+	logs, err := request.Do(ctx).Raw()
 	if err != nil {
 		return "", err
 	}
@@ -580,8 +580,8 @@ func getPodLogsInternal(c clientset.Interface, namespace, podName, containerName
 }
 
 // GetPodsInNamespace returns the pods in the given namespace.
-func GetPodsInNamespace(c clientset.Interface, ns string, ignoreLabels map[string]string) ([]*v1.Pod, error) {
-	pods, err := c.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{})
+func GetPodsInNamespace(ctx context.Context, c clientset.Interface, ns string, ignoreLabels map[string]string) ([]*v1.Pod, error) {
+	pods, err := c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return []*v1.Pod{}, err
 	}
@@ -598,10 +598,10 @@ func GetPodsInNamespace(c clientset.Interface, ns string, ignoreLabels map[strin
 }
 
 // GetPods return the label matched pods in the given ns
-func GetPods(c clientset.Interface, ns string, matchLabels map[string]string) ([]v1.Pod, error) {
+func GetPods(ctx context.Context, c clientset.Interface, ns string, matchLabels map[string]string) ([]v1.Pod, error) {
 	label := labels.SelectorFromSet(matchLabels)
 	listOpts := metav1.ListOptions{LabelSelector: label.String()}
-	pods, err := c.CoreV1().Pods(ns).List(context.TODO(), listOpts)
+	pods, err := c.CoreV1().Pods(ns).List(ctx, listOpts)
 	if err != nil {
 		return []v1.Pod{}, err
 	}
@@ -609,13 +609,13 @@ func GetPods(c clientset.Interface, ns string, matchLabels map[string]string) ([
 }
 
 // GetPodSecretUpdateTimeout returns the timeout duration for updating pod secret.
-func GetPodSecretUpdateTimeout(c clientset.Interface) time.Duration {
+func GetPodSecretUpdateTimeout(ctx context.Context, c clientset.Interface) time.Duration {
 	// With SecretManager(ConfigMapManager), we may have to wait up to full sync period +
 	// TTL of secret(configmap) to elapse before the Kubelet projects the update into the
 	// volume and the container picks it up.
 	// So this timeout is based on default Kubelet sync period (1 minute) + maximum TTL for
 	// secret(configmap) that's based on cluster size + additional time as a fudge factor.
-	secretTTL, err := getNodeTTLAnnotationValue(c)
+	secretTTL, err := getNodeTTLAnnotationValue(ctx, c)
 	if err != nil {
 		framework.Logf("Couldn't get node TTL annotation (using default value of 0): %v", err)
 	}
@@ -624,16 +624,16 @@ func GetPodSecretUpdateTimeout(c clientset.Interface) time.Duration {
 }
 
 // VerifyPodHasConditionWithType verifies the pod has the expected condition by type
-func VerifyPodHasConditionWithType(f *framework.Framework, pod *v1.Pod, cType v1.PodConditionType) {
-	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+func VerifyPodHasConditionWithType(ctx context.Context, f *framework.Framework, pod *v1.Pod, cType v1.PodConditionType) {
+	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err, "Failed to get the recent pod object for name: %q", pod.Name)
 	if condition := FindPodConditionByType(&pod.Status, cType); condition == nil {
 		framework.Failf("pod %q should have the condition: %q, pod status: %v", pod.Name, cType, pod.Status)
 	}
 }
 
-func getNodeTTLAnnotationValue(c clientset.Interface) (time.Duration, error) {
-	nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+func getNodeTTLAnnotationValue(ctx context.Context, c clientset.Interface) (time.Duration, error) {
+	nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil || len(nodes.Items) == 0 {
 		return time.Duration(0), fmt.Errorf("Couldn't list any nodes to get TTL annotation: %v", err)
 	}

--- a/test/e2e/framework/pod/resource_test.go
+++ b/test/e2e/framework/pod/resource_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -52,7 +53,7 @@ func TestGetPodsInNamespace(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cs := fakeclient.NewSimpleClientset(tt.pods...)
-			got, err := GetPodsInNamespace(cs, "", map[string]string{})
+			got, err := GetPodsInNamespace(context.Background(), cs, "", map[string]string{})
 			if (err != nil) != tt.expectErr {
 				t.Errorf("expectErr = %v, but got err = %v", tt.expectErr, err)
 			}

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -180,7 +180,7 @@ func errorBadPodsStates(badPods []v1.Pod, desiredPods int, ns, desiredState stri
 //
 // If minPods or allowedNotReadyPods are -1, this method returns immediately
 // without waiting.
-func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods, allowedNotReadyPods int32, timeout time.Duration, ignoreLabels map[string]string) error {
+func WaitForPodsRunningReady(ctx context.Context, c clientset.Interface, ns string, minPods, allowedNotReadyPods int32, timeout time.Duration, ignoreLabels map[string]string) error {
 	if minPods == -1 || allowedNotReadyPods == -1 {
 		return nil
 	}
@@ -195,7 +195,7 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods, allowedN
 	notReady := int32(0)
 	var lastAPIError error
 
-	if wait.PollImmediate(poll, timeout, func() (bool, error) {
+	if wait.PollImmediateWithContext(ctx, poll, timeout, func(ctx context.Context) (bool, error) {
 		// We get the new list of pods, replication controllers, and
 		// replica sets in every iteration because more pods come
 		// online during startup and we want to ensure they are also
@@ -204,7 +204,7 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods, allowedN
 		// Clear API error from the last attempt in case the following calls succeed.
 		lastAPIError = nil
 
-		rcList, err := c.CoreV1().ReplicationControllers(ns).List(context.TODO(), metav1.ListOptions{})
+		rcList, err := c.CoreV1().ReplicationControllers(ns).List(ctx, metav1.ListOptions{})
 		lastAPIError = err
 		if err != nil {
 			return handleWaitingAPIError(err, false, "listing replication controllers in namespace %s", ns)
@@ -214,7 +214,7 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods, allowedN
 			replicaOk += rc.Status.ReadyReplicas
 		}
 
-		rsList, err := c.AppsV1().ReplicaSets(ns).List(context.TODO(), metav1.ListOptions{})
+		rsList, err := c.AppsV1().ReplicaSets(ns).List(ctx, metav1.ListOptions{})
 		lastAPIError = err
 		if err != nil {
 			return handleWaitingAPIError(err, false, "listing replication sets in namespace %s", ns)
@@ -224,7 +224,7 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods, allowedN
 			replicaOk += rs.Status.ReadyReplicas
 		}
 
-		podList, err := c.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{})
+		podList, err := c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
 		lastAPIError = err
 		if err != nil {
 			return handleWaitingAPIError(err, false, "listing pods in namespace %s", ns)
@@ -280,15 +280,15 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods, allowedN
 // WaitForPodCondition waits a pods to be matched to the given condition.
 // If the condition callback returns an error that matches FinalErr (checked with IsFinal),
 // then polling aborts early.
-func WaitForPodCondition(c clientset.Interface, ns, podName, conditionDesc string, timeout time.Duration, condition podCondition) error {
+func WaitForPodCondition(ctx context.Context, c clientset.Interface, ns, podName, conditionDesc string, timeout time.Duration, condition podCondition) error {
 	framework.Logf("Waiting up to %v for pod %q in namespace %q to be %q", timeout, podName, ns, conditionDesc)
 	var (
 		lastPodError error
 		lastPod      *v1.Pod
 		start        = time.Now()
 	)
-	err := wait.PollImmediate(poll, timeout, func() (bool, error) {
-		pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+	err := wait.PollImmediateWithContext(ctx, poll, timeout, func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
 		lastPodError = err
 		if err != nil {
 			return handleWaitingAPIError(err, true, "getting pod %s", podIdentifier(ns, podName))
@@ -329,12 +329,12 @@ func WaitForPodCondition(c clientset.Interface, ns, podName, conditionDesc strin
 
 // WaitForAllPodsCondition waits for the listed pods to match the given condition.
 // To succeed, at least minPods must be listed, and all listed pods must match the condition.
-func WaitForAllPodsCondition(c clientset.Interface, ns string, opts metav1.ListOptions, minPods int, conditionDesc string, timeout time.Duration, condition podCondition) (*v1.PodList, error) {
+func WaitForAllPodsCondition(ctx context.Context, c clientset.Interface, ns string, opts metav1.ListOptions, minPods int, conditionDesc string, timeout time.Duration, condition podCondition) (*v1.PodList, error) {
 	framework.Logf("Waiting up to %v for at least %d pods in namespace %s to be %s", timeout, minPods, ns, conditionDesc)
 	var pods *v1.PodList
 	matched := 0
-	err := wait.PollImmediate(poll, timeout, func() (done bool, err error) {
-		pods, err = c.CoreV1().Pods(ns).List(context.TODO(), opts)
+	err := wait.PollImmediateWithContext(ctx, poll, timeout, func(ctx context.Context) (done bool, err error) {
+		pods, err = c.CoreV1().Pods(ns).List(ctx, opts)
 		if err != nil {
 			return handleWaitingAPIError(err, true, "listing pods")
 		}
@@ -440,8 +440,8 @@ func WaitForPodsWithSchedulingGates(c clientset.Interface, ns string, num int, t
 // terminate) with an unexpected reason. Typically called to test that the passed-in pod is fully
 // terminated (reason==""), but may be called to detect if a pod did *not* terminate according to
 // the supplied reason.
-func WaitForPodTerminatedInNamespace(c clientset.Interface, podName, reason, namespace string) error {
-	return WaitForPodCondition(c, namespace, podName, fmt.Sprintf("terminated with reason %s", reason), podStartTimeout, func(pod *v1.Pod) (bool, error) {
+func WaitForPodTerminatedInNamespace(ctx context.Context, c clientset.Interface, podName, reason, namespace string) error {
+	return WaitForPodCondition(ctx, c, namespace, podName, fmt.Sprintf("terminated with reason %s", reason), podStartTimeout, func(pod *v1.Pod) (bool, error) {
 		// Only consider Failed pods. Successful pods will be deleted and detected in
 		// waitForPodCondition's Get call returning `IsNotFound`
 		if pod.Status.Phase == v1.PodFailed {
@@ -455,8 +455,8 @@ func WaitForPodTerminatedInNamespace(c clientset.Interface, podName, reason, nam
 }
 
 // WaitForPodTerminatingInNamespaceTimeout returns if the pod is terminating, or an error if it is not after the timeout.
-func WaitForPodTerminatingInNamespaceTimeout(c clientset.Interface, podName, namespace string, timeout time.Duration) error {
-	return WaitForPodCondition(c, namespace, podName, "is terminating", timeout, func(pod *v1.Pod) (bool, error) {
+func WaitForPodTerminatingInNamespaceTimeout(ctx context.Context, c clientset.Interface, podName, namespace string, timeout time.Duration) error {
+	return WaitForPodCondition(ctx, c, namespace, podName, "is terminating", timeout, func(pod *v1.Pod) (bool, error) {
 		if pod.DeletionTimestamp != nil {
 			return true, nil
 		}
@@ -465,8 +465,8 @@ func WaitForPodTerminatingInNamespaceTimeout(c clientset.Interface, podName, nam
 }
 
 // WaitForPodSuccessInNamespaceTimeout returns nil if the pod reached state success, or an error if it reached failure or ran too long.
-func WaitForPodSuccessInNamespaceTimeout(c clientset.Interface, podName, namespace string, timeout time.Duration) error {
-	return WaitForPodCondition(c, namespace, podName, fmt.Sprintf("%s or %s", v1.PodSucceeded, v1.PodFailed), timeout, func(pod *v1.Pod) (bool, error) {
+func WaitForPodSuccessInNamespaceTimeout(ctx context.Context, c clientset.Interface, podName, namespace string, timeout time.Duration) error {
+	return WaitForPodCondition(ctx, c, namespace, podName, fmt.Sprintf("%s or %s", v1.PodSucceeded, v1.PodFailed), timeout, func(pod *v1.Pod) (bool, error) {
 		if pod.Spec.RestartPolicy == v1.RestartPolicyAlways {
 			return true, fmt.Errorf("pod %q will never terminate with a succeeded state since its restart policy is Always", podName)
 		}
@@ -486,8 +486,8 @@ func WaitForPodSuccessInNamespaceTimeout(c clientset.Interface, podName, namespa
 // and have condition Status equal to Unschedulable,
 // if the pod Get api returns an error (IsNotFound or other), or if the pod failed with an unexpected reason.
 // Typically called to test that the passed-in pod is Pending and Unschedulable.
-func WaitForPodNameUnschedulableInNamespace(c clientset.Interface, podName, namespace string) error {
-	return WaitForPodCondition(c, namespace, podName, v1.PodReasonUnschedulable, podStartTimeout, func(pod *v1.Pod) (bool, error) {
+func WaitForPodNameUnschedulableInNamespace(ctx context.Context, c clientset.Interface, podName, namespace string) error {
+	return WaitForPodCondition(ctx, c, namespace, podName, v1.PodReasonUnschedulable, podStartTimeout, func(pod *v1.Pod) (bool, error) {
 		// Only consider Failed pods. Successful pods will be deleted and detected in
 		// waitForPodCondition's Get call returning `IsNotFound`
 		if pod.Status.Phase == v1.PodPending {
@@ -506,20 +506,20 @@ func WaitForPodNameUnschedulableInNamespace(c clientset.Interface, podName, name
 
 // WaitForPodNameRunningInNamespace waits default amount of time (PodStartTimeout) for the specified pod to become running.
 // Returns an error if timeout occurs first, or pod goes in to failed state.
-func WaitForPodNameRunningInNamespace(c clientset.Interface, podName, namespace string) error {
-	return WaitTimeoutForPodRunningInNamespace(c, podName, namespace, podStartTimeout)
+func WaitForPodNameRunningInNamespace(ctx context.Context, c clientset.Interface, podName, namespace string) error {
+	return WaitTimeoutForPodRunningInNamespace(ctx, c, podName, namespace, podStartTimeout)
 }
 
 // WaitForPodRunningInNamespaceSlow waits an extended amount of time (slowPodStartTimeout) for the specified pod to become running.
 // The resourceVersion is used when Watching object changes, it tells since when we care
 // about changes to the pod. Returns an error if timeout occurs first, or pod goes in to failed state.
-func WaitForPodRunningInNamespaceSlow(c clientset.Interface, podName, namespace string) error {
-	return WaitTimeoutForPodRunningInNamespace(c, podName, namespace, slowPodStartTimeout)
+func WaitForPodRunningInNamespaceSlow(ctx context.Context, c clientset.Interface, podName, namespace string) error {
+	return WaitTimeoutForPodRunningInNamespace(ctx, c, podName, namespace, slowPodStartTimeout)
 }
 
 // WaitTimeoutForPodRunningInNamespace waits the given timeout duration for the specified pod to become running.
-func WaitTimeoutForPodRunningInNamespace(c clientset.Interface, podName, namespace string, timeout time.Duration) error {
-	return WaitForPodCondition(c, namespace, podName, "running", timeout, func(pod *v1.Pod) (bool, error) {
+func WaitTimeoutForPodRunningInNamespace(ctx context.Context, c clientset.Interface, podName, namespace string, timeout time.Duration) error {
+	return WaitForPodCondition(ctx, c, namespace, podName, "running", timeout, func(pod *v1.Pod) (bool, error) {
 		switch pod.Status.Phase {
 		case v1.PodRunning:
 			return true, nil
@@ -534,16 +534,16 @@ func WaitTimeoutForPodRunningInNamespace(c clientset.Interface, podName, namespa
 
 // WaitForPodRunningInNamespace waits default amount of time (podStartTimeout) for the specified pod to become running.
 // Returns an error if timeout occurs first, or pod goes in to failed state.
-func WaitForPodRunningInNamespace(c clientset.Interface, pod *v1.Pod) error {
+func WaitForPodRunningInNamespace(ctx context.Context, c clientset.Interface, pod *v1.Pod) error {
 	if pod.Status.Phase == v1.PodRunning {
 		return nil
 	}
-	return WaitTimeoutForPodRunningInNamespace(c, pod.Name, pod.Namespace, podStartTimeout)
+	return WaitTimeoutForPodRunningInNamespace(ctx, c, pod.Name, pod.Namespace, podStartTimeout)
 }
 
 // WaitTimeoutForPodNoLongerRunningInNamespace waits the given timeout duration for the specified pod to stop.
-func WaitTimeoutForPodNoLongerRunningInNamespace(c clientset.Interface, podName, namespace string, timeout time.Duration) error {
-	return WaitForPodCondition(c, namespace, podName, "completed", timeout, func(pod *v1.Pod) (bool, error) {
+func WaitTimeoutForPodNoLongerRunningInNamespace(ctx context.Context, c clientset.Interface, podName, namespace string, timeout time.Duration) error {
+	return WaitForPodCondition(ctx, c, namespace, podName, "completed", timeout, func(pod *v1.Pod) (bool, error) {
 		switch pod.Status.Phase {
 		case v1.PodFailed, v1.PodSucceeded:
 			return true, nil
@@ -554,14 +554,14 @@ func WaitTimeoutForPodNoLongerRunningInNamespace(c clientset.Interface, podName,
 
 // WaitForPodNoLongerRunningInNamespace waits default amount of time (defaultPodDeletionTimeout) for the specified pod to stop running.
 // Returns an error if timeout occurs first.
-func WaitForPodNoLongerRunningInNamespace(c clientset.Interface, podName, namespace string) error {
-	return WaitTimeoutForPodNoLongerRunningInNamespace(c, podName, namespace, defaultPodDeletionTimeout)
+func WaitForPodNoLongerRunningInNamespace(ctx context.Context, c clientset.Interface, podName, namespace string) error {
+	return WaitTimeoutForPodNoLongerRunningInNamespace(ctx, c, podName, namespace, defaultPodDeletionTimeout)
 }
 
 // WaitTimeoutForPodReadyInNamespace waits the given timeout duration for the
 // specified pod to be ready and running.
-func WaitTimeoutForPodReadyInNamespace(c clientset.Interface, podName, namespace string, timeout time.Duration) error {
-	return WaitForPodCondition(c, namespace, podName, "running and ready", timeout, func(pod *v1.Pod) (bool, error) {
+func WaitTimeoutForPodReadyInNamespace(ctx context.Context, c clientset.Interface, podName, namespace string, timeout time.Duration) error {
+	return WaitForPodCondition(ctx, c, namespace, podName, "running and ready", timeout, func(pod *v1.Pod) (bool, error) {
 		switch pod.Status.Phase {
 		case v1.PodFailed:
 			framework.Logf("The phase of Pod %s is %s which is unexpected, pod status: %#v", pod.Name, pod.Status.Phase, pod.Status)
@@ -581,8 +581,8 @@ func WaitTimeoutForPodReadyInNamespace(c clientset.Interface, podName, namespace
 // WaitForPodNotPending returns an error if it took too long for the pod to go out of pending state.
 // The resourceVersion is used when Watching object changes, it tells since when we care
 // about changes to the pod.
-func WaitForPodNotPending(c clientset.Interface, ns, podName string) error {
-	return WaitForPodCondition(c, ns, podName, "not pending", podStartTimeout, func(pod *v1.Pod) (bool, error) {
+func WaitForPodNotPending(ctx context.Context, c clientset.Interface, ns, podName string) error {
+	return WaitForPodCondition(ctx, c, ns, podName, "not pending", podStartTimeout, func(pod *v1.Pod) (bool, error) {
 		switch pod.Status.Phase {
 		case v1.PodPending:
 			return false, nil
@@ -593,23 +593,23 @@ func WaitForPodNotPending(c clientset.Interface, ns, podName string) error {
 }
 
 // WaitForPodSuccessInNamespace returns nil if the pod reached state success, or an error if it reached failure or until podStartupTimeout.
-func WaitForPodSuccessInNamespace(c clientset.Interface, podName string, namespace string) error {
-	return WaitForPodSuccessInNamespaceTimeout(c, podName, namespace, podStartTimeout)
+func WaitForPodSuccessInNamespace(ctx context.Context, c clientset.Interface, podName string, namespace string) error {
+	return WaitForPodSuccessInNamespaceTimeout(ctx, c, podName, namespace, podStartTimeout)
 }
 
 // WaitForPodSuccessInNamespaceSlow returns nil if the pod reached state success, or an error if it reached failure or until slowPodStartupTimeout.
-func WaitForPodSuccessInNamespaceSlow(c clientset.Interface, podName string, namespace string) error {
-	return WaitForPodSuccessInNamespaceTimeout(c, podName, namespace, slowPodStartTimeout)
+func WaitForPodSuccessInNamespaceSlow(ctx context.Context, c clientset.Interface, podName string, namespace string) error {
+	return WaitForPodSuccessInNamespaceTimeout(ctx, c, podName, namespace, slowPodStartTimeout)
 }
 
 // WaitForPodNotFoundInNamespace returns an error if it takes too long for the pod to fully terminate.
 // Unlike `waitForPodTerminatedInNamespace`, the pod's Phase and Reason are ignored. If the pod Get
 // api returns IsNotFound then the wait stops and nil is returned. If the Get api returns an error other
 // than "not found" then that error is returned and the wait stops.
-func WaitForPodNotFoundInNamespace(c clientset.Interface, podName, ns string, timeout time.Duration) error {
+func WaitForPodNotFoundInNamespace(ctx context.Context, c clientset.Interface, podName, ns string, timeout time.Duration) error {
 	var lastPod *v1.Pod
-	err := wait.PollImmediate(poll, timeout, func() (bool, error) {
-		pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+	err := wait.PollImmediateWithContext(ctx, poll, timeout, func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil // done
 		}
@@ -631,12 +631,12 @@ func WaitForPodNotFoundInNamespace(c clientset.Interface, podName, ns string, ti
 }
 
 // WaitForPodToDisappear waits the given timeout duration for the specified pod to disappear.
-func WaitForPodToDisappear(c clientset.Interface, ns, podName string, label labels.Selector, interval, timeout time.Duration) error {
+func WaitForPodToDisappear(ctx context.Context, c clientset.Interface, ns, podName string, label labels.Selector, interval, timeout time.Duration) error {
 	var lastPod *v1.Pod
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+	err := wait.PollImmediateWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
 		framework.Logf("Waiting for pod %s to disappear", podName)
 		options := metav1.ListOptions{LabelSelector: label.String()}
-		pods, err := c.CoreV1().Pods(ns).List(context.TODO(), options)
+		pods, err := c.CoreV1().Pods(ns).List(ctx, options)
 		if err != nil {
 			return handleWaitingAPIError(err, true, "listing pods")
 		}
@@ -667,20 +667,20 @@ func WaitForPodToDisappear(c clientset.Interface, ns, podName string, label labe
 }
 
 // PodsResponding waits for the pods to response.
-func PodsResponding(c clientset.Interface, ns, name string, wantName bool, pods *v1.PodList) error {
+func PodsResponding(ctx context.Context, c clientset.Interface, ns, name string, wantName bool, pods *v1.PodList) error {
 	ginkgo.By("trying to dial each unique pod")
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
-	err := wait.PollImmediate(poll, podRespondingTimeout, NewProxyResponseChecker(c, ns, label, name, wantName, pods).CheckAllResponses)
+	err := wait.PollImmediateWithContext(ctx, poll, podRespondingTimeout, NewProxyResponseChecker(c, ns, label, name, wantName, pods).CheckAllResponses)
 	return maybeTimeoutError(err, "waiting for pods to be responsive")
 }
 
 // WaitForNumberOfPods waits up to timeout to ensure there are exact
 // `num` pods in namespace `ns`.
 // It returns the matching Pods or a timeout error.
-func WaitForNumberOfPods(c clientset.Interface, ns string, num int, timeout time.Duration) (pods *v1.PodList, err error) {
+func WaitForNumberOfPods(ctx context.Context, c clientset.Interface, ns string, num int, timeout time.Duration) (pods *v1.PodList, err error) {
 	actualNum := 0
-	err = wait.PollImmediate(poll, timeout, func() (bool, error) {
-		pods, err = c.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{})
+	err = wait.PollImmediateWithContext(ctx, poll, timeout, func(ctx context.Context) (bool, error) {
+		pods, err = c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return handleWaitingAPIError(err, false, "listing pods")
 		}
@@ -692,9 +692,9 @@ func WaitForNumberOfPods(c clientset.Interface, ns string, num int, timeout time
 
 // WaitForPodsWithLabelScheduled waits for all matching pods to become scheduled and at least one
 // matching pod exists.  Return the list of matching pods.
-func WaitForPodsWithLabelScheduled(c clientset.Interface, ns string, label labels.Selector) (pods *v1.PodList, err error) {
+func WaitForPodsWithLabelScheduled(ctx context.Context, c clientset.Interface, ns string, label labels.Selector) (pods *v1.PodList, err error) {
 	opts := metav1.ListOptions{LabelSelector: label.String()}
-	return WaitForAllPodsCondition(c, ns, opts, 1, "scheduled", podScheduledBeforeTimeout, func(pod *v1.Pod) (bool, error) {
+	return WaitForAllPodsCondition(ctx, c, ns, opts, 1, "scheduled", podScheduledBeforeTimeout, func(pod *v1.Pod) (bool, error) {
 		if pod.Spec.NodeName == "" {
 			return false, nil
 		}
@@ -703,26 +703,26 @@ func WaitForPodsWithLabelScheduled(c clientset.Interface, ns string, label label
 }
 
 // WaitForPodsWithLabel waits up to podListTimeout for getting pods with certain label
-func WaitForPodsWithLabel(c clientset.Interface, ns string, label labels.Selector) (*v1.PodList, error) {
+func WaitForPodsWithLabel(ctx context.Context, c clientset.Interface, ns string, label labels.Selector) (*v1.PodList, error) {
 	opts := metav1.ListOptions{LabelSelector: label.String()}
-	return WaitForAllPodsCondition(c, ns, opts, 1, "existent", podListTimeout, func(pod *v1.Pod) (bool, error) {
+	return WaitForAllPodsCondition(ctx, c, ns, opts, 1, "existent", podListTimeout, func(pod *v1.Pod) (bool, error) {
 		return true, nil
 	})
 }
 
 // WaitForPodsWithLabelRunningReady waits for exact amount of matching pods to become running and ready.
 // Return the list of matching pods.
-func WaitForPodsWithLabelRunningReady(c clientset.Interface, ns string, label labels.Selector, num int, timeout time.Duration) (pods *v1.PodList, err error) {
+func WaitForPodsWithLabelRunningReady(ctx context.Context, c clientset.Interface, ns string, label labels.Selector, num int, timeout time.Duration) (pods *v1.PodList, err error) {
 	opts := metav1.ListOptions{LabelSelector: label.String()}
-	return WaitForAllPodsCondition(c, ns, opts, 1, "running and ready", timeout, testutils.PodRunningReady)
+	return WaitForAllPodsCondition(ctx, c, ns, opts, 1, "running and ready", timeout, testutils.PodRunningReady)
 }
 
 // WaitForNRestartablePods tries to list restarting pods using ps until it finds expect of them,
 // returning their names if it can do so before timeout.
-func WaitForNRestartablePods(ps *testutils.PodStore, expect int, timeout time.Duration) ([]string, error) {
+func WaitForNRestartablePods(ctx context.Context, ps *testutils.PodStore, expect int, timeout time.Duration) ([]string, error) {
 	var pods []*v1.Pod
 	var errLast error
-	found := wait.Poll(poll, timeout, func() (bool, error) {
+	found := wait.PollWithContext(ctx, poll, timeout, func(ctx context.Context) (bool, error) {
 		allPods := ps.List()
 		pods = FilterNonRestartablePods(allPods)
 		if len(pods) != expect {
@@ -746,9 +746,9 @@ func WaitForNRestartablePods(ps *testutils.PodStore, expect int, timeout time.Du
 // WaitForPodContainerToFail waits for the given Pod container to fail with the given reason, specifically due to
 // invalid container configuration. In this case, the container will remain in a waiting state with a specific
 // reason set, which should match the given reason.
-func WaitForPodContainerToFail(c clientset.Interface, namespace, podName string, containerIndex int, reason string, timeout time.Duration) error {
+func WaitForPodContainerToFail(ctx context.Context, c clientset.Interface, namespace, podName string, containerIndex int, reason string, timeout time.Duration) error {
 	conditionDesc := fmt.Sprintf("container %d failed with reason %s", containerIndex, reason)
-	return WaitForPodCondition(c, namespace, podName, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
+	return WaitForPodCondition(ctx, c, namespace, podName, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
 		switch pod.Status.Phase {
 		case v1.PodPending:
 			if len(pod.Status.ContainerStatuses) == 0 {
@@ -767,9 +767,9 @@ func WaitForPodContainerToFail(c clientset.Interface, namespace, podName string,
 }
 
 // WaitForPodContainerStarted waits for the given Pod container to start, after a successful run of the startupProbe.
-func WaitForPodContainerStarted(c clientset.Interface, namespace, podName string, containerIndex int, timeout time.Duration) error {
+func WaitForPodContainerStarted(ctx context.Context, c clientset.Interface, namespace, podName string, containerIndex int, timeout time.Duration) error {
 	conditionDesc := fmt.Sprintf("container %d started", containerIndex)
-	return WaitForPodCondition(c, namespace, podName, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
+	return WaitForPodCondition(ctx, c, namespace, podName, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
 		if containerIndex > len(pod.Status.ContainerStatuses)-1 {
 			return false, nil
 		}
@@ -779,9 +779,9 @@ func WaitForPodContainerStarted(c clientset.Interface, namespace, podName string
 }
 
 // WaitForPodFailedReason wait for pod failed reason in status, for example "SysctlForbidden".
-func WaitForPodFailedReason(c clientset.Interface, pod *v1.Pod, reason string, timeout time.Duration) error {
+func WaitForPodFailedReason(ctx context.Context, c clientset.Interface, pod *v1.Pod, reason string, timeout time.Duration) error {
 	conditionDesc := fmt.Sprintf("failed with reason %s", reason)
-	return WaitForPodCondition(c, pod.Namespace, pod.Name, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
+	return WaitForPodCondition(ctx, c, pod.Namespace, pod.Name, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
 		switch pod.Status.Phase {
 		case v1.PodSucceeded:
 			return true, errors.New("pod succeeded unexpectedly")
@@ -797,9 +797,9 @@ func WaitForPodFailedReason(c clientset.Interface, pod *v1.Pod, reason string, t
 }
 
 // WaitForContainerRunning waits for the given Pod container to have a state of running
-func WaitForContainerRunning(c clientset.Interface, namespace, podName, containerName string, timeout time.Duration) error {
+func WaitForContainerRunning(ctx context.Context, c clientset.Interface, namespace, podName, containerName string, timeout time.Duration) error {
 	conditionDesc := fmt.Sprintf("container %s running", containerName)
-	return WaitForPodCondition(c, namespace, podName, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
+	return WaitForPodCondition(ctx, c, namespace, podName, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
 		for _, statuses := range [][]v1.ContainerStatus{pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses, pod.Status.EphemeralContainerStatuses} {
 			for _, cs := range statuses {
 				if cs.Name == containerName {

--- a/test/e2e/framework/pod/wait_test.go
+++ b/test/e2e/framework/pod/wait_test.go
@@ -53,11 +53,11 @@ import (
 
 var _ = ginkgo.Describe("pod", func() {
 	ginkgo.It("not found", func(ctx context.Context) {
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(clientSet, "no-such-pod", "default", timeout /* no explanation here to cover that code path */))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(ctx, clientSet, "no-such-pod", "default", timeout /* no explanation here to cover that code path */))
 	})
 
 	ginkgo.It("not running", func(ctx context.Context) {
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(clientSet, podName, podNamespace, timeout), "wait for pod %s running", podName /* tests printf formatting */)
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(ctx, clientSet, podName, podNamespace, timeout), "wait for pod %s running", podName /* tests printf formatting */)
 	})
 })
 

--- a/test/e2e/framework/provider.go
+++ b/test/e2e/framework/provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -100,12 +101,12 @@ type ProviderInterface interface {
 	CreateShare() (string, string, string, error)
 	DeleteShare(accountName, shareName string) error
 
-	CreatePVSource(zone, diskName string) (*v1.PersistentVolumeSource, error)
-	DeletePVSource(pvSource *v1.PersistentVolumeSource) error
+	CreatePVSource(ctx context.Context, zone, diskName string) (*v1.PersistentVolumeSource, error)
+	DeletePVSource(ctx context.Context, pvSource *v1.PersistentVolumeSource) error
 
-	CleanupServiceResources(c clientset.Interface, loadBalancerName, region, zone string)
+	CleanupServiceResources(ctx context.Context, c clientset.Interface, loadBalancerName, region, zone string)
 
-	EnsureLoadBalancerResourcesDeleted(ip, portRange string) error
+	EnsureLoadBalancerResourcesDeleted(ctx context.Context, ip, portRange string) error
 	LoadBalancerSrcRanges() []string
 	EnableAndDisableInternalLB() (enable, disable func(svc *v1.Service))
 }
@@ -159,21 +160,21 @@ func (n NullProvider) DeletePD(pdName string) error {
 }
 
 // CreatePVSource is a base implementation which creates PV source.
-func (n NullProvider) CreatePVSource(zone, diskName string) (*v1.PersistentVolumeSource, error) {
+func (n NullProvider) CreatePVSource(ctx context.Context, zone, diskName string) (*v1.PersistentVolumeSource, error) {
 	return nil, fmt.Errorf("Provider not supported")
 }
 
 // DeletePVSource is a base implementation which deletes PV source.
-func (n NullProvider) DeletePVSource(pvSource *v1.PersistentVolumeSource) error {
+func (n NullProvider) DeletePVSource(ctx context.Context, pvSource *v1.PersistentVolumeSource) error {
 	return fmt.Errorf("Provider not supported")
 }
 
 // CleanupServiceResources is a base implementation which cleans up service resources.
-func (n NullProvider) CleanupServiceResources(c clientset.Interface, loadBalancerName, region, zone string) {
+func (n NullProvider) CleanupServiceResources(ctx context.Context, c clientset.Interface, loadBalancerName, region, zone string) {
 }
 
 // EnsureLoadBalancerResourcesDeleted is a base implementation which ensures load balancer is deleted.
-func (n NullProvider) EnsureLoadBalancerResourcesDeleted(ip, portRange string) error {
+func (n NullProvider) EnsureLoadBalancerResourcesDeleted(ctx context.Context, ip, portRange string) error {
 	return nil
 }
 

--- a/test/e2e/framework/providers/aws/aws.go
+++ b/test/e2e/framework/providers/aws/aws.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -163,7 +164,7 @@ func (p *Provider) DeletePD(pdName string) error {
 }
 
 // CreatePVSource creates a persistent volume source
-func (p *Provider) CreatePVSource(zone, diskName string) (*v1.PersistentVolumeSource, error) {
+func (p *Provider) CreatePVSource(ctx context.Context, zone, diskName string) (*v1.PersistentVolumeSource, error) {
 	return &v1.PersistentVolumeSource{
 		AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
 			VolumeID: diskName,
@@ -173,8 +174,8 @@ func (p *Provider) CreatePVSource(zone, diskName string) (*v1.PersistentVolumeSo
 }
 
 // DeletePVSource deletes a persistent volume source
-func (p *Provider) DeletePVSource(pvSource *v1.PersistentVolumeSource) error {
-	return e2epv.DeletePDWithRetry(pvSource.AWSElasticBlockStore.VolumeID)
+func (p *Provider) DeletePVSource(ctx context.Context, pvSource *v1.PersistentVolumeSource) error {
+	return e2epv.DeletePDWithRetry(ctx, pvSource.AWSElasticBlockStore.VolumeID)
 }
 
 func newAWSClient(zone string) *ec2.EC2 {

--- a/test/e2e/framework/providers/gce/util.go
+++ b/test/e2e/framework/providers/gce/util.go
@@ -80,12 +80,12 @@ func RecreateNodes(c clientset.Interface, nodes []v1.Node) error {
 }
 
 // WaitForNodeBootIdsToChange waits for the boot ids of the given nodes to change in order to verify the node has been recreated.
-func WaitForNodeBootIdsToChange(c clientset.Interface, nodes []v1.Node, timeout time.Duration) error {
+func WaitForNodeBootIdsToChange(ctx context.Context, c clientset.Interface, nodes []v1.Node, timeout time.Duration) error {
 	errMsg := []string{}
 	for i := range nodes {
 		node := &nodes[i]
-		if err := wait.Poll(30*time.Second, timeout, func() (bool, error) {
-			newNode, err := c.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+		if err := wait.PollWithContext(ctx, 30*time.Second, timeout, func(ctx context.Context) (bool, error) {
+			newNode, err := c.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 			if err != nil {
 				framework.Logf("Could not get node info: %s. Retrying in %v.", err, 30*time.Second)
 				return false, nil

--- a/test/e2e/framework/providers/gcp.go
+++ b/test/e2e/framework/providers/gcp.go
@@ -17,6 +17,7 @@ limitations under the License.
 package providers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -58,7 +59,7 @@ func LocationParamGKE() string {
 }
 
 // MasterUpgradeGKE upgrades master node to the specified version on GKE.
-func MasterUpgradeGKE(namespace string, v string) error {
+func MasterUpgradeGKE(ctx context.Context, namespace string, v string) error {
 	framework.Logf("Upgrading master to %q", v)
 	args := []string{
 		"container",
@@ -76,7 +77,7 @@ func MasterUpgradeGKE(namespace string, v string) error {
 		return err
 	}
 
-	e2enode.WaitForSSHTunnels(namespace)
+	e2enode.WaitForSSHTunnels(ctx, namespace)
 
 	return nil
 }

--- a/test/e2e/framework/pv/pv.go
+++ b/test/e2e/framework/pv/pv.go
@@ -135,11 +135,11 @@ type PersistentVolumeClaimConfig struct {
 
 // PVPVCCleanup cleans up a pv and pvc in a single pv/pvc test case.
 // Note: delete errors are appended to []error so that we can attempt to delete both the pvc and pv.
-func PVPVCCleanup(c clientset.Interface, ns string, pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim) []error {
+func PVPVCCleanup(ctx context.Context, c clientset.Interface, ns string, pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim) []error {
 	var errs []error
 
 	if pvc != nil {
-		err := DeletePersistentVolumeClaim(c, pvc.Name, ns)
+		err := DeletePersistentVolumeClaim(ctx, c, pvc.Name, ns)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete PVC %q: %v", pvc.Name, err))
 		}
@@ -147,7 +147,7 @@ func PVPVCCleanup(c clientset.Interface, ns string, pv *v1.PersistentVolume, pvc
 		framework.Logf("pvc is nil")
 	}
 	if pv != nil {
-		err := DeletePersistentVolume(c, pv.Name)
+		err := DeletePersistentVolume(ctx, c, pv.Name)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete PV %q: %v", pv.Name, err))
 		}
@@ -160,11 +160,11 @@ func PVPVCCleanup(c clientset.Interface, ns string, pv *v1.PersistentVolume, pvc
 // PVPVCMapCleanup Cleans up pvs and pvcs in multi-pv-pvc test cases. Entries found in the pv and claim maps are
 // deleted as long as the Delete api call succeeds.
 // Note: delete errors are appended to []error so that as many pvcs and pvs as possible are deleted.
-func PVPVCMapCleanup(c clientset.Interface, ns string, pvols PVMap, claims PVCMap) []error {
+func PVPVCMapCleanup(ctx context.Context, c clientset.Interface, ns string, pvols PVMap, claims PVCMap) []error {
 	var errs []error
 
 	for pvcKey := range claims {
-		err := DeletePersistentVolumeClaim(c, pvcKey.Name, ns)
+		err := DeletePersistentVolumeClaim(ctx, c, pvcKey.Name, ns)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete PVC %q: %v", pvcKey.Name, err))
 		} else {
@@ -173,7 +173,7 @@ func PVPVCMapCleanup(c clientset.Interface, ns string, pvols PVMap, claims PVCMa
 	}
 
 	for pvKey := range pvols {
-		err := DeletePersistentVolume(c, pvKey)
+		err := DeletePersistentVolume(ctx, c, pvKey)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete PV %q: %v", pvKey, err))
 		} else {
@@ -184,10 +184,10 @@ func PVPVCMapCleanup(c clientset.Interface, ns string, pvols PVMap, claims PVCMa
 }
 
 // DeletePersistentVolume deletes the PV.
-func DeletePersistentVolume(c clientset.Interface, pvName string) error {
+func DeletePersistentVolume(ctx context.Context, c clientset.Interface, pvName string) error {
 	if c != nil && len(pvName) > 0 {
 		framework.Logf("Deleting PersistentVolume %q", pvName)
-		err := c.CoreV1().PersistentVolumes().Delete(context.TODO(), pvName, metav1.DeleteOptions{})
+		err := c.CoreV1().PersistentVolumes().Delete(ctx, pvName, metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("PV Delete API error: %v", err)
 		}
@@ -196,10 +196,10 @@ func DeletePersistentVolume(c clientset.Interface, pvName string) error {
 }
 
 // DeletePersistentVolumeClaim deletes the Claim.
-func DeletePersistentVolumeClaim(c clientset.Interface, pvcName string, ns string) error {
+func DeletePersistentVolumeClaim(ctx context.Context, c clientset.Interface, pvcName string, ns string) error {
 	if c != nil && len(pvcName) > 0 {
 		framework.Logf("Deleting PersistentVolumeClaim %q", pvcName)
-		err := c.CoreV1().PersistentVolumeClaims(ns).Delete(context.TODO(), pvcName, metav1.DeleteOptions{})
+		err := c.CoreV1().PersistentVolumeClaims(ns).Delete(ctx, pvcName, metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("PVC Delete API error: %v", err)
 		}
@@ -210,23 +210,23 @@ func DeletePersistentVolumeClaim(c clientset.Interface, pvcName string, ns strin
 // DeletePVCandValidatePV deletes the PVC and waits for the PV to enter its expected phase. Validate that the PV
 // has been reclaimed (assumption here about reclaimPolicy). Caller tells this func which
 // phase value to expect for the pv bound to the to-be-deleted claim.
-func DeletePVCandValidatePV(c clientset.Interface, timeouts *framework.TimeoutContext, ns string, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume, expectPVPhase v1.PersistentVolumePhase) error {
+func DeletePVCandValidatePV(ctx context.Context, c clientset.Interface, timeouts *framework.TimeoutContext, ns string, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume, expectPVPhase v1.PersistentVolumePhase) error {
 	pvname := pvc.Spec.VolumeName
 	framework.Logf("Deleting PVC %v to trigger reclamation of PV %v", pvc.Name, pvname)
-	err := DeletePersistentVolumeClaim(c, pvc.Name, ns)
+	err := DeletePersistentVolumeClaim(ctx, c, pvc.Name, ns)
 	if err != nil {
 		return err
 	}
 
 	// Wait for the PV's phase to return to be `expectPVPhase`
 	framework.Logf("Waiting for reclaim process to complete.")
-	err = WaitForPersistentVolumePhase(expectPVPhase, c, pv.Name, framework.Poll, timeouts.PVReclaim)
+	err = WaitForPersistentVolumePhase(ctx, expectPVPhase, c, pv.Name, framework.Poll, timeouts.PVReclaim)
 	if err != nil {
 		return fmt.Errorf("pv %q phase did not become %v: %v", pv.Name, expectPVPhase, err)
 	}
 
 	// examine the pv's ClaimRef and UID and compare to expected values
-	pv, err = c.CoreV1().PersistentVolumes().Get(context.TODO(), pv.Name, metav1.GetOptions{})
+	pv, err = c.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("PV Get API error: %v", err)
 	}
@@ -254,11 +254,11 @@ func DeletePVCandValidatePV(c clientset.Interface, timeouts *framework.TimeoutCo
 // Note: if there are more claims than pvs then some of the remaining claims may bind to just made
 //
 //	available pvs.
-func DeletePVCandValidatePVGroup(c clientset.Interface, timeouts *framework.TimeoutContext, ns string, pvols PVMap, claims PVCMap, expectPVPhase v1.PersistentVolumePhase) error {
+func DeletePVCandValidatePVGroup(ctx context.Context, c clientset.Interface, timeouts *framework.TimeoutContext, ns string, pvols PVMap, claims PVCMap, expectPVPhase v1.PersistentVolumePhase) error {
 	var boundPVs, deletedPVCs int
 
 	for pvName := range pvols {
-		pv, err := c.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
+		pv, err := c.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("PV Get API error: %v", err)
 		}
@@ -273,9 +273,9 @@ func DeletePVCandValidatePVGroup(c clientset.Interface, timeouts *framework.Time
 				return fmt.Errorf("internal: claims map is missing pvc %q", pvcKey)
 			}
 			// get the pvc for the delete call below
-			pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), cr.Name, metav1.GetOptions{})
+			pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, cr.Name, metav1.GetOptions{})
 			if err == nil {
-				if err = DeletePVCandValidatePV(c, timeouts, ns, pvc, pv, expectPVPhase); err != nil {
+				if err = DeletePVCandValidatePV(ctx, c, timeouts, ns, pvc, pv, expectPVPhase); err != nil {
 					return err
 				}
 			} else if !apierrors.IsNotFound(err) {
@@ -294,11 +294,11 @@ func DeletePVCandValidatePVGroup(c clientset.Interface, timeouts *framework.Time
 }
 
 // create the PV resource. Fails test on error.
-func createPV(c clientset.Interface, timeouts *framework.TimeoutContext, pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+func createPV(ctx context.Context, c clientset.Interface, timeouts *framework.TimeoutContext, pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
 	var resultPV *v1.PersistentVolume
 	var lastCreateErr error
-	err := wait.PollImmediate(29*time.Second, timeouts.PVCreate, func() (done bool, err error) {
-		resultPV, lastCreateErr = c.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{})
+	err := wait.PollImmediateWithContext(ctx, 29*time.Second, timeouts.PVCreate, func(ctx context.Context) (done bool, err error) {
+		resultPV, lastCreateErr = c.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 		if lastCreateErr != nil {
 			// If we hit a quota problem, we are not done and should retry again.  This happens to be the quota failure string for GCP.
 			// If quota failure strings are found for other platforms, they can be added to improve reliability when running
@@ -326,13 +326,13 @@ func createPV(c clientset.Interface, timeouts *framework.TimeoutContext, pv *v1.
 }
 
 // CreatePV creates the PV resource. Fails test on error.
-func CreatePV(c clientset.Interface, timeouts *framework.TimeoutContext, pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
-	return createPV(c, timeouts, pv)
+func CreatePV(ctx context.Context, c clientset.Interface, timeouts *framework.TimeoutContext, pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	return createPV(ctx, c, timeouts, pv)
 }
 
 // CreatePVC creates the PVC resource. Fails test on error.
-func CreatePVC(c clientset.Interface, ns string, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
-	pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), pvc, metav1.CreateOptions{})
+func CreatePVC(ctx context.Context, c clientset.Interface, ns string, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
+	pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Create(ctx, pvc, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("PVC Create API error: %v", err)
 	}
@@ -346,7 +346,7 @@ func CreatePVC(c clientset.Interface, ns string, pvc *v1.PersistentVolumeClaim) 
 //
 //	known until after the PVC is instantiated. This is why the pvc is created
 //	before the pv.
-func CreatePVCPV(c clientset.Interface, timeouts *framework.TimeoutContext, pvConfig PersistentVolumeConfig, pvcConfig PersistentVolumeClaimConfig, ns string, preBind bool) (*v1.PersistentVolume, *v1.PersistentVolumeClaim, error) {
+func CreatePVCPV(ctx context.Context, c clientset.Interface, timeouts *framework.TimeoutContext, pvConfig PersistentVolumeConfig, pvcConfig PersistentVolumeClaimConfig, ns string, preBind bool) (*v1.PersistentVolume, *v1.PersistentVolumeClaim, error) {
 	// make the pvc spec
 	pvc := MakePersistentVolumeClaim(pvcConfig, ns)
 	preBindMsg := ""
@@ -358,7 +358,7 @@ func CreatePVCPV(c clientset.Interface, timeouts *framework.TimeoutContext, pvCo
 	pv := MakePersistentVolume(pvConfig)
 
 	ginkgo.By(fmt.Sprintf("Creating a PVC followed by a%s PV", preBindMsg))
-	pvc, err := CreatePVC(c, ns, pvc)
+	pvc, err := CreatePVC(ctx, c, ns, pvc)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -367,7 +367,7 @@ func CreatePVCPV(c clientset.Interface, timeouts *framework.TimeoutContext, pvCo
 	if preBind {
 		pv.Spec.ClaimRef.Name = pvc.Name
 	}
-	pv, err = createPV(c, timeouts, pv)
+	pv, err = createPV(ctx, c, timeouts, pv)
 	if err != nil {
 		return nil, pvc, err
 	}
@@ -382,7 +382,7 @@ func CreatePVCPV(c clientset.Interface, timeouts *framework.TimeoutContext, pvCo
 //
 //	known until after the PV is instantiated. This is why the pv is created
 //	before the pvc.
-func CreatePVPVC(c clientset.Interface, timeouts *framework.TimeoutContext, pvConfig PersistentVolumeConfig, pvcConfig PersistentVolumeClaimConfig, ns string, preBind bool) (*v1.PersistentVolume, *v1.PersistentVolumeClaim, error) {
+func CreatePVPVC(ctx context.Context, c clientset.Interface, timeouts *framework.TimeoutContext, pvConfig PersistentVolumeConfig, pvcConfig PersistentVolumeClaimConfig, ns string, preBind bool) (*v1.PersistentVolume, *v1.PersistentVolumeClaim, error) {
 	preBindMsg := ""
 	if preBind {
 		preBindMsg = " pre-bound"
@@ -394,7 +394,7 @@ func CreatePVPVC(c clientset.Interface, timeouts *framework.TimeoutContext, pvCo
 	pvc := MakePersistentVolumeClaim(pvcConfig, ns)
 
 	// instantiate the pv
-	pv, err := createPV(c, timeouts, pv)
+	pv, err := createPV(ctx, c, timeouts, pv)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -402,7 +402,7 @@ func CreatePVPVC(c clientset.Interface, timeouts *framework.TimeoutContext, pvCo
 	if preBind {
 		pvc.Spec.VolumeName = pv.Name
 	}
-	pvc, err = CreatePVC(c, ns, pvc)
+	pvc, err = CreatePVC(ctx, c, ns, pvc)
 	if err != nil {
 		return pv, nil, err
 	}
@@ -417,7 +417,7 @@ func CreatePVPVC(c clientset.Interface, timeouts *framework.TimeoutContext, pvCo
 // Note: when the test suite deletes the namespace orphaned pvcs and pods are deleted. However,
 //
 //	orphaned pvs are not deleted and will remain after the suite completes.
-func CreatePVsPVCs(numpvs, numpvcs int, c clientset.Interface, timeouts *framework.TimeoutContext, ns string, pvConfig PersistentVolumeConfig, pvcConfig PersistentVolumeClaimConfig) (PVMap, PVCMap, error) {
+func CreatePVsPVCs(ctx context.Context, numpvs, numpvcs int, c clientset.Interface, timeouts *framework.TimeoutContext, ns string, pvConfig PersistentVolumeConfig, pvcConfig PersistentVolumeClaimConfig) (PVMap, PVCMap, error) {
 	pvMap := make(PVMap, numpvs)
 	pvcMap := make(PVCMap, numpvcs)
 	extraPVCs := 0
@@ -430,7 +430,7 @@ func CreatePVsPVCs(numpvs, numpvcs int, c clientset.Interface, timeouts *framewo
 
 	// create pvs and pvcs
 	for i := 0; i < pvsToCreate; i++ {
-		pv, pvc, err := CreatePVPVC(c, timeouts, pvConfig, pvcConfig, ns, false)
+		pv, pvc, err := CreatePVPVC(ctx, c, timeouts, pvConfig, pvcConfig, ns, false)
 		if err != nil {
 			return pvMap, pvcMap, err
 		}
@@ -441,7 +441,7 @@ func CreatePVsPVCs(numpvs, numpvcs int, c clientset.Interface, timeouts *framewo
 	// create extra pvs or pvcs as needed
 	for i := 0; i < extraPVs; i++ {
 		pv := MakePersistentVolume(pvConfig)
-		pv, err := createPV(c, timeouts, pv)
+		pv, err := createPV(ctx, c, timeouts, pv)
 		if err != nil {
 			return pvMap, pvcMap, err
 		}
@@ -449,7 +449,7 @@ func CreatePVsPVCs(numpvs, numpvcs int, c clientset.Interface, timeouts *framewo
 	}
 	for i := 0; i < extraPVCs; i++ {
 		pvc := MakePersistentVolumeClaim(pvcConfig, ns)
-		pvc, err := CreatePVC(c, ns, pvc)
+		pvc, err := CreatePVC(ctx, c, ns, pvc)
 		if err != nil {
 			return pvMap, pvcMap, err
 		}
@@ -459,27 +459,27 @@ func CreatePVsPVCs(numpvs, numpvcs int, c clientset.Interface, timeouts *framewo
 }
 
 // WaitOnPVandPVC waits for the pv and pvc to bind to each other.
-func WaitOnPVandPVC(c clientset.Interface, timeouts *framework.TimeoutContext, ns string, pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim) error {
+func WaitOnPVandPVC(ctx context.Context, c clientset.Interface, timeouts *framework.TimeoutContext, ns string, pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim) error {
 	// Wait for newly created PVC to bind to the PV
 	framework.Logf("Waiting for PV %v to bind to PVC %v", pv.Name, pvc.Name)
-	err := WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, pvc.Name, framework.Poll, timeouts.ClaimBound)
+	err := WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, c, ns, pvc.Name, framework.Poll, timeouts.ClaimBound)
 	if err != nil {
 		return fmt.Errorf("PVC %q did not become Bound: %v", pvc.Name, err)
 	}
 
 	// Wait for PersistentVolume.Status.Phase to be Bound, which it should be
 	// since the PVC is already bound.
-	err = WaitForPersistentVolumePhase(v1.VolumeBound, c, pv.Name, framework.Poll, timeouts.PVBound)
+	err = WaitForPersistentVolumePhase(ctx, v1.VolumeBound, c, pv.Name, framework.Poll, timeouts.PVBound)
 	if err != nil {
 		return fmt.Errorf("PV %q did not become Bound: %v", pv.Name, err)
 	}
 
 	// Re-get the pv and pvc objects
-	pv, err = c.CoreV1().PersistentVolumes().Get(context.TODO(), pv.Name, metav1.GetOptions{})
+	pv, err = c.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("PV Get API error: %v", err)
 	}
-	pvc, err = c.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+	pvc, err = c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvc.Name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("PVC Get API error: %v", err)
 	}
@@ -508,7 +508,7 @@ func WaitOnPVandPVC(c clientset.Interface, timeouts *framework.TimeoutContext, n
 //	to situations where the maximum wait times are reached several times in succession,
 //	extending test time. Thus, it is recommended to keep the delta between PVs and PVCs
 //	small.
-func WaitAndVerifyBinds(c clientset.Interface, timeouts *framework.TimeoutContext, ns string, pvols PVMap, claims PVCMap, testExpected bool) error {
+func WaitAndVerifyBinds(ctx context.Context, c clientset.Interface, timeouts *framework.TimeoutContext, ns string, pvols PVMap, claims PVCMap, testExpected bool) error {
 	var actualBinds int
 	expectedBinds := len(pvols)
 	if expectedBinds > len(claims) { // want the min of # pvs or #pvcs
@@ -516,7 +516,7 @@ func WaitAndVerifyBinds(c clientset.Interface, timeouts *framework.TimeoutContex
 	}
 
 	for pvName := range pvols {
-		err := WaitForPersistentVolumePhase(v1.VolumeBound, c, pvName, framework.Poll, timeouts.PVBound)
+		err := WaitForPersistentVolumePhase(ctx, v1.VolumeBound, c, pvName, framework.Poll, timeouts.PVBound)
 		if err != nil && len(pvols) > len(claims) {
 			framework.Logf("WARN: pv %v is not bound after max wait", pvName)
 			framework.Logf("      This may be ok since there are more pvs than pvcs")
@@ -526,7 +526,7 @@ func WaitAndVerifyBinds(c clientset.Interface, timeouts *framework.TimeoutContex
 			return fmt.Errorf("PV %q did not become Bound: %v", pvName, err)
 		}
 
-		pv, err := c.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
+		pv, err := c.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("PV Get API error: %v", err)
 		}
@@ -539,7 +539,7 @@ func WaitAndVerifyBinds(c clientset.Interface, timeouts *framework.TimeoutContex
 				return fmt.Errorf("internal: claims map is missing pvc %q", pvcKey)
 			}
 
-			err := WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, cr.Name, framework.Poll, timeouts.ClaimBound)
+			err := WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, c, ns, cr.Name, framework.Poll, timeouts.ClaimBound)
 			if err != nil {
 				return fmt.Errorf("PVC %q did not become Bound: %v", cr.Name, err)
 			}
@@ -659,10 +659,15 @@ func MakePersistentVolumeClaim(cfg PersistentVolumeClaimConfig, ns string) *v1.P
 	}
 }
 
-func createPDWithRetry(zone string) (string, error) {
+func createPDWithRetry(ctx context.Context, zone string) (string, error) {
 	var err error
 	var newDiskName string
-	for start := time.Now(); time.Since(start) < pdRetryTimeout; time.Sleep(pdRetryPollTime) {
+	for start := time.Now(); ; time.Sleep(pdRetryPollTime) {
+		if time.Since(start) >= pdRetryTimeout ||
+			ctx.Err() != nil {
+			return "", fmt.Errorf("timed out while trying to create PD in zone %q, last error: %v", zone, err)
+		}
+
 		newDiskName, err = createPD(zone)
 		if err != nil {
 			framework.Logf("Couldn't create a new PD in zone %q, sleeping 5 seconds: %v", zone, err)
@@ -671,7 +676,6 @@ func createPDWithRetry(zone string) (string, error) {
 		framework.Logf("Successfully created a new PD in zone %q: %q.", zone, newDiskName)
 		return newDiskName, nil
 	}
-	return "", err
 }
 
 func CreateShare() (string, string, string, error) {
@@ -683,19 +687,23 @@ func DeleteShare(accountName, shareName string) error {
 }
 
 // CreatePDWithRetry creates PD with retry.
-func CreatePDWithRetry() (string, error) {
-	return createPDWithRetry("")
+func CreatePDWithRetry(ctx context.Context) (string, error) {
+	return createPDWithRetry(ctx, "")
 }
 
 // CreatePDWithRetryAndZone creates PD on zone with retry.
-func CreatePDWithRetryAndZone(zone string) (string, error) {
-	return createPDWithRetry(zone)
+func CreatePDWithRetryAndZone(ctx context.Context, zone string) (string, error) {
+	return createPDWithRetry(ctx, zone)
 }
 
 // DeletePDWithRetry deletes PD with retry.
-func DeletePDWithRetry(diskName string) error {
+func DeletePDWithRetry(ctx context.Context, diskName string) error {
 	var err error
-	for start := time.Now(); time.Since(start) < pdRetryTimeout; time.Sleep(pdRetryPollTime) {
+	for start := time.Now(); ; time.Sleep(pdRetryPollTime) {
+		if time.Since(start) >= pdRetryTimeout ||
+			ctx.Err() != nil {
+			return fmt.Errorf("timed out while trying to delete PD %q, last error: %v", diskName, err)
+		}
 		err = deletePD(diskName)
 		if err != nil {
 			framework.Logf("Couldn't delete PD %q, sleeping %v: %v", diskName, pdRetryPollTime, err)
@@ -704,7 +712,6 @@ func DeletePDWithRetry(diskName string) error {
 		framework.Logf("Successfully deleted PD %q.", diskName)
 		return nil
 	}
-	return fmt.Errorf("unable to delete PD %q: %v", diskName, err)
 }
 
 func createPD(zone string) (string, error) {
@@ -719,21 +726,21 @@ func deletePD(pdName string) error {
 }
 
 // WaitForPVClaimBoundPhase waits until all pvcs phase set to bound
-func WaitForPVClaimBoundPhase(client clientset.Interface, pvclaims []*v1.PersistentVolumeClaim, timeout time.Duration) ([]*v1.PersistentVolume, error) {
+func WaitForPVClaimBoundPhase(ctx context.Context, client clientset.Interface, pvclaims []*v1.PersistentVolumeClaim, timeout time.Duration) ([]*v1.PersistentVolume, error) {
 	persistentvolumes := make([]*v1.PersistentVolume, len(pvclaims))
 
 	for index, claim := range pvclaims {
-		err := WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, claim.Namespace, claim.Name, framework.Poll, timeout)
+		err := WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client, claim.Namespace, claim.Name, framework.Poll, timeout)
 		if err != nil {
 			return persistentvolumes, err
 		}
 		// Get new copy of the claim
-		claim, err = client.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(context.TODO(), claim.Name, metav1.GetOptions{})
+		claim, err = client.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(ctx, claim.Name, metav1.GetOptions{})
 		if err != nil {
 			return persistentvolumes, fmt.Errorf("PVC Get API error: %v", err)
 		}
 		// Get the bounded PV
-		persistentvolumes[index], err = client.CoreV1().PersistentVolumes().Get(context.TODO(), claim.Spec.VolumeName, metav1.GetOptions{})
+		persistentvolumes[index], err = client.CoreV1().PersistentVolumes().Get(ctx, claim.Spec.VolumeName, metav1.GetOptions{})
 		if err != nil {
 			return persistentvolumes, fmt.Errorf("PV Get API error: %v", err)
 		}
@@ -742,10 +749,10 @@ func WaitForPVClaimBoundPhase(client clientset.Interface, pvclaims []*v1.Persist
 }
 
 // WaitForPersistentVolumePhase waits for a PersistentVolume to be in a specific phase or until timeout occurs, whichever comes first.
-func WaitForPersistentVolumePhase(phase v1.PersistentVolumePhase, c clientset.Interface, pvName string, poll, timeout time.Duration) error {
+func WaitForPersistentVolumePhase(ctx context.Context, phase v1.PersistentVolumePhase, c clientset.Interface, pvName string, poll, timeout time.Duration) error {
 	framework.Logf("Waiting up to %v for PersistentVolume %s to have phase %s", timeout, pvName, phase)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
-		pv, err := c.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
+		pv, err := c.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
 		if err != nil {
 			framework.Logf("Get persistent volume %s in failed, ignoring for %v: %v", pvName, poll, err)
 			continue
@@ -760,13 +767,13 @@ func WaitForPersistentVolumePhase(phase v1.PersistentVolumePhase, c clientset.In
 }
 
 // WaitForPersistentVolumeClaimPhase waits for a PersistentVolumeClaim to be in a specific phase or until timeout occurs, whichever comes first.
-func WaitForPersistentVolumeClaimPhase(phase v1.PersistentVolumeClaimPhase, c clientset.Interface, ns string, pvcName string, poll, timeout time.Duration) error {
-	return WaitForPersistentVolumeClaimsPhase(phase, c, ns, []string{pvcName}, poll, timeout, true)
+func WaitForPersistentVolumeClaimPhase(ctx context.Context, phase v1.PersistentVolumeClaimPhase, c clientset.Interface, ns string, pvcName string, poll, timeout time.Duration) error {
+	return WaitForPersistentVolumeClaimsPhase(ctx, phase, c, ns, []string{pvcName}, poll, timeout, true)
 }
 
 // WaitForPersistentVolumeClaimsPhase waits for any (if matchAny is true) or all (if matchAny is false) PersistentVolumeClaims
 // to be in a specific phase or until timeout occurs, whichever comes first.
-func WaitForPersistentVolumeClaimsPhase(phase v1.PersistentVolumeClaimPhase, c clientset.Interface, ns string, pvcNames []string, poll, timeout time.Duration, matchAny bool) error {
+func WaitForPersistentVolumeClaimsPhase(ctx context.Context, phase v1.PersistentVolumeClaimPhase, c clientset.Interface, ns string, pvcNames []string, poll, timeout time.Duration, matchAny bool) error {
 	if len(pvcNames) == 0 {
 		return fmt.Errorf("Incorrect parameter: Need at least one PVC to track. Found 0")
 	}
@@ -774,7 +781,7 @@ func WaitForPersistentVolumeClaimsPhase(phase v1.PersistentVolumeClaimPhase, c c
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
 		phaseFoundInAllClaims := true
 		for _, pvcName := range pvcNames {
-			pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), pvcName, metav1.GetOptions{})
+			pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{})
 			if err != nil {
 				framework.Logf("Failed to get claim %q, retrying in %v. Error: %v", pvcName, poll, err)
 				phaseFoundInAllClaims = false
@@ -798,22 +805,22 @@ func WaitForPersistentVolumeClaimsPhase(phase v1.PersistentVolumeClaimPhase, c c
 }
 
 // CreatePVSource creates a PV source.
-func CreatePVSource(zone string) (*v1.PersistentVolumeSource, error) {
-	diskName, err := CreatePDWithRetryAndZone(zone)
+func CreatePVSource(ctx context.Context, zone string) (*v1.PersistentVolumeSource, error) {
+	diskName, err := CreatePDWithRetryAndZone(ctx, zone)
 	if err != nil {
 		return nil, err
 	}
-	return framework.TestContext.CloudConfig.Provider.CreatePVSource(zone, diskName)
+	return framework.TestContext.CloudConfig.Provider.CreatePVSource(ctx, zone, diskName)
 }
 
 // DeletePVSource deletes a PV source.
-func DeletePVSource(pvSource *v1.PersistentVolumeSource) error {
-	return framework.TestContext.CloudConfig.Provider.DeletePVSource(pvSource)
+func DeletePVSource(ctx context.Context, pvSource *v1.PersistentVolumeSource) error {
+	return framework.TestContext.CloudConfig.Provider.DeletePVSource(ctx, pvSource)
 }
 
 // GetDefaultStorageClassName returns default storageClass or return error
-func GetDefaultStorageClassName(c clientset.Interface) (string, error) {
-	list, err := c.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
+func GetDefaultStorageClassName(ctx context.Context, c clientset.Interface) (string, error) {
+	list, err := c.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return "", fmt.Errorf("Error listing storage classes: %v", err)
 	}
@@ -834,18 +841,18 @@ func GetDefaultStorageClassName(c clientset.Interface) (string, error) {
 }
 
 // SkipIfNoDefaultStorageClass skips tests if no default SC can be found.
-func SkipIfNoDefaultStorageClass(c clientset.Interface) {
-	_, err := GetDefaultStorageClassName(c)
+func SkipIfNoDefaultStorageClass(ctx context.Context, c clientset.Interface) {
+	_, err := GetDefaultStorageClassName(ctx, c)
 	if err != nil {
 		e2eskipper.Skipf("error finding default storageClass : %v", err)
 	}
 }
 
 // WaitForPersistentVolumeDeleted waits for a PersistentVolume to get deleted or until timeout occurs, whichever comes first.
-func WaitForPersistentVolumeDeleted(c clientset.Interface, pvName string, poll, timeout time.Duration) error {
+func WaitForPersistentVolumeDeleted(ctx context.Context, c clientset.Interface, pvName string, poll, timeout time.Duration) error {
 	framework.Logf("Waiting up to %v for PersistentVolume %s to get deleted", timeout, pvName)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
-		pv, err := c.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
+		pv, err := c.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
 		if err == nil {
 			framework.Logf("PersistentVolume %s found and phase=%s (%v)", pvName, pv.Status.Phase, time.Since(start))
 			continue

--- a/test/e2e/framework/rc/rc_utils.go
+++ b/test/e2e/framework/rc/rc_utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rc
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
@@ -70,20 +71,21 @@ func ByNameContainer(name string, replicas int32, labels map[string]string, c v1
 }
 
 // DeleteRCAndWaitForGC deletes only the Replication Controller and waits for GC to delete the pods.
-func DeleteRCAndWaitForGC(c clientset.Interface, ns, name string) error {
-	return e2eresource.DeleteResourceAndWaitForGC(c, schema.GroupKind{Kind: "ReplicationController"}, ns, name)
+func DeleteRCAndWaitForGC(ctx context.Context, c clientset.Interface, ns, name string) error {
+	// TODO (pohly): context support
+	return e2eresource.DeleteResourceAndWaitForGC(ctx, c, schema.GroupKind{Kind: "ReplicationController"}, ns, name)
 }
 
 // ScaleRC scales Replication Controller to be desired size.
-func ScaleRC(clientset clientset.Interface, scalesGetter scaleclient.ScalesGetter, ns, name string, size uint, wait bool) error {
-	return e2eresource.ScaleResource(clientset, scalesGetter, ns, name, size, wait, schema.GroupKind{Kind: "ReplicationController"}, v1.SchemeGroupVersion.WithResource("replicationcontrollers"))
+func ScaleRC(ctx context.Context, clientset clientset.Interface, scalesGetter scaleclient.ScalesGetter, ns, name string, size uint, wait bool) error {
+	return e2eresource.ScaleResource(ctx, clientset, scalesGetter, ns, name, size, wait, schema.GroupKind{Kind: "ReplicationController"}, v1.SchemeGroupVersion.WithResource("replicationcontrollers"))
 }
 
 // RunRC Launches (and verifies correctness) of a Replication Controller
 // and will wait for all pods it spawns to become "Running".
-func RunRC(config testutils.RCConfig) error {
+func RunRC(ctx context.Context, config testutils.RCConfig) error {
 	ginkgo.By(fmt.Sprintf("creating replication controller %s in namespace %s", config.Name, config.Namespace))
 	config.NodeDumpFunc = e2edebug.DumpNodeDebugInfo
 	config.ContainerDumpFunc = e2ekubectl.LogFailedContainers
-	return testutils.RunRC(config)
+	return testutils.RunRC(ctx, config)
 }

--- a/test/e2e/framework/replicaset/wait.go
+++ b/test/e2e/framework/replicaset/wait.go
@@ -29,9 +29,9 @@ import (
 )
 
 // WaitForReadyReplicaSet waits until the replicaset has all of its replicas ready.
-func WaitForReadyReplicaSet(c clientset.Interface, ns, name string) error {
-	err := wait.Poll(framework.Poll, framework.PodStartTimeout, func() (bool, error) {
-		rs, err := c.AppsV1().ReplicaSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+func WaitForReadyReplicaSet(ctx context.Context, c clientset.Interface, ns, name string) error {
+	err := wait.PollWithContext(ctx, framework.Poll, framework.PodStartTimeout, func(ctx context.Context) (bool, error) {
+		rs, err := c.AppsV1().ReplicaSets(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -44,16 +44,16 @@ func WaitForReadyReplicaSet(c clientset.Interface, ns, name string) error {
 }
 
 // WaitForReplicaSetTargetAvailableReplicas waits for .status.availableReplicas of a RS to equal targetReplicaNum
-func WaitForReplicaSetTargetAvailableReplicas(c clientset.Interface, replicaSet *appsv1.ReplicaSet, targetReplicaNum int32) error {
-	return WaitForReplicaSetTargetAvailableReplicasWithTimeout(c, replicaSet, targetReplicaNum, framework.PodStartTimeout)
+func WaitForReplicaSetTargetAvailableReplicas(ctx context.Context, c clientset.Interface, replicaSet *appsv1.ReplicaSet, targetReplicaNum int32) error {
+	return WaitForReplicaSetTargetAvailableReplicasWithTimeout(ctx, c, replicaSet, targetReplicaNum, framework.PodStartTimeout)
 }
 
 // WaitForReplicaSetTargetAvailableReplicasWithTimeout waits for .status.availableReplicas of a RS to equal targetReplicaNum
 // with given timeout.
-func WaitForReplicaSetTargetAvailableReplicasWithTimeout(c clientset.Interface, replicaSet *appsv1.ReplicaSet, targetReplicaNum int32, timeout time.Duration) error {
+func WaitForReplicaSetTargetAvailableReplicasWithTimeout(ctx context.Context, c clientset.Interface, replicaSet *appsv1.ReplicaSet, targetReplicaNum int32, timeout time.Duration) error {
 	desiredGeneration := replicaSet.Generation
-	err := wait.PollImmediate(framework.Poll, timeout, func() (bool, error) {
-		rs, err := c.AppsV1().ReplicaSets(replicaSet.Namespace).Get(context.TODO(), replicaSet.Name, metav1.GetOptions{})
+	err := wait.PollImmediateWithContext(ctx, framework.Poll, timeout, func(ctx context.Context) (bool, error) {
+		rs, err := c.AppsV1().ReplicaSets(replicaSet.Namespace).Get(ctx, replicaSet.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/framework/resource/resources.go
+++ b/test/e2e/framework/resource/resources.go
@@ -46,6 +46,7 @@ const (
 
 // ScaleResource scales resource to the given size.
 func ScaleResource(
+	ctx context.Context,
 	clientset clientset.Interface,
 	scalesGetter scaleclient.ScalesGetter,
 	ns, name string,
@@ -61,14 +62,14 @@ func ScaleResource(
 	if !wait {
 		return nil
 	}
-	return WaitForControlledPodsRunning(clientset, ns, name, kind)
+	return WaitForControlledPodsRunning(ctx, clientset, ns, name, kind)
 }
 
 // DeleteResourceAndWaitForGC deletes only given resource and waits for GC to delete the pods.
-func DeleteResourceAndWaitForGC(c clientset.Interface, kind schema.GroupKind, ns, name string) error {
+func DeleteResourceAndWaitForGC(ctx context.Context, c clientset.Interface, kind schema.GroupKind, ns, name string) error {
 	ginkgo.By(fmt.Sprintf("deleting %v %s in namespace %s, will wait for the garbage collector to delete the pods", kind, name, ns))
 
-	rtObject, err := GetRuntimeObjectForKind(c, kind, ns, name)
+	rtObject, err := GetRuntimeObjectForKind(ctx, c, kind, ns, name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			framework.Logf("%v %s not found: %v", kind, name, err)
@@ -80,15 +81,15 @@ func DeleteResourceAndWaitForGC(c clientset.Interface, kind schema.GroupKind, ns
 		background := metav1.DeletePropagationBackground
 		return testutils.DeleteResource(c, kind, ns, name, metav1.DeleteOptions{PropagationPolicy: &background})
 	}
-	return deleteObjectAndWaitForGC(c, rtObject, deleteObject, ns, name, kind.String())
+	return deleteObjectAndWaitForGC(ctx, c, rtObject, deleteObject, ns, name, kind.String())
 }
 
 // DeleteCustomResourceAndWaitForGC deletes only given resource and waits for GC to delete the pods.
 // Enables to provide a custom resourece client, e.g. to fetch a CRD object.
-func DeleteCustomResourceAndWaitForGC(c clientset.Interface, dynamicClient dynamic.Interface, scaleClient scaleclient.ScalesGetter, gvr schema.GroupVersionResource, ns, name string) error {
+func DeleteCustomResourceAndWaitForGC(ctx context.Context, c clientset.Interface, dynamicClient dynamic.Interface, scaleClient scaleclient.ScalesGetter, gvr schema.GroupVersionResource, ns, name string) error {
 	ginkgo.By(fmt.Sprintf("deleting %v %s in namespace %s, will wait for the garbage collector to delete the pods", gvr, name, ns))
 	resourceClient := dynamicClient.Resource(gvr).Namespace(ns)
-	_, err := resourceClient.Get(context.TODO(), name, metav1.GetOptions{})
+	_, err := resourceClient.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			framework.Logf("%v %s not found: %v", gvr, name, err)
@@ -96,19 +97,19 @@ func DeleteCustomResourceAndWaitForGC(c clientset.Interface, dynamicClient dynam
 		}
 		return err
 	}
-	scaleObj, err := scaleClient.Scales(ns).Get(context.TODO(), gvr.GroupResource(), name, metav1.GetOptions{})
+	scaleObj, err := scaleClient.Scales(ns).Get(ctx, gvr.GroupResource(), name, metav1.GetOptions{})
 	if err != nil {
 		framework.Logf("error while trying to get scale subresource of kind %v with name %v: %v", gvr, name, err)
 		return nil
 	}
 	deleteObject := func() error {
 		background := metav1.DeletePropagationBackground
-		return resourceClient.Delete(context.TODO(), name, metav1.DeleteOptions{PropagationPolicy: &background})
+		return resourceClient.Delete(ctx, name, metav1.DeleteOptions{PropagationPolicy: &background})
 	}
-	return deleteObjectAndWaitForGC(c, scaleObj, deleteObject, ns, name, gvr.String())
+	return deleteObjectAndWaitForGC(ctx, c, scaleObj, deleteObject, ns, name, gvr.String())
 }
 
-func deleteObjectAndWaitForGC(c clientset.Interface, rtObject runtime.Object, deleteObject func() error, ns, name, description string) error {
+func deleteObjectAndWaitForGC(ctx context.Context, c clientset.Interface, rtObject runtime.Object, deleteObject func() error, ns, name, description string) error {
 	selector, err := GetSelectorFromRuntimeObject(rtObject)
 	if err != nil {
 		return err
@@ -154,7 +155,7 @@ func deleteObjectAndWaitForGC(c clientset.Interface, rtObject runtime.Object, de
 		timeout = timeout + 3*time.Minute
 	}
 
-	err = waitForPodsInactive(ps, interval, timeout)
+	err = waitForPodsInactive(ctx, ps, interval, timeout)
 	if err != nil {
 		return fmt.Errorf("error while waiting for pods to become inactive %s: %v", name, err)
 	}
@@ -164,7 +165,7 @@ func deleteObjectAndWaitForGC(c clientset.Interface, rtObject runtime.Object, de
 	// In gce, at any point, small percentage of nodes can disappear for
 	// ~10 minutes due to hostError. 20 minutes should be long enough to
 	// restart VM in that case and delete the pod.
-	err = waitForPodsGone(ps, interval, 20*time.Minute)
+	err = waitForPodsGone(ctx, ps, interval, 20*time.Minute)
 	if err != nil {
 		return fmt.Errorf("error while waiting for pods gone %s: %v", name, err)
 	}
@@ -172,9 +173,9 @@ func deleteObjectAndWaitForGC(c clientset.Interface, rtObject runtime.Object, de
 }
 
 // waitForPodsGone waits until there are no pods left in the PodStore.
-func waitForPodsGone(ps *testutils.PodStore, interval, timeout time.Duration) error {
+func waitForPodsGone(ctx context.Context, ps *testutils.PodStore, interval, timeout time.Duration) error {
 	var pods []*v1.Pod
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+	err := wait.PollImmediateWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
 		if pods = ps.List(); len(pods) == 0 {
 			return true, nil
 		}
@@ -194,9 +195,9 @@ func waitForPodsGone(ps *testutils.PodStore, interval, timeout time.Duration) er
 // This is to make a fair comparison of deletion time between DeleteRCAndPods
 // and DeleteRCAndWaitForGC, because the RC controller decreases status.replicas
 // when the pod is inactvie.
-func waitForPodsInactive(ps *testutils.PodStore, interval, timeout time.Duration) error {
+func waitForPodsInactive(ctx context.Context, ps *testutils.PodStore, interval, timeout time.Duration) error {
 	var activePods []*v1.Pod
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+	err := wait.PollImmediateWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
 		pods := ps.List()
 		activePods = e2epod.FilterActivePods(pods)
 		if len(activePods) != 0 {
@@ -215,8 +216,8 @@ func waitForPodsInactive(ps *testutils.PodStore, interval, timeout time.Duration
 }
 
 // WaitForControlledPodsRunning waits up to 10 minutes for pods to become Running.
-func WaitForControlledPodsRunning(c clientset.Interface, ns, name string, kind schema.GroupKind) error {
-	rtObject, err := GetRuntimeObjectForKind(c, kind, ns, name)
+func WaitForControlledPodsRunning(ctx context.Context, c clientset.Interface, ns, name string, kind schema.GroupKind) error {
+	rtObject, err := GetRuntimeObjectForKind(ctx, c, kind, ns, name)
 	if err != nil {
 		return err
 	}
@@ -236,8 +237,8 @@ func WaitForControlledPodsRunning(c clientset.Interface, ns, name string, kind s
 }
 
 // WaitForControlledPods waits up to podListTimeout for getting pods of the specified controller name and return them.
-func WaitForControlledPods(c clientset.Interface, ns, name string, kind schema.GroupKind) (pods *v1.PodList, err error) {
-	rtObject, err := GetRuntimeObjectForKind(c, kind, ns, name)
+func WaitForControlledPods(ctx context.Context, c clientset.Interface, ns, name string, kind schema.GroupKind) (pods *v1.PodList, err error) {
+	rtObject, err := GetRuntimeObjectForKind(ctx, c, kind, ns, name)
 	if err != nil {
 		return nil, err
 	}
@@ -245,5 +246,5 @@ func WaitForControlledPods(c clientset.Interface, ns, name string, kind schema.G
 	if err != nil {
 		return nil, err
 	}
-	return e2epod.WaitForPodsWithLabel(c, ns, selector)
+	return e2epod.WaitForPodsWithLabel(ctx, c, ns, selector)
 }

--- a/test/e2e/framework/resource/runtimeobj.go
+++ b/test/e2e/framework/resource/runtimeobj.go
@@ -44,18 +44,18 @@ var (
 
 // GetRuntimeObjectForKind returns a runtime.Object based on its GroupKind,
 // namespace and name.
-func GetRuntimeObjectForKind(c clientset.Interface, kind schema.GroupKind, ns, name string) (runtime.Object, error) {
+func GetRuntimeObjectForKind(ctx context.Context, c clientset.Interface, kind schema.GroupKind, ns, name string) (runtime.Object, error) {
 	switch kind {
 	case kindReplicationController:
-		return c.CoreV1().ReplicationControllers(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		return c.CoreV1().ReplicationControllers(ns).Get(ctx, name, metav1.GetOptions{})
 	case kindExtensionsReplicaSet, kindAppsReplicaSet:
-		return c.AppsV1().ReplicaSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		return c.AppsV1().ReplicaSets(ns).Get(ctx, name, metav1.GetOptions{})
 	case kindExtensionsDeployment, kindAppsDeployment:
-		return c.AppsV1().Deployments(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		return c.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
 	case kindExtensionsDaemonSet:
-		return c.AppsV1().DaemonSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		return c.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
 	case kindBatchJob:
-		return c.BatchV1().Jobs(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		return c.BatchV1().Jobs(ns).Get(ctx, name, metav1.GetOptions{})
 	default:
 		return nil, fmt.Errorf("Unsupported kind when getting runtime object: %v", kind)
 	}

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -108,12 +108,12 @@ func (j *TestJig) newServiceTemplate(proto v1.Protocol, port int32) *v1.Service 
 // CreateTCPServiceWithPort creates a new TCP Service with given port based on the
 // j's defaults. Callers can provide a function to tweak the Service object before
 // it is created.
-func (j *TestJig) CreateTCPServiceWithPort(tweak func(svc *v1.Service), port int32) (*v1.Service, error) {
+func (j *TestJig) CreateTCPServiceWithPort(ctx context.Context, tweak func(svc *v1.Service), port int32) (*v1.Service, error) {
 	svc := j.newServiceTemplate(v1.ProtocolTCP, port)
 	if tweak != nil {
 		tweak(svc)
 	}
-	result, err := j.Client.CoreV1().Services(j.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	result, err := j.Client.CoreV1().Services(j.Namespace).Create(ctx, svc, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TCP Service %q: %v", svc.Name, err)
 	}
@@ -123,19 +123,19 @@ func (j *TestJig) CreateTCPServiceWithPort(tweak func(svc *v1.Service), port int
 // CreateTCPService creates a new TCP Service based on the j's
 // defaults.  Callers can provide a function to tweak the Service object before
 // it is created.
-func (j *TestJig) CreateTCPService(tweak func(svc *v1.Service)) (*v1.Service, error) {
-	return j.CreateTCPServiceWithPort(tweak, 80)
+func (j *TestJig) CreateTCPService(ctx context.Context, tweak func(svc *v1.Service)) (*v1.Service, error) {
+	return j.CreateTCPServiceWithPort(ctx, tweak, 80)
 }
 
 // CreateUDPService creates a new UDP Service based on the j's
 // defaults.  Callers can provide a function to tweak the Service object before
 // it is created.
-func (j *TestJig) CreateUDPService(tweak func(svc *v1.Service)) (*v1.Service, error) {
+func (j *TestJig) CreateUDPService(ctx context.Context, tweak func(svc *v1.Service)) (*v1.Service, error) {
 	svc := j.newServiceTemplate(v1.ProtocolUDP, 80)
 	if tweak != nil {
 		tweak(svc)
 	}
-	result, err := j.Client.CoreV1().Services(j.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	result, err := j.Client.CoreV1().Services(j.Namespace).Create(ctx, svc, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create UDP Service %q: %v", svc.Name, err)
 	}
@@ -144,7 +144,7 @@ func (j *TestJig) CreateUDPService(tweak func(svc *v1.Service)) (*v1.Service, er
 
 // CreateExternalNameService creates a new ExternalName type Service based on the j's defaults.
 // Callers can provide a function to tweak the Service object before it is created.
-func (j *TestJig) CreateExternalNameService(tweak func(svc *v1.Service)) (*v1.Service, error) {
+func (j *TestJig) CreateExternalNameService(ctx context.Context, tweak func(svc *v1.Service)) (*v1.Service, error) {
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: j.Namespace,
@@ -160,7 +160,7 @@ func (j *TestJig) CreateExternalNameService(tweak func(svc *v1.Service)) (*v1.Se
 	if tweak != nil {
 		tweak(svc)
 	}
-	result, err := j.Client.CoreV1().Services(j.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	result, err := j.Client.CoreV1().Services(j.Namespace).Create(ctx, svc, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ExternalName Service %q: %v", svc.Name, err)
 	}
@@ -168,9 +168,9 @@ func (j *TestJig) CreateExternalNameService(tweak func(svc *v1.Service)) (*v1.Se
 }
 
 // ChangeServiceType updates the given service's ServiceType to the given newType.
-func (j *TestJig) ChangeServiceType(newType v1.ServiceType, timeout time.Duration) error {
+func (j *TestJig) ChangeServiceType(ctx context.Context, newType v1.ServiceType, timeout time.Duration) error {
 	ingressIP := ""
-	svc, err := j.UpdateService(func(s *v1.Service) {
+	svc, err := j.UpdateService(ctx, func(s *v1.Service) {
 		for _, ing := range s.Status.LoadBalancer.Ingress {
 			if ing.IP != "" {
 				ingressIP = ing.IP
@@ -183,7 +183,7 @@ func (j *TestJig) ChangeServiceType(newType v1.ServiceType, timeout time.Duratio
 		return err
 	}
 	if ingressIP != "" {
-		_, err = j.WaitForLoadBalancerDestroy(ingressIP, int(svc.Spec.Ports[0].Port), timeout)
+		_, err = j.WaitForLoadBalancerDestroy(ctx, ingressIP, int(svc.Spec.Ports[0].Port), timeout)
 	}
 	return err
 }
@@ -192,9 +192,9 @@ func (j *TestJig) ChangeServiceType(newType v1.ServiceType, timeout time.Duratio
 // ExternalTrafficPolicy set to Local and sanity checks its nodePort.
 // If createPod is true, it also creates an RC with 1 replica of
 // the standard netexec container used everywhere in this test.
-func (j *TestJig) CreateOnlyLocalNodePortService(createPod bool) (*v1.Service, error) {
+func (j *TestJig) CreateOnlyLocalNodePortService(ctx context.Context, createPod bool) (*v1.Service, error) {
 	ginkgo.By("creating a service " + j.Namespace + "/" + j.Name + " with type=NodePort and ExternalTrafficPolicy=Local")
-	svc, err := j.CreateTCPService(func(svc *v1.Service) {
+	svc, err := j.CreateTCPService(ctx, func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeNodePort
 		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
 		svc.Spec.Ports = []v1.ServicePort{{Protocol: v1.ProtocolTCP, Port: 80}}
@@ -205,7 +205,7 @@ func (j *TestJig) CreateOnlyLocalNodePortService(createPod bool) (*v1.Service, e
 
 	if createPod {
 		ginkgo.By("creating a pod to be part of the service " + j.Name)
-		_, err = j.Run(nil)
+		_, err = j.Run(ctx, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -217,9 +217,9 @@ func (j *TestJig) CreateOnlyLocalNodePortService(createPod bool) (*v1.Service, e
 // ExternalTrafficPolicy set to Local and waits for it to acquire an ingress IP.
 // If createPod is true, it also creates an RC with 1 replica of
 // the standard netexec container used everywhere in this test.
-func (j *TestJig) CreateOnlyLocalLoadBalancerService(timeout time.Duration, createPod bool,
+func (j *TestJig) CreateOnlyLocalLoadBalancerService(ctx context.Context, timeout time.Duration, createPod bool,
 	tweak func(svc *v1.Service)) (*v1.Service, error) {
-	_, err := j.CreateLoadBalancerService(timeout, func(svc *v1.Service) {
+	_, err := j.CreateLoadBalancerService(ctx, timeout, func(svc *v1.Service) {
 		ginkgo.By("setting ExternalTrafficPolicy=Local")
 		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
 		if tweak != nil {
@@ -232,18 +232,18 @@ func (j *TestJig) CreateOnlyLocalLoadBalancerService(timeout time.Duration, crea
 
 	if createPod {
 		ginkgo.By("creating a pod to be part of the service " + j.Name)
-		_, err = j.Run(nil)
+		_, err = j.Run(ctx, nil)
 		if err != nil {
 			return nil, err
 		}
 	}
 	ginkgo.By("waiting for loadbalancer for service " + j.Namespace + "/" + j.Name)
-	return j.WaitForLoadBalancer(timeout)
+	return j.WaitForLoadBalancer(ctx, timeout)
 }
 
 // CreateLoadBalancerService creates a loadbalancer service and waits
 // for it to acquire an ingress IP.
-func (j *TestJig) CreateLoadBalancerService(timeout time.Duration, tweak func(svc *v1.Service)) (*v1.Service, error) {
+func (j *TestJig) CreateLoadBalancerService(ctx context.Context, timeout time.Duration, tweak func(svc *v1.Service)) (*v1.Service, error) {
 	ginkgo.By("creating a service " + j.Namespace + "/" + j.Name + " with type=LoadBalancer")
 	svc := j.newServiceTemplate(v1.ProtocolTCP, 80)
 	svc.Spec.Type = v1.ServiceTypeLoadBalancer
@@ -252,25 +252,25 @@ func (j *TestJig) CreateLoadBalancerService(timeout time.Duration, tweak func(sv
 	if tweak != nil {
 		tweak(svc)
 	}
-	_, err := j.Client.CoreV1().Services(j.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	_, err := j.Client.CoreV1().Services(j.Namespace).Create(ctx, svc, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create LoadBalancer Service %q: %v", svc.Name, err)
 	}
 
 	ginkgo.By("waiting for loadbalancer for service " + j.Namespace + "/" + j.Name)
-	return j.WaitForLoadBalancer(timeout)
+	return j.WaitForLoadBalancer(ctx, timeout)
 }
 
 // GetEndpointNodes returns a map of nodenames:external-ip on which the
 // endpoints of the Service are running.
-func (j *TestJig) GetEndpointNodes() (map[string][]string, error) {
-	return j.GetEndpointNodesWithIP(v1.NodeExternalIP)
+func (j *TestJig) GetEndpointNodes(ctx context.Context) (map[string][]string, error) {
+	return j.GetEndpointNodesWithIP(ctx, v1.NodeExternalIP)
 }
 
 // GetEndpointNodesWithIP returns a map of nodenames:<ip of given type> on which the
 // endpoints of the Service are running.
-func (j *TestJig) GetEndpointNodesWithIP(addressType v1.NodeAddressType) (map[string][]string, error) {
-	nodes, err := j.ListNodesWithEndpoint()
+func (j *TestJig) GetEndpointNodesWithIP(ctx context.Context, addressType v1.NodeAddressType) (map[string][]string, error) {
+	nodes, err := j.ListNodesWithEndpoint(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -283,12 +283,11 @@ func (j *TestJig) GetEndpointNodesWithIP(addressType v1.NodeAddressType) (map[st
 
 // ListNodesWithEndpoint returns a list of nodes on which the
 // endpoints of the given Service are running.
-func (j *TestJig) ListNodesWithEndpoint() ([]v1.Node, error) {
-	nodeNames, err := j.GetEndpointNodeNames()
+func (j *TestJig) ListNodesWithEndpoint(ctx context.Context) ([]v1.Node, error) {
+	nodeNames, err := j.GetEndpointNodeNames(ctx)
 	if err != nil {
 		return nil, err
 	}
-	ctx := context.TODO()
 	allNodes, err := j.Client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -304,12 +303,12 @@ func (j *TestJig) ListNodesWithEndpoint() ([]v1.Node, error) {
 
 // GetEndpointNodeNames returns a string set of node names on which the
 // endpoints of the given Service are running.
-func (j *TestJig) GetEndpointNodeNames() (sets.String, error) {
-	err := j.waitForAvailableEndpoint(ServiceEndpointsTimeout)
+func (j *TestJig) GetEndpointNodeNames(ctx context.Context) (sets.String, error) {
+	err := j.waitForAvailableEndpoint(ctx, ServiceEndpointsTimeout)
 	if err != nil {
 		return nil, err
 	}
-	endpoints, err := j.Client.CoreV1().Endpoints(j.Namespace).Get(context.TODO(), j.Name, metav1.GetOptions{})
+	endpoints, err := j.Client.CoreV1().Endpoints(j.Namespace).Get(ctx, j.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("get endpoints for service %s/%s failed (%s)", j.Namespace, j.Name, err)
 	}
@@ -328,9 +327,9 @@ func (j *TestJig) GetEndpointNodeNames() (sets.String, error) {
 }
 
 // WaitForEndpointOnNode waits for a service endpoint on the given node.
-func (j *TestJig) WaitForEndpointOnNode(nodeName string) error {
-	return wait.PollImmediate(framework.Poll, KubeProxyLagTimeout, func() (bool, error) {
-		endpoints, err := j.Client.CoreV1().Endpoints(j.Namespace).Get(context.TODO(), j.Name, metav1.GetOptions{})
+func (j *TestJig) WaitForEndpointOnNode(ctx context.Context, nodeName string) error {
+	return wait.PollImmediateWithContext(ctx, framework.Poll, KubeProxyLagTimeout, func(ctx context.Context) (bool, error) {
+		endpoints, err := j.Client.CoreV1().Endpoints(j.Namespace).Get(ctx, j.Name, metav1.GetOptions{})
 		if err != nil {
 			framework.Logf("Get endpoints for service %s/%s failed (%s)", j.Namespace, j.Name, err)
 			return false, nil
@@ -355,7 +354,7 @@ func (j *TestJig) WaitForEndpointOnNode(nodeName string) error {
 }
 
 // waitForAvailableEndpoint waits for at least 1 endpoint to be available till timeout
-func (j *TestJig) waitForAvailableEndpoint(timeout time.Duration) error {
+func (j *TestJig) waitForAvailableEndpoint(ctx context.Context, timeout time.Duration) error {
 	//Wait for endpoints to be created, this may take longer time if service backing pods are taking longer time to run
 	endpointSelector := fields.OneTermEqualSelector("metadata.name", j.Name)
 	stopCh := make(chan struct{})
@@ -367,12 +366,12 @@ func (j *TestJig) waitForAvailableEndpoint(timeout time.Duration) error {
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.FieldSelector = endpointSelector.String()
-				obj, err := j.Client.CoreV1().Endpoints(j.Namespace).List(context.TODO(), options)
+				obj, err := j.Client.CoreV1().Endpoints(j.Namespace).List(ctx, options)
 				return runtime.Object(obj), err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.FieldSelector = endpointSelector.String()
-				return j.Client.CoreV1().Endpoints(j.Namespace).Watch(context.TODO(), options)
+				return j.Client.CoreV1().Endpoints(j.Namespace).Watch(ctx, options)
 			},
 		},
 		&v1.Endpoints{},
@@ -405,12 +404,12 @@ func (j *TestJig) waitForAvailableEndpoint(timeout time.Duration) error {
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.LabelSelector = "kubernetes.io/service-name=" + j.Name
-				obj, err := j.Client.DiscoveryV1().EndpointSlices(j.Namespace).List(context.TODO(), options)
+				obj, err := j.Client.DiscoveryV1().EndpointSlices(j.Namespace).List(ctx, options)
 				return runtime.Object(obj), err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = "kubernetes.io/service-name=" + j.Name
-				return j.Client.DiscoveryV1().EndpointSlices(j.Namespace).Watch(context.TODO(), options)
+				return j.Client.DiscoveryV1().EndpointSlices(j.Namespace).Watch(ctx, options)
 			},
 		},
 		&discoveryv1.EndpointSlice{},
@@ -441,7 +440,7 @@ func (j *TestJig) waitForAvailableEndpoint(timeout time.Duration) error {
 
 	go esController.Run(stopCh)
 
-	err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
+	err := wait.PollWithContext(ctx, 1*time.Second, timeout, func(ctx context.Context) (bool, error) {
 		return endpointAvailable && endpointSliceAvailable, nil
 	})
 	if err != nil {
@@ -518,14 +517,14 @@ func needsNodePorts(svc *v1.Service) bool {
 // UpdateService fetches a service, calls the update function on it, and
 // then attempts to send the updated service. It tries up to 3 times in the
 // face of timeouts and conflicts.
-func (j *TestJig) UpdateService(update func(*v1.Service)) (*v1.Service, error) {
+func (j *TestJig) UpdateService(ctx context.Context, update func(*v1.Service)) (*v1.Service, error) {
 	for i := 0; i < 3; i++ {
-		service, err := j.Client.CoreV1().Services(j.Namespace).Get(context.TODO(), j.Name, metav1.GetOptions{})
+		service, err := j.Client.CoreV1().Services(j.Namespace).Get(ctx, j.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get Service %q: %v", j.Name, err)
 		}
 		update(service)
-		result, err := j.Client.CoreV1().Services(j.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+		result, err := j.Client.CoreV1().Services(j.Namespace).Update(ctx, service, metav1.UpdateOptions{})
 		if err == nil {
 			return j.sanityCheckService(result, service.Spec.Type)
 		}
@@ -537,9 +536,9 @@ func (j *TestJig) UpdateService(update func(*v1.Service)) (*v1.Service, error) {
 }
 
 // WaitForNewIngressIP waits for the given service to get a new ingress IP, or returns an error after the given timeout
-func (j *TestJig) WaitForNewIngressIP(existingIP string, timeout time.Duration) (*v1.Service, error) {
+func (j *TestJig) WaitForNewIngressIP(ctx context.Context, existingIP string, timeout time.Duration) (*v1.Service, error) {
 	framework.Logf("Waiting up to %v for service %q to get a new ingress IP", timeout, j.Name)
-	service, err := j.waitForCondition(timeout, "have a new ingress IP", func(svc *v1.Service) bool {
+	service, err := j.waitForCondition(ctx, timeout, "have a new ingress IP", func(svc *v1.Service) bool {
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
 			return false
 		}
@@ -556,14 +555,14 @@ func (j *TestJig) WaitForNewIngressIP(existingIP string, timeout time.Duration) 
 }
 
 // ChangeServiceNodePort changes node ports of the given service.
-func (j *TestJig) ChangeServiceNodePort(initial int) (*v1.Service, error) {
+func (j *TestJig) ChangeServiceNodePort(ctx context.Context, initial int) (*v1.Service, error) {
 	var err error
 	var service *v1.Service
 	for i := 1; i < NodePortRange.Size; i++ {
 		offs1 := initial - NodePortRange.Base
 		offs2 := (offs1 + i) % NodePortRange.Size
 		newPort := NodePortRange.Base + offs2
-		service, err = j.UpdateService(func(s *v1.Service) {
+		service, err = j.UpdateService(ctx, func(s *v1.Service) {
 			s.Spec.Ports[0].NodePort = int32(newPort)
 		})
 		if err != nil && strings.Contains(err.Error(), errAllocated.Error()) {
@@ -577,9 +576,9 @@ func (j *TestJig) ChangeServiceNodePort(initial int) (*v1.Service, error) {
 }
 
 // WaitForLoadBalancer waits the given service to have a LoadBalancer, or returns an error after the given timeout
-func (j *TestJig) WaitForLoadBalancer(timeout time.Duration) (*v1.Service, error) {
+func (j *TestJig) WaitForLoadBalancer(ctx context.Context, timeout time.Duration) (*v1.Service, error) {
 	framework.Logf("Waiting up to %v for service %q to have a LoadBalancer", timeout, j.Name)
-	service, err := j.waitForCondition(timeout, "have a load balancer", func(svc *v1.Service) bool {
+	service, err := j.waitForCondition(ctx, timeout, "have a load balancer", func(svc *v1.Service) bool {
 		return len(svc.Status.LoadBalancer.Ingress) > 0
 	})
 	if err != nil {
@@ -596,16 +595,16 @@ func (j *TestJig) WaitForLoadBalancer(timeout time.Duration) (*v1.Service, error
 }
 
 // WaitForLoadBalancerDestroy waits the given service to destroy a LoadBalancer, or returns an error after the given timeout
-func (j *TestJig) WaitForLoadBalancerDestroy(ip string, port int, timeout time.Duration) (*v1.Service, error) {
+func (j *TestJig) WaitForLoadBalancerDestroy(ctx context.Context, ip string, port int, timeout time.Duration) (*v1.Service, error) {
 	// TODO: once support ticket 21807001 is resolved, reduce this timeout back to something reasonable
 	defer func() {
-		if err := framework.EnsureLoadBalancerResourcesDeleted(ip, strconv.Itoa(port)); err != nil {
+		if err := framework.EnsureLoadBalancerResourcesDeleted(ctx, ip, strconv.Itoa(port)); err != nil {
 			framework.Logf("Failed to delete cloud resources for service: %s %d (%v)", ip, port, err)
 		}
 	}()
 
 	framework.Logf("Waiting up to %v for service %q to have no LoadBalancer", timeout, j.Name)
-	service, err := j.waitForCondition(timeout, "have no load balancer", func(svc *v1.Service) bool {
+	service, err := j.waitForCondition(ctx, timeout, "have no load balancer", func(svc *v1.Service) bool {
 		return len(svc.Status.LoadBalancer.Ingress) == 0
 	})
 	if err != nil {
@@ -614,10 +613,10 @@ func (j *TestJig) WaitForLoadBalancerDestroy(ip string, port int, timeout time.D
 	return j.sanityCheckService(service, service.Spec.Type)
 }
 
-func (j *TestJig) waitForCondition(timeout time.Duration, message string, conditionFn func(*v1.Service) bool) (*v1.Service, error) {
+func (j *TestJig) waitForCondition(ctx context.Context, timeout time.Duration, message string, conditionFn func(*v1.Service) bool) (*v1.Service, error) {
 	var service *v1.Service
-	pollFunc := func() (bool, error) {
-		svc, err := j.Client.CoreV1().Services(j.Namespace).Get(context.TODO(), j.Name, metav1.GetOptions{})
+	pollFunc := func(ctx context.Context) (bool, error) {
+		svc, err := j.Client.CoreV1().Services(j.Namespace).Get(ctx, j.Name, metav1.GetOptions{})
 		if err != nil {
 			framework.Logf("Retrying .... error trying to get Service %s: %v", j.Name, err)
 			return false, nil
@@ -628,7 +627,7 @@ func (j *TestJig) waitForCondition(timeout time.Duration, message string, condit
 		}
 		return false, nil
 	}
-	if err := wait.PollImmediate(framework.Poll, timeout, pollFunc); err != nil {
+	if err := wait.PollImmediateWithContext(ctx, framework.Poll, timeout, pollFunc); err != nil {
 		return nil, fmt.Errorf("timed out waiting for service %q to %s: %w", j.Name, message, err)
 	}
 	return service, nil
@@ -700,13 +699,13 @@ func (j *TestJig) AddRCAntiAffinity(rc *v1.ReplicationController) {
 }
 
 // CreatePDB returns a PodDisruptionBudget for the given ReplicationController, or returns an error if a PodDisruptionBudget isn't ready
-func (j *TestJig) CreatePDB(rc *v1.ReplicationController) (*policyv1.PodDisruptionBudget, error) {
+func (j *TestJig) CreatePDB(ctx context.Context, rc *v1.ReplicationController) (*policyv1.PodDisruptionBudget, error) {
 	pdb := j.newPDBTemplate(rc)
-	newPdb, err := j.Client.PolicyV1().PodDisruptionBudgets(j.Namespace).Create(context.TODO(), pdb, metav1.CreateOptions{})
+	newPdb, err := j.Client.PolicyV1().PodDisruptionBudgets(j.Namespace).Create(ctx, pdb, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PDB %q %v", pdb.Name, err)
 	}
-	if err := j.waitForPdbReady(); err != nil {
+	if err := j.waitForPdbReady(ctx); err != nil {
 		return nil, fmt.Errorf("failed waiting for PDB to be ready: %v", err)
 	}
 
@@ -737,53 +736,53 @@ func (j *TestJig) newPDBTemplate(rc *v1.ReplicationController) *policyv1.PodDisr
 // Run creates a ReplicationController and Pod(s) and waits for the
 // Pod(s) to be running. Callers can provide a function to tweak the RC object
 // before it is created.
-func (j *TestJig) Run(tweak func(rc *v1.ReplicationController)) (*v1.ReplicationController, error) {
+func (j *TestJig) Run(ctx context.Context, tweak func(rc *v1.ReplicationController)) (*v1.ReplicationController, error) {
 	rc := j.newRCTemplate()
 	if tweak != nil {
 		tweak(rc)
 	}
-	result, err := j.Client.CoreV1().ReplicationControllers(j.Namespace).Create(context.TODO(), rc, metav1.CreateOptions{})
+	result, err := j.Client.CoreV1().ReplicationControllers(j.Namespace).Create(ctx, rc, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create RC %q: %v", rc.Name, err)
 	}
-	pods, err := j.waitForPodsCreated(int(*(rc.Spec.Replicas)))
+	pods, err := j.waitForPodsCreated(ctx, int(*(rc.Spec.Replicas)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pods: %v", err)
 	}
-	if err := j.waitForPodsReady(pods); err != nil {
+	if err := j.waitForPodsReady(ctx, pods); err != nil {
 		return nil, fmt.Errorf("failed waiting for pods to be running: %v", err)
 	}
 	return result, nil
 }
 
 // Scale scales pods to the given replicas
-func (j *TestJig) Scale(replicas int) error {
+func (j *TestJig) Scale(ctx context.Context, replicas int) error {
 	rc := j.Name
-	scale, err := j.Client.CoreV1().ReplicationControllers(j.Namespace).GetScale(context.TODO(), rc, metav1.GetOptions{})
+	scale, err := j.Client.CoreV1().ReplicationControllers(j.Namespace).GetScale(ctx, rc, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get scale for RC %q: %v", rc, err)
 	}
 
 	scale.ResourceVersion = "" // indicate the scale update should be unconditional
 	scale.Spec.Replicas = int32(replicas)
-	_, err = j.Client.CoreV1().ReplicationControllers(j.Namespace).UpdateScale(context.TODO(), rc, scale, metav1.UpdateOptions{})
+	_, err = j.Client.CoreV1().ReplicationControllers(j.Namespace).UpdateScale(ctx, rc, scale, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to scale RC %q: %v", rc, err)
 	}
-	pods, err := j.waitForPodsCreated(replicas)
+	pods, err := j.waitForPodsCreated(ctx, replicas)
 	if err != nil {
 		return fmt.Errorf("failed waiting for pods: %v", err)
 	}
-	if err := j.waitForPodsReady(pods); err != nil {
+	if err := j.waitForPodsReady(ctx, pods); err != nil {
 		return fmt.Errorf("failed waiting for pods to be running: %v", err)
 	}
 	return nil
 }
 
-func (j *TestJig) waitForPdbReady() error {
+func (j *TestJig) waitForPdbReady(ctx context.Context) error {
 	timeout := 2 * time.Minute
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(2 * time.Second) {
-		pdb, err := j.Client.PolicyV1().PodDisruptionBudgets(j.Namespace).Get(context.TODO(), j.Name, metav1.GetOptions{})
+		pdb, err := j.Client.PolicyV1().PodDisruptionBudgets(j.Namespace).Get(ctx, j.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -795,14 +794,15 @@ func (j *TestJig) waitForPdbReady() error {
 	return fmt.Errorf("timeout waiting for PDB %q to be ready", j.Name)
 }
 
-func (j *TestJig) waitForPodsCreated(replicas int) ([]string, error) {
+func (j *TestJig) waitForPodsCreated(ctx context.Context, replicas int) ([]string, error) {
+	// TODO (pohly): replace with gomega.Eventually
 	timeout := 2 * time.Minute
 	// List the pods, making sure we observe all the replicas.
 	label := labels.SelectorFromSet(labels.Set(j.Labels))
 	framework.Logf("Waiting up to %v for %d pods to be created", timeout, replicas)
-	for start := time.Now(); time.Since(start) < timeout; time.Sleep(2 * time.Second) {
+	for start := time.Now(); time.Since(start) < timeout && ctx.Err() == nil; time.Sleep(2 * time.Second) {
 		options := metav1.ListOptions{LabelSelector: label.String()}
-		pods, err := j.Client.CoreV1().Pods(j.Namespace).List(context.TODO(), options)
+		pods, err := j.Client.CoreV1().Pods(j.Namespace).List(ctx, options)
 		if err != nil {
 			return nil, err
 		}
@@ -823,31 +823,31 @@ func (j *TestJig) waitForPodsCreated(replicas int) ([]string, error) {
 	return nil, fmt.Errorf("timeout waiting for %d pods to be created", replicas)
 }
 
-func (j *TestJig) waitForPodsReady(pods []string) error {
+func (j *TestJig) waitForPodsReady(ctx context.Context, pods []string) error {
 	timeout := 2 * time.Minute
-	if !e2epod.CheckPodsRunningReady(j.Client, j.Namespace, pods, timeout) {
+	if !e2epod.CheckPodsRunningReady(ctx, j.Client, j.Namespace, pods, timeout) {
 		return fmt.Errorf("timeout waiting for %d pods to be ready", len(pods))
 	}
 	return nil
 }
 
-func testReachabilityOverServiceName(serviceName string, sp v1.ServicePort, execPod *v1.Pod) error {
-	return testEndpointReachability(serviceName, sp.Port, sp.Protocol, execPod)
+func testReachabilityOverServiceName(ctx context.Context, serviceName string, sp v1.ServicePort, execPod *v1.Pod) error {
+	return testEndpointReachability(ctx, serviceName, sp.Port, sp.Protocol, execPod)
 }
 
-func testReachabilityOverClusterIP(clusterIP string, sp v1.ServicePort, execPod *v1.Pod) error {
+func testReachabilityOverClusterIP(ctx context.Context, clusterIP string, sp v1.ServicePort, execPod *v1.Pod) error {
 	// If .spec.clusterIP is set to "" or "None" for service, ClusterIP is not created, so reachability can not be tested over clusterIP:servicePort
 	if netutils.ParseIPSloppy(clusterIP) == nil {
 		return fmt.Errorf("unable to parse ClusterIP: %s", clusterIP)
 	}
-	return testEndpointReachability(clusterIP, sp.Port, sp.Protocol, execPod)
+	return testEndpointReachability(ctx, clusterIP, sp.Port, sp.Protocol, execPod)
 }
 
-func testReachabilityOverExternalIP(externalIP string, sp v1.ServicePort, execPod *v1.Pod) error {
-	return testEndpointReachability(externalIP, sp.Port, sp.Protocol, execPod)
+func testReachabilityOverExternalIP(ctx context.Context, externalIP string, sp v1.ServicePort, execPod *v1.Pod) error {
+	return testEndpointReachability(ctx, externalIP, sp.Port, sp.Protocol, execPod)
 }
 
-func testReachabilityOverNodePorts(nodes *v1.NodeList, sp v1.ServicePort, pod *v1.Pod, clusterIP string, externalIPs bool) error {
+func testReachabilityOverNodePorts(ctx context.Context, nodes *v1.NodeList, sp v1.ServicePort, pod *v1.Pod, clusterIP string, externalIPs bool) error {
 	internalAddrs := e2enode.CollectAddresses(nodes, v1.NodeInternalIP)
 	isClusterIPV4 := netutils.IsIPv4String(clusterIP)
 
@@ -864,7 +864,7 @@ func testReachabilityOverNodePorts(nodes *v1.NodeList, sp v1.ServicePort, pod *v
 			continue
 		}
 
-		err := testEndpointReachability(internalAddr, sp.NodePort, sp.Protocol, pod)
+		err := testEndpointReachability(ctx, internalAddr, sp.NodePort, sp.Protocol, pod)
 		if err != nil {
 			return err
 		}
@@ -876,7 +876,7 @@ func testReachabilityOverNodePorts(nodes *v1.NodeList, sp v1.ServicePort, pod *v
 				framework.Logf("skipping testEndpointReachability() for external address %s as it does not match clusterIP (%s) family", externalAddr, clusterIP)
 				continue
 			}
-			err := testEndpointReachability(externalAddr, sp.NodePort, sp.Protocol, pod)
+			err := testEndpointReachability(ctx, externalAddr, sp.NodePort, sp.Protocol, pod)
 			if err != nil {
 				return err
 			}
@@ -898,7 +898,7 @@ func isInvalidOrLocalhostAddress(ip string) bool {
 // testEndpointReachability tests reachability to endpoints (i.e. IP, ServiceName) and ports. Test request is initiated from specified execPod.
 // TCP and UDP protocol based service are supported at this moment
 // TODO: add support to test SCTP Protocol based services.
-func testEndpointReachability(endpoint string, port int32, protocol v1.Protocol, execPod *v1.Pod) error {
+func testEndpointReachability(ctx context.Context, endpoint string, port int32, protocol v1.Protocol, execPod *v1.Pod) error {
 	ep := net.JoinHostPort(endpoint, strconv.Itoa(int(port)))
 	cmd := ""
 	switch protocol {
@@ -910,7 +910,7 @@ func testEndpointReachability(endpoint string, port int32, protocol v1.Protocol,
 		return fmt.Errorf("service reachability check is not supported for %v", protocol)
 	}
 
-	err := wait.PollImmediate(1*time.Second, ServiceReachabilityShortPollTimeout, func() (bool, error) {
+	err := wait.PollImmediateWithContext(ctx, 1*time.Second, ServiceReachabilityShortPollTimeout, func(ctx context.Context) (bool, error) {
 		_, err := e2epodoutput.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
 		if err != nil {
 			framework.Logf("Service reachability failing with error: %v\nRetrying...", err)
@@ -926,28 +926,28 @@ func testEndpointReachability(endpoint string, port int32, protocol v1.Protocol,
 
 // checkClusterIPServiceReachability ensures that service of type ClusterIP is reachable over
 // - ServiceName:ServicePort, ClusterIP:ServicePort
-func (j *TestJig) checkClusterIPServiceReachability(svc *v1.Service, pod *v1.Pod) error {
+func (j *TestJig) checkClusterIPServiceReachability(ctx context.Context, svc *v1.Service, pod *v1.Pod) error {
 	clusterIP := svc.Spec.ClusterIP
 	servicePorts := svc.Spec.Ports
 	externalIPs := svc.Spec.ExternalIPs
 
-	err := j.waitForAvailableEndpoint(ServiceEndpointsTimeout)
+	err := j.waitForAvailableEndpoint(ctx, ServiceEndpointsTimeout)
 	if err != nil {
 		return err
 	}
 
 	for _, servicePort := range servicePorts {
-		err = testReachabilityOverServiceName(svc.Name, servicePort, pod)
+		err = testReachabilityOverServiceName(ctx, svc.Name, servicePort, pod)
 		if err != nil {
 			return err
 		}
-		err = testReachabilityOverClusterIP(clusterIP, servicePort, pod)
+		err = testReachabilityOverClusterIP(ctx, clusterIP, servicePort, pod)
 		if err != nil {
 			return err
 		}
 		if len(externalIPs) > 0 {
 			for _, externalIP := range externalIPs {
-				err = testReachabilityOverExternalIP(externalIP, servicePort, pod)
+				err = testReachabilityOverExternalIP(ctx, externalIP, servicePort, pod)
 				if err != nil {
 					return err
 				}
@@ -962,31 +962,31 @@ func (j *TestJig) checkClusterIPServiceReachability(svc *v1.Service, pod *v1.Pod
 //     ServiceName:ServicePort, ClusterIP:ServicePort and NodeInternalIPs:NodePort
 //   - External clients should be reachable to service over -
 //     NodePublicIPs:NodePort
-func (j *TestJig) checkNodePortServiceReachability(svc *v1.Service, pod *v1.Pod) error {
+func (j *TestJig) checkNodePortServiceReachability(ctx context.Context, svc *v1.Service, pod *v1.Pod) error {
 	clusterIP := svc.Spec.ClusterIP
 	servicePorts := svc.Spec.Ports
 
 	// Consider only 2 nodes for testing
-	nodes, err := e2enode.GetBoundedReadySchedulableNodes(j.Client, 2)
+	nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, j.Client, 2)
 	if err != nil {
 		return err
 	}
 
-	err = j.waitForAvailableEndpoint(ServiceEndpointsTimeout)
+	err = j.waitForAvailableEndpoint(ctx, ServiceEndpointsTimeout)
 	if err != nil {
 		return err
 	}
 
 	for _, servicePort := range servicePorts {
-		err = testReachabilityOverServiceName(svc.Name, servicePort, pod)
+		err = testReachabilityOverServiceName(ctx, svc.Name, servicePort, pod)
 		if err != nil {
 			return err
 		}
-		err = testReachabilityOverClusterIP(clusterIP, servicePort, pod)
+		err = testReachabilityOverClusterIP(ctx, clusterIP, servicePort, pod)
 		if err != nil {
 			return err
 		}
-		err = testReachabilityOverNodePorts(nodes, servicePort, pod, clusterIP, j.ExternalIPs)
+		err = testReachabilityOverNodePorts(ctx, nodes, servicePort, pod, clusterIP, j.ExternalIPs)
 		if err != nil {
 			return err
 		}
@@ -997,12 +997,12 @@ func (j *TestJig) checkNodePortServiceReachability(svc *v1.Service, pod *v1.Pod)
 
 // checkExternalServiceReachability ensures service of type externalName resolves to IP address and no fake externalName is set
 // FQDN of kubernetes is used as externalName(for air tight platforms).
-func (j *TestJig) checkExternalServiceReachability(svc *v1.Service, pod *v1.Pod) error {
+func (j *TestJig) checkExternalServiceReachability(ctx context.Context, svc *v1.Service, pod *v1.Pod) error {
 	// NOTE(claudiub): Windows does not support PQDN.
 	svcName := fmt.Sprintf("%s.%s.svc.%s", svc.Name, svc.Namespace, framework.TestContext.ClusterDNSDomain)
 	// Service must resolve to IP
 	cmd := fmt.Sprintf("nslookup %s", svcName)
-	return wait.PollImmediate(framework.Poll, ServiceReachabilityShortPollTimeout, func() (done bool, err error) {
+	return wait.PollImmediateWithContext(ctx, framework.Poll, ServiceReachabilityShortPollTimeout, func(ctx context.Context) (done bool, err error) {
 		_, stderr, err := e2epodoutput.RunHostCmdWithFullOutput(pod.Namespace, pod.Name, cmd)
 		// NOTE(claudiub): nslookup may return 0 on Windows, even though the DNS name was not found. In this case,
 		// we can check stderr for the error.
@@ -1015,7 +1015,7 @@ func (j *TestJig) checkExternalServiceReachability(svc *v1.Service, pod *v1.Pod)
 }
 
 // CheckServiceReachability ensures that request are served by the services. Only supports Services with type ClusterIP, NodePort and ExternalName.
-func (j *TestJig) CheckServiceReachability(svc *v1.Service, pod *v1.Pod) error {
+func (j *TestJig) CheckServiceReachability(ctx context.Context, svc *v1.Service, pod *v1.Pod) error {
 	svcType := svc.Spec.Type
 
 	_, err := j.sanityCheckService(svc, svcType)
@@ -1025,20 +1025,20 @@ func (j *TestJig) CheckServiceReachability(svc *v1.Service, pod *v1.Pod) error {
 
 	switch svcType {
 	case v1.ServiceTypeClusterIP:
-		return j.checkClusterIPServiceReachability(svc, pod)
+		return j.checkClusterIPServiceReachability(ctx, svc, pod)
 	case v1.ServiceTypeNodePort:
-		return j.checkNodePortServiceReachability(svc, pod)
+		return j.checkNodePortServiceReachability(ctx, svc, pod)
 	case v1.ServiceTypeExternalName:
-		return j.checkExternalServiceReachability(svc, pod)
+		return j.checkExternalServiceReachability(ctx, svc, pod)
 	case v1.ServiceTypeLoadBalancer:
-		return j.checkClusterIPServiceReachability(svc, pod)
+		return j.checkClusterIPServiceReachability(ctx, svc, pod)
 	default:
 		return fmt.Errorf("unsupported service type \"%s\" to verify service reachability for \"%s\" service. This may due to diverse implementation of the service type", svcType, svc.Name)
 	}
 }
 
 // CreateServicePods creates a replication controller with the label same as service. Service listens to TCP and UDP.
-func (j *TestJig) CreateServicePods(replica int) error {
+func (j *TestJig) CreateServicePods(ctx context.Context, replica int) error {
 	config := testutils.RCConfig{
 		Client:       j.Client,
 		Name:         j.Name,
@@ -1050,18 +1050,18 @@ func (j *TestJig) CreateServicePods(replica int) error {
 		Timeout:      framework.PodReadyBeforeTimeout,
 		Replicas:     replica,
 	}
-	return e2erc.RunRC(config)
+	return e2erc.RunRC(ctx, config)
 }
 
 // CreateSCTPServiceWithPort creates a new SCTP Service with given port based on the
 // j's defaults. Callers can provide a function to tweak the Service object before
 // it is created.
-func (j *TestJig) CreateSCTPServiceWithPort(tweak func(svc *v1.Service), port int32) (*v1.Service, error) {
+func (j *TestJig) CreateSCTPServiceWithPort(ctx context.Context, tweak func(svc *v1.Service), port int32) (*v1.Service, error) {
 	svc := j.newServiceTemplate(v1.ProtocolSCTP, port)
 	if tweak != nil {
 		tweak(svc)
 	}
-	result, err := j.Client.CoreV1().Services(j.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	result, err := j.Client.CoreV1().Services(j.Namespace).Create(ctx, svc, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SCTP Service %q: %v", svc.Name, err)
 	}

--- a/test/e2e/framework/service/resource.go
+++ b/test/e2e/framework/service/resource.go
@@ -65,18 +65,18 @@ func CreateServiceSpec(serviceName, externalName string, isHeadless bool, select
 // UpdateService fetches a service, calls the update function on it,
 // and then attempts to send the updated service. It retries up to 2
 // times in the face of timeouts and conflicts.
-func UpdateService(c clientset.Interface, namespace, serviceName string, update func(*v1.Service)) (*v1.Service, error) {
+func UpdateService(ctx context.Context, c clientset.Interface, namespace, serviceName string, update func(*v1.Service)) (*v1.Service, error) {
 	var service *v1.Service
 	var err error
 	for i := 0; i < 3; i++ {
-		service, err = c.CoreV1().Services(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
+		service, err = c.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 		if err != nil {
 			return service, err
 		}
 
 		update(service)
 
-		service, err = c.CoreV1().Services(namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+		service, err = c.CoreV1().Services(namespace).Update(ctx, service, metav1.UpdateOptions{})
 
 		if !apierrors.IsConflict(err) && !apierrors.IsServerTimeout(err) {
 			return service, err
@@ -86,8 +86,8 @@ func UpdateService(c clientset.Interface, namespace, serviceName string, update 
 }
 
 // CleanupServiceResources cleans up service Type=LoadBalancer resources.
-func CleanupServiceResources(c clientset.Interface, loadBalancerName, region, zone string) {
-	framework.TestContext.CloudConfig.Provider.CleanupServiceResources(c, loadBalancerName, region, zone)
+func CleanupServiceResources(ctx context.Context, c clientset.Interface, loadBalancerName, region, zone string) {
+	framework.TestContext.CloudConfig.Provider.CleanupServiceResources(ctx, c, loadBalancerName, region, zone)
 }
 
 // GetIngressPoint returns a host on which ingress serves.
@@ -100,8 +100,8 @@ func GetIngressPoint(ing *v1.LoadBalancerIngress) string {
 }
 
 // GetServiceLoadBalancerCreationTimeout returns a timeout value for creating a load balancer of a service.
-func GetServiceLoadBalancerCreationTimeout(cs clientset.Interface) time.Duration {
-	nodes, err := e2enode.GetReadySchedulableNodes(cs)
+func GetServiceLoadBalancerCreationTimeout(ctx context.Context, cs clientset.Interface) time.Duration {
+	nodes, err := e2enode.GetReadySchedulableNodes(ctx, cs)
 	framework.ExpectNoError(err)
 	if len(nodes.Items) > LargeClusterMinNodesNumber {
 		return loadBalancerCreateTimeoutLarge
@@ -110,8 +110,8 @@ func GetServiceLoadBalancerCreationTimeout(cs clientset.Interface) time.Duration
 }
 
 // GetServiceLoadBalancerPropagationTimeout returns a timeout value for propagating a load balancer of a service.
-func GetServiceLoadBalancerPropagationTimeout(cs clientset.Interface) time.Duration {
-	nodes, err := e2enode.GetReadySchedulableNodes(cs)
+func GetServiceLoadBalancerPropagationTimeout(ctx context.Context, cs clientset.Interface) time.Duration {
+	nodes, err := e2enode.GetReadySchedulableNodes(ctx, cs)
 	framework.ExpectNoError(err)
 	if len(nodes.Items) > LargeClusterMinNodesNumber {
 		return loadBalancerPropagationTimeoutLarge
@@ -120,10 +120,10 @@ func GetServiceLoadBalancerPropagationTimeout(cs clientset.Interface) time.Durat
 }
 
 // CreateServiceForSimpleAppWithPods is a convenience wrapper to create a service and its matching pods all at once.
-func CreateServiceForSimpleAppWithPods(c clientset.Interface, contPort int, svcPort int, namespace, appName string, podSpec func(n v1.Node) v1.PodSpec, count int, block bool) (*v1.Service, error) {
+func CreateServiceForSimpleAppWithPods(ctx context.Context, c clientset.Interface, contPort int, svcPort int, namespace, appName string, podSpec func(n v1.Node) v1.PodSpec, count int, block bool) (*v1.Service, error) {
 	var err error
-	theService := CreateServiceForSimpleApp(c, contPort, svcPort, namespace, appName)
-	e2enode.CreatePodsPerNodeForSimpleApp(c, namespace, appName, podSpec, count)
+	theService := CreateServiceForSimpleApp(ctx, c, contPort, svcPort, namespace, appName)
+	e2enode.CreatePodsPerNodeForSimpleApp(ctx, c, namespace, appName, podSpec, count)
 	if block {
 		err = testutils.WaitForPodsWithLabelRunning(c, namespace, labels.SelectorFromSet(labels.Set(theService.Spec.Selector)))
 	}
@@ -131,7 +131,7 @@ func CreateServiceForSimpleAppWithPods(c clientset.Interface, contPort int, svcP
 }
 
 // CreateServiceForSimpleApp returns a service that selects/exposes pods (send -1 ports if no exposure needed) with an app label.
-func CreateServiceForSimpleApp(c clientset.Interface, contPort, svcPort int, namespace, appName string) *v1.Service {
+func CreateServiceForSimpleApp(ctx context.Context, c clientset.Interface, contPort, svcPort int, namespace, appName string) *v1.Service {
 	if appName == "" {
 		panic(fmt.Sprintf("no app name provided"))
 	}
@@ -152,7 +152,7 @@ func CreateServiceForSimpleApp(c clientset.Interface, contPort, svcPort int, nam
 		}}
 	}
 	framework.Logf("Creating a service-for-%v for selecting app=%v-pod", appName, appName)
-	service, err := c.CoreV1().Services(namespace).Create(context.TODO(), &v1.Service{
+	service, err := c.CoreV1().Services(namespace).Create(ctx, &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "service-for-" + appName,
 			Labels: map[string]string{

--- a/test/e2e/framework/service/util.go
+++ b/test/e2e/framework/service/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -25,13 +26,13 @@ import (
 )
 
 // TestReachableHTTP tests that the given host serves HTTP on the given port.
-func TestReachableHTTP(host string, port int, timeout time.Duration) {
-	TestReachableHTTPWithRetriableErrorCodes(host, port, []int{}, timeout)
+func TestReachableHTTP(ctx context.Context, host string, port int, timeout time.Duration) {
+	TestReachableHTTPWithRetriableErrorCodes(ctx, host, port, []int{}, timeout)
 }
 
 // TestReachableHTTPWithRetriableErrorCodes tests that the given host serves HTTP on the given port with the given retriableErrCodes.
-func TestReachableHTTPWithRetriableErrorCodes(host string, port int, retriableErrCodes []int, timeout time.Duration) {
-	pollfn := func() (bool, error) {
+func TestReachableHTTPWithRetriableErrorCodes(ctx context.Context, host string, port int, retriableErrCodes []int, timeout time.Duration) {
+	pollfn := func(ctx context.Context) (bool, error) {
 		result := e2enetwork.PokeHTTP(host, port, "/echo?msg=hello",
 			&e2enetwork.HTTPPokeParams{
 				BodyContains:   "hello",
@@ -43,7 +44,7 @@ func TestReachableHTTPWithRetriableErrorCodes(host string, port int, retriableEr
 		return false, nil // caller can retry
 	}
 
-	if err := wait.PollImmediate(framework.Poll, timeout, pollfn); err != nil {
+	if err := wait.PollImmediateWithContext(ctx, framework.Poll, timeout, pollfn); err != nil {
 		if err == wait.ErrWaitTimeout {
 			framework.Failf("Could not reach HTTP service through %v:%v after %v", host, port, timeout)
 		} else {

--- a/test/e2e/framework/service/wait.go
+++ b/test/e2e/framework/service/wait.go
@@ -31,15 +31,15 @@ import (
 )
 
 // WaitForServiceDeletedWithFinalizer waits for the service with finalizer to be deleted.
-func WaitForServiceDeletedWithFinalizer(cs clientset.Interface, namespace, name string) {
+func WaitForServiceDeletedWithFinalizer(ctx context.Context, cs clientset.Interface, namespace, name string) {
 	ginkgo.By("Delete service with finalizer")
-	if err := cs.CoreV1().Services(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
+	if err := cs.CoreV1().Services(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
 		framework.Failf("Failed to delete service %s/%s", namespace, name)
 	}
 
 	ginkgo.By("Wait for service to disappear")
-	if pollErr := wait.PollImmediate(LoadBalancerPollInterval, GetServiceLoadBalancerCreationTimeout(cs), func() (bool, error) {
-		svc, err := cs.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if pollErr := wait.PollImmediateWithContext(ctx, LoadBalancerPollInterval, GetServiceLoadBalancerCreationTimeout(ctx, cs), func(ctx context.Context) (bool, error) {
+		svc, err := cs.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				framework.Logf("Service %s/%s is gone.", namespace, name)
@@ -56,10 +56,10 @@ func WaitForServiceDeletedWithFinalizer(cs clientset.Interface, namespace, name 
 
 // WaitForServiceUpdatedWithFinalizer waits for the service to be updated to have or
 // don't have a finalizer.
-func WaitForServiceUpdatedWithFinalizer(cs clientset.Interface, namespace, name string, hasFinalizer bool) {
+func WaitForServiceUpdatedWithFinalizer(ctx context.Context, cs clientset.Interface, namespace, name string, hasFinalizer bool) {
 	ginkgo.By(fmt.Sprintf("Wait for service to hasFinalizer=%t", hasFinalizer))
-	if pollErr := wait.PollImmediate(LoadBalancerPollInterval, GetServiceLoadBalancerCreationTimeout(cs), func() (bool, error) {
-		svc, err := cs.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if pollErr := wait.PollImmediateWithContext(ctx, LoadBalancerPollInterval, GetServiceLoadBalancerCreationTimeout(ctx, cs), func(ctx context.Context) (bool, error) {
+		svc, err := cs.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/framework/skipper/skipper_test.go
+++ b/test/e2e/framework/skipper/skipper_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package skipper_test
 
 import (
-	"context"
 	"flag"
 	"testing"
 
@@ -47,10 +46,11 @@ import (
 //
 //
 //
+//
 // This must be line #50.
 
 var _ = ginkgo.Describe("e2e", func() {
-	ginkgo.It("skips", func(ctx context.Context) {
+	ginkgo.It("skips", func() {
 		e2eskipper.Skipf("skipping %d, %d, %d", 1, 3, 4)
 	})
 })

--- a/test/e2e/framework/ssh/ssh.go
+++ b/test/e2e/framework/ssh/ssh.go
@@ -119,8 +119,8 @@ func makePrivateKeySignerFromFile(key string) (ssh.Signer, error) {
 // looking for internal IPs. If it can't find an internal IP for every node it
 // returns an error, though it still returns all hosts that it found in that
 // case.
-func NodeSSHHosts(c clientset.Interface) ([]string, error) {
-	nodelist := waitListSchedulableNodesOrDie(c)
+func NodeSSHHosts(ctx context.Context, c clientset.Interface) ([]string, error) {
+	nodelist := waitListSchedulableNodesOrDie(ctx, c)
 
 	hosts := nodeAddresses(nodelist, v1.NodeExternalIP)
 	// If  ExternalIPs aren't available for all nodes, try falling back to the InternalIPs.
@@ -188,14 +188,14 @@ type Result struct {
 // NodeExec execs the given cmd on node via SSH. Note that the nodeName is an sshable name,
 // eg: the name returned by framework.GetMasterHost(). This is also not guaranteed to work across
 // cloud providers since it involves ssh.
-func NodeExec(nodeName, cmd, provider string) (Result, error) {
-	return SSH(cmd, net.JoinHostPort(nodeName, SSHPort), provider)
+func NodeExec(ctx context.Context, nodeName, cmd, provider string) (Result, error) {
+	return SSH(ctx, cmd, net.JoinHostPort(nodeName, SSHPort), provider)
 }
 
 // SSH synchronously SSHs to a node running on provider and runs cmd. If there
 // is no error performing the SSH, the stdout, stderr, and exit code are
 // returned.
-func SSH(cmd, host, provider string) (Result, error) {
+func SSH(ctx context.Context, cmd, host, provider string) (Result, error) {
 	result := Result{Host: host, Cmd: cmd}
 
 	// Get a signer for the provider.
@@ -212,14 +212,14 @@ func SSH(cmd, host, provider string) (Result, error) {
 	}
 
 	if bastion := os.Getenv(sshBastionEnvKey); len(bastion) > 0 {
-		stdout, stderr, code, err := runSSHCommandViaBastion(cmd, result.User, bastion, host, signer)
+		stdout, stderr, code, err := runSSHCommandViaBastion(ctx, cmd, result.User, bastion, host, signer)
 		result.Stdout = stdout
 		result.Stderr = stderr
 		result.Code = code
 		return result, err
 	}
 
-	stdout, stderr, code, err := runSSHCommand(cmd, result.User, host, signer)
+	stdout, stderr, code, err := runSSHCommand(ctx, cmd, result.User, host, signer)
 	result.Stdout = stdout
 	result.Stderr = stderr
 	result.Code = code
@@ -229,7 +229,7 @@ func SSH(cmd, host, provider string) (Result, error) {
 
 // runSSHCommandViaBastion returns the stdout, stderr, and exit code from running cmd on
 // host as specific user, along with any SSH-level error.
-func runSSHCommand(cmd, user, host string, signer ssh.Signer) (string, string, int, error) {
+func runSSHCommand(ctx context.Context, cmd, user, host string, signer ssh.Signer) (string, string, int, error) {
 	if user == "" {
 		user = os.Getenv("USER")
 	}
@@ -241,7 +241,7 @@ func runSSHCommand(cmd, user, host string, signer ssh.Signer) (string, string, i
 	}
 	client, err := ssh.Dial("tcp", host, config)
 	if err != nil {
-		err = wait.Poll(5*time.Second, 20*time.Second, func() (bool, error) {
+		err = wait.PollWithContext(ctx, 5*time.Second, 20*time.Second, func(ctx context.Context) (bool, error) {
 			fmt.Printf("error dialing %s@%s: '%v', retrying\n", user, host, err)
 			if client, err = ssh.Dial("tcp", host, config); err != nil {
 				return false, nil // retrying, error will be logged above
@@ -285,7 +285,7 @@ func runSSHCommand(cmd, user, host string, signer ssh.Signer) (string, string, i
 // host as specific user, along with any SSH-level error. It uses an SSH proxy to connect
 // to bastion, then via that tunnel connects to the remote host. Similar to
 // sshutil.RunSSHCommand but scoped to the needs of the test infrastructure.
-func runSSHCommandViaBastion(cmd, user, bastion, host string, signer ssh.Signer) (string, string, int, error) {
+func runSSHCommandViaBastion(ctx context.Context, cmd, user, bastion, host string, signer ssh.Signer) (string, string, int, error) {
 	// Setup the config, dial the server, and open a session.
 	config := &ssh.ClientConfig{
 		User:            user,
@@ -295,7 +295,7 @@ func runSSHCommandViaBastion(cmd, user, bastion, host string, signer ssh.Signer)
 	}
 	bastionClient, err := ssh.Dial("tcp", bastion, config)
 	if err != nil {
-		err = wait.Poll(5*time.Second, 20*time.Second, func() (bool, error) {
+		err = wait.PollWithContext(ctx, 5*time.Second, 20*time.Second, func(ctx context.Context) (bool, error) {
 			fmt.Printf("error dialing %s@%s: '%v', retrying\n", user, bastion, err)
 			if bastionClient, err = ssh.Dial("tcp", bastion, config); err != nil {
 				return false, err
@@ -359,7 +359,7 @@ func LogResult(result Result) {
 }
 
 // IssueSSHCommandWithResult tries to execute a SSH command and returns the execution result
-func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*Result, error) {
+func IssueSSHCommandWithResult(ctx context.Context, cmd, provider string, node *v1.Node) (*Result, error) {
 	framework.Logf("Getting external IP address for %s", node.Name)
 	host := ""
 	for _, a := range node.Status.Addresses {
@@ -384,7 +384,7 @@ func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*Result, er
 	}
 
 	framework.Logf("SSH %q on %s(%s)", cmd, node.Name, host)
-	result, err := SSH(cmd, host, provider)
+	result, err := SSH(ctx, cmd, host, provider)
 	LogResult(result)
 
 	if result.Code != 0 || err != nil {
@@ -396,8 +396,8 @@ func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*Result, er
 }
 
 // IssueSSHCommand tries to execute a SSH command
-func IssueSSHCommand(cmd, provider string, node *v1.Node) error {
-	_, err := IssueSSHCommandWithResult(cmd, provider, node)
+func IssueSSHCommand(ctx context.Context, cmd, provider string, node *v1.Node) error {
+	_, err := IssueSSHCommandWithResult(ctx, cmd, provider, node)
 	if err != nil {
 		return err
 	}
@@ -419,11 +419,11 @@ func nodeAddresses(nodelist *v1.NodeList, addrType v1.NodeAddressType) []string 
 }
 
 // waitListSchedulableNodes is a wrapper around listing nodes supporting retries.
-func waitListSchedulableNodes(c clientset.Interface) (*v1.NodeList, error) {
+func waitListSchedulableNodes(ctx context.Context, c clientset.Interface) (*v1.NodeList, error) {
 	var nodes *v1.NodeList
 	var err error
-	if wait.PollImmediate(pollNodeInterval, singleCallTimeout, func() (bool, error) {
-		nodes, err = c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{FieldSelector: fields.Set{
+	if wait.PollImmediateWithContext(ctx, pollNodeInterval, singleCallTimeout, func(ctx context.Context) (bool, error) {
+		nodes, err = c.CoreV1().Nodes().List(ctx, metav1.ListOptions{FieldSelector: fields.Set{
 			"spec.unschedulable": "false",
 		}.AsSelector().String()})
 		if err != nil {
@@ -437,8 +437,8 @@ func waitListSchedulableNodes(c clientset.Interface) (*v1.NodeList, error) {
 }
 
 // waitListSchedulableNodesOrDie is a wrapper around listing nodes supporting retries.
-func waitListSchedulableNodesOrDie(c clientset.Interface) *v1.NodeList {
-	nodes, err := waitListSchedulableNodes(c)
+func waitListSchedulableNodesOrDie(ctx context.Context, c clientset.Interface) *v1.NodeList {
+	nodes, err := waitListSchedulableNodes(ctx, c)
 	if err != nil {
 		expectNoError(err, "Non-retryable failure or timed out while listing nodes for e2e cluster.")
 	}

--- a/test/e2e/framework/statefulset/fixtures.go
+++ b/test/e2e/framework/statefulset/fixtures.go
@@ -17,6 +17,7 @@ limitations under the License.
 package statefulset
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -153,8 +154,8 @@ func PauseNewPods(ss *appsv1.StatefulSet) {
 // It fails the test if it finds any pods that are not in phase Running,
 // or if it finds more than one paused Pod existing at the same time.
 // This is a no-op if there are no paused pods.
-func ResumeNextPod(c clientset.Interface, ss *appsv1.StatefulSet) {
-	podList := GetPodList(c, ss)
+func ResumeNextPod(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet) {
+	podList := GetPodList(ctx, c, ss)
 	resumedPod := ""
 	for _, pod := range podList.Items {
 		if pod.Status.Phase != v1.PodRunning {

--- a/test/e2e/framework/statefulset/rest.go
+++ b/test/e2e/framework/statefulset/rest.go
@@ -38,7 +38,7 @@ import (
 )
 
 // CreateStatefulSet creates a StatefulSet from the manifest at manifestPath in the Namespace ns using kubectl create.
-func CreateStatefulSet(c clientset.Interface, manifestPath, ns string) *appsv1.StatefulSet {
+func CreateStatefulSet(ctx context.Context, c clientset.Interface, manifestPath, ns string) *appsv1.StatefulSet {
 	mkpath := func(file string) string {
 		return filepath.Join(manifestPath, file)
 	}
@@ -51,28 +51,28 @@ func CreateStatefulSet(c clientset.Interface, manifestPath, ns string) *appsv1.S
 	framework.ExpectNoError(err)
 
 	framework.Logf(fmt.Sprintf("creating " + ss.Name + " service"))
-	_, err = c.CoreV1().Services(ns).Create(context.TODO(), svc, metav1.CreateOptions{})
+	_, err = c.CoreV1().Services(ns).Create(ctx, svc, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	framework.Logf(fmt.Sprintf("creating statefulset %v/%v with %d replicas and selector %+v", ss.Namespace, ss.Name, *(ss.Spec.Replicas), ss.Spec.Selector))
-	_, err = c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+	_, err = c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
-	WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
+	WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 	return ss
 }
 
 // GetPodList gets the current Pods in ss.
-func GetPodList(c clientset.Interface, ss *appsv1.StatefulSet) *v1.PodList {
+func GetPodList(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet) *v1.PodList {
 	selector, err := metav1.LabelSelectorAsSelector(ss.Spec.Selector)
 	framework.ExpectNoError(err)
-	podList, err := c.CoreV1().Pods(ss.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	podList, err := c.CoreV1().Pods(ss.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 	framework.ExpectNoError(err)
 	return podList
 }
 
 // DeleteAllStatefulSets deletes all StatefulSet API Objects in Namespace ns.
-func DeleteAllStatefulSets(c clientset.Interface, ns string) {
-	ssList, err := c.AppsV1().StatefulSets(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Everything().String()})
+func DeleteAllStatefulSets(ctx context.Context, c clientset.Interface, ns string) {
+	ssList, err := c.AppsV1().StatefulSets(ns).List(ctx, metav1.ListOptions{LabelSelector: labels.Everything().String()})
 	framework.ExpectNoError(err)
 
 	// Scale down each statefulset, then delete it completely.
@@ -81,14 +81,14 @@ func DeleteAllStatefulSets(c clientset.Interface, ns string) {
 	for i := range ssList.Items {
 		ss := &ssList.Items[i]
 		var err error
-		if ss, err = Scale(c, ss, 0); err != nil {
+		if ss, err = Scale(ctx, c, ss, 0); err != nil {
 			errList = append(errList, fmt.Sprintf("%v", err))
 		}
-		WaitForStatusReplicas(c, ss, 0)
+		WaitForStatusReplicas(ctx, c, ss, 0)
 		framework.Logf("Deleting statefulset %v", ss.Name)
 		// Use OrphanDependents=false so it's deleted synchronously.
 		// We already made sure the Pods are gone inside Scale().
-		if err := c.AppsV1().StatefulSets(ss.Namespace).Delete(context.TODO(), ss.Name, metav1.DeleteOptions{OrphanDependents: new(bool)}); err != nil {
+		if err := c.AppsV1().StatefulSets(ss.Namespace).Delete(ctx, ss.Name, metav1.DeleteOptions{OrphanDependents: new(bool)}); err != nil {
 			errList = append(errList, fmt.Sprintf("%v", err))
 		}
 	}
@@ -96,8 +96,8 @@ func DeleteAllStatefulSets(c clientset.Interface, ns string) {
 	// pvs are global, so we need to wait for the exact ones bound to the statefulset pvcs.
 	pvNames := sets.NewString()
 	// TODO: Don't assume all pvcs in the ns belong to a statefulset
-	pvcPollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout, func() (bool, error) {
-		pvcList, err := c.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Everything().String()})
+	pvcPollErr := wait.PollImmediateWithContext(ctx, StatefulSetPoll, StatefulSetTimeout, func(ctx context.Context) (bool, error) {
+		pvcList, err := c.CoreV1().PersistentVolumeClaims(ns).List(ctx, metav1.ListOptions{LabelSelector: labels.Everything().String()})
 		if err != nil {
 			framework.Logf("WARNING: Failed to list pvcs, retrying %v", err)
 			return false, nil
@@ -106,7 +106,7 @@ func DeleteAllStatefulSets(c clientset.Interface, ns string) {
 			pvNames.Insert(pvc.Spec.VolumeName)
 			// TODO: Double check that there are no pods referencing the pvc
 			framework.Logf("Deleting pvc: %v with volume %v", pvc.Name, pvc.Spec.VolumeName)
-			if err := c.CoreV1().PersistentVolumeClaims(ns).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{}); err != nil {
+			if err := c.CoreV1().PersistentVolumeClaims(ns).Delete(ctx, pvc.Name, metav1.DeleteOptions{}); err != nil {
 				return false, nil
 			}
 		}
@@ -116,8 +116,8 @@ func DeleteAllStatefulSets(c clientset.Interface, ns string) {
 		errList = append(errList, fmt.Sprintf("Timeout waiting for pvc deletion."))
 	}
 
-	pollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout, func() (bool, error) {
-		pvList, err := c.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Everything().String()})
+	pollErr := wait.PollImmediateWithContext(ctx, StatefulSetPoll, StatefulSetTimeout, func(ctx context.Context) (bool, error) {
+		pvList, err := c.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{LabelSelector: labels.Everything().String()})
 		if err != nil {
 			framework.Logf("WARNING: Failed to list pvs, retrying %v", err)
 			return false, nil
@@ -143,16 +143,16 @@ func DeleteAllStatefulSets(c clientset.Interface, ns string) {
 }
 
 // Scale scales ss to count replicas.
-func Scale(c clientset.Interface, ss *appsv1.StatefulSet, count int32) (*appsv1.StatefulSet, error) {
+func Scale(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, count int32) (*appsv1.StatefulSet, error) {
 	name := ss.Name
 	ns := ss.Namespace
 
 	framework.Logf("Scaling statefulset %s to %d", name, count)
-	ss = update(c, ns, name, func(ss *appsv1.StatefulSet) { *(ss.Spec.Replicas) = count })
+	ss = update(ctx, c, ns, name, func(ss *appsv1.StatefulSet) { *(ss.Spec.Replicas) = count })
 
 	var statefulPodList *v1.PodList
-	pollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout, func() (bool, error) {
-		statefulPodList = GetPodList(c, ss)
+	pollErr := wait.PollImmediateWithContext(ctx, StatefulSetPoll, StatefulSetTimeout, func(ctx context.Context) (bool, error) {
+		statefulPodList = GetPodList(ctx, c, ss)
 		if int32(len(statefulPodList.Items)) == count {
 			return true, nil
 		}
@@ -172,26 +172,26 @@ func Scale(c clientset.Interface, ss *appsv1.StatefulSet, count int32) (*appsv1.
 }
 
 // UpdateReplicas updates the replicas of ss to count.
-func UpdateReplicas(c clientset.Interface, ss *appsv1.StatefulSet, count int32) {
-	update(c, ss.Namespace, ss.Name, func(ss *appsv1.StatefulSet) { *(ss.Spec.Replicas) = count })
+func UpdateReplicas(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, count int32) {
+	update(ctx, c, ss.Namespace, ss.Name, func(ss *appsv1.StatefulSet) { *(ss.Spec.Replicas) = count })
 }
 
 // Restart scales ss to 0 and then back to its previous number of replicas.
-func Restart(c clientset.Interface, ss *appsv1.StatefulSet) {
+func Restart(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet) {
 	oldReplicas := *(ss.Spec.Replicas)
-	ss, err := Scale(c, ss, 0)
+	ss, err := Scale(ctx, c, ss, 0)
 	framework.ExpectNoError(err)
 	// Wait for controller to report the desired number of Pods.
 	// This way we know the controller has observed all Pod deletions
 	// before we scale it back up.
-	WaitForStatusReplicas(c, ss, 0)
-	update(c, ss.Namespace, ss.Name, func(ss *appsv1.StatefulSet) { *(ss.Spec.Replicas) = oldReplicas })
+	WaitForStatusReplicas(ctx, c, ss, 0)
+	update(ctx, c, ss.Namespace, ss.Name, func(ss *appsv1.StatefulSet) { *(ss.Spec.Replicas) = oldReplicas })
 }
 
 // CheckHostname verifies that all Pods in ss have the correct Hostname. If the returned error is not nil than verification failed.
-func CheckHostname(c clientset.Interface, ss *appsv1.StatefulSet) error {
+func CheckHostname(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet) error {
 	cmd := "printf $(hostname)"
-	podList := GetPodList(c, ss)
+	podList := GetPodList(ctx, c, ss)
 	for _, statefulPod := range podList.Items {
 		hostname, err := e2epodoutput.RunHostCmdWithRetries(statefulPod.Namespace, statefulPod.Name, cmd, StatefulSetPoll, StatefulPodTimeout)
 		if err != nil {
@@ -205,7 +205,7 @@ func CheckHostname(c clientset.Interface, ss *appsv1.StatefulSet) error {
 }
 
 // CheckMount checks that the mount at mountPath is valid for all Pods in ss.
-func CheckMount(c clientset.Interface, ss *appsv1.StatefulSet, mountPath string) error {
+func CheckMount(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, mountPath string) error {
 	for _, cmd := range []string{
 		// Print inode, size etc
 		fmt.Sprintf("ls -idlh %v", mountPath),
@@ -214,7 +214,7 @@ func CheckMount(c clientset.Interface, ss *appsv1.StatefulSet, mountPath string)
 		// Try writing
 		fmt.Sprintf("touch %v", filepath.Join(mountPath, fmt.Sprintf("%v", time.Now().UnixNano()))),
 	} {
-		if err := ExecInStatefulPods(c, ss, cmd); err != nil {
+		if err := ExecInStatefulPods(ctx, c, ss, cmd); err != nil {
 			return fmt.Errorf("failed to execute %v, error: %v", cmd, err)
 		}
 	}
@@ -234,8 +234,8 @@ func CheckServiceName(ss *appsv1.StatefulSet, expectedServiceName string) error 
 }
 
 // ExecInStatefulPods executes cmd in all Pods in ss. If a error occurs it is returned and cmd is not execute in any subsequent Pods.
-func ExecInStatefulPods(c clientset.Interface, ss *appsv1.StatefulSet, cmd string) error {
-	podList := GetPodList(c, ss)
+func ExecInStatefulPods(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, cmd string) error {
+	podList := GetPodList(ctx, c, ss)
 	for _, statefulPod := range podList.Items {
 		stdout, err := e2epodoutput.RunHostCmdWithRetries(statefulPod.Namespace, statefulPod.Name, cmd, StatefulSetPoll, StatefulPodTimeout)
 		framework.Logf("stdout of %v on %v: %v", cmd, statefulPod.Name, stdout)
@@ -247,14 +247,14 @@ func ExecInStatefulPods(c clientset.Interface, ss *appsv1.StatefulSet, cmd strin
 }
 
 // update updates a statefulset, and it is only used within rest.go
-func update(c clientset.Interface, ns, name string, update func(ss *appsv1.StatefulSet)) *appsv1.StatefulSet {
+func update(ctx context.Context, c clientset.Interface, ns, name string, update func(ss *appsv1.StatefulSet)) *appsv1.StatefulSet {
 	for i := 0; i < 3; i++ {
-		ss, err := c.AppsV1().StatefulSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		ss, err := c.AppsV1().StatefulSets(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("failed to get statefulset %q: %v", name, err)
 		}
 		update(ss)
-		ss, err = c.AppsV1().StatefulSets(ns).Update(context.TODO(), ss, metav1.UpdateOptions{})
+		ss, err = c.AppsV1().StatefulSets(ns).Update(ctx, ss, metav1.UpdateOptions{})
 		if err == nil {
 			return ss
 		}

--- a/test/e2e/framework/statefulset/wait.go
+++ b/test/e2e/framework/statefulset/wait.go
@@ -31,10 +31,10 @@ import (
 
 // WaitForRunning waits for numPodsRunning in ss to be Running and for the first
 // numPodsReady ordinals to be Ready.
-func WaitForRunning(c clientset.Interface, numPodsRunning, numPodsReady int32, ss *appsv1.StatefulSet) {
-	pollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout,
-		func() (bool, error) {
-			podList := GetPodList(c, ss)
+func WaitForRunning(ctx context.Context, c clientset.Interface, numPodsRunning, numPodsReady int32, ss *appsv1.StatefulSet) {
+	pollErr := wait.PollImmediateWithContext(ctx, StatefulSetPoll, StatefulSetTimeout,
+		func(ctx context.Context) (bool, error) {
+			podList := GetPodList(ctx, c, ss)
 			SortStatefulPods(podList)
 			if int32(len(podList.Items)) < numPodsRunning {
 				framework.Logf("Found %d stateful pods, waiting for %d", len(podList.Items), numPodsRunning)
@@ -60,14 +60,14 @@ func WaitForRunning(c clientset.Interface, numPodsRunning, numPodsReady int32, s
 }
 
 // WaitForState periodically polls for the ss and its pods until the until function returns either true or an error
-func WaitForState(c clientset.Interface, ss *appsv1.StatefulSet, until func(*appsv1.StatefulSet, *v1.PodList) (bool, error)) {
-	pollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout,
-		func() (bool, error) {
-			ssGet, err := c.AppsV1().StatefulSets(ss.Namespace).Get(context.TODO(), ss.Name, metav1.GetOptions{})
+func WaitForState(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, until func(*appsv1.StatefulSet, *v1.PodList) (bool, error)) {
+	pollErr := wait.PollImmediateWithContext(ctx, StatefulSetPoll, StatefulSetTimeout,
+		func(ctx context.Context) (bool, error) {
+			ssGet, err := c.AppsV1().StatefulSets(ss.Namespace).Get(ctx, ss.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
-			podList := GetPodList(c, ssGet)
+			podList := GetPodList(ctx, c, ssGet)
 			return until(ssGet, podList)
 		})
 	if pollErr != nil {
@@ -76,14 +76,14 @@ func WaitForState(c clientset.Interface, ss *appsv1.StatefulSet, until func(*app
 }
 
 // WaitForRunningAndReady waits for numStatefulPods in ss to be Running and Ready.
-func WaitForRunningAndReady(c clientset.Interface, numStatefulPods int32, ss *appsv1.StatefulSet) {
-	WaitForRunning(c, numStatefulPods, numStatefulPods, ss)
+func WaitForRunningAndReady(ctx context.Context, c clientset.Interface, numStatefulPods int32, ss *appsv1.StatefulSet) {
+	WaitForRunning(ctx, c, numStatefulPods, numStatefulPods, ss)
 }
 
 // WaitForPodReady waits for the Pod named podName in set to exist and have a Ready condition.
-func WaitForPodReady(c clientset.Interface, set *appsv1.StatefulSet, podName string) (*appsv1.StatefulSet, *v1.PodList) {
+func WaitForPodReady(ctx context.Context, c clientset.Interface, set *appsv1.StatefulSet, podName string) (*appsv1.StatefulSet, *v1.PodList) {
 	var pods *v1.PodList
-	WaitForState(c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
+	WaitForState(ctx, c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
 		set = set2
 		pods = pods2
 		for i := range pods.Items {
@@ -97,13 +97,13 @@ func WaitForPodReady(c clientset.Interface, set *appsv1.StatefulSet, podName str
 }
 
 // WaitForStatusReadyReplicas waits for the ss.Status.ReadyReplicas to be equal to expectedReplicas
-func WaitForStatusReadyReplicas(c clientset.Interface, ss *appsv1.StatefulSet, expectedReplicas int32) {
+func WaitForStatusReadyReplicas(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, expectedReplicas int32) {
 	framework.Logf("Waiting for statefulset status.replicas updated to %d", expectedReplicas)
 
 	ns, name := ss.Namespace, ss.Name
-	pollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout,
-		func() (bool, error) {
-			ssGet, err := c.AppsV1().StatefulSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	pollErr := wait.PollImmediateWithContext(ctx, StatefulSetPoll, StatefulSetTimeout,
+		func(ctx context.Context) (bool, error) {
+			ssGet, err := c.AppsV1().StatefulSets(ns).Get(ctx, name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -122,13 +122,13 @@ func WaitForStatusReadyReplicas(c clientset.Interface, ss *appsv1.StatefulSet, e
 }
 
 // WaitForStatusAvailableReplicas waits for the ss.Status.Available to be equal to expectedReplicas
-func WaitForStatusAvailableReplicas(c clientset.Interface, ss *appsv1.StatefulSet, expectedReplicas int32) {
+func WaitForStatusAvailableReplicas(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, expectedReplicas int32) {
 	framework.Logf("Waiting for statefulset status.AvailableReplicas updated to %d", expectedReplicas)
 
 	ns, name := ss.Namespace, ss.Name
-	pollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout,
-		func() (bool, error) {
-			ssGet, err := c.AppsV1().StatefulSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	pollErr := wait.PollImmediateWithContext(ctx, StatefulSetPoll, StatefulSetTimeout,
+		func(ctx context.Context) (bool, error) {
+			ssGet, err := c.AppsV1().StatefulSets(ns).Get(ctx, name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -147,13 +147,13 @@ func WaitForStatusAvailableReplicas(c clientset.Interface, ss *appsv1.StatefulSe
 }
 
 // WaitForStatusReplicas waits for the ss.Status.Replicas to be equal to expectedReplicas
-func WaitForStatusReplicas(c clientset.Interface, ss *appsv1.StatefulSet, expectedReplicas int32) {
+func WaitForStatusReplicas(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, expectedReplicas int32) {
 	framework.Logf("Waiting for statefulset status.replicas updated to %d", expectedReplicas)
 
 	ns, name := ss.Namespace, ss.Name
-	pollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout,
-		func() (bool, error) {
-			ssGet, err := c.AppsV1().StatefulSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	pollErr := wait.PollImmediateWithContext(ctx, StatefulSetPoll, StatefulSetTimeout,
+		func(ctx context.Context) (bool, error) {
+			ssGet, err := c.AppsV1().StatefulSets(ns).Get(ctx, name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -172,12 +172,12 @@ func WaitForStatusReplicas(c clientset.Interface, ss *appsv1.StatefulSet, expect
 }
 
 // Saturate waits for all Pods in ss to become Running and Ready.
-func Saturate(c clientset.Interface, ss *appsv1.StatefulSet) {
+func Saturate(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet) {
 	var i int32
 	for i = 0; i < *(ss.Spec.Replicas); i++ {
 		framework.Logf("Waiting for stateful pod at index %v to enter Running", i)
-		WaitForRunning(c, i+1, i, ss)
+		WaitForRunning(ctx, c, i+1, i, ss)
 		framework.Logf("Resuming stateful pod at index %v", i)
-		ResumeNextPod(c, ss)
+		ResumeNextPod(ctx, c, ss)
 	}
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
@@ -214,8 +215,10 @@ type NodeKillerConfig struct {
 	JitterFactor float64
 	// SimulatedDowntime is a duration between node is killed and recreated.
 	SimulatedDowntime time.Duration
-	// NodeKillerStopCh is a channel that is used to notify NodeKiller to stop killing nodes.
-	NodeKillerStopCh chan struct{}
+	// NodeKillerStopCtx is a context that is used to notify NodeKiller to stop killing nodes.
+	NodeKillerStopCtx context.Context
+	// NodeKillerStop is the cancel function for NodeKillerStopCtx.
+	NodeKillerStop func()
 }
 
 // NodeTestContextType is part of TestContextType, it is shared by all node e2e test.

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -146,7 +146,7 @@ var (
 var RunID = uuid.NewUUID()
 
 // CreateTestingNSFn is a func that is responsible for creating namespace used for executing e2e tests.
-type CreateTestingNSFn func(baseName string, c clientset.Interface, labels map[string]string) (*v1.Namespace, error)
+type CreateTestingNSFn func(ctx context.Context, baseName string, c clientset.Interface, labels map[string]string) (*v1.Namespace, error)
 
 // APIAddress returns a address of an instance.
 func APIAddress() string {
@@ -198,9 +198,9 @@ func NodeOSArchIs(supportedNodeOsArchs ...string) bool {
 // DeleteNamespaces deletes all namespaces that match the given delete and skip filters.
 // Filter is by simple strings.Contains; first skip filter, then delete filter.
 // Returns the list of deleted namespaces or an error.
-func DeleteNamespaces(c clientset.Interface, deleteFilter, skipFilter []string) ([]string, error) {
+func DeleteNamespaces(ctx context.Context, c clientset.Interface, deleteFilter, skipFilter []string) ([]string, error) {
 	ginkgo.By("Deleting namespaces")
-	nsList, err := c.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	nsList, err := c.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	ExpectNoError(err, "Failed to get namespace list")
 	var deleted []string
 	var wg sync.WaitGroup
@@ -228,7 +228,7 @@ OUTER:
 		go func(nsName string) {
 			defer wg.Done()
 			defer ginkgo.GinkgoRecover()
-			gomega.Expect(c.CoreV1().Namespaces().Delete(context.TODO(), nsName, metav1.DeleteOptions{})).To(gomega.Succeed())
+			gomega.Expect(c.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})).To(gomega.Succeed())
 			Logf("namespace : %v api call to delete is complete ", nsName)
 		}(item.Name)
 	}
@@ -237,16 +237,16 @@ OUTER:
 }
 
 // WaitForNamespacesDeleted waits for the namespaces to be deleted.
-func WaitForNamespacesDeleted(c clientset.Interface, namespaces []string, timeout time.Duration) error {
+func WaitForNamespacesDeleted(ctx context.Context, c clientset.Interface, namespaces []string, timeout time.Duration) error {
 	ginkgo.By(fmt.Sprintf("Waiting for namespaces %+v to vanish", namespaces))
 	nsMap := map[string]bool{}
 	for _, ns := range namespaces {
 		nsMap[ns] = true
 	}
 	//Now POLL until all namespaces have been eradicated.
-	return wait.Poll(2*time.Second, timeout,
-		func() (bool, error) {
-			nsList, err := c.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	return wait.PollWithContext(ctx, 2*time.Second, timeout,
+		func(ctx context.Context) (bool, error) {
+			nsList, err := c.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -259,20 +259,20 @@ func WaitForNamespacesDeleted(c clientset.Interface, namespaces []string, timeou
 		})
 }
 
-func waitForConfigMapInNamespace(c clientset.Interface, ns, name string, timeout time.Duration) error {
+func waitForConfigMapInNamespace(ctx context.Context, c clientset.Interface, ns, name string, timeout time.Duration) error {
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", name).String()
+	ctx, cancel := watchtools.ContextWithOptionalTimeout(ctx, timeout)
+	defer cancel()
 	lw := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (object runtime.Object, e error) {
 			options.FieldSelector = fieldSelector
-			return c.CoreV1().ConfigMaps(ns).List(context.TODO(), options)
+			return c.CoreV1().ConfigMaps(ns).List(ctx, options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
 			options.FieldSelector = fieldSelector
-			return c.CoreV1().ConfigMaps(ns).Watch(context.TODO(), options)
+			return c.CoreV1().ConfigMaps(ns).Watch(ctx, options)
 		},
 	}
-	ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), timeout)
-	defer cancel()
 	_, err := watchtools.UntilWithSync(ctx, lw, &v1.ConfigMap{}, nil, func(event watch.Event) (bool, error) {
 		switch event.Type {
 		case watch.Deleted:
@@ -285,20 +285,20 @@ func waitForConfigMapInNamespace(c clientset.Interface, ns, name string, timeout
 	return err
 }
 
-func waitForServiceAccountInNamespace(c clientset.Interface, ns, serviceAccountName string, timeout time.Duration) error {
+func waitForServiceAccountInNamespace(ctx context.Context, c clientset.Interface, ns, serviceAccountName string, timeout time.Duration) error {
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", serviceAccountName).String()
+	ctx, cancel := watchtools.ContextWithOptionalTimeout(ctx, timeout)
+	defer cancel()
 	lw := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (object runtime.Object, e error) {
 			options.FieldSelector = fieldSelector
-			return c.CoreV1().ServiceAccounts(ns).List(context.TODO(), options)
+			return c.CoreV1().ServiceAccounts(ns).List(ctx, options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
 			options.FieldSelector = fieldSelector
-			return c.CoreV1().ServiceAccounts(ns).Watch(context.TODO(), options)
+			return c.CoreV1().ServiceAccounts(ns).Watch(ctx, options)
 		},
 	}
-	ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), timeout)
-	defer cancel()
 	_, err := watchtools.UntilWithSync(ctx, lw, &v1.ServiceAccount{}, nil, func(event watch.Event) (bool, error) {
 		switch event.Type {
 		case watch.Deleted:
@@ -317,20 +317,20 @@ func waitForServiceAccountInNamespace(c clientset.Interface, ns, serviceAccountN
 // WaitForDefaultServiceAccountInNamespace waits for the default service account to be provisioned
 // the default service account is what is associated with pods when they do not specify a service account
 // as a result, pods are not able to be provisioned in a namespace until the service account is provisioned
-func WaitForDefaultServiceAccountInNamespace(c clientset.Interface, namespace string) error {
-	return waitForServiceAccountInNamespace(c, namespace, "default", ServiceAccountProvisionTimeout)
+func WaitForDefaultServiceAccountInNamespace(ctx context.Context, c clientset.Interface, namespace string) error {
+	return waitForServiceAccountInNamespace(ctx, c, namespace, "default", ServiceAccountProvisionTimeout)
 }
 
 // WaitForKubeRootCAInNamespace waits for the configmap kube-root-ca.crt containing the service account
 // CA trust bundle to be provisioned in the specified namespace so that pods do not have to retry mounting
 // the config map (which creates noise that hides other issues in the Kubelet).
-func WaitForKubeRootCAInNamespace(c clientset.Interface, namespace string) error {
-	return waitForConfigMapInNamespace(c, namespace, "kube-root-ca.crt", ServiceAccountProvisionTimeout)
+func WaitForKubeRootCAInNamespace(ctx context.Context, c clientset.Interface, namespace string) error {
+	return waitForConfigMapInNamespace(ctx, c, namespace, "kube-root-ca.crt", ServiceAccountProvisionTimeout)
 }
 
 // CreateTestingNS should be used by every test, note that we append a common prefix to the provided test name.
 // Please see NewFramework instead of using this directly.
-func CreateTestingNS(baseName string, c clientset.Interface, labels map[string]string) (*v1.Namespace, error) {
+func CreateTestingNS(ctx context.Context, baseName string, c clientset.Interface, labels map[string]string) (*v1.Namespace, error) {
 	if labels == nil {
 		labels = map[string]string{}
 	}
@@ -351,9 +351,9 @@ func CreateTestingNS(baseName string, c clientset.Interface, labels map[string]s
 	}
 	// Be robust about making the namespace creation call.
 	var got *v1.Namespace
-	if err := wait.PollImmediate(Poll, 30*time.Second, func() (bool, error) {
+	if err := wait.PollImmediateWithContext(ctx, Poll, 30*time.Second, func(ctx context.Context) (bool, error) {
 		var err error
-		got, err = c.CoreV1().Namespaces().Create(context.TODO(), namespaceObj, metav1.CreateOptions{})
+		got, err = c.CoreV1().Namespaces().Create(ctx, namespaceObj, metav1.CreateOptions{})
 		if err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				// regenerate on conflict
@@ -370,7 +370,7 @@ func CreateTestingNS(baseName string, c clientset.Interface, labels map[string]s
 	}
 
 	if TestContext.VerifyServiceAccount {
-		if err := WaitForDefaultServiceAccountInNamespace(c, got.Name); err != nil {
+		if err := WaitForDefaultServiceAccountInNamespace(ctx, c, got.Name); err != nil {
 			// Even if we fail to create serviceAccount in the namespace,
 			// we have successfully create a namespace.
 			// So, return the created namespace.
@@ -382,7 +382,7 @@ func CreateTestingNS(baseName string, c clientset.Interface, labels map[string]s
 
 // CheckTestingNSDeletedExcept checks whether all e2e based existing namespaces are in the Terminating state
 // and waits until they are finally deleted. It ignores namespace skip.
-func CheckTestingNSDeletedExcept(c clientset.Interface, skip string) error {
+func CheckTestingNSDeletedExcept(ctx context.Context, c clientset.Interface, skip string) error {
 	// TODO: Since we don't have support for bulk resource deletion in the API,
 	// while deleting a namespace we are deleting all objects from that namespace
 	// one by one (one deletion == one API call). This basically exposes us to
@@ -398,7 +398,7 @@ func CheckTestingNSDeletedExcept(c clientset.Interface, skip string) error {
 
 	Logf("Waiting for terminating namespaces to be deleted...")
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(15 * time.Second) {
-		namespaces, err := c.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+		namespaces, err := c.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			Logf("Listing namespaces failed: %v", err)
 			continue
@@ -420,10 +420,10 @@ func CheckTestingNSDeletedExcept(c clientset.Interface, skip string) error {
 }
 
 // WaitForServiceEndpointsNum waits until the amount of endpoints that implement service to expectNum.
-func WaitForServiceEndpointsNum(c clientset.Interface, namespace, serviceName string, expectNum int, interval, timeout time.Duration) error {
-	return wait.Poll(interval, timeout, func() (bool, error) {
+func WaitForServiceEndpointsNum(ctx context.Context, c clientset.Interface, namespace, serviceName string, expectNum int, interval, timeout time.Duration) error {
+	return wait.PollWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
 		Logf("Waiting for amount of service:%s endpoints to be %d", serviceName, expectNum)
-		list, err := c.CoreV1().Endpoints(namespace).List(context.TODO(), metav1.ListOptions{})
+		list, err := c.CoreV1().Endpoints(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -547,8 +547,8 @@ func TryKill(cmd *exec.Cmd) {
 
 // EnsureLoadBalancerResourcesDeleted ensures that cloud load balancer resources that were created
 // are actually cleaned up.  Currently only implemented for GCE/GKE.
-func EnsureLoadBalancerResourcesDeleted(ip, portRange string) error {
-	return TestContext.CloudConfig.Provider.EnsureLoadBalancerResourcesDeleted(ip, portRange)
+func EnsureLoadBalancerResourcesDeleted(ctx context.Context, ip, portRange string) error {
+	return TestContext.CloudConfig.Provider.EnsureLoadBalancerResourcesDeleted(ctx, ip, portRange)
 }
 
 // CoreDump SSHs to the master and all nodes and dumps their logs into dir.
@@ -613,11 +613,11 @@ func RunCmdEnv(env []string, command string, args ...string) (string, string, er
 
 // getControlPlaneAddresses returns the externalIP, internalIP and hostname fields of control plane nodes.
 // If any of these is unavailable, empty slices are returned.
-func getControlPlaneAddresses(c clientset.Interface) ([]string, []string, []string) {
+func getControlPlaneAddresses(ctx context.Context, c clientset.Interface) ([]string, []string, []string) {
 	var externalIPs, internalIPs, hostnames []string
 
 	// Populate the internal IPs.
-	eps, err := c.CoreV1().Endpoints(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+	eps, err := c.CoreV1().Endpoints(metav1.NamespaceDefault).Get(ctx, "kubernetes", metav1.GetOptions{})
 	if err != nil {
 		Failf("Failed to get kubernetes endpoints: %v", err)
 	}
@@ -647,8 +647,8 @@ func getControlPlaneAddresses(c clientset.Interface) ([]string, []string, []stri
 // It may return internal and external IPs, even if we expect for
 // e.g. internal IPs to be used (issue #56787), so that we can be
 // sure to block the control plane fully during tests.
-func GetControlPlaneAddresses(c clientset.Interface) []string {
-	externalIPs, internalIPs, _ := getControlPlaneAddresses(c)
+func GetControlPlaneAddresses(ctx context.Context, c clientset.Interface) []string {
+	externalIPs, internalIPs, _ := getControlPlaneAddresses(ctx, c)
 
 	ips := sets.NewString()
 	switch TestContext.Provider {
@@ -685,7 +685,7 @@ func PrettyPrintJSON(metrics interface{}) string {
 // WatchEventSequenceVerifier ...
 // manages a watch for a given resource, ensures that events take place in a given order, retries the test on failure
 //
-//	testContext         cancellation signal across API boundaries, e.g: context.TODO()
+//	ctx                 cancellation signal across API boundaries, e.g: context from Ginkgo
 //	dc                  sets up a client to the API
 //	resourceType        specify the type of resource
 //	namespace           select a namespace

--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -149,7 +149,7 @@ type Test struct {
 }
 
 // NewNFSServer is a NFS-specific wrapper for CreateStorageServer.
-func NewNFSServer(cs clientset.Interface, namespace string, args []string) (config TestConfig, pod *v1.Pod, host string) {
+func NewNFSServer(ctx context.Context, cs clientset.Interface, namespace string, args []string) (config TestConfig, pod *v1.Pod, host string) {
 	config = TestConfig{
 		Namespace:          namespace,
 		Prefix:             "nfs",
@@ -161,7 +161,7 @@ func NewNFSServer(cs clientset.Interface, namespace string, args []string) (conf
 	if len(args) > 0 {
 		config.ServerArgs = args
 	}
-	pod, host = CreateStorageServer(cs, config)
+	pod, host = CreateStorageServer(ctx, cs, config)
 	if strings.Contains(host, ":") {
 		host = "[" + host + "]"
 	}
@@ -171,8 +171,8 @@ func NewNFSServer(cs clientset.Interface, namespace string, args []string) (conf
 // CreateStorageServer is a wrapper for startVolumeServer(). A storage server config is passed in, and a pod pointer
 // and ip address string are returned.
 // Note: Expect() is called so no error is returned.
-func CreateStorageServer(cs clientset.Interface, config TestConfig) (pod *v1.Pod, ip string) {
-	pod = startVolumeServer(cs, config)
+func CreateStorageServer(ctx context.Context, cs clientset.Interface, config TestConfig) (pod *v1.Pod, ip string) {
+	pod = startVolumeServer(ctx, cs, config)
 	gomega.Expect(pod).NotTo(gomega.BeNil(), "storage server pod should not be nil")
 	ip = pod.Status.PodIP
 	gomega.Expect(len(ip)).NotTo(gomega.BeZero(), fmt.Sprintf("pod %s's IP should not be empty", pod.Name))
@@ -182,7 +182,7 @@ func CreateStorageServer(cs clientset.Interface, config TestConfig) (pod *v1.Pod
 
 // GetVolumeAttachmentName returns the hash value of the provisioner, the config ClientNodeSelection name,
 // and the VolumeAttachment name of the PV that is bound to the PVC with the passed in claimName and claimNamespace.
-func GetVolumeAttachmentName(cs clientset.Interface, config TestConfig, provisioner string, claimName string, claimNamespace string) string {
+func GetVolumeAttachmentName(ctx context.Context, cs clientset.Interface, config TestConfig, provisioner string, claimName string, claimNamespace string) string {
 	var nodeName string
 	// For provisioning tests, ClientNodeSelection is not set so we do not know the NodeName of the VolumeAttachment of the PV that is
 	// bound to the PVC with the passed in claimName and claimNamespace. We need this NodeName because it is used to generate the
@@ -190,9 +190,9 @@ func GetVolumeAttachmentName(cs clientset.Interface, config TestConfig, provisio
 	// To get the nodeName of the VolumeAttachment, we get all the VolumeAttachments, look for the VolumeAttachment with a
 	// PersistentVolumeName equal to the PV that is bound to the passed in PVC, and then we get the NodeName from that VolumeAttachment.
 	if config.ClientNodeSelection.Name == "" {
-		claim, _ := cs.CoreV1().PersistentVolumeClaims(claimNamespace).Get(context.TODO(), claimName, metav1.GetOptions{})
+		claim, _ := cs.CoreV1().PersistentVolumeClaims(claimNamespace).Get(ctx, claimName, metav1.GetOptions{})
 		pvName := claim.Spec.VolumeName
-		volumeAttachments, _ := cs.StorageV1().VolumeAttachments().List(context.TODO(), metav1.ListOptions{})
+		volumeAttachments, _ := cs.StorageV1().VolumeAttachments().List(ctx, metav1.ListOptions{})
 		for _, volumeAttachment := range volumeAttachments.Items {
 			if *volumeAttachment.Spec.Source.PersistentVolumeName == pvName {
 				nodeName = volumeAttachment.Spec.NodeName
@@ -202,21 +202,21 @@ func GetVolumeAttachmentName(cs clientset.Interface, config TestConfig, provisio
 	} else {
 		nodeName = config.ClientNodeSelection.Name
 	}
-	handle := getVolumeHandle(cs, claimName, claimNamespace)
+	handle := getVolumeHandle(ctx, cs, claimName, claimNamespace)
 	attachmentHash := sha256.Sum256([]byte(fmt.Sprintf("%s%s%s", handle, provisioner, nodeName)))
 	return fmt.Sprintf("csi-%x", attachmentHash)
 }
 
 // getVolumeHandle returns the VolumeHandle of the PV that is bound to the PVC with the passed in claimName and claimNamespace.
-func getVolumeHandle(cs clientset.Interface, claimName string, claimNamespace string) string {
+func getVolumeHandle(ctx context.Context, cs clientset.Interface, claimName string, claimNamespace string) string {
 	// re-get the claim to the latest state with bound volume
-	claim, err := cs.CoreV1().PersistentVolumeClaims(claimNamespace).Get(context.TODO(), claimName, metav1.GetOptions{})
+	claim, err := cs.CoreV1().PersistentVolumeClaims(claimNamespace).Get(ctx, claimName, metav1.GetOptions{})
 	if err != nil {
 		framework.ExpectNoError(err, "Cannot get PVC")
 		return ""
 	}
 	pvName := claim.Spec.VolumeName
-	pv, err := cs.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
+	pv, err := cs.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
 	if err != nil {
 		framework.ExpectNoError(err, "Cannot get PV")
 		return ""
@@ -229,9 +229,9 @@ func getVolumeHandle(cs clientset.Interface, claimName string, claimNamespace st
 }
 
 // WaitForVolumeAttachmentTerminated waits for the VolumeAttachment with the passed in attachmentName to be terminated.
-func WaitForVolumeAttachmentTerminated(attachmentName string, cs clientset.Interface, timeout time.Duration) error {
-	waitErr := wait.PollImmediate(10*time.Second, timeout, func() (bool, error) {
-		_, err := cs.StorageV1().VolumeAttachments().Get(context.TODO(), attachmentName, metav1.GetOptions{})
+func WaitForVolumeAttachmentTerminated(ctx context.Context, attachmentName string, cs clientset.Interface, timeout time.Duration) error {
+	waitErr := wait.PollImmediateWithContext(ctx, 10*time.Second, timeout, func(ctx context.Context) (bool, error) {
+		_, err := cs.StorageV1().VolumeAttachments().Get(ctx, attachmentName, metav1.GetOptions{})
 		if err != nil {
 			// if the volumeattachment object is not found, it means it has been terminated.
 			if apierrors.IsNotFound(err) {
@@ -250,7 +250,7 @@ func WaitForVolumeAttachmentTerminated(attachmentName string, cs clientset.Inter
 // startVolumeServer starts a container specified by config.serverImage and exports all
 // config.serverPorts from it. The returned pod should be used to get the server
 // IP address and create appropriate VolumeSource.
-func startVolumeServer(client clientset.Interface, config TestConfig) *v1.Pod {
+func startVolumeServer(ctx context.Context, client clientset.Interface, config TestConfig) *v1.Pod {
 	podClient := client.CoreV1().Pods(config.Namespace)
 
 	portCount := len(config.ServerPorts)
@@ -331,13 +331,13 @@ func startVolumeServer(client clientset.Interface, config TestConfig) *v1.Pod {
 	}
 
 	var pod *v1.Pod
-	serverPod, err := podClient.Create(context.TODO(), serverPod, metav1.CreateOptions{})
+	serverPod, err := podClient.Create(ctx, serverPod, metav1.CreateOptions{})
 	// ok if the server pod already exists. TODO: make this controllable by callers
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			framework.Logf("Ignore \"already-exists\" error, re-get pod...")
 			ginkgo.By(fmt.Sprintf("re-getting the %q server pod", serverPodName))
-			serverPod, err = podClient.Get(context.TODO(), serverPodName, metav1.GetOptions{})
+			serverPod, err = podClient.Get(ctx, serverPodName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Cannot re-get the server pod %q: %v", serverPodName, err)
 			pod = serverPod
 		} else {
@@ -345,13 +345,13 @@ func startVolumeServer(client clientset.Interface, config TestConfig) *v1.Pod {
 		}
 	}
 	if config.WaitForCompletion {
-		framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(client, serverPod.Name, serverPod.Namespace))
-		framework.ExpectNoError(podClient.Delete(context.TODO(), serverPod.Name, metav1.DeleteOptions{}))
+		framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(ctx, client, serverPod.Name, serverPod.Namespace))
+		framework.ExpectNoError(podClient.Delete(ctx, serverPod.Name, metav1.DeleteOptions{}))
 	} else {
-		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(client, serverPod))
+		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, client, serverPod))
 		if pod == nil {
 			ginkgo.By(fmt.Sprintf("locating the %q server pod", serverPodName))
-			pod, err = podClient.Get(context.TODO(), serverPodName, metav1.GetOptions{})
+			pod, err = podClient.Get(ctx, serverPodName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Cannot locate the server pod %q: %v", serverPodName, err)
 		}
 	}
@@ -363,7 +363,7 @@ func startVolumeServer(client clientset.Interface, config TestConfig) *v1.Pod {
 }
 
 // TestServerCleanup cleans server pod.
-func TestServerCleanup(f *framework.Framework, config TestConfig) {
+func TestServerCleanup(ctx context.Context, f *framework.Framework, config TestConfig) {
 	ginkgo.By(fmt.Sprint("cleaning the environment after ", config.Prefix))
 	defer ginkgo.GinkgoRecover()
 
@@ -371,11 +371,11 @@ func TestServerCleanup(f *framework.Framework, config TestConfig) {
 		return
 	}
 
-	err := e2epod.DeletePodWithWaitByName(f.ClientSet, config.Prefix+"-server", config.Namespace)
+	err := e2epod.DeletePodWithWaitByName(ctx, f.ClientSet, config.Prefix+"-server", config.Namespace)
 	gomega.Expect(err).To(gomega.BeNil(), "Failed to delete pod %v in namespace %v", config.Prefix+"-server", config.Namespace)
 }
 
-func runVolumeTesterPod(client clientset.Interface, timeouts *framework.TimeoutContext, config TestConfig, podSuffix string, privileged bool, fsGroup *int64, tests []Test, slow bool) (*v1.Pod, error) {
+func runVolumeTesterPod(ctx context.Context, client clientset.Interface, timeouts *framework.TimeoutContext, config TestConfig, podSuffix string, privileged bool, fsGroup *int64, tests []Test, slow bool) (*v1.Pod, error) {
 	ginkgo.By(fmt.Sprint("starting ", config.Prefix, "-", podSuffix))
 	var gracePeriod int64 = 1
 	var command string
@@ -453,18 +453,18 @@ func runVolumeTesterPod(client clientset.Interface, timeouts *framework.TimeoutC
 		})
 	}
 	podsNamespacer := client.CoreV1().Pods(config.Namespace)
-	clientPod, err := podsNamespacer.Create(context.TODO(), clientPod, metav1.CreateOptions{})
+	clientPod, err := podsNamespacer.Create(ctx, clientPod, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
 	if slow {
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(client, clientPod.Name, clientPod.Namespace, timeouts.PodStartSlow)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, client, clientPod.Name, clientPod.Namespace, timeouts.PodStartSlow)
 	} else {
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(client, clientPod.Name, clientPod.Namespace, timeouts.PodStart)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, client, clientPod.Name, clientPod.Namespace, timeouts.PodStart)
 	}
 	if err != nil {
-		e2epod.DeletePodOrFail(client, clientPod.Namespace, clientPod.Name)
-		e2epod.WaitForPodToDisappear(client, clientPod.Namespace, clientPod.Name, labels.Everything(), framework.Poll, timeouts.PodDelete)
+		e2epod.DeletePodOrFail(ctx, client, clientPod.Namespace, clientPod.Name)
+		_ = e2epod.WaitForPodToDisappear(ctx, client, clientPod.Namespace, clientPod.Name, labels.Everything(), framework.Poll, timeouts.PodDelete)
 		return nil, err
 	}
 	return clientPod, nil
@@ -519,8 +519,8 @@ func testVolumeContent(f *framework.Framework, pod *v1.Pod, containerName string
 // Timeout for dynamic provisioning (if "WaitForFirstConsumer" is set && provided PVC is not bound yet),
 // pod creation, scheduling and complete pod startup (incl. volume attach & mount) is pod.podStartTimeout.
 // It should be used for cases where "regular" dynamic provisioning of an empty volume is requested.
-func TestVolumeClient(f *framework.Framework, config TestConfig, fsGroup *int64, fsType string, tests []Test) {
-	testVolumeClient(f, config, fsGroup, fsType, tests, false)
+func TestVolumeClient(ctx context.Context, f *framework.Framework, config TestConfig, fsGroup *int64, fsType string, tests []Test) {
+	testVolumeClient(ctx, f, config, fsGroup, fsType, tests, false)
 }
 
 // TestVolumeClientSlow is the same as TestVolumeClient except for its timeout.
@@ -528,21 +528,21 @@ func TestVolumeClient(f *framework.Framework, config TestConfig, fsGroup *int64,
 // pod creation, scheduling and complete pod startup (incl. volume attach & mount) is pod.slowPodStartTimeout.
 // It should be used for cases where "special" dynamic provisioning is requested, such as volume cloning
 // or snapshot restore.
-func TestVolumeClientSlow(f *framework.Framework, config TestConfig, fsGroup *int64, fsType string, tests []Test) {
-	testVolumeClient(f, config, fsGroup, fsType, tests, true)
+func TestVolumeClientSlow(ctx context.Context, f *framework.Framework, config TestConfig, fsGroup *int64, fsType string, tests []Test) {
+	testVolumeClient(ctx, f, config, fsGroup, fsType, tests, true)
 }
 
-func testVolumeClient(f *framework.Framework, config TestConfig, fsGroup *int64, fsType string, tests []Test, slow bool) {
+func testVolumeClient(ctx context.Context, f *framework.Framework, config TestConfig, fsGroup *int64, fsType string, tests []Test, slow bool) {
 	timeouts := f.Timeouts
-	clientPod, err := runVolumeTesterPod(f.ClientSet, timeouts, config, "client", false, fsGroup, tests, slow)
+	clientPod, err := runVolumeTesterPod(ctx, f.ClientSet, timeouts, config, "client", false, fsGroup, tests, slow)
 	if err != nil {
 		framework.Failf("Failed to create client pod: %v", err)
 	}
 	defer func() {
 		// testVolumeClient might get used more than once per test, therefore
 		// we have to clean up before returning.
-		e2epod.DeletePodOrFail(f.ClientSet, clientPod.Namespace, clientPod.Name)
-		framework.ExpectNoError(e2epod.WaitForPodToDisappear(f.ClientSet, clientPod.Namespace, clientPod.Name, labels.Everything(), framework.Poll, timeouts.PodDelete))
+		e2epod.DeletePodOrFail(ctx, f.ClientSet, clientPod.Namespace, clientPod.Name)
+		framework.ExpectNoError(e2epod.WaitForPodToDisappear(ctx, f.ClientSet, clientPod.Namespace, clientPod.Name, labels.Everything(), framework.Poll, timeouts.PodDelete))
 	}()
 
 	testVolumeContent(f, clientPod, "", fsGroup, fsType, tests)
@@ -553,7 +553,7 @@ func testVolumeClient(f *framework.Framework, config TestConfig, fsGroup *int64,
 	}
 	ec.Resources = v1.ResourceRequirements{}
 	ec.Name = "volume-ephemeral-container"
-	err = e2epod.NewPodClient(f).AddEphemeralContainerSync(clientPod, ec, timeouts.PodStart)
+	err = e2epod.NewPodClient(f).AddEphemeralContainerSync(ctx, clientPod, ec, timeouts.PodStart)
 	// The API server will return NotFound for the subresource when the feature is disabled
 	framework.ExpectNoError(err, "failed to add ephemeral container for re-test")
 	testVolumeContent(f, clientPod, ec.Name, fsGroup, fsType, tests)
@@ -562,13 +562,13 @@ func testVolumeClient(f *framework.Framework, config TestConfig, fsGroup *int64,
 // InjectContent inserts index.html with given content into given volume. It does so by
 // starting and auxiliary pod which writes the file there.
 // The volume must be writable.
-func InjectContent(f *framework.Framework, config TestConfig, fsGroup *int64, fsType string, tests []Test) {
+func InjectContent(ctx context.Context, f *framework.Framework, config TestConfig, fsGroup *int64, fsType string, tests []Test) {
 	privileged := true
 	timeouts := f.Timeouts
 	if framework.NodeOSDistroIs("windows") {
 		privileged = false
 	}
-	injectorPod, err := runVolumeTesterPod(f.ClientSet, timeouts, config, "injector", privileged, fsGroup, tests, false /*slow*/)
+	injectorPod, err := runVolumeTesterPod(ctx, f.ClientSet, timeouts, config, "injector", privileged, fsGroup, tests, false /*slow*/)
 	if err != nil {
 		framework.Failf("Failed to create injector pod: %v", err)
 		return
@@ -576,8 +576,8 @@ func InjectContent(f *framework.Framework, config TestConfig, fsGroup *int64, fs
 	defer func() {
 		// This pod must get deleted before the function returns becaue the test relies on
 		// the volume not being in use.
-		e2epod.DeletePodOrFail(f.ClientSet, injectorPod.Namespace, injectorPod.Name)
-		framework.ExpectNoError(e2epod.WaitForPodToDisappear(f.ClientSet, injectorPod.Namespace, injectorPod.Name, labels.Everything(), framework.Poll, timeouts.PodDelete))
+		e2epod.DeletePodOrFail(ctx, f.ClientSet, injectorPod.Namespace, injectorPod.Name)
+		framework.ExpectNoError(e2epod.WaitForPodToDisappear(ctx, f.ClientSet, injectorPod.Namespace, injectorPod.Name, labels.Everything(), framework.Poll, timeouts.PodDelete))
 	}()
 
 	ginkgo.By("Writing text file contents in the container.")

--- a/test/e2e/instrumentation/core_events.go
+++ b/test/e2e/instrumentation/core_events.go
@@ -62,7 +62,7 @@ var _ = common.SIGDescribe("Events", func() {
 
 		ginkgo.By("creating a test event")
 		// create a test event in test namespace
-		_, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Create(context.TODO(), &v1.Event{
+		_, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Create(ctx, &v1.Event{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: eventTestName,
 				Labels: map[string]string{
@@ -81,7 +81,7 @@ var _ = common.SIGDescribe("Events", func() {
 
 		ginkgo.By("listing all events in all namespaces")
 		// get a list of Events in all namespaces to ensure endpoint coverage
-		eventsList, err := f.ClientSet.CoreV1().Events("").List(context.TODO(), metav1.ListOptions{
+		eventsList, err := f.ClientSet.CoreV1().Events("").List(ctx, metav1.ListOptions{
 			LabelSelector: "testevent-constant=true",
 		})
 		framework.ExpectNoError(err, "failed list all events")
@@ -107,18 +107,18 @@ var _ = common.SIGDescribe("Events", func() {
 		})
 		framework.ExpectNoError(err, "failed to marshal the patch JSON payload")
 
-		_, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Patch(context.TODO(), eventTestName, types.StrategicMergePatchType, []byte(eventPatch), metav1.PatchOptions{})
+		_, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Patch(ctx, eventTestName, types.StrategicMergePatchType, []byte(eventPatch), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch the test event")
 
 		ginkgo.By("fetching the test event")
 		// get event by name
-		event, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Get(context.TODO(), eventCreatedName, metav1.GetOptions{})
+		event, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Get(ctx, eventCreatedName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to fetch the test event")
 		framework.ExpectEqual(event.Message, eventPatchMessage, "test event message does not match patch message")
 
 		ginkgo.By("updating the test event")
 
-		testEvent, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Get(context.TODO(), event.Name, metav1.GetOptions{})
+		testEvent, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Get(ctx, event.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get test event")
 
 		testEvent.Series = &v1.EventSeries{
@@ -130,11 +130,11 @@ var _ = common.SIGDescribe("Events", func() {
 		testEvent.ObjectMeta.ResourceVersion = ""
 		testEvent.ObjectMeta.ManagedFields = nil
 
-		_, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Update(context.TODO(), testEvent, metav1.UpdateOptions{})
+		_, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Update(ctx, testEvent, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "failed to update the test event")
 
 		ginkgo.By("getting the test event")
-		event, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Get(context.TODO(), testEvent.Name, metav1.GetOptions{})
+		event, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Get(ctx, testEvent.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get test event")
 		// clear ResourceVersion and ManagedFields which are set by control-plane
 		event.ObjectMeta.ResourceVersion = ""
@@ -145,12 +145,12 @@ var _ = common.SIGDescribe("Events", func() {
 
 		ginkgo.By("deleting the test event")
 		// delete original event
-		err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Delete(context.TODO(), eventCreatedName, metav1.DeleteOptions{})
+		err = f.ClientSet.CoreV1().Events(f.Namespace.Name).Delete(ctx, eventCreatedName, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete the test event")
 
 		ginkgo.By("listing all events in all namespaces")
 		// get a list of Events list namespace
-		eventsList, err = f.ClientSet.CoreV1().Events("").List(context.TODO(), metav1.ListOptions{
+		eventsList, err = f.ClientSet.CoreV1().Events("").List(ctx, metav1.ListOptions{
 			LabelSelector: "testevent-constant=true",
 		})
 		framework.ExpectNoError(err, "fail to list all events")
@@ -179,7 +179,7 @@ var _ = common.SIGDescribe("Events", func() {
 		// create a test event in test namespace
 		for _, eventTestName := range eventTestNames {
 			eventMessage := "This is " + eventTestName
-			_, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Create(context.TODO(), &v1.Event{
+			_, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).Create(ctx, &v1.Event{
 
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   eventTestName,
@@ -199,7 +199,7 @@ var _ = common.SIGDescribe("Events", func() {
 
 		ginkgo.By("get a list of Events with a label in the current namespace")
 		// get a list of events
-		eventList, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{
+		eventList, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{
 			LabelSelector: "testevent-set=true",
 		})
 		framework.ExpectNoError(err, "failed to get a list of events")
@@ -210,25 +210,25 @@ var _ = common.SIGDescribe("Events", func() {
 		// delete collection
 
 		framework.Logf("requesting DeleteCollection of events")
-		err = f.ClientSet.CoreV1().Events(f.Namespace.Name).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
+		err = f.ClientSet.CoreV1().Events(f.Namespace.Name).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
 			LabelSelector: "testevent-set=true"})
 		framework.ExpectNoError(err, "failed to delete the test event")
 
 		ginkgo.By("check that the list of events matches the requested quantity")
 
-		err = wait.PollImmediate(eventRetryPeriod, eventRetryTimeout, checkEventListQuantity(f, "testevent-set=true", 0))
+		err = wait.PollImmediateWithContext(ctx, eventRetryPeriod, eventRetryTimeout, checkEventListQuantity(f, "testevent-set=true", 0))
 		framework.ExpectNoError(err, "failed to count required events")
 	})
 
 })
 
-func checkEventListQuantity(f *framework.Framework, label string, quantity int) func() (bool, error) {
-	return func() (bool, error) {
+func checkEventListQuantity(f *framework.Framework, label string, quantity int) func(ctx context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
 		var err error
 
 		framework.Logf("requesting list of events to confirm quantity")
 
-		eventList, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{
+		eventList, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{
 			LabelSelector: label})
 
 		if err != nil {

--- a/test/e2e/instrumentation/logging/generic_soak.go
+++ b/test/e2e/instrumentation/logging/generic_soak.go
@@ -67,7 +67,7 @@ var _ = instrumentation.SIGDescribe("Logging soak [Performance] [Slow] [Disrupti
 				defer ginkgo.GinkgoRecover()
 				wave := fmt.Sprintf("wave%v", strconv.Itoa(i))
 				framework.Logf("Starting logging soak, wave = %v", wave)
-				RunLogPodsWithSleepOf(f, kbRateInSeconds, wave, totalLogTime)
+				RunLogPodsWithSleepOf(ctx, f, kbRateInSeconds, wave, totalLogTime)
 				framework.Logf("Completed logging soak, wave %v", i)
 			}(i)
 			// Niceness.
@@ -80,9 +80,9 @@ var _ = instrumentation.SIGDescribe("Logging soak [Performance] [Slow] [Disrupti
 
 // RunLogPodsWithSleepOf creates a pod on every node, logs continuously (with "sleep" pauses), and verifies that the log string
 // was produced in each and every pod at least once.  The final arg is the timeout for the test to verify all the pods got logs.
-func RunLogPodsWithSleepOf(f *framework.Framework, sleep time.Duration, podname string, timeout time.Duration) {
+func RunLogPodsWithSleepOf(ctx context.Context, f *framework.Framework, sleep time.Duration, podname string, timeout time.Duration) {
 
-	nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+	nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
 	framework.ExpectNoError(err)
 	totalPods := len(nodes.Items)
 	framework.ExpectNotEqual(totalPods, 0)
@@ -91,6 +91,7 @@ func RunLogPodsWithSleepOf(f *framework.Framework, sleep time.Duration, podname 
 
 	appName := "logging-soak" + podname
 	podlables := e2enode.CreatePodsPerNodeForSimpleApp(
+		ctx,
 		f.ClientSet,
 		f.Namespace.Name,
 		appName,
@@ -127,7 +128,7 @@ func RunLogPodsWithSleepOf(f *framework.Framework, sleep time.Duration, podname 
 	)
 
 	largeClusterForgiveness := time.Duration(len(nodes.Items)/5) * time.Second // i.e. a 100 node cluster gets an extra 20 seconds to complete.
-	pods, err := logSoakVerification.WaitFor(totalPods, timeout+largeClusterForgiveness)
+	pods, err := logSoakVerification.WaitFor(ctx, totalPods, timeout+largeClusterForgiveness)
 
 	if err != nil {
 		framework.Failf("Error in wait... %v", err)

--- a/test/e2e/instrumentation/monitoring/accelerator.go
+++ b/test/e2e/instrumentation/monitoring/accelerator.go
@@ -57,15 +57,14 @@ var _ = instrumentation.SIGDescribe("Stackdriver Monitoring", func() {
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.It("should have accelerator metrics [Feature:StackdriverAcceleratorMonitoring]", func(ctx context.Context) {
-		testStackdriverAcceleratorMonitoring(f)
+		testStackdriverAcceleratorMonitoring(ctx, f)
 	})
 
 })
 
-func testStackdriverAcceleratorMonitoring(f *framework.Framework) {
+func testStackdriverAcceleratorMonitoring(ctx context.Context, f *framework.Framework) {
 	projectID := framework.TestContext.CloudConfig.ProjectID
 
-	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, gcm.CloudPlatformScope)
 	framework.ExpectNoError(err)
 
@@ -80,9 +79,9 @@ func testStackdriverAcceleratorMonitoring(f *framework.Framework) {
 		gcmService.BasePath = basePathOverride
 	}
 
-	scheduling.SetupNVIDIAGPUNode(f, false)
+	scheduling.SetupNVIDIAGPUNode(ctx, f, false)
 
-	e2epod.NewPodClient(f).Create(&v1.Pod{
+	e2epod.NewPodClient(f).Create(ctx, &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: rcName,
 		},

--- a/test/e2e/instrumentation/monitoring/metrics_grabber.go
+++ b/test/e2e/instrumentation/monitoring/metrics_grabber.go
@@ -39,12 +39,12 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var c, ec clientset.Interface
 	var grabber *e2emetrics.Grabber
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		var err error
 		c = f.ClientSet
 		ec = f.KubemarkExternalClusterClientSet
-		gomega.Eventually(func() error {
-			grabber, err = e2emetrics.NewMetricsGrabber(c, ec, f.ClientConfig(), true, true, true, true, true, true)
+		gomega.Eventually(ctx, func() error {
+			grabber, err = e2emetrics.NewMetricsGrabber(ctx, c, ec, f.ClientConfig(), true, true, true, true, true, true)
 			if err != nil {
 				return fmt.Errorf("failed to create metrics grabber: %v", err)
 			}
@@ -54,7 +54,7 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 
 	ginkgo.It("should grab all metrics from API server.", func(ctx context.Context) {
 		ginkgo.By("Connecting to /metrics endpoint")
-		response, err := grabber.GrabFromAPIServer()
+		response, err := grabber.GrabFromAPIServer(ctx)
 		if errors.Is(err, e2emetrics.MetricsGrabbingDisabledError) {
 			e2eskipper.Skipf("%v", err)
 		}
@@ -64,19 +64,19 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 
 	ginkgo.It("should grab all metrics from a Kubelet.", func(ctx context.Context) {
 		ginkgo.By("Proxying to Node through the API server")
-		node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 		if errors.Is(err, e2emetrics.MetricsGrabbingDisabledError) {
 			e2eskipper.Skipf("%v", err)
 		}
 		framework.ExpectNoError(err)
-		response, err := grabber.GrabFromKubelet(node.Name)
+		response, err := grabber.GrabFromKubelet(ctx, node.Name)
 		framework.ExpectNoError(err)
 		gomega.Expect(response).NotTo(gomega.BeEmpty())
 	})
 
 	ginkgo.It("should grab all metrics from a Scheduler.", func(ctx context.Context) {
 		ginkgo.By("Proxying to Pod through the API server")
-		response, err := grabber.GrabFromScheduler()
+		response, err := grabber.GrabFromScheduler(ctx)
 		if errors.Is(err, e2emetrics.MetricsGrabbingDisabledError) {
 			e2eskipper.Skipf("%v", err)
 		}
@@ -86,7 +86,7 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 
 	ginkgo.It("should grab all metrics from a ControllerManager.", func(ctx context.Context) {
 		ginkgo.By("Proxying to Pod through the API server")
-		response, err := grabber.GrabFromControllerManager()
+		response, err := grabber.GrabFromControllerManager(ctx)
 		if errors.Is(err, e2emetrics.MetricsGrabbingDisabledError) {
 			e2eskipper.Skipf("%v", err)
 		}

--- a/test/e2e/instrumentation/monitoring/stackdriver.go
+++ b/test/e2e/instrumentation/monitoring/stackdriver.go
@@ -69,15 +69,14 @@ var _ = instrumentation.SIGDescribe("Stackdriver Monitoring", func() {
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.It("should have cluster metrics [Feature:StackdriverMonitoring]", func(ctx context.Context) {
-		testStackdriverMonitoring(f, 1, 100, 200)
+		testStackdriverMonitoring(ctx, f, 1, 100, 200)
 	})
 
 })
 
-func testStackdriverMonitoring(f *framework.Framework, pods, allPodsCPU int, perPodCPU int64) {
+func testStackdriverMonitoring(ctx context.Context, f *framework.Framework, pods, allPodsCPU int, perPodCPU int64) {
 	projectID := framework.TestContext.CloudConfig.ProjectID
 
-	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, gcm.CloudPlatformScope)
 	framework.ExpectNoError(err)
 
@@ -105,10 +104,10 @@ func testStackdriverMonitoring(f *framework.Framework, pods, allPodsCPU int, per
 
 	framework.ExpectNoError(err)
 
-	rc := e2eautoscaling.NewDynamicResourceConsumer(rcName, f.Namespace.Name, e2eautoscaling.KindDeployment, pods, allPodsCPU, memoryUsed, 0, perPodCPU, memoryLimit, f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle)
+	rc := e2eautoscaling.NewDynamicResourceConsumer(ctx, rcName, f.Namespace.Name, e2eautoscaling.KindDeployment, pods, allPodsCPU, memoryUsed, 0, perPodCPU, memoryLimit, f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle)
 	ginkgo.DeferCleanup(rc.CleanUp)
 
-	rc.WaitForReplicas(pods, 15*time.Minute)
+	rc.WaitForReplicas(ctx, pods, 15*time.Minute)
 
 	metricsMap := map[string]bool{}
 	pollingFunction := checkForMetrics(projectID, gcmService, time.Now(), metricsMap, allPodsCPU, perPodCPU)

--- a/test/e2e/instrumentation/monitoring/stackdriver_metadata_agent.go
+++ b/test/e2e/instrumentation/monitoring/stackdriver_metadata_agent.go
@@ -56,11 +56,11 @@ var _ = instrumentation.SIGDescribe("Stackdriver Monitoring", func() {
 
 	ginkgo.It("should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]", func(ctx context.Context) {
 		kubeClient = f.ClientSet
-		testAgent(f, kubeClient)
+		testAgent(ctx, f, kubeClient)
 	})
 })
 
-func testAgent(f *framework.Framework, kubeClient clientset.Interface) {
+func testAgent(ctx context.Context, f *framework.Framework, kubeClient clientset.Interface) {
 	projectID := framework.TestContext.CloudConfig.ProjectID
 	resourceType := "k8s_container"
 	uniqueContainerName := fmt.Sprintf("test-container-%v", time.Now().Unix())
@@ -70,13 +70,13 @@ func testAgent(f *framework.Framework, kubeClient clientset.Interface) {
 		resourceType,
 		uniqueContainerName)
 
-	oauthClient, err := google.DefaultClient(context.Background(), MonitoringScope)
+	oauthClient, err := google.DefaultClient(ctx, MonitoringScope)
 	if err != nil {
 		framework.Failf("Failed to create oauth client: %s", err)
 	}
 
 	// Create test pod with unique name.
-	_ = e2epod.CreateExecPodOrFail(kubeClient, f.Namespace.Name, uniqueContainerName, func(pod *v1.Pod) {
+	_ = e2epod.CreateExecPodOrFail(ctx, kubeClient, f.Namespace.Name, uniqueContainerName, func(pod *v1.Pod) {
 		pod.Spec.Containers[0].Name = uniqueContainerName
 	})
 	ginkgo.DeferCleanup(kubeClient.CoreV1().Pods(f.Namespace.Name).Delete, uniqueContainerName, metav1.DeleteOptions{})

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -266,8 +266,8 @@ var _ = SIGDescribe("Kubectl client", func() {
 				ValidPhases: []v1.PodPhase{v1.PodRunning /*v1.PodPending*/},
 			})
 	}
-	forEachPod := func(podFunc func(p v1.Pod)) {
-		clusterState().ForEach(podFunc)
+	forEachPod := func(ctx context.Context, podFunc func(p v1.Pod)) {
+		_ = clusterState().ForEach(ctx, podFunc)
 	}
 	var c clientset.Interface
 	var ns string
@@ -280,11 +280,11 @@ var _ = SIGDescribe("Kubectl client", func() {
 	// idiomatic way to wrap the ClusterVerification structs for syntactic sugar in large
 	// test files.
 	// Print debug info if atLeast Pods are not found before the timeout
-	waitForOrFailWithDebug := func(atLeast int) {
-		pods, err := clusterState().WaitFor(atLeast, framework.PodStartTimeout)
+	waitForOrFailWithDebug := func(ctx context.Context, atLeast int) {
+		pods, err := clusterState().WaitFor(ctx, atLeast, framework.PodStartTimeout)
 		if err != nil || len(pods) < atLeast {
 			// TODO: Generalize integrating debug info into these tests so we always get debug info when we need it
-			e2edebug.DumpAllNamespaceInfo(f.ClientSet, ns)
+			e2edebug.DumpAllNamespaceInfo(ctx, f.ClientSet, ns)
 			framework.Failf("Verified %d of %d pods , error: %v", len(pods), atLeast, err)
 		}
 	}
@@ -341,7 +341,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 
 			ginkgo.By("creating a replication controller")
 			e2ekubectl.RunKubectlOrDieInput(ns, nautilus, "create", "-f", "-")
-			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
+			validateController(ctx, c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 		})
 
 		/*
@@ -354,15 +354,15 @@ var _ = SIGDescribe("Kubectl client", func() {
 
 			ginkgo.By("creating a replication controller")
 			e2ekubectl.RunKubectlOrDieInput(ns, nautilus, "create", "-f", "-")
-			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
+			validateController(ctx, c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 			ginkgo.By("scaling down the replication controller")
 			debugDiscovery()
 			e2ekubectl.RunKubectlOrDie(ns, "scale", "rc", "update-demo-nautilus", "--replicas=1", "--timeout=5m")
-			validateController(c, nautilusImage, 1, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
+			validateController(ctx, c, nautilusImage, 1, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 			ginkgo.By("scaling up the replication controller")
 			debugDiscovery()
 			e2ekubectl.RunKubectlOrDie(ns, "scale", "rc", "update-demo-nautilus", "--replicas=2", "--timeout=5m")
-			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
+			validateController(ctx, c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 		})
 	})
 
@@ -402,17 +402,17 @@ var _ = SIGDescribe("Kubectl client", func() {
 			})
 
 			ginkgo.By("validating guestbook app")
-			validateGuestbookApp(c, ns)
+			validateGuestbookApp(ctx, c, ns)
 		})
 	})
 
 	ginkgo.Describe("Simple pod", func() {
 		var podYaml string
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			ginkgo.By(fmt.Sprintf("creating the pod from %v", podYaml))
 			podYaml = commonutils.SubstituteImageName(string(readTestFileOrDie("pod-with-readiness-probe.yaml.in")))
 			e2ekubectl.RunKubectlOrDieInput(ns, podYaml, "create", "-f", "-")
-			framework.ExpectEqual(e2epod.CheckPodsRunningReady(c, ns, []string{simplePodName}, framework.PodStartTimeout), true)
+			framework.ExpectEqual(e2epod.CheckPodsRunningReady(ctx, c, ns, []string{simplePodName}, framework.PodStartTimeout), true)
 		})
 		ginkgo.AfterEach(func() {
 			cleanupKubectlInputs(podYaml, ns, simplePodSelector)
@@ -579,7 +579,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 				if !strings.Contains(ee.String(), "timed out") {
 					framework.Failf("Missing expected 'timed out' error, got: %#v", ee)
 				}
-				e2epod.WaitForPodToDisappear(f.ClientSet, ns, "failure-3", labels.Everything(), 2*time.Second, wait.ForeverTestTimeout)
+				framework.ExpectNoError(e2epod.WaitForPodToDisappear(ctx, f.ClientSet, ns, "failure-3", labels.Everything(), 2*time.Second, wait.ForeverTestTimeout))
 			})
 
 			ginkgo.It("[Slow] running a failing command with --leave-stdin-open", func(ctx context.Context) {
@@ -613,7 +613,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			gomega.Expect(runOutput).To(gomega.ContainSubstring("abcd1234"))
 			gomega.Expect(runOutput).To(gomega.ContainSubstring("stdin closed"))
 
-			gomega.Expect(c.CoreV1().Pods(ns).Delete(context.TODO(), "run-test", metav1.DeleteOptions{})).To(gomega.BeNil())
+			gomega.Expect(c.CoreV1().Pods(ns).Delete(ctx, "run-test", metav1.DeleteOptions{})).To(gomega.BeNil())
 
 			ginkgo.By("executing a command with run and attach without stdin")
 			// There is a race on this scenario described in #73099
@@ -629,7 +629,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			gomega.Expect(runOutput).ToNot(gomega.ContainSubstring("abcd1234"))
 			gomega.Expect(runOutput).To(gomega.ContainSubstring("stdin closed"))
 
-			gomega.Expect(c.CoreV1().Pods(ns).Delete(context.TODO(), "run-test-2", metav1.DeleteOptions{})).To(gomega.BeNil())
+			gomega.Expect(c.CoreV1().Pods(ns).Delete(ctx, "run-test-2", metav1.DeleteOptions{})).To(gomega.BeNil())
 
 			ginkgo.By("executing a command with run and attach with stdin with open stdin should remain running")
 			e2ekubectl.NewKubectlCommand(ns, "run", "run-test-3", "--image="+busyboxImage, "--restart=OnFailure", podRunningTimeoutArg, "--attach=true", "--leave-stdin-open=true", "--stdin", "--", "sh", "-c", "cat && echo 'stdin closed'").
@@ -643,11 +643,11 @@ var _ = SIGDescribe("Kubectl client", func() {
 			g := func(pods []*v1.Pod) sort.Interface { return sort.Reverse(controller.ActivePods(pods)) }
 			runTestPod, _, err := polymorphichelpers.GetFirstPod(f.ClientSet.CoreV1(), ns, "run=run-test-3", 1*time.Minute, g)
 			framework.ExpectNoError(err)
-			if !e2epod.CheckPodsRunningReady(c, ns, []string{runTestPod.Name}, time.Minute) {
+			if !e2epod.CheckPodsRunningReady(ctx, c, ns, []string{runTestPod.Name}, time.Minute) {
 				framework.Failf("Pod %q of Job %q should still be running", runTestPod.Name, "run-test-3")
 			}
 
-			gomega.Expect(c.CoreV1().Pods(ns).Delete(context.TODO(), "run-test-3", metav1.DeleteOptions{})).To(gomega.BeNil())
+			gomega.Expect(c.CoreV1().Pods(ns).Delete(ctx, "run-test-3", metav1.DeleteOptions{})).To(gomega.BeNil())
 		})
 
 		ginkgo.It("should contain last line of the log", func(ctx context.Context) {
@@ -656,7 +656,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			ginkgo.By("executing a command with run")
 			e2ekubectl.RunKubectlOrDie(ns, "run", podName, "--image="+busyboxImage, "--restart=OnFailure", podRunningTimeoutArg, "--", "sh", "-c", "sleep 10; seq 100 | while read i; do echo $i; sleep 0.01; done; echo EOF")
 
-			if !e2epod.CheckPodsRunningReadyOrSucceeded(c, ns, []string{podName}, framework.PodStartTimeout) {
+			if !e2epod.CheckPodsRunningReadyOrSucceeded(ctx, c, ns, []string{podName}, framework.PodStartTimeout) {
 				framework.Failf("Pod for run-log-test was not ready")
 			}
 
@@ -693,11 +693,11 @@ var _ = SIGDescribe("Kubectl client", func() {
 
 			ginkgo.By("adding rbac permissions")
 			// grant the view permission widely to allow inspection of the `invalid` namespace and the default namespace
-			err := e2eauth.BindClusterRole(f.ClientSet.RbacV1(), "view", f.Namespace.Name,
+			err := e2eauth.BindClusterRole(ctx, f.ClientSet.RbacV1(), "view", f.Namespace.Name,
 				rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Namespace: f.Namespace.Name, Name: "default"})
 			framework.ExpectNoError(err)
 
-			err = e2eauth.WaitForAuthorizationUpdate(f.ClientSet.AuthorizationV1(),
+			err = e2eauth.WaitForAuthorizationUpdate(ctx, f.ClientSet.AuthorizationV1(),
 				serviceaccount.MakeUsername(f.Namespace.Name, "default"),
 				f.Namespace.Name, "list", schema.GroupResource{Resource: "pods"}, true)
 			framework.ExpectNoError(err)
@@ -855,7 +855,7 @@ metadata:
 				WithStdinReader(stdin).
 				ExecOrDie(ns)
 			ginkgo.By("checking the result")
-			forEachReplicationController(c, ns, "app", "agnhost", validateReplicationControllerConfiguration)
+			forEachReplicationController(ctx, c, ns, "app", "agnhost", validateReplicationControllerConfiguration)
 		})
 		ginkgo.It("should reuse port when apply to an existing SVC", func(ctx context.Context) {
 			serviceJSON := readTestFileOrDie(agnhostServiceFilename)
@@ -969,7 +969,7 @@ metadata:
 			e2ekubectl.RunKubectlOrDie(ns, "patch", "pod", podName, "-p", specImage, "--dry-run=server")
 
 			ginkgo.By("verifying the pod " + podName + " has the right image " + httpdImage)
-			pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+			pod, err := c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
 			if err != nil {
 				framework.Failf("Failed getting pod %s: %v", podName, err)
 			}
@@ -1281,10 +1281,10 @@ metadata:
 			e2ekubectl.RunKubectlOrDieInput(ns, string(serviceJSON[:]), "create", "-f", "-")
 
 			ginkgo.By("Waiting for Agnhost primary to start.")
-			waitForOrFailWithDebug(1)
+			waitForOrFailWithDebug(ctx, 1)
 
 			// Pod
-			forEachPod(func(pod v1.Pod) {
+			forEachPod(ctx, func(pod v1.Pod) {
 				output := e2ekubectl.RunKubectlOrDie(ns, "describe", "pod", pod.Name)
 				requiredStrings := [][]string{
 					{"Name:", "agnhost-primary-"},
@@ -1336,7 +1336,7 @@ metadata:
 
 			// Node
 			// It should be OK to list unschedulable Nodes here.
-			nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+			nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 			framework.ExpectNoError(err)
 			node := nodes.Items[0]
 			output = e2ekubectl.RunKubectlOrDie(ns, "describe", "node", node.Name)
@@ -1377,7 +1377,7 @@ metadata:
 
 			ginkgo.By("waiting for cronjob to start.")
 			err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
-				cj, err := c.BatchV1().CronJobs(ns).List(context.TODO(), metav1.ListOptions{})
+				cj, err := c.BatchV1().CronJobs(ns).List(ctx, metav1.ListOptions{})
 				if err != nil {
 					return false, fmt.Errorf("Failed getting CronJob %s: %v", ns, err)
 				}
@@ -1424,14 +1424,14 @@ metadata:
 
 			// It may take a while for the pods to get registered in some cases, wait to be sure.
 			ginkgo.By("Waiting for Agnhost primary to start.")
-			waitForOrFailWithDebug(1)
-			forEachPod(func(pod v1.Pod) {
+			waitForOrFailWithDebug(ctx, 1)
+			forEachPod(ctx, func(pod v1.Pod) {
 				framework.Logf("wait on agnhost-primary startup in %v ", ns)
 				e2eoutput.LookForStringInLog(ns, pod.Name, "agnhost-primary", "Paused", framework.PodStartTimeout)
 			})
 			validateService := func(name string, servicePort int, timeout time.Duration) {
 				err := wait.Poll(framework.Poll, timeout, func() (bool, error) {
-					ep, err := c.CoreV1().Endpoints(ns).Get(context.TODO(), name, metav1.GetOptions{})
+					ep, err := c.CoreV1().Endpoints(ns).Get(ctx, name, metav1.GetOptions{})
 					if err != nil {
 						// log the real error
 						framework.Logf("Get endpoints failed (interval %v): %v", framework.Poll, err)
@@ -1462,7 +1462,7 @@ metadata:
 				})
 				framework.ExpectNoError(err)
 
-				e2eservice, err := c.CoreV1().Services(ns).Get(context.TODO(), name, metav1.GetOptions{})
+				e2eservice, err := c.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
 
 				if len(e2eservice.Spec.Ports) != 1 {
@@ -1479,23 +1479,23 @@ metadata:
 
 			ginkgo.By("exposing RC")
 			e2ekubectl.RunKubectlOrDie(ns, "expose", "rc", "agnhost-primary", "--name=rm2", "--port=1234", fmt.Sprintf("--target-port=%d", agnhostPort))
-			e2enetwork.WaitForService(c, ns, "rm2", true, framework.Poll, framework.ServiceStartTimeout)
+			framework.ExpectNoError(e2enetwork.WaitForService(ctx, c, ns, "rm2", true, framework.Poll, framework.ServiceStartTimeout))
 			validateService("rm2", 1234, framework.ServiceStartTimeout)
 
 			ginkgo.By("exposing service")
 			e2ekubectl.RunKubectlOrDie(ns, "expose", "service", "rm2", "--name=rm3", "--port=2345", fmt.Sprintf("--target-port=%d", agnhostPort))
-			e2enetwork.WaitForService(c, ns, "rm3", true, framework.Poll, framework.ServiceStartTimeout)
+			framework.ExpectNoError(e2enetwork.WaitForService(ctx, c, ns, "rm3", true, framework.Poll, framework.ServiceStartTimeout))
 			validateService("rm3", 2345, framework.ServiceStartTimeout)
 		})
 	})
 
 	ginkgo.Describe("Kubectl label", func() {
 		var podYaml string
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			ginkgo.By("creating the pod")
 			podYaml = commonutils.SubstituteImageName(string(readTestFileOrDie("pause-pod.yaml.in")))
 			e2ekubectl.RunKubectlOrDieInput(ns, podYaml, "create", "-f", "-")
-			framework.ExpectEqual(e2epod.CheckPodsRunningReady(c, ns, []string{pausePodName}, framework.PodStartTimeout), true)
+			framework.ExpectEqual(e2epod.CheckPodsRunningReady(ctx, c, ns, []string{pausePodName}, framework.PodStartTimeout), true)
 		})
 		ginkgo.AfterEach(func() {
 			cleanupKubectlInputs(podYaml, ns, pausePodSelector)
@@ -1530,11 +1530,11 @@ metadata:
 
 	ginkgo.Describe("Kubectl copy", func() {
 		var podYaml string
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			ginkgo.By("creating the pod")
 			podYaml = commonutils.SubstituteImageName(string(readTestFileOrDie("busybox-pod.yaml.in")))
 			e2ekubectl.RunKubectlOrDieInput(ns, podYaml, "create", "-f", "-")
-			framework.ExpectEqual(e2epod.CheckPodsRunningReady(c, ns, []string{busyboxPodName}, framework.PodStartTimeout), true)
+			framework.ExpectEqual(e2epod.CheckPodsRunningReady(ctx, c, ns, []string{busyboxPodName}, framework.PodStartTimeout), true)
 		})
 		ginkgo.AfterEach(func() {
 			cleanupKubectlInputs(podYaml, ns, busyboxPodSelector)
@@ -1597,7 +1597,7 @@ metadata:
 			}
 
 			ginkgo.By("Waiting for log generator to start.")
-			if !e2epod.CheckPodsRunningReadyOrSucceeded(c, ns, []string{podName}, framework.PodStartTimeout) {
+			if !e2epod.CheckPodsRunningReadyOrSucceeded(ctx, c, ns, []string{podName}, framework.PodStartTimeout) {
 				framework.Failf("Pod %s was not ready", podName)
 			}
 
@@ -1654,14 +1654,14 @@ metadata:
 			ginkgo.By("creating Agnhost RC")
 			e2ekubectl.RunKubectlOrDieInput(ns, controllerJSON, "create", "-f", "-")
 			ginkgo.By("Waiting for Agnhost primary to start.")
-			waitForOrFailWithDebug(1)
+			waitForOrFailWithDebug(ctx, 1)
 			ginkgo.By("patching all pods")
-			forEachPod(func(pod v1.Pod) {
+			forEachPod(ctx, func(pod v1.Pod) {
 				e2ekubectl.RunKubectlOrDie(ns, "patch", "pod", pod.Name, "-p", "{\"metadata\":{\"annotations\":{\"x\":\"y\"}}}")
 			})
 
 			ginkgo.By("checking annotations")
-			forEachPod(func(pod v1.Pod) {
+			forEachPod(ctx, func(pod v1.Pod) {
 				found := false
 				for key, val := range pod.Annotations {
 					if key == "x" && val == "y" {
@@ -1714,7 +1714,7 @@ metadata:
 			ginkgo.By("running the image " + httpdImage)
 			e2ekubectl.RunKubectlOrDie(ns, "run", podName, "--restart=Never", podRunningTimeoutArg, "--image="+httpdImage)
 			ginkgo.By("verifying the pod " + podName + " was created")
-			pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+			pod, err := c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
 			if err != nil {
 				framework.Failf("Failed getting pod %s: %v", podName, err)
 			}
@@ -1766,7 +1766,7 @@ metadata:
 			e2ekubectl.RunKubectlOrDieInput(ns, podJSON, "replace", "-f", "-")
 
 			ginkgo.By("verifying the pod " + podName + " has the right image " + busyboxImage)
-			pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+			pod, err := c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
 			if err != nil {
 				framework.Failf("Failed getting deployment %s: %v", podName, err)
 			}
@@ -1849,7 +1849,7 @@ metadata:
 				Effect: v1.TaintEffectNoSchedule,
 			}
 
-			nodeName := scheduling.GetNodeThatCanRunPod(f)
+			nodeName := scheduling.GetNodeThatCanRunPod(ctx, f)
 
 			ginkgo.By("adding the taint " + testTaint.ToString() + " to a node")
 			runKubectlRetryOrDie(ns, "taint", "nodes", nodeName, testTaint.ToString())
@@ -1880,7 +1880,7 @@ metadata:
 				Effect: v1.TaintEffectNoSchedule,
 			}
 
-			nodeName := scheduling.GetNodeThatCanRunPod(f)
+			nodeName := scheduling.GetNodeThatCanRunPod(ctx, f)
 
 			ginkgo.By("adding the taint " + testTaint.ToString() + " to a node")
 			runKubectlRetryOrDie(ns, "taint", "nodes", nodeName, testTaint.ToString())
@@ -1980,7 +1980,7 @@ metadata:
 			e2ekubectl.RunKubectlOrDie(ns, "create", "quota", quotaName, "--hard=pods=1000000,services=1000000")
 
 			ginkgo.By("verifying that the quota was created")
-			quota, err := c.CoreV1().ResourceQuotas(ns).Get(context.TODO(), quotaName, metav1.GetOptions{})
+			quota, err := c.CoreV1().ResourceQuotas(ns).Get(ctx, quotaName, metav1.GetOptions{})
 			if err != nil {
 				framework.Failf("Failed getting quota %s: %v", quotaName, err)
 			}
@@ -2008,7 +2008,7 @@ metadata:
 			e2ekubectl.RunKubectlOrDie(ns, "create", "quota", quotaName, "--hard=pods=1000000", "--scopes=BestEffort,NotTerminating")
 
 			ginkgo.By("verifying that the quota was created")
-			quota, err := c.CoreV1().ResourceQuotas(ns).Get(context.TODO(), quotaName, metav1.GetOptions{})
+			quota, err := c.CoreV1().ResourceQuotas(ns).Get(ctx, quotaName, metav1.GetOptions{})
 			if err != nil {
 				framework.Failf("Failed getting quota %s: %v", quotaName, err)
 			}
@@ -2163,31 +2163,31 @@ func curl(url string) (string, error) {
 	return curlTransport(url, utilnet.SetTransportDefaults(&http.Transport{}))
 }
 
-func validateGuestbookApp(c clientset.Interface, ns string) {
+func validateGuestbookApp(ctx context.Context, c clientset.Interface, ns string) {
 	framework.Logf("Waiting for all frontend pods to be Running.")
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"tier": "frontend", "app": "guestbook"}))
 	err := testutils.WaitForPodsWithLabelRunning(c, ns, label)
 	framework.ExpectNoError(err)
 	framework.Logf("Waiting for frontend to serve content.")
-	if !waitForGuestbookResponse(c, "get", "", `{"data":""}`, guestbookStartupTimeout, ns) {
+	if !waitForGuestbookResponse(ctx, c, "get", "", `{"data":""}`, guestbookStartupTimeout, ns) {
 		framework.Failf("Frontend service did not start serving content in %v seconds.", guestbookStartupTimeout.Seconds())
 	}
 
 	framework.Logf("Trying to add a new entry to the guestbook.")
-	if !waitForGuestbookResponse(c, "set", "TestEntry", `{"message":"Updated"}`, guestbookResponseTimeout, ns) {
+	if !waitForGuestbookResponse(ctx, c, "set", "TestEntry", `{"message":"Updated"}`, guestbookResponseTimeout, ns) {
 		framework.Failf("Cannot added new entry in %v seconds.", guestbookResponseTimeout.Seconds())
 	}
 
 	framework.Logf("Verifying that added entry can be retrieved.")
-	if !waitForGuestbookResponse(c, "get", "", `{"data":"TestEntry"}`, guestbookResponseTimeout, ns) {
+	if !waitForGuestbookResponse(ctx, c, "get", "", `{"data":"TestEntry"}`, guestbookResponseTimeout, ns) {
 		framework.Failf("Entry to guestbook wasn't correctly added in %v seconds.", guestbookResponseTimeout.Seconds())
 	}
 }
 
 // Returns whether received expected response from guestbook on time.
-func waitForGuestbookResponse(c clientset.Interface, cmd, arg, expectedResponse string, timeout time.Duration, ns string) bool {
-	for start := time.Now(); time.Since(start) < timeout; time.Sleep(5 * time.Second) {
-		res, err := makeRequestToGuestbook(c, cmd, arg, ns)
+func waitForGuestbookResponse(ctx context.Context, c clientset.Interface, cmd, arg, expectedResponse string, timeout time.Duration, ns string) bool {
+	for start := time.Now(); time.Since(start) < timeout && ctx.Err() == nil; time.Sleep(5 * time.Second) {
+		res, err := makeRequestToGuestbook(ctx, c, cmd, arg, ns)
 		if err == nil && res == expectedResponse {
 			return true
 		}
@@ -2196,13 +2196,13 @@ func waitForGuestbookResponse(c clientset.Interface, cmd, arg, expectedResponse 
 	return false
 }
 
-func makeRequestToGuestbook(c clientset.Interface, cmd, value string, ns string) (string, error) {
+func makeRequestToGuestbook(ctx context.Context, c clientset.Interface, cmd, value string, ns string) (string, error) {
 	proxyRequest, errProxy := e2eservice.GetServicesProxyRequest(c, c.CoreV1().RESTClient().Get())
 	if errProxy != nil {
 		return "", errProxy
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
+	ctx, cancel := context.WithTimeout(ctx, framework.SingleCallTimeout)
 	defer cancel()
 
 	result, err := proxyRequest.Namespace(ns).
@@ -2244,13 +2244,13 @@ func modifyReplicationControllerConfiguration(contents string) io.Reader {
 	return bytes.NewReader(data)
 }
 
-func forEachReplicationController(c clientset.Interface, ns, selectorKey, selectorValue string, fn func(v1.ReplicationController)) {
+func forEachReplicationController(ctx context.Context, c clientset.Interface, ns, selectorKey, selectorValue string, fn func(v1.ReplicationController)) {
 	var rcs *v1.ReplicationControllerList
 	var err error
-	for t := time.Now(); time.Since(t) < framework.PodListTimeout; time.Sleep(framework.Poll) {
+	for t := time.Now(); time.Since(t) < framework.PodListTimeout && ctx.Err() == nil; time.Sleep(framework.Poll) {
 		label := labels.SelectorFromSet(labels.Set(map[string]string{selectorKey: selectorValue}))
 		options := metav1.ListOptions{LabelSelector: label.String()}
-		rcs, err = c.CoreV1().ReplicationControllers(ns).List(context.TODO(), options)
+		rcs, err = c.CoreV1().ReplicationControllers(ns).List(ctx, options)
 		framework.ExpectNoError(err)
 		if len(rcs.Items) > 0 {
 			break
@@ -2281,13 +2281,13 @@ func validateReplicationControllerConfiguration(rc v1.ReplicationController) {
 // getUDData creates a validator function based on the input string (i.e. kitten.jpg).
 // For example, if you send "kitten.jpg", this function verifies that the image jpg = kitten.jpg
 // in the container's json field.
-func getUDData(jpgExpected string, ns string) func(clientset.Interface, string) error {
+func getUDData(jpgExpected string, ns string) func(context.Context, clientset.Interface, string) error {
 
 	// getUDData validates data.json in the update-demo (returns nil if data is ok).
-	return func(c clientset.Interface, podID string) error {
+	return func(ctx context.Context, c clientset.Interface, podID string) error {
 		framework.Logf("validating pod %s", podID)
 
-		ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
+		ctx, cancel := context.WithTimeout(ctx, framework.SingleCallTimeout)
 		defer cancel()
 
 		body, err := c.CoreV1().RESTClient().Get().
@@ -2296,7 +2296,7 @@ func getUDData(jpgExpected string, ns string) func(clientset.Interface, string) 
 			SubResource("proxy").
 			Name(podID).
 			Suffix("data.json").
-			Do(context.TODO()).
+			Do(ctx).
 			Raw()
 
 		if err != nil {
@@ -2373,7 +2373,7 @@ func trimDockerRegistry(imagename string) string {
 
 // validatorFn is the function which is individual tests will implement.
 // we may want it to return more than just an error, at some point.
-type validatorFn func(c clientset.Interface, podID string) error
+type validatorFn func(ctx context.Context, c clientset.Interface, podID string) error
 
 // validateController is a generic mechanism for testing RC's that are running.
 // It takes a container name, a test name, and a validator function which is plugged in by a specific test.
@@ -2381,7 +2381,7 @@ type validatorFn func(c clientset.Interface, podID string) error
 // "containerImage" : this is the name of the image we expect to be launched.  Not to confuse w/ images (kitten.jpg)  which are validated.
 // "testname":  which gets bubbled up to the logging/failure messages if errors happen.
 // "validator" function: This function is given a podID and a client, and it can do some specific validations that way.
-func validateController(c clientset.Interface, containerImage string, replicas int, containername string, testname string, validator validatorFn, ns string) {
+func validateController(ctx context.Context, c clientset.Interface, containerImage string, replicas int, containername string, testname string, validator validatorFn, ns string) {
 	containerImage = trimDockerRegistry(containerImage)
 	getPodsTemplate := "--template={{range.items}}{{.metadata.name}} {{end}}"
 
@@ -2391,7 +2391,7 @@ func validateController(c clientset.Interface, containerImage string, replicas i
 
 	ginkgo.By(fmt.Sprintf("waiting for all containers in %s pods to come up.", testname)) //testname should be selector
 waitLoop:
-	for start := time.Now(); time.Since(start) < framework.PodStartTimeout; time.Sleep(5 * time.Second) {
+	for start := time.Now(); time.Since(start) < framework.PodStartTimeout && ctx.Err() == nil; time.Sleep(5 * time.Second) {
 		getPodsOutput := e2ekubectl.RunKubectlOrDie(ns, "get", "pods", "-o", "template", getPodsTemplate, "-l", testname)
 		pods := strings.Fields(getPodsOutput)
 		if numPods := len(pods); numPods != replicas {
@@ -2415,7 +2415,7 @@ waitLoop:
 
 			// Call the generic validator function here.
 			// This might validate for example, that (1) getting a url works and (2) url is serving correct content.
-			if err := validator(c, podID); err != nil {
+			if err := validator(ctx, c, podID); err != nil {
 				framework.Logf("%s is running right image but validator function failed: %v", podID, err)
 				continue waitLoop
 			}

--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -124,8 +124,8 @@ func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string, bi
 }
 
 // WaitForTerminatedContainer waits till a given container be terminated for a given pod.
-func WaitForTerminatedContainer(f *framework.Framework, pod *v1.Pod, containerName string) error {
-	return e2epod.WaitForPodCondition(f.ClientSet, f.Namespace.Name, pod.Name, "container terminated", framework.PodStartTimeout, func(pod *v1.Pod) (bool, error) {
+func WaitForTerminatedContainer(ctx context.Context, f *framework.Framework, pod *v1.Pod, containerName string) error {
+	return e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "container terminated", framework.PodStartTimeout, func(pod *v1.Pod) (bool, error) {
 		if len(testutils.TerminatedContainers(pod)[containerName]) > 0 {
 			return true, nil
 		}
@@ -207,13 +207,13 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 	}
 }
 
-func doTestConnectSendDisconnect(bindAddress string, f *framework.Framework) {
+func doTestConnectSendDisconnect(ctx context.Context, bindAddress string, f *framework.Framework) {
 	ginkgo.By("Creating the target pod")
 	pod := pfPod("", "10", "10", "100", fmt.Sprintf("%s", bindAddress))
-	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 		framework.Failf("Couldn't create pod: %v", err)
 	}
-	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
+	if err := e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
 		framework.Failf("Pod did not start running: %v", err)
 	}
 
@@ -242,26 +242,26 @@ func doTestConnectSendDisconnect(bindAddress string, f *framework.Framework) {
 	}
 
 	ginkgo.By("Waiting for the target pod to stop running")
-	if err := WaitForTerminatedContainer(f, pod, "portforwardtester"); err != nil {
+	if err := WaitForTerminatedContainer(ctx, f, pod, "portforwardtester"); err != nil {
 		framework.Failf("Container did not terminate: %v", err)
 	}
 
 	ginkgo.By("Verifying logs")
-	gomega.Eventually(func() (string, error) {
-		return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, "portforwardtester")
+	gomega.Eventually(ctx, func() (string, error) {
+		return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "portforwardtester")
 	}, postStartWaitTimeout, podCheckInterval).Should(gomega.SatisfyAll(
 		gomega.ContainSubstring("Accepted client connection"),
 		gomega.ContainSubstring("Done"),
 	))
 }
 
-func doTestMustConnectSendNothing(bindAddress string, f *framework.Framework) {
+func doTestMustConnectSendNothing(ctx context.Context, bindAddress string, f *framework.Framework) {
 	ginkgo.By("Creating the target pod")
 	pod := pfPod("abc", "1", "1", "1", fmt.Sprintf("%s", bindAddress))
-	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 		framework.Failf("Couldn't create pod: %v", err)
 	}
-	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
+	if err := e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
 		framework.Failf("Pod did not start running: %v", err)
 	}
 
@@ -279,26 +279,26 @@ func doTestMustConnectSendNothing(bindAddress string, f *framework.Framework) {
 	conn.Close()
 
 	ginkgo.By("Waiting for the target pod to stop running")
-	if err := WaitForTerminatedContainer(f, pod, "portforwardtester"); err != nil {
+	if err := WaitForTerminatedContainer(ctx, f, pod, "portforwardtester"); err != nil {
 		framework.Failf("Container did not terminate: %v", err)
 	}
 
 	ginkgo.By("Verifying logs")
-	gomega.Eventually(func() (string, error) {
-		return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, "portforwardtester")
+	gomega.Eventually(ctx, func() (string, error) {
+		return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "portforwardtester")
 	}, postStartWaitTimeout, podCheckInterval).Should(gomega.SatisfyAll(
 		gomega.ContainSubstring("Accepted client connection"),
 		gomega.ContainSubstring("Expected to read 3 bytes from client, but got 0 instead"),
 	))
 }
 
-func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework) {
+func doTestMustConnectSendDisconnect(ctx context.Context, bindAddress string, f *framework.Framework) {
 	ginkgo.By("Creating the target pod")
 	pod := pfPod("abc", "10", "10", "100", fmt.Sprintf("%s", bindAddress))
-	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 		framework.Failf("Couldn't create pod: %v", err)
 	}
-	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
+	if err := e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
 		framework.Failf("Pod did not start running: %v", err)
 	}
 
@@ -330,7 +330,7 @@ func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework)
 	}
 
 	if e, a := strings.Repeat("x", 100), string(fromServer); e != a {
-		podlogs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, "portforwardtester")
+		podlogs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "portforwardtester")
 		if err != nil {
 			framework.Logf("Failed to get logs of portforwardtester pod: %v", err)
 		} else {
@@ -345,13 +345,13 @@ func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework)
 	}
 
 	ginkgo.By("Waiting for the target pod to stop running")
-	if err := WaitForTerminatedContainer(f, pod, "portforwardtester"); err != nil {
+	if err := WaitForTerminatedContainer(ctx, f, pod, "portforwardtester"); err != nil {
 		framework.Failf("Container did not terminate: %v", err)
 	}
 
 	ginkgo.By("Verifying logs")
-	gomega.Eventually(func() (string, error) {
-		return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, "portforwardtester")
+	gomega.Eventually(ctx, func() (string, error) {
+		return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "portforwardtester")
 	}, postStartWaitTimeout, podCheckInterval).Should(gomega.SatisfyAll(
 		gomega.ContainSubstring("Accepted client connection"),
 		gomega.ContainSubstring("Received expected client data"),
@@ -359,16 +359,16 @@ func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework)
 	))
 }
 
-func doTestOverWebSockets(bindAddress string, f *framework.Framework) {
+func doTestOverWebSockets(ctx context.Context, bindAddress string, f *framework.Framework) {
 	config, err := framework.LoadConfig()
 	framework.ExpectNoError(err, "unable to get base config")
 
 	ginkgo.By("Creating the pod")
 	pod := pfPod("def", "10", "10", "100", fmt.Sprintf("%s", bindAddress))
-	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 		framework.Failf("Couldn't create pod: %v", err)
 	}
-	if err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
+	if err := e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
 		framework.Failf("Pod did not start running: %v", err)
 	}
 
@@ -386,7 +386,7 @@ func doTestOverWebSockets(bindAddress string, f *framework.Framework) {
 	}
 	defer ws.Close()
 
-	gomega.Eventually(func() error {
+	gomega.Eventually(ctx, func() error {
 		channel, msg, err := wsRead(ws)
 		if err != nil {
 			return fmt.Errorf("failed to read completely from websocket %s: %v", url.String(), err)
@@ -400,7 +400,7 @@ func doTestOverWebSockets(bindAddress string, f *framework.Framework) {
 		return nil
 	}, time.Minute, 10*time.Second).Should(gomega.Succeed())
 
-	gomega.Eventually(func() error {
+	gomega.Eventually(ctx, func() error {
 		channel, msg, err := wsRead(ws)
 		if err != nil {
 			return fmt.Errorf("failed to read completely from websocket %s: %v", url.String(), err)
@@ -423,7 +423,7 @@ func doTestOverWebSockets(bindAddress string, f *framework.Framework) {
 	ginkgo.By("Reading data from the local port")
 	buf := bytes.Buffer{}
 	expectedData := bytes.Repeat([]byte("x"), 100)
-	gomega.Eventually(func() error {
+	gomega.Eventually(ctx, func() error {
 		channel, msg, err := wsRead(ws)
 		if err != nil {
 			return fmt.Errorf("failed to read completely from websocket %s: %v", url.String(), err)
@@ -439,8 +439,8 @@ func doTestOverWebSockets(bindAddress string, f *framework.Framework) {
 	}, time.Minute, 10*time.Second).Should(gomega.Succeed())
 
 	ginkgo.By("Verifying logs")
-	gomega.Eventually(func() (string, error) {
-		return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, "portforwardtester")
+	gomega.Eventually(ctx, func() (string, error) {
+		return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "portforwardtester")
 	}, postStartWaitTimeout, podCheckInterval).Should(gomega.SatisfyAll(
 		gomega.ContainSubstring("Accepted client connection"),
 		gomega.ContainSubstring("Received expected client data"),
@@ -454,21 +454,21 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 	ginkgo.Describe("With a server listening on 0.0.0.0", func() {
 		ginkgo.Describe("that expects a client request", func() {
 			ginkgo.It("should support a client that connects, sends NO DATA, and disconnects", func(ctx context.Context) {
-				doTestMustConnectSendNothing("0.0.0.0", f)
+				doTestMustConnectSendNothing(ctx, "0.0.0.0", f)
 			})
 			ginkgo.It("should support a client that connects, sends DATA, and disconnects", func(ctx context.Context) {
-				doTestMustConnectSendDisconnect("0.0.0.0", f)
+				doTestMustConnectSendDisconnect(ctx, "0.0.0.0", f)
 			})
 		})
 
 		ginkgo.Describe("that expects NO client request", func() {
 			ginkgo.It("should support a client that connects, sends DATA, and disconnects", func(ctx context.Context) {
-				doTestConnectSendDisconnect("0.0.0.0", f)
+				doTestConnectSendDisconnect(ctx, "0.0.0.0", f)
 			})
 		})
 
 		ginkgo.It("should support forwarding over websockets", func(ctx context.Context) {
-			doTestOverWebSockets("0.0.0.0", f)
+			doTestOverWebSockets(ctx, "0.0.0.0", f)
 		})
 	})
 
@@ -476,21 +476,21 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 	ginkgo.Describe("With a server listening on localhost", func() {
 		ginkgo.Describe("that expects a client request", func() {
 			ginkgo.It("should support a client that connects, sends NO DATA, and disconnects", func(ctx context.Context) {
-				doTestMustConnectSendNothing("localhost", f)
+				doTestMustConnectSendNothing(ctx, "localhost", f)
 			})
 			ginkgo.It("should support a client that connects, sends DATA, and disconnects", func(ctx context.Context) {
-				doTestMustConnectSendDisconnect("localhost", f)
+				doTestMustConnectSendDisconnect(ctx, "localhost", f)
 			})
 		})
 
 		ginkgo.Describe("that expects NO client request", func() {
 			ginkgo.It("should support a client that connects, sends DATA, and disconnects", func(ctx context.Context) {
-				doTestConnectSendDisconnect("localhost", f)
+				doTestConnectSendDisconnect(ctx, "localhost", f)
 			})
 		})
 
 		ginkgo.It("should support forwarding over websockets", func(ctx context.Context) {
-			doTestOverWebSockets("localhost", f)
+			doTestOverWebSockets(ctx, "localhost", f)
 		})
 	})
 })

--- a/test/e2e/lifecycle/bootstrap/bootstrap_signer.go
+++ b/test/e2e/lifecycle/bootstrap/bootstrap_signer.go
@@ -43,10 +43,10 @@ var _ = lifecycle.SIGDescribe("[Feature:BootstrapTokens]", func() {
 
 	f := framework.NewDefaultFramework("bootstrap-signer")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	ginkgo.AfterEach(func() {
+	ginkgo.AfterEach(func(ctx context.Context) {
 		if len(secretNeedClean) > 0 {
 			ginkgo.By("delete the bootstrap token secret")
-			err := c.CoreV1().Secrets(metav1.NamespaceSystem).Delete(context.TODO(), secretNeedClean, metav1.DeleteOptions{})
+			err := c.CoreV1().Secrets(metav1.NamespaceSystem).Delete(ctx, secretNeedClean, metav1.DeleteOptions{})
 			framework.ExpectNoError(err)
 			secretNeedClean = ""
 		}
@@ -60,7 +60,7 @@ var _ = lifecycle.SIGDescribe("[Feature:BootstrapTokens]", func() {
 		tokenID, err := GenerateTokenID()
 		framework.ExpectNoError(err)
 		secret := newTokenSecret(tokenID, "tokenSecret")
-		_, err = c.CoreV1().Secrets(metav1.NamespaceSystem).Create(context.TODO(), secret, metav1.CreateOptions{})
+		_, err = c.CoreV1().Secrets(metav1.NamespaceSystem).Create(ctx, secret, metav1.CreateOptions{})
 		secretNeedClean = bootstrapapi.BootstrapTokenSecretPrefix + tokenID
 
 		framework.ExpectNoError(err)
@@ -75,7 +75,7 @@ var _ = lifecycle.SIGDescribe("[Feature:BootstrapTokens]", func() {
 		tokenID, err := GenerateTokenID()
 		framework.ExpectNoError(err)
 		secret := newTokenSecret(tokenID, "tokenSecret")
-		_, err = c.CoreV1().Secrets(metav1.NamespaceSystem).Create(context.TODO(), secret, metav1.CreateOptions{})
+		_, err = c.CoreV1().Secrets(metav1.NamespaceSystem).Create(ctx, secret, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		secretNeedClean = bootstrapapi.BootstrapTokenSecretPrefix + tokenID
 
@@ -83,7 +83,7 @@ var _ = lifecycle.SIGDescribe("[Feature:BootstrapTokens]", func() {
 		err = WaitforSignedClusterInfoByBootStrapToken(c, tokenID)
 		framework.ExpectNoError(err)
 
-		cfgMap, err := f.ClientSet.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(context.TODO(), bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
+		cfgMap, err := f.ClientSet.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(ctx, bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		signedToken, ok := cfgMap.Data[bootstrapapi.JWSSignatureKeyPrefix+tokenID]
 		if !ok {
@@ -95,14 +95,14 @@ var _ = lifecycle.SIGDescribe("[Feature:BootstrapTokens]", func() {
 		updatedKubeConfig, err := randBytes(20)
 		framework.ExpectNoError(err)
 		cfgMap.Data[bootstrapapi.KubeConfigKey] = updatedKubeConfig
-		_, err = f.ClientSet.CoreV1().ConfigMaps(metav1.NamespacePublic).Update(context.TODO(), cfgMap, metav1.UpdateOptions{})
+		_, err = f.ClientSet.CoreV1().ConfigMaps(metav1.NamespacePublic).Update(ctx, cfgMap, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 		defer func() {
 			ginkgo.By("update back the cluster-info ConfigMap")
-			cfgMap, err = f.ClientSet.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(context.TODO(), bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
+			cfgMap, err = f.ClientSet.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(ctx, bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 			cfgMap.Data[bootstrapapi.KubeConfigKey] = originalData
-			_, err = f.ClientSet.CoreV1().ConfigMaps(metav1.NamespacePublic).Update(context.TODO(), cfgMap, metav1.UpdateOptions{})
+			_, err = f.ClientSet.CoreV1().ConfigMaps(metav1.NamespacePublic).Update(ctx, cfgMap, metav1.UpdateOptions{})
 			framework.ExpectNoError(err)
 		}()
 
@@ -116,7 +116,7 @@ var _ = lifecycle.SIGDescribe("[Feature:BootstrapTokens]", func() {
 		tokenID, err := GenerateTokenID()
 		framework.ExpectNoError(err)
 		secret := newTokenSecret(tokenID, "tokenSecret")
-		_, err = c.CoreV1().Secrets(metav1.NamespaceSystem).Create(context.TODO(), secret, metav1.CreateOptions{})
+		_, err = c.CoreV1().Secrets(metav1.NamespaceSystem).Create(ctx, secret, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("wait for the bootstrap secret be signed")
@@ -124,7 +124,7 @@ var _ = lifecycle.SIGDescribe("[Feature:BootstrapTokens]", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("delete the bootstrap token secret")
-		err = c.CoreV1().Secrets(metav1.NamespaceSystem).Delete(context.TODO(), bootstrapapi.BootstrapTokenSecretPrefix+tokenID, metav1.DeleteOptions{})
+		err = c.CoreV1().Secrets(metav1.NamespaceSystem).Delete(ctx, bootstrapapi.BootstrapTokenSecretPrefix+tokenID, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("wait for the bootstrap token removed from cluster-info ConfigMap")

--- a/test/e2e/lifecycle/bootstrap/bootstrap_token_cleaner.go
+++ b/test/e2e/lifecycle/bootstrap/bootstrap_token_cleaner.go
@@ -42,10 +42,10 @@ var _ = lifecycle.SIGDescribe("[Feature:BootstrapTokens]", func() {
 		c = f.ClientSet
 	})
 
-	ginkgo.AfterEach(func() {
+	ginkgo.AfterEach(func(ctx context.Context) {
 		if len(secretNeedClean) > 0 {
 			ginkgo.By("delete the bootstrap token secret")
-			err := c.CoreV1().Secrets(metav1.NamespaceSystem).Delete(context.TODO(), secretNeedClean, metav1.DeleteOptions{})
+			err := c.CoreV1().Secrets(metav1.NamespaceSystem).Delete(ctx, secretNeedClean, metav1.DeleteOptions{})
 			secretNeedClean = ""
 			framework.ExpectNoError(err)
 		}
@@ -59,7 +59,7 @@ var _ = lifecycle.SIGDescribe("[Feature:BootstrapTokens]", func() {
 
 		secret := newTokenSecret(tokenID, tokenSecret)
 		addSecretExpiration(secret, TimeStringFromNow(-time.Hour))
-		_, err = c.CoreV1().Secrets(metav1.NamespaceSystem).Create(context.TODO(), secret, metav1.CreateOptions{})
+		_, err = c.CoreV1().Secrets(metav1.NamespaceSystem).Create(ctx, secret, metav1.CreateOptions{})
 
 		framework.ExpectNoError(err)
 
@@ -76,7 +76,7 @@ var _ = lifecycle.SIGDescribe("[Feature:BootstrapTokens]", func() {
 		framework.ExpectNoError(err)
 		secret := newTokenSecret(tokenID, tokenSecret)
 		addSecretExpiration(secret, TimeStringFromNow(time.Hour))
-		_, err = c.CoreV1().Secrets(metav1.NamespaceSystem).Create(context.TODO(), secret, metav1.CreateOptions{})
+		_, err = c.CoreV1().Secrets(metav1.NamespaceSystem).Create(ctx, secret, metav1.CreateOptions{})
 		secretNeedClean = bootstrapapi.BootstrapTokenSecretPrefix + tokenID
 		framework.ExpectNoError(err)
 

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -63,7 +63,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		// Run a pod which probes DNS and exposes the results by HTTP.
 		ginkgo.By("creating a pod to probe DNS")
 		pod := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
-		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
+		validateDNSResults(ctx, f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
 	// Added due to #8512. This is critical for GCE and GKE deployments.
@@ -85,7 +85,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		// Run a pod which probes DNS and exposes the results by HTTP.
 		ginkgo.By("creating a pod to probe DNS")
 		pod := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
-		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
+		validateDNSResults(ctx, f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
 	// [LinuxOnly]: As Windows currently does not support resolving PQDNs.
@@ -106,7 +106,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		// Run a pod which probes DNS and exposes the results by HTTP.
 		ginkgo.By("creating a pod to probe DNS")
 		pod := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
-		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
+		validateDNSResults(ctx, f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
 	/*
@@ -126,7 +126,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		// Run a pod which probes /etc/hosts and exposes the results by HTTP.
 		ginkgo.By("creating a pod to probe /etc/hosts")
 		pod := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
-		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
+		validateDNSResults(ctx, f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
 	/*
@@ -142,7 +142,7 @@ var _ = common.SIGDescribe("DNS", func() {
 			"dns-test": "true",
 		}
 		headlessService := e2eservice.CreateServiceSpec(dnsTestServiceName, "", true, testServiceSelector)
-		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), headlessService, metav1.CreateOptions{})
+		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, headlessService, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create headless service: %s", dnsTestServiceName)
 		ginkgo.DeferCleanup(func(ctx context.Context) error {
 			ginkgo.By("deleting the test headless service")
@@ -151,7 +151,7 @@ var _ = common.SIGDescribe("DNS", func() {
 
 		regularServiceName := "test-service-2"
 		regularService := e2eservice.CreateServiceSpec(regularServiceName, "", false, testServiceSelector)
-		regularService, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), regularService, metav1.CreateOptions{})
+		regularService, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, regularService, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create regular service: %s", regularServiceName)
 
 		ginkgo.DeferCleanup(func(ctx context.Context) error {
@@ -179,7 +179,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		pod := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
 		pod.ObjectMeta.Labels = testServiceSelector
 
-		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
+		validateDNSResults(ctx, f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
 	/*
@@ -195,7 +195,7 @@ var _ = common.SIGDescribe("DNS", func() {
 			"dns-test": "true",
 		}
 		headlessService := e2eservice.CreateServiceSpec(dnsTestServiceName, "", true, testServiceSelector)
-		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), headlessService, metav1.CreateOptions{})
+		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, headlessService, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create headless service: %s", dnsTestServiceName)
 		ginkgo.DeferCleanup(func(ctx context.Context) error {
 			ginkgo.By("deleting the test headless service")
@@ -204,7 +204,7 @@ var _ = common.SIGDescribe("DNS", func() {
 
 		regularServiceName := "test-service-2"
 		regularService := e2eservice.CreateServiceSpec(regularServiceName, "", false, testServiceSelector)
-		regularService, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), regularService, metav1.CreateOptions{})
+		regularService, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, regularService, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create regular service: %s", regularServiceName)
 		ginkgo.DeferCleanup(func(ctx context.Context) error {
 			ginkgo.By("deleting the test service")
@@ -232,7 +232,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		pod := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
 		pod.ObjectMeta.Labels = testServiceSelector
 
-		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
+		validateDNSResults(ctx, f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
 	/*
@@ -250,7 +250,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		serviceName := "dns-test-service-2"
 		podHostname := "dns-querier-2"
 		headlessService := e2eservice.CreateServiceSpec(serviceName, "", true, testServiceSelector)
-		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), headlessService, metav1.CreateOptions{})
+		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, headlessService, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create headless service: %s", serviceName)
 
 		ginkgo.DeferCleanup(func(ctx context.Context) error {
@@ -274,7 +274,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		pod1.Spec.Hostname = podHostname
 		pod1.Spec.Subdomain = serviceName
 
-		validateDNSResults(f, pod1, append(wheezyFileNames, jessieFileNames...))
+		validateDNSResults(ctx, f, pod1, append(wheezyFileNames, jessieFileNames...))
 	})
 
 	/*
@@ -292,7 +292,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		serviceName := "dns-test-service-2"
 		podHostname := "dns-querier-2"
 		headlessService := e2eservice.CreateServiceSpec(serviceName, "", true, testServiceSelector)
-		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), headlessService, metav1.CreateOptions{})
+		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, headlessService, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create headless service: %s", serviceName)
 
 		ginkgo.DeferCleanup(func(ctx context.Context) error {
@@ -317,7 +317,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		pod1.Spec.Hostname = podHostname
 		pod1.Spec.Subdomain = serviceName
 
-		validateDNSResults(f, pod1, append(wheezyFileNames, jessieFileNames...))
+		validateDNSResults(ctx, f, pod1, append(wheezyFileNames, jessieFileNames...))
 	})
 
 	/*
@@ -331,7 +331,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		ginkgo.By("Creating a test externalName service")
 		serviceName := "dns-test-service-3"
 		externalNameService := e2eservice.CreateServiceSpec(serviceName, "foo.example.com", false, nil)
-		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), externalNameService, metav1.CreateOptions{})
+		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, externalNameService, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create ExternalName service: %s", serviceName)
 
 		ginkgo.DeferCleanup(func(ctx context.Context) error {
@@ -349,11 +349,11 @@ var _ = common.SIGDescribe("DNS", func() {
 		ginkgo.By("creating a pod to probe DNS")
 		pod1 := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
 
-		validateTargetedProbeOutput(f, pod1, []string{wheezyFileName, jessieFileName}, "foo.example.com.")
+		validateTargetedProbeOutput(ctx, f, pod1, []string{wheezyFileName, jessieFileName}, "foo.example.com.")
 
 		// Test changing the externalName field
 		ginkgo.By("changing the externalName to bar.example.com")
-		_, err = e2eservice.UpdateService(f.ClientSet, f.Namespace.Name, serviceName, func(s *v1.Service) {
+		_, err = e2eservice.UpdateService(ctx, f.ClientSet, f.Namespace.Name, serviceName, func(s *v1.Service) {
 			s.Spec.ExternalName = "bar.example.com"
 		})
 		framework.ExpectNoError(err, "failed to change externalName of service: %s", serviceName)
@@ -366,11 +366,11 @@ var _ = common.SIGDescribe("DNS", func() {
 		ginkgo.By("creating a second pod to probe DNS")
 		pod2 := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
 
-		validateTargetedProbeOutput(f, pod2, []string{wheezyFileName, jessieFileName}, "bar.example.com.")
+		validateTargetedProbeOutput(ctx, f, pod2, []string{wheezyFileName, jessieFileName}, "bar.example.com.")
 
 		// Test changing type from ExternalName to ClusterIP
 		ginkgo.By("changing the service to type=ClusterIP")
-		_, err = e2eservice.UpdateService(f.ClientSet, f.Namespace.Name, serviceName, func(s *v1.Service) {
+		_, err = e2eservice.UpdateService(ctx, f.ClientSet, f.Namespace.Name, serviceName, func(s *v1.Service) {
 			s.Spec.Type = v1.ServiceTypeClusterIP
 			s.Spec.Ports = []v1.ServicePort{
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP},
@@ -392,10 +392,10 @@ var _ = common.SIGDescribe("DNS", func() {
 		ginkgo.By("creating a third pod to probe DNS")
 		pod3 := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
 
-		svc, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Get(context.TODO(), externalNameService.Name, metav1.GetOptions{})
+		svc, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Get(ctx, externalNameService.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get service: %s", externalNameService.Name)
 
-		validateTargetedProbeOutput(f, pod3, []string{wheezyFileName, jessieFileName}, svc.Spec.ClusterIP)
+		validateTargetedProbeOutput(ctx, f, pod3, []string{wheezyFileName, jessieFileName}, svc.Spec.ClusterIP)
 	})
 
 	/*
@@ -414,14 +414,14 @@ var _ = common.SIGDescribe("DNS", func() {
 			Nameservers: []string{testServerIP},
 			Searches:    []string{testSearchPath},
 		}
-		testAgnhostPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), testAgnhostPod, metav1.CreateOptions{})
+		testAgnhostPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, testAgnhostPod, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create pod: %s", testAgnhostPod.Name)
 		framework.Logf("Created pod %v", testAgnhostPod)
 		ginkgo.DeferCleanup(func(ctx context.Context) error {
 			framework.Logf("Deleting pod %s...", testAgnhostPod.Name)
-			return f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), testAgnhostPod.Name, *metav1.NewDeleteOptions(0))
+			return f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, testAgnhostPod.Name, *metav1.NewDeleteOptions(0))
 		})
-		err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, testAgnhostPod.Name, f.Namespace.Name, framework.PodStartTimeout)
+		err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, testAgnhostPod.Name, f.Namespace.Name, framework.PodStartTimeout)
 		framework.ExpectNoError(err, "failed to wait for pod %s to be running", testAgnhostPod.Name)
 
 		runCommand := func(arg string) string {
@@ -461,7 +461,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		corednsConfig := generateCoreDNSConfigmap(f.Namespace.Name, map[string]string{
 			testDNSNameFull: testInjectedIP,
 		})
-		corednsConfig, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), corednsConfig, metav1.CreateOptions{})
+		corednsConfig, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, corednsConfig, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "unable to create test configMap %s", corednsConfig.Name)
 
 		ginkgo.DeferCleanup(func(ctx context.Context) error {
@@ -470,18 +470,18 @@ var _ = common.SIGDescribe("DNS", func() {
 		})
 
 		testServerPod := generateCoreDNSServerPod(corednsConfig)
-		testServerPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), testServerPod, metav1.CreateOptions{})
+		testServerPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, testServerPod, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create pod: %s", testServerPod.Name)
 		framework.Logf("Created pod %v", testServerPod)
 		ginkgo.DeferCleanup(func(ctx context.Context) error {
 			framework.Logf("Deleting pod %s...", testServerPod.Name)
-			return f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), testServerPod.Name, *metav1.NewDeleteOptions(0))
+			return f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, testServerPod.Name, *metav1.NewDeleteOptions(0))
 		})
-		err = e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, testServerPod.Name, f.Namespace.Name)
+		err = e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, testServerPod.Name, f.Namespace.Name)
 		framework.ExpectNoError(err, "failed to wait for pod %s to be running", testServerPod.Name)
 
 		// Retrieve server pod IP.
-		testServerPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), testServerPod.Name, metav1.GetOptions{})
+		testServerPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, testServerPod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get pod %v", testServerPod.Name)
 		testServerIP := testServerPod.Status.PodIP
 		framework.Logf("testServerIP is %s", testServerIP)
@@ -500,14 +500,14 @@ var _ = common.SIGDescribe("DNS", func() {
 				},
 			},
 		}
-		testUtilsPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), testUtilsPod, metav1.CreateOptions{})
+		testUtilsPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, testUtilsPod, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create pod: %s", testUtilsPod.Name)
 		framework.Logf("Created pod %v", testUtilsPod)
 		ginkgo.DeferCleanup(func(ctx context.Context) error {
 			framework.Logf("Deleting pod %s...", testUtilsPod.Name)
-			return f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), testUtilsPod.Name, *metav1.NewDeleteOptions(0))
+			return f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, testUtilsPod.Name, *metav1.NewDeleteOptions(0))
 		})
-		err = e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, testUtilsPod.Name, f.Namespace.Name)
+		err = e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, testUtilsPod.Name, f.Namespace.Name)
 		framework.ExpectNoError(err, "failed to wait for pod %s to be running", testUtilsPod.Name)
 
 		ginkgo.By("Verifying customized DNS option is configured on pod...")
@@ -560,7 +560,7 @@ var _ = common.SIGDescribe("DNS", func() {
 
 	ginkgo.It("should work with the pod containing more than 6 DNS search paths and longer than 256 search list characters", func(ctx context.Context) {
 		ginkgo.By("Getting the kube-dns IP")
-		svc, err := f.ClientSet.CoreV1().Services("kube-system").Get(context.TODO(), "kube-dns", metav1.GetOptions{})
+		svc, err := f.ClientSet.CoreV1().Services("kube-system").Get(ctx, "kube-dns", metav1.GetOptions{})
 		framework.ExpectNoError(err, "Failed to get kube-dns service")
 		kubednsIP := svc.Spec.ClusterIP
 
@@ -599,7 +599,7 @@ var _ = common.SIGDescribe("DNS", func() {
 				},
 			},
 		}
-		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
+		validateDNSResults(ctx, f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
 })
@@ -615,12 +615,12 @@ var _ = common.SIGDescribe("DNS HostNetwork", func() {
 			"dns-test": "true",
 		}
 		headlessService := e2eservice.CreateServiceSpec(dnsTestServiceName, "", true, testServiceSelector)
-		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), headlessService, metav1.CreateOptions{})
+		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, headlessService, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create headless service: %s", dnsTestServiceName)
 
 		regularServiceName := "test-service-2"
 		regularService := e2eservice.CreateServiceSpec(regularServiceName, "", false, testServiceSelector)
-		regularService, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), regularService, metav1.CreateOptions{})
+		regularService, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, regularService, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create regular service: %s", regularServiceName)
 
 		// All the names we need to be able to resolve.
@@ -645,7 +645,7 @@ var _ = common.SIGDescribe("DNS HostNetwork", func() {
 		pod.ObjectMeta.Labels = testServiceSelector
 		pod.Spec.HostNetwork = true
 		pod.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
-		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
+		validateDNSResults(ctx, f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
 })

--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -41,22 +41,22 @@ type dnsNameserverTest struct {
 	dnsTestCommon
 }
 
-func (t *dnsNameserverTest) run(isIPv6 bool) {
-	t.init()
+func (t *dnsNameserverTest) run(ctx context.Context, isIPv6 bool) {
+	t.init(ctx)
 
-	t.createUtilPodLabel("e2e-dns-configmap")
+	t.createUtilPodLabel(ctx, "e2e-dns-configmap")
 	ginkgo.DeferCleanup(t.deleteUtilPod)
-	originalConfigMapData := t.fetchDNSConfigMapData()
+	originalConfigMapData := t.fetchDNSConfigMapData(ctx)
 	ginkgo.DeferCleanup(t.restoreDNSConfigMap, originalConfigMapData)
 
 	if isIPv6 {
-		t.createDNSServer(t.f.Namespace.Name, map[string]string{
+		t.createDNSServer(ctx, t.f.Namespace.Name, map[string]string{
 			"abc.acme.local": "2606:4700:4700::1111",
 			"def.acme.local": "2606:4700:4700::2222",
 			"widget.local":   "2606:4700:4700::3333",
 		})
 	} else {
-		t.createDNSServer(t.f.Namespace.Name, map[string]string{
+		t.createDNSServer(ctx, t.f.Namespace.Name, map[string]string{
 			"abc.acme.local": "1.1.1.1",
 			"def.acme.local": "2.2.2.2",
 			"widget.local":   "3.3.3.3",
@@ -65,7 +65,7 @@ func (t *dnsNameserverTest) run(isIPv6 bool) {
 	ginkgo.DeferCleanup(t.deleteDNSServerPod)
 
 	if t.name == "coredns" {
-		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
+		t.setConfigMap(ctx, &v1.ConfigMap{Data: map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
         health
         ready
@@ -81,9 +81,9 @@ func (t *dnsNameserverTest) run(isIPv6 bool) {
     }`, framework.TestContext.ClusterDNSDomain, t.dnsServerPod.Status.PodIP, t.dnsServerPod.Status.PodIP),
 		}})
 
-		t.deleteCoreDNSPods()
+		t.deleteCoreDNSPods(ctx)
 	} else {
-		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
+		t.setConfigMap(ctx, &v1.ConfigMap{Data: map[string]string{
 			"stubDomains":         fmt.Sprintf(`{"acme.local":["%v"]}`, t.dnsServerPod.Status.PodIP),
 			"upstreamNameservers": fmt.Sprintf(`["%v"]`, t.dnsServerPod.Status.PodIP),
 		}})
@@ -123,7 +123,7 @@ func (t *dnsNameserverTest) run(isIPv6 bool) {
 			moreForeverTestTimeout)
 	}
 
-	t.restoreDNSConfigMap(originalConfigMapData)
+	t.restoreDNSConfigMap(ctx, originalConfigMapData)
 	// Wait for the deleted ConfigMap to take effect, otherwise the
 	// configuration can bleed into other tests.
 	t.checkDNSRecordFrom(
@@ -137,15 +137,15 @@ type dnsPtrFwdTest struct {
 	dnsTestCommon
 }
 
-func (t *dnsPtrFwdTest) run(isIPv6 bool) {
-	t.init()
+func (t *dnsPtrFwdTest) run(ctx context.Context, isIPv6 bool) {
+	t.init(ctx)
 
-	t.createUtilPodLabel("e2e-dns-configmap")
+	t.createUtilPodLabel(ctx, "e2e-dns-configmap")
 	ginkgo.DeferCleanup(t.deleteUtilPod)
-	originalConfigMapData := t.fetchDNSConfigMapData()
+	originalConfigMapData := t.fetchDNSConfigMapData(ctx)
 	ginkgo.DeferCleanup(t.restoreDNSConfigMap, originalConfigMapData)
 
-	t.createDNSServerWithPtrRecord(t.f.Namespace.Name, isIPv6)
+	t.createDNSServerWithPtrRecord(ctx, t.f.Namespace.Name, isIPv6)
 	ginkgo.DeferCleanup(t.deleteDNSServerPod)
 
 	// Should still be able to lookup public nameserver without explicit upstream nameserver set.
@@ -164,7 +164,7 @@ func (t *dnsPtrFwdTest) run(isIPv6 bool) {
 	}
 
 	if t.name == "coredns" {
-		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
+		t.setConfigMap(ctx, &v1.ConfigMap{Data: map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
         health
         ready
@@ -177,9 +177,9 @@ func (t *dnsPtrFwdTest) run(isIPv6 bool) {
     }`, framework.TestContext.ClusterDNSDomain, t.dnsServerPod.Status.PodIP),
 		}})
 
-		t.deleteCoreDNSPods()
+		t.deleteCoreDNSPods(ctx)
 	} else {
-		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
+		t.setConfigMap(ctx, &v1.ConfigMap{Data: map[string]string{
 			"upstreamNameservers": fmt.Sprintf(`["%v"]`, t.dnsServerPod.Status.PodIP),
 		}})
 	}
@@ -191,7 +191,7 @@ func (t *dnsPtrFwdTest) run(isIPv6 bool) {
 			"ptr-record",
 			moreForeverTestTimeout)
 
-		t.restoreDNSConfigMap(originalConfigMapData)
+		t.restoreDNSConfigMap(ctx, originalConfigMapData)
 		t.checkDNSRecordFrom(
 			"2001:db8::29",
 			func(actual []string) bool { return len(actual) == 0 },
@@ -205,7 +205,7 @@ func (t *dnsPtrFwdTest) run(isIPv6 bool) {
 			"ptr-record",
 			moreForeverTestTimeout)
 
-		t.restoreDNSConfigMap(originalConfigMapData)
+		t.restoreDNSConfigMap(ctx, originalConfigMapData)
 		t.checkDNSRecordFrom(
 			"192.0.2.123",
 			func(actual []string) bool { return len(actual) == 0 },
@@ -218,21 +218,21 @@ type dnsExternalNameTest struct {
 	dnsTestCommon
 }
 
-func (t *dnsExternalNameTest) run(isIPv6 bool) {
-	t.init()
+func (t *dnsExternalNameTest) run(ctx context.Context, isIPv6 bool) {
+	t.init(ctx)
 
-	t.createUtilPodLabel("e2e-dns-configmap")
+	t.createUtilPodLabel(ctx, "e2e-dns-configmap")
 	ginkgo.DeferCleanup(t.deleteUtilPod)
-	originalConfigMapData := t.fetchDNSConfigMapData()
+	originalConfigMapData := t.fetchDNSConfigMapData(ctx)
 	ginkgo.DeferCleanup(t.restoreDNSConfigMap, originalConfigMapData)
 
 	fooHostname := "foo.example.com"
 	if isIPv6 {
-		t.createDNSServer(t.f.Namespace.Name, map[string]string{
+		t.createDNSServer(ctx, t.f.Namespace.Name, map[string]string{
 			fooHostname: "2001:db8::29",
 		})
 	} else {
-		t.createDNSServer(t.f.Namespace.Name, map[string]string{
+		t.createDNSServer(ctx, t.f.Namespace.Name, map[string]string{
 			fooHostname: "192.0.2.123",
 		})
 	}
@@ -241,13 +241,13 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
 	f := t.f
 	serviceName := "dns-externalname-upstream-test"
 	externalNameService := e2eservice.CreateServiceSpec(serviceName, googleDNSHostname, false, nil)
-	if _, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), externalNameService, metav1.CreateOptions{}); err != nil {
+	if _, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, externalNameService, metav1.CreateOptions{}); err != nil {
 		ginkgo.Fail(fmt.Sprintf("ginkgo.Failed when creating service: %v", err))
 	}
 	ginkgo.DeferCleanup(f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete, externalNameService.Name, metav1.DeleteOptions{})
 	serviceNameLocal := "dns-externalname-upstream-local"
 	externalNameServiceLocal := e2eservice.CreateServiceSpec(serviceNameLocal, fooHostname, false, nil)
-	if _, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), externalNameServiceLocal, metav1.CreateOptions{}); err != nil {
+	if _, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, externalNameServiceLocal, metav1.CreateOptions{}); err != nil {
 		ginkgo.Fail(fmt.Sprintf("ginkgo.Failed when creating service: %v", err))
 	}
 	ginkgo.DeferCleanup(f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete, externalNameServiceLocal.Name, metav1.DeleteOptions{})
@@ -271,7 +271,7 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
 	}
 
 	if t.name == "coredns" {
-		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
+		t.setConfigMap(ctx, &v1.ConfigMap{Data: map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
         health
         ready
@@ -284,9 +284,9 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
     }`, framework.TestContext.ClusterDNSDomain, t.dnsServerPod.Status.PodIP),
 		}})
 
-		t.deleteCoreDNSPods()
+		t.deleteCoreDNSPods(ctx)
 	} else {
-		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
+		t.setConfigMap(ctx, &v1.ConfigMap{Data: map[string]string{
 			"upstreamNameservers": fmt.Sprintf(`["%v"]`, t.dnsServerPod.Status.PodIP),
 		}})
 	}
@@ -308,7 +308,7 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
 			moreForeverTestTimeout)
 	}
 
-	t.restoreDNSConfigMap(originalConfigMapData)
+	t.restoreDNSConfigMap(ctx, originalConfigMapData)
 }
 
 var _ = common.SIGDescribe("DNS configMap nameserver", func() {
@@ -318,7 +318,7 @@ var _ = common.SIGDescribe("DNS configMap nameserver", func() {
 
 		ginkgo.It("should be able to change stubDomain configuration [Slow][Serial]", func(ctx context.Context) {
 			nsTest.c = nsTest.f.ClientSet
-			nsTest.run(framework.TestContext.ClusterIsIPv6())
+			nsTest.run(ctx, framework.TestContext.ClusterIsIPv6())
 		})
 	})
 
@@ -327,7 +327,7 @@ var _ = common.SIGDescribe("DNS configMap nameserver", func() {
 
 		ginkgo.It("should forward PTR records lookup to upstream nameserver [Slow][Serial]", func(ctx context.Context) {
 			fwdTest.c = fwdTest.f.ClientSet
-			fwdTest.run(framework.TestContext.ClusterIsIPv6())
+			fwdTest.run(ctx, framework.TestContext.ClusterIsIPv6())
 		})
 	})
 
@@ -336,7 +336,7 @@ var _ = common.SIGDescribe("DNS configMap nameserver", func() {
 
 		ginkgo.It("should forward externalname lookup to upstream nameserver [Slow][Serial]", func(ctx context.Context) {
 			externalNameTest.c = externalNameTest.f.ClientSet
-			externalNameTest.run(framework.TestContext.ClusterIsIPv6())
+			externalNameTest.run(ctx, framework.TestContext.ClusterIsIPv6())
 		})
 	})
 })

--- a/test/e2e/network/funny_ips.go
+++ b/test/e2e/network/funny_ips.go
@@ -96,13 +96,13 @@ var _ = common.SIGDescribe("CVE-2021-29923", func() {
 		servicePort := 7180
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 
-		clusterIPZero, clusterIPOctal := getServiceIPWithLeadingZeros(cs)
+		clusterIPZero, clusterIPOctal := getServiceIPWithLeadingZeros(ctx, cs)
 		if clusterIPZero == "" {
 			e2eskipper.Skipf("Couldn't find a free ClusterIP")
 		}
 
 		ginkgo.By("creating service " + serviceName + " with type=ClusterIP and ip " + clusterIPZero + " in namespace " + ns)
-		_, err := jig.CreateTCPService(func(svc *v1.Service) {
+		_, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.ClusterIP = clusterIPZero // IP with a leading zero
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.Ports = []v1.ServicePort{
@@ -111,10 +111,10 @@ var _ = common.SIGDescribe("CVE-2021-29923", func() {
 		})
 		framework.ExpectNoError(err)
 
-		err = jig.CreateServicePods(1)
+		err = jig.CreateServicePods(ctx, 1)
 		framework.ExpectNoError(err)
 
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
 		ip := netutils.ParseIPSloppy(clusterIPZero)
 		cmd := fmt.Sprintf("echo hostName | nc -v -t -w 2 %s %v", ip.String(), servicePort)
 		err = wait.PollImmediate(1*time.Second, e2eservice.ServiceReachabilityShortPollTimeout, func() (bool, error) {
@@ -160,11 +160,11 @@ var _ = common.SIGDescribe("CVE-2021-29923", func() {
 // Try to get a free IP that has different decimal and binary interpretation with leading zeros.
 // Return both IPs, the one interpretad as binary and the one interpreted as decimal.
 // Return empty if not IPs are found.
-func getServiceIPWithLeadingZeros(cs clientset.Interface) (string, string) {
+func getServiceIPWithLeadingZeros(ctx context.Context, cs clientset.Interface) (string, string) {
 	clusterIPMap := map[string]struct{}{}
 	var clusterIPPrefix string
 	// Dump all the IPs and look for the ones we want.
-	list, err := cs.CoreV1().Services(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	list, err := cs.CoreV1().Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	framework.ExpectNoError(err)
 	for _, svc := range list.Items {
 		if len(svc.Spec.ClusterIP) == 0 || svc.Spec.ClusterIP == v1.ClusterIPNone {

--- a/test/e2e/network/ingress_scale.go
+++ b/test/e2e/network/ingress_scale.go
@@ -45,23 +45,23 @@ var _ = common.SIGDescribe("Loadbalancing: L7 Scalability", func() {
 			scaleFramework *scale.IngressScaleFramework
 		)
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			e2eskipper.SkipUnlessProviderIs("gce", "gke")
 
 			scaleFramework = scale.NewIngressScaleFramework(f.ClientSet, ns, framework.TestContext.CloudConfig)
-			if err := scaleFramework.PrepareScaleTest(); err != nil {
+			if err := scaleFramework.PrepareScaleTest(ctx); err != nil {
 				framework.Failf("Unexpected error while preparing ingress scale test: %v", err)
 			}
 		})
 
-		ginkgo.AfterEach(func() {
-			if errs := scaleFramework.CleanupScaleTest(); len(errs) != 0 {
+		ginkgo.AfterEach(func(ctx context.Context) {
+			if errs := scaleFramework.CleanupScaleTest(ctx); len(errs) != 0 {
 				framework.Failf("Unexpected error while cleaning up ingress scale test: %v", errs)
 			}
 		})
 
 		ginkgo.It("Creating and updating ingresses should happen promptly with small/medium/large amount of ingresses", func(ctx context.Context) {
-			if errs := scaleFramework.RunScaleTest(); len(errs) != 0 {
+			if errs := scaleFramework.RunScaleTest(ctx); len(errs) != 0 {
 				framework.Failf("Unexpected error while running ingress scale test: %v", errs)
 			}
 

--- a/test/e2e/network/ingressclass.go
+++ b/test/e2e/network/ingressclass.go
@@ -46,19 +46,19 @@ var _ = common.SIGDescribe("IngressClass [Feature:Ingress]", func() {
 	})
 
 	ginkgo.It("should set default value on new IngressClass [Serial]", func(ctx context.Context) {
-		ingressClass1, err := createIngressClass(cs, "ingressclass1", true, f.UniqueName)
+		ingressClass1, err := createIngressClass(ctx, cs, "ingressclass1", true, f.UniqueName)
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(deleteIngressClass, cs, ingressClass1.Name)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		lastFailure := ""
 
 		// the admission controller may take a few seconds to observe the ingress classes
-		if err := wait.Poll(time.Second, time.Minute, func() (bool, error) {
+		if err := wait.PollWithContext(ctx, time.Second, time.Minute, func(ctx context.Context) (bool, error) {
 			lastFailure = ""
 
-			ingress, err := createBasicIngress(cs, f.Namespace.Name)
+			ingress, err := createBasicIngress(ctx, cs, f.Namespace.Name)
 			if err != nil {
 				lastFailure = err.Error()
 				return false, err
@@ -83,19 +83,19 @@ var _ = common.SIGDescribe("IngressClass [Feature:Ingress]", func() {
 	})
 
 	ginkgo.It("should not set default value if no default IngressClass [Serial]", func(ctx context.Context) {
-		ingressClass1, err := createIngressClass(cs, "ingressclass1", false, f.UniqueName)
+		ingressClass1, err := createIngressClass(ctx, cs, "ingressclass1", false, f.UniqueName)
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(deleteIngressClass, cs, ingressClass1.Name)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		lastFailure := ""
 
 		// the admission controller may take a few seconds to observe the ingress classes
-		if err := wait.Poll(time.Second, time.Minute, func() (bool, error) {
+		if err := wait.PollWithContext(ctx, time.Second, time.Minute, func(ctx context.Context) (bool, error) {
 			lastFailure = ""
 
-			ingress, err := createBasicIngress(cs, f.Namespace.Name)
+			ingress, err := createBasicIngress(ctx, cs, f.Namespace.Name)
 			if err != nil {
 				lastFailure = err.Error()
 				return false, err
@@ -117,11 +117,11 @@ var _ = common.SIGDescribe("IngressClass [Feature:Ingress]", func() {
 	})
 
 	ginkgo.It("should choose the one with the later CreationTimestamp, if equal the one with the lower name when two ingressClasses are marked as default[Serial]", func(ctx context.Context) {
-		ingressClass1, err := createIngressClass(cs, "ingressclass1", true, f.UniqueName)
+		ingressClass1, err := createIngressClass(ctx, cs, "ingressclass1", true, f.UniqueName)
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(deleteIngressClass, cs, ingressClass1.Name)
 
-		ingressClass2, err := createIngressClass(cs, "ingressclass2", true, f.UniqueName)
+		ingressClass2, err := createIngressClass(ctx, cs, "ingressclass2", true, f.UniqueName)
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(deleteIngressClass, cs, ingressClass2.Name)
 
@@ -130,7 +130,7 @@ var _ = common.SIGDescribe("IngressClass [Feature:Ingress]", func() {
 			expectedName = ingressClass2.Name
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
 		// the admission controller may take a few seconds to observe both ingress classes
@@ -148,7 +148,7 @@ var _ = common.SIGDescribe("IngressClass [Feature:Ingress]", func() {
 			if cntDefault < 2 {
 				return false, nil
 			}
-			ingress, err := createBasicIngress(cs, f.Namespace.Name)
+			ingress, err := createBasicIngress(ctx, cs, f.Namespace.Name)
 			if err != nil {
 				return false, nil
 			}
@@ -184,7 +184,7 @@ var _ = common.SIGDescribe("IngressClass [Feature:Ingress]", func() {
 				},
 			},
 		}
-		createdIngressClass, err := cs.NetworkingV1().IngressClasses().Create(context.TODO(), ingressClass, metav1.CreateOptions{})
+		createdIngressClass, err := cs.NetworkingV1().IngressClasses().Create(ctx, ingressClass, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(deleteIngressClass, cs, createdIngressClass.Name)
 
@@ -203,7 +203,7 @@ var _ = common.SIGDescribe("IngressClass [Feature:Ingress]", func() {
 
 })
 
-func createIngressClass(cs clientset.Interface, name string, isDefault bool, uniqueName string) (*networkingv1.IngressClass, error) {
+func createIngressClass(ctx context.Context, cs clientset.Interface, name string, isDefault bool, uniqueName string) (*networkingv1.IngressClass, error) {
 	ingressClass := &networkingv1.IngressClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -221,11 +221,11 @@ func createIngressClass(cs clientset.Interface, name string, isDefault bool, uni
 		ingressClass.Annotations = map[string]string{networkingv1.AnnotationIsDefaultIngressClass: "true"}
 	}
 
-	return cs.NetworkingV1().IngressClasses().Create(context.TODO(), ingressClass, metav1.CreateOptions{})
+	return cs.NetworkingV1().IngressClasses().Create(ctx, ingressClass, metav1.CreateOptions{})
 }
 
-func createBasicIngress(cs clientset.Interface, namespace string) (*networkingv1.Ingress, error) {
-	return cs.NetworkingV1().Ingresses(namespace).Create(context.TODO(), &networkingv1.Ingress{
+func createBasicIngress(ctx context.Context, cs clientset.Interface, namespace string) (*networkingv1.Ingress, error) {
+	return cs.NetworkingV1().Ingresses(namespace).Create(ctx, &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ingress1",
 		},
@@ -242,8 +242,8 @@ func createBasicIngress(cs clientset.Interface, namespace string) (*networkingv1
 	}, metav1.CreateOptions{})
 }
 
-func deleteIngressClass(cs clientset.Interface, name string) {
-	err := cs.NetworkingV1().IngressClasses().Delete(context.TODO(), name, metav1.DeleteOptions{})
+func deleteIngressClass(ctx context.Context, cs clientset.Interface, name string) {
+	err := cs.NetworkingV1().IngressClasses().Delete(ctx, name, metav1.DeleteOptions{})
 	framework.ExpectNoError(err)
 }
 
@@ -292,7 +292,7 @@ var _ = common.SIGDescribe("IngressClass API", func() {
 		ginkgo.By("getting /apis/networking.k8s.io")
 		{
 			group := &metav1.APIGroup{}
-			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/networking.k8s.io").Do(context.TODO()).Into(group)
+			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/networking.k8s.io").Do(ctx).Into(group)
 			framework.ExpectNoError(err)
 			found := false
 			for _, version := range group.Versions {
@@ -324,38 +324,38 @@ var _ = common.SIGDescribe("IngressClass API", func() {
 
 		// IngressClass resource create/read/update/watch verbs
 		ginkgo.By("creating")
-		ingressClass1, err := createIngressClass(cs, "ingressclass1", false, f.UniqueName)
+		ingressClass1, err := createIngressClass(ctx, cs, "ingressclass1", false, f.UniqueName)
 		framework.ExpectNoError(err)
-		_, err = createIngressClass(cs, "ingressclass2", false, f.UniqueName)
+		_, err = createIngressClass(ctx, cs, "ingressclass2", false, f.UniqueName)
 		framework.ExpectNoError(err)
-		_, err = createIngressClass(cs, "ingressclass3", false, f.UniqueName)
+		_, err = createIngressClass(ctx, cs, "ingressclass3", false, f.UniqueName)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("getting")
-		gottenIC, err := icClient.Get(context.TODO(), ingressClass1.Name, metav1.GetOptions{})
+		gottenIC, err := icClient.Get(ctx, ingressClass1.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(gottenIC.UID, ingressClass1.UID)
 		framework.ExpectEqual(gottenIC.UID, ingressClass1.UID)
 
 		ginkgo.By("listing")
-		ics, err := icClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=generic"})
+		ics, err := icClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=generic"})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(ics.Items), 3, "filtered list should have 3 items")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
-		icWatch, err := icClient.Watch(context.TODO(), metav1.ListOptions{ResourceVersion: ics.ResourceVersion, LabelSelector: "ingressclass=" + f.UniqueName})
+		icWatch, err := icClient.Watch(ctx, metav1.ListOptions{ResourceVersion: ics.ResourceVersion, LabelSelector: "ingressclass=" + f.UniqueName})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("patching")
-		patchedIC, err := icClient.Patch(context.TODO(), ingressClass1.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
+		patchedIC, err := icClient.Patch(ctx, ingressClass1.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(patchedIC.Annotations["patched"], "true", "patched object should have the applied annotation")
 
 		ginkgo.By("updating")
 		icToUpdate := patchedIC.DeepCopy()
 		icToUpdate.Annotations["updated"] = "true"
-		updatedIC, err := icClient.Update(context.TODO(), icToUpdate, metav1.UpdateOptions{})
+		updatedIC, err := icClient.Update(ctx, icToUpdate, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(updatedIC.Annotations["updated"], "true", "updated object should have the applied annotation")
 
@@ -385,20 +385,20 @@ var _ = common.SIGDescribe("IngressClass API", func() {
 
 		// IngressClass resource delete operations
 		ginkgo.By("deleting")
-		err = icClient.Delete(context.TODO(), ingressClass1.Name, metav1.DeleteOptions{})
+		err = icClient.Delete(ctx, ingressClass1.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
-		_, err = icClient.Get(context.TODO(), ingressClass1.Name, metav1.GetOptions{})
+		_, err = icClient.Get(ctx, ingressClass1.Name, metav1.GetOptions{})
 		if !apierrors.IsNotFound(err) {
 			framework.Failf("expected 404, got %#v", err)
 		}
-		ics, err = icClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "ingressclass=" + f.UniqueName})
+		ics, err = icClient.List(ctx, metav1.ListOptions{LabelSelector: "ingressclass=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(ics.Items), 2, "filtered list should have 2 items")
 
 		ginkgo.By("deleting a collection")
-		err = icClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "ingressclass=" + f.UniqueName})
+		err = icClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "ingressclass=" + f.UniqueName})
 		framework.ExpectNoError(err)
-		ics, err = icClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "ingressclass=" + f.UniqueName})
+		ics, err = icClient.List(ctx, metav1.ListOptions{LabelSelector: "ingressclass=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(ics.Items), 0, "filtered list should have 0 items")
 	})

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -54,7 +54,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 	fr.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.It("should set TCP CLOSE_WAIT timeout [Privileged]", func(ctx context.Context) {
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(fr.ClientSet, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, fr.ClientSet, 2)
 		framework.ExpectNoError(err)
 		if len(nodes.Items) < 2 {
 			e2eskipper.Skipf(
@@ -118,7 +118,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 				},
 			},
 		}
-		e2epod.NewPodClient(fr).CreateSync(hostExecPod)
+		e2epod.NewPodClient(fr).CreateSync(ctx, hostExecPod)
 
 		// Create the client and server pods
 		clientPodSpec := &v1.Pod{
@@ -186,10 +186,10 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 			serverNodeInfo.name,
 			serverNodeInfo.nodeIP,
 			kubeProxyE2eImage))
-		e2epod.NewPodClient(fr).CreateSync(serverPodSpec)
+		e2epod.NewPodClient(fr).CreateSync(ctx, serverPodSpec)
 
 		// The server should be listening before spawning the client pod
-		if readyErr := e2epod.WaitTimeoutForPodReadyInNamespace(fr.ClientSet, serverPodSpec.Name, fr.Namespace.Name, framework.PodStartTimeout); readyErr != nil {
+		if readyErr := e2epod.WaitTimeoutForPodReadyInNamespace(ctx, fr.ClientSet, serverPodSpec.Name, fr.Namespace.Name, framework.PodStartTimeout); readyErr != nil {
 			framework.Failf("error waiting for server pod %s to be ready: %v", serverPodSpec.Name, readyErr)
 		}
 		// Connect to the server and leak the connection
@@ -198,7 +198,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 			clientNodeInfo.name,
 			clientNodeInfo.nodeIP,
 			kubeProxyE2eImage))
-		e2epod.NewPodClient(fr).CreateSync(clientPodSpec)
+		e2epod.NewPodClient(fr).CreateSync(ctx, clientPodSpec)
 
 		ginkgo.By("Checking conntrack entries for the timeout")
 		// These must be synchronized from the default values set in

--- a/test/e2e/network/netpol/network_policy_api.go
+++ b/test/e2e/network/netpol/network_policy_api.go
@@ -93,7 +93,7 @@ var _ = common.SIGDescribe("Netpol API", func() {
 		ginkgo.By("getting /apis/networking.k8s.io")
 		{
 			group := &metav1.APIGroup{}
-			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/networking.k8s.io").Do(context.TODO()).Into(group)
+			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/networking.k8s.io").Do(ctx).Into(group)
 			framework.ExpectNoError(err)
 			found := false
 			for _, version := range group.Versions {
@@ -123,48 +123,48 @@ var _ = common.SIGDescribe("Netpol API", func() {
 		}
 		// NetPol resource create/read/update/watch verbs
 		ginkgo.By("creating")
-		_, err := npClient.Create(context.TODO(), npTemplate, metav1.CreateOptions{})
+		_, err := npClient.Create(ctx, npTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		_, err = npClient.Create(context.TODO(), npTemplate, metav1.CreateOptions{})
+		_, err = npClient.Create(ctx, npTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		createdNetPol, err := npClient.Create(context.TODO(), npTemplate, metav1.CreateOptions{})
+		createdNetPol, err := npClient.Create(ctx, npTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("getting")
-		gottenNetPol, err := npClient.Get(context.TODO(), createdNetPol.Name, metav1.GetOptions{})
+		gottenNetPol, err := npClient.Get(ctx, createdNetPol.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(gottenNetPol.UID, createdNetPol.UID)
 
 		ginkgo.By("listing")
-		nps, err := npClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		nps, err := npClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(nps.Items), 3, "filtered list should have 3 items")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
-		npWatch, err := npClient.Watch(context.TODO(), metav1.ListOptions{ResourceVersion: nps.ResourceVersion, LabelSelector: "special-label=" + f.UniqueName})
+		npWatch, err := npClient.Watch(ctx, metav1.ListOptions{ResourceVersion: nps.ResourceVersion, LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		// Test cluster-wide list and watch
 		clusterNPClient := f.ClientSet.NetworkingV1().NetworkPolicies("")
 		ginkgo.By("cluster-wide listing")
-		clusterNPs, err := clusterNPClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		clusterNPs, err := clusterNPClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(clusterNPs.Items), 3, "filtered list should have 3 items")
 
 		ginkgo.By("cluster-wide watching")
 		framework.Logf("starting watch")
-		_, err = clusterNPClient.Watch(context.TODO(), metav1.ListOptions{ResourceVersion: nps.ResourceVersion, LabelSelector: "special-label=" + f.UniqueName})
+		_, err = clusterNPClient.Watch(ctx, metav1.ListOptions{ResourceVersion: nps.ResourceVersion, LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("patching")
-		patchedNetPols, err := npClient.Patch(context.TODO(), createdNetPol.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
+		patchedNetPols, err := npClient.Patch(ctx, createdNetPol.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(patchedNetPols.Annotations["patched"], "true", "patched object should have the applied annotation")
 
 		ginkgo.By("updating")
 		npToUpdate := patchedNetPols.DeepCopy()
 		npToUpdate.Annotations["updated"] = "true"
-		updatedNetPols, err := npClient.Update(context.TODO(), npToUpdate, metav1.UpdateOptions{})
+		updatedNetPols, err := npClient.Update(ctx, npToUpdate, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(updatedNetPols.Annotations["updated"], "true", "updated object should have the applied annotation")
 
@@ -193,20 +193,20 @@ var _ = common.SIGDescribe("Netpol API", func() {
 		}
 		// NetPol resource delete operations
 		ginkgo.By("deleting")
-		err = npClient.Delete(context.TODO(), createdNetPol.Name, metav1.DeleteOptions{})
+		err = npClient.Delete(ctx, createdNetPol.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
-		_, err = npClient.Get(context.TODO(), createdNetPol.Name, metav1.GetOptions{})
+		_, err = npClient.Get(ctx, createdNetPol.Name, metav1.GetOptions{})
 		if !apierrors.IsNotFound(err) {
 			framework.Failf("expected 404, got %#v", err)
 		}
-		nps, err = npClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		nps, err = npClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(nps.Items), 2, "filtered list should have 2 items")
 
 		ginkgo.By("deleting a collection")
-		err = npClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		err = npClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
-		nps, err = npClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		nps, err = npClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(nps.Items), 0, "filtered list should have 0 items")
 	})
@@ -231,14 +231,14 @@ var _ = common.SIGDescribe("Netpol API", func() {
 			SetObjectMetaLabel(map[string]string{"special-label": f.UniqueName}),
 			SetSpecPodSelectorMatchLabels(map[string]string{"pod-name": "test-pod"}),
 			SetSpecEgressRules(egressRule))
-		_, err := npClient.Create(context.TODO(), npTemplate, metav1.CreateOptions{})
+		_, err := npClient.Create(ctx, npTemplate, metav1.CreateOptions{})
 		framework.ExpectError(err, "request template:%v", npTemplate)
 
 		ginkgo.By("EndPort field cannot be defined if the Port field is defined as a named (string) port.")
 		egressRule = networkingv1.NetworkPolicyEgressRule{}
 		egressRule.Ports = append(egressRule.Ports, networkingv1.NetworkPolicyPort{Port: &intstr.IntOrString{Type: intstr.String, StrVal: "serve-80"}, EndPort: &endport})
 		npTemplate.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{egressRule}
-		_, err = npClient.Create(context.TODO(), npTemplate, metav1.CreateOptions{})
+		_, err = npClient.Create(ctx, npTemplate, metav1.CreateOptions{})
 		framework.ExpectError(err, "request template:%v", npTemplate)
 
 		ginkgo.By("EndPort field must be equal or greater than port.")
@@ -246,26 +246,26 @@ var _ = common.SIGDescribe("Netpol API", func() {
 		egressRule = networkingv1.NetworkPolicyEgressRule{}
 		egressRule.Ports = append(egressRule.Ports, networkingv1.NetworkPolicyPort{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 30000}, EndPort: &endport})
 		npTemplate.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{egressRule}
-		_, err = npClient.Create(context.TODO(), npTemplate, metav1.CreateOptions{})
+		_, err = npClient.Create(ctx, npTemplate, metav1.CreateOptions{})
 		framework.ExpectError(err, "request template:%v", npTemplate)
 
 		ginkgo.By("EndPort field is equal with port.")
 		egressRule.Ports[0].Port = &intstr.IntOrString{Type: intstr.Int, IntVal: 20000}
 		npTemplate.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{egressRule}
-		_, err = npClient.Create(context.TODO(), npTemplate, metav1.CreateOptions{})
+		_, err = npClient.Create(ctx, npTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "request template:%v", npTemplate)
 
 		ginkgo.By("EndPort field is greater than port.")
 		egressRule = networkingv1.NetworkPolicyEgressRule{}
 		egressRule.Ports = append(egressRule.Ports, networkingv1.NetworkPolicyPort{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 10000}, EndPort: &endport})
 		npTemplate.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{egressRule}
-		_, err = npClient.Create(context.TODO(), npTemplate, metav1.CreateOptions{})
+		_, err = npClient.Create(ctx, npTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "request template:%v", npTemplate)
 
 		ginkgo.By("deleting all test collection")
-		err = npClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		err = npClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
-		nps, err := npClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		nps, err := npClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(nps.Items), 0, "filtered list should be 0 items")
 	})
@@ -301,7 +301,7 @@ var _ = common.SIGDescribe("Netpol API", func() {
 			SetObjectMetaLabel(map[string]string{"special-label": f.UniqueName}),
 			SetSpecPodSelectorMatchLabels(map[string]string{"pod-name": "test-pod"}),
 			SetSpecIngressRules(ingressRule))
-		newNetPol, err := npClient.Create(context.TODO(), npTemplate, metav1.CreateOptions{})
+		newNetPol, err := npClient.Create(ctx, npTemplate, metav1.CreateOptions{})
 
 		framework.ExpectNoError(err, "request template:%v", npTemplate)
 
@@ -323,24 +323,24 @@ var _ = common.SIGDescribe("Netpol API", func() {
 		ginkgo.By("NetworkPolicy should support valid status condition")
 		newNetPol.Status = status
 
-		_, err = npClient.UpdateStatus(context.TODO(), newNetPol, metav1.UpdateOptions{})
+		_, err = npClient.UpdateStatus(ctx, newNetPol, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "request template:%v", newNetPol)
 
 		ginkgo.By("NetworkPolicy should not support status condition without reason field")
 		newNetPol.Status.Conditions[0].Reason = ""
-		_, err = npClient.UpdateStatus(context.TODO(), newNetPol, metav1.UpdateOptions{})
+		_, err = npClient.UpdateStatus(ctx, newNetPol, metav1.UpdateOptions{})
 		framework.ExpectError(err, "request template:%v", newNetPol)
 
 		ginkgo.By("NetworkPolicy should not support status condition with duplicated types")
 		newNetPol.Status.Conditions = []metav1.Condition{condition, condition}
 		newNetPol.Status.Conditions[1].Status = metav1.ConditionFalse
-		_, err = npClient.UpdateStatus(context.TODO(), newNetPol, metav1.UpdateOptions{})
+		_, err = npClient.UpdateStatus(ctx, newNetPol, metav1.UpdateOptions{})
 		framework.ExpectError(err, "request template:%v", newNetPol)
 
 		ginkgo.By("deleting all test collection")
-		err = npClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		err = npClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
-		nps, err := npClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		nps, err := npClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(nps.Items), 0, "filtered list should be 0 items")
 	})

--- a/test/e2e/network/network_tiers.go
+++ b/test/e2e/network/network_tiers.go
@@ -53,32 +53,32 @@ var _ = common.SIGDescribe("Services GCE [Slow]", func() {
 		cs = f.ClientSet
 	})
 
-	ginkgo.AfterEach(func() {
+	ginkgo.AfterEach(func(ctx context.Context) {
 		if ginkgo.CurrentSpecReport().Failed() {
 			DescribeSvc(f.Namespace.Name)
 		}
 		for _, lb := range serviceLBNames {
 			framework.Logf("cleaning gce resource for %s", lb)
-			framework.TestContext.CloudConfig.Provider.CleanupServiceResources(cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
+			framework.TestContext.CloudConfig.Provider.CleanupServiceResources(ctx, cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
 		}
 		//reset serviceLBNames
 		serviceLBNames = []string{}
 	})
 	ginkgo.It("should be able to create and tear down a standard-tier load balancer [Slow]", func(ctx context.Context) {
 		lagTimeout := e2eservice.LoadBalancerLagTimeoutDefault
-		createTimeout := e2eservice.GetServiceLoadBalancerCreationTimeout(cs)
+		createTimeout := e2eservice.GetServiceLoadBalancerCreationTimeout(ctx, cs)
 
 		svcName := "net-tiers-svc"
 		ns := f.Namespace.Name
 		jig := e2eservice.NewTestJig(cs, ns, svcName)
 
 		ginkgo.By("creating a pod to be part of the service " + svcName)
-		_, err := jig.Run(nil)
+		_, err := jig.Run(ctx, nil)
 		framework.ExpectNoError(err)
 
 		// Test 1: create a standard tiered LB for the Service.
 		ginkgo.By("creating a Service of type LoadBalancer using the standard network tier")
-		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 			setNetworkTier(svc, string(gcecloud.NetworkTierAnnotationStandard))
 		})
@@ -91,11 +91,11 @@ var _ = common.SIGDescribe("Services GCE [Slow]", func() {
 		serviceLBNames = append(serviceLBNames, cloudprovider.DefaultLoadBalancerName(svc))
 
 		// Wait and verify the LB.
-		ingressIP := waitAndVerifyLBWithTier(jig, "", createTimeout, lagTimeout)
+		ingressIP := waitAndVerifyLBWithTier(ctx, jig, "", createTimeout, lagTimeout)
 
 		// Test 2: re-create a LB of a different tier for the updated Service.
 		ginkgo.By("updating the Service to use the premium (default) tier")
-		svc, err = jig.UpdateService(func(svc *v1.Service) {
+		svc, err = jig.UpdateService(ctx, func(svc *v1.Service) {
 			setNetworkTier(svc, string(gcecloud.NetworkTierAnnotationPremium))
 		})
 		framework.ExpectNoError(err)
@@ -106,7 +106,7 @@ var _ = common.SIGDescribe("Services GCE [Slow]", func() {
 
 		// Wait until the ingress IP changes. Each tier has its own pool of
 		// IPs, so changing tiers implies changing IPs.
-		ingressIP = waitAndVerifyLBWithTier(jig, ingressIP, createTimeout, lagTimeout)
+		ingressIP = waitAndVerifyLBWithTier(ctx, jig, ingressIP, createTimeout, lagTimeout)
 
 		// Test 3: create a standard-tierd LB with a user-requested IP.
 		ginkgo.By("reserving a static IP for the load balancer")
@@ -127,7 +127,7 @@ var _ = common.SIGDescribe("Services GCE [Slow]", func() {
 		framework.Logf("Allocated static IP to be used by the load balancer: %q", requestedIP)
 
 		ginkgo.By("updating the Service to use the standard tier with a requested IP")
-		svc, err = jig.UpdateService(func(svc *v1.Service) {
+		svc, err = jig.UpdateService(ctx, func(svc *v1.Service) {
 			svc.Spec.LoadBalancerIP = requestedIP
 			setNetworkTier(svc, string(gcecloud.NetworkTierAnnotationStandard))
 		})
@@ -139,14 +139,14 @@ var _ = common.SIGDescribe("Services GCE [Slow]", func() {
 		framework.ExpectEqual(svcTier, cloud.NetworkTierStandard)
 
 		// Wait until the ingress IP changes and verifies the LB.
-		waitAndVerifyLBWithTier(jig, ingressIP, createTimeout, lagTimeout)
+		waitAndVerifyLBWithTier(ctx, jig, ingressIP, createTimeout, lagTimeout)
 	})
 })
 
-func waitAndVerifyLBWithTier(jig *e2eservice.TestJig, existingIP string, waitTimeout, checkTimeout time.Duration) string {
+func waitAndVerifyLBWithTier(ctx context.Context, jig *e2eservice.TestJig, existingIP string, waitTimeout, checkTimeout time.Duration) string {
 	// If existingIP is "" this will wait for any ingress IP to show up. Otherwise
 	// it will wait for the ingress IP to change to something different.
-	svc, err := jig.WaitForNewIngressIP(existingIP, waitTimeout)
+	svc, err := jig.WaitForNewIngressIP(ctx, existingIP, waitTimeout)
 	framework.ExpectNoError(err)
 
 	svcPort := int(svc.Spec.Ports[0].Port)
@@ -161,7 +161,7 @@ func waitAndVerifyLBWithTier(jig *e2eservice.TestJig, existingIP string, waitTim
 	// If the IP has been used by previous test, sometimes we get the lingering
 	// 404 errors even after the LB is long gone. Tolerate and retry until the
 	// new LB is fully established.
-	e2eservice.TestReachableHTTPWithRetriableErrorCodes(ingressIP, svcPort, []int{http.StatusNotFound}, checkTimeout)
+	e2eservice.TestReachableHTTPWithRetriableErrorCodes(ctx, ingressIP, svcPort, []int{http.StatusNotFound}, checkTimeout)
 
 	// Verify the network tier matches the desired.
 	svcNetTier, err := gcecloud.GetServiceNetworkTier(svc)

--- a/test/e2e/network/networking_perf.go
+++ b/test/e2e/network/networking_perf.go
@@ -57,7 +57,7 @@ const (
 	serverServiceName = "iperf2-server"
 )
 
-func iperf2ServerDeployment(client clientset.Interface, namespace string, isIPV6 bool) (*appsv1.Deployment, error) {
+func iperf2ServerDeployment(ctx context.Context, client clientset.Interface, namespace string, isIPV6 bool) (*appsv1.Deployment, error) {
 	framework.Logf("deploying iperf2 server")
 	one := int64(1)
 	replicas := int32(1)
@@ -83,7 +83,7 @@ func iperf2ServerDeployment(client clientset.Interface, namespace string, isIPV6
 		},
 	}
 
-	deployment, err := client.AppsV1().Deployments(namespace).Create(context.TODO(), deploymentSpec, metav1.CreateOptions{})
+	deployment, err := client.AppsV1().Deployments(namespace).Create(ctx, deploymentSpec, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("deployment %q Create API error: %v", deploymentSpec.Name, err)
 	}
@@ -96,7 +96,7 @@ func iperf2ServerDeployment(client clientset.Interface, namespace string, isIPV6
 	return deployment, nil
 }
 
-func iperf2ServerService(client clientset.Interface, namespace string) (*v1.Service, error) {
+func iperf2ServerService(ctx context.Context, client clientset.Interface, namespace string) (*v1.Service, error) {
 	service := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: serverServiceName},
 		Spec: v1.ServiceSpec{
@@ -108,16 +108,16 @@ func iperf2ServerService(client clientset.Interface, namespace string) (*v1.Serv
 			},
 		},
 	}
-	return client.CoreV1().Services(namespace).Create(context.TODO(), service, metav1.CreateOptions{})
+	return client.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
 }
 
-func iperf2ClientDaemonSet(client clientset.Interface, namespace string) (*appsv1.DaemonSet, error) {
+func iperf2ClientDaemonSet(ctx context.Context, client clientset.Interface, namespace string) (*appsv1.DaemonSet, error) {
 	one := int64(1)
 	labels := map[string]string{labelKey: clientLabelValue}
 	spec := e2edaemonset.NewDaemonSet("iperf2-clients", imageutils.GetE2EImage(imageutils.Agnhost), labels, nil, nil, nil)
 	spec.Spec.Template.Spec.TerminationGracePeriodSeconds = &one
 
-	ds, err := client.AppsV1().DaemonSets(namespace).Create(context.TODO(), spec, metav1.CreateOptions{})
+	ds, err := client.AppsV1().DaemonSets(namespace).Create(ctx, spec, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("daemonset %s Create API error: %v", spec.Name, err)
 	}
@@ -142,8 +142,8 @@ var _ = common.SIGDescribe("Networking IPerf2 [Feature:Networking-Performance]",
 	f := framework.NewDefaultFramework("network-perf")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 
-	ginkgo.It(fmt.Sprintf("should run iperf2"), func(ctx context.Context) {
-		readySchedulableNodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+	ginkgo.It("should run iperf2", func(ctx context.Context) {
+		readySchedulableNodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 
 		familyStr := ""
@@ -156,22 +156,22 @@ var _ = common.SIGDescribe("Networking IPerf2 [Feature:Networking-Performance]",
 		}
 
 		// Step 1: set up iperf2 server -- a single pod on any node
-		_, err = iperf2ServerDeployment(f.ClientSet, f.Namespace.Name, framework.TestContext.ClusterIsIPv6())
+		_, err = iperf2ServerDeployment(ctx, f.ClientSet, f.Namespace.Name, framework.TestContext.ClusterIsIPv6())
 		framework.ExpectNoError(err, "deploy iperf2 server deployment")
 
-		_, err = iperf2ServerService(f.ClientSet, f.Namespace.Name)
+		_, err = iperf2ServerService(ctx, f.ClientSet, f.Namespace.Name)
 		framework.ExpectNoError(err, "deploy iperf2 server service")
 
 		// Step 2: set up iperf2 client daemonset
 		//   initially, the clients don't do anything -- they simply pause until they're called
-		_, err = iperf2ClientDaemonSet(f.ClientSet, f.Namespace.Name)
+		_, err = iperf2ClientDaemonSet(ctx, f.ClientSet, f.Namespace.Name)
 		framework.ExpectNoError(err, "deploy iperf2 client daemonset")
 
 		// Make sure the server is ready to go
 		framework.Logf("waiting for iperf2 server endpoints")
 		err = wait.Poll(2*time.Second, largeClusterTimeout, func() (done bool, err error) {
 			listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", discoveryv1.LabelServiceName, serverServiceName)}
-			esList, err := f.ClientSet.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(context.TODO(), listOptions)
+			esList, err := f.ClientSet.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(ctx, listOptions)
 			framework.ExpectNoError(err, "Error fetching EndpointSlice for Service %s/%s", f.Namespace.Name, serverServiceName)
 
 			if len(esList.Items) == 0 {
@@ -190,7 +190,7 @@ var _ = common.SIGDescribe("Networking IPerf2 [Feature:Networking-Performance]",
 		framework.Logf("waiting for client pods to be running")
 		var clientPodList *v1.PodList
 		err = wait.Poll(2*time.Second, largeClusterTimeout, func() (done bool, err error) {
-			clientPodList, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), clientPodsListOptions)
+			clientPodList, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, clientPodsListOptions)
 			if err != nil {
 				return false, err
 			}
@@ -208,7 +208,7 @@ var _ = common.SIGDescribe("Networking IPerf2 [Feature:Networking-Performance]",
 		framework.Logf("all client pods are ready: %d pods", len(clientPodList.Items))
 
 		// Get a reference to the server pod for later
-		serverPodList, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), serverPodsListOptions)
+		serverPodList, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, serverPodsListOptions)
 		framework.ExpectNoError(err)
 		if len(serverPodList.Items) != 1 {
 			framework.Failf("expected 1 server pod, found %d", len(serverPodList.Items))
@@ -235,7 +235,7 @@ var _ = common.SIGDescribe("Networking IPerf2 [Feature:Networking-Performance]",
 			podName := pod.Name
 			nodeName := pod.Spec.NodeName
 
-			iperfVersion := e2epod.ExecShellInPod(f, podName, "iperf -v || true")
+			iperfVersion := e2epod.ExecShellInPod(ctx, f, podName, "iperf -v || true")
 			framework.Logf("iperf version: %s", iperfVersion)
 
 			for try := 0; ; try++ {
@@ -248,7 +248,7 @@ var _ = common.SIGDescribe("Networking IPerf2 [Feature:Networking-Performance]",
 				 */
 				command := fmt.Sprintf(`iperf %s -e -p %d --reportstyle C -i 1 -c %s && sleep 5`, familyStr, iperf2Port, serverServiceName)
 				framework.Logf("attempting to run command '%s' in client pod %s (node %s)", command, podName, nodeName)
-				output := e2epod.ExecShellInPod(f, podName, command)
+				output := e2epod.ExecShellInPod(ctx, f, podName, command)
 				framework.Logf("output from exec on client pod %s (node %s): \n%s\n", podName, nodeName, output)
 
 				results, err := ParseIPerf2EnhancedResultsFromCSV(output)

--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -70,7 +70,7 @@ var _ = common.SIGDescribe("NoSNAT [Feature:NoSNAT] [Slow]", func() {
 		pc := cs.CoreV1().Pods(f.Namespace.Name)
 
 		ginkgo.By("creating a test pod on each Node")
-		nodes, err := e2enode.GetReadySchedulableNodes(cs)
+		nodes, err := e2enode.GetReadySchedulableNodes(ctx, cs)
 		framework.ExpectNoError(err)
 		framework.ExpectNotEqual(len(nodes.Items), 0, "no Nodes in the cluster")
 
@@ -78,13 +78,13 @@ var _ = common.SIGDescribe("NoSNAT [Feature:NoSNAT] [Slow]", func() {
 			// target Pod at Node
 			nodeSelection := e2epod.NodeSelection{Name: node.Name}
 			e2epod.SetNodeSelection(&testPod.Spec, nodeSelection)
-			_, err = pc.Create(context.TODO(), &testPod, metav1.CreateOptions{})
+			_, err = pc.Create(ctx, &testPod, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 		}
 
 		ginkgo.By("waiting for all of the no-snat-test pods to be scheduled and running")
 		err = wait.PollImmediate(10*time.Second, 1*time.Minute, func() (bool, error) {
-			pods, err := pc.List(context.TODO(), metav1.ListOptions{LabelSelector: noSNATTestName})
+			pods, err := pc.List(ctx, metav1.ListOptions{LabelSelector: noSNATTestName})
 			if err != nil {
 				return false, err
 			}
@@ -103,7 +103,7 @@ var _ = common.SIGDescribe("NoSNAT [Feature:NoSNAT] [Slow]", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("sending traffic from each pod to the others and checking that SNAT does not occur")
-		pods, err := pc.List(context.TODO(), metav1.ListOptions{LabelSelector: noSNATTestName})
+		pods, err := pc.List(ctx, metav1.ListOptions{LabelSelector: noSNATTestName})
 		framework.ExpectNoError(err)
 
 		// hit the /clientip endpoint on every other Pods to check if source ip is preserved

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -83,13 +83,13 @@ var _ = common.SIGDescribe("Proxy", func() {
 			Test for Proxy, logs port endpoint
 			Select any node in the cluster to invoke /proxy/nodes/<nodeip>:10250/logs endpoint. This endpoint MUST be reachable.
 		*/
-		ginkgo.It("should proxy logs on node with explicit kubelet port using proxy subresource ", func() { nodeProxyTest(f, prefix+"/nodes/", ":10250/proxy/logs/") })
+		ginkgo.It("should proxy logs on node with explicit kubelet port using proxy subresource ", func(ctx context.Context) { nodeProxyTest(ctx, f, prefix+"/nodes/", ":10250/proxy/logs/") })
 
 		/*
 			Test for Proxy, logs endpoint
 			Select any node in the cluster to invoke /proxy/nodes/<nodeip>//logs endpoint. This endpoint MUST be reachable.
 		*/
-		ginkgo.It("should proxy logs on node using proxy subresource ", func() { nodeProxyTest(f, prefix+"/nodes/", "/proxy/logs/") })
+		ginkgo.It("should proxy logs on node using proxy subresource ", func(ctx context.Context) { nodeProxyTest(ctx, f, prefix+"/nodes/", "/proxy/logs/") })
 
 		// using the porter image to serve content, access the content
 		// (of multiple pods?) from multiple (endpoints/services?)
@@ -101,7 +101,7 @@ var _ = common.SIGDescribe("Proxy", func() {
 		framework.ConformanceIt("should proxy through a service and a pod ", func(ctx context.Context) {
 			start := time.Now()
 			labels := map[string]string{"proxy-service-target": "true"}
-			service, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), &v1.Service{
+			service, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "proxy-service-",
 				},
@@ -176,11 +176,11 @@ var _ = common.SIGDescribe("Proxy", func() {
 				Labels:      labels,
 				CreatedPods: &pods,
 			}
-			err = e2erc.RunRC(cfg)
+			err = e2erc.RunRC(ctx, cfg)
 			framework.ExpectNoError(err)
 			ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, cfg.Name)
 
-			err = waitForEndpoint(f.ClientSet, f.Namespace.Name, service.Name)
+			err = waitForEndpoint(ctx, f.ClientSet, f.Namespace.Name, service.Name)
 			framework.ExpectNoError(err)
 
 			// table constructors
@@ -238,7 +238,7 @@ var _ = common.SIGDescribe("Proxy", func() {
 					go func(i int, path, val string) {
 						defer wg.Done()
 						// this runs the test case
-						body, status, d, err := doProxy(f, path, i)
+						body, status, d, err := doProxy(ctx, f, path, i)
 
 						if err != nil {
 							if serr, ok := err.(*apierrors.StatusError); ok {
@@ -264,7 +264,7 @@ var _ = common.SIGDescribe("Proxy", func() {
 			}
 
 			if len(errs) != 0 {
-				body, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).GetLogs(pods[0].Name, &v1.PodLogOptions{}).Do(context.TODO()).Raw()
+				body, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).GetLogs(pods[0].Name, &v1.PodLogOptions{}).Do(ctx).Raw()
 				if err != nil {
 					framework.Logf("Error getting logs for pod %s: %v", pods[0].Name, err)
 				} else {
@@ -310,12 +310,12 @@ var _ = common.SIGDescribe("Proxy", func() {
 					}},
 					RestartPolicy: v1.RestartPolicyNever,
 				}}
-			_, err := f.ClientSet.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+			_, err := f.ClientSet.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "failed to create pod")
-			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, pod), "Pod didn't start within time out period")
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod), "Pod didn't start within time out period")
 
 			framework.Logf("Creating service...")
-			_, err = f.ClientSet.CoreV1().Services(ns).Create(context.TODO(), &v1.Service{
+			_, err = f.ClientSet.CoreV1().Services(ns).Create(ctx, &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testSvcName,
 					Namespace: ns,
@@ -404,12 +404,12 @@ var _ = common.SIGDescribe("Proxy", func() {
 					}},
 					RestartPolicy: v1.RestartPolicyNever,
 				}}
-			_, err := f.ClientSet.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+			_, err := f.ClientSet.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "failed to create pod")
-			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, pod), "Pod didn't start within time out period")
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod), "Pod didn't start within time out period")
 
 			framework.Logf("Creating service...")
-			_, err = f.ClientSet.CoreV1().Services(ns).Create(context.TODO(), &v1.Service{
+			_, err = f.ClientSet.CoreV1().Services(ns).Create(ctx, &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testSvcName,
 					Namespace: ns,
@@ -544,7 +544,7 @@ func validateProxyVerbRequest(client *http.Client, urlString string, httpVerb st
 	}
 }
 
-func doProxy(f *framework.Framework, path string, i int) (body []byte, statusCode int, d time.Duration, err error) {
+func doProxy(ctx context.Context, f *framework.Framework, path string, i int) (body []byte, statusCode int, d time.Duration, err error) {
 	// About all of the proxy accesses in this file:
 	// * AbsPath is used because it preserves the trailing '/'.
 	// * Do().Raw() is used (instead of DoRaw()) because it will turn an
@@ -552,7 +552,7 @@ func doProxy(f *framework.Framework, path string, i int) (body []byte, statusCod
 	//   chance of the things we are talking to being confused for an error
 	//   that apiserver would have emitted.
 	start := time.Now()
-	body, err = f.ClientSet.CoreV1().RESTClient().Get().AbsPath(path).Do(context.TODO()).StatusCode(&statusCode).Raw()
+	body, err = f.ClientSet.CoreV1().RESTClient().Get().AbsPath(path).Do(ctx).StatusCode(&statusCode).Raw()
 	d = time.Since(start)
 	if len(body) > 0 {
 		framework.Logf("(%v) %v: %s (%v; %v)", i, path, truncate(body, maxDisplayBodyLen), statusCode, d)
@@ -571,16 +571,16 @@ func truncate(b []byte, maxLen int) []byte {
 	return b2
 }
 
-func nodeProxyTest(f *framework.Framework, prefix, nodeDest string) {
+func nodeProxyTest(ctx context.Context, f *framework.Framework, prefix, nodeDest string) {
 	// TODO: investigate why it doesn't work on master Node.
-	node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+	node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 	framework.ExpectNoError(err)
 
 	// TODO: Change it to test whether all requests succeeded when requests
 	// not reaching Kubelet issue is debugged.
 	serviceUnavailableErrors := 0
 	for i := 0; i < proxyAttempts; i++ {
-		_, status, d, err := doProxy(f, prefix+node.Name+nodeDest, i)
+		_, status, d, err := doProxy(ctx, f, prefix+node.Name+nodeDest, i)
 		if status == http.StatusServiceUnavailable {
 			framework.Logf("ginkgo.Failed proxying node logs due to service unavailable: %v", err)
 			time.Sleep(time.Second)
@@ -599,11 +599,11 @@ func nodeProxyTest(f *framework.Framework, prefix, nodeDest string) {
 }
 
 // waitForEndpoint waits for the specified endpoint to be ready.
-func waitForEndpoint(c clientset.Interface, ns, name string) error {
+func waitForEndpoint(ctx context.Context, c clientset.Interface, ns, name string) error {
 	// registerTimeout is how long to wait for an endpoint to be registered.
 	registerTimeout := time.Minute
 	for t := time.Now(); time.Since(t) < registerTimeout; time.Sleep(framework.Poll) {
-		endpoint, err := c.CoreV1().Endpoints(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		endpoint, err := c.CoreV1().Endpoints(ns).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			framework.Logf("Endpoint %s/%s is not ready yet", ns, name)
 			continue

--- a/test/e2e/network/scale/localrun/ingress_scale.go
+++ b/test/e2e/network/scale/localrun/ingress_scale.go
@@ -166,23 +166,26 @@ func main() {
 		f.NumIngressesTest = numIngressesTest
 	}
 
+	// This could be used to set a deadline.
+	ctx := context.Background()
+
 	// Real test begins.
 	if cleanup {
 		defer func() {
-			if errs := f.CleanupScaleTest(); len(errs) != 0 {
+			if errs := f.CleanupScaleTest(ctx); len(errs) != 0 {
 				klog.Errorf("Failed to cleanup scale test: %v", errs)
 				testSuccessFlag = false
 			}
 		}()
 	}
-	err = f.PrepareScaleTest()
+	err = f.PrepareScaleTest(ctx)
 	if err != nil {
 		klog.Errorf("Failed to prepare scale test: %v", err)
 		testSuccessFlag = false
 		return
 	}
 
-	if errs := f.RunScaleTest(); len(errs) != 0 {
+	if errs := f.RunScaleTest(ctx); len(errs) != 0 {
 		klog.Errorf("Failed while running scale test: %v", errs)
 		testSuccessFlag = false
 	}

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -154,9 +154,9 @@ func affinityCheckFromPod(execPod *v1.Pod, serviceIP string, servicePort int) (t
 
 // affinityCheckFromTest returns interval, timeout and function pinging the service and
 // returning pinged hosts for pinging the service from the test itself.
-func affinityCheckFromTest(cs clientset.Interface, serviceIP string, servicePort int) (time.Duration, time.Duration, func() []string) {
+func affinityCheckFromTest(ctx context.Context, cs clientset.Interface, serviceIP string, servicePort int) (time.Duration, time.Duration, func() []string) {
 	interval := 2 * time.Second
-	timeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(cs)
+	timeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, cs)
 
 	params := &e2enetwork.HTTPPokeParams{Timeout: 2 * time.Second}
 	getHosts := func() []string {
@@ -178,13 +178,13 @@ func affinityCheckFromTest(cs clientset.Interface, serviceIP string, servicePort
 // number of same response observed in a row. If affinity is not expected, the
 // test will keep observe until different responses observed. The function will
 // return false only in case of unexpected errors.
-func checkAffinity(cs clientset.Interface, execPod *v1.Pod, serviceIP string, servicePort int, shouldHold bool) bool {
+func checkAffinity(ctx context.Context, cs clientset.Interface, execPod *v1.Pod, serviceIP string, servicePort int, shouldHold bool) bool {
 	var interval, timeout time.Duration
 	var getHosts func() []string
 	if execPod != nil {
 		interval, timeout, getHosts = affinityCheckFromPod(execPod, serviceIP, servicePort)
 	} else {
-		interval, timeout, getHosts = affinityCheckFromTest(cs, serviceIP, servicePort)
+		interval, timeout, getHosts = affinityCheckFromTest(ctx, cs, serviceIP, servicePort)
 	}
 
 	var tracker affinityTracker
@@ -264,11 +264,11 @@ func checkAffinityFailed(tracker affinityTracker, err string) {
 
 // StartServeHostnameService creates a replication controller that serves its
 // hostname and a service on top of it.
-func StartServeHostnameService(c clientset.Interface, svc *v1.Service, ns string, replicas int) ([]string, string, error) {
+func StartServeHostnameService(ctx context.Context, c clientset.Interface, svc *v1.Service, ns string, replicas int) ([]string, string, error) {
 	podNames := make([]string, replicas)
 	name := svc.ObjectMeta.Name
 	ginkgo.By("creating service " + name + " in namespace " + ns)
-	_, err := c.CoreV1().Services(ns).Create(context.TODO(), svc, metav1.CreateOptions{})
+	_, err := c.CoreV1().Services(ns).Create(ctx, svc, metav1.CreateOptions{})
 	if err != nil {
 		return podNames, "", err
 	}
@@ -287,7 +287,7 @@ func StartServeHostnameService(c clientset.Interface, svc *v1.Service, ns string
 		CreatedPods:          &createdPods,
 		MaxContainerFailures: &maxContainerFailures,
 	}
-	err = e2erc.RunRC(config)
+	err = e2erc.RunRC(ctx, config)
 	if err != nil {
 		return podNames, "", err
 	}
@@ -301,7 +301,7 @@ func StartServeHostnameService(c clientset.Interface, svc *v1.Service, ns string
 	}
 	sort.StringSlice(podNames).Sort()
 
-	service, err := c.CoreV1().Services(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	service, err := c.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return podNames, "", err
 	}
@@ -313,11 +313,11 @@ func StartServeHostnameService(c clientset.Interface, svc *v1.Service, ns string
 }
 
 // StopServeHostnameService stops the given service.
-func StopServeHostnameService(clientset clientset.Interface, ns, name string) error {
-	if err := e2erc.DeleteRCAndWaitForGC(clientset, ns, name); err != nil {
+func StopServeHostnameService(ctx context.Context, clientset clientset.Interface, ns, name string) error {
+	if err := e2erc.DeleteRCAndWaitForGC(ctx, clientset, ns, name); err != nil {
 		return err
 	}
-	if err := clientset.CoreV1().Services(ns).Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
+	if err := clientset.CoreV1().Services(ns).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 	return nil
@@ -327,15 +327,15 @@ func StopServeHostnameService(clientset clientset.Interface, ns, name string) er
 // host exec pod of host network type and from the exec pod of container network type.
 // Each pod in the service is expected to echo its name. These names are compared with the
 // given expectedPods list after a sort | uniq.
-func verifyServeHostnameServiceUp(c clientset.Interface, ns string, expectedPods []string, serviceIP string, servicePort int) error {
+func verifyServeHostnameServiceUp(ctx context.Context, c clientset.Interface, ns string, expectedPods []string, serviceIP string, servicePort int) error {
 	// to verify from host network
-	hostExecPod := launchHostExecPod(c, ns, "verify-service-up-host-exec-pod")
+	hostExecPod := launchHostExecPod(ctx, c, ns, "verify-service-up-host-exec-pod")
 
 	// to verify from container's network
-	execPod := e2epod.CreateExecPodOrFail(c, ns, "verify-service-up-exec-pod-", nil)
+	execPod := e2epod.CreateExecPodOrFail(ctx, c, ns, "verify-service-up-exec-pod-", nil)
 	defer func() {
-		e2epod.DeletePodOrFail(c, ns, hostExecPod.Name)
-		e2epod.DeletePodOrFail(c, ns, execPod.Name)
+		e2epod.DeletePodOrFail(ctx, c, ns, hostExecPod.Name)
+		e2epod.DeletePodOrFail(ctx, c, ns, execPod.Name)
 	}()
 
 	// verify service from pod
@@ -397,11 +397,11 @@ func verifyServeHostnameServiceUp(c clientset.Interface, ns string, expectedPods
 }
 
 // verifyServeHostnameServiceDown verifies that the given service isn't served.
-func verifyServeHostnameServiceDown(c clientset.Interface, ns string, serviceIP string, servicePort int) error {
+func verifyServeHostnameServiceDown(ctx context.Context, c clientset.Interface, ns string, serviceIP string, servicePort int) error {
 	// verify from host network
-	hostExecPod := launchHostExecPod(c, ns, "verify-service-down-host-exec-pod")
+	hostExecPod := launchHostExecPod(ctx, c, ns, "verify-service-down-host-exec-pod")
 	defer func() {
-		e2epod.DeletePodOrFail(c, ns, hostExecPod.Name)
+		e2epod.DeletePodOrFail(ctx, c, ns, hostExecPod.Name)
 	}()
 
 	ipPort := net.JoinHostPort(serviceIP, strconv.Itoa(servicePort))
@@ -681,10 +681,10 @@ func testHTTPHealthCheckNodePort(ip string, port int, request string) (bool, err
 	return false, fmt.Errorf("unexpected HTTP response code %s from health check responder at %s", resp.Status, url)
 }
 
-func testHTTPHealthCheckNodePortFromTestContainer(config *e2enetwork.NetworkingTestConfig, host string, port int, timeout time.Duration, expectSucceed bool, threshold int) error {
+func testHTTPHealthCheckNodePortFromTestContainer(ctx context.Context, config *e2enetwork.NetworkingTestConfig, host string, port int, timeout time.Duration, expectSucceed bool, threshold int) error {
 	count := 0
 	pollFn := func() (bool, error) {
-		statusCode, err := config.GetHTTPCodeFromTestContainer(
+		statusCode, err := config.GetHTTPCodeFromTestContainer(ctx,
 			"/healthz",
 			host,
 			port)
@@ -728,9 +728,9 @@ func getServeHostnameService(name string) *v1.Service {
 }
 
 // waitForAPIServerUp waits for the kube-apiserver to be up.
-func waitForAPIServerUp(c clientset.Interface) error {
+func waitForAPIServerUp(ctx context.Context, c clientset.Interface) error {
 	for start := time.Now(); time.Since(start) < time.Minute; time.Sleep(5 * time.Second) {
-		body, err := c.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(context.TODO()).Raw()
+		body, err := c.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(ctx).Raw()
 		if err == nil && string(body) == "ok" {
 			return nil
 		}
@@ -740,8 +740,8 @@ func waitForAPIServerUp(c clientset.Interface) error {
 
 // getEndpointNodesWithInternalIP returns a map of nodenames:internal-ip on which the
 // endpoints of the Service are running.
-func getEndpointNodesWithInternalIP(jig *e2eservice.TestJig) (map[string]string, error) {
-	nodesWithIPs, err := jig.GetEndpointNodesWithIP(v1.NodeInternalIP)
+func getEndpointNodesWithInternalIP(ctx context.Context, jig *e2eservice.TestJig) (map[string]string, error) {
+	nodesWithIPs, err := jig.GetEndpointNodesWithIP(ctx, v1.NodeInternalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -773,7 +773,7 @@ var _ = common.SIGDescribe("Services", func() {
 		Description: By default when a kubernetes cluster is running there MUST be a 'kubernetes' service running in the cluster.
 	*/
 	framework.ConformanceIt("should provide secure master service ", func(ctx context.Context) {
-		_, err := cs.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+		_, err := cs.CoreV1().Services(metav1.NamespaceDefault).Get(ctx, "kubernetes", metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to fetch the service object for the service named kubernetes")
 	})
 
@@ -792,10 +792,10 @@ var _ = common.SIGDescribe("Services", func() {
 			err := cs.CoreV1().Services(ns).Delete(ctx, serviceName, metav1.DeleteOptions{})
 			framework.ExpectNoError(err, "failed to delete service: %s in namespace: %s", serviceName, ns)
 		})
-		svc, err := jig.CreateTCPServiceWithPort(nil, 80)
+		svc, err := jig.CreateTCPServiceWithPort(ctx, nil, 80)
 		framework.ExpectNoError(err)
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{})
 
 		names := map[string]bool{}
 		ginkgo.DeferCleanup(func(ctx context.Context) {
@@ -808,34 +808,34 @@ var _ = common.SIGDescribe("Services", func() {
 		name1 := "pod1"
 		name2 := "pod2"
 
-		createPodOrFail(f, ns, name1, jig.Labels, []v1.ContainerPort{{ContainerPort: 80}}, "netexec", "--http-port", "80")
+		createPodOrFail(ctx, f, ns, name1, jig.Labels, []v1.ContainerPort{{ContainerPort: 80}}, "netexec", "--http-port", "80")
 		names[name1] = true
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name1: {80}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{name1: {80}})
 
 		ginkgo.By("Checking if the Service forwards traffic to pod1")
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
-		err = jig.CheckServiceReachability(svc, execPod)
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
+		err = jig.CheckServiceReachability(ctx, svc, execPod)
 		framework.ExpectNoError(err)
 
-		createPodOrFail(f, ns, name2, jig.Labels, []v1.ContainerPort{{ContainerPort: 80}}, "netexec", "--http-port", "80")
+		createPodOrFail(ctx, f, ns, name2, jig.Labels, []v1.ContainerPort{{ContainerPort: 80}}, "netexec", "--http-port", "80")
 		names[name2] = true
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name1: {80}, name2: {80}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{name1: {80}, name2: {80}})
 
 		ginkgo.By("Checking if the Service forwards traffic to pod1 and pod2")
-		err = jig.CheckServiceReachability(svc, execPod)
+		err = jig.CheckServiceReachability(ctx, svc, execPod)
 		framework.ExpectNoError(err)
 
-		e2epod.DeletePodOrFail(cs, ns, name1)
+		e2epod.DeletePodOrFail(ctx, cs, ns, name1)
 		delete(names, name1)
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name2: {80}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{name2: {80}})
 
 		ginkgo.By("Checking if the Service forwards traffic to pod2")
-		err = jig.CheckServiceReachability(svc, execPod)
+		err = jig.CheckServiceReachability(ctx, svc, execPod)
 		framework.ExpectNoError(err)
 
-		e2epod.DeletePodOrFail(cs, ns, name2)
+		e2epod.DeletePodOrFail(ctx, cs, ns, name2)
 		delete(names, name2)
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{})
 	})
 
 	/*
@@ -858,7 +858,7 @@ var _ = common.SIGDescribe("Services", func() {
 		svc2port := "svc2"
 
 		ginkgo.By("creating service " + serviceName + " in namespace " + ns)
-		svc, err := jig.CreateTCPService(func(service *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(service *v1.Service) {
 			service.Spec.Ports = []v1.ServicePort{
 				{
 					Name:       "portname1",
@@ -876,7 +876,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		port1 := 100
 		port2 := 101
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{})
 
 		names := map[string]bool{}
 		ginkgo.DeferCleanup(func(ctx context.Context) {
@@ -902,26 +902,26 @@ var _ = common.SIGDescribe("Services", func() {
 		podname1 := "pod1"
 		podname2 := "pod2"
 
-		createPodOrFail(f, ns, podname1, jig.Labels, containerPorts1, "netexec", "--http-port", strconv.Itoa(port1))
+		createPodOrFail(ctx, f, ns, podname1, jig.Labels, containerPorts1, "netexec", "--http-port", strconv.Itoa(port1))
 		names[podname1] = true
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podname1: {port1}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{podname1: {port1}})
 
-		createPodOrFail(f, ns, podname2, jig.Labels, containerPorts2, "netexec", "--http-port", strconv.Itoa(port2))
+		createPodOrFail(ctx, f, ns, podname2, jig.Labels, containerPorts2, "netexec", "--http-port", strconv.Itoa(port2))
 		names[podname2] = true
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podname1: {port1}, podname2: {port2}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{podname1: {port1}, podname2: {port2}})
 
 		ginkgo.By("Checking if the Service forwards traffic to pods")
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
-		err = jig.CheckServiceReachability(svc, execPod)
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
+		err = jig.CheckServiceReachability(ctx, svc, execPod)
 		framework.ExpectNoError(err)
 
-		e2epod.DeletePodOrFail(cs, ns, podname1)
+		e2epod.DeletePodOrFail(ctx, cs, ns, podname1)
 		delete(names, podname1)
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podname2: {port2}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{podname2: {port2}})
 
-		e2epod.DeletePodOrFail(cs, ns, podname2)
+		e2epod.DeletePodOrFail(ctx, cs, ns, podname2)
 		delete(names, podname2)
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{})
 	})
 
 	ginkgo.It("should be updated after adding or deleting ports ", func(ctx context.Context) {
@@ -931,7 +931,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		svc1port := "svc1"
 		ginkgo.By("creating service " + serviceName + " in namespace " + ns)
-		svc, err := jig.CreateTCPService(func(service *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(service *v1.Service) {
 			service.Spec.Ports = []v1.ServicePort{
 				{
 					Name:       "portname1",
@@ -941,7 +941,7 @@ var _ = common.SIGDescribe("Services", func() {
 			}
 		})
 		framework.ExpectNoError(err)
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{})
 
 		podname1 := "pod1"
 		port1 := 100
@@ -951,17 +951,17 @@ var _ = common.SIGDescribe("Services", func() {
 				ContainerPort: int32(port1),
 			},
 		}
-		createPodOrFail(f, ns, podname1, jig.Labels, containerPorts1, "netexec", "--http-port", strconv.Itoa(port1))
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podname1: {port1}})
+		createPodOrFail(ctx, f, ns, podname1, jig.Labels, containerPorts1, "netexec", "--http-port", strconv.Itoa(port1))
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{podname1: {port1}})
 
 		ginkgo.By("Checking if the Service " + serviceName + " forwards traffic to " + podname1)
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
-		err = jig.CheckServiceReachability(svc, execPod)
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
+		err = jig.CheckServiceReachability(ctx, svc, execPod)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Adding a new port to service " + serviceName)
 		svc2port := "svc2"
-		svc, err = jig.UpdateService(func(s *v1.Service) {
+		svc, err = jig.UpdateService(ctx, func(s *v1.Service) {
 			s.Spec.Ports = []v1.ServicePort{
 				{
 					Name:       "portname1",
@@ -986,15 +986,15 @@ var _ = common.SIGDescribe("Services", func() {
 				ContainerPort: int32(port2),
 			},
 		}
-		createPodOrFail(f, ns, podname2, jig.Labels, containerPorts2, "netexec", "--http-port", strconv.Itoa(port2))
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podname1: {port1}, podname2: {port2}})
+		createPodOrFail(ctx, f, ns, podname2, jig.Labels, containerPorts2, "netexec", "--http-port", strconv.Itoa(port2))
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{podname1: {port1}, podname2: {port2}})
 
 		ginkgo.By("Checking if the Service forwards traffic to " + podname1 + " and " + podname2)
-		err = jig.CheckServiceReachability(svc, execPod)
+		err = jig.CheckServiceReachability(ctx, svc, execPod)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Deleting a port from service " + serviceName)
-		svc, err = jig.UpdateService(func(s *v1.Service) {
+		svc, err = jig.UpdateService(ctx, func(s *v1.Service) {
 			s.Spec.Ports = []v1.ServicePort{
 				{
 					Name:       "portname1",
@@ -1006,8 +1006,8 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Checking if the Service forwards traffic to " + podname1 + " and not forwards to " + podname2)
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{podname1: {port1}})
-		err = jig.CheckServiceReachability(svc, execPod)
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{podname1: {port1}})
+		err = jig.CheckServiceReachability(ctx, svc, execPod)
 		framework.ExpectNoError(err)
 	})
 
@@ -1017,7 +1017,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		// This behavior is not supported if Kube-proxy is in "userspace" mode.
 		// So we check the kube-proxy mode and skip this test if that's the case.
-		if proxyMode, err := proxyMode(f); err == nil {
+		if proxyMode, err := proxyMode(ctx, f); err == nil {
 			if proxyMode == "userspace" {
 				e2eskipper.Skipf("The test doesn't work with kube-proxy in userspace mode")
 			}
@@ -1032,7 +1032,7 @@ var _ = common.SIGDescribe("Services", func() {
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 		jig.ExternalIPs = true
 		servicePort := 8080
-		tcpService, err := jig.CreateTCPServiceWithPort(nil, int32(servicePort))
+		tcpService, err := jig.CreateTCPServiceWithPort(ctx, nil, int32(servicePort))
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			framework.Logf("Cleaning up the sourceip test service")
@@ -1043,7 +1043,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.Logf("sourceip-test cluster ip: %s", serviceIP)
 
 		ginkgo.By("Picking 2 Nodes to test whether source IP is preserved or not")
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
 		framework.ExpectNoError(err)
 		nodeCounts := len(nodes.Items)
 		if nodeCounts < 2 {
@@ -1054,19 +1054,19 @@ var _ = common.SIGDescribe("Services", func() {
 		serverPodName := "echo-sourceip"
 		pod := e2epod.NewAgnhostPod(ns, serverPodName, nil, nil, nil, "netexec", "--http-port", strconv.Itoa(servicePort))
 		pod.Labels = jig.Labels
-		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout))
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			framework.Logf("Cleaning up the echo server pod")
 			err := cs.CoreV1().Pods(ns).Delete(ctx, serverPodName, metav1.DeleteOptions{})
 			framework.ExpectNoError(err, "failed to delete pod: %s on node", serverPodName)
 		})
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{serverPodName: {servicePort}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{serverPodName: {servicePort}})
 
 		ginkgo.By("Creating pause pod deployment")
-		deployment := createPausePodDeployment(cs, "pause-pod", ns, nodeCounts)
+		deployment := createPausePodDeployment(ctx, cs, "pause-pod", ns, nodeCounts)
 
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			framework.Logf("Deleting deployment")
@@ -1076,11 +1076,11 @@ var _ = common.SIGDescribe("Services", func() {
 
 		framework.ExpectNoError(e2edeployment.WaitForDeploymentComplete(cs, deployment), "Failed to complete pause pod deployment")
 
-		deployment, err = cs.AppsV1().Deployments(ns).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
+		deployment, err = cs.AppsV1().Deployments(ns).Get(ctx, deployment.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "Error in retrieving pause pod deployment")
 		labelSelector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
 
-		pausePods, err := cs.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
+		pausePods, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: labelSelector.String()})
 		framework.ExpectNoError(err, "Error in listing pods associated with pause pod deployments")
 
 		framework.ExpectNotEqual(pausePods.Items[0].Spec.NodeName, pausePods.Items[1].Spec.NodeName)
@@ -1102,7 +1102,7 @@ var _ = common.SIGDescribe("Services", func() {
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 		jig.ExternalIPs = true
 		servicePort := 8080
-		svc, err := jig.CreateTCPServiceWithPort(nil, int32(servicePort))
+		svc, err := jig.CreateTCPServiceWithPort(ctx, nil, int32(servicePort))
 		framework.ExpectNoError(err)
 		serviceIP := svc.Spec.ClusterIP
 		framework.Logf("hairpin-test cluster ip: %s", serviceIP)
@@ -1111,15 +1111,15 @@ var _ = common.SIGDescribe("Services", func() {
 		serverPodName := "hairpin"
 		podTemplate := e2epod.NewAgnhostPod(ns, serverPodName, nil, nil, nil, "netexec", "--http-port", strconv.Itoa(servicePort))
 		podTemplate.Labels = jig.Labels
-		pod, err := cs.CoreV1().Pods(ns).Create(context.TODO(), podTemplate, metav1.CreateOptions{})
+		pod, err := cs.CoreV1().Pods(ns).Create(ctx, podTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		ginkgo.By("waiting for the service to expose an endpoint")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{serverPodName: {servicePort}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{serverPodName: {servicePort}})
 
 		ginkgo.By("Checking if the pod can reach itself")
-		err = jig.CheckServiceReachability(svc, pod)
+		err = jig.CheckServiceReachability(ctx, svc, pod)
 		framework.ExpectNoError(err)
 	})
 
@@ -1132,30 +1132,30 @@ var _ = common.SIGDescribe("Services", func() {
 		svc3 := "up-down-3"
 
 		ginkgo.By("creating " + svc1 + " in namespace " + ns)
-		podNames1, svc1IP, err := StartServeHostnameService(cs, getServeHostnameService(svc1), ns, numPods)
+		podNames1, svc1IP, err := StartServeHostnameService(ctx, cs, getServeHostnameService(svc1), ns, numPods)
 		framework.ExpectNoError(err, "failed to create replication controller with service: %s in the namespace: %s", svc1, ns)
 		ginkgo.By("creating " + svc2 + " in namespace " + ns)
-		podNames2, svc2IP, err := StartServeHostnameService(cs, getServeHostnameService(svc2), ns, numPods)
+		podNames2, svc2IP, err := StartServeHostnameService(ctx, cs, getServeHostnameService(svc2), ns, numPods)
 		framework.ExpectNoError(err, "failed to create replication controller with service: %s in the namespace: %s", svc2, ns)
 
 		ginkgo.By("verifying service " + svc1 + " is up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames1, svc1IP, servicePort))
 
 		ginkgo.By("verifying service " + svc2 + " is up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames2, svc2IP, servicePort))
 
 		// Stop service 1 and make sure it is gone.
 		ginkgo.By("stopping service " + svc1)
-		framework.ExpectNoError(StopServeHostnameService(f.ClientSet, ns, svc1))
+		framework.ExpectNoError(StopServeHostnameService(ctx, f.ClientSet, ns, svc1))
 
 		ginkgo.By("verifying service " + svc1 + " is not up")
-		framework.ExpectNoError(verifyServeHostnameServiceDown(cs, ns, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceDown(ctx, cs, ns, svc1IP, servicePort))
 		ginkgo.By("verifying service " + svc2 + " is still up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames2, svc2IP, servicePort))
 
 		// Start another service and verify both are up.
 		ginkgo.By("creating service " + svc3 + " in namespace " + ns)
-		podNames3, svc3IP, err := StartServeHostnameService(cs, getServeHostnameService(svc3), ns, numPods)
+		podNames3, svc3IP, err := StartServeHostnameService(ctx, cs, getServeHostnameService(svc3), ns, numPods)
 		framework.ExpectNoError(err, "failed to create replication controller with service: %s in the namespace: %s", svc3, ns)
 
 		if svc2IP == svc3IP {
@@ -1163,10 +1163,10 @@ var _ = common.SIGDescribe("Services", func() {
 		}
 
 		ginkgo.By("verifying service " + svc2 + " is still up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames2, svc2IP, servicePort))
 
 		ginkgo.By("verifying service " + svc3 + " is up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames3, svc3IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames3, svc3IP, servicePort))
 	})
 
 	ginkgo.It("should work after the service has been recreated", func(ctx context.Context) {
@@ -1176,16 +1176,16 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("creating the service " + serviceName + " in namespace " + ns)
 		ginkgo.DeferCleanup(StopServeHostnameService, f.ClientSet, ns, serviceName)
-		podNames, svcIP, _ := StartServeHostnameService(cs, getServeHostnameService(serviceName), ns, numPods)
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames, svcIP, servicePort))
+		podNames, svcIP, _ := StartServeHostnameService(ctx, cs, getServeHostnameService(serviceName), ns, numPods)
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames, svcIP, servicePort))
 
 		ginkgo.By("deleting the service " + serviceName + " in namespace " + ns)
-		err := cs.CoreV1().Services(ns).Delete(context.TODO(), serviceName, metav1.DeleteOptions{})
+		err := cs.CoreV1().Services(ns).Delete(ctx, serviceName, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Waiting for the service " + serviceName + " in namespace " + ns + " to disappear")
 		if pollErr := wait.PollImmediate(framework.Poll, e2eservice.RespondingTimeout, func() (bool, error) {
-			_, err := cs.CoreV1().Services(ns).Get(context.TODO(), serviceName, metav1.GetOptions{})
+			_, err := cs.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					framework.Logf("Service %s/%s is gone.", ns, serviceName)
@@ -1200,14 +1200,14 @@ var _ = common.SIGDescribe("Services", func() {
 		}
 
 		ginkgo.By("recreating the service " + serviceName + " in namespace " + ns)
-		svc, err := cs.CoreV1().Services(ns).Create(context.TODO(), getServeHostnameService(serviceName), metav1.CreateOptions{})
+		svc, err := cs.CoreV1().Services(ns).Create(ctx, getServeHostnameService(serviceName), metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames, svc.Spec.ClusterIP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames, svc.Spec.ClusterIP, servicePort))
 	})
 
 	ginkgo.It("should work after restarting kube-proxy [Disruptive]", func(ctx context.Context) {
 		kubeProxyLabelSet := map[string]string{clusterAddonLabelKey: kubeProxyLabelName}
-		e2eskipper.SkipUnlessComponentRunsAsPodsAndClientCanDeleteThem(kubeProxyLabelName, cs, metav1.NamespaceSystem, kubeProxyLabelSet)
+		e2eskipper.SkipUnlessComponentRunsAsPodsAndClientCanDeleteThem(ctx, kubeProxyLabelName, cs, metav1.NamespaceSystem, kubeProxyLabelSet)
 
 		// TODO: use the ServiceTestJig here
 		ns := f.Namespace.Name
@@ -1217,31 +1217,31 @@ var _ = common.SIGDescribe("Services", func() {
 		svc2 := "restart-proxy-2"
 
 		ginkgo.DeferCleanup(StopServeHostnameService, f.ClientSet, ns, svc1)
-		podNames1, svc1IP, err := StartServeHostnameService(cs, getServeHostnameService(svc1), ns, numPods)
+		podNames1, svc1IP, err := StartServeHostnameService(ctx, cs, getServeHostnameService(svc1), ns, numPods)
 		framework.ExpectNoError(err, "failed to create replication controller with service: %s in the namespace: %s", svc1, ns)
 
 		ginkgo.DeferCleanup(StopServeHostnameService, f.ClientSet, ns, svc2)
-		podNames2, svc2IP, err := StartServeHostnameService(cs, getServeHostnameService(svc2), ns, numPods)
+		podNames2, svc2IP, err := StartServeHostnameService(ctx, cs, getServeHostnameService(svc2), ns, numPods)
 		framework.ExpectNoError(err, "failed to create replication controller with service: %s in the namespace: %s", svc2, ns)
 
 		if svc1IP == svc2IP {
 			framework.Failf("VIPs conflict: %v", svc1IP)
 		}
 
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames1, svc1IP, servicePort))
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames2, svc2IP, servicePort))
 
-		if err := restartComponent(cs, kubeProxyLabelName, metav1.NamespaceSystem, kubeProxyLabelSet); err != nil {
+		if err := restartComponent(ctx, cs, kubeProxyLabelName, metav1.NamespaceSystem, kubeProxyLabelSet); err != nil {
 			framework.Failf("error restarting kube-proxy: %v", err)
 		}
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames1, svc1IP, servicePort))
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames2, svc2IP, servicePort))
 	})
 
 	ginkgo.It("should work after restarting apiserver [Disruptive]", func(ctx context.Context) {
 
 		if !framework.ProviderIs("gke") {
-			e2eskipper.SkipUnlessComponentRunsAsPodsAndClientCanDeleteThem(kubeAPIServerLabelName, cs, metav1.NamespaceSystem, map[string]string{clusterComponentKey: kubeAPIServerLabelName})
+			e2eskipper.SkipUnlessComponentRunsAsPodsAndClientCanDeleteThem(ctx, kubeAPIServerLabelName, cs, metav1.NamespaceSystem, map[string]string{clusterComponentKey: kubeAPIServerLabelName})
 		}
 
 		// TODO: use the ServiceTestJig here
@@ -1252,32 +1252,32 @@ var _ = common.SIGDescribe("Services", func() {
 		svc2 := "restart-apiserver-2"
 
 		ginkgo.DeferCleanup(StopServeHostnameService, f.ClientSet, ns, svc1)
-		podNames1, svc1IP, err := StartServeHostnameService(cs, getServeHostnameService(svc1), ns, numPods)
+		podNames1, svc1IP, err := StartServeHostnameService(ctx, cs, getServeHostnameService(svc1), ns, numPods)
 		framework.ExpectNoError(err, "failed to create replication controller with service: %s in the namespace: %s", svc1, ns)
 
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames1, svc1IP, servicePort))
 
 		// Restart apiserver
 		ginkgo.By("Restarting apiserver")
-		if err := restartApiserver(ns, cs); err != nil {
+		if err := restartApiserver(ctx, ns, cs); err != nil {
 			framework.Failf("error restarting apiserver: %v", err)
 		}
 		ginkgo.By("Waiting for apiserver to come up by polling /healthz")
-		if err := waitForAPIServerUp(cs); err != nil {
+		if err := waitForAPIServerUp(ctx, cs); err != nil {
 			framework.Failf("error while waiting for apiserver up: %v", err)
 		}
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames1, svc1IP, servicePort))
 
 		// Create a new service and check if it's not reusing IP.
 		ginkgo.DeferCleanup(StopServeHostnameService, f.ClientSet, ns, svc2)
-		podNames2, svc2IP, err := StartServeHostnameService(cs, getServeHostnameService(svc2), ns, numPods)
+		podNames2, svc2IP, err := StartServeHostnameService(ctx, cs, getServeHostnameService(svc2), ns, numPods)
 		framework.ExpectNoError(err, "failed to create replication controller with service: %s in the namespace: %s", svc2, ns)
 
 		if svc1IP == svc2IP {
 			framework.Failf("VIPs conflict: %v", svc1IP)
 		}
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames1, svc1IP, servicePort))
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podNames2, svc2IP, servicePort))
 	})
 
 	/*
@@ -1294,17 +1294,17 @@ var _ = common.SIGDescribe("Services", func() {
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 
 		ginkgo.By("creating service " + serviceName + " with type=NodePort in namespace " + ns)
-		nodePortService, err := jig.CreateTCPService(func(svc *v1.Service) {
+		nodePortService, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeNodePort
 			svc.Spec.Ports = []v1.ServicePort{
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(9376)},
 			}
 		})
 		framework.ExpectNoError(err)
-		err = jig.CreateServicePods(2)
+		err = jig.CreateServicePods(ctx, 2)
 		framework.ExpectNoError(err)
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
-		err = jig.CheckServiceReachability(nodePortService, execPod)
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
+		err = jig.CheckServiceReachability(ctx, nodePortService, execPod)
 		framework.ExpectNoError(err)
 	})
 
@@ -1325,7 +1325,7 @@ var _ = common.SIGDescribe("Services", func() {
 		jig.ExternalIPs = true
 
 		ginkgo.By("creating service " + serviceName + " with type=clusterIP in namespace " + ns)
-		clusterIPService, err := jig.CreateTCPService(func(svc *v1.Service) {
+		clusterIPService, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.ExternalIPs = []string{externalIP}
 			svc.Spec.Ports = []v1.ServicePort{
@@ -1336,10 +1336,10 @@ var _ = common.SIGDescribe("Services", func() {
 			e2eskipper.Skipf("Admission controller to deny services with external IPs is enabled - skip.")
 		}
 		framework.ExpectNoError(err)
-		err = jig.CreateServicePods(2)
+		err = jig.CreateServicePods(ctx, 2)
 		framework.ExpectNoError(err)
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
-		err = jig.CheckServiceReachability(clusterIPService, execPod)
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
+		err = jig.CheckServiceReachability(ctx, clusterIPService, execPod)
 		framework.ExpectNoError(err)
 	})
 
@@ -1357,7 +1357,7 @@ var _ = common.SIGDescribe("Services", func() {
 		jig.ExternalIPs = true
 
 		ginkgo.By("creating a TCP service " + serviceName + " with type=ClusterIP in namespace " + ns)
-		tcpService, err := jig.CreateTCPService(nil)
+		tcpService, err := jig.CreateTCPService(ctx, nil)
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			framework.Logf("Cleaning up the updating NodePorts test service")
@@ -1367,7 +1367,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.Logf("Service Port TCP: %v", tcpService.Spec.Ports[0].Port)
 
 		ginkgo.By("changing the TCP service to type=NodePort")
-		nodePortService, err := jig.UpdateService(func(s *v1.Service) {
+		nodePortService, err := jig.UpdateService(ctx, func(s *v1.Service) {
 			s.Spec.Type = v1.ServiceTypeNodePort
 			s.Spec.Ports = []v1.ServicePort{
 				{
@@ -1380,14 +1380,14 @@ var _ = common.SIGDescribe("Services", func() {
 		})
 		framework.ExpectNoError(err)
 
-		err = jig.CreateServicePods(2)
+		err = jig.CreateServicePods(ctx, 2)
 		framework.ExpectNoError(err)
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
-		err = jig.CheckServiceReachability(nodePortService, execPod)
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
+		err = jig.CheckServiceReachability(ctx, nodePortService, execPod)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Updating NodePort service to listen TCP and UDP based requests over same Port")
-		nodePortService, err = jig.UpdateService(func(s *v1.Service) {
+		nodePortService, err = jig.UpdateService(ctx, func(s *v1.Service) {
 			s.Spec.Type = v1.ServiceTypeNodePort
 			s.Spec.Ports = []v1.ServicePort{
 				{
@@ -1405,7 +1405,7 @@ var _ = common.SIGDescribe("Services", func() {
 			}
 		})
 		framework.ExpectNoError(err)
-		err = jig.CheckServiceReachability(nodePortService, execPod)
+		err = jig.CheckServiceReachability(ctx, nodePortService, execPod)
 		framework.ExpectNoError(err)
 		nodePortCounts := len(nodePortService.Spec.Ports)
 		framework.ExpectEqual(nodePortCounts, 2, "updated service should have two Ports but found %d Ports", nodePortCounts)
@@ -1429,7 +1429,7 @@ var _ = common.SIGDescribe("Services", func() {
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 
 		ginkgo.By("creating a service " + serviceName + " with the type=ExternalName in namespace " + ns)
-		_, err := jig.CreateExternalNameService(nil)
+		_, err := jig.CreateExternalNameService(ctx, nil)
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			framework.Logf("Cleaning up the ExternalName to ClusterIP test service")
@@ -1438,7 +1438,7 @@ var _ = common.SIGDescribe("Services", func() {
 		})
 
 		ginkgo.By("changing the ExternalName service to type=ClusterIP")
-		clusterIPService, err := jig.UpdateService(func(s *v1.Service) {
+		clusterIPService, err := jig.UpdateService(ctx, func(s *v1.Service) {
 			s.Spec.Type = v1.ServiceTypeClusterIP
 			s.Spec.ExternalName = ""
 			s.Spec.Ports = []v1.ServicePort{
@@ -1447,10 +1447,10 @@ var _ = common.SIGDescribe("Services", func() {
 		})
 		framework.ExpectNoError(err)
 
-		err = jig.CreateServicePods(2)
+		err = jig.CreateServicePods(ctx, 2)
 		framework.ExpectNoError(err)
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
-		err = jig.CheckServiceReachability(clusterIPService, execPod)
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
+		err = jig.CheckServiceReachability(ctx, clusterIPService, execPod)
 		framework.ExpectNoError(err)
 	})
 
@@ -1468,7 +1468,7 @@ var _ = common.SIGDescribe("Services", func() {
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 
 		ginkgo.By("creating a service " + serviceName + " with the type=ExternalName in namespace " + ns)
-		_, err := jig.CreateExternalNameService(nil)
+		_, err := jig.CreateExternalNameService(ctx, nil)
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			framework.Logf("Cleaning up the ExternalName to NodePort test service")
@@ -1477,7 +1477,7 @@ var _ = common.SIGDescribe("Services", func() {
 		})
 
 		ginkgo.By("changing the ExternalName service to type=NodePort")
-		nodePortService, err := jig.UpdateService(func(s *v1.Service) {
+		nodePortService, err := jig.UpdateService(ctx, func(s *v1.Service) {
 			s.Spec.Type = v1.ServiceTypeNodePort
 			s.Spec.ExternalName = ""
 			s.Spec.Ports = []v1.ServicePort{
@@ -1485,11 +1485,11 @@ var _ = common.SIGDescribe("Services", func() {
 			}
 		})
 		framework.ExpectNoError(err)
-		err = jig.CreateServicePods(2)
+		err = jig.CreateServicePods(ctx, 2)
 		framework.ExpectNoError(err)
 
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
-		err = jig.CheckServiceReachability(nodePortService, execPod)
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
+		err = jig.CheckServiceReachability(ctx, nodePortService, execPod)
 		framework.ExpectNoError(err)
 	})
 
@@ -1506,7 +1506,7 @@ var _ = common.SIGDescribe("Services", func() {
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 
 		ginkgo.By("creating a service " + serviceName + " with the type=ClusterIP in namespace " + ns)
-		_, err := jig.CreateTCPService(nil)
+		_, err := jig.CreateTCPService(ctx, nil)
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			framework.Logf("Cleaning up the ClusterIP to ExternalName test service")
@@ -1516,11 +1516,11 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("Creating active service to test reachability when its FQDN is referred as externalName for another service")
 		externalServiceName := "externalsvc"
-		externalServiceFQDN := createAndGetExternalServiceFQDN(cs, ns, externalServiceName)
+		externalServiceFQDN := createAndGetExternalServiceFQDN(ctx, cs, ns, externalServiceName)
 		ginkgo.DeferCleanup(StopServeHostnameService, f.ClientSet, ns, externalServiceName)
 
 		ginkgo.By("changing the ClusterIP service to type=ExternalName")
-		externalNameService, err := jig.UpdateService(func(s *v1.Service) {
+		externalNameService, err := jig.UpdateService(ctx, func(s *v1.Service) {
 			s.Spec.Type = v1.ServiceTypeExternalName
 			s.Spec.ExternalName = externalServiceFQDN
 		})
@@ -1528,8 +1528,8 @@ var _ = common.SIGDescribe("Services", func() {
 		if externalNameService.Spec.ClusterIP != "" {
 			framework.Failf("Spec.ClusterIP was not cleared")
 		}
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
-		err = jig.CheckServiceReachability(externalNameService, execPod)
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
+		err = jig.CheckServiceReachability(ctx, externalNameService, execPod)
 		framework.ExpectNoError(err)
 	})
 
@@ -1546,7 +1546,7 @@ var _ = common.SIGDescribe("Services", func() {
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 
 		ginkgo.By("creating a service " + serviceName + " with the type=NodePort in namespace " + ns)
-		_, err := jig.CreateTCPService(func(svc *v1.Service) {
+		_, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeNodePort
 		})
 		framework.ExpectNoError(err)
@@ -1558,11 +1558,11 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("Creating active service to test reachability when its FQDN is referred as externalName for another service")
 		externalServiceName := "externalsvc"
-		externalServiceFQDN := createAndGetExternalServiceFQDN(cs, ns, externalServiceName)
+		externalServiceFQDN := createAndGetExternalServiceFQDN(ctx, cs, ns, externalServiceName)
 		ginkgo.DeferCleanup(StopServeHostnameService, f.ClientSet, ns, externalServiceName)
 
 		ginkgo.By("changing the NodePort service to type=ExternalName")
-		externalNameService, err := jig.UpdateService(func(s *v1.Service) {
+		externalNameService, err := jig.UpdateService(ctx, func(s *v1.Service) {
 			s.Spec.Type = v1.ServiceTypeExternalName
 			s.Spec.ExternalName = externalServiceFQDN
 		})
@@ -1570,8 +1570,8 @@ var _ = common.SIGDescribe("Services", func() {
 		if externalNameService.Spec.ClusterIP != "" {
 			framework.Failf("Spec.ClusterIP was not cleared")
 		}
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
-		err = jig.CheckServiceReachability(externalNameService, execPod)
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
+		err = jig.CheckServiceReachability(ctx, externalNameService, execPod)
 		framework.ExpectNoError(err)
 	})
 
@@ -1672,7 +1672,7 @@ var _ = common.SIGDescribe("Services", func() {
 			}
 		}
 		ginkgo.By(fmt.Sprintf("changing service "+serviceName+" to out-of-range NodePort %d", outOfRangeNodePort))
-		result, err := e2eservice.UpdateService(cs, ns, serviceName, func(s *v1.Service) {
+		result, err := e2eservice.UpdateService(ctx, cs, ns, serviceName, func(s *v1.Service) {
 			s.Spec.Ports[0].NodePort = int32(outOfRangeNodePort)
 		})
 		if err == nil {
@@ -1736,7 +1736,7 @@ var _ = common.SIGDescribe("Services", func() {
 		err = t.DeleteService(serviceName)
 		framework.ExpectNoError(err, "failed to delete service: %s in namespace: %s", serviceName, ns)
 
-		hostExec := launchHostExecPod(f.ClientSet, f.Namespace.Name, "hostexec")
+		hostExec := launchHostExecPod(ctx, f.ClientSet, f.Namespace.Name, "hostexec")
 		cmd := fmt.Sprintf(`! ss -ant46 'sport = :%d' | tail -n +2 | grep LISTEN`, nodePort)
 		var stdout string
 		if pollErr := wait.PollImmediate(framework.Poll, e2eservice.KubeProxyLagTimeout, func() (bool, error) {
@@ -1823,16 +1823,16 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Verifying pods for RC " + t.Name)
-		framework.ExpectNoError(e2epod.VerifyPods(t.Client, t.Namespace, t.Name, false, 1))
+		framework.ExpectNoError(e2epod.VerifyPods(ctx, t.Client, t.Namespace, t.Name, false, 1))
 
 		svcName := fmt.Sprintf("%v.%v.svc.%v", serviceName, f.Namespace.Name, framework.TestContext.ClusterDNSDomain)
 		ginkgo.By("Waiting for endpoints of Service with DNS name " + svcName)
 
-		execPod := e2epod.CreateExecPodOrFail(f.ClientSet, f.Namespace.Name, "execpod-", nil)
+		execPod := e2epod.CreateExecPodOrFail(ctx, f.ClientSet, f.Namespace.Name, "execpod-", nil)
 		execPodName := execPod.Name
 		cmd := fmt.Sprintf("curl -q -s --connect-timeout 2 http://%s:%d/", svcName, port)
 		var stdout string
-		if pollErr := wait.PollImmediate(framework.Poll, e2eservice.KubeProxyLagTimeout, func() (bool, error) {
+		if pollErr := wait.PollImmediateWithContext(ctx, framework.Poll, e2eservice.KubeProxyLagTimeout, func(ctx context.Context) (bool, error) {
 			var err error
 			stdout, err = e2eoutput.RunHostCmd(f.Namespace.Name, execPodName, cmd)
 			if err != nil {
@@ -1845,10 +1845,10 @@ var _ = common.SIGDescribe("Services", func() {
 		}
 
 		ginkgo.By("Scaling down replication controller to zero")
-		e2erc.ScaleRC(f.ClientSet, f.ScalesGetter, t.Namespace, rcSpec.Name, 0, false)
+		e2erc.ScaleRC(ctx, f.ClientSet, f.ScalesGetter, t.Namespace, rcSpec.Name, 0, false)
 
 		ginkgo.By("Update service to not tolerate unready services")
-		_, err = e2eservice.UpdateService(f.ClientSet, t.Namespace, t.ServiceName, func(s *v1.Service) {
+		_, err = e2eservice.UpdateService(ctx, f.ClientSet, t.Namespace, t.ServiceName, func(s *v1.Service) {
 			s.Spec.PublishNotReadyAddresses = false
 		})
 		framework.ExpectNoError(err)
@@ -1868,7 +1868,7 @@ var _ = common.SIGDescribe("Services", func() {
 		}
 
 		ginkgo.By("Update service to tolerate unready services again")
-		_, err = e2eservice.UpdateService(f.ClientSet, t.Namespace, t.ServiceName, func(s *v1.Service) {
+		_, err = e2eservice.UpdateService(ctx, f.ClientSet, t.Namespace, t.ServiceName, func(s *v1.Service) {
 			s.Spec.PublishNotReadyAddresses = true
 		})
 		framework.ExpectNoError(err)
@@ -1891,13 +1891,13 @@ var _ = common.SIGDescribe("Services", func() {
 		label := labels.SelectorFromSet(labels.Set(t.Labels))
 		options := metav1.ListOptions{LabelSelector: label.String()}
 		podClient := t.Client.CoreV1().Pods(f.Namespace.Name)
-		pods, err := podClient.List(context.TODO(), options)
+		pods, err := podClient.List(ctx, options)
 		if err != nil {
 			framework.Logf("warning: error retrieving pods: %s", err)
 		} else {
 			for _, pod := range pods.Items {
 				var gracePeriodSeconds int64 = 0
-				err := podClient.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriodSeconds})
+				err := podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriodSeconds})
 				if err != nil {
 					framework.Logf("warning: error force deleting pod '%s': %s", pod.Name, err)
 				}
@@ -1906,7 +1906,7 @@ var _ = common.SIGDescribe("Services", func() {
 	})
 
 	ginkgo.It("should be able to connect to terminating and unready endpoints if PublishNotReadyAddresses is true", func(ctx context.Context) {
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
 		framework.ExpectNoError(err)
 		nodeCounts := len(nodes.Items)
 		if nodeCounts < 2 {
@@ -1921,7 +1921,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("creating a NodePort TCP service " + serviceName + " that PublishNotReadyAddresses on" + ns)
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(80)},
 			}
@@ -1977,21 +1977,21 @@ var _ = common.SIGDescribe("Services", func() {
 		webserverPod0.Spec.TerminationGracePeriodSeconds = utilpointer.Int64(gracePeriod)
 		e2epod.SetNodeSelection(&webserverPod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Pods(ns).Create(ctx, webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create pod")
-		err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout)
+		err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout)
 		if err != nil {
 			framework.Failf("error waiting for pod %s to be ready %v", webserverPod0.Name, err)
 		}
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
 
 		ginkgo.By("Creating 1 pause pods that will try to connect to the webservers")
 		pausePod1 := e2epod.NewAgnhostPod(ns, "pause-pod-1", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod1.Spec, e2epod.NodeSelection{Name: node1.Name})
 
-		pausePod1, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod1, metav1.CreateOptions{})
+		pausePod1, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod1, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create pod")
-		err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout)
+		err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout)
 		if err != nil {
 			framework.Failf("error waiting for pod %s to be ready %v", pausePod1.Name, err)
 		}
@@ -1999,11 +1999,11 @@ var _ = common.SIGDescribe("Services", func() {
 		// webserver should continue to serve traffic through the Service after delete since:
 		//  - it has a 600s termination grace period
 		//  - it is unready but PublishNotReadyAddresses is true
-		err = cs.CoreV1().Pods(ns).Delete(context.TODO(), webserverPod0.Name, metav1.DeleteOptions{})
+		err = cs.CoreV1().Pods(ns).Delete(ctx, webserverPod0.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 
 		// Wait until the pod becomes unready
-		err = e2epod.WaitForPodCondition(f.ClientSet, f.Namespace.Name, webserverPod0.Name, "pod not ready", framework.PodStartTimeout, func(pod *v1.Pod) (bool, error) {
+		err = e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, webserverPod0.Name, "pod not ready", framework.PodStartTimeout, func(pod *v1.Pod) (bool, error) {
 			return !podutil.IsPodReady(pod), nil
 		})
 		if err != nil {
@@ -2025,7 +2025,7 @@ var _ = common.SIGDescribe("Services", func() {
 	})
 
 	ginkgo.It("should not be able to connect to terminating and unready endpoints if PublishNotReadyAddresses is false", func(ctx context.Context) {
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
 		framework.ExpectNoError(err)
 		nodeCounts := len(nodes.Items)
 		if nodeCounts < 2 {
@@ -2040,7 +2040,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("creating a NodePort TCP service " + serviceName + " that PublishNotReadyAddresses on" + ns)
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(80)},
 			}
@@ -2096,21 +2096,21 @@ var _ = common.SIGDescribe("Services", func() {
 		webserverPod0.Spec.TerminationGracePeriodSeconds = utilpointer.Int64(gracePeriod)
 		e2epod.SetNodeSelection(&webserverPod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Pods(ns).Create(ctx, webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create pod")
-		err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout)
+		err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout)
 		if err != nil {
 			framework.Failf("error waiting for pod %s to be ready %v", webserverPod0.Name, err)
 		}
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
 
 		ginkgo.By("Creating 1 pause pods that will try to connect to the webservers")
 		pausePod1 := e2epod.NewAgnhostPod(ns, "pause-pod-1", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod1.Spec, e2epod.NodeSelection{Name: node1.Name})
 
-		pausePod1, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod1, metav1.CreateOptions{})
+		pausePod1, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod1, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create pod")
-		err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout)
+		err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout)
 		if err != nil {
 			framework.Failf("error waiting for pod %s to be ready %v", pausePod1.Name, err)
 		}
@@ -2118,11 +2118,11 @@ var _ = common.SIGDescribe("Services", func() {
 		// webserver should stop to serve traffic through the Service after delete since:
 		//  - it has a 600s termination grace period
 		//  - it is unready but PublishNotReadyAddresses is false
-		err = cs.CoreV1().Pods(ns).Delete(context.TODO(), webserverPod0.Name, metav1.DeleteOptions{})
+		err = cs.CoreV1().Pods(ns).Delete(ctx, webserverPod0.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 
 		// Wait until the pod becomes unready
-		err = e2epod.WaitForPodCondition(f.ClientSet, f.Namespace.Name, webserverPod0.Name, "pod not ready", framework.PodStartTimeout, func(pod *v1.Pod) (bool, error) {
+		err = e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, webserverPod0.Name, "pod not ready", framework.PodStartTimeout, func(pod *v1.Pod) (bool, error) {
 			return !podutil.IsPodReady(pod), nil
 		})
 		if err != nil {
@@ -2175,13 +2175,13 @@ var _ = common.SIGDescribe("Services", func() {
 	framework.ConformanceIt("should have session affinity work for service with type clusterIP [LinuxOnly]", func(ctx context.Context) {
 		svc := getServeHostnameService("affinity-clusterip")
 		svc.Spec.Type = v1.ServiceTypeClusterIP
-		execAffinityTestForNonLBService(f, cs, svc)
+		execAffinityTestForNonLBService(ctx, f, cs, svc)
 	})
 
 	ginkgo.It("should have session affinity timeout work for service with type clusterIP [LinuxOnly]", func(ctx context.Context) {
 		svc := getServeHostnameService("affinity-clusterip-timeout")
 		svc.Spec.Type = v1.ServiceTypeClusterIP
-		execAffinityTestForSessionAffinityTimeout(f, cs, svc)
+		execAffinityTestForSessionAffinityTimeout(ctx, f, cs, svc)
 	})
 
 	/*
@@ -2197,7 +2197,7 @@ var _ = common.SIGDescribe("Services", func() {
 	framework.ConformanceIt("should be able to switch session affinity for service with type clusterIP [LinuxOnly]", func(ctx context.Context) {
 		svc := getServeHostnameService("affinity-clusterip-transition")
 		svc.Spec.Type = v1.ServiceTypeClusterIP
-		execAffinityTestForNonLBServiceWithTransition(f, cs, svc)
+		execAffinityTestForNonLBServiceWithTransition(ctx, f, cs, svc)
 	})
 
 	/*
@@ -2212,13 +2212,13 @@ var _ = common.SIGDescribe("Services", func() {
 	framework.ConformanceIt("should have session affinity work for NodePort service [LinuxOnly]", func(ctx context.Context) {
 		svc := getServeHostnameService("affinity-nodeport")
 		svc.Spec.Type = v1.ServiceTypeNodePort
-		execAffinityTestForNonLBService(f, cs, svc)
+		execAffinityTestForNonLBService(ctx, f, cs, svc)
 	})
 
 	ginkgo.It("should have session affinity timeout work for NodePort service [LinuxOnly]", func(ctx context.Context) {
 		svc := getServeHostnameService("affinity-nodeport-timeout")
 		svc.Spec.Type = v1.ServiceTypeNodePort
-		execAffinityTestForSessionAffinityTimeout(f, cs, svc)
+		execAffinityTestForSessionAffinityTimeout(ctx, f, cs, svc)
 	})
 
 	/*
@@ -2234,7 +2234,7 @@ var _ = common.SIGDescribe("Services", func() {
 	framework.ConformanceIt("should be able to switch session affinity for NodePort service [LinuxOnly]", func(ctx context.Context) {
 		svc := getServeHostnameService("affinity-nodeport-transition")
 		svc.Spec.Type = v1.ServiceTypeNodePort
-		execAffinityTestForNonLBServiceWithTransition(f, cs, svc)
+		execAffinityTestForNonLBServiceWithTransition(ctx, f, cs, svc)
 	})
 
 	ginkgo.It("should implement service.kubernetes.io/service-proxy-name", func(ctx context.Context) {
@@ -2250,42 +2250,42 @@ var _ = common.SIGDescribe("Services", func() {
 		ginkgo.By("creating service-disabled in namespace " + ns)
 		svcDisabled := getServeHostnameService("service-proxy-disabled")
 		svcDisabled.ObjectMeta.Labels = serviceProxyNameLabels
-		_, svcDisabledIP, err := StartServeHostnameService(cs, svcDisabled, ns, numPods)
+		_, svcDisabledIP, err := StartServeHostnameService(ctx, cs, svcDisabled, ns, numPods)
 		framework.ExpectNoError(err, "failed to create replication controller with service: %s in the namespace: %s", svcDisabledIP, ns)
 
 		ginkgo.By("creating service in namespace " + ns)
 		svcToggled := getServeHostnameService("service-proxy-toggled")
-		podToggledNames, svcToggledIP, err := StartServeHostnameService(cs, svcToggled, ns, numPods)
+		podToggledNames, svcToggledIP, err := StartServeHostnameService(ctx, cs, svcToggled, ns, numPods)
 		framework.ExpectNoError(err, "failed to create replication controller with service: %s in the namespace: %s", svcToggledIP, ns)
 
 		jig := e2eservice.NewTestJig(cs, ns, svcToggled.ObjectMeta.Name)
 
 		ginkgo.By("verifying service is up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podToggledNames, svcToggledIP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podToggledNames, svcToggledIP, servicePort))
 
 		ginkgo.By("verifying service-disabled is not up")
-		framework.ExpectNoError(verifyServeHostnameServiceDown(cs, ns, svcDisabledIP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceDown(ctx, cs, ns, svcDisabledIP, servicePort))
 
 		ginkgo.By("adding service-proxy-name label")
-		_, err = jig.UpdateService(func(svc *v1.Service) {
+		_, err = jig.UpdateService(ctx, func(svc *v1.Service) {
 			svc.ObjectMeta.Labels = serviceProxyNameLabels
 		})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("verifying service is not up")
-		framework.ExpectNoError(verifyServeHostnameServiceDown(cs, ns, svcToggledIP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceDown(ctx, cs, ns, svcToggledIP, servicePort))
 
 		ginkgo.By("removing service-proxy-name annotation")
-		_, err = jig.UpdateService(func(svc *v1.Service) {
+		_, err = jig.UpdateService(ctx, func(svc *v1.Service) {
 			svc.ObjectMeta.Labels = nil
 		})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("verifying service is up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podToggledNames, svcToggledIP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podToggledNames, svcToggledIP, servicePort))
 
 		ginkgo.By("verifying service-disabled is still not up")
-		framework.ExpectNoError(verifyServeHostnameServiceDown(cs, ns, svcDisabledIP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceDown(ctx, cs, ns, svcDisabledIP, servicePort))
 	})
 
 	ginkgo.It("should implement service.kubernetes.io/headless", func(ctx context.Context) {
@@ -2302,61 +2302,61 @@ var _ = common.SIGDescribe("Services", func() {
 		svcHeadless := getServeHostnameService("service-headless")
 		svcHeadless.ObjectMeta.Labels = serviceHeadlessLabels
 		// This should be improved, as we do not want a Headlesss Service to contain an IP...
-		_, svcHeadlessIP, err := StartServeHostnameService(cs, svcHeadless, ns, numPods)
+		_, svcHeadlessIP, err := StartServeHostnameService(ctx, cs, svcHeadless, ns, numPods)
 		framework.ExpectNoError(err, "failed to create replication controller with headless service: %s in the namespace: %s", svcHeadlessIP, ns)
 
 		ginkgo.By("creating service in namespace " + ns)
 		svcHeadlessToggled := getServeHostnameService("service-headless-toggled")
-		podHeadlessToggledNames, svcHeadlessToggledIP, err := StartServeHostnameService(cs, svcHeadlessToggled, ns, numPods)
+		podHeadlessToggledNames, svcHeadlessToggledIP, err := StartServeHostnameService(ctx, cs, svcHeadlessToggled, ns, numPods)
 		framework.ExpectNoError(err, "failed to create replication controller with service: %s in the namespace: %s", svcHeadlessToggledIP, ns)
 
 		jig := e2eservice.NewTestJig(cs, ns, svcHeadlessToggled.ObjectMeta.Name)
 
 		ginkgo.By("verifying service is up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podHeadlessToggledNames, svcHeadlessToggledIP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podHeadlessToggledNames, svcHeadlessToggledIP, servicePort))
 
 		ginkgo.By("verifying service-headless is not up")
-		framework.ExpectNoError(verifyServeHostnameServiceDown(cs, ns, svcHeadlessIP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceDown(ctx, cs, ns, svcHeadlessIP, servicePort))
 
 		ginkgo.By("adding service.kubernetes.io/headless label")
-		_, err = jig.UpdateService(func(svc *v1.Service) {
+		_, err = jig.UpdateService(ctx, func(svc *v1.Service) {
 			svc.ObjectMeta.Labels = serviceHeadlessLabels
 		})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("verifying service is not up")
-		framework.ExpectNoError(verifyServeHostnameServiceDown(cs, ns, svcHeadlessToggledIP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceDown(ctx, cs, ns, svcHeadlessToggledIP, servicePort))
 
 		ginkgo.By("removing service.kubernetes.io/headless annotation")
-		_, err = jig.UpdateService(func(svc *v1.Service) {
+		_, err = jig.UpdateService(ctx, func(svc *v1.Service) {
 			svc.ObjectMeta.Labels = nil
 		})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("verifying service is up")
-		framework.ExpectNoError(verifyServeHostnameServiceUp(cs, ns, podHeadlessToggledNames, svcHeadlessToggledIP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, cs, ns, podHeadlessToggledNames, svcHeadlessToggledIP, servicePort))
 
 		ginkgo.By("verifying service-headless is still not up")
-		framework.ExpectNoError(verifyServeHostnameServiceDown(cs, ns, svcHeadlessIP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceDown(ctx, cs, ns, svcHeadlessIP, servicePort))
 	})
 
 	ginkgo.It("should be rejected when no endpoints exist", func(ctx context.Context) {
 		namespace := f.Namespace.Name
 		serviceName := "no-pods"
 		jig := e2eservice.NewTestJig(cs, namespace, serviceName)
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, e2eservice.MaxNodesForEndpointsTests)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, e2eservice.MaxNodesForEndpointsTests)
 		framework.ExpectNoError(err)
 		port := 80
 
 		ginkgo.By("creating a service with no endpoints")
-		_, err = jig.CreateTCPServiceWithPort(nil, int32(port))
+		_, err = jig.CreateTCPServiceWithPort(ctx, nil, int32(port))
 		framework.ExpectNoError(err)
 
 		nodeName := nodes.Items[0].Name
 		podName := "execpod-noendpoints"
 
 		ginkgo.By(fmt.Sprintf("creating %v on node %v", podName, nodeName))
-		execPod := e2epod.CreateExecPodOrFail(f.ClientSet, namespace, podName, func(pod *v1.Pod) {
+		execPod := e2epod.CreateExecPodOrFail(ctx, f.ClientSet, namespace, podName, func(pod *v1.Pod) {
 			nodeSelection := e2epod.NodeSelection{Name: nodeName}
 			e2epod.SetNodeSelection(&pod.Spec, nodeSelection)
 		})
@@ -2389,14 +2389,14 @@ var _ = common.SIGDescribe("Services", func() {
 		namespace := f.Namespace.Name
 		serviceName := "evicted-pods"
 		jig := e2eservice.NewTestJig(cs, namespace, serviceName)
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, e2eservice.MaxNodesForEndpointsTests)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, e2eservice.MaxNodesForEndpointsTests)
 		framework.ExpectNoError(err)
 		nodeName := nodes.Items[0].Name
 
 		port := 80
 
 		ginkgo.By("creating a service with no endpoints")
-		_, err = jig.CreateTCPServiceWithPort(func(s *v1.Service) {
+		_, err = jig.CreateTCPServiceWithPort(ctx, func(s *v1.Service) {
 			// set publish not ready addresses to cover edge cases too
 			s.Spec.PublishNotReadyAddresses = true
 		}, int32(port))
@@ -2410,21 +2410,21 @@ var _ = common.SIGDescribe("Services", func() {
 		evictedPod.Spec.Containers[0].Resources = v1.ResourceRequirements{
 			Limits: v1.ResourceList{"ephemeral-storage": resource.MustParse("5Mi")},
 		}
-		e2epod.NewPodClient(f).Create(evictedPod)
-		err = e2epod.WaitForPodTerminatedInNamespace(f.ClientSet, evictedPod.Name, "Evicted", f.Namespace.Name)
+		e2epod.NewPodClient(f).Create(ctx, evictedPod)
+		err = e2epod.WaitForPodTerminatedInNamespace(ctx, f.ClientSet, evictedPod.Name, "Evicted", f.Namespace.Name)
 		if err != nil {
 			framework.Failf("error waiting for pod to be evicted: %v", err)
 		}
 
 		podName := "execpod-evictedpods"
 		ginkgo.By(fmt.Sprintf("creating %v on node %v", podName, nodeName))
-		execPod := e2epod.CreateExecPodOrFail(f.ClientSet, namespace, podName, func(pod *v1.Pod) {
+		execPod := e2epod.CreateExecPodOrFail(ctx, f.ClientSet, namespace, podName, func(pod *v1.Pod) {
 			nodeSelection := e2epod.NodeSelection{Name: nodeName}
 			e2epod.SetNodeSelection(&pod.Spec, nodeSelection)
 		})
 
 		if epErr := wait.PollImmediate(framework.Poll, e2eservice.ServiceEndpointsTimeout, func() (bool, error) {
-			endpoints, err := cs.CoreV1().Endpoints(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
+			endpoints, err := cs.CoreV1().Endpoints(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 			if err != nil {
 				framework.Logf("error fetching '%s/%s' Endpoints: %s", namespace, serviceName, err.Error())
 				return false, err
@@ -2433,7 +2433,7 @@ var _ = common.SIGDescribe("Services", func() {
 				framework.Logf("expected '%s/%s' Endpoints to be empty, got: %v", namespace, serviceName, endpoints.Subsets)
 				return false, nil
 			}
-			epsList, err := cs.DiscoveryV1().EndpointSlices(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", discoveryv1.LabelServiceName, serviceName)})
+			epsList, err := cs.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", discoveryv1.LabelServiceName, serviceName)})
 			if err != nil {
 				framework.Logf("error fetching '%s/%s' EndpointSlices: %s", namespace, serviceName, err.Error())
 				return false, err
@@ -2482,7 +2482,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		// This behavior is not supported if Kube-proxy is in "userspace" mode.
 		// So we check the kube-proxy mode and skip this test if that's the case.
-		if proxyMode, err := proxyMode(f); err == nil {
+		if proxyMode, err := proxyMode(ctx, f); err == nil {
 			if proxyMode == "userspace" {
 				e2eskipper.Skipf("The test doesn't work with kube-proxy in userspace mode")
 			}
@@ -2490,7 +2490,7 @@ var _ = common.SIGDescribe("Services", func() {
 			framework.Logf("Couldn't detect KubeProxy mode - test failure may be expected: %v", err)
 		}
 
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
 		framework.ExpectNoError(err)
 		nodeCounts := len(nodes.Items)
 		if nodeCounts < 2 {
@@ -2506,7 +2506,7 @@ var _ = common.SIGDescribe("Services", func() {
 		ginkgo.By("creating a TCP service " + serviceName + " with type=ClusterIP and internalTrafficPolicy=Local in namespace " + ns)
 		local := v1.ServiceInternalTrafficPolicyLocal
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(80)},
 			}
@@ -2519,26 +2519,26 @@ var _ = common.SIGDescribe("Services", func() {
 		webserverPod0.Labels = jig.Labels
 		e2epod.SetNodeSelection(&webserverPod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Pods(ns).Create(ctx, webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webservers")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		pausePod0, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod0, metav1.CreateOptions{})
+		pausePod0, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		pausePod1 := e2epod.NewAgnhostPod(ns, "pause-pod-1", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod1.Spec, e2epod.NodeSelection{Name: node1.Name})
 
-		pausePod1, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod1, metav1.CreateOptions{})
+		pausePod1, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod1, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		// assert 5 times that the first pause pod can connect to the Service locally and the second one errors with a timeout
 		serviceAddress := net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(servicePort))
@@ -2560,7 +2560,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		// This behavior is not supported if Kube-proxy is in "userspace" mode.
 		// So we check the kube-proxy mode and skip this test if that's the case.
-		if proxyMode, err := proxyMode(f); err == nil {
+		if proxyMode, err := proxyMode(ctx, f); err == nil {
 			if proxyMode == "userspace" {
 				e2eskipper.Skipf("The test doesn't work with kube-proxy in userspace mode")
 			}
@@ -2568,7 +2568,7 @@ var _ = common.SIGDescribe("Services", func() {
 			framework.Logf("Couldn't detect KubeProxy mode - test failure may be expected: %v", err)
 		}
 
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
 		framework.ExpectNoError(err)
 		nodeCounts := len(nodes.Items)
 		if nodeCounts < 2 {
@@ -2584,7 +2584,7 @@ var _ = common.SIGDescribe("Services", func() {
 		ginkgo.By("creating a TCP service " + serviceName + " with type=ClusterIP and internalTrafficPolicy=Local in namespace " + ns)
 		local := v1.ServiceInternalTrafficPolicyLocal
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
 				{Port: 8000, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(8000)},
 			}
@@ -2597,28 +2597,28 @@ var _ = common.SIGDescribe("Services", func() {
 		webserverPod0.Labels = jig.Labels
 		e2epod.SetNodeSelection(&webserverPod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Pods(ns).Create(ctx, webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webservers")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
 		pausePod0.Spec.HostNetwork = true
 		e2epod.SetNodeSelection(&pausePod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		pausePod0, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod0, metav1.CreateOptions{})
+		pausePod0, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		pausePod1 := e2epod.NewAgnhostPod(ns, "pause-pod-1", nil, nil, nil)
 		pausePod1.Spec.HostNetwork = true
 		e2epod.SetNodeSelection(&pausePod1.Spec, e2epod.NodeSelection{Name: node1.Name})
 
-		pausePod1, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod1, metav1.CreateOptions{})
+		pausePod1, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod1, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		// assert 5 times that the first pause pod can connect to the Service locally and the second one errors with a timeout
 		serviceAddress := net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(servicePort))
@@ -2640,7 +2640,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		// This behavior is not supported if Kube-proxy is in "userspace" mode.
 		// So we check the kube-proxy mode and skip this test if that's the case.
-		if proxyMode, err := proxyMode(f); err == nil {
+		if proxyMode, err := proxyMode(ctx, f); err == nil {
 			if proxyMode == "userspace" {
 				e2eskipper.Skipf("The test doesn't work with kube-proxy in userspace mode")
 			}
@@ -2648,7 +2648,7 @@ var _ = common.SIGDescribe("Services", func() {
 			framework.Logf("Couldn't detect KubeProxy mode - test failure may be expected: %v", err)
 		}
 
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
 		framework.ExpectNoError(err)
 		nodeCounts := len(nodes.Items)
 		if nodeCounts < 2 {
@@ -2667,7 +2667,7 @@ var _ = common.SIGDescribe("Services", func() {
 		ginkgo.By("creating a TCP service " + serviceName + " with type=ClusterIP and internalTrafficPolicy=Local in namespace " + ns)
 		local := v1.ServiceInternalTrafficPolicyLocal
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(endpointPort)},
 			}
@@ -2681,26 +2681,26 @@ var _ = common.SIGDescribe("Services", func() {
 		webserverPod0.Spec.HostNetwork = true
 		e2epod.SetNodeSelection(&webserverPod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Pods(ns).Create(ctx, webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
 
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {endpointPort}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{webserverPod0.Name: {endpointPort}})
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webserver")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		pausePod0, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod0, metav1.CreateOptions{})
+		pausePod0, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		pausePod1 := e2epod.NewAgnhostPod(ns, "pause-pod-1", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod1.Spec, e2epod.NodeSelection{Name: node1.Name})
 
-		pausePod1, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod1, metav1.CreateOptions{})
+		pausePod1, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod1, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		// assert 5 times that the first pause pod can connect to the Service locally and the second one errors with a timeout
 		serviceAddress := net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(servicePort))
@@ -2720,17 +2720,17 @@ var _ = common.SIGDescribe("Services", func() {
 		pausePod2.Spec.HostNetwork = true
 		e2epod.SetNodeSelection(&pausePod2.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		pausePod2, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod2, metav1.CreateOptions{})
+		pausePod2, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod2, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod2.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod2.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		pausePod3 := e2epod.NewAgnhostPod(ns, "pause-pod-3", nil, nil, nil)
 		pausePod3.Spec.HostNetwork = true
 		e2epod.SetNodeSelection(&pausePod3.Spec, e2epod.NodeSelection{Name: node1.Name})
 
-		pausePod3, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod3, metav1.CreateOptions{})
+		pausePod3, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod3, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod3.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod3.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		// assert 5 times that the first pause pod can connect to the Service locally and the second one errors with a timeout
 		for i := 0; i < 5; i++ {
@@ -2751,7 +2751,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		// This behavior is not supported if Kube-proxy is in "userspace" mode.
 		// So we check the kube-proxy mode and skip this test if that's the case.
-		if proxyMode, err := proxyMode(f); err == nil {
+		if proxyMode, err := proxyMode(ctx, f); err == nil {
 			if proxyMode == "userspace" {
 				e2eskipper.Skipf("The test doesn't work with kube-proxy in userspace mode")
 			}
@@ -2759,7 +2759,7 @@ var _ = common.SIGDescribe("Services", func() {
 			framework.Logf("Couldn't detect KubeProxy mode - test failure may be expected: %v", err)
 		}
 
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
 		framework.ExpectNoError(err)
 		nodeCounts := len(nodes.Items)
 		if nodeCounts < 2 {
@@ -2773,7 +2773,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("creating a TCP service " + serviceName + " where all pods are terminating" + ns)
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(80)},
 			}
@@ -2788,17 +2788,17 @@ var _ = common.SIGDescribe("Services", func() {
 		webserverPod0.Spec.TerminationGracePeriodSeconds = utilpointer.Int64(600)
 		e2epod.SetNodeSelection(&webserverPod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Pods(ns).Create(ctx, webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
 
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		pausePod0, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod0, metav1.CreateOptions{})
+		pausePod0, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		nodeIPs := e2enode.GetAddresses(&node0, v1.NodeInternalIP)
 		healthCheckNodePortAddr := net.JoinHostPort(nodeIPs[0], strconv.Itoa(int(svc.Spec.HealthCheckNodePort)))
@@ -2820,7 +2820,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		// webserver should continue to serve traffic through the Service after deletion, even though the health check node port should return 503
 		ginkgo.By("Terminating the webserver pod")
-		err = cs.CoreV1().Pods(ns).Delete(context.TODO(), webserverPod0.Name, metav1.DeleteOptions{})
+		err = cs.CoreV1().Pods(ns).Delete(ctx, webserverPod0.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 
 		// validate that the health check node port from kube-proxy returns 503 when there are no ready endpoints
@@ -2850,7 +2850,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		// This behavior is not supported if Kube-proxy is in "userspace" mode.
 		// So we check the kube-proxy mode and skip this test if that's the case.
-		if proxyMode, err := proxyMode(f); err == nil {
+		if proxyMode, err := proxyMode(ctx, f); err == nil {
 			if proxyMode == "userspace" {
 				e2eskipper.Skipf("The test doesn't work with kube-proxy in userspace mode")
 			}
@@ -2858,7 +2858,7 @@ var _ = common.SIGDescribe("Services", func() {
 			framework.Logf("Couldn't detect KubeProxy mode - test failure may be expected: %v", err)
 		}
 
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
 		framework.ExpectNoError(err)
 		nodeCounts := len(nodes.Items)
 		if nodeCounts < 2 {
@@ -2873,7 +2873,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("creating a TCP service " + serviceName + " where all pods are terminating" + ns)
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(80)},
 			}
@@ -2886,30 +2886,30 @@ var _ = common.SIGDescribe("Services", func() {
 		webserverPod0.Spec.TerminationGracePeriodSeconds = utilpointer.Int64(600)
 		e2epod.SetNodeSelection(&webserverPod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Pods(ns).Create(ctx, webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webservers")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		pausePod0, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod0, metav1.CreateOptions{})
+		pausePod0, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		pausePod1 := e2epod.NewAgnhostPod(ns, "pause-pod-1", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod1.Spec, e2epod.NodeSelection{Name: node1.Name})
 
-		pausePod1, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod1, metav1.CreateOptions{})
+		pausePod1, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod1, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		// webserver should continue to serve traffic through the Service after delete since:
 		//  - it has a 600s termination grace period
 		//  - it is the only ready endpoint
-		err = cs.CoreV1().Pods(ns).Delete(context.TODO(), webserverPod0.Name, metav1.DeleteOptions{})
+		err = cs.CoreV1().Pods(ns).Delete(ctx, webserverPod0.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 
 		// assert 5 times that both the local and remote pod can connect to the Service while all endpoints are terminating
@@ -2933,7 +2933,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		// This behavior is not supported if Kube-proxy is in "userspace" mode.
 		// So we check the kube-proxy mode and skip this test if that's the case.
-		if proxyMode, err := proxyMode(f); err == nil {
+		if proxyMode, err := proxyMode(ctx, f); err == nil {
 			if proxyMode == "userspace" {
 				e2eskipper.Skipf("The test doesn't work with kube-proxy in userspace mode")
 			}
@@ -2941,7 +2941,7 @@ var _ = common.SIGDescribe("Services", func() {
 			framework.Logf("Couldn't detect KubeProxy mode - test failure may be expected: %v", err)
 		}
 
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
 		framework.ExpectNoError(err)
 		nodeCounts := len(nodes.Items)
 		if nodeCounts < 2 {
@@ -2957,7 +2957,7 @@ var _ = common.SIGDescribe("Services", func() {
 		ginkgo.By("creating a TCP service " + serviceName + " where all pods are terminating" + ns)
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 		local := v1.ServiceInternalTrafficPolicyLocal
-		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(80)},
 			}
@@ -2971,30 +2971,30 @@ var _ = common.SIGDescribe("Services", func() {
 		webserverPod0.Spec.TerminationGracePeriodSeconds = utilpointer.Int64(600)
 		e2epod.SetNodeSelection(&webserverPod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Pods(ns).Create(ctx, webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webservers")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		pausePod0, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod0, metav1.CreateOptions{})
+		pausePod0, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		pausePod1 := e2epod.NewAgnhostPod(ns, "pause-pod-1", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod1.Spec, e2epod.NodeSelection{Name: node1.Name})
 
-		pausePod1, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod1, metav1.CreateOptions{})
+		pausePod1, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod1, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		// webserver should continue to serve traffic through the Service after delete since:
 		//  - it has a 600s termination grace period
 		//  - it is the only ready endpoint
-		err = cs.CoreV1().Pods(ns).Delete(context.TODO(), webserverPod0.Name, metav1.DeleteOptions{})
+		err = cs.CoreV1().Pods(ns).Delete(ctx, webserverPod0.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 
 		// assert 5 times that the first pause pod can connect to the Service locally and the second one errors with a timeout
@@ -3021,7 +3021,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		// This behavior is not supported if Kube-proxy is in "userspace" mode.
 		// So we check the kube-proxy mode and skip this test if that's the case.
-		if proxyMode, err := proxyMode(f); err == nil {
+		if proxyMode, err := proxyMode(ctx, f); err == nil {
 			if proxyMode == "userspace" {
 				e2eskipper.Skipf("The test doesn't work with kube-proxy in userspace mode")
 			}
@@ -3029,7 +3029,7 @@ var _ = common.SIGDescribe("Services", func() {
 			framework.Logf("Couldn't detect KubeProxy mode - test failure may be expected: %v", err)
 		}
 
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
 		framework.ExpectNoError(err)
 		nodeCounts := len(nodes.Items)
 		if nodeCounts < 2 {
@@ -3044,7 +3044,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("creating a TCP service " + serviceName + " where all pods are terminating" + ns)
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(80)},
 			}
@@ -3058,30 +3058,30 @@ var _ = common.SIGDescribe("Services", func() {
 		webserverPod0.Spec.TerminationGracePeriodSeconds = utilpointer.Int64(600)
 		e2epod.SetNodeSelection(&webserverPod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Pods(ns).Create(ctx, webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webservers")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		pausePod0, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod0, metav1.CreateOptions{})
+		pausePod0, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		pausePod1 := e2epod.NewAgnhostPod(ns, "pause-pod-1", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod1.Spec, e2epod.NodeSelection{Name: node1.Name})
 
-		pausePod1, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod1, metav1.CreateOptions{})
+		pausePod1, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod1, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		// webserver should continue to serve traffic through the Service after delete since:
 		//  - it has a 600s termination grace period
 		//  - it is the only ready endpoint
-		err = cs.CoreV1().Pods(ns).Delete(context.TODO(), webserverPod0.Name, metav1.DeleteOptions{})
+		err = cs.CoreV1().Pods(ns).Delete(ctx, webserverPod0.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 
 		// assert 5 times that both the local and remote pod can connect to the Service NodePort while all endpoints are terminating
@@ -3106,7 +3106,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		// This behavior is not supported if Kube-proxy is in "userspace" mode.
 		// So we check the kube-proxy mode and skip this test if that's the case.
-		if proxyMode, err := proxyMode(f); err == nil {
+		if proxyMode, err := proxyMode(ctx, f); err == nil {
 			if proxyMode == "userspace" {
 				e2eskipper.Skipf("The test doesn't work with kube-proxy in userspace mode")
 			}
@@ -3114,7 +3114,7 @@ var _ = common.SIGDescribe("Services", func() {
 			framework.Logf("Couldn't detect KubeProxy mode - test failure may be expected: %v", err)
 		}
 
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
 		framework.ExpectNoError(err)
 		nodeCounts := len(nodes.Items)
 		if nodeCounts < 2 {
@@ -3129,7 +3129,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("creating a TCP service " + serviceName + " where all pods are terminating" + ns)
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(80)},
 			}
@@ -3144,30 +3144,30 @@ var _ = common.SIGDescribe("Services", func() {
 		webserverPod0.Spec.TerminationGracePeriodSeconds = utilpointer.Int64(600)
 		e2epod.SetNodeSelection(&webserverPod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), webserverPod0, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Pods(ns).Create(ctx, webserverPod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, webserverPod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{webserverPod0.Name: {servicePort}})
 
 		ginkgo.By("Creating 2 pause pods that will try to connect to the webservers")
 		pausePod0 := e2epod.NewAgnhostPod(ns, "pause-pod-0", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
-		pausePod0, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod0, metav1.CreateOptions{})
+		pausePod0, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod0, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod0.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		pausePod1 := e2epod.NewAgnhostPod(ns, "pause-pod-1", nil, nil, nil)
 		e2epod.SetNodeSelection(&pausePod1.Spec, e2epod.NodeSelection{Name: node1.Name})
 
-		pausePod1, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pausePod1, metav1.CreateOptions{})
+		pausePod1, err = cs.CoreV1().Pods(ns).Create(ctx, pausePod1, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pausePod1.Name, f.Namespace.Name, framework.PodStartTimeout))
 
 		// webserver should continue to serve traffic through the Service after delete since:
 		//  - it has a 600s termination grace period
 		//  - it is the only ready endpoint
-		err = cs.CoreV1().Pods(ns).Delete(context.TODO(), webserverPod0.Name, metav1.DeleteOptions{})
+		err = cs.CoreV1().Pods(ns).Delete(ctx, webserverPod0.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 
 		// assert 5 times that the first pause pod can connect to the Service locally and the second one errors with a timeout
@@ -3202,7 +3202,7 @@ var _ = common.SIGDescribe("Services", func() {
 	*/
 	framework.ConformanceIt("should find a service from listing all namespaces", func(ctx context.Context) {
 		ginkgo.By("fetching services")
-		svcs, _ := f.ClientSet.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{})
+		svcs, _ := f.ClientSet.CoreV1().Services("").List(ctx, metav1.ListOptions{})
 
 		foundSvc := false
 		for _, svc := range svcs.Items {
@@ -3249,19 +3249,19 @@ var _ = common.SIGDescribe("Services", func() {
 		w := &cache.ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = "test-endpoint-static=true"
-				return f.ClientSet.CoreV1().Endpoints(testNamespaceName).Watch(context.TODO(), options)
+				return f.ClientSet.CoreV1().Endpoints(testNamespaceName).Watch(ctx, options)
 			},
 		}
-		endpointsList, err := f.ClientSet.CoreV1().Endpoints("").List(context.TODO(), metav1.ListOptions{LabelSelector: "test-endpoint-static=true"})
+		endpointsList, err := f.ClientSet.CoreV1().Endpoints("").List(ctx, metav1.ListOptions{LabelSelector: "test-endpoint-static=true"})
 		framework.ExpectNoError(err, "failed to list Endpoints")
 
 		ginkgo.By("creating an Endpoint")
-		_, err = f.ClientSet.CoreV1().Endpoints(testNamespaceName).Create(context.TODO(), &testEndpoints, metav1.CreateOptions{})
+		_, err = f.ClientSet.CoreV1().Endpoints(testNamespaceName).Create(ctx, &testEndpoints, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create Endpoint")
 		ginkgo.By("waiting for available Endpoint")
-		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		ctxUntil, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		_, err = watchtools.Until(ctx, endpointsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, endpointsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Added:
 				if endpoints, ok := event.Object.(*v1.Endpoints); ok {
@@ -3277,7 +3277,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err, "failed to see %v event", watch.Added)
 
 		ginkgo.By("listing all Endpoints")
-		endpointsList, err = f.ClientSet.CoreV1().Endpoints("").List(context.TODO(), metav1.ListOptions{LabelSelector: "test-endpoint-static=true"})
+		endpointsList, err = f.ClientSet.CoreV1().Endpoints("").List(ctx, metav1.ListOptions{LabelSelector: "test-endpoint-static=true"})
 		framework.ExpectNoError(err, "failed to list Endpoints")
 		eventFound := false
 		var foundEndpoint v1.Endpoints
@@ -3294,12 +3294,12 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("updating the Endpoint")
 		foundEndpoint.ObjectMeta.Labels["test-service"] = "updated"
-		_, err = f.ClientSet.CoreV1().Endpoints(testNamespaceName).Update(context.TODO(), &foundEndpoint, metav1.UpdateOptions{})
+		_, err = f.ClientSet.CoreV1().Endpoints(testNamespaceName).Update(ctx, &foundEndpoint, metav1.UpdateOptions{})
 		framework.ExpectNoError(err, "failed to update Endpoint with new label")
 
-		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		ctxUntil, cancel = context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		_, err = watchtools.Until(ctx, endpointsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, endpointsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Modified:
 				if endpoints, ok := event.Object.(*v1.Endpoints); ok {
@@ -3315,7 +3315,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err, "failed to see %v event", watch.Modified)
 
 		ginkgo.By("fetching the Endpoint")
-		endpoints, err := f.ClientSet.CoreV1().Endpoints(testNamespaceName).Get(context.TODO(), testEndpointName, metav1.GetOptions{})
+		endpoints, err := f.ClientSet.CoreV1().Endpoints(testNamespaceName).Get(ctx, testEndpointName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to fetch Endpoint")
 		framework.ExpectEqual(foundEndpoint.ObjectMeta.Labels["test-service"], "updated", "failed to update Endpoint %v in namespace %v label not updated", testEndpointName, testNamespaceName)
 
@@ -3343,11 +3343,11 @@ var _ = common.SIGDescribe("Services", func() {
 		})
 		framework.ExpectNoError(err, "failed to marshal JSON for WatchEvent patch")
 		ginkgo.By("patching the Endpoint")
-		_, err = f.ClientSet.CoreV1().Endpoints(testNamespaceName).Patch(context.TODO(), testEndpointName, types.StrategicMergePatchType, []byte(endpointPatch), metav1.PatchOptions{})
+		_, err = f.ClientSet.CoreV1().Endpoints(testNamespaceName).Patch(ctx, testEndpointName, types.StrategicMergePatchType, []byte(endpointPatch), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch Endpoint")
-		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		ctxUntil, cancel = context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		_, err = watchtools.Until(ctx, endpoints.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, endpoints.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Modified:
 				if endpoints, ok := event.Object.(*v1.Endpoints); ok {
@@ -3363,7 +3363,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err, "failed to see %v event", watch.Modified)
 
 		ginkgo.By("fetching the Endpoint")
-		endpoints, err = f.ClientSet.CoreV1().Endpoints(testNamespaceName).Get(context.TODO(), testEndpointName, metav1.GetOptions{})
+		endpoints, err = f.ClientSet.CoreV1().Endpoints(testNamespaceName).Get(ctx, testEndpointName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to fetch Endpoint")
 		framework.ExpectEqual(endpoints.ObjectMeta.Labels["test-service"], "patched", "failed to patch Endpoint with Label")
 		endpointSubsetOne := endpoints.Subsets[0]
@@ -3374,13 +3374,13 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectEqual(endpointSubsetOnePorts.Port, int32(8080), "failed to patch Endpoint")
 
 		ginkgo.By("deleting the Endpoint by Collection")
-		err = f.ClientSet.CoreV1().Endpoints(testNamespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test-endpoint-static=true"})
+		err = f.ClientSet.CoreV1().Endpoints(testNamespaceName).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test-endpoint-static=true"})
 		framework.ExpectNoError(err, "failed to delete Endpoint by Collection")
 
 		ginkgo.By("waiting for Endpoint deletion")
-		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		ctxUntil, cancel = context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		_, err = watchtools.Until(ctx, endpoints.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, endpoints.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Deleted:
 				if endpoints, ok := event.Object.(*v1.Endpoints); ok {
@@ -3396,7 +3396,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err, "failed to see %v event", watch.Deleted)
 
 		ginkgo.By("fetching the Endpoint")
-		_, err = f.ClientSet.CoreV1().Endpoints(testNamespaceName).Get(context.TODO(), testEndpointName, metav1.GetOptions{})
+		_, err = f.ClientSet.CoreV1().Endpoints(testNamespaceName).Get(ctx, testEndpointName, metav1.GetOptions{})
 		framework.ExpectError(err, "should not be able to fetch Endpoint")
 	})
 
@@ -3422,11 +3422,11 @@ var _ = common.SIGDescribe("Services", func() {
 		w := &cache.ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = testSvcLabelsFlat
-				return cs.CoreV1().Services(ns).Watch(context.TODO(), options)
+				return cs.CoreV1().Services(ns).Watch(ctx, options)
 			},
 		}
 
-		svcList, err := cs.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{LabelSelector: testSvcLabelsFlat})
+		svcList, err := cs.CoreV1().Services("").List(ctx, metav1.ListOptions{LabelSelector: testSvcLabelsFlat})
 		framework.ExpectNoError(err, "failed to list Services")
 
 		ginkgo.By("creating a Service")
@@ -3445,13 +3445,13 @@ var _ = common.SIGDescribe("Services", func() {
 				}},
 			},
 		}
-		_, err = cs.CoreV1().Services(ns).Create(context.TODO(), &testService, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Services(ns).Create(ctx, &testService, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create Service")
 
 		ginkgo.By("watching for the Service to be added")
-		ctx, cancel := context.WithTimeout(ctx, svcReadyTimeout)
+		ctxUntil, cancel := context.WithTimeout(ctx, svcReadyTimeout)
 		defer cancel()
-		_, err = watchtools.Until(ctx, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			if svc, ok := event.Object.(*v1.Service); ok {
 				found := svc.ObjectMeta.Name == testService.ObjectMeta.Name &&
 					svc.ObjectMeta.Namespace == ns &&
@@ -3470,7 +3470,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.Logf("Service %s created", testSvcName)
 
 		ginkgo.By("Getting /status")
-		svcStatusUnstructured, err := f.DynamicClient.Resource(svcResource).Namespace(ns).Get(context.TODO(), testSvcName, metav1.GetOptions{}, "status")
+		svcStatusUnstructured, err := f.DynamicClient.Resource(svcResource).Namespace(ns).Get(ctx, testSvcName, metav1.GetOptions{}, "status")
 		framework.ExpectNoError(err, "Failed to fetch ServiceStatus of Service %s in namespace %s", testSvcName, ns)
 		svcStatusBytes, err := json.Marshal(svcStatusUnstructured)
 		framework.ExpectNoError(err, "Failed to marshal unstructured response. %v", err)
@@ -3486,16 +3486,16 @@ var _ = common.SIGDescribe("Services", func() {
 		}
 		lbStatusJSON, err := json.Marshal(lbStatus)
 		framework.ExpectNoError(err, "Failed to marshal JSON. %v", err)
-		_, err = svcClient.Patch(context.TODO(), testSvcName, types.MergePatchType,
+		_, err = svcClient.Patch(ctx, testSvcName, types.MergePatchType,
 			[]byte(`{"metadata":{"annotations":{"patchedstatus":"true"}},"status":{"loadBalancer":`+string(lbStatusJSON)+`}}`),
 			metav1.PatchOptions{}, "status")
 		framework.ExpectNoError(err, "Could not patch service status", err)
 
 		ginkgo.By("watching for the Service to be patched")
-		ctx, cancel = context.WithTimeout(context.Background(), svcReadyTimeout)
+		ctxUntil, cancel = context.WithTimeout(ctx, svcReadyTimeout)
 		defer cancel()
 
-		_, err = watchtools.Until(ctx, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			if svc, ok := event.Object.(*v1.Service); ok {
 				found := svc.ObjectMeta.Name == testService.ObjectMeta.Name &&
 					svc.ObjectMeta.Namespace == ns &&
@@ -3517,7 +3517,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		var statusToUpdate, updatedStatus *v1.Service
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			statusToUpdate, err = svcClient.Get(context.TODO(), testSvcName, metav1.GetOptions{})
+			statusToUpdate, err = svcClient.Get(ctx, testSvcName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Unable to retrieve service %s", testSvcName)
 
 			statusToUpdate.Status.Conditions = append(statusToUpdate.Status.Conditions, metav1.Condition{
@@ -3527,16 +3527,16 @@ var _ = common.SIGDescribe("Services", func() {
 				Message: "Set from e2e test",
 			})
 
-			updatedStatus, err = svcClient.UpdateStatus(context.TODO(), statusToUpdate, metav1.UpdateOptions{})
+			updatedStatus, err = svcClient.UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})
 			return err
 		})
 		framework.ExpectNoError(err, "\n\n Failed to UpdateStatus. %v\n\n", err)
 		framework.Logf("updatedStatus.Conditions: %#v", updatedStatus.Status.Conditions)
 
 		ginkgo.By("watching for the Service to be updated")
-		ctx, cancel = context.WithTimeout(context.Background(), svcReadyTimeout)
+		ctxUntil, cancel = context.WithTimeout(ctx, svcReadyTimeout)
 		defer cancel()
-		_, err = watchtools.Until(ctx, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			if svc, ok := event.Object.(*v1.Service); ok {
 				found := svc.ObjectMeta.Name == testService.ObjectMeta.Name &&
 					svc.ObjectMeta.Namespace == ns &&
@@ -3572,13 +3572,13 @@ var _ = common.SIGDescribe("Services", func() {
 			},
 		})
 
-		_, err = svcClient.Patch(context.TODO(), testSvcName, types.StrategicMergePatchType, []byte(servicePatchPayload), metav1.PatchOptions{})
+		_, err = svcClient.Patch(ctx, testSvcName, types.StrategicMergePatchType, []byte(servicePatchPayload), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch service. %v", err)
 
 		ginkgo.By("watching for the Service to be patched")
-		ctx, cancel = context.WithTimeout(context.Background(), svcReadyTimeout)
+		ctxUntil, cancel = context.WithTimeout(ctx, svcReadyTimeout)
 		defer cancel()
-		_, err = watchtools.Until(ctx, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			if svc, ok := event.Object.(*v1.Service); ok {
 				found := svc.ObjectMeta.Name == testService.ObjectMeta.Name &&
 					svc.ObjectMeta.Namespace == ns &&
@@ -3597,13 +3597,13 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.Logf("Service %s patched", testSvcName)
 
 		ginkgo.By("deleting the service")
-		err = cs.CoreV1().Services(ns).Delete(context.TODO(), testSvcName, metav1.DeleteOptions{})
+		err = cs.CoreV1().Services(ns).Delete(ctx, testSvcName, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete the Service. %v", err)
 
 		ginkgo.By("watching for the Service to be deleted")
-		ctx, cancel = context.WithTimeout(context.Background(), svcReadyTimeout)
+		ctxUntil, cancel = context.WithTimeout(ctx, svcReadyTimeout)
 		defer cancel()
-		_, err = watchtools.Until(ctx, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		_, err = watchtools.Until(ctxUntil, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Deleted:
 				if svc, ok := event.Object.(*v1.Service); ok {
@@ -3688,21 +3688,21 @@ var _ = common.SIGDescribe("Services", func() {
 						}},
 					},
 				}
-				_, err := svcClient.Create(context.TODO(), &svc, metav1.CreateOptions{})
+				_, err := svcClient.Create(ctx, &svc, metav1.CreateOptions{})
 				framework.ExpectNoError(err, "failed to create Service")
 
 			}()
 		}
 
-		svcList, err := cs.CoreV1().Services(ns).List(context.TODO(), metav1.ListOptions{})
+		svcList, err := cs.CoreV1().Services(ns).List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "failed to list Services")
 		framework.ExpectEqual(len(svcList.Items), 3, "Required count of services out of sync")
 
 		ginkgo.By("deleting service collection")
-		err = svcDynamicClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: deleteLabel})
+		err = svcDynamicClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: deleteLabel})
 		framework.ExpectNoError(err, "failed to delete service collection. %v", err)
 
-		svcList, err = cs.CoreV1().Services(ns).List(context.TODO(), metav1.ListOptions{})
+		svcList, err = cs.CoreV1().Services(ns).List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "failed to list Services")
 		framework.ExpectEqual(len(svcList.Items), 1, "Required count of services out of sync")
 
@@ -3770,14 +3770,14 @@ var _ = common.SIGDescribe("Services", func() {
 
 		podname1 := "pod1"
 
-		createPodOrFail(f, ns, podname1, jig.Labels, containerPorts, "netexec", "--http-port", strconv.Itoa(containerPort), "--udp-port", strconv.Itoa(containerPort))
+		createPodOrFail(ctx, f, ns, podname1, jig.Labels, containerPorts, "netexec", "--http-port", strconv.Itoa(containerPort), "--udp-port", strconv.Itoa(containerPort))
 		validateEndpointsPortsWithProtocolsOrFail(cs, ns, serviceName, fullPortsByPodName{podname1: containerPorts})
 
 		ginkgo.By("Checking if the Service forwards traffic to pods")
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
-		err = jig.CheckServiceReachability(svc, execPod)
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
+		err = jig.CheckServiceReachability(ctx, svc, execPod)
 		framework.ExpectNoError(err)
-		e2epod.DeletePodOrFail(cs, ns, podname1)
+		e2epod.DeletePodOrFail(ctx, cs, ns, podname1)
 	})
 
 	// These is [Serial] because it can't run at the same time as the
@@ -3788,30 +3788,30 @@ var _ = common.SIGDescribe("Services", func() {
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 
 		ginkgo.By("getting the state of the sctp module on nodes")
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
 		framework.ExpectNoError(err)
-		sctpLoadedAtStart := CheckSCTPModuleLoadedOnNodes(f, nodes)
+		sctpLoadedAtStart := CheckSCTPModuleLoadedOnNodes(ctx, f, nodes)
 
 		ginkgo.By("creating service " + serviceName + " in namespace " + ns)
-		_, err = jig.CreateSCTPServiceWithPort(nil, 5060)
+		_, err = jig.CreateSCTPServiceWithPort(ctx, nil, 5060)
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			err := cs.CoreV1().Services(ns).Delete(ctx, serviceName, metav1.DeleteOptions{})
 			framework.ExpectNoError(err, "failed to delete service: %s in namespace: %s", serviceName, ns)
 		})
 
-		err = e2enetwork.WaitForService(f.ClientSet, ns, serviceName, true, 5*time.Second, e2eservice.TestTimeout)
+		err = e2enetwork.WaitForService(ctx, f.ClientSet, ns, serviceName, true, 5*time.Second, e2eservice.TestTimeout)
 		framework.ExpectNoError(err, fmt.Sprintf("error while waiting for service:%s err: %v", serviceName, err))
 
 		ginkgo.By("validating endpoints do not exist yet")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{})
 
 		ginkgo.By("creating a pod for the service")
 		names := map[string]bool{}
 
 		name1 := "pod1"
 
-		createPodOrFail(f, ns, name1, jig.Labels, []v1.ContainerPort{{ContainerPort: 5060, Protocol: v1.ProtocolSCTP}})
+		createPodOrFail(ctx, f, ns, name1, jig.Labels, []v1.ContainerPort{{ContainerPort: 5060, Protocol: v1.ProtocolSCTP}})
 		names[name1] = true
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			for name := range names {
@@ -3821,16 +3821,16 @@ var _ = common.SIGDescribe("Services", func() {
 		})
 
 		ginkgo.By("validating endpoints exists")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name1: {5060}})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{name1: {5060}})
 
 		ginkgo.By("deleting the pod")
-		e2epod.DeletePodOrFail(cs, ns, name1)
+		e2epod.DeletePodOrFail(ctx, cs, ns, name1)
 		delete(names, name1)
 		ginkgo.By("validating endpoints do not exist anymore")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(ctx, cs, ns, serviceName, portsByPodName{})
 
 		ginkgo.By("validating sctp module is still not loaded")
-		sctpLoadedAtEnd := CheckSCTPModuleLoadedOnNodes(f, nodes)
+		sctpLoadedAtEnd := CheckSCTPModuleLoadedOnNodes(ctx, f, nodes)
 		if !sctpLoadedAtStart && sctpLoadedAtEnd {
 			framework.Failf("The state of the sctp module has changed due to the test case")
 		}
@@ -3841,14 +3841,14 @@ var _ = common.SIGDescribe("Services", func() {
 // affinity test for non-load-balancer services. Session affinity will be
 // enabled when the service is created and a short timeout will be configured so
 // session affinity must change after the timeout expirese.
-func execAffinityTestForSessionAffinityTimeout(f *framework.Framework, cs clientset.Interface, svc *v1.Service) {
+func execAffinityTestForSessionAffinityTimeout(ctx context.Context, f *framework.Framework, cs clientset.Interface, svc *v1.Service) {
 	ns := f.Namespace.Name
 	numPods, servicePort, serviceName := 3, defaultServeHostnameServicePort, svc.ObjectMeta.Name
 	ginkgo.By("creating service in namespace " + ns)
 	serviceType := svc.Spec.Type
 	// set an affinity timeout equal to the number of connection requests
 	svcSessionAffinityTimeout := int32(AffinityConfirmCount)
-	if proxyMode, err := proxyMode(f); err == nil {
+	if proxyMode, err := proxyMode(ctx, f); err == nil {
 		if proxyMode == "ipvs" {
 			// session affinity timeout must be greater than 120 in ipvs mode,
 			// because IPVS module has a hardcoded TIME_WAIT timeout of 120s,
@@ -3864,15 +3864,15 @@ func execAffinityTestForSessionAffinityTimeout(f *framework.Framework, cs client
 	svc.Spec.SessionAffinityConfig = &v1.SessionAffinityConfig{
 		ClientIP: &v1.ClientIPConfig{TimeoutSeconds: &svcSessionAffinityTimeout},
 	}
-	_, _, err := StartServeHostnameService(cs, svc, ns, numPods)
+	_, _, err := StartServeHostnameService(ctx, cs, svc, ns, numPods)
 	framework.ExpectNoError(err, "failed to create replication controller with service in the namespace: %s", ns)
 	ginkgo.DeferCleanup(StopServeHostnameService, cs, ns, serviceName)
 	jig := e2eservice.NewTestJig(cs, ns, serviceName)
-	svc, err = jig.Client.CoreV1().Services(ns).Get(context.TODO(), serviceName, metav1.GetOptions{})
+	svc, err = jig.Client.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{})
 	framework.ExpectNoError(err, "failed to fetch service: %s in namespace: %s", serviceName, ns)
 	var svcIP string
 	if serviceType == v1.ServiceTypeNodePort {
-		nodes, err := e2enode.GetReadySchedulableNodes(cs)
+		nodes, err := e2enode.GetReadySchedulableNodes(ctx, cs)
 		framework.ExpectNoError(err)
 		// The node addresses must have the same IP family as the ClusterIP
 		family := v1.IPv4Protocol
@@ -3886,17 +3886,17 @@ func execAffinityTestForSessionAffinityTimeout(f *framework.Framework, cs client
 		svcIP = svc.Spec.ClusterIP
 	}
 
-	execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod-affinity", nil)
+	execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod-affinity", nil)
 	ginkgo.DeferCleanup(func(ctx context.Context) {
 		framework.Logf("Cleaning up the exec pod")
 		err := cs.CoreV1().Pods(ns).Delete(ctx, execPod.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", execPod.Name, ns)
 	})
-	err = jig.CheckServiceReachability(svc, execPod)
+	err = jig.CheckServiceReachability(ctx, svc, execPod)
 	framework.ExpectNoError(err)
 
 	// the service should be sticky until the timeout expires
-	framework.ExpectEqual(checkAffinity(cs, execPod, svcIP, servicePort, true), true)
+	framework.ExpectEqual(checkAffinity(ctx, cs, execPod, svcIP, servicePort, true), true)
 	// but it should return different hostnames after the timeout expires
 	// try several times to avoid the probability that we hit the same pod twice
 	hosts := sets.NewString()
@@ -3926,12 +3926,12 @@ func execAffinityTestForSessionAffinityTimeout(f *framework.Framework, cs client
 	framework.Fail("Session is sticky after reaching the timeout")
 }
 
-func execAffinityTestForNonLBServiceWithTransition(f *framework.Framework, cs clientset.Interface, svc *v1.Service) {
-	execAffinityTestForNonLBServiceWithOptionalTransition(f, cs, svc, true)
+func execAffinityTestForNonLBServiceWithTransition(ctx context.Context, f *framework.Framework, cs clientset.Interface, svc *v1.Service) {
+	execAffinityTestForNonLBServiceWithOptionalTransition(ctx, f, cs, svc, true)
 }
 
-func execAffinityTestForNonLBService(f *framework.Framework, cs clientset.Interface, svc *v1.Service) {
-	execAffinityTestForNonLBServiceWithOptionalTransition(f, cs, svc, false)
+func execAffinityTestForNonLBService(ctx context.Context, f *framework.Framework, cs clientset.Interface, svc *v1.Service) {
+	execAffinityTestForNonLBServiceWithOptionalTransition(ctx, f, cs, svc, false)
 }
 
 // execAffinityTestForNonLBServiceWithOptionalTransition is a helper function that wrap the logic of
@@ -3939,21 +3939,21 @@ func execAffinityTestForNonLBService(f *framework.Framework, cs clientset.Interf
 // enabled when the service is created. If parameter isTransitionTest is true,
 // session affinity will be switched off/on and test if the service converges
 // to a stable affinity state.
-func execAffinityTestForNonLBServiceWithOptionalTransition(f *framework.Framework, cs clientset.Interface, svc *v1.Service, isTransitionTest bool) {
+func execAffinityTestForNonLBServiceWithOptionalTransition(ctx context.Context, f *framework.Framework, cs clientset.Interface, svc *v1.Service, isTransitionTest bool) {
 	ns := f.Namespace.Name
 	numPods, servicePort, serviceName := 3, defaultServeHostnameServicePort, svc.ObjectMeta.Name
 	ginkgo.By("creating service in namespace " + ns)
 	serviceType := svc.Spec.Type
 	svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
-	_, _, err := StartServeHostnameService(cs, svc, ns, numPods)
+	_, _, err := StartServeHostnameService(ctx, cs, svc, ns, numPods)
 	framework.ExpectNoError(err, "failed to create replication controller with service in the namespace: %s", ns)
 	ginkgo.DeferCleanup(StopServeHostnameService, cs, ns, serviceName)
 	jig := e2eservice.NewTestJig(cs, ns, serviceName)
-	svc, err = jig.Client.CoreV1().Services(ns).Get(context.TODO(), serviceName, metav1.GetOptions{})
+	svc, err = jig.Client.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{})
 	framework.ExpectNoError(err, "failed to fetch service: %s in namespace: %s", serviceName, ns)
 	var svcIP string
 	if serviceType == v1.ServiceTypeNodePort {
-		nodes, err := e2enode.GetReadySchedulableNodes(cs)
+		nodes, err := e2enode.GetReadySchedulableNodes(ctx, cs)
 		framework.ExpectNoError(err)
 		// The node addresses must have the same IP family as the ClusterIP
 		family := v1.IPv4Protocol
@@ -3967,89 +3967,89 @@ func execAffinityTestForNonLBServiceWithOptionalTransition(f *framework.Framewor
 		svcIP = svc.Spec.ClusterIP
 	}
 
-	execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod-affinity", nil)
+	execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod-affinity", nil)
 	ginkgo.DeferCleanup(func(ctx context.Context) {
 		framework.Logf("Cleaning up the exec pod")
 		err := cs.CoreV1().Pods(ns).Delete(ctx, execPod.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", execPod.Name, ns)
 	})
-	err = jig.CheckServiceReachability(svc, execPod)
+	err = jig.CheckServiceReachability(ctx, svc, execPod)
 	framework.ExpectNoError(err)
 
 	if !isTransitionTest {
-		framework.ExpectEqual(checkAffinity(cs, execPod, svcIP, servicePort, true), true)
+		framework.ExpectEqual(checkAffinity(ctx, cs, execPod, svcIP, servicePort, true), true)
 	}
 	if isTransitionTest {
-		_, err = jig.UpdateService(func(svc *v1.Service) {
+		_, err = jig.UpdateService(ctx, func(svc *v1.Service) {
 			svc.Spec.SessionAffinity = v1.ServiceAffinityNone
 		})
 		framework.ExpectNoError(err)
-		framework.ExpectEqual(checkAffinity(cs, execPod, svcIP, servicePort, false), true)
-		_, err = jig.UpdateService(func(svc *v1.Service) {
+		framework.ExpectEqual(checkAffinity(ctx, cs, execPod, svcIP, servicePort, false), true)
+		_, err = jig.UpdateService(ctx, func(svc *v1.Service) {
 			svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
 		})
 		framework.ExpectNoError(err)
-		framework.ExpectEqual(checkAffinity(cs, execPod, svcIP, servicePort, true), true)
+		framework.ExpectEqual(checkAffinity(ctx, cs, execPod, svcIP, servicePort, true), true)
 	}
 }
 
-func execAffinityTestForLBServiceWithTransition(f *framework.Framework, cs clientset.Interface, svc *v1.Service) {
-	execAffinityTestForLBServiceWithOptionalTransition(f, cs, svc, true)
+func execAffinityTestForLBServiceWithTransition(ctx context.Context, f *framework.Framework, cs clientset.Interface, svc *v1.Service) {
+	execAffinityTestForLBServiceWithOptionalTransition(ctx, f, cs, svc, true)
 }
 
-func execAffinityTestForLBService(f *framework.Framework, cs clientset.Interface, svc *v1.Service) {
-	execAffinityTestForLBServiceWithOptionalTransition(f, cs, svc, false)
+func execAffinityTestForLBService(ctx context.Context, f *framework.Framework, cs clientset.Interface, svc *v1.Service) {
+	execAffinityTestForLBServiceWithOptionalTransition(ctx, f, cs, svc, false)
 }
 
 // execAffinityTestForLBServiceWithOptionalTransition is a helper function that wrap the logic of
 // affinity test for load balancer services, similar to
 // execAffinityTestForNonLBServiceWithOptionalTransition.
-func execAffinityTestForLBServiceWithOptionalTransition(f *framework.Framework, cs clientset.Interface, svc *v1.Service, isTransitionTest bool) {
+func execAffinityTestForLBServiceWithOptionalTransition(ctx context.Context, f *framework.Framework, cs clientset.Interface, svc *v1.Service, isTransitionTest bool) {
 	numPods, ns, serviceName := 3, f.Namespace.Name, svc.ObjectMeta.Name
 
 	ginkgo.By("creating service in namespace " + ns)
 	svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
-	_, _, err := StartServeHostnameService(cs, svc, ns, numPods)
+	_, _, err := StartServeHostnameService(ctx, cs, svc, ns, numPods)
 	framework.ExpectNoError(err, "failed to create replication controller with service in the namespace: %s", ns)
 	jig := e2eservice.NewTestJig(cs, ns, serviceName)
 	ginkgo.By("waiting for loadbalancer for service " + ns + "/" + serviceName)
-	svc, err = jig.WaitForLoadBalancer(e2eservice.GetServiceLoadBalancerCreationTimeout(cs))
+	svc, err = jig.WaitForLoadBalancer(ctx, e2eservice.GetServiceLoadBalancerCreationTimeout(ctx, cs))
 	framework.ExpectNoError(err)
 	ginkgo.DeferCleanup(func(ctx context.Context) {
-		podNodePairs, err := e2enode.PodNodePairs(cs, ns)
+		podNodePairs, err := e2enode.PodNodePairs(ctx, cs, ns)
 		framework.Logf("[pod,node] pairs: %+v; err: %v", podNodePairs, err)
-		StopServeHostnameService(cs, ns, serviceName)
+		_ = StopServeHostnameService(ctx, cs, ns, serviceName)
 		lb := cloudprovider.DefaultLoadBalancerName(svc)
 		framework.Logf("cleaning load balancer resource for %s", lb)
-		e2eservice.CleanupServiceResources(cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
+		e2eservice.CleanupServiceResources(ctx, cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
 	})
 	ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
 	port := int(svc.Spec.Ports[0].Port)
 
 	if !isTransitionTest {
-		framework.ExpectEqual(checkAffinity(cs, nil, ingressIP, port, true), true)
+		framework.ExpectEqual(checkAffinity(ctx, cs, nil, ingressIP, port, true), true)
 	}
 	if isTransitionTest {
-		svc, err = jig.UpdateService(func(svc *v1.Service) {
+		svc, err = jig.UpdateService(ctx, func(svc *v1.Service) {
 			svc.Spec.SessionAffinity = v1.ServiceAffinityNone
 		})
 		framework.ExpectNoError(err)
-		framework.ExpectEqual(checkAffinity(cs, nil, ingressIP, port, false), true)
-		svc, err = jig.UpdateService(func(svc *v1.Service) {
+		framework.ExpectEqual(checkAffinity(ctx, cs, nil, ingressIP, port, false), true)
+		svc, err = jig.UpdateService(ctx, func(svc *v1.Service) {
 			svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
 		})
 		framework.ExpectNoError(err)
-		framework.ExpectEqual(checkAffinity(cs, nil, ingressIP, port, true), true)
+		framework.ExpectEqual(checkAffinity(ctx, cs, nil, ingressIP, port, true), true)
 	}
 }
 
-func createAndGetExternalServiceFQDN(cs clientset.Interface, ns, serviceName string) string {
-	_, _, err := StartServeHostnameService(cs, getServeHostnameService(serviceName), ns, 2)
+func createAndGetExternalServiceFQDN(ctx context.Context, cs clientset.Interface, ns, serviceName string) string {
+	_, _, err := StartServeHostnameService(ctx, cs, getServeHostnameService(serviceName), ns, 2)
 	framework.ExpectNoError(err, "Expected Service %s to be running", serviceName)
 	return fmt.Sprintf("%s.%s.svc.%s", serviceName, ns, framework.TestContext.ClusterDNSDomain)
 }
 
-func createPausePodDeployment(cs clientset.Interface, name, ns string, replicas int) *appsv1.Deployment {
+func createPausePodDeployment(ctx context.Context, cs clientset.Interface, name, ns string, replicas int) *appsv1.Deployment {
 	labels := map[string]string{"deployment": "agnhost-pause"}
 	pauseDeployment := e2edeployment.NewDeployment(name, int32(replicas), labels, "", "", appsv1.RollingUpdateDeploymentStrategyType)
 
@@ -4066,30 +4066,30 @@ func createPausePodDeployment(cs clientset.Interface, name, ns string, replicas 
 		},
 	}
 
-	deployment, err := cs.AppsV1().Deployments(ns).Create(context.TODO(), pauseDeployment, metav1.CreateOptions{})
+	deployment, err := cs.AppsV1().Deployments(ns).Create(ctx, pauseDeployment, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "Error in creating deployment for pause pod")
 	return deployment
 }
 
 // createPodOrFail creates a pod with the specified containerPorts.
-func createPodOrFail(f *framework.Framework, ns, name string, labels map[string]string, containerPorts []v1.ContainerPort, args ...string) {
+func createPodOrFail(ctx context.Context, f *framework.Framework, ns, name string, labels map[string]string, containerPorts []v1.ContainerPort, args ...string) {
 	ginkgo.By(fmt.Sprintf("Creating pod %s in namespace %s", name, ns))
 	pod := e2epod.NewAgnhostPod(ns, name, nil, nil, containerPorts, args...)
 	pod.ObjectMeta.Labels = labels
 	// Add a dummy environment variable to work around a docker issue.
 	// https://github.com/docker/docker/issues/14203
 	pod.Spec.Containers[0].Env = []v1.EnvVar{{Name: "FOO", Value: " "}}
-	e2epod.NewPodClient(f).CreateSync(pod)
+	e2epod.NewPodClient(f).CreateSync(ctx, pod)
 }
 
 // launchHostExecPod launches a hostexec pod in the given namespace and waits
 // until it's Running
-func launchHostExecPod(client clientset.Interface, ns, name string) *v1.Pod {
+func launchHostExecPod(ctx context.Context, client clientset.Interface, ns, name string) *v1.Pod {
 	framework.Logf("Creating new host exec pod")
 	hostExecPod := e2epod.NewExecPodSpec(ns, name, true)
-	pod, err := client.CoreV1().Pods(ns).Create(context.TODO(), hostExecPod, metav1.CreateOptions{})
+	pod, err := client.CoreV1().Pods(ns).Create(ctx, hostExecPod, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
-	err = e2epod.WaitTimeoutForPodReadyInNamespace(client, name, ns, framework.PodStartTimeout)
+	err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, client, name, ns, framework.PodStartTimeout)
 	framework.ExpectNoError(err)
 	return pod
 }
@@ -4114,10 +4114,10 @@ func checkReachabilityFromPod(expectToBeReachable bool, timeout time.Duration, n
 }
 
 // proxyMode returns a proxyMode of a kube-proxy.
-func proxyMode(f *framework.Framework) (string, error) {
+func proxyMode(ctx context.Context, f *framework.Framework) (string, error) {
 	pod := e2epod.NewAgnhostPod(f.Namespace.Name, "kube-proxy-mode-detector", nil, nil, nil)
 	pod.Spec.HostNetwork = true
-	e2epod.NewPodClient(f).CreateSync(pod)
+	e2epod.NewPodClient(f).CreateSync(ctx, pod)
 	ginkgo.DeferCleanup(e2epod.NewPodClient(f).DeleteSync, pod.Name, metav1.DeleteOptions{}, e2epod.DefaultPodDeletionTimeout)
 
 	cmd := "curl -q -s --connect-timeout 1 http://localhost:10249/proxyMode"
@@ -4158,10 +4158,10 @@ func validatePorts(ep, expectedEndpoints portsByPodUID) error {
 	return nil
 }
 
-func translatePodNameToUID(c clientset.Interface, ns string, expectedEndpoints portsByPodName) (portsByPodUID, error) {
+func translatePodNameToUID(ctx context.Context, c clientset.Interface, ns string, expectedEndpoints portsByPodName) (portsByPodUID, error) {
 	portsByUID := make(portsByPodUID)
 	for name, portList := range expectedEndpoints {
-		pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		pod, err := c.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get pod %s, that's pretty weird. validation failed: %s", name, err)
 		}
@@ -4171,9 +4171,9 @@ func translatePodNameToUID(c clientset.Interface, ns string, expectedEndpoints p
 }
 
 // validateEndpointsPortsOrFail validates that the given service exists and is served by the given expectedEndpoints.
-func validateEndpointsPortsOrFail(c clientset.Interface, namespace, serviceName string, expectedEndpoints portsByPodName) {
+func validateEndpointsPortsOrFail(ctx context.Context, c clientset.Interface, namespace, serviceName string, expectedEndpoints portsByPodName) {
 	ginkgo.By(fmt.Sprintf("waiting up to %v for service %s in namespace %s to expose endpoints %v", framework.ServiceStartTimeout, serviceName, namespace, expectedEndpoints))
-	expectedPortsByPodUID, err := translatePodNameToUID(c, namespace, expectedEndpoints)
+	expectedPortsByPodUID, err := translatePodNameToUID(ctx, c, namespace, expectedEndpoints)
 	framework.ExpectNoError(err, "failed to translate pod name to UID, ns:%s, expectedEndpoints:%v", namespace, expectedEndpoints)
 
 	var (
@@ -4183,7 +4183,7 @@ func validateEndpointsPortsOrFail(c clientset.Interface, namespace, serviceName 
 	if pollErr = wait.PollImmediate(time.Second, framework.ServiceStartTimeout, func() (bool, error) {
 		i++
 
-		ep, err := c.CoreV1().Endpoints(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
+		ep, err := c.CoreV1().Endpoints(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 		if err != nil {
 			framework.Logf("Failed go get Endpoints object: %v", err)
 			// Retry the error
@@ -4203,7 +4203,7 @@ func validateEndpointsPortsOrFail(c clientset.Interface, namespace, serviceName 
 			opts := metav1.ListOptions{
 				LabelSelector: "kubernetes.io/service-name=" + serviceName,
 			}
-			es, err := c.DiscoveryV1().EndpointSlices(namespace).List(context.TODO(), opts)
+			es, err := c.DiscoveryV1().EndpointSlices(namespace).List(ctx, opts)
 			if err != nil {
 				framework.Logf("Failed go list EndpointSlice objects: %v", err)
 				// Retry the error
@@ -4221,7 +4221,7 @@ func validateEndpointsPortsOrFail(c clientset.Interface, namespace, serviceName 
 			serviceName, namespace, expectedEndpoints)
 		return true, nil
 	}); pollErr != nil {
-		if pods, err := c.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{}); err == nil {
+		if pods, err := c.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); err == nil {
 			for _, pod := range pods.Items {
 				framework.Logf("Pod %s\t%s\t%s\t%s", pod.Namespace, pod.Name, pod.Spec.NodeName, pod.DeletionTimestamp)
 			}
@@ -4232,22 +4232,22 @@ func validateEndpointsPortsOrFail(c clientset.Interface, namespace, serviceName 
 	framework.ExpectNoError(pollErr, "error waithing for service %s in namespace %s to expose endpoints %v: %v", serviceName, namespace, expectedEndpoints)
 }
 
-func restartApiserver(namespace string, cs clientset.Interface) error {
+func restartApiserver(ctx context.Context, namespace string, cs clientset.Interface) error {
 	if framework.ProviderIs("gke") {
 		// GKE use a same-version master upgrade to teardown/recreate master.
 		v, err := cs.Discovery().ServerVersion()
 		if err != nil {
 			return err
 		}
-		return e2eproviders.MasterUpgradeGKE(namespace, v.GitVersion[1:]) // strip leading 'v'
+		return e2eproviders.MasterUpgradeGKE(ctx, namespace, v.GitVersion[1:]) // strip leading 'v'
 	}
 
-	return restartComponent(cs, kubeAPIServerLabelName, metav1.NamespaceSystem, map[string]string{clusterComponentKey: kubeAPIServerLabelName})
+	return restartComponent(ctx, cs, kubeAPIServerLabelName, metav1.NamespaceSystem, map[string]string{clusterComponentKey: kubeAPIServerLabelName})
 }
 
 // restartComponent restarts component static pod
-func restartComponent(cs clientset.Interface, cName, ns string, matchLabels map[string]string) error {
-	pods, err := e2epod.GetPods(cs, ns, matchLabels)
+func restartComponent(ctx context.Context, cs clientset.Interface, cName, ns string, matchLabels map[string]string) error {
+	pods, err := e2epod.GetPods(ctx, cs, ns, matchLabels)
 	if err != nil {
 		return fmt.Errorf("failed to get %s's pods, err: %v", cName, err)
 	}
@@ -4255,11 +4255,11 @@ func restartComponent(cs clientset.Interface, cName, ns string, matchLabels map[
 		return fmt.Errorf("%s pod count is 0", cName)
 	}
 
-	if err := e2epod.DeletePodsWithGracePeriod(cs, pods, 0); err != nil {
+	if err := e2epod.DeletePodsWithGracePeriod(ctx, cs, pods, 0); err != nil {
 		return fmt.Errorf("failed to restart component: %s, err: %v", cName, err)
 	}
 
-	_, err = e2epod.PodsCreatedByLabel(cs, ns, cName, int32(len(pods)), labels.SelectorFromSet(matchLabels))
+	_, err = e2epod.PodsCreatedByLabel(ctx, cs, ns, cName, int32(len(pods)), labels.SelectorFromSet(matchLabels))
 	return err
 }
 

--- a/test/e2e/node/apparmor.go
+++ b/test/e2e/node/apparmor.go
@@ -34,23 +34,23 @@ var _ = SIGDescribe("AppArmor", func() {
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.Context("load AppArmor profiles", func() {
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			e2eskipper.SkipIfAppArmorNotSupported()
-			e2esecurity.LoadAppArmorProfiles(f.Namespace.Name, f.ClientSet)
+			e2esecurity.LoadAppArmorProfiles(ctx, f.Namespace.Name, f.ClientSet)
 		})
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			if !ginkgo.CurrentSpecReport().Failed() {
 				return
 			}
-			e2ekubectl.LogFailedContainers(f.ClientSet, f.Namespace.Name, framework.Logf)
+			e2ekubectl.LogFailedContainers(ctx, f.ClientSet, f.Namespace.Name, framework.Logf)
 		})
 
 		ginkgo.It("should enforce an AppArmor profile", func(ctx context.Context) {
-			e2esecurity.CreateAppArmorTestPod(f.Namespace.Name, f.ClientSet, e2epod.NewPodClient(f), false, true)
+			e2esecurity.CreateAppArmorTestPod(ctx, f.Namespace.Name, f.ClientSet, e2epod.NewPodClient(f), false, true)
 		})
 
 		ginkgo.It("can disable an AppArmor profile, using unconfined", func(ctx context.Context) {
-			e2esecurity.CreateAppArmorTestPod(f.Namespace.Name, f.ClientSet, e2epod.NewPodClient(f), true, true)
+			e2esecurity.CreateAppArmorTestPod(ctx, f.Namespace.Name, f.ClientSet, e2epod.NewPodClient(f), true, true)
 		})
 	})
 })

--- a/test/e2e/node/crictl.go
+++ b/test/e2e/node/crictl.go
@@ -39,7 +39,7 @@ var _ = SIGDescribe("crictl", func() {
 	})
 
 	ginkgo.It("should be able to run crictl on the node", func(ctx context.Context) {
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, maxNodes)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, f.ClientSet, maxNodes)
 		framework.ExpectNoError(err)
 
 		testCases := []string{
@@ -53,7 +53,7 @@ var _ = SIGDescribe("crictl", func() {
 			for _, node := range nodes.Items {
 				ginkgo.By(fmt.Sprintf("Testing %q on node %q ", testCase, node.GetName()))
 
-				res, err := hostExec.Execute(testCase, &node)
+				res, err := hostExec.Execute(ctx, testCase, &node)
 				framework.ExpectNoError(err)
 
 				if res.Stdout == "" && res.Stderr == "" {

--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -70,21 +70,21 @@ var _ = SIGDescribe("Events", func() {
 			ginkgo.By("deleting the pod")
 			return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
 		})
-		if _, err := podClient.Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+		if _, err := podClient.Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 			framework.Failf("Failed to create pod: %v", err)
 		}
 
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
 
 		ginkgo.By("verifying the pod is in kubernetes")
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
 		options := metav1.ListOptions{LabelSelector: selector.String()}
-		pods, err := podClient.List(context.TODO(), options)
+		pods, err := podClient.List(ctx, options)
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(pods.Items), 1)
 
 		ginkgo.By("retrieving the pod")
-		podWithUID, err := podClient.Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		podWithUID, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("Failed to get pod: %v", err)
 		}
@@ -100,7 +100,7 @@ var _ = SIGDescribe("Events", func() {
 				"source":                   v1.DefaultSchedulerName,
 			}.AsSelector().String()
 			options := metav1.ListOptions{FieldSelector: selector}
-			events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(context.TODO(), options)
+			events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, options)
 			if err != nil {
 				return false, err
 			}
@@ -120,7 +120,7 @@ var _ = SIGDescribe("Events", func() {
 				"source":                   "kubelet",
 			}.AsSelector().String()
 			options := metav1.ListOptions{FieldSelector: selector}
-			events, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).List(context.TODO(), options)
+			events, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, options)
 			if err != nil {
 				return false, err
 			}

--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -57,10 +57,10 @@ const (
 
 // getPodMatches returns a set of pod names on the given node that matches the
 // podNamePrefix and namespace.
-func getPodMatches(c clientset.Interface, nodeName string, podNamePrefix string, namespace string) sets.String {
+func getPodMatches(ctx context.Context, c clientset.Interface, nodeName string, podNamePrefix string, namespace string) sets.String {
 	matches := sets.NewString()
 	framework.Logf("Checking pods on node %v via /runningpods endpoint", nodeName)
-	runningPods, err := e2ekubelet.GetKubeletPods(c, nodeName)
+	runningPods, err := e2ekubelet.GetKubeletPods(ctx, c, nodeName)
 	if err != nil {
 		framework.Logf("Error checking running pods on %v: %v", nodeName, err)
 		return matches
@@ -81,14 +81,14 @@ func getPodMatches(c clientset.Interface, nodeName string, podNamePrefix string,
 // information; they are reconstructed by examining the container runtime. In
 // the scope of this test, we do not expect pod naming conflicts so
 // podNamePrefix should be sufficient to identify the pods.
-func waitTillNPodsRunningOnNodes(c clientset.Interface, nodeNames sets.String, podNamePrefix string, namespace string, targetNumPods int, timeout time.Duration) error {
-	return wait.Poll(pollInterval, timeout, func() (bool, error) {
+func waitTillNPodsRunningOnNodes(ctx context.Context, c clientset.Interface, nodeNames sets.String, podNamePrefix string, namespace string, targetNumPods int, timeout time.Duration) error {
+	return wait.PollWithContext(ctx, pollInterval, timeout, func(ctx context.Context) (bool, error) {
 		matchCh := make(chan sets.String, len(nodeNames))
 		for _, item := range nodeNames.List() {
 			// Launch a goroutine per node to check the pods running on the nodes.
 			nodeName := item
 			go func() {
-				matchCh <- getPodMatches(c, nodeName, podNamePrefix, namespace)
+				matchCh <- getPodMatches(ctx, c, nodeName, podNamePrefix, namespace)
 			}()
 		}
 
@@ -125,7 +125,7 @@ func stopNfsServer(serverPod *v1.Pod) {
 // Creates a pod that mounts an nfs volume that is served by the nfs-server pod. The container
 // will execute the passed in shell cmd. Waits for the pod to start.
 // Note: the nfs plugin is defined inline, no PV or PVC.
-func createPodUsingNfs(f *framework.Framework, c clientset.Interface, ns, nfsIP, cmd string) *v1.Pod {
+func createPodUsingNfs(ctx context.Context, f *framework.Framework, c clientset.Interface, ns, nfsIP, cmd string) *v1.Pod {
 	ginkgo.By("create pod using nfs volume")
 
 	isPrivileged := true
@@ -172,13 +172,13 @@ func createPodUsingNfs(f *framework.Framework, c clientset.Interface, ns, nfsIP,
 			},
 		},
 	}
-	rtnPod, err := c.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+	rtnPod, err := c.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
-	err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, rtnPod.Name, f.Namespace.Name, framework.PodStartTimeout) // running & ready
+	err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, rtnPod.Name, f.Namespace.Name, framework.PodStartTimeout) // running & ready
 	framework.ExpectNoError(err)
 
-	rtnPod, err = c.CoreV1().Pods(ns).Get(context.TODO(), rtnPod.Name, metav1.GetOptions{}) // return fresh pod
+	rtnPod, err = c.CoreV1().Pods(ns).Get(ctx, rtnPod.Name, metav1.GetOptions{}) // return fresh pod
 	framework.ExpectNoError(err)
 	return rtnPod
 }
@@ -186,8 +186,8 @@ func createPodUsingNfs(f *framework.Framework, c clientset.Interface, ns, nfsIP,
 // getHostExternalAddress gets the node for a pod and returns the first External
 // address. Returns an error if the node the pod is on doesn't have an External
 // address.
-func getHostExternalAddress(client clientset.Interface, p *v1.Pod) (externalAddress string, err error) {
-	node, err := client.CoreV1().Nodes().Get(context.TODO(), p.Spec.NodeName, metav1.GetOptions{})
+func getHostExternalAddress(ctx context.Context, client clientset.Interface, p *v1.Pod) (externalAddress string, err error) {
+	node, err := client.CoreV1().Nodes().Get(ctx, p.Spec.NodeName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -212,13 +212,13 @@ func getHostExternalAddress(client clientset.Interface, p *v1.Pod) (externalAddr
 // `ls <uid-dir>` should fail (since that dir was removed). If expectClean is false then we expect
 // the node is not cleaned up, and thus cmds like `ls <uid-dir>` should succeed. We wait for the
 // kubelet to be cleaned up, afterwhich an error is reported.
-func checkPodCleanup(c clientset.Interface, pod *v1.Pod, expectClean bool) {
+func checkPodCleanup(ctx context.Context, c clientset.Interface, pod *v1.Pod, expectClean bool) {
 	timeout := 5 * time.Minute
 	poll := 20 * time.Second
 	podDir := filepath.Join("/var/lib/kubelet/pods", string(pod.UID))
 	mountDir := filepath.Join(podDir, "volumes", "kubernetes.io~nfs")
 	// use ip rather than hostname in GCE
-	nodeIP, err := getHostExternalAddress(c, pod)
+	nodeIP, err := getHostExternalAddress(ctx, c, pod)
 	framework.ExpectNoError(err)
 
 	condMsg := "deleted"
@@ -244,8 +244,8 @@ func checkPodCleanup(c clientset.Interface, pod *v1.Pod, expectClean bool) {
 
 	for _, test := range tests {
 		framework.Logf("Wait up to %v for host's (%v) %q to be %v", timeout, nodeIP, test.feature, condMsg)
-		err = wait.Poll(poll, timeout, func() (bool, error) {
-			result, err := e2essh.NodeExec(nodeIP, test.cmd, framework.TestContext.Provider)
+		err = wait.PollWithContext(ctx, poll, timeout, func(ctx context.Context) (bool, error) {
+			result, err := e2essh.NodeExec(ctx, nodeIP, test.cmd, framework.TestContext.Provider)
 			framework.ExpectNoError(err)
 			e2essh.LogResult(result)
 			ok := (result.Code == 0 && len(result.Stdout) > 0 && len(result.Stderr) == 0)
@@ -296,12 +296,13 @@ var _ = SIGDescribe("kubelet", func() {
 			{podsPerNode: 10, timeout: 1 * time.Minute},
 		}
 
-		ginkgo.BeforeEach(func() {
+		// Must be called in each It with the context of the test.
+		start := func(ctx context.Context) {
 			// Use node labels to restrict the pods to be assigned only to the
 			// nodes we observe initially.
 			nodeLabels = make(map[string]string)
 			nodeLabels["kubelet_cleanup"] = "true"
-			nodes, err := e2enode.GetBoundedReadySchedulableNodes(c, maxNodesToCheck)
+			nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, c, maxNodesToCheck)
 			numNodes = len(nodes.Items)
 			framework.ExpectNoError(err)
 			nodeNames = sets.NewString()
@@ -318,27 +319,28 @@ var _ = SIGDescribe("kubelet", func() {
 			// While we only use a bounded number of nodes in the test. We need to know
 			// the actual number of nodes in the cluster, to avoid running resourceMonitor
 			// against large clusters.
-			actualNodes, err := e2enode.GetReadySchedulableNodes(c)
+			actualNodes, err := e2enode.GetReadySchedulableNodes(ctx, c)
 			framework.ExpectNoError(err)
 
 			// Start resourceMonitor only in small clusters.
 			if len(actualNodes.Items) <= maxNodesToCheck {
 				resourceMonitor = e2ekubelet.NewResourceMonitor(f.ClientSet, e2ekubelet.TargetContainers(), containerStatsPollingInterval)
-				resourceMonitor.Start()
+				resourceMonitor.Start(ctx)
 				ginkgo.DeferCleanup(resourceMonitor.Stop)
 			}
-		})
+		}
 
 		for _, itArg := range deleteTests {
 			name := fmt.Sprintf(
 				"kubelet should be able to delete %d pods per node in %v.", itArg.podsPerNode, itArg.timeout)
 			itArg := itArg
 			ginkgo.It(name, func(ctx context.Context) {
+				start(ctx)
 				totalPods := itArg.podsPerNode * numNodes
 				ginkgo.By(fmt.Sprintf("Creating a RC of %d pods and wait until all pods of this RC are running", totalPods))
 				rcName := fmt.Sprintf("cleanup%d-%s", totalPods, string(uuid.NewUUID()))
 
-				err := e2erc.RunRC(testutils.RCConfig{
+				err := e2erc.RunRC(ctx, testutils.RCConfig{
 					Client:       f.ClientSet,
 					Name:         rcName,
 					Namespace:    f.Namespace.Name,
@@ -351,14 +353,14 @@ var _ = SIGDescribe("kubelet", func() {
 				// running on the nodes according to kubelet. The timeout is set to
 				// only 30 seconds here because e2erc.RunRC already waited for all pods to
 				// transition to the running status.
-				err = waitTillNPodsRunningOnNodes(f.ClientSet, nodeNames, rcName, ns, totalPods, time.Second*30)
+				err = waitTillNPodsRunningOnNodes(ctx, f.ClientSet, nodeNames, rcName, ns, totalPods, time.Second*30)
 				framework.ExpectNoError(err)
 				if resourceMonitor != nil {
 					resourceMonitor.LogLatest()
 				}
 
 				ginkgo.By("Deleting the RC")
-				e2erc.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, rcName)
+				e2erc.DeleteRCAndWaitForGC(ctx, f.ClientSet, f.Namespace.Name, rcName)
 				// Check that the pods really are gone by querying /runningpods on the
 				// node. The /runningpods handler checks the container runtime (or its
 				// cache) and  returns a list of running pods. Some possible causes of
@@ -367,7 +369,7 @@ var _ = SIGDescribe("kubelet", func() {
 				//   - a bug in graceful termination (if it is enabled)
 				//   - docker slow to delete pods (or resource problems causing slowness)
 				start := time.Now()
-				err = waitTillNPodsRunningOnNodes(f.ClientSet, nodeNames, rcName, ns, 0, itArg.timeout)
+				err = waitTillNPodsRunningOnNodes(ctx, f.ClientSet, nodeNames, rcName, ns, 0, itArg.timeout)
 				framework.ExpectNoError(err)
 				framework.Logf("Deleting %d pods on %d nodes completed in %v after the RC was deleted", totalPods, len(nodeNames),
 					time.Since(start))
@@ -411,15 +413,15 @@ var _ = SIGDescribe("kubelet", func() {
 				},
 			}
 
-			ginkgo.BeforeEach(func() {
+			ginkgo.BeforeEach(func(ctx context.Context) {
 				e2eskipper.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
-				_, nfsServerPod, nfsIP = e2evolume.NewNFSServer(c, ns, []string{"-G", "777", "/exports"})
+				_, nfsServerPod, nfsIP = e2evolume.NewNFSServer(ctx, c, ns, []string{"-G", "777", "/exports"})
 			})
 
-			ginkgo.AfterEach(func() {
-				err := e2epod.DeletePodWithWait(c, pod)
+			ginkgo.AfterEach(func(ctx context.Context) {
+				err := e2epod.DeletePodWithWait(ctx, c, pod)
 				framework.ExpectNoError(err, "AfterEach: Failed to delete client pod ", pod.Name)
-				err = e2epod.DeletePodWithWait(c, nfsServerPod)
+				err = e2epod.DeletePodWithWait(ctx, c, nfsServerPod)
 				framework.ExpectNoError(err, "AfterEach: Failed to delete server pod ", nfsServerPod.Name)
 			})
 
@@ -427,24 +429,24 @@ var _ = SIGDescribe("kubelet", func() {
 			for _, t := range testTbl {
 				t := t
 				ginkgo.It(t.itDescr, func(ctx context.Context) {
-					pod = createPodUsingNfs(f, c, ns, nfsIP, t.podCmd)
+					pod = createPodUsingNfs(ctx, f, c, ns, nfsIP, t.podCmd)
 
 					ginkgo.By("Stop the NFS server")
 					stopNfsServer(nfsServerPod)
 
 					ginkgo.By("Delete the pod mounted to the NFS volume -- expect failure")
-					err := e2epod.DeletePodWithWait(c, pod)
+					err := e2epod.DeletePodWithWait(ctx, c, pod)
 					framework.ExpectError(err)
 					// pod object is now stale, but is intentionally not nil
 
 					ginkgo.By("Check if pod's host has been cleaned up -- expect not")
-					checkPodCleanup(c, pod, false)
+					checkPodCleanup(ctx, c, pod, false)
 
 					ginkgo.By("Restart the nfs server")
 					restartNfsServer(nfsServerPod)
 
 					ginkgo.By("Verify that the deleted client pod is now cleaned up")
-					checkPodCleanup(c, pod, true)
+					checkPodCleanup(ctx, c, pod, true)
 				})
 			}
 		})
@@ -457,8 +459,8 @@ var _ = SIGDescribe("kubelet", func() {
 			nodeNames sets.String
 		)
 
-		ginkgo.BeforeEach(func() {
-			nodes, err := e2enode.GetBoundedReadySchedulableNodes(c, maxNodesToCheck)
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, c, maxNodesToCheck)
 			numNodes = len(nodes.Items)
 			framework.ExpectNoError(err)
 			nodeNames = sets.NewString()

--- a/test/e2e/node/kubelet_perf.go
+++ b/test/e2e/node/kubelet_perf.go
@@ -54,9 +54,9 @@ type resourceTest struct {
 	memLimits   e2ekubelet.ResourceUsagePerContainer
 }
 
-func logPodsOnNodes(c clientset.Interface, nodeNames []string) {
+func logPodsOnNodes(ctx context.Context, c clientset.Interface, nodeNames []string) {
 	for _, n := range nodeNames {
-		podList, err := e2ekubelet.GetKubeletRunningPods(c, n)
+		podList, err := e2ekubelet.GetKubeletRunningPods(ctx, c, n)
 		if err != nil {
 			framework.Logf("Unable to retrieve kubelet pods for node %v", n)
 			continue
@@ -65,7 +65,7 @@ func logPodsOnNodes(c clientset.Interface, nodeNames []string) {
 	}
 }
 
-func runResourceTrackingTest(f *framework.Framework, podsPerNode int, nodeNames sets.String, rm *e2ekubelet.ResourceMonitor,
+func runResourceTrackingTest(ctx context.Context, f *framework.Framework, podsPerNode int, nodeNames sets.String, rm *e2ekubelet.ResourceMonitor,
 	expectedCPU map[string]map[float64]float64, expectedMemory e2ekubelet.ResourceUsagePerContainer) {
 	numNodes := nodeNames.Len()
 	totalPods := podsPerNode * numNodes
@@ -73,7 +73,7 @@ func runResourceTrackingTest(f *framework.Framework, podsPerNode int, nodeNames 
 	rcName := fmt.Sprintf("resource%d-%s", totalPods, string(uuid.NewUUID()))
 
 	// TODO: Use a more realistic workload
-	err := e2erc.RunRC(testutils.RCConfig{
+	err := e2erc.RunRC(ctx, testutils.RCConfig{
 		Client:    f.ClientSet,
 		Name:      rcName,
 		Namespace: f.Namespace.Name,
@@ -93,7 +93,7 @@ func runResourceTrackingTest(f *framework.Framework, podsPerNode int, nodeNames 
 	// for the current test duration, but we should reclaim the
 	// entries if we plan to monitor longer (e.g., 8 hours).
 	deadline := time.Now().Add(monitoringTime)
-	for time.Now().Before(deadline) {
+	for time.Now().Before(deadline) && ctx.Err() == nil {
 		timeLeft := time.Until(deadline)
 		framework.Logf("Still running...%v left", timeLeft)
 		if timeLeft < reportingPeriod {
@@ -101,18 +101,18 @@ func runResourceTrackingTest(f *framework.Framework, podsPerNode int, nodeNames 
 		} else {
 			time.Sleep(reportingPeriod)
 		}
-		logPodsOnNodes(f.ClientSet, nodeNames.List())
+		logPodsOnNodes(ctx, f.ClientSet, nodeNames.List())
 	}
 
 	ginkgo.By("Reporting overall resource usage")
-	logPodsOnNodes(f.ClientSet, nodeNames.List())
+	logPodsOnNodes(ctx, f.ClientSet, nodeNames.List())
 	usageSummary, err := rm.GetLatest()
 	framework.ExpectNoError(err)
 	// TODO(random-liu): Remove the original log when we migrate to new perfdash
 	framework.Logf("%s", rm.FormatResourceUsage(usageSummary))
 	// Log perf result
 	printPerfData(e2eperf.ResourceUsageToPerfData(rm.GetMasterNodeLatest(usageSummary)))
-	verifyMemoryLimits(f.ClientSet, expectedMemory, usageSummary)
+	verifyMemoryLimits(ctx, f.ClientSet, expectedMemory, usageSummary)
 
 	cpuSummary := rm.GetCPUSummary()
 	framework.Logf("%s", rm.FormatCPUSummary(cpuSummary))
@@ -121,10 +121,10 @@ func runResourceTrackingTest(f *framework.Framework, podsPerNode int, nodeNames 
 	verifyCPULimits(expectedCPU, cpuSummary)
 
 	ginkgo.By("Deleting the RC")
-	e2erc.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, rcName)
+	e2erc.DeleteRCAndWaitForGC(ctx, f.ClientSet, f.Namespace.Name, rcName)
 }
 
-func verifyMemoryLimits(c clientset.Interface, expected e2ekubelet.ResourceUsagePerContainer, actual e2ekubelet.ResourceUsagePerNode) {
+func verifyMemoryLimits(ctx context.Context, c clientset.Interface, expected e2ekubelet.ResourceUsagePerContainer, actual e2ekubelet.ResourceUsagePerNode) {
 	if expected == nil {
 		return
 	}
@@ -147,7 +147,7 @@ func verifyMemoryLimits(c clientset.Interface, expected e2ekubelet.ResourceUsage
 		}
 		if len(nodeErrs) > 0 {
 			errList = append(errList, fmt.Sprintf("node %v:\n %s", nodeName, strings.Join(nodeErrs, ", ")))
-			heapStats, err := e2ekubelet.GetKubeletHeapStats(c, nodeName)
+			heapStats, err := e2ekubelet.GetKubeletHeapStats(ctx, c, nodeName)
 			if err != nil {
 				framework.Logf("Unable to get heap stats from %q", nodeName)
 			} else {
@@ -202,21 +202,21 @@ var _ = SIGDescribe("Kubelet [Serial] [Slow]", func() {
 	var om *e2ekubelet.RuntimeOperationMonitor
 	var rm *e2ekubelet.ResourceMonitor
 
-	ginkgo.BeforeEach(func() {
-		nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 		nodeNames = sets.NewString()
 		for _, node := range nodes.Items {
 			nodeNames.Insert(node.Name)
 		}
-		om = e2ekubelet.NewRuntimeOperationMonitor(f.ClientSet)
+		om = e2ekubelet.NewRuntimeOperationMonitor(ctx, f.ClientSet)
 		rm = e2ekubelet.NewResourceMonitor(f.ClientSet, e2ekubelet.TargetContainers(), containerStatsPollingPeriod)
-		rm.Start()
+		rm.Start(ctx)
 	})
 
-	ginkgo.AfterEach(func() {
+	ginkgo.AfterEach(func(ctx context.Context) {
 		rm.Stop()
-		result := om.GetLatestRuntimeOperationErrorRate()
+		result := om.GetLatestRuntimeOperationErrorRate(ctx)
 		framework.Logf("runtime operation error metrics:\n%s", e2ekubelet.FormatRuntimeOperationErrorRate(result))
 	})
 	ginkgo.Describe("regular resource usage tracking [Feature:RegularResourceUsageTracking]", func() {
@@ -267,7 +267,7 @@ var _ = SIGDescribe("Kubelet [Serial] [Slow]", func() {
 			name := fmt.Sprintf(
 				"resource tracking for %d pods per node", podsPerNode)
 			ginkgo.It(name, func(ctx context.Context) {
-				runResourceTrackingTest(f, podsPerNode, nodeNames, rm, itArg.cpuLimits, itArg.memLimits)
+				runResourceTrackingTest(ctx, f, podsPerNode, nodeNames, rm, itArg.cpuLimits, itArg.memLimits)
 			})
 		}
 	})
@@ -278,7 +278,7 @@ var _ = SIGDescribe("Kubelet [Serial] [Slow]", func() {
 			name := fmt.Sprintf(
 				"resource tracking for %d pods per node", podsPerNode)
 			ginkgo.It(name, func(ctx context.Context) {
-				runResourceTrackingTest(f, podsPerNode, nodeNames, rm, nil, nil)
+				runResourceTrackingTest(ctx, f, podsPerNode, nodeNames, rm, nil, nil)
 			})
 		}
 	})

--- a/test/e2e/node/pod_gc.go
+++ b/test/e2e/node/pod_gc.go
@@ -41,13 +41,13 @@ var _ = SIGDescribe("Pod garbage collector [Feature:PodGarbageCollector] [Slow]"
 	ginkgo.It("should handle the creation of 1000 pods", func(ctx context.Context) {
 		var count int
 		for count < 1000 {
-			pod, err := createTerminatingPod(f)
+			pod, err := createTerminatingPod(ctx, f)
 			if err != nil {
 				framework.Failf("err creating pod: %v", err)
 			}
 			pod.ResourceVersion = ""
 			pod.Status.Phase = v1.PodFailed
-			_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).UpdateStatus(context.TODO(), pod, metav1.UpdateOptions{})
+			_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
 			if err != nil {
 				framework.Failf("err failing pod: %v", err)
 			}
@@ -69,7 +69,7 @@ var _ = SIGDescribe("Pod garbage collector [Feature:PodGarbageCollector] [Slow]"
 
 		ginkgo.By(fmt.Sprintf("Waiting for gc controller to gc all but %d pods", gcThreshold))
 		pollErr := wait.Poll(1*time.Minute, timeout, func() (bool, error) {
-			pods, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
+			pods, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 			if err != nil {
 				framework.Logf("Failed to list pod %v", err)
 				return false, nil
@@ -86,7 +86,7 @@ var _ = SIGDescribe("Pod garbage collector [Feature:PodGarbageCollector] [Slow]"
 	})
 })
 
-func createTerminatingPod(f *framework.Framework) (*v1.Pod, error) {
+func createTerminatingPod(ctx context.Context, f *framework.Framework) (*v1.Pod, error) {
 	uuid := uuid.NewUUID()
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -102,5 +102,5 @@ func createTerminatingPod(f *framework.Framework) (*v1.Pod, error) {
 			SchedulerName: "please don't schedule my pods",
 		},
 	}
-	return f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+	return f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 }

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -78,31 +78,31 @@ var _ = SIGDescribe("Pods Extended", func() {
 			ginkgo.By("setting up selector")
 			selector := labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
 			options := metav1.ListOptions{LabelSelector: selector.String()}
-			pods, err := podClient.List(context.TODO(), options)
+			pods, err := podClient.List(ctx, options)
 			framework.ExpectNoError(err, "failed to query for pod")
 			framework.ExpectEqual(len(pods.Items), 0)
 
 			ginkgo.By("submitting the pod to kubernetes")
-			podClient.Create(pod)
+			podClient.Create(ctx, pod)
 
 			ginkgo.By("verifying the pod is in kubernetes")
 			selector = labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
 			options = metav1.ListOptions{LabelSelector: selector.String()}
-			pods, err = podClient.List(context.TODO(), options)
+			pods, err = podClient.List(ctx, options)
 			framework.ExpectNoError(err, "failed to query for pod")
 			framework.ExpectEqual(len(pods.Items), 1)
 
 			// We need to wait for the pod to be running, otherwise the deletion
 			// may be carried out immediately rather than gracefully.
-			framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name))
+			framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
 			// save the running pod
-			pod, err = podClient.Get(context.TODO(), pod.Name, metav1.GetOptions{})
+			pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err, "failed to GET scheduled pod")
 
 			ginkgo.By("deleting the pod gracefully")
 			var lastPod v1.Pod
 			var statusCode int
-			err = f.ClientSet.CoreV1().RESTClient().Delete().AbsPath("/api/v1/namespaces", pod.Namespace, "pods", pod.Name).Param("gracePeriodSeconds", "30").Do(context.TODO()).StatusCode(&statusCode).Into(&lastPod)
+			err = f.ClientSet.CoreV1().RESTClient().Delete().AbsPath("/api/v1/namespaces", pod.Namespace, "pods", pod.Name).Param("gracePeriodSeconds", "30").Do(ctx).StatusCode(&statusCode).Into(&lastPod)
 			framework.ExpectNoError(err, "failed to use http client to send delete")
 			framework.ExpectEqual(statusCode, http.StatusOK, "failed to delete gracefully by client request")
 
@@ -113,7 +113,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			// latency between termination and reportal can be isolated further.
 			start := time.Now()
 			err = wait.Poll(time.Second*5, time.Second*30*3, func() (bool, error) {
-				podList, err := e2ekubelet.GetKubeletPods(f.ClientSet, pod.Spec.NodeName)
+				podList, err := e2ekubelet.GetKubeletPods(ctx, f.ClientSet, pod.Spec.NodeName)
 				if err != nil {
 					framework.Logf("Unable to retrieve kubelet pods for node %v: %v", pod.Spec.NodeName, err)
 					return false, nil
@@ -140,7 +140,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 
 			selector = labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
 			options = metav1.ListOptions{LabelSelector: selector.String()}
-			pods, err = podClient.List(context.TODO(), options)
+			pods, err = podClient.List(ctx, options)
 			framework.ExpectNoError(err, "failed to query for pods")
 			framework.ExpectEqual(len(pods.Items), 0)
 
@@ -190,10 +190,10 @@ var _ = SIGDescribe("Pods Extended", func() {
 			}
 
 			ginkgo.By("submitting the pod to kubernetes")
-			podClient.Create(pod)
+			podClient.Create(ctx, pod)
 
 			ginkgo.By("verifying QOS class is set on the pod")
-			pod, err := podClient.Get(context.TODO(), name, metav1.GetOptions{})
+			pod, err := podClient.Get(ctx, name, metav1.GetOptions{})
 			framework.ExpectNoError(err, "failed to query for pod")
 			framework.ExpectEqual(pod.Status.QOSClass, v1.PodQOSGuaranteed)
 		})
@@ -207,7 +207,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 
 		ginkgo.It("should never report success for a pending container", func(ctx context.Context) {
 			ginkgo.By("creating pods that should always exit 1 and terminating the pod after a random delay")
-			createAndTestPodRepeatedly(
+			createAndTestPodRepeatedly(ctx,
 				3, 15,
 				podFastDeleteScenario{client: podClient.PodInterface, delayMs: 2000},
 				podClient.PodInterface,
@@ -215,7 +215,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 		})
 		ginkgo.It("should never report container start when an init container fails", func(ctx context.Context) {
 			ginkgo.By("creating pods with an init container that always exit 1 and terminating the pod after a random delay")
-			createAndTestPodRepeatedly(
+			createAndTestPodRepeatedly(ctx,
 				3, 15,
 				podFastDeleteScenario{client: podClient.PodInterface, delayMs: 2000, initContainer: true},
 				podClient.PodInterface,
@@ -262,13 +262,13 @@ var _ = SIGDescribe("Pods Extended", func() {
 			}
 
 			ginkgo.By("submitting the pod to kubernetes")
-			createdPod := podClient.Create(pod)
+			createdPod := podClient.Create(ctx, pod)
 			ginkgo.DeferCleanup(func(ctx context.Context) error {
 				ginkgo.By("deleting the pod")
 				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
 			})
 
-			framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name))
+			framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
 
 			var eventList *v1.EventList
 			var err error
@@ -281,7 +281,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 					"source":                   "kubelet",
 				}.AsSelector().String()
 				options := metav1.ListOptions{FieldSelector: selector}
-				eventList, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).List(context.TODO(), options)
+				eventList, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, options)
 				if err != nil {
 					return false, err
 				}
@@ -327,13 +327,13 @@ var _ = SIGDescribe("Pods Extended", func() {
 			}
 
 			ginkgo.By("submitting the pod to kubernetes")
-			podClient.Create(pod)
+			podClient.Create(ctx, pod)
 			ginkgo.DeferCleanup(func(ctx context.Context) error {
 				ginkgo.By("deleting the pod")
 				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
 			})
 
-			err := e2epod.WaitForPodTerminatedInNamespace(f.ClientSet, pod.Name, "Evicted", f.Namespace.Name)
+			err := e2epod.WaitForPodTerminatedInNamespace(ctx, f.ClientSet, pod.Name, "Evicted", f.Namespace.Name)
 			if err != nil {
 				framework.Failf("error waiting for pod to be evicted: %v", err)
 			}
@@ -343,7 +343,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 
 })
 
-func createAndTestPodRepeatedly(workers, iterations int, scenario podScenario, podClient v1core.PodInterface) {
+func createAndTestPodRepeatedly(ctx context.Context, workers, iterations int, scenario podScenario, podClient v1core.PodInterface) {
 	var (
 		lock sync.Mutex
 		errs []error
@@ -373,7 +373,7 @@ func createAndTestPodRepeatedly(workers, iterations int, scenario podScenario, p
 
 				// create the pod, capture the change events, then delete the pod
 				start := time.Now()
-				created, err := podClient.Create(context.TODO(), pod, metav1.CreateOptions{})
+				created, err := podClient.Create(ctx, pod, metav1.CreateOptions{})
 				framework.ExpectNoError(err, "failed to create pod")
 
 				ch := make(chan []watch.Event)
@@ -381,7 +381,7 @@ func createAndTestPodRepeatedly(workers, iterations int, scenario podScenario, p
 				go func() {
 					defer ginkgo.GinkgoRecover()
 					defer close(ch)
-					w, err := podClient.Watch(context.TODO(), metav1.ListOptions{
+					w, err := podClient.Watch(ctx, metav1.ListOptions{
 						ResourceVersion: created.ResourceVersion,
 						FieldSelector:   fmt.Sprintf("metadata.name=%s", pod.Name),
 					})
@@ -412,7 +412,7 @@ func createAndTestPodRepeatedly(workers, iterations int, scenario podScenario, p
 				case <-waitForWatch: // when the watch is established
 				}
 
-				verifier, scenario, err := scenario.Action(pod)
+				verifier, scenario, err := scenario.Action(ctx, pod)
 				framework.ExpectNoError(err, "failed to take action")
 
 				var (
@@ -483,7 +483,7 @@ func createAndTestPodRepeatedly(workers, iterations int, scenario podScenario, p
 
 type podScenario interface {
 	Pod(worker, attempt int) *v1.Pod
-	Action(*v1.Pod) (podScenarioVerifier, string, error)
+	Action(context.Context, *v1.Pod) (podScenarioVerifier, string, error)
 	IsLastEvent(event watch.Event) bool
 }
 
@@ -510,11 +510,11 @@ func (s podFastDeleteScenario) IsLastEvent(event watch.Event) bool {
 	return false
 }
 
-func (s podFastDeleteScenario) Action(pod *v1.Pod) (podScenarioVerifier, string, error) {
+func (s podFastDeleteScenario) Action(ctx context.Context, pod *v1.Pod) (podScenarioVerifier, string, error) {
 	t := time.Duration(rand.Intn(s.delayMs)) * time.Millisecond
 	scenario := fmt.Sprintf("t=%s", t)
 	time.Sleep(t)
-	return &podStartVerifier{pod: pod}, scenario, s.client.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+	return &podStartVerifier{pod: pod}, scenario, s.client.Delete(ctx, pod.Name, metav1.DeleteOptions{})
 }
 
 func (s podFastDeleteScenario) Pod(worker, attempt int) *v1.Pod {

--- a/test/e2e/node/runtimeclass.go
+++ b/test/e2e/node/runtimeclass.go
@@ -53,14 +53,14 @@ var _ = SIGDescribe("RuntimeClass", func() {
 
 		runtimeClass := newRuntimeClass(f.Namespace.Name, "conflict-runtimeclass")
 		runtimeClass.Scheduling = scheduling
-		rc, err := f.ClientSet.NodeV1().RuntimeClasses().Create(context.TODO(), runtimeClass, metav1.CreateOptions{})
+		rc, err := f.ClientSet.NodeV1().RuntimeClasses().Create(ctx, runtimeClass, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create RuntimeClass resource")
 
 		pod := e2enode.NewRuntimeClassPod(rc.GetName())
 		pod.Spec.NodeSelector = map[string]string{
 			labelFooName: "bar",
 		}
-		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		if !apierrors.IsForbidden(err) {
 			framework.Failf("expected 'forbidden' as error, got instead: %v", err)
 		}
@@ -70,7 +70,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		labelFooName := "foo-" + string(uuid.NewUUID())
 		labelFizzName := "fizz-" + string(uuid.NewUUID())
 
-		nodeName := scheduling.GetNodeThatCanRunPod(f)
+		nodeName := scheduling.GetNodeThatCanRunPod(ctx, f)
 		nodeSelector := map[string]string{
 			labelFooName:  "bar",
 			labelFizzName: "buzz",
@@ -91,7 +91,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		ginkgo.By("Trying to apply a label on the found node.")
 		for key, value := range nodeSelector {
 			e2enode.AddOrUpdateLabelOnNode(f.ClientSet, nodeName, key, value)
-			e2enode.ExpectNodeHasLabel(f.ClientSet, nodeName, key, value)
+			e2enode.ExpectNodeHasLabel(ctx, f.ClientSet, nodeName, key, value)
 			ginkgo.DeferCleanup(e2enode.RemoveLabelOffNode, f.ClientSet, nodeName, key)
 		}
 
@@ -101,26 +101,26 @@ var _ = SIGDescribe("RuntimeClass", func() {
 			Value:  "bar",
 			Effect: v1.TaintEffectNoSchedule,
 		}
-		e2enode.AddOrUpdateTaintOnNode(f.ClientSet, nodeName, taint)
-		e2enode.ExpectNodeHasTaint(f.ClientSet, nodeName, &taint)
+		e2enode.AddOrUpdateTaintOnNode(ctx, f.ClientSet, nodeName, taint)
+		e2enode.ExpectNodeHasTaint(ctx, f.ClientSet, nodeName, &taint)
 		ginkgo.DeferCleanup(e2enode.RemoveTaintOffNode, f.ClientSet, nodeName, taint)
 
 		ginkgo.By("Trying to create runtimeclass and pod")
 		runtimeClass := newRuntimeClass(f.Namespace.Name, "non-conflict-runtimeclass")
 		runtimeClass.Scheduling = scheduling
-		rc, err := f.ClientSet.NodeV1().RuntimeClasses().Create(context.TODO(), runtimeClass, metav1.CreateOptions{})
+		rc, err := f.ClientSet.NodeV1().RuntimeClasses().Create(ctx, runtimeClass, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create RuntimeClass resource")
 
 		pod := e2enode.NewRuntimeClassPod(rc.GetName())
 		pod.Spec.NodeSelector = map[string]string{
 			labelFooName: "bar",
 		}
-		pod = e2epod.NewPodClient(f).Create(pod)
+		pod = e2epod.NewPodClient(f).Create(ctx, pod)
 
-		framework.ExpectNoError(e2epod.WaitForPodNotPending(f.ClientSet, f.Namespace.Name, pod.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNotPending(ctx, f.ClientSet, f.Namespace.Name, pod.Name))
 
 		// check that pod got scheduled on specified node.
-		scheduledPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		scheduledPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(nodeName, scheduledPod.Spec.NodeName)
 		framework.ExpectEqual(nodeSelector, pod.Spec.NodeSelector)
@@ -135,7 +135,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		labelFooName := "foo-" + string(uuid.NewUUID())
 		labelFizzName := "fizz-" + string(uuid.NewUUID())
 
-		nodeName := scheduling.GetNodeThatCanRunPod(f)
+		nodeName := scheduling.GetNodeThatCanRunPod(ctx, f)
 		nodeSelector := map[string]string{
 			labelFooName:  "bar",
 			labelFizzName: "buzz",
@@ -147,26 +147,26 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		ginkgo.By("Trying to apply a label on the found node.")
 		for key, value := range nodeSelector {
 			e2enode.AddOrUpdateLabelOnNode(f.ClientSet, nodeName, key, value)
-			e2enode.ExpectNodeHasLabel(f.ClientSet, nodeName, key, value)
+			e2enode.ExpectNodeHasLabel(ctx, f.ClientSet, nodeName, key, value)
 			ginkgo.DeferCleanup(e2enode.RemoveLabelOffNode, f.ClientSet, nodeName, key)
 		}
 
 		ginkgo.By("Trying to create runtimeclass and pod")
 		runtimeClass := newRuntimeClass(f.Namespace.Name, "non-conflict-runtimeclass")
 		runtimeClass.Scheduling = scheduling
-		rc, err := f.ClientSet.NodeV1().RuntimeClasses().Create(context.TODO(), runtimeClass, metav1.CreateOptions{})
+		rc, err := f.ClientSet.NodeV1().RuntimeClasses().Create(ctx, runtimeClass, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create RuntimeClass resource")
 
 		pod := e2enode.NewRuntimeClassPod(rc.GetName())
 		pod.Spec.NodeSelector = map[string]string{
 			labelFooName: "bar",
 		}
-		pod = e2epod.NewPodClient(f).Create(pod)
+		pod = e2epod.NewPodClient(f).Create(ctx, pod)
 
-		framework.ExpectNoError(e2epod.WaitForPodNotPending(f.ClientSet, f.Namespace.Name, pod.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNotPending(ctx, f.ClientSet, f.Namespace.Name, pod.Name))
 
 		// check that pod got scheduled on specified node.
-		scheduledPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		scheduledPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(nodeName, scheduledPod.Spec.NodeName)
 		framework.ExpectEqual(nodeSelector, pod.Spec.NodeSelector)

--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -74,7 +74,7 @@ var _ = SIGDescribe("Security Context", func() {
 		pod.Spec.Containers[0].Command = []string{"id", "-G"}
 		pod.Spec.SecurityContext.SupplementalGroups = []int64{1234, 5678}
 		groups := []string{"1234", "5678"}
-		e2eoutput.TestContainerOutput(f, "pod.Spec.SecurityContext.SupplementalGroups", pod, 0, groups)
+		e2eoutput.TestContainerOutput(ctx, f, "pod.Spec.SecurityContext.SupplementalGroups", pod, 0, groups)
 	})
 
 	ginkgo.When("if the container's primary UID belongs to some groups in the image [LinuxOnly]", func() {
@@ -100,6 +100,7 @@ var _ = SIGDescribe("Security Context", func() {
 			// $ id -G
 			// 1000 50000 60000
 			e2eoutput.TestContainerOutput(
+				ctx,
 				f,
 				"pod.Spec.SecurityContext.SupplementalGroups with pre-defined-group in the image",
 				pod, 0,
@@ -114,7 +115,7 @@ var _ = SIGDescribe("Security Context", func() {
 		pod.Spec.SecurityContext.RunAsUser = &userID
 		pod.Spec.Containers[0].Command = []string{"sh", "-c", "id"}
 
-		e2eoutput.TestContainerOutput(f, "pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
+		e2eoutput.TestContainerOutput(ctx, f, "pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
 			fmt.Sprintf("uid=%v", userID),
 			fmt.Sprintf("gid=%v", 0),
 		})
@@ -134,7 +135,7 @@ var _ = SIGDescribe("Security Context", func() {
 		pod.Spec.SecurityContext.RunAsGroup = &groupID
 		pod.Spec.Containers[0].Command = []string{"sh", "-c", "id"}
 
-		e2eoutput.TestContainerOutput(f, "pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
+		e2eoutput.TestContainerOutput(ctx, f, "pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
 			fmt.Sprintf("uid=%v", userID),
 			fmt.Sprintf("gid=%v", groupID),
 		})
@@ -149,7 +150,7 @@ var _ = SIGDescribe("Security Context", func() {
 		pod.Spec.Containers[0].SecurityContext.RunAsUser = &overrideUserID
 		pod.Spec.Containers[0].Command = []string{"sh", "-c", "id"}
 
-		e2eoutput.TestContainerOutput(f, "pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
+		e2eoutput.TestContainerOutput(ctx, f, "pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
 			fmt.Sprintf("uid=%v", overrideUserID),
 			fmt.Sprintf("gid=%v", 0),
 		})
@@ -174,22 +175,22 @@ var _ = SIGDescribe("Security Context", func() {
 		pod.Spec.Containers[0].SecurityContext.RunAsGroup = &overrideGroupID
 		pod.Spec.Containers[0].Command = []string{"sh", "-c", "id"}
 
-		e2eoutput.TestContainerOutput(f, "pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
+		e2eoutput.TestContainerOutput(ctx, f, "pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
 			fmt.Sprintf("uid=%v", overrideUserID),
 			fmt.Sprintf("gid=%v", overrideGroupID),
 		})
 	})
 
 	ginkgo.It("should support volume SELinux relabeling [Flaky] [LinuxOnly]", func(ctx context.Context) {
-		testPodSELinuxLabeling(f, false, false)
+		testPodSELinuxLabeling(ctx, f, false, false)
 	})
 
 	ginkgo.It("should support volume SELinux relabeling when using hostIPC [Flaky] [LinuxOnly]", func(ctx context.Context) {
-		testPodSELinuxLabeling(f, true, false)
+		testPodSELinuxLabeling(ctx, f, true, false)
 	})
 
 	ginkgo.It("should support volume SELinux relabeling when using hostPID [Flaky] [LinuxOnly]", func(ctx context.Context) {
-		testPodSELinuxLabeling(f, false, true)
+		testPodSELinuxLabeling(ctx, f, false, true)
 	})
 
 	ginkgo.It("should support seccomp unconfined on the container [LinuxOnly]", func(ctx context.Context) {
@@ -197,31 +198,31 @@ var _ = SIGDescribe("Security Context", func() {
 		pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}}
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault}}
 		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
-		e2eoutput.TestContainerOutput(f, "seccomp unconfined container", pod, 0, []string{"0"}) // seccomp disabled
+		e2eoutput.TestContainerOutput(ctx, f, "seccomp unconfined container", pod, 0, []string{"0"}) // seccomp disabled
 	})
 
 	ginkgo.It("should support seccomp unconfined on the pod [LinuxOnly]", func(ctx context.Context) {
 		pod := scTestPod(false, false)
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}}
 		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
-		e2eoutput.TestContainerOutput(f, "seccomp unconfined pod", pod, 0, []string{"0"}) // seccomp disabled
+		e2eoutput.TestContainerOutput(ctx, f, "seccomp unconfined pod", pod, 0, []string{"0"}) // seccomp disabled
 	})
 
 	ginkgo.It("should support seccomp runtime/default [LinuxOnly]", func(ctx context.Context) {
 		pod := scTestPod(false, false)
 		pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault}}
 		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
-		e2eoutput.TestContainerOutput(f, "seccomp runtime/default", pod, 0, []string{"2"}) // seccomp filtered
+		e2eoutput.TestContainerOutput(ctx, f, "seccomp runtime/default", pod, 0, []string{"2"}) // seccomp filtered
 	})
 
 	ginkgo.It("should support seccomp default which is unconfined [LinuxOnly]", func(ctx context.Context) {
 		pod := scTestPod(false, false)
 		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
-		e2eoutput.TestContainerOutput(f, "seccomp default unconfined", pod, 0, []string{"0"}) // seccomp disabled
+		e2eoutput.TestContainerOutput(ctx, f, "seccomp default unconfined", pod, 0, []string{"0"}) // seccomp disabled
 	})
 })
 
-func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) {
+func testPodSELinuxLabeling(ctx context.Context, f *framework.Framework, hostIPC bool, hostPID bool) {
 	// Write and read a file with an empty_dir volume
 	// with a pod with the MCS label s0:c0,c1
 	pod := scTestPod(hostIPC, hostPID)
@@ -249,10 +250,10 @@ func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) 
 	pod.Spec.Containers[0].Command = []string{"sleep", "6000"}
 
 	client := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
-	pod, err := client.Create(context.TODO(), pod, metav1.CreateOptions{})
+	pod, err := client.Create(ctx, pod, metav1.CreateOptions{})
 
 	framework.ExpectNoError(err, "Error creating pod %v", pod)
-	framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, pod))
+	framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
 
 	testContent := "hello"
 	testFilePath := mountPath + "/TEST"
@@ -263,7 +264,7 @@ func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) 
 	framework.ExpectNoError(err)
 	gomega.Expect(content).To(gomega.ContainSubstring(testContent))
 
-	foundPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+	foundPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 
 	// Confirm that the file can be accessed from a second
@@ -294,7 +295,7 @@ func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) 
 	pod.Spec.SecurityContext.SELinuxOptions = &v1.SELinuxOptions{
 		Level: "s0:c0,c1",
 	}
-	e2eoutput.TestContainerOutput(f, "Pod with same MCS label reading test file", pod, 0, []string{testContent})
+	e2eoutput.TestContainerOutput(ctx, f, "Pod with same MCS label reading test file", pod, 0, []string{testContent})
 
 	// Confirm that the same pod with a different MCS
 	// label cannot access the volume
@@ -306,10 +307,10 @@ func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) 
 	pod.Spec.SecurityContext.SELinuxOptions = &v1.SELinuxOptions{
 		Level: "s0:c2,c3",
 	}
-	_, err = client.Create(context.TODO(), pod, metav1.CreateOptions{})
+	_, err = client.Create(ctx, pod, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "Error creating pod %v", pod)
 
-	err = e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+	err = e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 	framework.ExpectNoError(err, "Error waiting for pod to run %v", pod)
 
 	// for this to work, SELinux should be in enforcing mode, so let's check that

--- a/test/e2e/node/ssh.go
+++ b/test/e2e/node/ssh.go
@@ -48,7 +48,7 @@ var _ = SIGDescribe("SSH", func() {
 	ginkgo.It("should SSH to all nodes and run commands", func(ctx context.Context) {
 		// Get all nodes' external IPs.
 		ginkgo.By("Getting all nodes' SSH-able IP addresses")
-		hosts, err := e2essh.NodeSSHHosts(f.ClientSet)
+		hosts, err := e2essh.NodeSSHHosts(ctx, f.ClientSet)
 		if err != nil {
 			framework.Failf("Error getting node hostnames: %v", err)
 		}
@@ -85,7 +85,7 @@ var _ = SIGDescribe("SSH", func() {
 			for _, host := range testhosts {
 				ginkgo.By(fmt.Sprintf("SSH'ing host %s", host))
 
-				result, err := e2essh.SSH(testCase.cmd, host, framework.TestContext.Provider)
+				result, err := e2essh.SSH(ctx, testCase.cmd, host, framework.TestContext.Provider)
 				stdout, stderr := strings.TrimSpace(result.Stdout), strings.TrimSpace(result.Stderr)
 				if err != testCase.expectedError {
 					framework.Failf("Ran %s on %s, got error %v, expected %v", testCase.cmd, host, err, testCase.expectedError)
@@ -111,7 +111,7 @@ var _ = SIGDescribe("SSH", func() {
 
 		// Quickly test that SSH itself errors correctly.
 		ginkgo.By("SSH'ing to a nonexistent host")
-		if _, err = e2essh.SSH(`echo "hello"`, "i.do.not.exist", framework.TestContext.Provider); err == nil {
+		if _, err = e2essh.SSH(ctx, `echo "hello"`, "i.do.not.exist", framework.TestContext.Provider); err == nil {
 			framework.Failf("Expected error trying to SSH to nonexistent host.")
 		}
 	})

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -81,33 +81,33 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		{name: highPriorityClassName, value: highPriority},
 	}
 
-	ginkgo.AfterEach(func() {
+	ginkgo.AfterEach(func(ctx context.Context) {
 		for _, pair := range priorityPairs {
-			cs.SchedulingV1().PriorityClasses().Delete(context.TODO(), pair.name, *metav1.NewDeleteOptions(0))
+			_ = cs.SchedulingV1().PriorityClasses().Delete(ctx, pair.name, *metav1.NewDeleteOptions(0))
 		}
 		for _, node := range nodeList.Items {
 			nodeCopy := node.DeepCopy()
 			delete(nodeCopy.Status.Capacity, testExtendedResource)
 			delete(nodeCopy.Status.Allocatable, testExtendedResource)
-			err := patchNode(cs, &node, nodeCopy)
+			err := patchNode(ctx, cs, &node, nodeCopy)
 			framework.ExpectNoError(err)
 		}
 	})
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		cs = f.ClientSet
 		ns = f.Namespace.Name
 		nodeList = &v1.NodeList{}
 		var err error
 		for _, pair := range priorityPairs {
-			_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(context.TODO(), &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: pair.name}, Value: pair.value}, metav1.CreateOptions{})
+			_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: pair.name}, Value: pair.value}, metav1.CreateOptions{})
 			if err != nil && !apierrors.IsAlreadyExists(err) {
 				framework.Failf("expected 'alreadyExists' as error, got instead: %v", err)
 			}
 		}
 
-		e2enode.WaitForTotalHealthy(cs, time.Minute)
-		nodeList, err = e2enode.GetReadySchedulableNodes(cs)
+		e2enode.WaitForTotalHealthy(ctx, cs, time.Minute)
+		nodeList, err = e2enode.GetReadySchedulableNodes(ctx, cs)
 		if err != nil {
 			framework.Logf("Unexpected error occurred: %v", err)
 		}
@@ -116,7 +116,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			workerNodes.Insert(n.Name)
 		}
 
-		err = framework.CheckTestingNSDeletedExcept(cs, ns)
+		err = framework.CheckTestingNSDeletedExcept(ctx, cs, ns)
 		framework.ExpectNoError(err)
 	})
 
@@ -140,7 +140,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			nodeCopy := node.DeepCopy()
 			nodeCopy.Status.Capacity[testExtendedResource] = resource.MustParse("5")
 			nodeCopy.Status.Allocatable[testExtendedResource] = resource.MustParse("5")
-			err := patchNode(cs, &node, nodeCopy)
+			err := patchNode(ctx, cs, &node, nodeCopy)
 			framework.ExpectNoError(err)
 
 			for j := 0; j < 2; j++ {
@@ -153,7 +153,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 				if len(pods) == 0 {
 					priorityName = lowPriorityClassName
 				}
-				pausePod := createPausePod(f, pausePodConfig{
+				pausePod := createPausePod(ctx, f, pausePodConfig{
 					Name:              fmt.Sprintf("pod%d-%d-%v", i, j, priorityName),
 					PriorityClassName: priorityName,
 					Resources: &v1.ResourceRequirements{
@@ -184,7 +184,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		}
 		ginkgo.By("Wait for pods to be scheduled.")
 		for _, pod := range pods {
-			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(cs, pod))
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, pod))
 		}
 
 		// Set the pod request to the first pod's resources (should be low priority pod)
@@ -192,7 +192,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 
 		ginkgo.By("Run a high priority pod that has same requirements as that of lower priority pod")
 		// Create a high priority pod and make sure it is scheduled on the same node as the low priority pod.
-		runPausePodWithTimeout(f, pausePodConfig{
+		runPausePodWithTimeout(ctx, f, pausePodConfig{
 			Name:              "preemptor-pod",
 			PriorityClassName: highPriorityClassName,
 			Resources: &v1.ResourceRequirements{
@@ -201,14 +201,14 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			},
 		}, framework.PodStartShortTimeout)
 
-		preemptedPod, err := cs.CoreV1().Pods(pods[0].Namespace).Get(context.TODO(), pods[0].Name, metav1.GetOptions{})
+		preemptedPod, err := cs.CoreV1().Pods(pods[0].Namespace).Get(ctx, pods[0].Name, metav1.GetOptions{})
 		podPreempted := (err != nil && apierrors.IsNotFound(err)) ||
 			(err == nil && preemptedPod.DeletionTimestamp != nil)
 		if !podPreempted {
 			framework.Failf("expected pod to be preempted, instead got pod %+v and error %v", preemptedPod, err)
 		}
 		for i := 1; i < len(pods); i++ {
-			livePod, err := cs.CoreV1().Pods(pods[i].Namespace).Get(context.TODO(), pods[i].Name, metav1.GetOptions{})
+			livePod, err := cs.CoreV1().Pods(pods[i].Namespace).Get(ctx, pods[i].Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 			gomega.Expect(livePod.DeletionTimestamp).To(gomega.BeNil())
 		}
@@ -231,7 +231,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			nodeCopy := node.DeepCopy()
 			nodeCopy.Status.Capacity[testExtendedResource] = resource.MustParse("5")
 			nodeCopy.Status.Allocatable[testExtendedResource] = resource.MustParse("5")
-			err := patchNode(cs, &node, nodeCopy)
+			err := patchNode(ctx, cs, &node, nodeCopy)
 			framework.ExpectNoError(err)
 
 			for j := 0; j < 2; j++ {
@@ -244,7 +244,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 				if len(pods) == 0 {
 					priorityName = lowPriorityClassName
 				}
-				pausePod := createPausePod(f, pausePodConfig{
+				pausePod := createPausePod(ctx, f, pausePodConfig{
 					Name:              fmt.Sprintf("pod%d-%d-%v", i, j, priorityName),
 					PriorityClassName: priorityName,
 					Resources: &v1.ResourceRequirements{
@@ -275,7 +275,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		}
 		ginkgo.By("Wait for pods to be scheduled.")
 		for _, pod := range pods {
-			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(cs, pod))
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, pod))
 		}
 
 		// We want this pod to be preempted
@@ -285,12 +285,12 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		defer func() {
 			// Clean-up the critical pod
 			// Always run cleanup to make sure the pod is properly cleaned up.
-			err := f.ClientSet.CoreV1().Pods(metav1.NamespaceSystem).Delete(context.TODO(), "critical-pod", *metav1.NewDeleteOptions(0))
+			err := f.ClientSet.CoreV1().Pods(metav1.NamespaceSystem).Delete(ctx, "critical-pod", *metav1.NewDeleteOptions(0))
 			if err != nil && !apierrors.IsNotFound(err) {
 				framework.Failf("Error cleanup pod `%s/%s`: %v", metav1.NamespaceSystem, "critical-pod", err)
 			}
 		}()
-		runPausePodWithTimeout(f, pausePodConfig{
+		runPausePodWithTimeout(ctx, f, pausePodConfig{
 			Name:              "critical-pod",
 			Namespace:         metav1.NamespaceSystem,
 			PriorityClassName: scheduling.SystemClusterCritical,
@@ -302,15 +302,15 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 
 		defer func() {
 			// Clean-up the critical pod
-			err := f.ClientSet.CoreV1().Pods(metav1.NamespaceSystem).Delete(context.TODO(), "critical-pod", *metav1.NewDeleteOptions(0))
+			err := f.ClientSet.CoreV1().Pods(metav1.NamespaceSystem).Delete(ctx, "critical-pod", *metav1.NewDeleteOptions(0))
 			framework.ExpectNoError(err)
 		}()
 		// Make sure that the lowest priority pod is deleted.
-		preemptedPod, err := cs.CoreV1().Pods(pods[0].Namespace).Get(context.TODO(), pods[0].Name, metav1.GetOptions{})
+		preemptedPod, err := cs.CoreV1().Pods(pods[0].Namespace).Get(ctx, pods[0].Name, metav1.GetOptions{})
 		podPreempted := (err != nil && apierrors.IsNotFound(err)) ||
 			(err == nil && preemptedPod.DeletionTimestamp != nil)
 		for i := 1; i < len(pods); i++ {
-			livePod, err := cs.CoreV1().Pods(pods[i].Namespace).Get(context.TODO(), pods[i].Name, metav1.GetOptions{})
+			livePod, err := cs.CoreV1().Pods(pods[i].Namespace).Get(ctx, pods[i].Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 			gomega.Expect(livePod.DeletionTimestamp).To(gomega.BeNil())
 		}
@@ -333,7 +333,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		nodeCopy := node.DeepCopy()
 		nodeCopy.Status.Capacity[testExtendedResource] = resource.MustParse("1")
 		nodeCopy.Status.Allocatable[testExtendedResource] = resource.MustParse("1")
-		err := patchNode(cs, &node, nodeCopy)
+		err := patchNode(ctx, cs, &node, nodeCopy)
 		framework.ExpectNoError(err)
 
 		// prepare node affinity to make sure both the lower and higher priority pods are scheduled on the same node
@@ -352,7 +352,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		}
 
 		ginkgo.By("Create a low priority pod that consumes 1/1 of node resources")
-		victimPod := createPausePod(f, pausePodConfig{
+		victimPod := createPausePod(ctx, f, pausePodConfig{
 			Name:              "victim-pod",
 			PriorityClassName: lowPriorityClassName,
 			Resources: &v1.ResourceRequirements{
@@ -365,13 +365,13 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		framework.Logf("Created pod: %v", victimPod.Name)
 
 		ginkgo.By("Wait for the victim pod to be scheduled")
-		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(cs, victimPod))
+		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, victimPod))
 
 		// Remove the finalizer so that the victim pod can be GCed
-		defer e2epod.NewPodClient(f).RemoveFinalizer(victimPod.Name, testFinalizer)
+		defer e2epod.NewPodClient(f).RemoveFinalizer(ctx, victimPod.Name, testFinalizer)
 
 		ginkgo.By("Create a high priority pod to trigger preemption of the lower priority pod")
-		preemptorPod := createPausePod(f, pausePodConfig{
+		preemptorPod := createPausePod(ctx, f, pausePodConfig{
 			Name:              "preemptor-pod",
 			PriorityClassName: highPriorityClassName,
 			Resources: &v1.ResourceRequirements{
@@ -383,11 +383,11 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		framework.Logf("Created pod: %v", preemptorPod.Name)
 
 		ginkgo.By("Waiting for the victim pod to be terminating")
-		err = e2epod.WaitForPodTerminatingInNamespaceTimeout(f.ClientSet, victimPod.Name, victimPod.Namespace, framework.PodDeleteTimeout)
+		err = e2epod.WaitForPodTerminatingInNamespaceTimeout(ctx, f.ClientSet, victimPod.Name, victimPod.Namespace, framework.PodDeleteTimeout)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Verifying the pod has the pod disruption condition")
-		e2epod.VerifyPodHasConditionWithType(f, victimPod, v1.DisruptionTarget)
+		e2epod.VerifyPodHasConditionWithType(ctx, f, victimPod, v1.DisruptionTarget)
 	})
 
 	ginkgo.Context("PodTopologySpread Preemption", func() {
@@ -396,29 +396,29 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		topologyKey := "kubernetes.io/e2e-pts-preemption"
 		var fakeRes v1.ResourceName = "example.com/fakePTSRes"
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			if len(nodeList.Items) < 2 {
 				ginkgo.Skip("At least 2 nodes are required to run the test")
 			}
 			ginkgo.By("Trying to get 2 available nodes which can run pod")
-			nodeNames = Get2NodesThatCanRunPod(f)
+			nodeNames = Get2NodesThatCanRunPod(ctx, f)
 			ginkgo.By(fmt.Sprintf("Apply dedicated topologyKey %v for this test on the 2 nodes.", topologyKey))
 			for _, nodeName := range nodeNames {
 				e2enode.AddOrUpdateLabelOnNode(cs, nodeName, topologyKey, nodeName)
 
-				node, err := cs.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+				node, err := cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 				framework.ExpectNoError(err)
 				// update Node API object with a fake resource
 				ginkgo.By(fmt.Sprintf("Apply 10 fake resource to node %v.", node.Name))
 				nodeCopy := node.DeepCopy()
 				nodeCopy.Status.Capacity[fakeRes] = resource.MustParse("10")
 				nodeCopy.Status.Allocatable[fakeRes] = resource.MustParse("10")
-				err = patchNode(cs, node, nodeCopy)
+				err = patchNode(ctx, cs, node, nodeCopy)
 				framework.ExpectNoError(err)
 				nodes = append(nodes, node)
 			}
 		})
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			for _, nodeName := range nodeNames {
 				e2enode.RemoveLabelOffNode(cs, nodeName, topologyKey)
 			}
@@ -426,7 +426,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 				nodeCopy := node.DeepCopy()
 				delete(nodeCopy.Status.Capacity, fakeRes)
 				delete(nodeCopy.Status.Allocatable, fakeRes)
-				err := patchNode(cs, node, nodeCopy)
+				err := patchNode(ctx, cs, node, nodeCopy)
 				framework.ExpectNoError(err)
 			}
 		})
@@ -474,10 +474,10 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 
 			ginkgo.By("Create 1 High Pod and 3 Low Pods to occupy 9/10 of fake resources on both nodes.")
 			// Prepare 1 High Pod and 3 Low Pods
-			runPausePod(f, highPodCfg)
+			runPausePod(ctx, f, highPodCfg)
 			for i := 1; i <= 3; i++ {
 				lowPodCfg.Name = fmt.Sprintf("low-%v", i)
-				runPausePod(f, lowPodCfg)
+				runPausePod(ctx, f, lowPodCfg)
 			}
 
 			ginkgo.By("Create 1 Medium Pod with TopologySpreadConstraints")
@@ -511,14 +511,14 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			// However, in that case, the Pods spread becomes [<high>, <medium, low, low>], which doesn't
 			// satisfy the pod topology spread constraints. Hence it needs to preempt another low pod
 			// to make the Pods spread like [<high>, <medium, low>].
-			runPausePod(f, mediumPodCfg)
+			runPausePod(ctx, f, mediumPodCfg)
 
 			ginkgo.By("Verify there are 3 Pods left in this namespace")
 			wantPods := sets.NewString("high", "medium", "low")
 
 			// Wait until the number of pods stabilizes. Note that `medium` pod can get scheduled once the
 			// second low priority pod is marked as terminating.
-			pods, err := e2epod.WaitForNumberOfPods(cs, ns, 3, framework.PollShortTimeout)
+			pods, err := e2epod.WaitForNumberOfPods(ctx, cs, ns, 3, framework.PollShortTimeout)
 			framework.ExpectNoError(err)
 
 			for _, pod := range pods.Items {
@@ -546,11 +546,11 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 
 		priorityPairs := make([]priorityPair, 0)
 
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			// print out additional info if tests failed
 			if ginkgo.CurrentSpecReport().Failed() {
 				// List existing PriorityClasses.
-				priorityList, err := cs.SchedulingV1().PriorityClasses().List(context.TODO(), metav1.ListOptions{})
+				priorityList, err := cs.SchedulingV1().PriorityClasses().List(ctx, metav1.ListOptions{})
 				if err != nil {
 					framework.Logf("Unable to list PriorityClasses: %v", err)
 				} else {
@@ -565,26 +565,26 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 				nodeCopy := node.DeepCopy()
 				delete(nodeCopy.Status.Capacity, fakecpu)
 				delete(nodeCopy.Status.Allocatable, fakecpu)
-				err := patchNode(cs, node, nodeCopy)
+				err := patchNode(ctx, cs, node, nodeCopy)
 				framework.ExpectNoError(err)
 			}
 			for _, pair := range priorityPairs {
-				cs.SchedulingV1().PriorityClasses().Delete(context.TODO(), pair.name, *metav1.NewDeleteOptions(0))
+				_ = cs.SchedulingV1().PriorityClasses().Delete(ctx, pair.name, *metav1.NewDeleteOptions(0))
 			}
 		})
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			cs = f.ClientSet
 			ns = f.Namespace.Name
 
 			// find an available node
 			ginkgo.By("Finding an available node")
-			nodeName := GetNodeThatCanRunPod(f)
+			nodeName := GetNodeThatCanRunPod(ctx, f)
 			framework.Logf("found a healthy node: %s", nodeName)
 
 			// get the node API object
 			var err error
-			node, err = cs.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+			node, err = cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 			if err != nil {
 				framework.Failf("error getting node %q: %v", nodeName, err)
 			}
@@ -598,7 +598,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			nodeCopy := node.DeepCopy()
 			nodeCopy.Status.Capacity[fakecpu] = resource.MustParse("1000")
 			nodeCopy.Status.Allocatable[fakecpu] = resource.MustParse("1000")
-			err = patchNode(cs, node, nodeCopy)
+			err = patchNode(ctx, cs, node, nodeCopy)
 			framework.ExpectNoError(err)
 
 			// create four PriorityClass: p1, p2, p3, p4
@@ -606,7 +606,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 				priorityName := fmt.Sprintf("p%d", i)
 				priorityVal := int32(i)
 				priorityPairs = append(priorityPairs, priorityPair{name: priorityName, value: priorityVal})
-				_, err := cs.SchedulingV1().PriorityClasses().Create(context.TODO(), &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: priorityName}, Value: priorityVal}, metav1.CreateOptions{})
+				_, err := cs.SchedulingV1().PriorityClasses().Create(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: priorityName}, Value: priorityVal}, metav1.CreateOptions{})
 				if err != nil {
 					framework.Logf("Failed to create priority '%v/%v'. Reason: %v. Msg: %v", priorityName, priorityVal, apierrors.ReasonForError(err), err)
 				}
@@ -629,11 +629,11 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			_, podController := cache.NewInformer(
 				&cache.ListWatch{
 					ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-						obj, err := f.ClientSet.CoreV1().Pods(ns).List(context.TODO(), options)
+						obj, err := f.ClientSet.CoreV1().Pods(ns).List(ctx, options)
 						return runtime.Object(obj), err
 					},
 					WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-						return f.ClientSet.CoreV1().Pods(ns).Watch(context.TODO(), options)
+						return f.ClientSet.CoreV1().Pods(ns).Watch(ctx, options)
 					},
 				},
 				&v1.Pod{},
@@ -702,7 +702,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			}
 			// create ReplicaSet{1,2,3} so as to occupy 950/1000 fake resource
 			for i := range rsConfs {
-				runPauseRS(f, rsConfs[i])
+				runPauseRS(ctx, f, rsConfs[i])
 			}
 
 			framework.Logf("pods created so far: %v", podNamesSeen)
@@ -720,8 +720,8 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 					Limits:   v1.ResourceList{fakecpu: resource.MustParse("500")},
 				},
 			}
-			preemptorPod := createPod(f, preemptorPodConf)
-			waitForPreemptingWithTimeout(f, preemptorPod, framework.PodGetTimeout)
+			preemptorPod := createPod(ctx, f, preemptorPodConf)
+			waitForPreemptingWithTimeout(ctx, f, preemptorPod, framework.PodGetTimeout)
 
 			framework.Logf("pods created so far: %v", podNamesSeen)
 
@@ -768,12 +768,12 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		testUUID := uuid.New().String()
 		var pcs []*schedulingv1.PriorityClass
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			cs = f.ClientSet
 			// Create 2 PriorityClass: p1, p2.
 			for i := 1; i <= 2; i++ {
 				name, val := fmt.Sprintf("p%d", i), int32(i)
-				pc, err := cs.SchedulingV1().PriorityClasses().Create(context.TODO(), &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{"e2e": testUUID}}, Value: val}, metav1.CreateOptions{})
+				pc, err := cs.SchedulingV1().PriorityClasses().Create(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{"e2e": testUUID}}, Value: val}, metav1.CreateOptions{})
 				if err != nil {
 					framework.Logf("Failed to create priority '%v/%v'. Reason: %v. Msg: %v", name, val, apierrors.ReasonForError(err), err)
 				}
@@ -784,11 +784,11 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			}
 		})
 
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			// Print out additional info if tests failed.
 			if ginkgo.CurrentSpecReport().Failed() {
 				// List existing PriorityClasses.
-				priorityList, err := cs.SchedulingV1().PriorityClasses().List(context.TODO(), metav1.ListOptions{})
+				priorityList, err := cs.SchedulingV1().PriorityClasses().List(ctx, metav1.ListOptions{})
 				if err != nil {
 					framework.Logf("Unable to list PriorityClasses: %v", err)
 				} else {
@@ -800,7 +800,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			}
 
 			// Collection deletion on created PriorityClasses.
-			err := cs.SchedulingV1().PriorityClasses().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: fmt.Sprintf("e2e=%v", testUUID)})
+			err := cs.SchedulingV1().PriorityClasses().DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: fmt.Sprintf("e2e=%v", testUUID)})
 			framework.ExpectNoError(err)
 		})
 
@@ -815,13 +815,13 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			// 1. Patch/Update on immutable fields will fail.
 			pcCopy := pcs[0].DeepCopy()
 			pcCopy.Value = pcCopy.Value * 10
-			err := patchPriorityClass(cs, pcs[0], pcCopy)
+			err := patchPriorityClass(ctx, cs, pcs[0], pcCopy)
 			framework.ExpectError(err, "expect a patch error on an immutable field")
 			framework.Logf("%v", err)
 
 			pcCopy = pcs[1].DeepCopy()
 			pcCopy.Value = pcCopy.Value * 10
-			_, err = cs.SchedulingV1().PriorityClasses().Update(context.TODO(), pcCopy, metav1.UpdateOptions{})
+			_, err = cs.SchedulingV1().PriorityClasses().Update(ctx, pcCopy, metav1.UpdateOptions{})
 			framework.ExpectError(err, "expect an update error on an immutable field")
 			framework.Logf("%v", err)
 
@@ -829,21 +829,21 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			newDesc := "updated description"
 			pcCopy = pcs[0].DeepCopy()
 			pcCopy.Description = newDesc
-			err = patchPriorityClass(cs, pcs[0], pcCopy)
+			err = patchPriorityClass(ctx, cs, pcs[0], pcCopy)
 			framework.ExpectNoError(err)
 
 			pcCopy = pcs[1].DeepCopy()
 			pcCopy.Description = newDesc
-			_, err = cs.SchedulingV1().PriorityClasses().Update(context.TODO(), pcCopy, metav1.UpdateOptions{})
+			_, err = cs.SchedulingV1().PriorityClasses().Update(ctx, pcCopy, metav1.UpdateOptions{})
 			framework.ExpectNoError(err)
 
 			// 3. List existing PriorityClasses.
-			_, err = cs.SchedulingV1().PriorityClasses().List(context.TODO(), metav1.ListOptions{})
+			_, err = cs.SchedulingV1().PriorityClasses().List(ctx, metav1.ListOptions{})
 			framework.ExpectNoError(err)
 
 			// 4. Verify fields of updated PriorityClasses.
 			for _, pc := range pcs {
-				livePC, err := cs.SchedulingV1().PriorityClasses().Get(context.TODO(), pc.Name, metav1.GetOptions{})
+				livePC, err := cs.SchedulingV1().PriorityClasses().Get(ctx, pc.Name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
 				framework.ExpectEqual(livePC.Value, pc.Value)
 				framework.ExpectEqual(livePC.Description, newDesc)
@@ -878,37 +878,37 @@ func initPauseRS(f *framework.Framework, conf pauseRSConfig) *appsv1.ReplicaSet 
 	return pauseRS
 }
 
-func createPauseRS(f *framework.Framework, conf pauseRSConfig) *appsv1.ReplicaSet {
+func createPauseRS(ctx context.Context, f *framework.Framework, conf pauseRSConfig) *appsv1.ReplicaSet {
 	namespace := conf.PodConfig.Namespace
 	if len(namespace) == 0 {
 		namespace = f.Namespace.Name
 	}
-	rs, err := f.ClientSet.AppsV1().ReplicaSets(namespace).Create(context.TODO(), initPauseRS(f, conf), metav1.CreateOptions{})
+	rs, err := f.ClientSet.AppsV1().ReplicaSets(namespace).Create(ctx, initPauseRS(f, conf), metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	return rs
 }
 
-func runPauseRS(f *framework.Framework, conf pauseRSConfig) *appsv1.ReplicaSet {
-	rs := createPauseRS(f, conf)
-	framework.ExpectNoError(e2ereplicaset.WaitForReplicaSetTargetAvailableReplicasWithTimeout(f.ClientSet, rs, conf.Replicas, framework.PodGetTimeout))
+func runPauseRS(ctx context.Context, f *framework.Framework, conf pauseRSConfig) *appsv1.ReplicaSet {
+	rs := createPauseRS(ctx, f, conf)
+	framework.ExpectNoError(e2ereplicaset.WaitForReplicaSetTargetAvailableReplicasWithTimeout(ctx, f.ClientSet, rs, conf.Replicas, framework.PodGetTimeout))
 	return rs
 }
 
-func createPod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
+func createPod(ctx context.Context, f *framework.Framework, conf pausePodConfig) *v1.Pod {
 	namespace := conf.Namespace
 	if len(namespace) == 0 {
 		namespace = f.Namespace.Name
 	}
-	pod, err := f.ClientSet.CoreV1().Pods(namespace).Create(context.TODO(), initPausePod(f, conf), metav1.CreateOptions{})
+	pod, err := f.ClientSet.CoreV1().Pods(namespace).Create(ctx, initPausePod(f, conf), metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	return pod
 }
 
 // waitForPreemptingWithTimeout verifies if 'pod' is preempting within 'timeout', specifically it checks
 // if the 'spec.NodeName' field of preemptor 'pod' has been set.
-func waitForPreemptingWithTimeout(f *framework.Framework, pod *v1.Pod, timeout time.Duration) {
+func waitForPreemptingWithTimeout(ctx context.Context, f *framework.Framework, pod *v1.Pod, timeout time.Duration) {
 	err := wait.Poll(2*time.Second, timeout, func() (bool, error) {
-		pod, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		pod, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -920,7 +920,7 @@ func waitForPreemptingWithTimeout(f *framework.Framework, pod *v1.Pod, timeout t
 	framework.ExpectNoError(err, "pod %v/%v failed to preempt other pods", pod.Namespace, pod.Name)
 }
 
-func patchNode(client clientset.Interface, old *v1.Node, new *v1.Node) error {
+func patchNode(ctx context.Context, client clientset.Interface, old *v1.Node, new *v1.Node) error {
 	oldData, err := json.Marshal(old)
 	if err != nil {
 		return err
@@ -934,11 +934,11 @@ func patchNode(client clientset.Interface, old *v1.Node, new *v1.Node) error {
 	if err != nil {
 		return fmt.Errorf("failed to create merge patch for node %q: %v", old.Name, err)
 	}
-	_, err = client.CoreV1().Nodes().Patch(context.TODO(), old.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+	_, err = client.CoreV1().Nodes().Patch(ctx, old.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
 	return err
 }
 
-func patchPriorityClass(cs clientset.Interface, old, new *schedulingv1.PriorityClass) error {
+func patchPriorityClass(ctx context.Context, cs clientset.Interface, old, new *schedulingv1.PriorityClass) error {
 	oldData, err := json.Marshal(old)
 	if err != nil {
 		return err
@@ -952,6 +952,6 @@ func patchPriorityClass(cs clientset.Interface, old, new *schedulingv1.PriorityC
 	if err != nil {
 		return fmt.Errorf("failed to create merge patch for PriorityClass %q: %v", old.Name, err)
 	}
-	_, err = cs.SchedulingV1().PriorityClasses().Patch(context.TODO(), old.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	_, err = cs.SchedulingV1().PriorityClasses().Patch(ctx, old.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
 	return err
 }

--- a/test/e2e/scheduling/ubernetes_lite.go
+++ b/test/e2e/scheduling/ubernetes_lite.go
@@ -47,11 +47,11 @@ var _ = SIGDescribe("Multi-AZ Clusters", func() {
 	var zoneCount int
 	var err error
 	var zoneNames sets.String
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		cs := f.ClientSet
 
 		if zoneCount <= 0 {
-			zoneNames, err = e2enode.GetSchedulableClusterZones(cs)
+			zoneNames, err = e2enode.GetSchedulableClusterZones(ctx, cs)
 			framework.ExpectNoError(err)
 			zoneCount = len(zoneNames)
 		}
@@ -60,26 +60,26 @@ var _ = SIGDescribe("Multi-AZ Clusters", func() {
 		e2eskipper.SkipUnlessAtLeast(zoneCount, 2, msg)
 		// TODO: SkipUnlessDefaultScheduler() // Non-default schedulers might not spread
 
-		e2enode.WaitForTotalHealthy(cs, time.Minute)
-		nodeList, err := e2enode.GetReadySchedulableNodes(cs)
+		e2enode.WaitForTotalHealthy(ctx, cs, time.Minute)
+		nodeList, err := e2enode.GetReadySchedulableNodes(ctx, cs)
 		framework.ExpectNoError(err)
 
 		// make the nodes have balanced cpu,mem usage
-		err = createBalancedPodForNodes(f, cs, f.Namespace.Name, nodeList.Items, podRequestedResource, 0.0)
+		err = createBalancedPodForNodes(ctx, f, cs, f.Namespace.Name, nodeList.Items, podRequestedResource, 0.0)
 		framework.ExpectNoError(err)
 	})
 	ginkgo.It("should spread the pods of a service across zones [Serial]", func(ctx context.Context) {
-		SpreadServiceOrFail(f, 5*zoneCount, zoneNames, imageutils.GetPauseImageName())
+		SpreadServiceOrFail(ctx, f, 5*zoneCount, zoneNames, imageutils.GetPauseImageName())
 	})
 
 	ginkgo.It("should spread the pods of a replication controller across zones [Serial]", func(ctx context.Context) {
-		SpreadRCOrFail(f, int32(5*zoneCount), zoneNames, framework.ServeHostnameImage, []string{"serve-hostname"})
+		SpreadRCOrFail(ctx, f, int32(5*zoneCount), zoneNames, framework.ServeHostnameImage, []string{"serve-hostname"})
 	})
 })
 
 // SpreadServiceOrFail check that the pods comprising a service
 // get spread evenly across available zones
-func SpreadServiceOrFail(f *framework.Framework, replicaCount int, zoneNames sets.String, image string) {
+func SpreadServiceOrFail(ctx context.Context, f *framework.Framework, replicaCount int, zoneNames sets.String, image string) {
 	// First create the service
 	serviceName := "test-service"
 	serviceSpec := &v1.Service{
@@ -97,7 +97,7 @@ func SpreadServiceOrFail(f *framework.Framework, replicaCount int, zoneNames set
 			}},
 		},
 	}
-	_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), serviceSpec, metav1.CreateOptions{})
+	_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, serviceSpec, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	// Now create some pods behind the service
@@ -124,11 +124,11 @@ func SpreadServiceOrFail(f *framework.Framework, replicaCount int, zoneNames set
 
 	// Wait for all of them to be scheduled
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"service": serviceName}))
-	pods, err := e2epod.WaitForPodsWithLabelScheduled(f.ClientSet, f.Namespace.Name, selector)
+	pods, err := e2epod.WaitForPodsWithLabelScheduled(ctx, f.ClientSet, f.Namespace.Name, selector)
 	framework.ExpectNoError(err)
 
 	// Now make sure they're spread across zones
-	checkZoneSpreading(f.ClientSet, pods, zoneNames.List())
+	checkZoneSpreading(ctx, f.ClientSet, pods, zoneNames.List())
 }
 
 // Find the name of the zone in which a Node is running
@@ -143,16 +143,16 @@ func getZoneNameForNode(node v1.Node) (string, error) {
 }
 
 // Find the name of the zone in which the pod is scheduled
-func getZoneNameForPod(c clientset.Interface, pod v1.Pod) (string, error) {
+func getZoneNameForPod(ctx context.Context, c clientset.Interface, pod v1.Pod) (string, error) {
 	ginkgo.By(fmt.Sprintf("Getting zone name for pod %s, on node %s", pod.Name, pod.Spec.NodeName))
-	node, err := c.CoreV1().Nodes().Get(context.TODO(), pod.Spec.NodeName, metav1.GetOptions{})
+	node, err := c.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	return getZoneNameForNode(*node)
 }
 
 // Determine whether a set of pods are approximately evenly spread
 // across a given set of zones
-func checkZoneSpreading(c clientset.Interface, pods *v1.PodList, zoneNames []string) {
+func checkZoneSpreading(ctx context.Context, c clientset.Interface, pods *v1.PodList, zoneNames []string) {
 	podsPerZone := make(map[string]int)
 	for _, zoneName := range zoneNames {
 		podsPerZone[zoneName] = 0
@@ -161,7 +161,7 @@ func checkZoneSpreading(c clientset.Interface, pods *v1.PodList, zoneNames []str
 		if pod.DeletionTimestamp != nil {
 			continue
 		}
-		zoneName, err := getZoneNameForPod(c, pod)
+		zoneName, err := getZoneNameForPod(ctx, c, pod)
 		framework.ExpectNoError(err)
 		podsPerZone[zoneName] = podsPerZone[zoneName] + 1
 	}
@@ -182,10 +182,10 @@ func checkZoneSpreading(c clientset.Interface, pods *v1.PodList, zoneNames []str
 
 // SpreadRCOrFail Check that the pods comprising a replication
 // controller get spread evenly across available zones
-func SpreadRCOrFail(f *framework.Framework, replicaCount int32, zoneNames sets.String, image string, args []string) {
+func SpreadRCOrFail(ctx context.Context, f *framework.Framework, replicaCount int32, zoneNames sets.String, image string, args []string) {
 	name := "ubelite-spread-rc-" + string(uuid.NewUUID())
 	ginkgo.By(fmt.Sprintf("Creating replication controller %s", name))
-	controller, err := f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(context.TODO(), &v1.ReplicationController{
+	controller, err := f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(ctx, &v1.ReplicationController{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: f.Namespace.Name,
 			Name:      name,
@@ -216,20 +216,20 @@ func SpreadRCOrFail(f *framework.Framework, replicaCount int32, zoneNames sets.S
 	// Cleanup the replication controller when we are done.
 	defer func() {
 		// Resize the replication controller to zero to get rid of pods.
-		if err := e2erc.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, controller.Name); err != nil {
+		if err := e2erc.DeleteRCAndWaitForGC(ctx, f.ClientSet, f.Namespace.Name, controller.Name); err != nil {
 			framework.Logf("Failed to cleanup replication controller %v: %v.", controller.Name, err)
 		}
 	}()
 	// List the pods, making sure we observe all the replicas.
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
-	_, err = e2epod.PodsCreated(f.ClientSet, f.Namespace.Name, name, replicaCount)
+	_, err = e2epod.PodsCreated(ctx, f.ClientSet, f.Namespace.Name, name, replicaCount)
 	framework.ExpectNoError(err)
 
 	// Wait for all of them to be scheduled
 	ginkgo.By(fmt.Sprintf("Waiting for %d replicas of %s to be scheduled.  Selector: %v", replicaCount, name, selector))
-	pods, err := e2epod.WaitForPodsWithLabelScheduled(f.ClientSet, f.Namespace.Name, selector)
+	pods, err := e2epod.WaitForPodsWithLabelScheduled(ctx, f.ClientSet, f.Namespace.Name, selector)
 	framework.ExpectNoError(err)
 
 	// Now make sure they're spread across zones
-	checkZoneSpreading(f.ClientSet, pods, zoneNames.List())
+	checkZoneSpreading(ctx, f.ClientSet, pods, zoneNames.List())
 }

--- a/test/e2e/storage/csi_inline.go
+++ b/test/e2e/storage/csi_inline.go
@@ -82,33 +82,33 @@ var _ = utils.SIGDescribe("CSIInlineVolumes", func() {
 		}
 
 		ginkgo.By("creating")
-		createdDriver1, err := client.Create(context.TODO(), driver1, metav1.CreateOptions{})
+		createdDriver1, err := client.Create(ctx, driver1, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		createdDriver2, err := client.Create(context.TODO(), driver2, metav1.CreateOptions{})
+		createdDriver2, err := client.Create(ctx, driver2, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		_, err = client.Create(context.TODO(), driver1, metav1.CreateOptions{})
+		_, err = client.Create(ctx, driver1, metav1.CreateOptions{})
 		if !apierrors.IsAlreadyExists(err) {
 			framework.Failf("expected 409, got %#v", err)
 		}
 
 		ginkgo.By("getting")
-		retrievedDriver1, err := client.Get(context.TODO(), createdDriver1.Name, metav1.GetOptions{})
+		retrievedDriver1, err := client.Get(ctx, createdDriver1.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(retrievedDriver1.UID, createdDriver1.UID)
-		retrievedDriver2, err := client.Get(context.TODO(), createdDriver2.Name, metav1.GetOptions{})
+		retrievedDriver2, err := client.Get(ctx, createdDriver2.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(retrievedDriver2.UID, createdDriver2.UID)
 
 		ginkgo.By("listing")
-		driverList, err := client.List(context.TODO(), metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		driverList, err := client.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(driverList.Items), 2, "filtered list should have 2 items, got: %s", driverList)
 
 		ginkgo.By("deleting")
 		for _, driver := range driverList.Items {
-			err := client.Delete(context.TODO(), driver.Name, metav1.DeleteOptions{})
+			err := client.Delete(ctx, driver.Name, metav1.DeleteOptions{})
 			framework.ExpectNoError(err)
-			retrievedDriver, err := client.Get(context.TODO(), driver.Name, metav1.GetOptions{})
+			retrievedDriver, err := client.Get(ctx, driver.Name, metav1.GetOptions{})
 			switch {
 			case apierrors.IsNotFound(err):
 				// Okay, normal case.
@@ -188,32 +188,32 @@ var _ = utils.SIGDescribe("CSIInlineVolumes", func() {
 		}
 
 		ginkgo.By("creating")
-		createdPod, err := client.Create(context.TODO(), pod, metav1.CreateOptions{})
+		createdPod, err := client.Create(ctx, pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		_, err = client.Create(context.TODO(), pod, metav1.CreateOptions{})
+		_, err = client.Create(ctx, pod, metav1.CreateOptions{})
 		if !apierrors.IsAlreadyExists(err) {
 			framework.Failf("expected 409, got %#v", err)
 		}
 
 		ginkgo.By("getting")
-		retrievedPod, err := client.Get(context.TODO(), podName, metav1.GetOptions{})
+		retrievedPod, err := client.Get(ctx, podName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(retrievedPod.UID, createdPod.UID)
 
 		ginkgo.By("listing in namespace")
-		podList, err := client.List(context.TODO(), metav1.ListOptions{})
+		podList, err := client.List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(podList.Items), 1, "list should have 1 items, got: %s", podList)
 
 		ginkgo.By("patching")
-		patchedPod, err := client.Patch(context.TODO(), createdPod.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
+		patchedPod, err := client.Patch(ctx, createdPod.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(patchedPod.Annotations["patched"], "true", "patched object should have the applied annotation")
 
 		ginkgo.By("deleting")
-		err = client.Delete(context.TODO(), createdPod.Name, metav1.DeleteOptions{})
+		err = client.Delete(ctx, createdPod.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
-		retrievedPod, err = client.Get(context.TODO(), createdPod.Name, metav1.GetOptions{})
+		retrievedPod, err = client.Get(ctx, createdPod.Name, metav1.GetOptions{})
 		switch {
 		case apierrors.IsNotFound(err):
 			// Okay, normal case.

--- a/test/e2e/storage/csi_mock/base.go
+++ b/test/e2e/storage/csi_mock/base.go
@@ -143,7 +143,7 @@ func newMockDriverSetup(f *framework.Framework) *mockDriverSetup {
 	}
 }
 
-func (m *mockDriverSetup) init(tp testParameters) {
+func (m *mockDriverSetup) init(ctx context.Context, tp testParameters) {
 	m.cs = m.f.ClientSet
 	m.tp = tp
 
@@ -190,7 +190,7 @@ func (m *mockDriverSetup) init(tp testParameters) {
 	}
 
 	m.driver = drivers.InitMockCSIDriver(driverOpts)
-	config := m.driver.PrepareTest(m.f)
+	config := m.driver.PrepareTest(ctx, m.f)
 	m.config = config
 	m.provisioner = config.GetUniqueDriverName()
 
@@ -202,17 +202,17 @@ func (m *mockDriverSetup) init(tp testParameters) {
 
 	// Wait for the CSIDriver actually get deployed and CSINode object to be generated.
 	// This indicates the mock CSI driver pod is up and running healthy.
-	err = drivers.WaitForCSIDriverRegistrationOnNode(m.config.ClientNodeSelection.Name, m.config.GetUniqueDriverName(), m.cs)
+	err = drivers.WaitForCSIDriverRegistrationOnNode(ctx, m.config.ClientNodeSelection.Name, m.config.GetUniqueDriverName(), m.cs)
 	framework.ExpectNoError(err, "Failed to register CSIDriver %v", m.config.GetUniqueDriverName())
 }
 
-func (m *mockDriverSetup) cleanup() {
+func (m *mockDriverSetup) cleanup(ctx context.Context) {
 	cs := m.f.ClientSet
 	var errs []error
 
 	for _, pod := range m.pods {
 		ginkgo.By(fmt.Sprintf("Deleting pod %s", pod.Name))
-		errs = append(errs, e2epod.DeletePodWithWait(cs, pod))
+		errs = append(errs, e2epod.DeletePodWithWait(ctx, cs, pod))
 	}
 
 	for _, claim := range m.pvcs {
@@ -223,7 +223,7 @@ func (m *mockDriverSetup) cleanup() {
 				errs = append(errs, err)
 			}
 			if claim.Spec.VolumeName != "" {
-				errs = append(errs, e2epv.WaitForPersistentVolumeDeleted(cs, claim.Spec.VolumeName, framework.Poll, 2*time.Minute))
+				errs = append(errs, e2epv.WaitForPersistentVolumeDeleted(ctx, cs, claim.Spec.VolumeName, framework.Poll, 2*time.Minute))
 			}
 		}
 	}
@@ -242,11 +242,11 @@ func (m *mockDriverSetup) cleanup() {
 	framework.ExpectNoError(err, "while cleaning up after test")
 }
 
-func (m *mockDriverSetup) createPod(withVolume volumeType) (class *storagev1.StorageClass, claim *v1.PersistentVolumeClaim, pod *v1.Pod) {
+func (m *mockDriverSetup) createPod(ctx context.Context, withVolume volumeType) (class *storagev1.StorageClass, claim *v1.PersistentVolumeClaim, pod *v1.Pod) {
 	ginkgo.By("Creating pod")
 	f := m.f
 
-	sc := m.driver.GetDynamicProvisionStorageClass(m.config, "")
+	sc := m.driver.GetDynamicProvisionStorageClass(ctx, m.config, "")
 	scTest := testsuites.StorageClassTest{
 		Name:                 m.driver.GetDriverInfo().Name,
 		Timeouts:             f.Timeouts,
@@ -275,7 +275,7 @@ func (m *mockDriverSetup) createPod(withVolume volumeType) (class *storagev1.Sto
 			},
 		}
 	case pvcReference:
-		class, claim, pod = startPausePod(f.ClientSet, scTest, nodeSelection, m.tp.scName, f.Namespace.Name)
+		class, claim, pod = startPausePod(ctx, f.ClientSet, scTest, nodeSelection, m.tp.scName, f.Namespace.Name)
 		if class != nil {
 			m.sc[class.Name] = class
 		}
@@ -300,12 +300,12 @@ func (m *mockDriverSetup) createPodWithPVC(pvc *v1.PersistentVolumeClaim) (*v1.P
 	return pod, err
 }
 
-func (m *mockDriverSetup) createPodWithFSGroup(fsGroup *int64) (*storagev1.StorageClass, *v1.PersistentVolumeClaim, *v1.Pod) {
+func (m *mockDriverSetup) createPodWithFSGroup(ctx context.Context, fsGroup *int64) (*storagev1.StorageClass, *v1.PersistentVolumeClaim, *v1.Pod) {
 	f := m.f
 
 	ginkgo.By("Creating pod with fsGroup")
 	nodeSelection := m.config.ClientNodeSelection
-	sc := m.driver.GetDynamicProvisionStorageClass(m.config, "")
+	sc := m.driver.GetDynamicProvisionStorageClass(ctx, m.config, "")
 	scTest := testsuites.StorageClassTest{
 		Name:                 m.driver.GetDriverInfo().Name,
 		Provisioner:          sc.Provisioner,
@@ -315,7 +315,7 @@ func (m *mockDriverSetup) createPodWithFSGroup(fsGroup *int64) (*storagev1.Stora
 		DelayBinding:         m.tp.lateBinding,
 		AllowVolumeExpansion: m.tp.enableResizing,
 	}
-	class, claim, pod := startBusyBoxPod(f.ClientSet, scTest, nodeSelection, m.tp.scName, f.Namespace.Name, fsGroup)
+	class, claim, pod := startBusyBoxPod(ctx, f.ClientSet, scTest, nodeSelection, m.tp.scName, f.Namespace.Name, fsGroup)
 
 	if class != nil {
 		m.sc[class.Name] = class
@@ -331,11 +331,11 @@ func (m *mockDriverSetup) createPodWithFSGroup(fsGroup *int64) (*storagev1.Stora
 	return class, claim, pod
 }
 
-func (m *mockDriverSetup) createPodWithSELinux(accessModes []v1.PersistentVolumeAccessMode, mountOptions []string, seLinuxOpts *v1.SELinuxOptions) (*storagev1.StorageClass, *v1.PersistentVolumeClaim, *v1.Pod) {
+func (m *mockDriverSetup) createPodWithSELinux(ctx context.Context, accessModes []v1.PersistentVolumeAccessMode, mountOptions []string, seLinuxOpts *v1.SELinuxOptions) (*storagev1.StorageClass, *v1.PersistentVolumeClaim, *v1.Pod) {
 	ginkgo.By("Creating pod with SELinux context")
 	f := m.f
 	nodeSelection := m.config.ClientNodeSelection
-	sc := m.driver.GetDynamicProvisionStorageClass(m.config, "")
+	sc := m.driver.GetDynamicProvisionStorageClass(ctx, m.config, "")
 	scTest := testsuites.StorageClassTest{
 		Name:                 m.driver.GetDriverInfo().Name,
 		Provisioner:          sc.Provisioner,
@@ -346,7 +346,7 @@ func (m *mockDriverSetup) createPodWithSELinux(accessModes []v1.PersistentVolume
 		AllowVolumeExpansion: m.tp.enableResizing,
 		MountOptions:         mountOptions,
 	}
-	class, claim := createClaim(f.ClientSet, scTest, nodeSelection, m.tp.scName, f.Namespace.Name, accessModes)
+	class, claim := createClaim(ctx, f.ClientSet, scTest, nodeSelection, m.tp.scName, f.Namespace.Name, accessModes)
 	pod, err := startPausePodWithSELinuxOptions(f.ClientSet, claim, nodeSelection, f.Namespace.Name, seLinuxOpts)
 	framework.ExpectNoError(err, "Failed to create pause pod with SELinux context %s: %v", seLinuxOpts, err)
 
@@ -474,7 +474,7 @@ func createSC(cs clientset.Interface, t testsuites.StorageClassTest, scName, ns 
 	return class
 }
 
-func createClaim(cs clientset.Interface, t testsuites.StorageClassTest, node e2epod.NodeSelection, scName, ns string, accessModes []v1.PersistentVolumeAccessMode) (*storagev1.StorageClass, *v1.PersistentVolumeClaim) {
+func createClaim(ctx context.Context, cs clientset.Interface, t testsuites.StorageClassTest, node e2epod.NodeSelection, scName, ns string, accessModes []v1.PersistentVolumeAccessMode) (*storagev1.StorageClass, *v1.PersistentVolumeClaim) {
 	class := createSC(cs, t, scName, ns)
 	claim := e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
 		ClaimSize:        t.ClaimSize,
@@ -487,22 +487,22 @@ func createClaim(cs clientset.Interface, t testsuites.StorageClassTest, node e2e
 
 	if !t.DelayBinding {
 		pvcClaims := []*v1.PersistentVolumeClaim{claim}
-		_, err = e2epv.WaitForPVClaimBoundPhase(cs, pvcClaims, framework.ClaimProvisionTimeout)
+		_, err = e2epv.WaitForPVClaimBoundPhase(ctx, cs, pvcClaims, framework.ClaimProvisionTimeout)
 		framework.ExpectNoError(err, "Failed waiting for PVC to be bound: %v", err)
 	}
 	return class, claim
 }
 
-func startPausePod(cs clientset.Interface, t testsuites.StorageClassTest, node e2epod.NodeSelection, scName, ns string) (*storagev1.StorageClass, *v1.PersistentVolumeClaim, *v1.Pod) {
-	class, claim := createClaim(cs, t, node, scName, ns, nil)
+func startPausePod(ctx context.Context, cs clientset.Interface, t testsuites.StorageClassTest, node e2epod.NodeSelection, scName, ns string) (*storagev1.StorageClass, *v1.PersistentVolumeClaim, *v1.Pod) {
+	class, claim := createClaim(ctx, cs, t, node, scName, ns, nil)
 
 	pod, err := startPausePodWithClaim(cs, claim, node, ns)
 	framework.ExpectNoError(err, "Failed to create pause pod: %v", err)
 	return class, claim, pod
 }
 
-func startBusyBoxPod(cs clientset.Interface, t testsuites.StorageClassTest, node e2epod.NodeSelection, scName, ns string, fsGroup *int64) (*storagev1.StorageClass, *v1.PersistentVolumeClaim, *v1.Pod) {
-	class, claim := createClaim(cs, t, node, scName, ns, nil)
+func startBusyBoxPod(ctx context.Context, cs clientset.Interface, t testsuites.StorageClassTest, node e2epod.NodeSelection, scName, ns string, fsGroup *int64) (*storagev1.StorageClass, *v1.PersistentVolumeClaim, *v1.Pod) {
+	class, claim := createClaim(ctx, cs, t, node, scName, ns, nil)
 	pod, err := startBusyBoxPodWithClaim(cs, claim, node, ns, fsGroup)
 	framework.ExpectNoError(err, "Failed to create busybox pod: %v", err)
 	return class, claim, pod
@@ -668,7 +668,7 @@ func startPausePodWithSELinuxOptions(cs clientset.Interface, pvc *v1.PersistentV
 	return cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 }
 
-func checkPodLogs(getCalls func() ([]drivers.MockCSICall, error), pod *v1.Pod, expectPodInfo, ephemeralVolume, csiInlineVolumesEnabled, csiServiceAccountTokenEnabled bool, expectedNumNodePublish int) error {
+func checkPodLogs(ctx context.Context, getCalls func(ctx context.Context) ([]drivers.MockCSICall, error), pod *v1.Pod, expectPodInfo, ephemeralVolume, csiInlineVolumesEnabled, csiServiceAccountTokenEnabled bool, expectedNumNodePublish int) error {
 	expectedAttributes := map[string]string{}
 	if expectPodInfo {
 		expectedAttributes["csi.storage.k8s.io/pod.name"] = pod.Name
@@ -690,7 +690,7 @@ func checkPodLogs(getCalls func() ([]drivers.MockCSICall, error), pod *v1.Pod, e
 	foundAttributes := sets.NewString()
 	numNodePublishVolume := 0
 	numNodeUnpublishVolume := 0
-	calls, err := getCalls()
+	calls, err := getCalls(ctx)
 	if err != nil {
 		return err
 	}
@@ -776,8 +776,8 @@ func createPreHook(method string, callback func(counter int64) error) *drivers.H
 //
 // Only permanent errors are returned. Other errors are logged and no
 // calls are returned. The caller is expected to retry.
-func compareCSICalls(trackedCalls []string, expectedCallSequence []csiCall, getCalls func() ([]drivers.MockCSICall, error)) ([]drivers.MockCSICall, int, error) {
-	allCalls, err := getCalls()
+func compareCSICalls(ctx context.Context, trackedCalls []string, expectedCallSequence []csiCall, getCalls func(ctx context.Context) ([]drivers.MockCSICall, error)) ([]drivers.MockCSICall, int, error) {
+	allCalls, err := getCalls(ctx)
 	if err != nil {
 		framework.Logf("intermittent (?) log retrieval error, proceeding without output: %v", err)
 		return nil, 0, nil

--- a/test/e2e/storage/csi_mock/csi_fsgroup_mount.go
+++ b/test/e2e/storage/csi_mock/csi_fsgroup_mount.go
@@ -55,7 +55,7 @@ var _ = utils.SIGDescribe("CSI Mock fsgroup as mount option", func() {
 				if framework.NodeOSDistroIs("windows") {
 					e2eskipper.Skipf("FSGroupPolicy is only applied on linux nodes -- skipping")
 				}
-				m.init(testParameters{
+				m.init(ctx, testParameters{
 					disableAttach:          true,
 					registerDriver:         true,
 					enableVolumeMountGroup: t.enableVolumeMountGroup,
@@ -67,9 +67,9 @@ var _ = utils.SIGDescribe("CSI Mock fsgroup as mount option", func() {
 				fsGroup := &fsGroupVal
 				fsGroupStr := strconv.FormatInt(fsGroupVal, 10 /* base */)
 
-				_, _, pod := m.createPodWithFSGroup(fsGroup) /* persistent volume */
+				_, _, pod := m.createPodWithFSGroup(ctx, fsGroup) /* persistent volume */
 
-				err := e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				err := e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "failed to start pod")
 
 				if t.enableVolumeMountGroup {

--- a/test/e2e/storage/csi_mock/csi_fsgroup_policy.go
+++ b/test/e2e/storage/csi_mock/csi_fsgroup_policy.go
@@ -67,7 +67,7 @@ var _ = utils.SIGDescribe("CSI Mock volume fsgroup policies", func() {
 				if framework.NodeOSDistroIs("windows") {
 					e2eskipper.Skipf("FSGroupPolicy is only applied on linux nodes -- skipping")
 				}
-				m.init(testParameters{
+				m.init(ctx, testParameters{
 					disableAttach:  true,
 					registerDriver: true,
 					fsGroupPolicy:  &test.fsGroupPolicy,
@@ -82,13 +82,13 @@ var _ = utils.SIGDescribe("CSI Mock volume fsgroup policies", func() {
 				fsGroupVal := int64(rand.Int63n(20000) + 1024)
 				fsGroup := &fsGroupVal
 
-				_, _, pod := m.createPodWithFSGroup(fsGroup) /* persistent volume */
+				_, _, pod := m.createPodWithFSGroup(ctx, fsGroup) /* persistent volume */
 
 				mountPath := pod.Spec.Containers[0].VolumeMounts[0].MountPath
 				dirName := mountPath + "/" + f.UniqueName
 				fileName := dirName + "/" + f.UniqueName
 
-				err := e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				err := e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "failed to start pod")
 
 				// Create the subdirectory to ensure that fsGroup propagates

--- a/test/e2e/storage/csi_mock/csi_selinux_mount.go
+++ b/test/e2e/storage/csi_mock/csi_selinux_mount.go
@@ -95,7 +95,7 @@ var _ = utils.SIGDescribe("CSI Mock selinux on mount", func() {
 					e2eskipper.Skipf("SELinuxMount is only applied on linux nodes -- skipping")
 				}
 				var nodeStageMountOpts, nodePublishMountOpts []string
-				m.init(testParameters{
+				m.init(ctx, testParameters{
 					disableAttach:      true,
 					registerDriver:     true,
 					enableSELinuxMount: &t.seLinuxEnabled,
@@ -110,8 +110,8 @@ var _ = utils.SIGDescribe("CSI Mock selinux on mount", func() {
 					podSELinuxOpts = &seLinuxOpts
 				}
 
-				_, _, pod := m.createPodWithSELinux(accessModes, t.mountOptions, podSELinuxOpts)
-				err := e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				_, _, pod := m.createPodWithSELinux(ctx, accessModes, t.mountOptions, podSELinuxOpts)
+				err := e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "failed to start pod")
 
 				framework.ExpectEqual(nodeStageMountOpts, t.expectedMountOptions, "Expect NodeStageVolumeRequest.VolumeCapability.MountVolume. to equal %q; got: %q", t.expectedMountOptions, nodeStageMountOpts)

--- a/test/e2e/storage/csi_mock/csi_service_account_token.go
+++ b/test/e2e/storage/csi_mock/csi_service_account_token.go
@@ -63,7 +63,7 @@ var _ = utils.SIGDescribe("CSI Mock volume service account token", func() {
 			test := test
 			csiServiceAccountTokenEnabled := test.tokenRequests != nil
 			ginkgo.It(test.desc, func(ctx context.Context) {
-				m.init(testParameters{
+				m.init(ctx, testParameters{
 					registerDriver:    test.deployCSIDriverObject,
 					tokenRequests:     test.tokenRequests,
 					requiresRepublish: &csiServiceAccountTokenEnabled,
@@ -71,11 +71,11 @@ var _ = utils.SIGDescribe("CSI Mock volume service account token", func() {
 
 				ginkgo.DeferCleanup(m.cleanup)
 
-				_, _, pod := m.createPod(pvcReference)
+				_, _, pod := m.createPod(ctx, pvcReference)
 				if pod == nil {
 					return
 				}
-				err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				err = e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "Failed to start pod: %v", err)
 
 				// sleep to make sure RequiresRepublish triggers more than 1 NodePublishVolume
@@ -86,11 +86,11 @@ var _ = utils.SIGDescribe("CSI Mock volume service account token", func() {
 				}
 
 				ginkgo.By("Deleting the previously created pod")
-				err = e2epod.DeletePodWithWait(m.cs, pod)
+				err = e2epod.DeletePodWithWait(ctx, m.cs, pod)
 				framework.ExpectNoError(err, "while deleting")
 
 				ginkgo.By("Checking CSI driver logs")
-				err = checkPodLogs(m.driver.GetCalls, pod, false, false, false, test.deployCSIDriverObject && csiServiceAccountTokenEnabled, numNodePublishVolume)
+				err = checkPodLogs(ctx, m.driver.GetCalls, pod, false, false, false, test.deployCSIDriverObject && csiServiceAccountTokenEnabled, numNodePublishVolume)
 				framework.ExpectNoError(err)
 			})
 		}

--- a/test/e2e/storage/csi_mock/csi_volume_expansion.go
+++ b/test/e2e/storage/csi_mock/csi_volume_expansion.go
@@ -114,22 +114,22 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 					tp.registerDriver = true
 				}
 
-				m.init(tp)
+				m.init(ctx, tp)
 				ginkgo.DeferCleanup(m.cleanup)
 
-				sc, pvc, pod := m.createPod(pvcReference)
+				sc, pvc, pod := m.createPod(ctx, pvcReference)
 				gomega.Expect(pod).NotTo(gomega.BeNil(), "while creating pod for resizing")
 
 				if !*sc.AllowVolumeExpansion {
 					framework.Fail("failed creating sc with allowed expansion")
 				}
 
-				err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				err = e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
 				ginkgo.By("Expanding current pvc")
 				newSize := resource.MustParse("6Gi")
-				newPVC, err := testsuites.ExpandPVCSize(pvc, newSize, m.cs)
+				newPVC, err := testsuites.ExpandPVCSize(ctx, pvc, newSize, m.cs)
 				framework.ExpectNoError(err, "While updating pvc for more size")
 				pvc = newPVC
 				gomega.Expect(pvc).NotTo(gomega.BeNil())
@@ -139,18 +139,18 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 					framework.Failf("error updating pvc size %q", pvc.Name)
 				}
 				if test.expectFailure {
-					err = testsuites.WaitForResizingCondition(pvc, m.cs, csiResizingConditionWait)
+					err = testsuites.WaitForResizingCondition(ctx, pvc, m.cs, csiResizingConditionWait)
 					framework.ExpectError(err, "unexpected resizing condition on PVC")
 					return
 				}
 
 				ginkgo.By("Waiting for persistent volume resize to finish")
-				err = testsuites.WaitForControllerVolumeResize(pvc, m.cs, csiResizeWaitPeriod)
+				err = testsuites.WaitForControllerVolumeResize(ctx, pvc, m.cs, csiResizeWaitPeriod)
 				framework.ExpectNoError(err, "While waiting for CSI PV resize to finish")
 
 				checkPVCSize := func() {
 					ginkgo.By("Waiting for PVC resize to finish")
-					pvc, err = testsuites.WaitForFSResize(pvc, m.cs)
+					pvc, err = testsuites.WaitForFSResize(ctx, pvc, m.cs)
 					framework.ExpectNoError(err, "while waiting for PVC resize to finish")
 
 					pvcConditions := pvc.Status.Conditions
@@ -162,7 +162,7 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 					checkPVCSize()
 				} else {
 					ginkgo.By("Checking for conditions on pvc")
-					npvc, err := testsuites.WaitForPendingFSResizeCondition(pvc, m.cs)
+					npvc, err := testsuites.WaitForPendingFSResizeCondition(ctx, pvc, m.cs)
 					framework.ExpectNoError(err, "While waiting for pvc to have fs resizing condition")
 					pvc = npvc
 
@@ -172,7 +172,7 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 					}
 
 					ginkgo.By("Deleting the previously created pod")
-					err = e2epod.DeletePodWithWait(m.cs, pod)
+					err = e2epod.DeletePodWithWait(ctx, m.cs, pod)
 					framework.ExpectNoError(err, "while deleting pod for resizing")
 
 					ginkgo.By("Creating a new pod with same volume")
@@ -208,22 +208,22 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 					params.registerDriver = true
 				}
 
-				m.init(params)
+				m.init(ctx, params)
 				ginkgo.DeferCleanup(m.cleanup)
 
-				sc, pvc, pod := m.createPod(pvcReference)
+				sc, pvc, pod := m.createPod(ctx, pvcReference)
 				gomega.Expect(pod).NotTo(gomega.BeNil(), "while creating pod for resizing")
 
 				if !*sc.AllowVolumeExpansion {
 					framework.Fail("failed creating sc with allowed expansion")
 				}
 
-				err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				err = e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
 				ginkgo.By("Expanding current pvc")
 				newSize := resource.MustParse("6Gi")
-				newPVC, err := testsuites.ExpandPVCSize(pvc, newSize, m.cs)
+				newPVC, err := testsuites.ExpandPVCSize(ctx, pvc, newSize, m.cs)
 				framework.ExpectNoError(err, "While updating pvc for more size")
 				pvc = newPVC
 				gomega.Expect(pvc).NotTo(gomega.BeNil())
@@ -234,11 +234,11 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 				}
 
 				ginkgo.By("Waiting for persistent volume resize to finish")
-				err = testsuites.WaitForControllerVolumeResize(pvc, m.cs, csiResizeWaitPeriod)
+				err = testsuites.WaitForControllerVolumeResize(ctx, pvc, m.cs, csiResizeWaitPeriod)
 				framework.ExpectNoError(err, "While waiting for PV resize to finish")
 
 				ginkgo.By("Waiting for PVC resize to finish")
-				pvc, err = testsuites.WaitForFSResize(pvc, m.cs)
+				pvc, err = testsuites.WaitForFSResize(ctx, pvc, m.cs)
 				framework.ExpectNoError(err, "while waiting for PVC to finish")
 
 				pvcConditions := pvc.Status.Conditions
@@ -285,22 +285,22 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 					params.hooks = createExpansionHook(test.simulatedCSIDriverError)
 				}
 
-				m.init(params)
+				m.init(ctx, params)
 				ginkgo.DeferCleanup(m.cleanup)
 
-				sc, pvc, pod := m.createPod(pvcReference)
+				sc, pvc, pod := m.createPod(ctx, pvcReference)
 				gomega.Expect(pod).NotTo(gomega.BeNil(), "while creating pod for resizing")
 
 				if !*sc.AllowVolumeExpansion {
 					framework.Fail("failed creating sc with allowed expansion")
 				}
 
-				err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				err = e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
 				ginkgo.By("Expanding current pvc")
 				newSize := resource.MustParse(test.pvcRequestSize)
-				newPVC, err := testsuites.ExpandPVCSize(pvc, newSize, m.cs)
+				newPVC, err := testsuites.ExpandPVCSize(ctx, pvc, newSize, m.cs)
 				framework.ExpectNoError(err, "While updating pvc for more size")
 				pvc = newPVC
 				gomega.Expect(pvc).NotTo(gomega.BeNil())
@@ -311,9 +311,9 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 				}
 
 				if test.simulatedCSIDriverError == expansionSuccess {
-					validateExpansionSuccess(pvc, m, test, test.allocatedResource)
+					validateExpansionSuccess(ctx, pvc, m, test, test.allocatedResource)
 				} else {
-					validateRecoveryBehaviour(pvc, m, test)
+					validateRecoveryBehaviour(ctx, pvc, m, test)
 				}
 			})
 		}
@@ -321,7 +321,7 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 	})
 })
 
-func validateRecoveryBehaviour(pvc *v1.PersistentVolumeClaim, m *mockDriverSetup, test recoveryTest) {
+func validateRecoveryBehaviour(ctx context.Context, pvc *v1.PersistentVolumeClaim, m *mockDriverSetup, test recoveryTest) {
 	var err error
 	ginkgo.By("Waiting for resizer to set allocated resource")
 	err = waitForAllocatedResource(pvc, m, test.allocatedResource)
@@ -332,7 +332,7 @@ func validateRecoveryBehaviour(pvc *v1.PersistentVolumeClaim, m *mockDriverSetup
 	framework.ExpectNoError(err, "While waiting for resize status to be set")
 
 	ginkgo.By("Recover pvc size")
-	newPVC, err := testsuites.ExpandPVCSize(pvc, test.recoverySize, m.cs)
+	newPVC, err := testsuites.ExpandPVCSize(ctx, pvc, test.recoverySize, m.cs)
 	framework.ExpectNoError(err, "While updating pvc for more size")
 	pvc = newPVC
 	gomega.Expect(pvc).NotTo(gomega.BeNil())
@@ -344,7 +344,7 @@ func validateRecoveryBehaviour(pvc *v1.PersistentVolumeClaim, m *mockDriverSetup
 
 	// if expansion failed on controller with final error, then recovery should be possible
 	if test.simulatedCSIDriverError == expansionFailedOnController {
-		validateExpansionSuccess(pvc, m, test, test.recoverySize.String())
+		validateExpansionSuccess(ctx, pvc, m, test, test.recoverySize.String())
 		return
 	}
 
@@ -369,14 +369,14 @@ func validateRecoveryBehaviour(pvc *v1.PersistentVolumeClaim, m *mockDriverSetup
 	}
 }
 
-func validateExpansionSuccess(pvc *v1.PersistentVolumeClaim, m *mockDriverSetup, test recoveryTest, expectedAllocatedSize string) {
+func validateExpansionSuccess(ctx context.Context, pvc *v1.PersistentVolumeClaim, m *mockDriverSetup, test recoveryTest, expectedAllocatedSize string) {
 	var err error
 	ginkgo.By("Waiting for persistent volume resize to finish")
-	err = testsuites.WaitForControllerVolumeResize(pvc, m.cs, csiResizeWaitPeriod)
+	err = testsuites.WaitForControllerVolumeResize(ctx, pvc, m.cs, csiResizeWaitPeriod)
 	framework.ExpectNoError(err, "While waiting for PV resize to finish")
 
 	ginkgo.By("Waiting for PVC resize to finish")
-	pvc, err = testsuites.WaitForFSResize(pvc, m.cs)
+	pvc, err = testsuites.WaitForFSResize(ctx, pvc, m.cs)
 	framework.ExpectNoError(err, "while waiting for PVC to finish")
 
 	pvcConditions := pvc.Status.Conditions

--- a/test/e2e/storage/csi_mock/csi_volume_limit.go
+++ b/test/e2e/storage/csi_mock/csi_volume_limit.go
@@ -43,7 +43,7 @@ var _ = utils.SIGDescribe("CSI Mock volume limit", func() {
 		ginkgo.It("should report attach limit when limit is bigger than 0 [Slow]", func(ctx context.Context) {
 			// define volume limit to be 2 for this test
 			var err error
-			m.init(testParameters{attachLimit: 2})
+			m.init(ctx, testParameters{attachLimit: 2})
 			ginkgo.DeferCleanup(m.cleanup)
 
 			nodeName := m.config.ClientNodeSelection.Name
@@ -54,19 +54,19 @@ var _ = utils.SIGDescribe("CSI Mock volume limit", func() {
 
 			gomega.Expect(csiNodeAttachLimit).To(gomega.BeNumerically("==", 2))
 
-			_, _, pod1 := m.createPod(pvcReference)
+			_, _, pod1 := m.createPod(ctx, pvcReference)
 			gomega.Expect(pod1).NotTo(gomega.BeNil(), "while creating first pod")
 
-			err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod1.Name, pod1.Namespace)
+			err = e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod1.Name, pod1.Namespace)
 			framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
-			_, _, pod2 := m.createPod(pvcReference)
+			_, _, pod2 := m.createPod(ctx, pvcReference)
 			gomega.Expect(pod2).NotTo(gomega.BeNil(), "while creating second pod")
 
-			err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod2.Name, pod2.Namespace)
+			err = e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod2.Name, pod2.Namespace)
 			framework.ExpectNoError(err, "Failed to start pod2: %v", err)
 
-			_, _, pod3 := m.createPod(pvcReference)
+			_, _, pod3 := m.createPod(ctx, pvcReference)
 			gomega.Expect(pod3).NotTo(gomega.BeNil(), "while creating third pod")
 			err = waitForMaxVolumeCondition(pod3, m.cs)
 			framework.ExpectNoError(err, "while waiting for max volume condition on pod : %+v", pod3)
@@ -75,7 +75,7 @@ var _ = utils.SIGDescribe("CSI Mock volume limit", func() {
 		ginkgo.It("should report attach limit for generic ephemeral volume when persistent volume is attached [Slow]", func(ctx context.Context) {
 			// define volume limit to be 2 for this test
 			var err error
-			m.init(testParameters{attachLimit: 1})
+			m.init(ctx, testParameters{attachLimit: 1})
 			ginkgo.DeferCleanup(m.cleanup)
 
 			nodeName := m.config.ClientNodeSelection.Name
@@ -86,13 +86,13 @@ var _ = utils.SIGDescribe("CSI Mock volume limit", func() {
 
 			gomega.Expect(csiNodeAttachLimit).To(gomega.BeNumerically("==", 1))
 
-			_, _, pod1 := m.createPod(pvcReference)
+			_, _, pod1 := m.createPod(ctx, pvcReference)
 			gomega.Expect(pod1).NotTo(gomega.BeNil(), "while creating pod with persistent volume")
 
-			err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod1.Name, pod1.Namespace)
+			err = e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod1.Name, pod1.Namespace)
 			framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
-			_, _, pod2 := m.createPod(genericEphemeral)
+			_, _, pod2 := m.createPod(ctx, genericEphemeral)
 			gomega.Expect(pod2).NotTo(gomega.BeNil(), "while creating pod with ephemeral volume")
 			err = waitForMaxVolumeCondition(pod2, m.cs)
 			framework.ExpectNoError(err, "while waiting for max volume condition on pod : %+v", pod2)
@@ -101,7 +101,7 @@ var _ = utils.SIGDescribe("CSI Mock volume limit", func() {
 		ginkgo.It("should report attach limit for persistent volume when generic ephemeral volume is attached [Slow]", func(ctx context.Context) {
 			// define volume limit to be 2 for this test
 			var err error
-			m.init(testParameters{attachLimit: 1})
+			m.init(ctx, testParameters{attachLimit: 1})
 			ginkgo.DeferCleanup(m.cleanup)
 
 			nodeName := m.config.ClientNodeSelection.Name
@@ -112,13 +112,13 @@ var _ = utils.SIGDescribe("CSI Mock volume limit", func() {
 
 			gomega.Expect(csiNodeAttachLimit).To(gomega.BeNumerically("==", 1))
 
-			_, _, pod1 := m.createPod(genericEphemeral)
+			_, _, pod1 := m.createPod(ctx, genericEphemeral)
 			gomega.Expect(pod1).NotTo(gomega.BeNil(), "while creating pod with persistent volume")
 
-			err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod1.Name, pod1.Namespace)
+			err = e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod1.Name, pod1.Namespace)
 			framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
-			_, _, pod2 := m.createPod(pvcReference)
+			_, _, pod2 := m.createPod(ctx, pvcReference)
 			gomega.Expect(pod2).NotTo(gomega.BeNil(), "while creating pod with ephemeral volume")
 			err = waitForMaxVolumeCondition(pod2, m.cs)
 			framework.ExpectNoError(err, "while waiting for max volume condition on pod : %+v", pod2)

--- a/test/e2e/storage/csi_mock/csi_workload.go
+++ b/test/e2e/storage/csi_mock/csi_workload.go
@@ -83,7 +83,7 @@ var _ = utils.SIGDescribe("CSI Mock workload info", func() {
 		for _, t := range tests {
 			test := t
 			ginkgo.It(t.name, func(ctx context.Context) {
-				m.init(testParameters{
+				m.init(ctx, testParameters{
 					registerDriver: test.deployClusterRegistrar,
 					podInfo:        test.podInfoOnMount})
 
@@ -93,11 +93,11 @@ var _ = utils.SIGDescribe("CSI Mock workload info", func() {
 				if test.expectEphemeral {
 					withVolume = csiEphemeral
 				}
-				_, _, pod := m.createPod(withVolume)
+				_, _, pod := m.createPod(ctx, withVolume)
 				if pod == nil {
 					return
 				}
-				err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				err = e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "Failed to start pod: %v", err)
 
 				// If we expect an ephemeral volume, the feature has to be enabled.
@@ -111,11 +111,11 @@ var _ = utils.SIGDescribe("CSI Mock workload info", func() {
 				}
 
 				ginkgo.By("Deleting the previously created pod")
-				err = e2epod.DeletePodWithWait(m.cs, pod)
+				err = e2epod.DeletePodWithWait(ctx, m.cs, pod)
 				framework.ExpectNoError(err, "while deleting")
 
 				ginkgo.By("Checking CSI driver logs")
-				err = checkPodLogs(m.driver.GetCalls, pod, test.expectPodInfo, test.expectEphemeral, csiInlineVolumesEnabled, false, 1)
+				err = checkPodLogs(ctx, m.driver.GetCalls, pod, test.expectPodInfo, test.expectEphemeral, csiInlineVolumesEnabled, false, 1)
 				framework.ExpectNoError(err)
 			})
 		}

--- a/test/e2e/storage/csistoragecapacity.go
+++ b/test/e2e/storage/csistoragecapacity.go
@@ -96,7 +96,7 @@ var _ = utils.SIGDescribe("CSIStorageCapacity", func() {
 		ginkgo.By("getting /apis/storage.k8s.io")
 		{
 			group := &metav1.APIGroup{}
-			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/storage.k8s.io").Do(context.TODO()).Into(group)
+			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/storage.k8s.io").Do(ctx).Into(group)
 			framework.ExpectNoError(err)
 			found := false
 			for _, version := range group.Versions {
@@ -129,50 +129,50 @@ var _ = utils.SIGDescribe("CSIStorageCapacity", func() {
 		// Main resource create/read/update/watch operations
 
 		ginkgo.By("creating")
-		createdCSC, err := cscClient.Create(context.TODO(), csc, metav1.CreateOptions{})
+		createdCSC, err := cscClient.Create(ctx, csc, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		_, err = cscClient.Create(context.TODO(), csc, metav1.CreateOptions{})
+		_, err = cscClient.Create(ctx, csc, metav1.CreateOptions{})
 		if !apierrors.IsAlreadyExists(err) {
 			framework.Failf("expected 409, got %#v", err)
 		}
-		_, err = cscClient.Create(context.TODO(), csc2, metav1.CreateOptions{})
+		_, err = cscClient.Create(ctx, csc2, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
-		cscWatch, err := cscClient.Watch(context.TODO(), metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		cscWatch, err := cscClient.Watch(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
-		cscWatchNoNamespace, err := cscClientNoNamespace.Watch(context.TODO(), metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		cscWatchNoNamespace, err := cscClientNoNamespace.Watch(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
 
 		// added for a watch
-		_, err = cscClient.Create(context.TODO(), csc3, metav1.CreateOptions{})
+		_, err = cscClient.Create(ctx, csc3, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("getting")
-		gottenCSC, err := cscClient.Get(context.TODO(), csc.Name, metav1.GetOptions{})
+		gottenCSC, err := cscClient.Get(ctx, csc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(gottenCSC.UID, createdCSC.UID)
 
 		ginkgo.By("listing in namespace")
-		cscs, err := cscClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		cscs, err := cscClient.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(cscs.Items), 3, "filtered list should have 3 items, got: %s", cscs)
 
 		ginkgo.By("listing across namespaces")
-		cscs, err = cscClientNoNamespace.List(context.TODO(), metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		cscs, err = cscClientNoNamespace.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(cscs.Items), 3, "filtered list should have 3 items, got: %s", cscs)
 
 		ginkgo.By("patching")
-		patchedCSC, err := cscClient.Patch(context.TODO(), createdCSC.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
+		patchedCSC, err := cscClient.Patch(ctx, createdCSC.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(patchedCSC.Annotations["patched"], "true", "patched object should have the applied annotation")
 
 		ginkgo.By("updating")
 		csrToUpdate := patchedCSC.DeepCopy()
 		csrToUpdate.Annotations["updated"] = "true"
-		updatedCSC, err := cscClient.Update(context.TODO(), csrToUpdate, metav1.UpdateOptions{})
+		updatedCSC, err := cscClient.Update(ctx, csrToUpdate, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(updatedCSC.Annotations["updated"], "true", "updated object should have the applied annotation")
 
@@ -218,9 +218,9 @@ var _ = utils.SIGDescribe("CSIStorageCapacity", func() {
 		// main resource delete operations
 
 		ginkgo.By("deleting")
-		err = cscClient.Delete(context.TODO(), createdCSC.Name, metav1.DeleteOptions{})
+		err = cscClient.Delete(ctx, createdCSC.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
-		csc, err = cscClient.Get(context.TODO(), createdCSC.Name, metav1.GetOptions{})
+		csc, err = cscClient.Get(ctx, createdCSC.Name, metav1.GetOptions{})
 		min := 2
 		max := min
 		switch {
@@ -236,7 +236,7 @@ var _ = utils.SIGDescribe("CSIStorageCapacity", func() {
 		default:
 			framework.Failf("CSIStorageCapacitity should have been deleted or have DeletionTimestamp and Finalizers, but instead got: %s", csc)
 		}
-		cscs, err = cscClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		cscs, err = cscClient.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		actualLen := len(cscs.Items)
 		if actualLen < min || actualLen > max {
@@ -244,9 +244,9 @@ var _ = utils.SIGDescribe("CSIStorageCapacity", func() {
 		}
 
 		ginkgo.By("deleting a collection")
-		err = cscClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		err = cscClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
-		cscs, err = cscClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
+		cscs, err = cscClient.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		for _, csc := range cscs.Items {
 			// Any remaining objects should be marked for deletion

--- a/test/e2e/storage/detach_mounted.go
+++ b/test/e2e/storage/detach_mounted.go
@@ -55,7 +55,7 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Detaching volumes", func() {
 	var node *v1.Node
 	var suffix string
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		e2eskipper.SkipUnlessProviderIs("gce", "local")
 		e2eskipper.SkipUnlessMasterOSDistroIs("debian", "ubuntu", "gci", "custom")
 		e2eskipper.SkipUnlessNodeOSDistroIs("debian", "ubuntu", "gci", "custom")
@@ -64,7 +64,7 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Detaching volumes", func() {
 		cs = f.ClientSet
 		ns = f.Namespace
 		var err error
-		node, err = e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		node, err = e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 		suffix = ns.Name
 	})
@@ -76,9 +76,9 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Detaching volumes", func() {
 		driverInstallAs := driver + "-" + suffix
 
 		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
-		installFlex(cs, node, "k8s", driverInstallAs, path.Join(driverDir, driver))
+		installFlex(ctx, cs, node, "k8s", driverInstallAs, path.Join(driverDir, driver))
 		ginkgo.By(fmt.Sprintf("installing flexvolume %s on master as %s", path.Join(driverDir, driver), driverInstallAs))
-		installFlex(cs, nil, "k8s", driverInstallAs, path.Join(driverDir, driver))
+		installFlex(ctx, cs, nil, "k8s", driverInstallAs, path.Join(driverDir, driver))
 		volumeSource := v1.VolumeSource{
 			FlexVolume: &v1.FlexVolumeSource{
 				Driver: "k8s/" + driverInstallAs,
@@ -87,31 +87,31 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Detaching volumes", func() {
 
 		clientPod := getFlexVolumePod(volumeSource, node.Name)
 		ginkgo.By("Creating pod that uses slow format volume")
-		pod, err := cs.CoreV1().Pods(ns.Name).Create(context.TODO(), clientPod, metav1.CreateOptions{})
+		pod, err := cs.CoreV1().Pods(ns.Name).Create(ctx, clientPod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		uniqueVolumeName := getUniqueVolumeName(pod, driverInstallAs)
 
 		ginkgo.By("waiting for volumes to be attached to node")
-		err = waitForVolumesAttached(cs, node.Name, uniqueVolumeName)
+		err = waitForVolumesAttached(ctx, cs, node.Name, uniqueVolumeName)
 		framework.ExpectNoError(err, "while waiting for volume to attach to %s node", node.Name)
 
 		ginkgo.By("waiting for volume-in-use on the node after pod creation")
-		err = waitForVolumesInUse(cs, node.Name, uniqueVolumeName)
+		err = waitForVolumesInUse(ctx, cs, node.Name, uniqueVolumeName)
 		framework.ExpectNoError(err, "while waiting for volume in use")
 
 		ginkgo.By("waiting for kubelet to start mounting the volume")
 		time.Sleep(20 * time.Second)
 
 		ginkgo.By("Deleting the flexvolume pod")
-		err = e2epod.DeletePodWithWait(cs, pod)
+		err = e2epod.DeletePodWithWait(ctx, cs, pod)
 		framework.ExpectNoError(err, "in deleting the pod")
 
 		// Wait a bit for node to sync the volume status
 		time.Sleep(30 * time.Second)
 
 		ginkgo.By("waiting for volume-in-use on the node after pod deletion")
-		err = waitForVolumesInUse(cs, node.Name, uniqueVolumeName)
+		err = waitForVolumesInUse(ctx, cs, node.Name, uniqueVolumeName)
 		framework.ExpectNoError(err, "while waiting for volume in use")
 
 		// Wait for 110s because mount device operation has a sleep of 120 seconds
@@ -119,13 +119,13 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Detaching volumes", func() {
 		time.Sleep(durationForStuckMount)
 
 		ginkgo.By("waiting for volume to disappear from node in-use")
-		err = waitForVolumesNotInUse(cs, node.Name, uniqueVolumeName)
+		err = waitForVolumesNotInUse(ctx, cs, node.Name, uniqueVolumeName)
 		framework.ExpectNoError(err, "while waiting for volume to be removed from in-use")
 
 		ginkgo.By(fmt.Sprintf("uninstalling flexvolume %s from node %s", driverInstallAs, node.Name))
-		uninstallFlex(cs, node, "k8s", driverInstallAs)
+		uninstallFlex(ctx, cs, node, "k8s", driverInstallAs)
 		ginkgo.By(fmt.Sprintf("uninstalling flexvolume %s from master", driverInstallAs))
-		uninstallFlex(cs, nil, "k8s", driverInstallAs)
+		uninstallFlex(ctx, cs, nil, "k8s", driverInstallAs)
 	})
 })
 
@@ -133,9 +133,9 @@ func getUniqueVolumeName(pod *v1.Pod, driverName string) string {
 	return fmt.Sprintf("k8s/%s/%s", driverName, pod.Spec.Volumes[0].Name)
 }
 
-func waitForVolumesNotInUse(client clientset.Interface, nodeName, volumeName string) error {
-	waitErr := wait.PollImmediate(10*time.Second, 60*time.Second, func() (bool, error) {
-		node, err := client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+func waitForVolumesNotInUse(ctx context.Context, client clientset.Interface, nodeName, volumeName string) error {
+	waitErr := wait.PollImmediateWithContext(ctx, 10*time.Second, 60*time.Second, func(ctx context.Context) (bool, error) {
+		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error fetching node %s with %v", nodeName, err)
 		}
@@ -153,9 +153,9 @@ func waitForVolumesNotInUse(client clientset.Interface, nodeName, volumeName str
 	return nil
 }
 
-func waitForVolumesAttached(client clientset.Interface, nodeName, volumeName string) error {
-	waitErr := wait.PollImmediate(2*time.Second, 2*time.Minute, func() (bool, error) {
-		node, err := client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+func waitForVolumesAttached(ctx context.Context, client clientset.Interface, nodeName, volumeName string) error {
+	waitErr := wait.PollImmediateWithContext(ctx, 2*time.Second, 2*time.Minute, func(ctx context.Context) (bool, error) {
+		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error fetching node %s with %v", nodeName, err)
 		}
@@ -173,9 +173,9 @@ func waitForVolumesAttached(client clientset.Interface, nodeName, volumeName str
 	return nil
 }
 
-func waitForVolumesInUse(client clientset.Interface, nodeName, volumeName string) error {
-	waitErr := wait.PollImmediate(10*time.Second, 60*time.Second, func() (bool, error) {
-		node, err := client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+func waitForVolumesInUse(ctx context.Context, client clientset.Interface, nodeName, volumeName string) error {
+	waitErr := wait.PollImmediateWithContext(ctx, 10*time.Second, 60*time.Second, func(ctx context.Context) (bool, error) {
+		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error fetching node %s with %v", nodeName, err)
 		}

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -80,7 +80,7 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 		}
 
 		var err error
-		if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+		if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
 		}
 
@@ -97,7 +97,7 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 			},
 		}
 
-		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 		}
 
@@ -146,18 +146,18 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 				},
 			},
 		}
-		pod = e2epod.NewPodClient(f).CreateSync(pod)
+		pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			ginkgo.By("Cleaning up the secret")
-			if err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{}); err != nil {
+			if err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, secret.Name, metav1.DeleteOptions{}); err != nil {
 				framework.Failf("unable to delete secret %v: %v", secret.Name, err)
 			}
 			ginkgo.By("Cleaning up the configmap")
-			if err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(context.TODO(), configMap.Name, metav1.DeleteOptions{}); err != nil {
+			if err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, configMap.Name, metav1.DeleteOptions{}); err != nil {
 				framework.Failf("unable to delete configmap %v: %v", configMap.Name, err)
 			}
 			ginkgo.By("Cleaning up the pod")
-			if err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, *metav1.NewDeleteOptions(0)); err != nil {
+			if err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0)); err != nil {
 				framework.Failf("unable to delete pod %v: %v", pod.Name, err)
 			}
 		})
@@ -186,11 +186,11 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 		Description: Create 50 ConfigMaps Volumes and 5 replicas of pod with these ConfigMapvolumes mounted. Pod MUST NOT fail waiting for Volumes.
 	*/
 	framework.ConformanceIt("should not cause race condition when used for configmaps [Serial]", func(ctx context.Context) {
-		configMapNames := createConfigmapsForRace(f)
+		configMapNames := createConfigmapsForRace(ctx, f)
 		ginkgo.DeferCleanup(deleteConfigMaps, f, configMapNames)
 		volumes, volumeMounts := makeConfigMapVolumes(configMapNames)
 		for i := 0; i < wrappedVolumeRaceConfigMapIterationCount; i++ {
-			testNoWrappedVolumeRace(f, volumes, volumeMounts, wrappedVolumeRaceConfigMapPodCount)
+			testNoWrappedVolumeRace(ctx, f, volumes, volumeMounts, wrappedVolumeRaceConfigMapPodCount)
 		}
 	})
 
@@ -199,16 +199,16 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 	// To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
 	// This projected volume maps approach can also be tested with secrets and downwardapi VolumeSource but are less prone to the race problem.
 	ginkgo.It("should not cause race condition when used for git_repo [Serial] [Slow]", func(ctx context.Context) {
-		gitURL, gitRepo, cleanup := createGitServer(f)
+		gitURL, gitRepo, cleanup := createGitServer(ctx, f)
 		defer cleanup()
 		volumes, volumeMounts := makeGitRepoVolumes(gitURL, gitRepo)
 		for i := 0; i < wrappedVolumeRaceGitRepoIterationCount; i++ {
-			testNoWrappedVolumeRace(f, volumes, volumeMounts, wrappedVolumeRaceGitRepoPodCount)
+			testNoWrappedVolumeRace(ctx, f, volumes, volumeMounts, wrappedVolumeRaceGitRepoPodCount)
 		}
 	})
 })
 
-func createGitServer(f *framework.Framework) (gitURL string, gitRepo string, cleanup func()) {
+func createGitServer(ctx context.Context, f *framework.Framework) (gitURL string, gitRepo string, cleanup func()) {
 	var err error
 	gitServerPodName := "git-server-" + string(uuid.NewUUID())
 	containerPort := 8000
@@ -217,7 +217,7 @@ func createGitServer(f *framework.Framework) (gitURL string, gitRepo string, cle
 
 	gitServerPod := e2epod.NewAgnhostPod(f.Namespace.Name, gitServerPodName, nil, nil, []v1.ContainerPort{{ContainerPort: int32(containerPort)}}, "fake-gitserver")
 	gitServerPod.ObjectMeta.Labels = labels
-	e2epod.NewPodClient(f).CreateSync(gitServerPod)
+	e2epod.NewPodClient(f).CreateSync(ctx, gitServerPod)
 
 	// Portal IP and port
 	httpPort := 2345
@@ -238,17 +238,17 @@ func createGitServer(f *framework.Framework) (gitURL string, gitRepo string, cle
 		},
 	}
 
-	if gitServerSvc, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), gitServerSvc, metav1.CreateOptions{}); err != nil {
+	if gitServerSvc, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, gitServerSvc, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create test git server service %s: %v", gitServerSvc.Name, err)
 	}
 
 	return "http://" + gitServerSvc.Spec.ClusterIP + ":" + strconv.Itoa(httpPort), "test", func() {
 		ginkgo.By("Cleaning up the git server pod")
-		if err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), gitServerPod.Name, *metav1.NewDeleteOptions(0)); err != nil {
+		if err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, gitServerPod.Name, *metav1.NewDeleteOptions(0)); err != nil {
 			framework.Failf("unable to delete git server pod %v: %v", gitServerPod.Name, err)
 		}
 		ginkgo.By("Cleaning up the git server svc")
-		if err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete(context.TODO(), gitServerSvc.Name, metav1.DeleteOptions{}); err != nil {
+		if err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete(ctx, gitServerSvc.Name, metav1.DeleteOptions{}); err != nil {
 			framework.Failf("unable to delete git server svc %v: %v", gitServerSvc.Name, err)
 		}
 	}
@@ -274,7 +274,7 @@ func makeGitRepoVolumes(gitURL, gitRepo string) (volumes []v1.Volume, volumeMoun
 	return
 }
 
-func createConfigmapsForRace(f *framework.Framework) (configMapNames []string) {
+func createConfigmapsForRace(ctx context.Context, f *framework.Framework) (configMapNames []string) {
 	ginkgo.By(fmt.Sprintf("Creating %d configmaps", wrappedVolumeRaceConfigMapVolumeCount))
 	for i := 0; i < wrappedVolumeRaceConfigMapVolumeCount; i++ {
 		configMapName := fmt.Sprintf("racey-configmap-%d", i)
@@ -288,16 +288,16 @@ func createConfigmapsForRace(f *framework.Framework) (configMapNames []string) {
 				"data-1": "value-1",
 			},
 		}
-		_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 	}
 	return
 }
 
-func deleteConfigMaps(f *framework.Framework, configMapNames []string) {
+func deleteConfigMaps(ctx context.Context, f *framework.Framework, configMapNames []string) {
 	ginkgo.By("Cleaning up the configMaps")
 	for _, configMapName := range configMapNames {
-		err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(context.TODO(), configMapName, metav1.DeleteOptions{})
+		err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, configMapName, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "unable to delete configMap %v", configMapName)
 	}
 }
@@ -329,11 +329,11 @@ func makeConfigMapVolumes(configMapNames []string) (volumes []v1.Volume, volumeM
 	return
 }
 
-func testNoWrappedVolumeRace(f *framework.Framework, volumes []v1.Volume, volumeMounts []v1.VolumeMount, podCount int32) {
+func testNoWrappedVolumeRace(ctx context.Context, f *framework.Framework, volumes []v1.Volume, volumeMounts []v1.VolumeMount, podCount int32) {
 	const nodeHostnameLabelKey = "kubernetes.io/hostname"
 
 	rcName := wrappedVolumeRaceRCNamePrefix + string(uuid.NewUUID())
-	targetNode, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+	targetNode, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Creating RC which spawns configmap-volume pods")
@@ -383,12 +383,12 @@ func testNoWrappedVolumeRace(f *framework.Framework, volumes []v1.Volume, volume
 			},
 		},
 	}
-	_, err = f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(context.TODO(), rc, metav1.CreateOptions{})
+	_, err = f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(ctx, rc, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "error creating replication controller")
 
 	ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, rcName)
 
-	pods, err := e2epod.PodsCreated(f.ClientSet, f.Namespace.Name, rcName, podCount)
+	pods, err := e2epod.PodsCreated(ctx, f.ClientSet, f.Namespace.Name, rcName, podCount)
 	framework.ExpectNoError(err, "error creating pods")
 
 	ginkgo.By("Ensuring each pod is running")
@@ -399,7 +399,7 @@ func testNoWrappedVolumeRace(f *framework.Framework, volumes []v1.Volume, volume
 		if pod.DeletionTimestamp != nil {
 			continue
 		}
-		err = e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+		err = e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 		framework.ExpectNoError(err, "Failed waiting for pod %s to enter running state", pod.Name)
 	}
 }

--- a/test/e2e/storage/ephemeral_volume.go
+++ b/test/e2e/storage/ephemeral_volume.go
@@ -57,13 +57,13 @@ var _ = utils.SIGDescribe("Ephemeralstorage", func() {
 			testSource := testSource
 			ginkgo.It(fmt.Sprintf("should allow deletion of pod with invalid volume : %s", testSource.volumeType), func(ctx context.Context) {
 				pod := testEphemeralVolumePod(f, testSource.volumeType, testSource.source)
-				pod, err := c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+				pod, err := c.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 				framework.ExpectNoError(err)
 
 				// Allow it to sleep for 30 seconds
 				time.Sleep(30 * time.Second)
 				framework.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
-				framework.ExpectNoError(e2epod.DeletePodWithWait(c, pod))
+				framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, c, pod))
 			})
 		}
 	})

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -270,7 +270,7 @@ func (d *driverDefinition) SkipUnsupportedTest(pattern storageframework.TestPatt
 
 }
 
-func (d *driverDefinition) GetDynamicProvisionStorageClass(e2econfig *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
+func (d *driverDefinition) GetDynamicProvisionStorageClass(ctx context.Context, e2econfig *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
 	var (
 		sc  *storagev1.StorageClass
 		err error
@@ -281,7 +281,7 @@ func (d *driverDefinition) GetDynamicProvisionStorageClass(e2econfig *storagefra
 	case d.StorageClass.FromName:
 		sc = &storagev1.StorageClass{Provisioner: d.DriverInfo.Name}
 	case d.StorageClass.FromExistingClassName != "":
-		sc, err = f.ClientSet.StorageV1().StorageClasses().Get(context.TODO(), d.StorageClass.FromExistingClassName, metav1.GetOptions{})
+		sc, err = f.ClientSet.StorageV1().StorageClasses().Get(ctx, d.StorageClass.FromExistingClassName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "getting storage class %s", d.StorageClass.FromExistingClassName)
 	case d.StorageClass.FromFile != "":
 		var ok bool
@@ -360,7 +360,7 @@ func loadSnapshotClass(filename string) (*unstructured.Unstructured, error) {
 	return snapshotClass, nil
 }
 
-func (d *driverDefinition) GetSnapshotClass(e2econfig *storageframework.PerTestConfig, parameters map[string]string) *unstructured.Unstructured {
+func (d *driverDefinition) GetSnapshotClass(ctx context.Context, e2econfig *storageframework.PerTestConfig, parameters map[string]string) *unstructured.Unstructured {
 	if !d.SnapshotClass.FromName && d.SnapshotClass.FromFile == "" && d.SnapshotClass.FromExistingClassName == "" {
 		e2eskipper.Skipf("Driver %q does not support snapshotting - skipping", d.DriverInfo.Name)
 	}
@@ -373,7 +373,7 @@ func (d *driverDefinition) GetSnapshotClass(e2econfig *storageframework.PerTestC
 	case d.SnapshotClass.FromName:
 		// Do nothing (just use empty parameters)
 	case d.SnapshotClass.FromExistingClassName != "":
-		snapshotClass, err := f.DynamicClient.Resource(utils.SnapshotClassGVR).Get(context.TODO(), d.SnapshotClass.FromExistingClassName, metav1.GetOptions{})
+		snapshotClass, err := f.DynamicClient.Resource(utils.SnapshotClassGVR).Get(ctx, d.SnapshotClass.FromExistingClassName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "getting snapshot class %s", d.SnapshotClass.FromExistingClassName)
 
 		if params, ok := snapshotClass.Object["parameters"].(map[string]interface{}); ok {
@@ -415,7 +415,7 @@ func (d *driverDefinition) GetCSIDriverName(e2econfig *storageframework.PerTestC
 	return d.DriverInfo.Name
 }
 
-func (d *driverDefinition) PrepareTest(f *framework.Framework) *storageframework.PerTestConfig {
+func (d *driverDefinition) PrepareTest(ctx context.Context, f *framework.Framework) *storageframework.PerTestConfig {
 	e2econfig := &storageframework.PerTestConfig{
 		Driver:              d,
 		Prefix:              "external",

--- a/test/e2e/storage/flexvolume_mounted_volume_resize.go
+++ b/test/e2e/storage/flexvolume_mounted_volume_resize.go
@@ -62,16 +62,16 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Mounted flexvolume expand[Slow]
 
 	f := framework.NewDefaultFramework("mounted-flexvolume-expand")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		e2eskipper.SkipUnlessProviderIs("aws", "gce", "local")
 		e2eskipper.SkipUnlessMasterOSDistroIs("debian", "ubuntu", "gci", "custom")
 		e2eskipper.SkipUnlessNodeOSDistroIs("debian", "ubuntu", "gci", "custom")
 		e2eskipper.SkipUnlessSSHKeyPresent()
 		c = f.ClientSet
 		ns = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, framework.TestContext.NodeSchedulableTimeout))
 
-		node, err = e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		node, err = e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 		nodeName = node.Name
 
@@ -89,7 +89,7 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Mounted flexvolume expand[Slow]
 			Provisioner:          "flex-expand",
 		}
 
-		resizableSc, err = c.StorageV1().StorageClasses().Create(context.TODO(), newStorageClass(test, ns, "resizing"), metav1.CreateOptions{})
+		resizableSc, err = c.StorageV1().StorageClasses().Create(ctx, newStorageClass(test, ns, "resizing"), metav1.CreateOptions{})
 		if err != nil {
 			fmt.Printf("storage class creation error: %v\n", err)
 		}
@@ -102,11 +102,11 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Mounted flexvolume expand[Slow]
 			StorageClassName: &(resizableSc.Name),
 			ClaimSize:        "2Gi",
 		}, ns)
-		pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+		pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Error creating pvc")
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			framework.Logf("AfterEach: Cleaning up resources for mounted volume resize")
-			if errs := e2epv.PVPVCCleanup(c, ns, nil, pvc); len(errs) > 0 {
+			if errs := e2epv.PVPVCCleanup(ctx, c, ns, nil, pvc); len(errs) > 0 {
 				framework.Failf("AfterEach: Failed to delete PVC and/or PV. Errors: %v", utilerrors.NewAggregate(errs))
 			}
 		})
@@ -115,9 +115,9 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Mounted flexvolume expand[Slow]
 	ginkgo.It("Should verify mounted flex volumes can be resized", func(ctx context.Context) {
 		driver := "dummy-attachable"
 		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driver))
-		installFlex(c, node, "k8s", driver, path.Join(driverDir, driver))
+		installFlex(ctx, c, node, "k8s", driver, path.Join(driverDir, driver))
 		ginkgo.By(fmt.Sprintf("installing flexvolume %s on (master) node %s as %s", path.Join(driverDir, driver), node.Name, driver))
-		installFlex(c, nil, "k8s", driver, path.Join(driverDir, driver))
+		installFlex(ctx, c, nil, "k8s", driver, path.Join(driverDir, driver))
 
 		pv := e2epv.MakePersistentVolume(e2epv.PersistentVolumeConfig{
 			PVSource: v1.PersistentVolumeSource{
@@ -129,25 +129,25 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Mounted flexvolume expand[Slow]
 			VolumeMode:       pvc.Spec.VolumeMode,
 		})
 
-		_, err = e2epv.CreatePV(c, f.Timeouts, pv)
+		_, err = e2epv.CreatePV(ctx, c, f.Timeouts, pv)
 		framework.ExpectNoError(err, "Error creating pv %v", err)
 
 		ginkgo.By("Waiting for PVC to be in bound phase")
 		pvcClaims := []*v1.PersistentVolumeClaim{pvc}
 		var pvs []*v1.PersistentVolume
 
-		pvs, err = e2epv.WaitForPVClaimBoundPhase(c, pvcClaims, framework.ClaimProvisionTimeout)
+		pvs, err = e2epv.WaitForPVClaimBoundPhase(ctx, c, pvcClaims, framework.ClaimProvisionTimeout)
 		framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
 		framework.ExpectEqual(len(pvs), 1)
 
 		ginkgo.By("Creating a deployment with the provisioned volume")
-		deployment, err := e2edeployment.CreateDeployment(c, int32(1), map[string]string{"test": "app"}, nodeKeyValueLabel, ns, pvcClaims, "")
+		deployment, err := e2edeployment.CreateDeployment(ctx, c, int32(1), map[string]string{"test": "app"}, nodeKeyValueLabel, ns, pvcClaims, "")
 		framework.ExpectNoError(err, "Failed creating deployment %v", err)
 		ginkgo.DeferCleanup(c.AppsV1().Deployments(ns).Delete, deployment.Name, metav1.DeleteOptions{})
 
 		ginkgo.By("Expanding current pvc")
 		newSize := resource.MustParse("6Gi")
-		newPVC, err := testsuites.ExpandPVCSize(pvc, newSize, c)
+		newPVC, err := testsuites.ExpandPVCSize(ctx, pvc, newSize, c)
 		framework.ExpectNoError(err, "While updating pvc for more size")
 		pvc = newPVC
 		gomega.Expect(pvc).NotTo(gomega.BeNil())
@@ -158,25 +158,25 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Mounted flexvolume expand[Slow]
 		}
 
 		ginkgo.By("Waiting for cloudprovider resize to finish")
-		err = testsuites.WaitForControllerVolumeResize(pvc, c, totalResizeWaitPeriod)
+		err = testsuites.WaitForControllerVolumeResize(ctx, pvc, c, totalResizeWaitPeriod)
 		framework.ExpectNoError(err, "While waiting for pvc resize to finish")
 
 		ginkgo.By("Getting a pod from deployment")
-		podList, err := e2edeployment.GetPodsForDeployment(c, deployment)
+		podList, err := e2edeployment.GetPodsForDeployment(ctx, c, deployment)
 		framework.ExpectNoError(err, "While getting pods from deployment")
 		gomega.Expect(podList.Items).NotTo(gomega.BeEmpty())
 		pod := podList.Items[0]
 
 		ginkgo.By("Deleting the pod from deployment")
-		err = e2epod.DeletePodWithWait(c, &pod)
+		err = e2epod.DeletePodWithWait(ctx, c, &pod)
 		framework.ExpectNoError(err, "while deleting pod for resizing")
 
 		ginkgo.By("Waiting for deployment to create new pod")
-		pod, err = waitForDeploymentToRecreatePod(c, deployment)
+		pod, err = waitForDeploymentToRecreatePod(ctx, c, deployment)
 		framework.ExpectNoError(err, "While waiting for pod to be recreated")
 
 		ginkgo.By("Waiting for file system resize to finish")
-		pvc, err = testsuites.WaitForFSResize(pvc, c)
+		pvc, err = testsuites.WaitForFSResize(ctx, pvc, c)
 		framework.ExpectNoError(err, "while waiting for fs resize to finish")
 
 		pvcConditions := pvc.Status.Conditions

--- a/test/e2e/storage/framework/driver_operations.go
+++ b/test/e2e/storage/framework/driver_operations.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"fmt"
 
 	storagev1 "k8s.io/api/storage/v1"
@@ -36,11 +37,11 @@ func GetDriverNameWithFeatureTags(driver TestDriver) string {
 }
 
 // CreateVolume creates volume for test unless dynamicPV or CSI ephemeral inline volume test
-func CreateVolume(driver TestDriver, config *PerTestConfig, volType TestVolType) TestVolume {
+func CreateVolume(ctx context.Context, driver TestDriver, config *PerTestConfig, volType TestVolType) TestVolume {
 	switch volType {
 	case InlineVolume, PreprovisionedPV:
 		if pDriver, ok := driver.(PreprovisionedVolumeTestDriver); ok {
-			return pDriver.CreateVolume(config, volType)
+			return pDriver.CreateVolume(ctx, config, volType)
 		}
 	case CSIInlineVolume, GenericEphemeralVolume, DynamicPV:
 		// No need to create volume

--- a/test/e2e/storage/framework/snapshot_resource.go
+++ b/test/e2e/storage/framework/snapshot_resource.go
@@ -45,7 +45,7 @@ type SnapshotResource struct {
 // CreateSnapshot creates a VolumeSnapshotClass with given SnapshotDeletionPolicy and a VolumeSnapshot
 // from the VolumeSnapshotClass using a dynamic client.
 // Returns the unstructured VolumeSnapshotClass and VolumeSnapshot objects.
-func CreateSnapshot(sDriver SnapshottableTestDriver, config *PerTestConfig, pattern TestPattern, pvcName string, pvcNamespace string, timeouts *framework.TimeoutContext, parameters map[string]string) (*unstructured.Unstructured, *unstructured.Unstructured) {
+func CreateSnapshot(ctx context.Context, sDriver SnapshottableTestDriver, config *PerTestConfig, pattern TestPattern, pvcName string, pvcNamespace string, timeouts *framework.TimeoutContext, parameters map[string]string) (*unstructured.Unstructured, *unstructured.Unstructured) {
 	defer ginkgo.GinkgoRecover()
 	var err error
 	if pattern.SnapshotType != DynamicCreatedSnapshot && pattern.SnapshotType != PreprovisionedCreatedSnapshot {
@@ -55,23 +55,23 @@ func CreateSnapshot(sDriver SnapshottableTestDriver, config *PerTestConfig, patt
 	dc := config.Framework.DynamicClient
 
 	ginkgo.By("creating a SnapshotClass")
-	sclass := sDriver.GetSnapshotClass(config, parameters)
+	sclass := sDriver.GetSnapshotClass(ctx, config, parameters)
 	if sclass == nil {
 		framework.Failf("Failed to get snapshot class based on test config")
 	}
 	sclass.Object["deletionPolicy"] = pattern.SnapshotDeletionPolicy.String()
 
-	sclass, err = dc.Resource(utils.SnapshotClassGVR).Create(context.TODO(), sclass, metav1.CreateOptions{})
+	sclass, err = dc.Resource(utils.SnapshotClassGVR).Create(ctx, sclass, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
-	sclass, err = dc.Resource(utils.SnapshotClassGVR).Get(context.TODO(), sclass.GetName(), metav1.GetOptions{})
+	sclass, err = dc.Resource(utils.SnapshotClassGVR).Get(ctx, sclass.GetName(), metav1.GetOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("creating a dynamic VolumeSnapshot")
 	// prepare a dynamically provisioned volume snapshot with certain data
 	snapshot := getSnapshot(pvcName, pvcNamespace, sclass.GetName())
 
-	snapshot, err = dc.Resource(utils.SnapshotGVR).Namespace(snapshot.GetNamespace()).Create(context.TODO(), snapshot, metav1.CreateOptions{})
+	snapshot, err = dc.Resource(utils.SnapshotGVR).Namespace(snapshot.GetNamespace()).Create(ctx, snapshot, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	return sclass, snapshot
@@ -79,17 +79,17 @@ func CreateSnapshot(sDriver SnapshottableTestDriver, config *PerTestConfig, patt
 
 // CreateSnapshotResource creates a snapshot resource for the current test. It knows how to deal with
 // different test pattern snapshot provisioning and deletion policy
-func CreateSnapshotResource(sDriver SnapshottableTestDriver, config *PerTestConfig, pattern TestPattern, pvcName string, pvcNamespace string, timeouts *framework.TimeoutContext, parameters map[string]string) *SnapshotResource {
+func CreateSnapshotResource(ctx context.Context, sDriver SnapshottableTestDriver, config *PerTestConfig, pattern TestPattern, pvcName string, pvcNamespace string, timeouts *framework.TimeoutContext, parameters map[string]string) *SnapshotResource {
 	var err error
 	r := SnapshotResource{
 		Config:  config,
 		Pattern: pattern,
 	}
-	r.Vsclass, r.Vs = CreateSnapshot(sDriver, config, pattern, pvcName, pvcNamespace, timeouts, parameters)
+	r.Vsclass, r.Vs = CreateSnapshot(ctx, sDriver, config, pattern, pvcName, pvcNamespace, timeouts, parameters)
 
 	dc := r.Config.Framework.DynamicClient
 
-	r.Vscontent = utils.GetSnapshotContentFromSnapshot(dc, r.Vs, timeouts.SnapshotCreate)
+	r.Vscontent = utils.GetSnapshotContentFromSnapshot(ctx, dc, r.Vs, timeouts.SnapshotCreate)
 
 	if pattern.SnapshotType == PreprovisionedCreatedSnapshot {
 		// prepare a pre-provisioned VolumeSnapshotContent with certain data
@@ -101,7 +101,7 @@ func CreateSnapshotResource(sDriver SnapshottableTestDriver, config *PerTestConf
 		ginkgo.By("updating the snapshot content deletion policy to retain")
 		r.Vscontent.Object["spec"].(map[string]interface{})["deletionPolicy"] = "Retain"
 
-		r.Vscontent, err = dc.Resource(utils.SnapshotContentGVR).Update(context.TODO(), r.Vscontent, metav1.UpdateOptions{})
+		r.Vscontent, err = dc.Resource(utils.SnapshotContentGVR).Update(ctx, r.Vscontent, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("recording properties of the preprovisioned snapshot")
@@ -117,24 +117,24 @@ func CreateSnapshotResource(sDriver SnapshottableTestDriver, config *PerTestConf
 		// when the vscontent is manually deleted then the underlying snapshot resource will not be deleted.
 		// We exploit this to create a snapshot resource from which we can create a preprovisioned snapshot
 		ginkgo.By("deleting the snapshot and snapshot content")
-		err = dc.Resource(utils.SnapshotGVR).Namespace(r.Vs.GetNamespace()).Delete(context.TODO(), r.Vs.GetName(), metav1.DeleteOptions{})
+		err = dc.Resource(utils.SnapshotGVR).Namespace(r.Vs.GetNamespace()).Delete(ctx, r.Vs.GetName(), metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			err = nil
 		}
 		framework.ExpectNoError(err)
 
 		ginkgo.By("checking the Snapshot has been deleted")
-		err = utils.WaitForNamespacedGVRDeletion(dc, utils.SnapshotGVR, r.Vs.GetName(), r.Vs.GetNamespace(), framework.Poll, timeouts.SnapshotDelete)
+		err = utils.WaitForNamespacedGVRDeletion(ctx, dc, utils.SnapshotGVR, r.Vs.GetName(), r.Vs.GetNamespace(), framework.Poll, timeouts.SnapshotDelete)
 		framework.ExpectNoError(err)
 
-		err = dc.Resource(utils.SnapshotContentGVR).Delete(context.TODO(), r.Vscontent.GetName(), metav1.DeleteOptions{})
+		err = dc.Resource(utils.SnapshotContentGVR).Delete(ctx, r.Vscontent.GetName(), metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			err = nil
 		}
 		framework.ExpectNoError(err)
 
 		ginkgo.By("checking the Snapshot content has been deleted")
-		err = utils.WaitForGVRDeletion(dc, utils.SnapshotContentGVR, r.Vscontent.GetName(), framework.Poll, timeouts.SnapshotDelete)
+		err = utils.WaitForGVRDeletion(ctx, dc, utils.SnapshotContentGVR, r.Vscontent.GetName(), framework.Poll, timeouts.SnapshotDelete)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("creating a snapshot content with the snapshot handle")
@@ -144,29 +144,29 @@ func CreateSnapshotResource(sDriver SnapshottableTestDriver, config *PerTestConf
 		snapcontentName := getPreProvisionedSnapshotContentName(uuid)
 
 		r.Vscontent = getPreProvisionedSnapshotContent(snapcontentName, snapshotContentAnnotations, snapName, pvcNamespace, snapshotHandle, pattern.SnapshotDeletionPolicy.String(), csiDriverName)
-		r.Vscontent, err = dc.Resource(utils.SnapshotContentGVR).Create(context.TODO(), r.Vscontent, metav1.CreateOptions{})
+		r.Vscontent, err = dc.Resource(utils.SnapshotContentGVR).Create(ctx, r.Vscontent, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("creating a snapshot with that snapshot content")
 		r.Vs = getPreProvisionedSnapshot(snapName, pvcNamespace, snapcontentName)
-		r.Vs, err = dc.Resource(utils.SnapshotGVR).Namespace(r.Vs.GetNamespace()).Create(context.TODO(), r.Vs, metav1.CreateOptions{})
+		r.Vs, err = dc.Resource(utils.SnapshotGVR).Namespace(r.Vs.GetNamespace()).Create(ctx, r.Vs, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
-		err = utils.WaitForSnapshotReady(dc, r.Vs.GetNamespace(), r.Vs.GetName(), framework.Poll, timeouts.SnapshotCreate)
+		err = utils.WaitForSnapshotReady(ctx, dc, r.Vs.GetNamespace(), r.Vs.GetName(), framework.Poll, timeouts.SnapshotCreate)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("getting the snapshot and snapshot content")
-		r.Vs, err = dc.Resource(utils.SnapshotGVR).Namespace(r.Vs.GetNamespace()).Get(context.TODO(), r.Vs.GetName(), metav1.GetOptions{})
+		r.Vs, err = dc.Resource(utils.SnapshotGVR).Namespace(r.Vs.GetNamespace()).Get(ctx, r.Vs.GetName(), metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
-		r.Vscontent, err = dc.Resource(utils.SnapshotContentGVR).Get(context.TODO(), r.Vscontent.GetName(), metav1.GetOptions{})
+		r.Vscontent, err = dc.Resource(utils.SnapshotContentGVR).Get(ctx, r.Vscontent.GetName(), metav1.GetOptions{})
 		framework.ExpectNoError(err)
 	}
 	return &r
 }
 
 // CleanupResource cleans up the snapshot resource and ignores not found errors
-func (sr *SnapshotResource) CleanupResource(timeouts *framework.TimeoutContext) error {
+func (sr *SnapshotResource) CleanupResource(ctx context.Context, timeouts *framework.TimeoutContext) error {
 	var err error
 	var cleanupErrs []error
 
@@ -175,7 +175,7 @@ func (sr *SnapshotResource) CleanupResource(timeouts *framework.TimeoutContext) 
 	if sr.Vs != nil {
 		framework.Logf("deleting snapshot %q/%q", sr.Vs.GetNamespace(), sr.Vs.GetName())
 
-		sr.Vs, err = dc.Resource(utils.SnapshotGVR).Namespace(sr.Vs.GetNamespace()).Get(context.TODO(), sr.Vs.GetName(), metav1.GetOptions{})
+		sr.Vs, err = dc.Resource(utils.SnapshotGVR).Namespace(sr.Vs.GetNamespace()).Get(ctx, sr.Vs.GetName(), metav1.GetOptions{})
 		switch {
 		case err == nil:
 			snapshotStatus := sr.Vs.Object["status"].(map[string]interface{})
@@ -183,7 +183,7 @@ func (sr *SnapshotResource) CleanupResource(timeouts *framework.TimeoutContext) 
 			framework.Logf("received snapshotStatus %v", snapshotStatus)
 			framework.Logf("snapshotContentName %s", snapshotContentName)
 
-			boundVsContent, err := dc.Resource(utils.SnapshotContentGVR).Get(context.TODO(), snapshotContentName, metav1.GetOptions{})
+			boundVsContent, err := dc.Resource(utils.SnapshotContentGVR).Get(ctx, snapshotContentName, metav1.GetOptions{})
 			switch {
 			case err == nil:
 				if boundVsContent.Object["spec"].(map[string]interface{})["deletionPolicy"] != "Delete" {
@@ -191,27 +191,27 @@ func (sr *SnapshotResource) CleanupResource(timeouts *framework.TimeoutContext) 
 					// We must update the SnapshotContent to have Delete Deletion policy,
 					// or else the physical snapshot content will be leaked.
 					boundVsContent.Object["spec"].(map[string]interface{})["deletionPolicy"] = "Delete"
-					boundVsContent, err = dc.Resource(utils.SnapshotContentGVR).Update(context.TODO(), boundVsContent, metav1.UpdateOptions{})
+					boundVsContent, err = dc.Resource(utils.SnapshotContentGVR).Update(ctx, boundVsContent, metav1.UpdateOptions{})
 					framework.ExpectNoError(err)
 				}
-				err = dc.Resource(utils.SnapshotGVR).Namespace(sr.Vs.GetNamespace()).Delete(context.TODO(), sr.Vs.GetName(), metav1.DeleteOptions{})
+				err = dc.Resource(utils.SnapshotGVR).Namespace(sr.Vs.GetNamespace()).Delete(ctx, sr.Vs.GetName(), metav1.DeleteOptions{})
 				if apierrors.IsNotFound(err) {
 					err = nil
 				}
 				framework.ExpectNoError(err)
 
-				err = utils.WaitForGVRDeletion(dc, utils.SnapshotContentGVR, boundVsContent.GetName(), framework.Poll, timeouts.SnapshotDelete)
+				err = utils.WaitForGVRDeletion(ctx, dc, utils.SnapshotContentGVR, boundVsContent.GetName(), framework.Poll, timeouts.SnapshotDelete)
 				framework.ExpectNoError(err)
 
 			case apierrors.IsNotFound(err):
 				// the volume snapshot is not bound to snapshot content yet
-				err = dc.Resource(utils.SnapshotGVR).Namespace(sr.Vs.GetNamespace()).Delete(context.TODO(), sr.Vs.GetName(), metav1.DeleteOptions{})
+				err = dc.Resource(utils.SnapshotGVR).Namespace(sr.Vs.GetNamespace()).Delete(ctx, sr.Vs.GetName(), metav1.DeleteOptions{})
 				if apierrors.IsNotFound(err) {
 					err = nil
 				}
 				framework.ExpectNoError(err)
 
-				err = utils.WaitForNamespacedGVRDeletion(dc, utils.SnapshotGVR, sr.Vs.GetName(), sr.Vs.GetNamespace(), framework.Poll, timeouts.SnapshotDelete)
+				err = utils.WaitForNamespacedGVRDeletion(ctx, dc, utils.SnapshotGVR, sr.Vs.GetName(), sr.Vs.GetNamespace(), framework.Poll, timeouts.SnapshotDelete)
 				framework.ExpectNoError(err)
 			default:
 				cleanupErrs = append(cleanupErrs, err)
@@ -225,7 +225,7 @@ func (sr *SnapshotResource) CleanupResource(timeouts *framework.TimeoutContext) 
 	if sr.Vscontent != nil {
 		framework.Logf("deleting snapshot content %q", sr.Vscontent.GetName())
 
-		sr.Vscontent, err = dc.Resource(utils.SnapshotContentGVR).Get(context.TODO(), sr.Vscontent.GetName(), metav1.GetOptions{})
+		sr.Vscontent, err = dc.Resource(utils.SnapshotContentGVR).Get(ctx, sr.Vscontent.GetName(), metav1.GetOptions{})
 		switch {
 		case err == nil:
 			if sr.Vscontent.Object["spec"].(map[string]interface{})["deletionPolicy"] != "Delete" {
@@ -233,16 +233,16 @@ func (sr *SnapshotResource) CleanupResource(timeouts *framework.TimeoutContext) 
 				// We must update the SnapshotContent to have Delete Deletion policy,
 				// or else the physical snapshot content will be leaked.
 				sr.Vscontent.Object["spec"].(map[string]interface{})["deletionPolicy"] = "Delete"
-				sr.Vscontent, err = dc.Resource(utils.SnapshotContentGVR).Update(context.TODO(), sr.Vscontent, metav1.UpdateOptions{})
+				sr.Vscontent, err = dc.Resource(utils.SnapshotContentGVR).Update(ctx, sr.Vscontent, metav1.UpdateOptions{})
 				framework.ExpectNoError(err)
 			}
-			err = dc.Resource(utils.SnapshotContentGVR).Delete(context.TODO(), sr.Vscontent.GetName(), metav1.DeleteOptions{})
+			err = dc.Resource(utils.SnapshotContentGVR).Delete(ctx, sr.Vscontent.GetName(), metav1.DeleteOptions{})
 			if apierrors.IsNotFound(err) {
 				err = nil
 			}
 			framework.ExpectNoError(err)
 
-			err = utils.WaitForGVRDeletion(dc, utils.SnapshotContentGVR, sr.Vscontent.GetName(), framework.Poll, timeouts.SnapshotDelete)
+			err = utils.WaitForGVRDeletion(ctx, dc, utils.SnapshotContentGVR, sr.Vscontent.GetName(), framework.Poll, timeouts.SnapshotDelete)
 			framework.ExpectNoError(err)
 		case apierrors.IsNotFound(err):
 			// Hope the underlying physical snapshot resource has been deleted already
@@ -253,11 +253,11 @@ func (sr *SnapshotResource) CleanupResource(timeouts *framework.TimeoutContext) 
 	if sr.Vsclass != nil {
 		framework.Logf("deleting snapshot class %q", sr.Vsclass.GetName())
 		// typically this snapshot class has already been deleted
-		err = dc.Resource(utils.SnapshotClassGVR).Delete(context.TODO(), sr.Vsclass.GetName(), metav1.DeleteOptions{})
+		err = dc.Resource(utils.SnapshotClassGVR).Delete(ctx, sr.Vsclass.GetName(), metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			framework.Failf("Error deleting snapshot class %q. Error: %v", sr.Vsclass.GetName(), err)
 		}
-		err = utils.WaitForGVRDeletion(dc, utils.SnapshotClassGVR, sr.Vsclass.GetName(), framework.Poll, timeouts.SnapshotDelete)
+		err = utils.WaitForGVRDeletion(ctx, dc, utils.SnapshotClassGVR, sr.Vsclass.GetName(), framework.Poll, timeouts.SnapshotDelete)
 		framework.ExpectNoError(err)
 	}
 	return utilerrors.NewAggregate(cleanupErrs)

--- a/test/e2e/storage/framework/testdriver.go
+++ b/test/e2e/storage/framework/testdriver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -49,21 +50,21 @@ type TestDriver interface {
 	// PrepareTest is called at test execution time each time a new test case is about to start.
 	// It sets up all necessary resources and returns the per-test configuration.
 	// Cleanup is handled via ginkgo.DeferCleanup inside PrepareTest.
-	PrepareTest(f *framework.Framework) *PerTestConfig
+	PrepareTest(ctx context.Context, f *framework.Framework) *PerTestConfig
 }
 
 // TestVolume is the result of PreprovisionedVolumeTestDriver.CreateVolume.
 // The only common functionality is to delete it. Individual driver interfaces
 // have additional methods that work with volumes created by them.
 type TestVolume interface {
-	DeleteVolume()
+	DeleteVolume(ctx context.Context)
 }
 
 // PreprovisionedVolumeTestDriver represents an interface for a TestDriver that has pre-provisioned volume
 type PreprovisionedVolumeTestDriver interface {
 	TestDriver
 	// CreateVolume creates a pre-provisioned volume of the desired volume type.
-	CreateVolume(config *PerTestConfig, volumeType TestVolType) TestVolume
+	CreateVolume(ctx context.Context, config *PerTestConfig, volumeType TestVolType) TestVolume
 }
 
 // InlineVolumeTestDriver represents an interface for a TestDriver that supports InlineVolume
@@ -89,12 +90,12 @@ type PreprovisionedPVTestDriver interface {
 type DynamicPVTestDriver interface {
 	TestDriver
 	// GetDynamicProvisionStorageClass returns a StorageClass dynamic provision Persistent Volume.
-	// The StorageClass must be created in the current test's namespace and have
-	// a unique name inside that namespace because GetDynamicProvisionStorageClass might
+	// The StorageClass must have
+	// a unique name because GetDynamicProvisionStorageClass might
 	// be called more than once per test.
 	// It will set fsType to the StorageClass, if TestDriver supports it.
 	// It will return nil, if the TestDriver doesn't support it.
-	GetDynamicProvisionStorageClass(config *PerTestConfig, fsType string) *storagev1.StorageClass
+	GetDynamicProvisionStorageClass(ctx context.Context, config *PerTestConfig, fsType string) *storagev1.StorageClass
 }
 
 // EphemeralTestDriver represents an interface for a TestDriver that supports ephemeral inline volumes.
@@ -126,7 +127,7 @@ type SnapshottableTestDriver interface {
 	TestDriver
 	// GetSnapshotClass returns a SnapshotClass to create snapshot.
 	// It will return nil, if the TestDriver doesn't support it.
-	GetSnapshotClass(config *PerTestConfig, parameters map[string]string) *unstructured.Unstructured
+	GetSnapshotClass(ctx context.Context, config *PerTestConfig, parameters map[string]string) *unstructured.Unstructured
 }
 
 // CustomTimeoutsTestDriver represents an interface fo a TestDriver that supports custom timeouts.

--- a/test/e2e/storage/gke_local_ssd.go
+++ b/test/e2e/storage/gke_local_ssd.go
@@ -45,7 +45,7 @@ var _ = utils.SIGDescribe("GKE local SSD [Feature:GKELocalSSD]", func() {
 	ginkgo.It("should write and read from node local SSD [Feature:GKELocalSSD]", func(ctx context.Context) {
 		framework.Logf("Start local SSD test")
 		createNodePoolWithLocalSsds("np-ssd")
-		doTestWriteAndReadToLocalSsd(f)
+		doTestWriteAndReadToLocalSsd(ctx, f)
 	})
 })
 
@@ -62,12 +62,12 @@ func createNodePoolWithLocalSsds(nodePoolName string) {
 	framework.Logf("Successfully created node pool %s:\n%v", nodePoolName, string(out))
 }
 
-func doTestWriteAndReadToLocalSsd(f *framework.Framework) {
+func doTestWriteAndReadToLocalSsd(ctx context.Context, f *framework.Framework) {
 	var pod = testPodWithSsd("echo 'hello world' > /mnt/disks/ssd0/data  && sleep 1 && cat /mnt/disks/ssd0/data")
 	var msg string
 	var out = []string{"hello world"}
 
-	e2eoutput.TestContainerOutput(f, msg, pod, 0, out)
+	e2eoutput.TestContainerOutput(ctx, f, msg, pod, 0, out)
 }
 
 func testPodWithSsd(command string) *v1.Pod {

--- a/test/e2e/storage/host_path_type.go
+++ b/test/e2e/storage/host_path_type.go
@@ -56,50 +56,50 @@ var _ = utils.SIGDescribe("HostPathType Directory [Slow]", func() {
 		hostPathBlockDev          = v1.HostPathBlockDev
 	)
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		ns = f.Namespace.Name
 
 		ginkgo.By("Create a pod for further testing")
 		hostBaseDir = path.Join("/tmp", ns)
 		mountBaseDir = "/mnt/test"
-		basePod = e2epod.NewPodClient(f).CreateSync(newHostPathTypeTestPod(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate))
+		basePod = e2epod.NewPodClient(f).CreateSync(ctx, newHostPathTypeTestPod(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate))
 		ginkgo.By(fmt.Sprintf("running on node %s", basePod.Spec.NodeName))
 		targetDir = path.Join(hostBaseDir, "adir")
 		ginkgo.By("Should automatically create a new directory 'adir' when HostPathType is HostPathDirectoryOrCreate")
-		verifyPodHostPathType(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetDir, &hostPathDirectoryOrCreate)
+		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetDir, &hostPathDirectoryOrCreate)
 	})
 
 	ginkgo.It("Should fail on mounting non-existent directory 'does-not-exist-dir' when HostPathType is HostPathDirectory", func(ctx context.Context) {
 		dirPath := path.Join(hostBaseDir, "does-not-exist-dir")
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			dirPath, fmt.Sprintf("%s is not a directory", dirPath), &hostPathDirectory)
 	})
 
 	ginkgo.It("Should be able to mount directory 'adir' successfully when HostPathType is HostPathDirectory", func(ctx context.Context) {
-		verifyPodHostPathType(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetDir, &hostPathDirectory)
+		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetDir, &hostPathDirectory)
 	})
 
 	ginkgo.It("Should be able to mount directory 'adir' successfully when HostPathType is HostPathUnset", func(ctx context.Context) {
-		verifyPodHostPathType(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetDir, &hostPathUnset)
+		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetDir, &hostPathUnset)
 	})
 
 	ginkgo.It("Should fail on mounting directory 'adir' when HostPathType is HostPathFile", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetDir, fmt.Sprintf("%s is not a file", targetDir), &hostPathFile)
 	})
 
 	ginkgo.It("Should fail on mounting directory 'adir' when HostPathType is HostPathSocket", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetDir, fmt.Sprintf("%s is not a socket", targetDir), &hostPathSocket)
 	})
 
 	ginkgo.It("Should fail on mounting directory 'adir' when HostPathType is HostPathCharDev", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetDir, fmt.Sprintf("%s is not a character device", targetDir), &hostPathCharDev)
 	})
 
 	ginkgo.It("Should fail on mounting directory 'adir' when HostPathType is HostPathBlockDev", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetDir, fmt.Sprintf("%s is not a block device", targetDir), &hostPathBlockDev)
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetDir, fmt.Sprintf("%s is not a block device", targetDir), &hostPathBlockDev)
 	})
 })
 
@@ -124,50 +124,50 @@ var _ = utils.SIGDescribe("HostPathType File [Slow]", func() {
 		hostPathBlockDev          = v1.HostPathBlockDev
 	)
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		ns = f.Namespace.Name
 
 		ginkgo.By("Create a pod for further testing")
 		hostBaseDir = path.Join("/tmp", ns)
 		mountBaseDir = "/mnt/test"
-		basePod = e2epod.NewPodClient(f).CreateSync(newHostPathTypeTestPod(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate))
+		basePod = e2epod.NewPodClient(f).CreateSync(ctx, newHostPathTypeTestPod(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate))
 		ginkgo.By(fmt.Sprintf("running on node %s", basePod.Spec.NodeName))
 		targetFile = path.Join(hostBaseDir, "afile")
 		ginkgo.By("Should automatically create a new file 'afile' when HostPathType is HostPathFileOrCreate")
-		verifyPodHostPathType(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetFile, &hostPathFileOrCreate)
+		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetFile, &hostPathFileOrCreate)
 	})
 
 	ginkgo.It("Should fail on mounting non-existent file 'does-not-exist-file' when HostPathType is HostPathFile", func(ctx context.Context) {
 		filePath := path.Join(hostBaseDir, "does-not-exist-file")
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			filePath, fmt.Sprintf("%s is not a file", filePath), &hostPathFile)
 	})
 
 	ginkgo.It("Should be able to mount file 'afile' successfully when HostPathType is HostPathFile", func(ctx context.Context) {
-		verifyPodHostPathType(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetFile, &hostPathFile)
+		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetFile, &hostPathFile)
 	})
 
 	ginkgo.It("Should be able to mount file 'afile' successfully when HostPathType is HostPathUnset", func(ctx context.Context) {
-		verifyPodHostPathType(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetFile, &hostPathUnset)
+		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetFile, &hostPathUnset)
 	})
 
 	ginkgo.It("Should fail on mounting file 'afile' when HostPathType is HostPathDirectory", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetFile, fmt.Sprintf("%s is not a directory", targetFile), &hostPathDirectory)
 	})
 
 	ginkgo.It("Should fail on mounting file 'afile' when HostPathType is HostPathSocket", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetFile, fmt.Sprintf("%s is not a socket", targetFile), &hostPathSocket)
 	})
 
 	ginkgo.It("Should fail on mounting file 'afile' when HostPathType is HostPathCharDev", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetFile, fmt.Sprintf("%s is not a character device", targetFile), &hostPathCharDev)
 	})
 
 	ginkgo.It("Should fail on mounting file 'afile' when HostPathType is HostPathBlockDev", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetFile, fmt.Sprintf("%s is not a block device", targetFile), &hostPathBlockDev)
 	})
 })
@@ -192,48 +192,48 @@ var _ = utils.SIGDescribe("HostPathType Socket [Slow]", func() {
 		hostPathBlockDev          = v1.HostPathBlockDev
 	)
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		ns = f.Namespace.Name
 
 		ginkgo.By("Create a pod for further testing")
 		hostBaseDir = path.Join("/tmp", ns)
 		mountBaseDir = "/mnt/test"
-		basePod = e2epod.NewPodClient(f).CreateSync(newHostPathTypeTestPodWithCommand(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate, fmt.Sprintf("nc -lU %s", path.Join(mountBaseDir, "asocket"))))
+		basePod = e2epod.NewPodClient(f).CreateSync(ctx, newHostPathTypeTestPodWithCommand(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate, fmt.Sprintf("nc -lU %s", path.Join(mountBaseDir, "asocket"))))
 		ginkgo.By(fmt.Sprintf("running on node %s", basePod.Spec.NodeName))
 		targetSocket = path.Join(hostBaseDir, "asocket")
 	})
 
 	ginkgo.It("Should fail on mounting non-existent socket 'does-not-exist-socket' when HostPathType is HostPathSocket", func(ctx context.Context) {
 		socketPath := path.Join(hostBaseDir, "does-not-exist-socket")
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			socketPath, fmt.Sprintf("%s is not a socket", socketPath), &hostPathSocket)
 	})
 
 	ginkgo.It("Should be able to mount socket 'asocket' successfully when HostPathType is HostPathSocket", func(ctx context.Context) {
-		verifyPodHostPathType(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetSocket, &hostPathSocket)
+		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetSocket, &hostPathSocket)
 	})
 
 	ginkgo.It("Should be able to mount socket 'asocket' successfully when HostPathType is HostPathUnset", func(ctx context.Context) {
-		verifyPodHostPathType(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetSocket, &hostPathUnset)
+		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetSocket, &hostPathUnset)
 	})
 
 	ginkgo.It("Should fail on mounting socket 'asocket' when HostPathType is HostPathDirectory", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetSocket, fmt.Sprintf("%s is not a directory", targetSocket), &hostPathDirectory)
 	})
 
 	ginkgo.It("Should fail on mounting socket 'asocket' when HostPathType is HostPathFile", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetSocket, fmt.Sprintf("%s is not a file", targetSocket), &hostPathFile)
 	})
 
 	ginkgo.It("Should fail on mounting socket 'asocket' when HostPathType is HostPathCharDev", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetSocket, fmt.Sprintf("%s is not a character device", targetSocket), &hostPathCharDev)
 	})
 
 	ginkgo.It("Should fail on mounting socket 'asocket' when HostPathType is HostPathBlockDev", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetSocket, fmt.Sprintf("%s is not a block device", targetSocket), &hostPathBlockDev)
 	})
 })
@@ -258,13 +258,13 @@ var _ = utils.SIGDescribe("HostPathType Character Device [Slow]", func() {
 		hostPathBlockDev          = v1.HostPathBlockDev
 	)
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		ns = f.Namespace.Name
 
 		ginkgo.By("Create a pod for further testing")
 		hostBaseDir = path.Join("/tmp", ns)
 		mountBaseDir = "/mnt/test"
-		basePod = e2epod.NewPodClient(f).CreateSync(newHostPathTypeTestPod(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate))
+		basePod = e2epod.NewPodClient(f).CreateSync(ctx, newHostPathTypeTestPod(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate))
 		ginkgo.By(fmt.Sprintf("running on node %s", basePod.Spec.NodeName))
 		targetCharDev = path.Join(hostBaseDir, "achardev")
 		ginkgo.By("Create a character device for further testing")
@@ -275,35 +275,35 @@ var _ = utils.SIGDescribe("HostPathType Character Device [Slow]", func() {
 
 	ginkgo.It("Should fail on mounting non-existent character device 'does-not-exist-char-dev' when HostPathType is HostPathCharDev", func(ctx context.Context) {
 		charDevPath := path.Join(hostBaseDir, "does-not-exist-char-dev")
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			charDevPath, fmt.Sprintf("%s is not a character device", charDevPath), &hostPathCharDev)
 	})
 
 	ginkgo.It("Should be able to mount character device 'achardev' successfully when HostPathType is HostPathCharDev", func(ctx context.Context) {
-		verifyPodHostPathType(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetCharDev, &hostPathCharDev)
+		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetCharDev, &hostPathCharDev)
 	})
 
 	ginkgo.It("Should be able to mount character device 'achardev' successfully when HostPathType is HostPathUnset", func(ctx context.Context) {
-		verifyPodHostPathType(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetCharDev, &hostPathUnset)
+		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetCharDev, &hostPathUnset)
 	})
 
 	ginkgo.It("Should fail on mounting character device 'achardev' when HostPathType is HostPathDirectory", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetCharDev, fmt.Sprintf("%s is not a directory", targetCharDev), &hostPathDirectory)
 	})
 
 	ginkgo.It("Should fail on mounting character device 'achardev' when HostPathType is HostPathFile", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetCharDev, fmt.Sprintf("%s is not a file", targetCharDev), &hostPathFile)
 	})
 
 	ginkgo.It("Should fail on mounting character device 'achardev' when HostPathType is HostPathSocket", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetCharDev, fmt.Sprintf("%s is not a socket", targetCharDev), &hostPathSocket)
 	})
 
 	ginkgo.It("Should fail on mounting character device 'achardev' when HostPathType is HostPathBlockDev", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetCharDev, fmt.Sprintf("%s is not a block device", targetCharDev), &hostPathBlockDev)
 	})
 })
@@ -328,13 +328,13 @@ var _ = utils.SIGDescribe("HostPathType Block Device [Slow]", func() {
 		hostPathBlockDev          = v1.HostPathBlockDev
 	)
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		ns = f.Namespace.Name
 
 		ginkgo.By("Create a pod for further testing")
 		hostBaseDir = path.Join("/tmp", ns)
 		mountBaseDir = "/mnt/test"
-		basePod = e2epod.NewPodClient(f).CreateSync(newHostPathTypeTestPod(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate))
+		basePod = e2epod.NewPodClient(f).CreateSync(ctx, newHostPathTypeTestPod(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate))
 		ginkgo.By(fmt.Sprintf("running on node %s", basePod.Spec.NodeName))
 		targetBlockDev = path.Join(hostBaseDir, "ablkdev")
 		ginkgo.By("Create a block device for further testing")
@@ -345,35 +345,35 @@ var _ = utils.SIGDescribe("HostPathType Block Device [Slow]", func() {
 
 	ginkgo.It("Should fail on mounting non-existent block device 'does-not-exist-blk-dev' when HostPathType is HostPathBlockDev", func(ctx context.Context) {
 		blkDevPath := path.Join(hostBaseDir, "does-not-exist-blk-dev")
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			blkDevPath, fmt.Sprintf("%s is not a block device", blkDevPath), &hostPathBlockDev)
 	})
 
 	ginkgo.It("Should be able to mount block device 'ablkdev' successfully when HostPathType is HostPathBlockDev", func(ctx context.Context) {
-		verifyPodHostPathType(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetBlockDev, &hostPathBlockDev)
+		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetBlockDev, &hostPathBlockDev)
 	})
 
 	ginkgo.It("Should be able to mount block device 'ablkdev' successfully when HostPathType is HostPathUnset", func(ctx context.Context) {
-		verifyPodHostPathType(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetBlockDev, &hostPathUnset)
+		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetBlockDev, &hostPathUnset)
 	})
 
 	ginkgo.It("Should fail on mounting block device 'ablkdev' when HostPathType is HostPathDirectory", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetBlockDev, fmt.Sprintf("%s is not a directory", targetBlockDev), &hostPathDirectory)
 	})
 
 	ginkgo.It("Should fail on mounting block device 'ablkdev' when HostPathType is HostPathFile", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetBlockDev, fmt.Sprintf("%s is not a file", targetBlockDev), &hostPathFile)
 	})
 
 	ginkgo.It("Should fail on mounting block device 'ablkdev' when HostPathType is HostPathSocket", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetBlockDev, fmt.Sprintf("%s is not a socket", targetBlockDev), &hostPathSocket)
 	})
 
 	ginkgo.It("Should fail on mounting block device 'ablkdev' when HostPathType is HostPathCharDev", func(ctx context.Context) {
-		verifyPodHostPathTypeFailure(f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
+		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			targetBlockDev, fmt.Sprintf("%s is not a character device", targetBlockDev), &hostPathCharDev)
 	})
 })
@@ -454,10 +454,10 @@ func newHostPathTypeTestPodWithCommand(nodeSelector map[string]string, hostDir, 
 	return pod
 }
 
-func verifyPodHostPathTypeFailure(f *framework.Framework, nodeSelector map[string]string, hostDir, pattern string, hostPathType *v1.HostPathType) {
+func verifyPodHostPathTypeFailure(ctx context.Context, f *framework.Framework, nodeSelector map[string]string, hostDir, pattern string, hostPathType *v1.HostPathType) {
 	pod := newHostPathTypeTestPod(nodeSelector, hostDir, "/mnt/test", hostPathType)
 	ginkgo.By(fmt.Sprintf("Creating pod %s", pod.Name))
-	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Checking for HostPathType error event")
@@ -469,25 +469,25 @@ func verifyPodHostPathTypeFailure(f *framework.Framework, nodeSelector map[strin
 	}.AsSelector().String()
 	msg := "hostPath type check failed"
 
-	err = e2eevents.WaitTimeoutForEvent(f.ClientSet, f.Namespace.Name, eventSelector, msg, f.Timeouts.PodStart)
+	err = e2eevents.WaitTimeoutForEvent(ctx, f.ClientSet, f.Namespace.Name, eventSelector, msg, f.Timeouts.PodStart)
 	// Events are unreliable, don't depend on the event. It's used only to speed up the test.
 	if err != nil {
 		framework.Logf("Warning: did not get event about FailedMountVolume")
 	}
 
 	// Check the pod is still not running
-	p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+	p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err, "could not re-read the pod after event (or timeout)")
 	framework.ExpectEqual(p.Status.Phase, v1.PodPending, "Pod phase isn't pending")
 
-	f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, *metav1.NewDeleteOptions(0))
+	f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
 }
 
-func verifyPodHostPathType(f *framework.Framework, nodeSelector map[string]string, hostDir string, hostPathType *v1.HostPathType) {
-	newPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(),
+func verifyPodHostPathType(ctx context.Context, f *framework.Framework, nodeSelector map[string]string, hostDir string, hostPathType *v1.HostPathType) {
+	newPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx,
 		newHostPathTypeTestPod(nodeSelector, hostDir, "/mnt/test", hostPathType), metav1.CreateOptions{})
 	framework.ExpectNoError(err)
-	framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, newPod.Name, newPod.Namespace, f.Timeouts.PodStart))
+	framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, newPod.Name, newPod.Namespace, f.Timeouts.PodStart))
 
-	f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), newPod.Name, *metav1.NewDeleteOptions(0))
+	f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, newPod.Name, *metav1.NewDeleteOptions(0))
 }

--- a/test/e2e/storage/mounted_volume_resize.go
+++ b/test/e2e/storage/mounted_volume_resize.go
@@ -62,9 +62,9 @@ var _ = utils.SIGDescribe("Mounted volume expand [Feature:StorageProvider]", fun
 		e2eskipper.SkipUnlessProviderIs("aws", "gce")
 		c = f.ClientSet
 		ns = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, framework.TestContext.NodeSchedulableTimeout))
 
-		node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 		nodeName = node.Name
 
@@ -93,12 +93,12 @@ var _ = utils.SIGDescribe("Mounted volume expand [Feature:StorageProvider]", fun
 			StorageClassName: &(sc.Name),
 			VolumeMode:       &test.VolumeMode,
 		}, ns)
-		pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+		pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Error creating pvc")
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			framework.Logf("AfterEach: Cleaning up resources for mounted volume resize")
 
-			if errs := e2epv.PVPVCCleanup(c, ns, nil, pvc); len(errs) > 0 {
+			if errs := e2epv.PVPVCCleanup(ctx, c, ns, nil, pvc); len(errs) > 0 {
 				framework.Failf("AfterEach: Failed to delete PVC and/or PV. Errors: %v", utilerrors.NewAggregate(errs))
 			}
 		})
@@ -111,19 +111,19 @@ var _ = utils.SIGDescribe("Mounted volume expand [Feature:StorageProvider]", fun
 		// Keeping pod on same node reproduces the scenario that volume might already be mounted when resize is attempted.
 		// We should consider adding a unit test that exercises this better.
 		ginkgo.By("Creating a deployment with selected PVC")
-		deployment, err := e2edeployment.CreateDeployment(c, int32(1), map[string]string{"test": "app"}, nodeKeyValueLabel, ns, pvcClaims, "")
+		deployment, err := e2edeployment.CreateDeployment(ctx, c, int32(1), map[string]string{"test": "app"}, nodeKeyValueLabel, ns, pvcClaims, "")
 		framework.ExpectNoError(err, "Failed creating deployment %v", err)
 		ginkgo.DeferCleanup(c.AppsV1().Deployments(ns).Delete, deployment.Name, metav1.DeleteOptions{})
 
 		// PVC should be bound at this point
 		ginkgo.By("Checking for bound PVC")
-		pvs, err := e2epv.WaitForPVClaimBoundPhase(c, pvcClaims, framework.ClaimProvisionTimeout)
+		pvs, err := e2epv.WaitForPVClaimBoundPhase(ctx, c, pvcClaims, framework.ClaimProvisionTimeout)
 		framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
 		framework.ExpectEqual(len(pvs), 1)
 
 		ginkgo.By("Expanding current pvc")
 		newSize := resource.MustParse("6Gi")
-		newPVC, err := testsuites.ExpandPVCSize(pvc, newSize, c)
+		newPVC, err := testsuites.ExpandPVCSize(ctx, pvc, newSize, c)
 		framework.ExpectNoError(err, "While updating pvc for more size")
 		pvc = newPVC
 		gomega.Expect(pvc).NotTo(gomega.BeNil())
@@ -134,25 +134,25 @@ var _ = utils.SIGDescribe("Mounted volume expand [Feature:StorageProvider]", fun
 		}
 
 		ginkgo.By("Waiting for cloudprovider resize to finish")
-		err = testsuites.WaitForControllerVolumeResize(pvc, c, totalResizeWaitPeriod)
+		err = testsuites.WaitForControllerVolumeResize(ctx, pvc, c, totalResizeWaitPeriod)
 		framework.ExpectNoError(err, "While waiting for pvc resize to finish")
 
 		ginkgo.By("Getting a pod from deployment")
-		podList, err := e2edeployment.GetPodsForDeployment(c, deployment)
+		podList, err := e2edeployment.GetPodsForDeployment(ctx, c, deployment)
 		framework.ExpectNoError(err, "While getting pods from deployment")
 		gomega.Expect(podList.Items).NotTo(gomega.BeEmpty())
 		pod := podList.Items[0]
 
 		ginkgo.By("Deleting the pod from deployment")
-		err = e2epod.DeletePodWithWait(c, &pod)
+		err = e2epod.DeletePodWithWait(ctx, c, &pod)
 		framework.ExpectNoError(err, "while deleting pod for resizing")
 
 		ginkgo.By("Waiting for deployment to create new pod")
-		pod, err = waitForDeploymentToRecreatePod(c, deployment)
+		pod, err = waitForDeploymentToRecreatePod(ctx, c, deployment)
 		framework.ExpectNoError(err, "While waiting for pod to be recreated")
 
 		ginkgo.By("Waiting for file system resize to finish")
-		pvc, err = testsuites.WaitForFSResize(pvc, c)
+		pvc, err = testsuites.WaitForFSResize(ctx, pvc, c)
 		framework.ExpectNoError(err, "while waiting for fs resize to finish")
 
 		pvcConditions := pvc.Status.Conditions
@@ -160,10 +160,10 @@ var _ = utils.SIGDescribe("Mounted volume expand [Feature:StorageProvider]", fun
 	})
 })
 
-func waitForDeploymentToRecreatePod(client clientset.Interface, deployment *appsv1.Deployment) (v1.Pod, error) {
+func waitForDeploymentToRecreatePod(ctx context.Context, client clientset.Interface, deployment *appsv1.Deployment) (v1.Pod, error) {
 	var runningPod v1.Pod
 	waitErr := wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
-		podList, err := e2edeployment.GetPodsForDeployment(client, deployment)
+		podList, err := e2edeployment.GetPodsForDeployment(ctx, client, deployment)
 		if err != nil {
 			return false, fmt.Errorf("failed to get pods for deployment: %v", err)
 		}

--- a/test/e2e/storage/nfs_persistent_volume-disruptive.go
+++ b/test/e2e/storage/nfs_persistent_volume-disruptive.go
@@ -42,18 +42,18 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-type testBody func(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, volumePath string)
+type testBody func(ctx context.Context, c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, volumePath string)
 type disruptiveTest struct {
 	testItStmt string
 	runTest    testBody
 }
 
 // checkForControllerManagerHealthy checks that the controller manager does not crash within "duration"
-func checkForControllerManagerHealthy(duration time.Duration) error {
+func checkForControllerManagerHealthy(ctx context.Context, duration time.Duration) error {
 	var PID string
 	cmd := "pidof kube-controller-manager"
-	for start := time.Now(); time.Since(start) < duration; time.Sleep(5 * time.Second) {
-		result, err := e2essh.SSH(cmd, net.JoinHostPort(framework.APIAddress(), e2essh.SSHPort), framework.TestContext.Provider)
+	for start := time.Now(); time.Since(start) < duration && ctx.Err() == nil; time.Sleep(5 * time.Second) {
+		result, err := e2essh.SSH(ctx, cmd, net.JoinHostPort(framework.APIAddress(), e2essh.SSHPort), framework.TestContext.Provider)
 		if err != nil {
 			// We don't necessarily know that it crashed, pipe could just be broken
 			e2essh.LogResult(result)
@@ -91,7 +91,7 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 		selector                    *metav1.LabelSelector
 	)
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		// To protect the NFS volume pod from the kubelet restart, we isolate it on its own node.
 		e2eskipper.SkipUnlessNodeCountIsAtLeast(minNodes)
 		e2eskipper.SkipIfProviderIs("local")
@@ -101,7 +101,7 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 		volLabel = labels.Set{e2epv.VolumeSelectorKey: ns}
 		selector = metav1.SetAsLabelSelector(volLabel)
 		// Start the NFS server pod.
-		_, nfsServerPod, nfsServerHost = e2evolume.NewNFSServer(c, ns, []string{"-G", "777", "/exports"})
+		_, nfsServerPod, nfsServerHost = e2evolume.NewNFSServer(ctx, c, ns, []string{"-G", "777", "/exports"})
 		ginkgo.DeferCleanup(e2epod.DeletePodWithWait, c, nfsServerPod)
 		nfsPVconfig = e2epv.PersistentVolumeConfig{
 			NamePrefix: "nfs-",
@@ -122,7 +122,7 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 		// Get the first ready node IP that is not hosting the NFS pod.
 		if clientNodeIP == "" {
 			framework.Logf("Designating test node")
-			nodes, err := e2enode.GetReadySchedulableNodes(c)
+			nodes, err := e2enode.GetReadySchedulableNodes(ctx, c)
 			framework.ExpectNoError(err)
 			for _, node := range nodes.Items {
 				if node.Name != nfsServerPod.Spec.NodeName {
@@ -136,10 +136,6 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 		}
 	})
 
-	ginkgo.AfterEach(func() {
-		e2epod.DeletePodWithWait(c, nfsServerPod)
-	})
-
 	ginkgo.Context("when kube-controller-manager restarts", func() {
 		var (
 			diskName1, diskName2 string
@@ -151,12 +147,12 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 			clientPod            *v1.Pod
 		)
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			e2eskipper.SkipUnlessProviderIs("gce")
 			e2eskipper.SkipUnlessSSHKeyPresent()
 
 			ginkgo.By("Initializing first PD with PVPVC binding")
-			pvSource1, diskName1 = createGCEVolume()
+			pvSource1, diskName1 = createGCEVolume(ctx)
 			framework.ExpectNoError(err)
 			pvConfig1 = e2epv.PersistentVolumeConfig{
 				NamePrefix: "gce-",
@@ -164,12 +160,12 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 				PVSource:   *pvSource1,
 				Prebind:    nil,
 			}
-			pv1, pvc1, err = e2epv.CreatePVPVC(c, f.Timeouts, pvConfig1, pvcConfig, ns, false)
+			pv1, pvc1, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfig1, pvcConfig, ns, false)
 			framework.ExpectNoError(err)
-			framework.ExpectNoError(e2epv.WaitOnPVandPVC(c, f.Timeouts, ns, pv1, pvc1))
+			framework.ExpectNoError(e2epv.WaitOnPVandPVC(ctx, c, f.Timeouts, ns, pv1, pvc1))
 
 			ginkgo.By("Initializing second PD with PVPVC binding")
-			pvSource2, diskName2 = createGCEVolume()
+			pvSource2, diskName2 = createGCEVolume(ctx)
 			framework.ExpectNoError(err)
 			pvConfig2 = e2epv.PersistentVolumeConfig{
 				NamePrefix: "gce-",
@@ -177,35 +173,35 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 				PVSource:   *pvSource2,
 				Prebind:    nil,
 			}
-			pv2, pvc2, err = e2epv.CreatePVPVC(c, f.Timeouts, pvConfig2, pvcConfig, ns, false)
+			pv2, pvc2, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfig2, pvcConfig, ns, false)
 			framework.ExpectNoError(err)
-			framework.ExpectNoError(e2epv.WaitOnPVandPVC(c, f.Timeouts, ns, pv2, pvc2))
+			framework.ExpectNoError(e2epv.WaitOnPVandPVC(ctx, c, f.Timeouts, ns, pv2, pvc2))
 
 			ginkgo.By("Attaching both PVC's to a single pod")
-			clientPod, err = e2epod.CreatePod(c, ns, nil, []*v1.PersistentVolumeClaim{pvc1, pvc2}, true, "")
+			clientPod, err = e2epod.CreatePod(ctx, c, ns, nil, []*v1.PersistentVolumeClaim{pvc1, pvc2}, true, "")
 			framework.ExpectNoError(err)
 		})
 
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			// Delete client/user pod first
-			framework.ExpectNoError(e2epod.DeletePodWithWait(c, clientPod))
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, c, clientPod))
 
 			// Delete PV and PVCs
-			if errs := e2epv.PVPVCCleanup(c, ns, pv1, pvc1); len(errs) > 0 {
+			if errs := e2epv.PVPVCCleanup(ctx, c, ns, pv1, pvc1); len(errs) > 0 {
 				framework.Failf("AfterEach: Failed to delete PVC and/or PV. Errors: %v", utilerrors.NewAggregate(errs))
 			}
 			pv1, pvc1 = nil, nil
-			if errs := e2epv.PVPVCCleanup(c, ns, pv2, pvc2); len(errs) > 0 {
+			if errs := e2epv.PVPVCCleanup(ctx, c, ns, pv2, pvc2); len(errs) > 0 {
 				framework.Failf("AfterEach: Failed to delete PVC and/or PV. Errors: %v", utilerrors.NewAggregate(errs))
 			}
 			pv2, pvc2 = nil, nil
 
 			// Delete the actual disks
 			if diskName1 != "" {
-				framework.ExpectNoError(e2epv.DeletePDWithRetry(diskName1))
+				framework.ExpectNoError(e2epv.DeletePDWithRetry(ctx, diskName1))
 			}
 			if diskName2 != "" {
-				framework.ExpectNoError(e2epv.DeletePDWithRetry(diskName2))
+				framework.ExpectNoError(e2epv.DeletePDWithRetry(ctx, diskName2))
 			}
 		})
 
@@ -213,20 +209,20 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 			e2eskipper.SkipUnlessSSHKeyPresent()
 
 			ginkgo.By("Deleting PVC for volume 2")
-			err = e2epv.DeletePersistentVolumeClaim(c, pvc2.Name, ns)
+			err = e2epv.DeletePersistentVolumeClaim(ctx, c, pvc2.Name, ns)
 			framework.ExpectNoError(err)
 			pvc2 = nil
 
 			ginkgo.By("Restarting the kube-controller-manager")
-			err = e2ekubesystem.RestartControllerManager()
+			err = e2ekubesystem.RestartControllerManager(ctx)
 			framework.ExpectNoError(err)
-			err = e2ekubesystem.WaitForControllerManagerUp()
+			err = e2ekubesystem.WaitForControllerManagerUp(ctx)
 			framework.ExpectNoError(err)
 			framework.Logf("kube-controller-manager restarted")
 
 			ginkgo.By("Observing the kube-controller-manager healthy for at least 2 minutes")
 			// Continue checking for 2 minutes to make sure kube-controller-manager is healthy
-			err = checkForControllerManagerHealthy(2 * time.Minute)
+			err = checkForControllerManagerHealthy(ctx, 2*time.Minute)
 			framework.ExpectNoError(err)
 		})
 
@@ -239,14 +235,14 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 			pvc       *v1.PersistentVolumeClaim
 		)
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			framework.Logf("Initializing test spec")
-			clientPod, pv, pvc = initTestCase(f, c, nfsPVconfig, pvcConfig, ns, clientNode.Name)
+			clientPod, pv, pvc = initTestCase(ctx, f, c, nfsPVconfig, pvcConfig, ns, clientNode.Name)
 		})
 
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			framework.Logf("Tearing down test spec")
-			tearDownTestCase(c, f, ns, clientPod, pvc, pv, true /* force PV delete */)
+			tearDownTestCase(ctx, c, f, ns, clientPod, pvc, pv, true /* force PV delete */)
 			pv, pvc, clientPod = nil, nil, nil
 		})
 
@@ -274,7 +270,7 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 				ginkgo.It(t.testItStmt, func(ctx context.Context) {
 					e2eskipper.SkipUnlessSSHKeyPresent()
 					ginkgo.By("Executing Spec")
-					t.runTest(c, f, clientPod, e2epod.VolumeMountPath1)
+					t.runTest(ctx, c, f, clientPod, e2epod.VolumeMountPath1)
 				})
 			}(test)
 		}
@@ -282,8 +278,8 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 })
 
 // createGCEVolume creates PersistentVolumeSource for GCEVolume.
-func createGCEVolume() (*v1.PersistentVolumeSource, string) {
-	diskName, err := e2epv.CreatePDWithRetry()
+func createGCEVolume(ctx context.Context) (*v1.PersistentVolumeSource, string) {
+	diskName, err := e2epv.CreatePDWithRetry(ctx)
 	framework.ExpectNoError(err)
 	return &v1.PersistentVolumeSource{
 		GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
@@ -296,8 +292,8 @@ func createGCEVolume() (*v1.PersistentVolumeSource, string) {
 
 // initTestCase initializes spec resources (pv, pvc, and pod) and returns pointers to be consumed
 // by the test.
-func initTestCase(f *framework.Framework, c clientset.Interface, pvConfig e2epv.PersistentVolumeConfig, pvcConfig e2epv.PersistentVolumeClaimConfig, ns, nodeName string) (*v1.Pod, *v1.PersistentVolume, *v1.PersistentVolumeClaim) {
-	pv, pvc, err := e2epv.CreatePVPVC(c, f.Timeouts, pvConfig, pvcConfig, ns, false)
+func initTestCase(ctx context.Context, f *framework.Framework, c clientset.Interface, pvConfig e2epv.PersistentVolumeConfig, pvcConfig e2epv.PersistentVolumeClaimConfig, ns, nodeName string) (*v1.Pod, *v1.PersistentVolume, *v1.PersistentVolumeClaim) {
+	pv, pvc, err := e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfig, pvcConfig, ns, false)
 	defer func() {
 		if err != nil {
 			ginkgo.DeferCleanup(e2epv.DeletePersistentVolumeClaim, c, pvc.Name, ns)
@@ -308,7 +304,7 @@ func initTestCase(f *framework.Framework, c clientset.Interface, pvConfig e2epv.
 	pod := e2epod.MakePod(ns, nil, []*v1.PersistentVolumeClaim{pvc}, true, "")
 	pod.Spec.NodeName = nodeName
 	framework.Logf("Creating NFS client pod.")
-	pod, err = c.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+	pod, err = c.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 	framework.Logf("NFS client Pod %q created on Node %q", pod.Name, nodeName)
 	framework.ExpectNoError(err)
 	defer func() {
@@ -316,27 +312,27 @@ func initTestCase(f *framework.Framework, c clientset.Interface, pvConfig e2epv.
 			ginkgo.DeferCleanup(e2epod.DeletePodWithWait, c, pod)
 		}
 	}()
-	err = e2epod.WaitTimeoutForPodRunningInNamespace(c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
+	err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
 	framework.ExpectNoError(err, fmt.Sprintf("Pod %q timed out waiting for phase: Running", pod.Name))
 	// Return created api objects
-	pod, err = c.CoreV1().Pods(ns).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+	pod, err = c.CoreV1().Pods(ns).Get(ctx, pod.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	pvc, err = c.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+	pvc, err = c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvc.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	pv, err = c.CoreV1().PersistentVolumes().Get(context.TODO(), pv.Name, metav1.GetOptions{})
+	pv, err = c.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	return pod, pv, pvc
 }
 
 // tearDownTestCase destroy resources created by initTestCase.
-func tearDownTestCase(c clientset.Interface, f *framework.Framework, ns string, client *v1.Pod, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume, forceDeletePV bool) {
+func tearDownTestCase(ctx context.Context, c clientset.Interface, f *framework.Framework, ns string, client *v1.Pod, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume, forceDeletePV bool) {
 	// Ignore deletion errors.  Failing on them will interrupt test cleanup.
-	e2epod.DeletePodWithWait(c, client)
-	e2epv.DeletePersistentVolumeClaim(c, pvc.Name, ns)
+	e2epod.DeletePodWithWait(ctx, c, client)
+	e2epv.DeletePersistentVolumeClaim(ctx, c, pvc.Name, ns)
 	if forceDeletePV && pv != nil {
-		e2epv.DeletePersistentVolume(c, pv.Name)
+		e2epv.DeletePersistentVolume(ctx, c, pv.Name)
 		return
 	}
-	err := e2epv.WaitForPersistentVolumeDeleted(c, pv.Name, 5*time.Second, 5*time.Minute)
+	err := e2epv.WaitForPersistentVolumeDeleted(ctx, c, pv.Name, 5*time.Second, 5*time.Minute)
 	framework.ExpectNoError(err, "Persistent Volume %v not deleted by dynamic provisioner", pv.Name)
 }

--- a/test/e2e/storage/pv_protection.go
+++ b/test/e2e/storage/pv_protection.go
@@ -51,10 +51,10 @@ var _ = utils.SIGDescribe("PV Protection", func() {
 
 	f := framework.NewDefaultFramework("pv-protection")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		client = f.ClientSet
 		nameSpace = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(client, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, framework.TestContext.NodeSchedulableTimeout))
 
 		// Enforce binding only within test space via selector labels
 		volLabel = labels.Set{e2epv.VolumeSelectorKey: nameSpace}
@@ -80,58 +80,58 @@ var _ = utils.SIGDescribe("PV Protection", func() {
 		// make the pv definitions
 		pv = e2epv.MakePersistentVolume(pvConfig)
 		// create the PV
-		pv, err = client.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{})
+		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Error creating PV")
 
 		ginkgo.By("Waiting for PV to enter phase Available")
-		framework.ExpectNoError(e2epv.WaitForPersistentVolumePhase(v1.VolumeAvailable, client, pv.Name, 1*time.Second, 30*time.Second))
+		framework.ExpectNoError(e2epv.WaitForPersistentVolumePhase(ctx, v1.VolumeAvailable, client, pv.Name, 1*time.Second, 30*time.Second))
 
 		ginkgo.By("Checking that PV Protection finalizer is set")
-		pv, err = client.CoreV1().PersistentVolumes().Get(context.TODO(), pv.Name, metav1.GetOptions{})
+		pv, err = client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While getting PV status")
 		framework.ExpectEqual(slice.ContainsString(pv.ObjectMeta.Finalizers, volumeutil.PVProtectionFinalizer, nil), true, "PV Protection finalizer(%v) is not set in %v", volumeutil.PVProtectionFinalizer, pv.ObjectMeta.Finalizers)
 	})
 
-	ginkgo.AfterEach(func() {
+	ginkgo.AfterEach(func(ctx context.Context) {
 		framework.Logf("AfterEach: Cleaning up test resources.")
-		if errs := e2epv.PVPVCCleanup(client, nameSpace, pv, pvc); len(errs) > 0 {
+		if errs := e2epv.PVPVCCleanup(ctx, client, nameSpace, pv, pvc); len(errs) > 0 {
 			framework.Failf("AfterEach: Failed to delete PVC and/or PV. Errors: %v", utilerrors.NewAggregate(errs))
 		}
 	})
 
 	ginkgo.It("Verify \"immediate\" deletion of a PV that is not bound to a PVC", func(ctx context.Context) {
 		ginkgo.By("Deleting the PV")
-		err = client.CoreV1().PersistentVolumes().Delete(context.TODO(), pv.Name, *metav1.NewDeleteOptions(0))
+		err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
 		framework.ExpectNoError(err, "Error deleting PV")
-		err = e2epv.WaitForPersistentVolumeDeleted(client, pv.Name, framework.Poll, f.Timeouts.PVDelete)
+		err = e2epv.WaitForPersistentVolumeDeleted(ctx, client, pv.Name, framework.Poll, f.Timeouts.PVDelete)
 		framework.ExpectNoError(err, "waiting for PV to be deleted")
 	})
 
 	ginkgo.It("Verify that PV bound to a PVC is not removed immediately", func(ctx context.Context) {
 		ginkgo.By("Creating a PVC")
 		pvc = e2epv.MakePersistentVolumeClaim(pvcConfig, nameSpace)
-		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Error creating PVC")
 
 		ginkgo.By("Waiting for PVC to become Bound")
-		err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, nameSpace, pvc.Name, framework.Poll, f.Timeouts.ClaimBound)
+		err = e2epv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client, nameSpace, pvc.Name, framework.Poll, f.Timeouts.ClaimBound)
 		framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
 
 		ginkgo.By("Deleting the PV, however, the PV must not be removed from the system as it's bound to a PVC")
-		err = client.CoreV1().PersistentVolumes().Delete(context.TODO(), pv.Name, *metav1.NewDeleteOptions(0))
+		err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
 		framework.ExpectNoError(err, "Error deleting PV")
 
 		ginkgo.By("Checking that the PV status is Terminating")
-		pv, err = client.CoreV1().PersistentVolumes().Get(context.TODO(), pv.Name, metav1.GetOptions{})
+		pv, err = client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While checking PV status")
 		framework.ExpectNotEqual(pv.ObjectMeta.DeletionTimestamp, nil)
 
 		ginkgo.By("Deleting the PVC that is bound to the PV")
-		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, *metav1.NewDeleteOptions(0))
+		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
 		framework.ExpectNoError(err, "Error deleting PVC")
 
 		ginkgo.By("Checking that the PV is automatically removed from the system because it's no longer bound to a PVC")
-		err = e2epv.WaitForPersistentVolumeDeleted(client, pv.Name, framework.Poll, f.Timeouts.PVDelete)
+		err = e2epv.WaitForPersistentVolumeDeleted(ctx, client, pv.Name, framework.Poll, f.Timeouts.PVDelete)
 		framework.ExpectNoError(err, "waiting for PV to be deleted")
 	})
 })

--- a/test/e2e/storage/pvc_protection.go
+++ b/test/e2e/storage/pvc_protection.go
@@ -45,10 +45,10 @@ const (
 )
 
 // waitForPersistentVolumeClaimDeleted waits for a PersistentVolumeClaim to be removed from the system until timeout occurs, whichever comes first.
-func waitForPersistentVolumeClaimDeleted(c clientset.Interface, ns string, pvcName string, Poll, timeout time.Duration) error {
+func waitForPersistentVolumeClaimDeleted(ctx context.Context, c clientset.Interface, ns string, pvcName string, Poll, timeout time.Duration) error {
 	framework.Logf("Waiting up to %v for PersistentVolumeClaim %s to be removed", timeout, pvcName)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(Poll) {
-		_, err := c.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), pvcName, metav1.GetOptions{})
+		_, err := c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				framework.Logf("Claim %q in namespace %q doesn't exist in the system", pvcName, ns)
@@ -72,14 +72,14 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 
 	f := framework.NewDefaultFramework("pvc-protection")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		client = f.ClientSet
 		nameSpace = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(client, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, framework.TestContext.NodeSchedulableTimeout))
 
 		ginkgo.By("Creating a PVC")
 		prefix := "pvc-protection"
-		e2epv.SkipIfNoDefaultStorageClass(client)
+		e2epv.SkipIfNoDefaultStorageClass(ctx, client)
 		t := testsuites.StorageClassTest{
 			Timeouts:  f.Timeouts,
 			ClaimSize: "1Gi",
@@ -89,91 +89,91 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 			ClaimSize:  t.ClaimSize,
 			VolumeMode: &t.VolumeMode,
 		}, nameSpace)
-		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Error creating PVC")
 		pvcCreatedAndNotDeleted = true
 
 		ginkgo.By("Creating a Pod that becomes Running and therefore is actively using the PVC")
 		pvcClaims := []*v1.PersistentVolumeClaim{pvc}
-		pod, err = e2epod.CreatePod(client, nameSpace, nil, pvcClaims, false, "")
+		pod, err = e2epod.CreatePod(ctx, client, nameSpace, nil, pvcClaims, false, "")
 		framework.ExpectNoError(err, "While creating pod that uses the PVC or waiting for the Pod to become Running")
 
 		ginkgo.By("Waiting for PVC to become Bound")
-		err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, nameSpace, pvc.Name, framework.Poll, f.Timeouts.ClaimBound)
+		err = e2epv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client, nameSpace, pvc.Name, framework.Poll, f.Timeouts.ClaimBound)
 		framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
 
 		ginkgo.By("Checking that PVC Protection finalizer is set")
-		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While getting PVC status")
 		framework.ExpectEqual(slice.ContainsString(pvc.ObjectMeta.Finalizers, volumeutil.PVCProtectionFinalizer, nil), true, "PVC Protection finalizer(%v) is not set in %v", volumeutil.PVCProtectionFinalizer, pvc.ObjectMeta.Finalizers)
 	})
 
-	ginkgo.AfterEach(func() {
+	ginkgo.AfterEach(func(ctx context.Context) {
 		if pvcCreatedAndNotDeleted {
-			e2epv.DeletePersistentVolumeClaim(client, pvc.Name, nameSpace)
+			e2epv.DeletePersistentVolumeClaim(ctx, client, pvc.Name, nameSpace)
 		}
 	})
 
 	ginkgo.It("Verify \"immediate\" deletion of a PVC that is not in active use by a pod", func(ctx context.Context) {
 		ginkgo.By("Deleting the pod using the PVC")
-		err = e2epod.DeletePodWithWait(client, pod)
+		err = e2epod.DeletePodWithWait(ctx, client, pod)
 		framework.ExpectNoError(err, "Error terminating and deleting pod")
 
 		ginkgo.By("Deleting the PVC")
-		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, *metav1.NewDeleteOptions(0))
+		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
 		framework.ExpectNoError(err, "Error deleting PVC")
-		waitForPersistentVolumeClaimDeleted(client, pvc.Namespace, pvc.Name, framework.Poll, claimDeletingTimeout)
+		waitForPersistentVolumeClaimDeleted(ctx, client, pvc.Namespace, pvc.Name, framework.Poll, claimDeletingTimeout)
 		pvcCreatedAndNotDeleted = false
 	})
 
 	ginkgo.It("Verify that PVC in active use by a pod is not removed immediately", func(ctx context.Context) {
 		ginkgo.By("Deleting the PVC, however, the PVC must not be removed from the system as it's in active use by a pod")
-		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, *metav1.NewDeleteOptions(0))
+		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
 		framework.ExpectNoError(err, "Error deleting PVC")
 
 		ginkgo.By("Checking that the PVC status is Terminating")
-		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While checking PVC status")
 		framework.ExpectNotEqual(pvc.ObjectMeta.DeletionTimestamp, nil)
 
 		ginkgo.By("Deleting the pod that uses the PVC")
-		err = e2epod.DeletePodWithWait(client, pod)
+		err = e2epod.DeletePodWithWait(ctx, client, pod)
 		framework.ExpectNoError(err, "Error terminating and deleting pod")
 
 		ginkgo.By("Checking that the PVC is automatically removed from the system because it's no longer in active use by a pod")
-		waitForPersistentVolumeClaimDeleted(client, pvc.Namespace, pvc.Name, framework.Poll, claimDeletingTimeout)
+		waitForPersistentVolumeClaimDeleted(ctx, client, pvc.Namespace, pvc.Name, framework.Poll, claimDeletingTimeout)
 		pvcCreatedAndNotDeleted = false
 	})
 
 	ginkgo.It("Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable", func(ctx context.Context) {
 		ginkgo.By("Deleting the PVC, however, the PVC must not be removed from the system as it's in active use by a pod")
-		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, *metav1.NewDeleteOptions(0))
+		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
 		framework.ExpectNoError(err, "Error deleting PVC")
 
 		ginkgo.By("Checking that the PVC status is Terminating")
-		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While checking PVC status")
 		framework.ExpectNotEqual(pvc.ObjectMeta.DeletionTimestamp, nil)
 
 		ginkgo.By("Creating second Pod whose scheduling fails because it uses a PVC that is being deleted")
-		secondPod, err2 := e2epod.CreateUnschedulablePod(client, nameSpace, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
+		secondPod, err2 := e2epod.CreateUnschedulablePod(ctx, client, nameSpace, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
 		framework.ExpectNoError(err2, "While creating second pod that uses a PVC that is being deleted and that is Unschedulable")
 
 		ginkgo.By("Deleting the second pod that uses the PVC that is being deleted")
-		err = e2epod.DeletePodWithWait(client, secondPod)
+		err = e2epod.DeletePodWithWait(ctx, client, secondPod)
 		framework.ExpectNoError(err, "Error terminating and deleting pod")
 
 		ginkgo.By("Checking again that the PVC status is Terminating")
-		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While checking PVC status")
 		framework.ExpectNotEqual(pvc.ObjectMeta.DeletionTimestamp, nil)
 
 		ginkgo.By("Deleting the first pod that uses the PVC")
-		err = e2epod.DeletePodWithWait(client, pod)
+		err = e2epod.DeletePodWithWait(ctx, client, pod)
 		framework.ExpectNoError(err, "Error terminating and deleting pod")
 
 		ginkgo.By("Checking that the PVC is automatically removed from the system because it's no longer in active use by a pod")
-		waitForPersistentVolumeClaimDeleted(client, pvc.Namespace, pvc.Name, framework.Poll, claimDeletingTimeout)
+		waitForPersistentVolumeClaimDeleted(ctx, client, pvc.Namespace, pvc.Name, framework.Poll, claimDeletingTimeout)
 		pvcCreatedAndNotDeleted = false
 	})
 })

--- a/test/e2e/storage/subpath.go
+++ b/test/e2e/storage/subpath.go
@@ -37,16 +37,16 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		var err error
 		var privilegedSecurityContext bool = false
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			ginkgo.By("Setting up data")
 			secret := &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "my-secret"}, Data: map[string][]byte{"secret-key": []byte("secret-value")}}
-			_, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{})
+			_, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{})
 			if err != nil && !apierrors.IsAlreadyExists(err) {
 				framework.ExpectNoError(err, "while creating secret")
 			}
 
 			configmap := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "my-configmap"}, Data: map[string]string{"configmap-key": "configmap-value"}}
-			_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configmap, metav1.CreateOptions{})
+			_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configmap, metav1.CreateOptions{})
 			if err != nil && !apierrors.IsAlreadyExists(err) {
 				framework.ExpectNoError(err, "while creating configmap")
 			}
@@ -59,7 +59,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		*/
 		framework.ConformanceIt("should support subpaths with secret pod", func(ctx context.Context) {
 			pod := testsuites.SubpathTestPod(f, "secret-key", "secret", &v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "my-secret"}}, privilegedSecurityContext)
-			testsuites.TestBasicSubpath(f, "secret-value", pod)
+			testsuites.TestBasicSubpath(ctx, f, "secret-value", pod)
 		})
 
 		/*
@@ -69,7 +69,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		*/
 		framework.ConformanceIt("should support subpaths with configmap pod", func(ctx context.Context) {
 			pod := testsuites.SubpathTestPod(f, "configmap-key", "configmap", &v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "my-configmap"}}}, privilegedSecurityContext)
-			testsuites.TestBasicSubpath(f, "configmap-value", pod)
+			testsuites.TestBasicSubpath(ctx, f, "configmap-value", pod)
 		})
 
 		/*
@@ -81,7 +81,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 			pod := testsuites.SubpathTestPod(f, "configmap-key", "configmap", &v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "my-configmap"}}}, privilegedSecurityContext)
 			file := "/etc/resolv.conf"
 			pod.Spec.Containers[0].VolumeMounts[0].MountPath = file
-			testsuites.TestBasicSubpathFile(f, "configmap-value", pod, file)
+			testsuites.TestBasicSubpathFile(ctx, f, "configmap-value", pod, file)
 		})
 
 		/*
@@ -95,7 +95,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 					Items: []v1.DownwardAPIVolumeFile{{Path: "downward/podname", FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.name"}}},
 				},
 			}, privilegedSecurityContext)
-			testsuites.TestBasicSubpath(f, pod.Name, pod)
+			testsuites.TestBasicSubpath(ctx, f, pod.Name, pod)
 		})
 
 		/*
@@ -114,7 +114,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 					},
 				},
 			}, privilegedSecurityContext)
-			testsuites.TestBasicSubpath(f, "configmap-value", pod)
+			testsuites.TestBasicSubpath(ctx, f, "configmap-value", pod)
 		})
 
 	})
@@ -123,7 +123,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		ginkgo.It("should verify that container can restart successfully after configmaps modified", func(ctx context.Context) {
 			configmapToModify := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "my-configmap-to-modify"}, Data: map[string]string{"configmap-key": "configmap-value"}}
 			configmapModified := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "my-configmap-to-modify"}, Data: map[string]string{"configmap-key": "configmap-modified-value"}}
-			testsuites.TestPodContainerRestartWithConfigmapModified(f, configmapToModify, configmapModified)
+			testsuites.TestPodContainerRestartWithConfigmapModified(ctx, f, configmapToModify, configmapModified)
 		})
 	})
 })

--- a/test/e2e/storage/testsuites/capacity.go
+++ b/test/e2e/storage/testsuites/capacity.go
@@ -90,24 +90,24 @@ func (p *capacityTestSuite) DefineTests(driver storageframework.TestDriver, patt
 	f := framework.NewFrameworkWithCustomTimeouts("capacity", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	init := func() {
+	init := func(ctx context.Context) {
 		dDriver, _ = driver.(storageframework.DynamicPVTestDriver)
 		// Now do the more expensive test initialization.
-		config := driver.PrepareTest(f)
-		sc = dDriver.GetDynamicProvisionStorageClass(config, pattern.FsType)
+		config := driver.PrepareTest(ctx, f)
+		sc = dDriver.GetDynamicProvisionStorageClass(ctx, config, pattern.FsType)
 		if sc == nil {
 			e2eskipper.Skipf("Driver %q does not define Dynamic Provision StorageClass - skipping", dInfo.Name)
 		}
 	}
 
 	ginkgo.It("provides storage capacity information", func(ctx context.Context) {
-		init()
+		init(ctx)
 
 		timeout := time.Minute
 		pollInterval := time.Second
 		matchSC := HaveCapacitiesForClass(sc.Name)
-		listAll := gomega.Eventually(func() (*storagev1.CSIStorageCapacityList, error) {
-			return f.ClientSet.StorageV1().CSIStorageCapacities("").List(context.Background(), metav1.ListOptions{})
+		listAll := gomega.Eventually(ctx, func() (*storagev1.CSIStorageCapacityList, error) {
+			return f.ClientSet.StorageV1().CSIStorageCapacities("").List(ctx, metav1.ListOptions{})
 		}, timeout, pollInterval)
 
 		// If we have further information about what storage
@@ -127,7 +127,7 @@ func (p *capacityTestSuite) DefineTests(driver storageframework.TestDriver, patt
 			// drivers with multiple keys might be
 			// possible, too, but is not currently
 			// implemented.
-			matcher = HaveCapacitiesForClassAndNodes(f.ClientSet, sc.Provisioner, sc.Name, dInfo.TopologyKeys[0])
+			matcher = HaveCapacitiesForClassAndNodes(ctx, f.ClientSet, sc.Provisioner, sc.Name, dInfo.TopologyKeys[0])
 		}
 
 		// Create storage class and wait for capacity information.
@@ -239,8 +239,9 @@ func (h *haveCSIStorageCapacities) NegatedFailureMessage(actual interface{}) (me
 
 // HaveCapacitiesForClassAndNodes matches objects by storage class name. It finds
 // all nodes on which the driver runs and expects one object per node.
-func HaveCapacitiesForClassAndNodes(client kubernetes.Interface, driverName, scName, topologyKey string) CapacityMatcher {
+func HaveCapacitiesForClassAndNodes(ctx context.Context, client kubernetes.Interface, driverName, scName, topologyKey string) CapacityMatcher {
 	return &haveLocalStorageCapacities{
+		ctx:         ctx,
 		client:      client,
 		driverName:  driverName,
 		match:       HaveCapacitiesForClass(scName),
@@ -249,6 +250,7 @@ func HaveCapacitiesForClassAndNodes(client kubernetes.Interface, driverName, scN
 }
 
 type haveLocalStorageCapacities struct {
+	ctx         context.Context
 	client      kubernetes.Interface
 	driverName  string
 	match       CapacityMatcher
@@ -263,6 +265,7 @@ type haveLocalStorageCapacities struct {
 var _ CapacityMatcher = &haveLocalStorageCapacities{}
 
 func (h *haveLocalStorageCapacities) Match(actual interface{}) (success bool, err error) {
+	ctx := h.ctx
 	h.expectedCapacities = nil
 	h.unexpectedCapacities = nil
 	h.missingTopologyValues = nil
@@ -275,7 +278,7 @@ func (h *haveLocalStorageCapacities) Match(actual interface{}) (success bool, er
 	}
 
 	// Find all nodes on which the driver runs.
-	csiNodes, err := h.client.StorageV1().CSINodes().List(context.Background(), metav1.ListOptions{})
+	csiNodes, err := h.client.StorageV1().CSINodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -285,7 +288,7 @@ func (h *haveLocalStorageCapacities) Match(actual interface{}) (success bool, er
 			if driver.Name != h.driverName {
 				continue
 			}
-			node, err := h.client.CoreV1().Nodes().Get(context.Background(), csiNode.Name, metav1.GetOptions{})
+			node, err := h.client.CoreV1().Nodes().Get(ctx, csiNode.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}

--- a/test/e2e/storage/testsuites/ephemeral.go
+++ b/test/e2e/storage/testsuites/ephemeral.go
@@ -140,8 +140,8 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 		}
 
 		// Now do the more expensive test initialization.
-		l.config = driver.PrepareTest(f)
-		l.resource = storageframework.CreateVolumeResource(driver, l.config, pattern, e2evolume.SizeRange{})
+		l.config = driver.PrepareTest(ctx, f)
+		l.resource = storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
 
 		switch pattern.VolType {
 		case storageframework.CSIInlineVolume:
@@ -166,9 +166,9 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 		}
 	}
 
-	cleanup := func() {
+	cleanup := func(ctx context.Context) {
 		var cleanUpErrs []error
-		cleanUpErrs = append(cleanUpErrs, l.resource.CleanupResource())
+		cleanUpErrs = append(cleanUpErrs, l.resource.CleanupResource(ctx))
 		err := utilerrors.NewAggregate(cleanUpErrs)
 		framework.ExpectNoError(err, "while cleaning up")
 	}
@@ -182,7 +182,7 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 		ginkgo.DeferCleanup(cleanup)
 
 		l.testCase.ReadOnly = true
-		l.testCase.RunningPodCheck = func(pod *v1.Pod) interface{} {
+		l.testCase.RunningPodCheck = func(ctx context.Context, pod *v1.Pod) interface{} {
 			command := "mount | grep /mnt/test | grep ro,"
 			if framework.NodeOSDistroIs("windows") {
 				// attempt to create a dummy file and expect for it not to be created
@@ -199,7 +199,7 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 		ginkgo.DeferCleanup(cleanup)
 
 		l.testCase.ReadOnly = false
-		l.testCase.RunningPodCheck = func(pod *v1.Pod) interface{} {
+		l.testCase.RunningPodCheck = func(ctx context.Context, pod *v1.Pod) interface{} {
 			command := "mount | grep /mnt/test | grep rw,"
 			if framework.NodeOSDistroIs("windows") {
 				// attempt to create a dummy file and expect for it to be created
@@ -227,7 +227,7 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 		}
 
 		l.testCase.ReadOnly = false
-		l.testCase.RunningPodCheck = func(pod *v1.Pod) interface{} {
+		l.testCase.RunningPodCheck = func(ctx context.Context, pod *v1.Pod) interface{} {
 			podName := pod.Name
 			framework.Logf("Running volume expansion checks %s", podName)
 
@@ -249,7 +249,7 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 			newSize.Add(resource.MustParse("1Gi"))
 			framework.Logf("currentPvcSize %s, requested new size %s", currentPvcSize.String(), newSize.String())
 
-			newPVC, err := ExpandPVCSize(pvc, newSize, f.ClientSet)
+			newPVC, err := ExpandPVCSize(ctx, pvc, newSize, f.ClientSet)
 			framework.ExpectNoError(err, "While updating pvc for more size")
 			pvc = newPVC
 			gomega.Expect(pvc).NotTo(gomega.BeNil())
@@ -260,11 +260,11 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 			}
 
 			ginkgo.By("Waiting for cloudprovider resize to finish")
-			err = WaitForControllerVolumeResize(pvc, f.ClientSet, totalResizeWaitPeriod)
+			err = WaitForControllerVolumeResize(ctx, pvc, f.ClientSet, totalResizeWaitPeriod)
 			framework.ExpectNoError(err, "While waiting for pvc resize to finish")
 
 			ginkgo.By("Waiting for file system resize to finish")
-			pvc, err = WaitForFSResize(pvc, f.ClientSet)
+			pvc, err = WaitForFSResize(ctx, pvc, f.ClientSet)
 			framework.ExpectNoError(err, "while waiting for fs resize to finish")
 
 			pvcConditions := pvc.Status.Conditions
@@ -287,13 +287,13 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 			_, shared, readOnly = eDriver.GetVolume(l.config, 0)
 		}
 
-		l.testCase.RunningPodCheck = func(pod *v1.Pod) interface{} {
+		l.testCase.RunningPodCheck = func(ctx context.Context, pod *v1.Pod) interface{} {
 			// Create another pod with the same inline volume attributes.
 			pod2 := StartInPodWithInlineVolume(ctx, f.ClientSet, f.Namespace.Name, "inline-volume-tester2", "sleep 100000",
 				[]v1.VolumeSource{pod.Spec.Volumes[0].VolumeSource},
 				readOnly,
 				l.testCase.Node)
-			framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod2.Name, pod2.Namespace, f.Timeouts.PodStartSlow), "waiting for second pod with inline volume")
+			framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, pod2.Name, pod2.Namespace, f.Timeouts.PodStartSlow), "waiting for second pod with inline volume")
 
 			// If (and only if) we were able to mount
 			// read/write and volume data is not shared
@@ -306,7 +306,11 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 				e2evolume.VerifyExecInPodSucceed(f, pod2, "[ ! -f /mnt/test-0/hello-world ]")
 			}
 
-			defer StopPodAndDependents(ctx, f.ClientSet, f.Timeouts, pod2)
+			// TestEphemeral expects the pod to be fully deleted
+			// when this function returns, so don't delay this
+			// cleanup.
+			StopPodAndDependents(ctx, f.ClientSet, f.Timeouts, pod2)
+
 			return nil
 		}
 
@@ -353,7 +357,7 @@ type EphemeralTest struct {
 	// RunningPodCheck is invoked while a pod using an inline volume is running.
 	// It can execute additional checks on the pod and its volume(s). Any data
 	// returned by it is passed to StoppedPodCheck.
-	RunningPodCheck func(pod *v1.Pod) interface{}
+	RunningPodCheck func(ctx context.Context, pod *v1.Pod) interface{}
 
 	// StoppedPodCheck is invoked after ensuring that the pod is gone.
 	// It is passed the data gather by RunningPodCheck or nil if that
@@ -361,7 +365,7 @@ type EphemeralTest struct {
 	// like for example verifying that the ephemeral volume was really
 	// removed. How to do such a check is driver-specific and not
 	// covered by the generic storage test suite.
-	StoppedPodCheck func(nodeName string, runningPodData interface{})
+	StoppedPodCheck func(ctx context.Context, nodeName string, runningPodData interface{})
 
 	// NumInlineVolumes sets the number of ephemeral inline volumes per pod.
 	// Unset (= zero) is the same as one.
@@ -410,7 +414,7 @@ func (t EphemeralTest) TestEphemeral(ctx context.Context) {
 		// pod might be nil now.
 		StopPodAndDependents(ctx, client, t.Timeouts, pod)
 	}()
-	framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(client, pod.Name, pod.Namespace, t.Timeouts.PodStartSlow), "waiting for pod with inline volume")
+	framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(ctx, client, pod.Name, pod.Namespace, t.Timeouts.PodStartSlow), "waiting for pod with inline volume")
 	runningPod, err := client.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err, "get pod")
 	actualNodeName := runningPod.Spec.NodeName
@@ -418,7 +422,7 @@ func (t EphemeralTest) TestEphemeral(ctx context.Context) {
 	// Run the checker of the running pod.
 	var runningPodData interface{}
 	if t.RunningPodCheck != nil {
-		runningPodData = t.RunningPodCheck(pod)
+		runningPodData = t.RunningPodCheck(ctx, pod)
 	}
 
 	StopPodAndDependents(ctx, client, t.Timeouts, pod)
@@ -431,7 +435,7 @@ func (t EphemeralTest) TestEphemeral(ctx context.Context) {
 	gomega.Expect(pvcs.Items).Should(gomega.BeEmpty(), "no dangling PVCs")
 
 	if t.StoppedPodCheck != nil {
-		t.StoppedPodCheck(actualNodeName, runningPodData)
+		t.StoppedPodCheck(ctx, actualNodeName, runningPodData)
 	}
 }
 

--- a/test/e2e/storage/testsuites/fsgroupchangepolicy.go
+++ b/test/e2e/storage/testsuites/fsgroupchangepolicy.go
@@ -108,19 +108,19 @@ func (s *fsGroupChangePolicyTestSuite) DefineTests(driver storageframework.TestD
 	f := framework.NewFrameworkWithCustomTimeouts("fsgroupchangepolicy", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	init := func() {
+	init := func(ctx context.Context) {
 		e2eskipper.SkipIfNodeOSDistroIs("windows")
 		l = local{}
 		l.driver = driver
-		l.config = driver.PrepareTest(f)
+		l.config = driver.PrepareTest(ctx, f)
 		testVolumeSizeRange := s.GetTestSuiteInfo().SupportedSizeRange
-		l.resource = storageframework.CreateVolumeResource(l.driver, l.config, pattern, testVolumeSizeRange)
+		l.resource = storageframework.CreateVolumeResource(ctx, l.driver, l.config, pattern, testVolumeSizeRange)
 	}
 
-	cleanup := func() {
+	cleanup := func(ctx context.Context) {
 		var errs []error
 		if l.resource != nil {
-			if err := l.resource.CleanupResource(); err != nil {
+			if err := l.resource.CleanupResource(ctx); err != nil {
 				errs = append(errs, err)
 			}
 			l.resource = nil
@@ -217,7 +217,7 @@ func (s *fsGroupChangePolicyTestSuite) DefineTests(driver storageframework.TestD
 				e2eskipper.Skipf("Driver %q supports VolumeMountGroup, which is incompatible with this test - skipping", dInfo.Name)
 			}
 
-			init()
+			init(ctx)
 			ginkgo.DeferCleanup(cleanup)
 			podConfig := e2epod.Config{
 				NS:                     f.Namespace.Name,
@@ -227,7 +227,7 @@ func (s *fsGroupChangePolicyTestSuite) DefineTests(driver storageframework.TestD
 				PodFSGroupChangePolicy: &policy,
 			}
 			// Create initial pod and create files in root and sub-directory and verify ownership.
-			pod := createPodAndVerifyContentGid(l.config.Framework, &podConfig, true /* createInitialFiles */, "" /* expectedRootDirFileOwnership */, "" /* expectedSubDirFileOwnership */)
+			pod := createPodAndVerifyContentGid(ctx, l.config.Framework, &podConfig, true /* createInitialFiles */, "" /* expectedRootDirFileOwnership */, "" /* expectedSubDirFileOwnership */)
 
 			// Change the ownership of files in the initial pod.
 			if test.changedRootDirFileOwnership != 0 {
@@ -241,21 +241,21 @@ func (s *fsGroupChangePolicyTestSuite) DefineTests(driver storageframework.TestD
 			}
 
 			ginkgo.By(fmt.Sprintf("Deleting Pod %s/%s", pod.Namespace, pod.Name))
-			framework.ExpectNoError(e2epod.DeletePodWithWait(f.ClientSet, pod))
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
 
 			// Create a second pod with existing volume and verify the contents ownership.
 			podConfig.FsGroup = utilpointer.Int64Ptr(int64(test.secondPodFsGroup))
-			pod = createPodAndVerifyContentGid(l.config.Framework, &podConfig, false /* createInitialFiles */, strconv.Itoa(test.finalExpectedRootDirFileOwnership), strconv.Itoa(test.finalExpectedSubDirFileOwnership))
+			pod = createPodAndVerifyContentGid(ctx, l.config.Framework, &podConfig, false /* createInitialFiles */, strconv.Itoa(test.finalExpectedRootDirFileOwnership), strconv.Itoa(test.finalExpectedSubDirFileOwnership))
 			ginkgo.By(fmt.Sprintf("Deleting Pod %s/%s", pod.Namespace, pod.Name))
-			framework.ExpectNoError(e2epod.DeletePodWithWait(f.ClientSet, pod))
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
 		})
 	}
 }
 
-func createPodAndVerifyContentGid(f *framework.Framework, podConfig *e2epod.Config, createInitialFiles bool, expectedRootDirFileOwnership, expectedSubDirFileOwnership string) *v1.Pod {
+func createPodAndVerifyContentGid(ctx context.Context, f *framework.Framework, podConfig *e2epod.Config, createInitialFiles bool, expectedRootDirFileOwnership, expectedSubDirFileOwnership string) *v1.Pod {
 	podFsGroup := strconv.FormatInt(*podConfig.FsGroup, 10)
 	ginkgo.By(fmt.Sprintf("Creating Pod in namespace %s with fsgroup %s", podConfig.NS, podFsGroup))
-	pod, err := e2epod.CreateSecPodWithNodeSelection(f.ClientSet, podConfig, f.Timeouts.PodStart)
+	pod, err := e2epod.CreateSecPodWithNodeSelection(ctx, f.ClientSet, podConfig, f.Timeouts.PodStart)
 	framework.ExpectNoError(err)
 	framework.Logf("Pod %s/%s started successfully", pod.Namespace, pod.Name)
 

--- a/test/e2e/storage/testsuites/topology.go
+++ b/test/e2e/storage/testsuites/topology.go
@@ -104,9 +104,9 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 	f := framework.NewFrameworkWithCustomTimeouts("topology", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	init := func() topologyTest {
+	init := func() *topologyTest {
 		dDriver, _ = driver.(storageframework.DynamicPVTestDriver)
-		l := topologyTest{}
+		l := &topologyTest{}
 
 		// Now do the more expensive test initialization.
 		l.config = driver.PrepareTest(f)
@@ -123,7 +123,7 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 			e2eskipper.Skipf("Driver didn't provide topology keys -- skipping")
 		}
 
-		ginkgo.DeferCleanup(t.CleanupResources, cs, &l)
+		ginkgo.DeferCleanup(t.CleanupResources, cs, l)
 
 		if dInfo.NumAllowedTopologies == 0 {
 			// Any plugin that supports topology defaults to 1 topology
@@ -166,7 +166,7 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 		}
 		allowedTopologies := t.setAllowedTopologies(l.resource.Sc, l.allTopologies, excludedIndex)
 
-		t.createResources(cs, &l, nil)
+		t.createResources(cs, l, nil)
 
 		err = e2epod.WaitTimeoutForPodRunningInNamespace(cs, l.pod.Name, l.pod.Namespace, f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
@@ -213,7 +213,7 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 				},
 			},
 		}
-		t.createResources(cs, &l, affinity)
+		t.createResources(cs, l, affinity)
 
 		// Wait for pod to fail scheduling
 		// With delayed binding, the scheduler errors before provisioning

--- a/test/e2e/storage/testsuites/topology.go
+++ b/test/e2e/storage/testsuites/topology.go
@@ -104,12 +104,12 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 	f := framework.NewFrameworkWithCustomTimeouts("topology", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	init := func() *topologyTest {
+	init := func(ctx context.Context) *topologyTest {
 		dDriver, _ = driver.(storageframework.DynamicPVTestDriver)
 		l := &topologyTest{}
 
 		// Now do the more expensive test initialization.
-		l.config = driver.PrepareTest(f)
+		l.config = driver.PrepareTest(ctx, f)
 
 		l.resource = storageframework.VolumeResource{
 			Config:  l.config,
@@ -131,13 +131,13 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 		}
 		// We collect 1 additional topology, if possible, for the conflicting topology test
 		// case, but it's not needed for the positive test
-		l.allTopologies, err = t.getCurrentTopologies(cs, keys, dInfo.NumAllowedTopologies+1)
+		l.allTopologies, err = t.getCurrentTopologies(ctx, cs, keys, dInfo.NumAllowedTopologies+1)
 		framework.ExpectNoError(err, "failed to get current driver topologies")
 		if len(l.allTopologies) < dInfo.NumAllowedTopologies {
 			e2eskipper.Skipf("Not enough topologies in cluster -- skipping")
 		}
 
-		l.resource.Sc = dDriver.GetDynamicProvisionStorageClass(l.config, pattern.FsType)
+		l.resource.Sc = dDriver.GetDynamicProvisionStorageClass(ctx, l.config, pattern.FsType)
 		framework.ExpectNotEqual(l.resource.Sc, nil, "driver failed to provide a StorageClass")
 		l.resource.Sc.VolumeBindingMode = &pattern.BindingMode
 
@@ -150,14 +150,14 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 			StorageClassName: &(l.resource.Sc.Name),
 		}, l.config.Framework.Namespace.Name)
 
-		migrationCheck := newMigrationOpCheck(f.ClientSet, f.ClientConfig(), dInfo.InTreePluginName)
+		migrationCheck := newMigrationOpCheck(ctx, f.ClientSet, f.ClientConfig(), dInfo.InTreePluginName)
 		ginkgo.DeferCleanup(migrationCheck.validateMigrationVolumeOpCounts)
 
 		return l
 	}
 
 	ginkgo.It("should provision a volume and schedule a pod with AllowedTopologies", func(ctx context.Context) {
-		l := init()
+		l := init(ctx)
 
 		// If possible, exclude one topology, otherwise allow them all
 		excludedIndex := -1
@@ -166,23 +166,23 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 		}
 		allowedTopologies := t.setAllowedTopologies(l.resource.Sc, l.allTopologies, excludedIndex)
 
-		t.createResources(cs, l, nil)
+		t.createResources(ctx, cs, l, nil)
 
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(cs, l.pod.Name, l.pod.Namespace, f.Timeouts.PodStart)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, cs, l.pod.Name, l.pod.Namespace, f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Verifying pod scheduled to correct node")
-		pod, err := cs.CoreV1().Pods(l.pod.Namespace).Get(context.TODO(), l.pod.Name, metav1.GetOptions{})
+		pod, err := cs.CoreV1().Pods(l.pod.Namespace).Get(ctx, l.pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
-		node, err := cs.CoreV1().Nodes().Get(context.TODO(), pod.Spec.NodeName, metav1.GetOptions{})
+		node, err := cs.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		t.verifyNodeTopology(node, allowedTopologies)
 	})
 
 	ginkgo.It("should fail to schedule a pod which has topologies that conflict with AllowedTopologies", func(ctx context.Context) {
-		l := init()
+		l := init(ctx)
 
 		if len(l.allTopologies) < dInfo.NumAllowedTopologies+1 {
 			e2eskipper.Skipf("Not enough topologies in cluster -- skipping")
@@ -213,19 +213,19 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 				},
 			},
 		}
-		t.createResources(cs, l, affinity)
+		t.createResources(ctx, cs, l, affinity)
 
 		// Wait for pod to fail scheduling
 		// With delayed binding, the scheduler errors before provisioning
 		// With immediate binding, the volume gets provisioned but cannot be scheduled
-		err = e2epod.WaitForPodNameUnschedulableInNamespace(cs, l.pod.Name, l.pod.Namespace)
+		err = e2epod.WaitForPodNameUnschedulableInNamespace(ctx, cs, l.pod.Name, l.pod.Namespace)
 		framework.ExpectNoError(err)
 	})
 }
 
 // getCurrentTopologies() goes through all Nodes and returns up to maxCount unique driver topologies
-func (t *topologyTestSuite) getCurrentTopologies(cs clientset.Interface, keys []string, maxCount int) ([]topology, error) {
-	nodes, err := e2enode.GetReadySchedulableNodes(cs)
+func (t *topologyTestSuite) getCurrentTopologies(ctx context.Context, cs clientset.Interface, keys []string, maxCount int) ([]topology, error) {
+	nodes, err := e2enode.GetReadySchedulableNodes(ctx, cs)
 	if err != nil {
 		return nil, err
 	}
@@ -309,16 +309,16 @@ func (t *topologyTestSuite) verifyNodeTopology(node *v1.Node, allowedTopos []top
 	framework.Failf("node %v topology labels %+v doesn't match allowed topologies +%v", node.Name, node.Labels, allowedTopos)
 }
 
-func (t *topologyTestSuite) createResources(cs clientset.Interface, l *topologyTest, affinity *v1.Affinity) {
+func (t *topologyTestSuite) createResources(ctx context.Context, cs clientset.Interface, l *topologyTest, affinity *v1.Affinity) {
 	var err error
 	framework.Logf("Creating storage class object and pvc object for driver - sc: %v, pvc: %v", l.resource.Sc, l.resource.Pvc)
 
 	ginkgo.By("Creating sc")
-	l.resource.Sc, err = cs.StorageV1().StorageClasses().Create(context.TODO(), l.resource.Sc, metav1.CreateOptions{})
+	l.resource.Sc, err = cs.StorageV1().StorageClasses().Create(ctx, l.resource.Sc, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Creating pvc")
-	l.resource.Pvc, err = cs.CoreV1().PersistentVolumeClaims(l.resource.Pvc.Namespace).Create(context.TODO(), l.resource.Pvc, metav1.CreateOptions{})
+	l.resource.Pvc, err = cs.CoreV1().PersistentVolumeClaims(l.resource.Pvc.Namespace).Create(ctx, l.resource.Pvc, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Creating pod")
@@ -331,17 +331,17 @@ func (t *topologyTestSuite) createResources(cs clientset.Interface, l *topologyT
 	}
 	l.pod, err = e2epod.MakeSecPod(&podConfig)
 	framework.ExpectNoError(err)
-	l.pod, err = cs.CoreV1().Pods(l.pod.Namespace).Create(context.TODO(), l.pod, metav1.CreateOptions{})
+	l.pod, err = cs.CoreV1().Pods(l.pod.Namespace).Create(ctx, l.pod, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 }
 
-func (t *topologyTestSuite) CleanupResources(cs clientset.Interface, l *topologyTest) {
+func (t *topologyTestSuite) CleanupResources(ctx context.Context, cs clientset.Interface, l *topologyTest) {
 	if l.pod != nil {
 		ginkgo.By("Deleting pod")
-		err := e2epod.DeletePodWithWait(cs, l.pod)
+		err := e2epod.DeletePodWithWait(ctx, cs, l.pod)
 		framework.ExpectNoError(err, "while deleting pod")
 	}
 
-	err := l.resource.CleanupResource()
+	err := l.resource.CleanupResource(ctx)
 	framework.ExpectNoError(err, "while clean up resource")
 }

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -116,44 +116,44 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 	f := framework.NewFrameworkWithCustomTimeouts("volume-expand", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	init := func() {
+	init := func(ctx context.Context) {
 		l = local{}
 
 		// Now do the more expensive test initialization.
-		l.config = driver.PrepareTest(f)
-		l.migrationCheck = newMigrationOpCheck(f.ClientSet, f.ClientConfig(), driver.GetDriverInfo().InTreePluginName)
+		l.config = driver.PrepareTest(ctx, f)
+		l.migrationCheck = newMigrationOpCheck(ctx, f.ClientSet, f.ClientConfig(), driver.GetDriverInfo().InTreePluginName)
 		testVolumeSizeRange := v.GetTestSuiteInfo().SupportedSizeRange
-		l.resource = storageframework.CreateVolumeResource(driver, l.config, pattern, testVolumeSizeRange)
+		l.resource = storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, testVolumeSizeRange)
 	}
 
-	cleanup := func() {
+	cleanup := func(ctx context.Context) {
 		var errs []error
 		if l.pod != nil {
 			ginkgo.By("Deleting pod")
-			err := e2epod.DeletePodWithWait(f.ClientSet, l.pod)
+			err := e2epod.DeletePodWithWait(ctx, f.ClientSet, l.pod)
 			errs = append(errs, err)
 			l.pod = nil
 		}
 
 		if l.pod2 != nil {
 			ginkgo.By("Deleting pod2")
-			err := e2epod.DeletePodWithWait(f.ClientSet, l.pod2)
+			err := e2epod.DeletePodWithWait(ctx, f.ClientSet, l.pod2)
 			errs = append(errs, err)
 			l.pod2 = nil
 		}
 
 		if l.resource != nil {
-			errs = append(errs, l.resource.CleanupResource())
+			errs = append(errs, l.resource.CleanupResource(ctx))
 			l.resource = nil
 		}
 
 		framework.ExpectNoError(errors.NewAggregate(errs), "while cleaning up resource")
-		l.migrationCheck.validateMigrationVolumeOpCounts()
+		l.migrationCheck.validateMigrationVolumeOpCounts(ctx)
 	}
 
 	if !pattern.AllowExpansion {
 		ginkgo.It("should not allow expansion of pvcs without AllowVolumeExpansion property", func(ctx context.Context) {
-			init()
+			init(ctx)
 			ginkgo.DeferCleanup(cleanup)
 
 			var err error
@@ -165,12 +165,12 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			newSize := currentPvcSize.DeepCopy()
 			newSize.Add(resource.MustParse("1Gi"))
 			framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
-			_, err = ExpandPVCSize(l.resource.Pvc, newSize, f.ClientSet)
+			_, err = ExpandPVCSize(ctx, l.resource.Pvc, newSize, f.ClientSet)
 			framework.ExpectError(err, "While updating non-expandable PVC")
 		})
 	} else {
 		ginkgo.It("Verify if offline PVC expansion works", func(ctx context.Context) {
-			init()
+			init(ctx)
 			ginkgo.DeferCleanup(cleanup)
 
 			if !driver.GetDriverInfo().Capabilities[storageframework.CapOfflineExpansion] {
@@ -186,12 +186,12 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 				NodeSelection: l.config.ClientNodeSelection,
 				ImageID:       e2epod.GetDefaultTestImageID(),
 			}
-			l.pod, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, &podConfig, f.Timeouts.PodStart)
+			l.pod, err = e2epod.CreateSecPodWithNodeSelection(ctx, f.ClientSet, &podConfig, f.Timeouts.PodStart)
 			ginkgo.DeferCleanup(e2epod.DeletePodWithWait, f.ClientSet, l.pod)
 			framework.ExpectNoError(err, "While creating pods for resizing")
 
 			ginkgo.By("Deleting the previously created pod")
-			err = e2epod.DeletePodWithWait(f.ClientSet, l.pod)
+			err = e2epod.DeletePodWithWait(ctx, f.ClientSet, l.pod)
 			framework.ExpectNoError(err, "while deleting pod for resizing")
 
 			// We expand the PVC while no pod is using it to ensure offline expansion
@@ -200,7 +200,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			newSize := currentPvcSize.DeepCopy()
 			newSize.Add(resource.MustParse("1Gi"))
 			framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
-			newPVC, err := ExpandPVCSize(l.resource.Pvc, newSize, f.ClientSet)
+			newPVC, err := ExpandPVCSize(ctx, l.resource.Pvc, newSize, f.ClientSet)
 			framework.ExpectNoError(err, "While updating pvc for more size")
 			l.resource.Pvc = newPVC
 			gomega.Expect(l.resource.Pvc).NotTo(gomega.BeNil())
@@ -211,11 +211,11 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			}
 
 			ginkgo.By("Waiting for cloudprovider resize to finish")
-			err = WaitForControllerVolumeResize(l.resource.Pvc, f.ClientSet, totalResizeWaitPeriod)
+			err = WaitForControllerVolumeResize(ctx, l.resource.Pvc, f.ClientSet, totalResizeWaitPeriod)
 			framework.ExpectNoError(err, "While waiting for pvc resize to finish")
 
 			ginkgo.By("Checking for conditions on pvc")
-			npvc, err := WaitForPendingFSResizeCondition(l.resource.Pvc, f.ClientSet)
+			npvc, err := WaitForPendingFSResizeCondition(ctx, l.resource.Pvc, f.ClientSet)
 			framework.ExpectNoError(err, "While waiting for pvc to have fs resizing condition")
 			l.resource.Pvc = npvc
 
@@ -227,12 +227,12 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 				NodeSelection: l.config.ClientNodeSelection,
 				ImageID:       e2epod.GetDefaultTestImageID(),
 			}
-			l.pod2, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, &podConfig, resizedPodStartupTimeout)
+			l.pod2, err = e2epod.CreateSecPodWithNodeSelection(ctx, f.ClientSet, &podConfig, resizedPodStartupTimeout)
 			ginkgo.DeferCleanup(e2epod.DeletePodWithWait, f.ClientSet, l.pod2)
 			framework.ExpectNoError(err, "while recreating pod for resizing")
 
 			ginkgo.By("Waiting for file system resize to finish")
-			l.resource.Pvc, err = WaitForFSResize(l.resource.Pvc, f.ClientSet)
+			l.resource.Pvc, err = WaitForFSResize(ctx, l.resource.Pvc, f.ClientSet)
 			framework.ExpectNoError(err, "while waiting for fs resize to finish")
 
 			pvcConditions := l.resource.Pvc.Status.Conditions
@@ -240,7 +240,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 		})
 
 		ginkgo.It("should resize volume when PVC is edited while pod is using it", func(ctx context.Context) {
-			init()
+			init(ctx)
 			ginkgo.DeferCleanup(cleanup)
 
 			if !driver.GetDriverInfo().Capabilities[storageframework.CapOnlineExpansion] {
@@ -256,7 +256,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 				NodeSelection: l.config.ClientNodeSelection,
 				ImageID:       e2epod.GetDefaultTestImageID(),
 			}
-			l.pod, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, &podConfig, f.Timeouts.PodStart)
+			l.pod, err = e2epod.CreateSecPodWithNodeSelection(ctx, f.ClientSet, &podConfig, f.Timeouts.PodStart)
 			ginkgo.DeferCleanup(e2epod.DeletePodWithWait, f.ClientSet, l.pod)
 			framework.ExpectNoError(err, "While creating pods for resizing")
 
@@ -266,7 +266,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			newSize := currentPvcSize.DeepCopy()
 			newSize.Add(resource.MustParse("1Gi"))
 			framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
-			newPVC, err := ExpandPVCSize(l.resource.Pvc, newSize, f.ClientSet)
+			newPVC, err := ExpandPVCSize(ctx, l.resource.Pvc, newSize, f.ClientSet)
 			framework.ExpectNoError(err, "While updating pvc for more size")
 			l.resource.Pvc = newPVC
 			gomega.Expect(l.resource.Pvc).NotTo(gomega.BeNil())
@@ -277,11 +277,11 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			}
 
 			ginkgo.By("Waiting for cloudprovider resize to finish")
-			err = WaitForControllerVolumeResize(l.resource.Pvc, f.ClientSet, totalResizeWaitPeriod)
+			err = WaitForControllerVolumeResize(ctx, l.resource.Pvc, f.ClientSet, totalResizeWaitPeriod)
 			framework.ExpectNoError(err, "While waiting for pvc resize to finish")
 
 			ginkgo.By("Waiting for file system resize to finish")
-			l.resource.Pvc, err = WaitForFSResize(l.resource.Pvc, f.ClientSet)
+			l.resource.Pvc, err = WaitForFSResize(ctx, l.resource.Pvc, f.ClientSet)
 			framework.ExpectNoError(err, "while waiting for fs resize to finish")
 
 			pvcConditions := l.resource.Pvc.Status.Conditions
@@ -292,7 +292,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 }
 
 // ExpandPVCSize expands PVC size
-func ExpandPVCSize(origPVC *v1.PersistentVolumeClaim, size resource.Quantity, c clientset.Interface) (*v1.PersistentVolumeClaim, error) {
+func ExpandPVCSize(ctx context.Context, origPVC *v1.PersistentVolumeClaim, size resource.Quantity, c clientset.Interface) (*v1.PersistentVolumeClaim, error) {
 	pvcName := origPVC.Name
 	updatedPVC := origPVC.DeepCopy()
 
@@ -301,13 +301,13 @@ func ExpandPVCSize(origPVC *v1.PersistentVolumeClaim, size resource.Quantity, c 
 	var lastUpdateError error
 	waitErr := wait.PollImmediate(resizePollInterval, 30*time.Second, func() (bool, error) {
 		var err error
-		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(origPVC.Namespace).Get(context.TODO(), pvcName, metav1.GetOptions{})
+		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(origPVC.Namespace).Get(ctx, pvcName, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error fetching pvc %q for resizing: %v", pvcName, err)
 		}
 
 		updatedPVC.Spec.Resources.Requests[v1.ResourceStorage] = size
-		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(origPVC.Namespace).Update(context.TODO(), updatedPVC, metav1.UpdateOptions{})
+		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(origPVC.Namespace).Update(ctx, updatedPVC, metav1.UpdateOptions{})
 		if err != nil {
 			framework.Logf("Error updating pvc %s: %v", pvcName, err)
 			lastUpdateError = err
@@ -325,10 +325,10 @@ func ExpandPVCSize(origPVC *v1.PersistentVolumeClaim, size resource.Quantity, c 
 }
 
 // WaitForResizingCondition waits for the pvc condition to be PersistentVolumeClaimResizing
-func WaitForResizingCondition(pvc *v1.PersistentVolumeClaim, c clientset.Interface, duration time.Duration) error {
-	waitErr := wait.PollImmediate(resizePollInterval, duration, func() (bool, error) {
+func WaitForResizingCondition(ctx context.Context, pvc *v1.PersistentVolumeClaim, c clientset.Interface, duration time.Duration) error {
+	waitErr := wait.PollImmediateWithContext(ctx, resizePollInterval, duration, func(ctx context.Context) (bool, error) {
 		var err error
-		updatedPVC, err := c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+		updatedPVC, err := c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 
 		if err != nil {
 			return false, fmt.Errorf("error fetching pvc %q for checking for resize status: %v", pvc.Name, err)
@@ -349,12 +349,12 @@ func WaitForResizingCondition(pvc *v1.PersistentVolumeClaim, c clientset.Interfa
 }
 
 // WaitForControllerVolumeResize waits for the controller resize to be finished
-func WaitForControllerVolumeResize(pvc *v1.PersistentVolumeClaim, c clientset.Interface, timeout time.Duration) error {
+func WaitForControllerVolumeResize(ctx context.Context, pvc *v1.PersistentVolumeClaim, c clientset.Interface, timeout time.Duration) error {
 	pvName := pvc.Spec.VolumeName
-	waitErr := wait.PollImmediate(resizePollInterval, timeout, func() (bool, error) {
+	waitErr := wait.PollImmediateWithContext(ctx, resizePollInterval, timeout, func(ctx context.Context) (bool, error) {
 		pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
 
-		pv, err := c.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
+		pv, err := c.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error fetching pv %q for resizing %v", pvName, err)
 		}
@@ -374,11 +374,11 @@ func WaitForControllerVolumeResize(pvc *v1.PersistentVolumeClaim, c clientset.In
 }
 
 // WaitForPendingFSResizeCondition waits for pvc to have resize condition
-func WaitForPendingFSResizeCondition(pvc *v1.PersistentVolumeClaim, c clientset.Interface) (*v1.PersistentVolumeClaim, error) {
+func WaitForPendingFSResizeCondition(ctx context.Context, pvc *v1.PersistentVolumeClaim, c clientset.Interface) (*v1.PersistentVolumeClaim, error) {
 	var updatedPVC *v1.PersistentVolumeClaim
-	waitErr := wait.PollImmediate(resizePollInterval, pvcConditionSyncPeriod, func() (bool, error) {
+	waitErr := wait.PollImmediateWithContext(ctx, resizePollInterval, pvcConditionSyncPeriod, func(ctx context.Context) (bool, error) {
 		var err error
-		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 
 		if err != nil {
 			return false, fmt.Errorf("error fetching pvc %q for checking for resize status : %v", pvc.Name, err)
@@ -402,11 +402,11 @@ func WaitForPendingFSResizeCondition(pvc *v1.PersistentVolumeClaim, c clientset.
 }
 
 // WaitForFSResize waits for the filesystem in the pv to be resized
-func WaitForFSResize(pvc *v1.PersistentVolumeClaim, c clientset.Interface) (*v1.PersistentVolumeClaim, error) {
+func WaitForFSResize(ctx context.Context, pvc *v1.PersistentVolumeClaim, c clientset.Interface) (*v1.PersistentVolumeClaim, error) {
 	var updatedPVC *v1.PersistentVolumeClaim
-	waitErr := wait.PollImmediate(resizePollInterval, totalResizeWaitPeriod, func() (bool, error) {
+	waitErr := wait.PollImmediateWithContext(ctx, resizePollInterval, totalResizeWaitPeriod, func(ctx context.Context) (bool, error) {
 		var err error
-		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 
 		if err != nil {
 			return false, fmt.Errorf("error fetching pvc %q for checking for resize status : %v", pvc.Name, err)

--- a/test/e2e/storage/testsuites/volume_stress.go
+++ b/test/e2e/storage/testsuites/volume_stress.go
@@ -112,22 +112,22 @@ func (t *volumeStressTestSuite) DefineTests(driver storageframework.TestDriver, 
 	f := framework.NewFrameworkWithCustomTimeouts("stress", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	init := func() {
+	init := func(ctx context.Context) {
 		cs = f.ClientSet
 		l = &volumeStressTest{}
 
 		// Now do the more expensive test initialization.
-		l.config = driver.PrepareTest(f)
-		l.migrationCheck = newMigrationOpCheck(f.ClientSet, f.ClientConfig(), dInfo.InTreePluginName)
+		l.config = driver.PrepareTest(ctx, f)
+		l.migrationCheck = newMigrationOpCheck(ctx, f.ClientSet, f.ClientConfig(), dInfo.InTreePluginName)
 		l.volumes = []*storageframework.VolumeResource{}
 		l.pods = []*v1.Pod{}
 		l.testOptions = *dInfo.StressTestOptions
 	}
 
-	createPodsAndVolumes := func() {
+	createPodsAndVolumes := func(ctx context.Context) {
 		for i := 0; i < l.testOptions.NumPods; i++ {
 			framework.Logf("Creating resources for pod %v/%v", i, l.testOptions.NumPods-1)
-			r := storageframework.CreateVolumeResource(driver, l.config, pattern, t.GetTestSuiteInfo().SupportedSizeRange)
+			r := storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, t.GetTestSuiteInfo().SupportedSizeRange)
 			l.volumes = append(l.volumes, r)
 			podConfig := e2epod.Config{
 				NS:           f.Namespace.Name,
@@ -141,7 +141,7 @@ func (t *volumeStressTestSuite) DefineTests(driver storageframework.TestDriver, 
 		}
 	}
 
-	cleanup := func() {
+	cleanup := func(ctx context.Context) {
 		framework.Logf("Stopping and waiting for all test routines to finish")
 		l.wg.Wait()
 
@@ -158,7 +158,7 @@ func (t *volumeStressTestSuite) DefineTests(driver storageframework.TestDriver, 
 				defer wg.Done()
 
 				framework.Logf("Deleting pod %v", pod.Name)
-				err := e2epod.DeletePodWithWait(cs, pod)
+				err := e2epod.DeletePodWithWait(ctx, cs, pod)
 				mu.Lock()
 				defer mu.Unlock()
 				errs = append(errs, err)
@@ -173,7 +173,7 @@ func (t *volumeStressTestSuite) DefineTests(driver storageframework.TestDriver, 
 				defer wg.Done()
 
 				framework.Logf("Deleting volume %s", volume.Pvc.GetName())
-				err := volume.CleanupResource()
+				err := volume.CleanupResource(ctx)
 				mu.Lock()
 				defer mu.Unlock()
 				errs = append(errs, err)
@@ -182,13 +182,13 @@ func (t *volumeStressTestSuite) DefineTests(driver storageframework.TestDriver, 
 		wg.Wait()
 
 		framework.ExpectNoError(errors.NewAggregate(errs), "while cleaning up resource")
-		l.migrationCheck.validateMigrationVolumeOpCounts()
+		l.migrationCheck.validateMigrationVolumeOpCounts(ctx)
 	}
 
 	ginkgo.It("multiple pods should access different volumes repeatedly [Slow] [Serial]", func(ctx context.Context) {
-		init()
+		init(ctx)
 		ginkgo.DeferCleanup(cleanup)
-		createPodsAndVolumes()
+		createPodsAndVolumes(ctx)
 		// Restart pod repeatedly
 		for i := 0; i < l.testOptions.NumPods; i++ {
 			podIndex := i
@@ -211,19 +211,19 @@ func (t *volumeStressTestSuite) DefineTests(driver storageframework.TestDriver, 
 					default:
 						pod := l.pods[podIndex]
 						framework.Logf("Pod-%v [%v], Iteration %v/%v", podIndex, pod.Name, j, l.testOptions.NumRestarts-1)
-						_, err := cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+						_, err := cs.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 						if err != nil {
 							framework.Failf("Failed to create pod-%v [%+v]. Error: %v", podIndex, pod, err)
 						}
 
-						err = e2epod.WaitTimeoutForPodRunningInNamespace(cs, pod.Name, pod.Namespace, f.Timeouts.PodStart)
+						err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, cs, pod.Name, pod.Namespace, f.Timeouts.PodStart)
 						if err != nil {
 							framework.Failf("Failed to wait for pod-%v [%+v] turn into running status. Error: %v", podIndex, pod, err)
 						}
 
 						// TODO: write data per pod and validate it every time
 
-						err = e2epod.DeletePodWithWait(f.ClientSet, pod)
+						err = e2epod.DeletePodWithWait(ctx, f.ClientSet, pod)
 						if err != nil {
 							framework.Failf("Failed to delete pod-%v [%+v]. Error: %v", podIndex, pod, err)
 						}

--- a/test/e2e/storage/utils/create.go
+++ b/test/e2e/storage/utils/create.go
@@ -141,7 +141,7 @@ func PatchItems(f *framework.Framework, driverNamespace *v1.Namespace, items ...
 // PatchItems has the some limitations as LoadFromManifests:
 // - only some common items are supported, unknown ones trigger an error
 // - only the latest stable API version for each item is supported
-func CreateItems(f *framework.Framework, ns *v1.Namespace, items ...interface{}) error {
+func CreateItems(ctx context.Context, f *framework.Framework, ns *v1.Namespace, items ...interface{}) error {
 	var result error
 	for _, item := range items {
 		// Each factory knows which item(s) it supports, so try each one.
@@ -151,7 +151,7 @@ func CreateItems(f *framework.Framework, ns *v1.Namespace, items ...interface{})
 		// description = fmt.Sprintf("%s:\n%s", description, PrettyPrint(item))
 		framework.Logf("creating %s", description)
 		for _, factory := range factories {
-			destructor, err := factory.Create(f, ns, item)
+			destructor, err := factory.Create(ctx, f, ns, item)
 			if destructor != nil {
 				ginkgo.DeferCleanup(framework.IgnoreNotFound(destructor), framework.AnnotatedLocation(fmt.Sprintf("deleting %s", description)))
 			}
@@ -175,7 +175,7 @@ func CreateItems(f *framework.Framework, ns *v1.Namespace, items ...interface{})
 // CreateFromManifests is a combination of LoadFromManifests,
 // PatchItems, patching with an optional custom function,
 // and CreateItems.
-func CreateFromManifests(f *framework.Framework, driverNamespace *v1.Namespace, patch func(item interface{}) error, files ...string) error {
+func CreateFromManifests(ctx context.Context, f *framework.Framework, driverNamespace *v1.Namespace, patch func(item interface{}) error, files ...string) error {
 	items, err := LoadFromManifests(files...)
 	if err != nil {
 		return fmt.Errorf("CreateFromManifests: %w", err)
@@ -190,7 +190,7 @@ func CreateFromManifests(f *framework.Framework, driverNamespace *v1.Namespace, 
 			}
 		}
 	}
-	return CreateItems(f, driverNamespace, items...)
+	return CreateItems(ctx, f, driverNamespace, items...)
 }
 
 // What is a subset of metav1.TypeMeta which (in contrast to
@@ -230,7 +230,7 @@ type ItemFactory interface {
 	// error or a cleanup function for the created item.
 	// If the item is of an unsupported type, it must return
 	// an error that has errorItemNotSupported as cause.
-	Create(f *framework.Framework, ns *v1.Namespace, item interface{}) (func() error, error)
+	Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, item interface{}) (func(ctx context.Context) error, error)
 }
 
 // describeItem always returns a string that describes the item,
@@ -389,17 +389,17 @@ func (f *serviceAccountFactory) New() runtime.Object {
 	return &v1.ServiceAccount{}
 }
 
-func (*serviceAccountFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*serviceAccountFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*v1.ServiceAccount)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 	client := f.ClientSet.CoreV1().ServiceAccounts(ns.Name)
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create ServiceAccount: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -409,7 +409,7 @@ func (f *clusterRoleFactory) New() runtime.Object {
 	return &rbacv1.ClusterRole{}
 }
 
-func (*clusterRoleFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*clusterRoleFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*rbacv1.ClusterRole)
 	if !ok {
 		return nil, errorItemNotSupported
@@ -417,11 +417,11 @@ func (*clusterRoleFactory) Create(f *framework.Framework, ns *v1.Namespace, i in
 
 	framework.Logf("Define cluster role %v", item.GetName())
 	client := f.ClientSet.RbacV1().ClusterRoles()
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create ClusterRole: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -431,18 +431,18 @@ func (f *clusterRoleBindingFactory) New() runtime.Object {
 	return &rbacv1.ClusterRoleBinding{}
 }
 
-func (*clusterRoleBindingFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*clusterRoleBindingFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*rbacv1.ClusterRoleBinding)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
 	client := f.ClientSet.RbacV1().ClusterRoleBindings()
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create ClusterRoleBinding: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -452,18 +452,18 @@ func (f *roleFactory) New() runtime.Object {
 	return &rbacv1.Role{}
 }
 
-func (*roleFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*roleFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*rbacv1.Role)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
 	client := f.ClientSet.RbacV1().Roles(ns.Name)
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create Role: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -473,18 +473,18 @@ func (f *roleBindingFactory) New() runtime.Object {
 	return &rbacv1.RoleBinding{}
 }
 
-func (*roleBindingFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*roleBindingFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*rbacv1.RoleBinding)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
 	client := f.ClientSet.RbacV1().RoleBindings(ns.Name)
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create RoleBinding: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -494,18 +494,18 @@ func (f *serviceFactory) New() runtime.Object {
 	return &v1.Service{}
 }
 
-func (*serviceFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*serviceFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*v1.Service)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
 	client := f.ClientSet.CoreV1().Services(ns.Name)
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create Service: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -515,18 +515,18 @@ func (f *statefulSetFactory) New() runtime.Object {
 	return &appsv1.StatefulSet{}
 }
 
-func (*statefulSetFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*statefulSetFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*appsv1.StatefulSet)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
 	client := f.ClientSet.AppsV1().StatefulSets(ns.Name)
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create StatefulSet: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -536,18 +536,18 @@ func (f *deploymentFactory) New() runtime.Object {
 	return &appsv1.Deployment{}
 }
 
-func (*deploymentFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*deploymentFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*appsv1.Deployment)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
 	client := f.ClientSet.AppsV1().Deployments(ns.Name)
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create Deployment: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -557,18 +557,18 @@ func (f *daemonSetFactory) New() runtime.Object {
 	return &appsv1.DaemonSet{}
 }
 
-func (*daemonSetFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*daemonSetFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*appsv1.DaemonSet)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
 	client := f.ClientSet.AppsV1().DaemonSets(ns.Name)
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create DaemonSet: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -578,18 +578,18 @@ func (f *replicaSetFactory) New() runtime.Object {
 	return &appsv1.ReplicaSet{}
 }
 
-func (*replicaSetFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*replicaSetFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*appsv1.ReplicaSet)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
 	client := f.ClientSet.AppsV1().ReplicaSets(ns.Name)
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create ReplicaSet: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -599,18 +599,18 @@ func (f *storageClassFactory) New() runtime.Object {
 	return &storagev1.StorageClass{}
 }
 
-func (*storageClassFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*storageClassFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*storagev1.StorageClass)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
 	client := f.ClientSet.StorageV1().StorageClasses()
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create StorageClass: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -620,18 +620,18 @@ func (f *csiDriverFactory) New() runtime.Object {
 	return &storagev1.CSIDriver{}
 }
 
-func (*csiDriverFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*csiDriverFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*storagev1.CSIDriver)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
 	client := f.ClientSet.StorageV1().CSIDrivers()
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create CSIDriver: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -641,18 +641,18 @@ func (f *secretFactory) New() runtime.Object {
 	return &v1.Secret{}
 }
 
-func (*secretFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*secretFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	item, ok := i.(*v1.Secret)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
 	client := f.ClientSet.CoreV1().Secrets(ns.Name)
-	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create Secret: %w", err)
 	}
-	return func() error {
-		return client.Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -662,7 +662,7 @@ func (f *customResourceDefinitionFactory) New() runtime.Object {
 	return &apiextensionsv1.CustomResourceDefinition{}
 }
 
-func (*customResourceDefinitionFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
+func (*customResourceDefinitionFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
 	var err error
 	unstructCRD := &unstructured.Unstructured{}
 	gvr := schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
@@ -677,11 +677,11 @@ func (*customResourceDefinitionFactory) Create(f *framework.Framework, ns *v1.Na
 		return nil, err
 	}
 
-	if _, err = f.DynamicClient.Resource(gvr).Create(context.TODO(), unstructCRD, metav1.CreateOptions{}); err != nil {
+	if _, err = f.DynamicClient.Resource(gvr).Create(ctx, unstructCRD, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("create CustomResourceDefinition: %w", err)
 	}
-	return func() error {
-		return f.DynamicClient.Resource(gvr).Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	return func(ctx context.Context) error {
+		return f.DynamicClient.Resource(gvr).Delete(ctx, item.GetName(), metav1.DeleteOptions{})
 	}, nil
 }
 

--- a/test/e2e/storage/utils/host_exec.go
+++ b/test/e2e/storage/utils/host_exec.go
@@ -47,10 +47,10 @@ func LogResult(result Result) {
 
 // HostExec represents interface we require to execute commands on remote host.
 type HostExec interface {
-	Execute(cmd string, node *v1.Node) (Result, error)
-	IssueCommandWithResult(cmd string, node *v1.Node) (string, error)
-	IssueCommand(cmd string, node *v1.Node) error
-	Cleanup()
+	Execute(ctx context.Context, cmd string, node *v1.Node) (Result, error)
+	IssueCommandWithResult(ctx context.Context, cmd string, node *v1.Node) (string, error)
+	IssueCommand(ctx context.Context, cmd string, node *v1.Node) error
+	Cleanup(ctx context.Context)
 }
 
 // hostExecutor implements HostExec
@@ -69,7 +69,7 @@ func NewHostExec(framework *framework.Framework) HostExec {
 
 // launchNodeExecPod launches a hostexec pod for local PV and waits
 // until it's Running.
-func (h *hostExecutor) launchNodeExecPod(node string) *v1.Pod {
+func (h *hostExecutor) launchNodeExecPod(ctx context.Context, node string) *v1.Pod {
 	f := h.Framework
 	cs := f.ClientSet
 	ns := f.Namespace
@@ -104,9 +104,9 @@ func (h *hostExecutor) launchNodeExecPod(node string) *v1.Pod {
 			return &privileged
 		}(true),
 	}
-	pod, err := cs.CoreV1().Pods(ns.Name).Create(context.TODO(), hostExecPod, metav1.CreateOptions{})
+	pod, err := cs.CoreV1().Pods(ns.Name).Create(ctx, hostExecPod, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
-	err = e2epod.WaitTimeoutForPodRunningInNamespace(cs, pod.Name, pod.Namespace, f.Timeouts.PodStart)
+	err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, cs, pod.Name, pod.Namespace, f.Timeouts.PodStart)
 	framework.ExpectNoError(err)
 	return pod
 }
@@ -115,8 +115,8 @@ func (h *hostExecutor) launchNodeExecPod(node string) *v1.Pod {
 // performing the remote command execution, the stdout, stderr and exit code
 // are returned.
 // This works like ssh.SSH(...) utility.
-func (h *hostExecutor) Execute(cmd string, node *v1.Node) (Result, error) {
-	result, err := h.exec(cmd, node)
+func (h *hostExecutor) Execute(ctx context.Context, cmd string, node *v1.Node) (Result, error) {
+	result, err := h.exec(ctx, cmd, node)
 	if codeExitErr, ok := err.(exec.CodeExitError); ok {
 		// extract the exit code of remote command and silence the command
 		// non-zero exit code error
@@ -126,14 +126,14 @@ func (h *hostExecutor) Execute(cmd string, node *v1.Node) (Result, error) {
 	return result, err
 }
 
-func (h *hostExecutor) exec(cmd string, node *v1.Node) (Result, error) {
+func (h *hostExecutor) exec(ctx context.Context, cmd string, node *v1.Node) (Result, error) {
 	result := Result{
 		Host: node.Name,
 		Cmd:  cmd,
 	}
 	pod, ok := h.nodeExecPods[node.Name]
 	if !ok {
-		pod = h.launchNodeExecPod(node.Name)
+		pod = h.launchNodeExecPod(ctx, node.Name)
 		if pod == nil {
 			return result, fmt.Errorf("failed to create hostexec pod for node %q", node)
 		}
@@ -165,8 +165,8 @@ func (h *hostExecutor) exec(cmd string, node *v1.Node) (Result, error) {
 // IssueCommandWithResult issues command on the given node and returns stdout as
 // result. It returns error if there are some issues executing the command or
 // the command exits non-zero.
-func (h *hostExecutor) IssueCommandWithResult(cmd string, node *v1.Node) (string, error) {
-	result, err := h.exec(cmd, node)
+func (h *hostExecutor) IssueCommandWithResult(ctx context.Context, cmd string, node *v1.Node) (string, error) {
+	result, err := h.exec(ctx, cmd, node)
 	if err != nil {
 		LogResult(result)
 	}
@@ -174,17 +174,17 @@ func (h *hostExecutor) IssueCommandWithResult(cmd string, node *v1.Node) (string
 }
 
 // IssueCommand works like IssueCommandWithResult, but discards result.
-func (h *hostExecutor) IssueCommand(cmd string, node *v1.Node) error {
-	_, err := h.IssueCommandWithResult(cmd, node)
+func (h *hostExecutor) IssueCommand(ctx context.Context, cmd string, node *v1.Node) error {
+	_, err := h.IssueCommandWithResult(ctx, cmd, node)
 	return err
 }
 
 // Cleanup cleanup resources it created during test.
 // Note that in most cases it is not necessary to call this because we create
 // pods under test namespace which will be destroyed in teardown phase.
-func (h *hostExecutor) Cleanup() {
+func (h *hostExecutor) Cleanup(ctx context.Context) {
 	for _, pod := range h.nodeExecPods {
-		e2epod.DeletePodOrFail(h.Framework.ClientSet, pod.Namespace, pod.Name)
+		e2epod.DeletePodOrFail(ctx, h.Framework.ClientSet, pod.Namespace, pod.Name)
 	}
 	h.nodeExecPods = make(map[string]*v1.Pod)
 }

--- a/test/e2e/storage/utils/local.go
+++ b/test/e2e/storage/utils/local.go
@@ -21,6 +21,7 @@ package utils
  */
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -69,9 +70,9 @@ type LocalTestResource struct {
 
 // LocalTestResourceManager represents interface to create/destroy local test resources on node
 type LocalTestResourceManager interface {
-	Create(node *v1.Node, volumeType LocalVolumeType, parameters map[string]string) *LocalTestResource
-	ExpandBlockDevice(ltr *LocalTestResource, mbToAdd int) error
-	Remove(ltr *LocalTestResource)
+	Create(ctx context.Context, node *v1.Node, volumeType LocalVolumeType, parameters map[string]string) *LocalTestResource
+	ExpandBlockDevice(ctx context.Context, ltr *LocalTestResource, mbToAdd int) error
+	Remove(ctx context.Context, ltr *LocalTestResource)
 }
 
 // ltrMgr implements LocalTestResourceManager
@@ -98,10 +99,10 @@ func (l *ltrMgr) getTestDir() string {
 	return filepath.Join(l.hostBase, testDirName)
 }
 
-func (l *ltrMgr) setupLocalVolumeTmpfs(node *v1.Node, parameters map[string]string) *LocalTestResource {
+func (l *ltrMgr) setupLocalVolumeTmpfs(ctx context.Context, node *v1.Node, parameters map[string]string) *LocalTestResource {
 	hostDir := l.getTestDir()
 	ginkgo.By(fmt.Sprintf("Creating tmpfs mount point on node %q at path %q", node.Name, hostDir))
-	err := l.hostExec.IssueCommand(fmt.Sprintf("mkdir -p %q && mount -t tmpfs -o size=10m tmpfs-%q %q", hostDir, hostDir, hostDir), node)
+	err := l.hostExec.IssueCommand(ctx, fmt.Sprintf("mkdir -p %q && mount -t tmpfs -o size=10m tmpfs-%q %q", hostDir, hostDir, hostDir), node)
 	framework.ExpectNoError(err)
 	return &LocalTestResource{
 		Node: node,
@@ -109,18 +110,18 @@ func (l *ltrMgr) setupLocalVolumeTmpfs(node *v1.Node, parameters map[string]stri
 	}
 }
 
-func (l *ltrMgr) cleanupLocalVolumeTmpfs(ltr *LocalTestResource) {
+func (l *ltrMgr) cleanupLocalVolumeTmpfs(ctx context.Context, ltr *LocalTestResource) {
 	ginkgo.By(fmt.Sprintf("Unmount tmpfs mount point on node %q at path %q", ltr.Node.Name, ltr.Path))
-	err := l.hostExec.IssueCommand(fmt.Sprintf("umount %q", ltr.Path), ltr.Node)
+	err := l.hostExec.IssueCommand(ctx, fmt.Sprintf("umount %q", ltr.Path), ltr.Node)
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Removing the test directory")
-	err = l.hostExec.IssueCommand(fmt.Sprintf("rm -r %s", ltr.Path), ltr.Node)
+	err = l.hostExec.IssueCommand(ctx, fmt.Sprintf("rm -r %s", ltr.Path), ltr.Node)
 	framework.ExpectNoError(err)
 }
 
 // createAndSetupLoopDevice creates an empty file and associates a loop devie with it.
-func (l *ltrMgr) createAndSetupLoopDevice(dir string, node *v1.Node, size int) {
+func (l *ltrMgr) createAndSetupLoopDevice(ctx context.Context, dir string, node *v1.Node, size int) {
 	ginkgo.By(fmt.Sprintf("Creating block device on node %q using path %q", node.Name, dir))
 	mkdirCmd := fmt.Sprintf("mkdir -p %s", dir)
 	count := size / 4096
@@ -130,22 +131,22 @@ func (l *ltrMgr) createAndSetupLoopDevice(dir string, node *v1.Node, size int) {
 	}
 	ddCmd := fmt.Sprintf("dd if=/dev/zero of=%s/file bs=4096 count=%d", dir, count)
 	losetupCmd := fmt.Sprintf("losetup -f %s/file", dir)
-	err := l.hostExec.IssueCommand(fmt.Sprintf("%s && %s && %s", mkdirCmd, ddCmd, losetupCmd), node)
+	err := l.hostExec.IssueCommand(ctx, fmt.Sprintf("%s && %s && %s", mkdirCmd, ddCmd, losetupCmd), node)
 	framework.ExpectNoError(err)
 }
 
 // findLoopDevice finds loop device path by its associated storage directory.
-func (l *ltrMgr) findLoopDevice(dir string, node *v1.Node) string {
+func (l *ltrMgr) findLoopDevice(ctx context.Context, dir string, node *v1.Node) string {
 	cmd := fmt.Sprintf("E2E_LOOP_DEV=$(losetup | grep %s/file | awk '{ print $1 }') 2>&1 > /dev/null && echo ${E2E_LOOP_DEV}", dir)
-	loopDevResult, err := l.hostExec.IssueCommandWithResult(cmd, node)
+	loopDevResult, err := l.hostExec.IssueCommandWithResult(ctx, cmd, node)
 	framework.ExpectNoError(err)
 	return strings.TrimSpace(loopDevResult)
 }
 
-func (l *ltrMgr) setupLocalVolumeBlock(node *v1.Node, parameters map[string]string) *LocalTestResource {
+func (l *ltrMgr) setupLocalVolumeBlock(ctx context.Context, node *v1.Node, parameters map[string]string) *LocalTestResource {
 	loopDir := l.getTestDir()
-	l.createAndSetupLoopDevice(loopDir, node, 20*1024*1024)
-	loopDev := l.findLoopDevice(loopDir, node)
+	l.createAndSetupLoopDevice(ctx, loopDir, node, 20*1024*1024)
+	loopDev := l.findLoopDevice(ctx, loopDir, node)
 	return &LocalTestResource{
 		Node:    node,
 		Path:    loopDev,
@@ -154,30 +155,30 @@ func (l *ltrMgr) setupLocalVolumeBlock(node *v1.Node, parameters map[string]stri
 }
 
 // teardownLoopDevice tears down loop device by its associated storage directory.
-func (l *ltrMgr) teardownLoopDevice(dir string, node *v1.Node) {
-	loopDev := l.findLoopDevice(dir, node)
+func (l *ltrMgr) teardownLoopDevice(ctx context.Context, dir string, node *v1.Node) {
+	loopDev := l.findLoopDevice(ctx, dir, node)
 	ginkgo.By(fmt.Sprintf("Tear down block device %q on node %q at path %s/file", loopDev, node.Name, dir))
 	losetupDeleteCmd := fmt.Sprintf("losetup -d %s", loopDev)
-	err := l.hostExec.IssueCommand(losetupDeleteCmd, node)
+	err := l.hostExec.IssueCommand(ctx, losetupDeleteCmd, node)
 	framework.ExpectNoError(err)
 	return
 }
 
-func (l *ltrMgr) cleanupLocalVolumeBlock(ltr *LocalTestResource) {
-	l.teardownLoopDevice(ltr.loopDir, ltr.Node)
+func (l *ltrMgr) cleanupLocalVolumeBlock(ctx context.Context, ltr *LocalTestResource) {
+	l.teardownLoopDevice(ctx, ltr.loopDir, ltr.Node)
 	ginkgo.By(fmt.Sprintf("Removing the test directory %s", ltr.loopDir))
 	removeCmd := fmt.Sprintf("rm -r %s", ltr.loopDir)
-	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
+	err := l.hostExec.IssueCommand(ctx, removeCmd, ltr.Node)
 	framework.ExpectNoError(err)
 }
 
-func (l *ltrMgr) setupLocalVolumeBlockFS(node *v1.Node, parameters map[string]string) *LocalTestResource {
-	ltr := l.setupLocalVolumeBlock(node, parameters)
+func (l *ltrMgr) setupLocalVolumeBlockFS(ctx context.Context, node *v1.Node, parameters map[string]string) *LocalTestResource {
+	ltr := l.setupLocalVolumeBlock(ctx, node, parameters)
 	loopDev := ltr.Path
 	loopDir := ltr.loopDir
 	// Format and mount at loopDir and give others rwx for read/write testing
 	cmd := fmt.Sprintf("mkfs -t ext4 %s && mount -t ext4 %s %s && chmod o+rwx %s", loopDev, loopDev, loopDir, loopDir)
-	err := l.hostExec.IssueCommand(cmd, node)
+	err := l.hostExec.IssueCommand(ctx, cmd, node)
 	framework.ExpectNoError(err)
 	return &LocalTestResource{
 		Node:    node,
@@ -186,17 +187,17 @@ func (l *ltrMgr) setupLocalVolumeBlockFS(node *v1.Node, parameters map[string]st
 	}
 }
 
-func (l *ltrMgr) cleanupLocalVolumeBlockFS(ltr *LocalTestResource) {
+func (l *ltrMgr) cleanupLocalVolumeBlockFS(ctx context.Context, ltr *LocalTestResource) {
 	umountCmd := fmt.Sprintf("umount %s", ltr.Path)
-	err := l.hostExec.IssueCommand(umountCmd, ltr.Node)
+	err := l.hostExec.IssueCommand(ctx, umountCmd, ltr.Node)
 	framework.ExpectNoError(err)
-	l.cleanupLocalVolumeBlock(ltr)
+	l.cleanupLocalVolumeBlock(ctx, ltr)
 }
 
-func (l *ltrMgr) setupLocalVolumeDirectory(node *v1.Node, parameters map[string]string) *LocalTestResource {
+func (l *ltrMgr) setupLocalVolumeDirectory(ctx context.Context, node *v1.Node, parameters map[string]string) *LocalTestResource {
 	hostDir := l.getTestDir()
 	mkdirCmd := fmt.Sprintf("mkdir -p %s", hostDir)
-	err := l.hostExec.IssueCommand(mkdirCmd, node)
+	err := l.hostExec.IssueCommand(ctx, mkdirCmd, node)
 	framework.ExpectNoError(err)
 	return &LocalTestResource{
 		Node: node,
@@ -204,18 +205,18 @@ func (l *ltrMgr) setupLocalVolumeDirectory(node *v1.Node, parameters map[string]
 	}
 }
 
-func (l *ltrMgr) cleanupLocalVolumeDirectory(ltr *LocalTestResource) {
+func (l *ltrMgr) cleanupLocalVolumeDirectory(ctx context.Context, ltr *LocalTestResource) {
 	ginkgo.By("Removing the test directory")
 	removeCmd := fmt.Sprintf("rm -r %s", ltr.Path)
-	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
+	err := l.hostExec.IssueCommand(ctx, removeCmd, ltr.Node)
 	framework.ExpectNoError(err)
 }
 
-func (l *ltrMgr) setupLocalVolumeDirectoryLink(node *v1.Node, parameters map[string]string) *LocalTestResource {
+func (l *ltrMgr) setupLocalVolumeDirectoryLink(ctx context.Context, node *v1.Node, parameters map[string]string) *LocalTestResource {
 	hostDir := l.getTestDir()
 	hostDirBackend := hostDir + "-backend"
 	cmd := fmt.Sprintf("mkdir %s && ln -s %s %s", hostDirBackend, hostDirBackend, hostDir)
-	err := l.hostExec.IssueCommand(cmd, node)
+	err := l.hostExec.IssueCommand(ctx, cmd, node)
 	framework.ExpectNoError(err)
 	return &LocalTestResource{
 		Node: node,
@@ -223,19 +224,19 @@ func (l *ltrMgr) setupLocalVolumeDirectoryLink(node *v1.Node, parameters map[str
 	}
 }
 
-func (l *ltrMgr) cleanupLocalVolumeDirectoryLink(ltr *LocalTestResource) {
+func (l *ltrMgr) cleanupLocalVolumeDirectoryLink(ctx context.Context, ltr *LocalTestResource) {
 	ginkgo.By("Removing the test directory")
 	hostDir := ltr.Path
 	hostDirBackend := hostDir + "-backend"
 	removeCmd := fmt.Sprintf("rm -r %s && rm -r %s", hostDir, hostDirBackend)
-	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
+	err := l.hostExec.IssueCommand(ctx, removeCmd, ltr.Node)
 	framework.ExpectNoError(err)
 }
 
-func (l *ltrMgr) setupLocalVolumeDirectoryBindMounted(node *v1.Node, parameters map[string]string) *LocalTestResource {
+func (l *ltrMgr) setupLocalVolumeDirectoryBindMounted(ctx context.Context, node *v1.Node, parameters map[string]string) *LocalTestResource {
 	hostDir := l.getTestDir()
 	cmd := fmt.Sprintf("mkdir %s && mount --bind %s %s", hostDir, hostDir, hostDir)
-	err := l.hostExec.IssueCommand(cmd, node)
+	err := l.hostExec.IssueCommand(ctx, cmd, node)
 	framework.ExpectNoError(err)
 	return &LocalTestResource{
 		Node: node,
@@ -243,19 +244,19 @@ func (l *ltrMgr) setupLocalVolumeDirectoryBindMounted(node *v1.Node, parameters 
 	}
 }
 
-func (l *ltrMgr) cleanupLocalVolumeDirectoryBindMounted(ltr *LocalTestResource) {
+func (l *ltrMgr) cleanupLocalVolumeDirectoryBindMounted(ctx context.Context, ltr *LocalTestResource) {
 	ginkgo.By("Removing the test directory")
 	hostDir := ltr.Path
 	removeCmd := fmt.Sprintf("umount %s && rm -r %s", hostDir, hostDir)
-	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
+	err := l.hostExec.IssueCommand(ctx, removeCmd, ltr.Node)
 	framework.ExpectNoError(err)
 }
 
-func (l *ltrMgr) setupLocalVolumeDirectoryLinkBindMounted(node *v1.Node, parameters map[string]string) *LocalTestResource {
+func (l *ltrMgr) setupLocalVolumeDirectoryLinkBindMounted(ctx context.Context, node *v1.Node, parameters map[string]string) *LocalTestResource {
 	hostDir := l.getTestDir()
 	hostDirBackend := hostDir + "-backend"
 	cmd := fmt.Sprintf("mkdir %s && mount --bind %s %s && ln -s %s %s", hostDirBackend, hostDirBackend, hostDirBackend, hostDirBackend, hostDir)
-	err := l.hostExec.IssueCommand(cmd, node)
+	err := l.hostExec.IssueCommand(ctx, cmd, node)
 	framework.ExpectNoError(err)
 	return &LocalTestResource{
 		Node: node,
@@ -263,17 +264,17 @@ func (l *ltrMgr) setupLocalVolumeDirectoryLinkBindMounted(node *v1.Node, paramet
 	}
 }
 
-func (l *ltrMgr) cleanupLocalVolumeDirectoryLinkBindMounted(ltr *LocalTestResource) {
+func (l *ltrMgr) cleanupLocalVolumeDirectoryLinkBindMounted(ctx context.Context, ltr *LocalTestResource) {
 	ginkgo.By("Removing the test directory")
 	hostDir := ltr.Path
 	hostDirBackend := hostDir + "-backend"
 	removeCmd := fmt.Sprintf("rm %s && umount %s && rm -r %s", hostDir, hostDirBackend, hostDirBackend)
-	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
+	err := l.hostExec.IssueCommand(ctx, removeCmd, ltr.Node)
 	framework.ExpectNoError(err)
 }
 
-func (l *ltrMgr) setupLocalVolumeGCELocalSSD(node *v1.Node, parameters map[string]string) *LocalTestResource {
-	res, err := l.hostExec.IssueCommandWithResult("ls /mnt/disks/by-uuid/google-local-ssds-scsi-fs/", node)
+func (l *ltrMgr) setupLocalVolumeGCELocalSSD(ctx context.Context, node *v1.Node, parameters map[string]string) *LocalTestResource {
+	res, err := l.hostExec.IssueCommandWithResult(ctx, "ls /mnt/disks/by-uuid/google-local-ssds-scsi-fs/", node)
 	framework.ExpectNoError(err)
 	dirName := strings.Fields(res)[0]
 	hostDir := "/mnt/disks/by-uuid/google-local-ssds-scsi-fs/" + dirName
@@ -283,47 +284,47 @@ func (l *ltrMgr) setupLocalVolumeGCELocalSSD(node *v1.Node, parameters map[strin
 	}
 }
 
-func (l *ltrMgr) cleanupLocalVolumeGCELocalSSD(ltr *LocalTestResource) {
+func (l *ltrMgr) cleanupLocalVolumeGCELocalSSD(ctx context.Context, ltr *LocalTestResource) {
 	// This filesystem is attached in cluster initialization, we clean all files to make it reusable.
 	removeCmd := fmt.Sprintf("find '%s' -mindepth 1 -maxdepth 1 -print0 | xargs -r -0 rm -rf", ltr.Path)
-	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
+	err := l.hostExec.IssueCommand(ctx, removeCmd, ltr.Node)
 	framework.ExpectNoError(err)
 }
 
-func (l *ltrMgr) expandLocalVolumeBlockFS(ltr *LocalTestResource, mbToAdd int) error {
+func (l *ltrMgr) expandLocalVolumeBlockFS(ctx context.Context, ltr *LocalTestResource, mbToAdd int) error {
 	ddCmd := fmt.Sprintf("dd if=/dev/zero of=%s/file conv=notrunc oflag=append bs=1M count=%d", ltr.loopDir, mbToAdd)
-	loopDev := l.findLoopDevice(ltr.loopDir, ltr.Node)
+	loopDev := l.findLoopDevice(ctx, ltr.loopDir, ltr.Node)
 	losetupCmd := fmt.Sprintf("losetup -c %s", loopDev)
-	return l.hostExec.IssueCommand(fmt.Sprintf("%s && %s", ddCmd, losetupCmd), ltr.Node)
+	return l.hostExec.IssueCommand(ctx, fmt.Sprintf("%s && %s", ddCmd, losetupCmd), ltr.Node)
 }
 
-func (l *ltrMgr) ExpandBlockDevice(ltr *LocalTestResource, mbtoAdd int) error {
+func (l *ltrMgr) ExpandBlockDevice(ctx context.Context, ltr *LocalTestResource, mbtoAdd int) error {
 	switch ltr.VolumeType {
 	case LocalVolumeBlockFS:
-		return l.expandLocalVolumeBlockFS(ltr, mbtoAdd)
+		return l.expandLocalVolumeBlockFS(ctx, ltr, mbtoAdd)
 	}
 	return fmt.Errorf("Failed to expand local test resource, unsupported volume type: %s", ltr.VolumeType)
 }
 
-func (l *ltrMgr) Create(node *v1.Node, volumeType LocalVolumeType, parameters map[string]string) *LocalTestResource {
+func (l *ltrMgr) Create(ctx context.Context, node *v1.Node, volumeType LocalVolumeType, parameters map[string]string) *LocalTestResource {
 	var ltr *LocalTestResource
 	switch volumeType {
 	case LocalVolumeDirectory:
-		ltr = l.setupLocalVolumeDirectory(node, parameters)
+		ltr = l.setupLocalVolumeDirectory(ctx, node, parameters)
 	case LocalVolumeDirectoryLink:
-		ltr = l.setupLocalVolumeDirectoryLink(node, parameters)
+		ltr = l.setupLocalVolumeDirectoryLink(ctx, node, parameters)
 	case LocalVolumeDirectoryBindMounted:
-		ltr = l.setupLocalVolumeDirectoryBindMounted(node, parameters)
+		ltr = l.setupLocalVolumeDirectoryBindMounted(ctx, node, parameters)
 	case LocalVolumeDirectoryLinkBindMounted:
-		ltr = l.setupLocalVolumeDirectoryLinkBindMounted(node, parameters)
+		ltr = l.setupLocalVolumeDirectoryLinkBindMounted(ctx, node, parameters)
 	case LocalVolumeTmpfs:
-		ltr = l.setupLocalVolumeTmpfs(node, parameters)
+		ltr = l.setupLocalVolumeTmpfs(ctx, node, parameters)
 	case LocalVolumeBlock:
-		ltr = l.setupLocalVolumeBlock(node, parameters)
+		ltr = l.setupLocalVolumeBlock(ctx, node, parameters)
 	case LocalVolumeBlockFS:
-		ltr = l.setupLocalVolumeBlockFS(node, parameters)
+		ltr = l.setupLocalVolumeBlockFS(ctx, node, parameters)
 	case LocalVolumeGCELocalSSD:
-		ltr = l.setupLocalVolumeGCELocalSSD(node, parameters)
+		ltr = l.setupLocalVolumeGCELocalSSD(ctx, node, parameters)
 	default:
 		framework.Failf("Failed to create local test resource on node %q, unsupported volume type: %v is specified", node.Name, volumeType)
 		return nil
@@ -335,24 +336,24 @@ func (l *ltrMgr) Create(node *v1.Node, volumeType LocalVolumeType, parameters ma
 	return ltr
 }
 
-func (l *ltrMgr) Remove(ltr *LocalTestResource) {
+func (l *ltrMgr) Remove(ctx context.Context, ltr *LocalTestResource) {
 	switch ltr.VolumeType {
 	case LocalVolumeDirectory:
-		l.cleanupLocalVolumeDirectory(ltr)
+		l.cleanupLocalVolumeDirectory(ctx, ltr)
 	case LocalVolumeDirectoryLink:
-		l.cleanupLocalVolumeDirectoryLink(ltr)
+		l.cleanupLocalVolumeDirectoryLink(ctx, ltr)
 	case LocalVolumeDirectoryBindMounted:
-		l.cleanupLocalVolumeDirectoryBindMounted(ltr)
+		l.cleanupLocalVolumeDirectoryBindMounted(ctx, ltr)
 	case LocalVolumeDirectoryLinkBindMounted:
-		l.cleanupLocalVolumeDirectoryLinkBindMounted(ltr)
+		l.cleanupLocalVolumeDirectoryLinkBindMounted(ctx, ltr)
 	case LocalVolumeTmpfs:
-		l.cleanupLocalVolumeTmpfs(ltr)
+		l.cleanupLocalVolumeTmpfs(ctx, ltr)
 	case LocalVolumeBlock:
-		l.cleanupLocalVolumeBlock(ltr)
+		l.cleanupLocalVolumeBlock(ctx, ltr)
 	case LocalVolumeBlockFS:
-		l.cleanupLocalVolumeBlockFS(ltr)
+		l.cleanupLocalVolumeBlockFS(ctx, ltr)
 	case LocalVolumeGCELocalSSD:
-		l.cleanupLocalVolumeGCELocalSSD(ltr)
+		l.cleanupLocalVolumeGCELocalSSD(ctx, ltr)
 	default:
 		framework.Failf("Failed to remove local test resource, unsupported volume type: %v is specified", ltr.VolumeType)
 	}

--- a/test/e2e/storage/utils/utils.go
+++ b/test/e2e/storage/utils/utils.go
@@ -75,7 +75,7 @@ func VerifyFSGroupInPod(f *framework.Framework, filePath, expectedFSGroup string
 }
 
 // getKubeletMainPid return the Main PID of the Kubelet Process
-func getKubeletMainPid(nodeIP string, sudoPresent bool, systemctlPresent bool) string {
+func getKubeletMainPid(ctx context.Context, nodeIP string, sudoPresent bool, systemctlPresent bool) string {
 	command := ""
 	if systemctlPresent {
 		command = "systemctl status kubelet | grep 'Main PID'"
@@ -86,7 +86,7 @@ func getKubeletMainPid(nodeIP string, sudoPresent bool, systemctlPresent bool) s
 		command = fmt.Sprintf("sudo %s", command)
 	}
 	framework.Logf("Attempting `%s`", command)
-	sshResult, err := e2essh.SSH(command, nodeIP, framework.TestContext.Provider)
+	sshResult, err := e2essh.SSH(ctx, command, nodeIP, framework.TestContext.Provider)
 	framework.ExpectNoError(err, fmt.Sprintf("SSH to Node %q errored.", nodeIP))
 	e2essh.LogResult(sshResult)
 	gomega.Expect(sshResult.Code).To(gomega.BeZero(), "Failed to get kubelet PID")
@@ -95,7 +95,7 @@ func getKubeletMainPid(nodeIP string, sudoPresent bool, systemctlPresent bool) s
 }
 
 // TestKubeletRestartsAndRestoresMount tests that a volume mounted to a pod remains mounted after a kubelet restarts
-func TestKubeletRestartsAndRestoresMount(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, volumePath string) {
+func TestKubeletRestartsAndRestoresMount(ctx context.Context, c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, volumePath string) {
 	byteLen := 64
 	seed := time.Now().UTC().UnixNano()
 
@@ -103,7 +103,7 @@ func TestKubeletRestartsAndRestoresMount(c clientset.Interface, f *framework.Fra
 	CheckWriteToPath(f, clientPod, v1.PersistentVolumeFilesystem, false, volumePath, byteLen, seed)
 
 	ginkgo.By("Restarting kubelet")
-	KubeletCommand(KRestart, c, clientPod)
+	KubeletCommand(ctx, KRestart, c, clientPod)
 
 	ginkgo.By("Testing that written file is accessible.")
 	CheckReadFromPath(f, clientPod, v1.PersistentVolumeFilesystem, false, volumePath, byteLen, seed)
@@ -112,7 +112,7 @@ func TestKubeletRestartsAndRestoresMount(c clientset.Interface, f *framework.Fra
 }
 
 // TestKubeletRestartsAndRestoresMap tests that a volume mapped to a pod remains mapped after a kubelet restarts
-func TestKubeletRestartsAndRestoresMap(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, volumePath string) {
+func TestKubeletRestartsAndRestoresMap(ctx context.Context, c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, volumePath string) {
 	byteLen := 64
 	seed := time.Now().UTC().UnixNano()
 
@@ -120,7 +120,7 @@ func TestKubeletRestartsAndRestoresMap(c clientset.Interface, f *framework.Frame
 	CheckWriteToPath(f, clientPod, v1.PersistentVolumeBlock, false, volumePath, byteLen, seed)
 
 	ginkgo.By("Restarting kubelet")
-	KubeletCommand(KRestart, c, clientPod)
+	KubeletCommand(ctx, KRestart, c, clientPod)
 
 	ginkgo.By("Testing that written pv is accessible.")
 	CheckReadFromPath(f, clientPod, v1.PersistentVolumeBlock, false, volumePath, byteLen, seed)
@@ -132,20 +132,20 @@ func TestKubeletRestartsAndRestoresMap(c clientset.Interface, f *framework.Frame
 // forceDelete is true indicating whether the pod is forcefully deleted.
 // checkSubpath is true indicating whether the subpath should be checked.
 // If secondPod is set, it is started when kubelet is down to check that the volume is usable while the old pod is being deleted and the new pod is starting.
-func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, forceDelete bool, checkSubpath bool, secondPod *v1.Pod, volumePath string) {
-	nodeIP, err := getHostAddress(c, clientPod)
+func TestVolumeUnmountsFromDeletedPodWithForceOption(ctx context.Context, c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, forceDelete bool, checkSubpath bool, secondPod *v1.Pod, volumePath string) {
+	nodeIP, err := getHostAddress(ctx, c, clientPod)
 	framework.ExpectNoError(err)
 	nodeIP = nodeIP + ":22"
 
 	ginkgo.By("Expecting the volume mount to be found.")
-	result, err := e2essh.SSH(fmt.Sprintf("mount | grep %s | grep -v volume-subpaths", clientPod.UID), nodeIP, framework.TestContext.Provider)
+	result, err := e2essh.SSH(ctx, fmt.Sprintf("mount | grep %s | grep -v volume-subpaths", clientPod.UID), nodeIP, framework.TestContext.Provider)
 	e2essh.LogResult(result)
 	framework.ExpectNoError(err, "Encountered SSH error.")
 	framework.ExpectEqual(result.Code, 0, fmt.Sprintf("Expected grep exit code of 0, got %d", result.Code))
 
 	if checkSubpath {
 		ginkgo.By("Expecting the volume subpath mount to be found.")
-		result, err := e2essh.SSH(fmt.Sprintf("cat /proc/self/mountinfo | grep %s | grep volume-subpaths", clientPod.UID), nodeIP, framework.TestContext.Provider)
+		result, err := e2essh.SSH(ctx, fmt.Sprintf("cat /proc/self/mountinfo | grep %s | grep volume-subpaths", clientPod.UID), nodeIP, framework.TestContext.Provider)
 		e2essh.LogResult(result)
 		framework.ExpectNoError(err, "Encountered SSH error.")
 		framework.ExpectEqual(result.Code, 0, fmt.Sprintf("Expected grep exit code of 0, got %d", result.Code))
@@ -159,7 +159,7 @@ func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *f
 	// This command is to make sure kubelet is started after test finishes no matter it fails or not.
 	ginkgo.DeferCleanup(KubeletCommand, KStart, c, clientPod)
 	ginkgo.By("Stopping the kubelet.")
-	KubeletCommand(KStop, c, clientPod)
+	KubeletCommand(ctx, KStop, c, clientPod)
 
 	if secondPod != nil {
 		ginkgo.By("Starting the second pod")
@@ -169,15 +169,15 @@ func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *f
 
 	ginkgo.By(fmt.Sprintf("Deleting Pod %q", clientPod.Name))
 	if forceDelete {
-		err = c.CoreV1().Pods(clientPod.Namespace).Delete(context.TODO(), clientPod.Name, *metav1.NewDeleteOptions(0))
+		err = c.CoreV1().Pods(clientPod.Namespace).Delete(ctx, clientPod.Name, *metav1.NewDeleteOptions(0))
 	} else {
-		err = c.CoreV1().Pods(clientPod.Namespace).Delete(context.TODO(), clientPod.Name, metav1.DeleteOptions{})
+		err = c.CoreV1().Pods(clientPod.Namespace).Delete(ctx, clientPod.Name, metav1.DeleteOptions{})
 	}
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Starting the kubelet and waiting for pod to delete.")
-	KubeletCommand(KStart, c, clientPod)
-	err = e2epod.WaitForPodNotFoundInNamespace(f.ClientSet, clientPod.Name, f.Namespace.Name, f.Timeouts.PodDelete)
+	KubeletCommand(ctx, KStart, c, clientPod)
+	err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, clientPod.Name, f.Namespace.Name, f.Timeouts.PodDelete)
 	if err != nil {
 		framework.ExpectNoError(err, "Expected pod to be not found.")
 	}
@@ -190,7 +190,7 @@ func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *f
 
 	if secondPod != nil {
 		ginkgo.By("Waiting for the second pod.")
-		err = e2epod.WaitForPodRunningInNamespace(c, secondPod)
+		err = e2epod.WaitForPodRunningInNamespace(ctx, c, secondPod)
 		framework.ExpectNoError(err, "while waiting for the second pod Running")
 
 		ginkgo.By("Getting the second pod uuid.")
@@ -198,7 +198,7 @@ func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *f
 		framework.ExpectNoError(err, "getting the second UID")
 
 		ginkgo.By("Expecting the volume mount to be found in the second pod.")
-		result, err := e2essh.SSH(fmt.Sprintf("mount | grep %s | grep -v volume-subpaths", secondPod.UID), nodeIP, framework.TestContext.Provider)
+		result, err := e2essh.SSH(ctx, fmt.Sprintf("mount | grep %s | grep -v volume-subpaths", secondPod.UID), nodeIP, framework.TestContext.Provider)
 		e2essh.LogResult(result)
 		framework.ExpectNoError(err, "Encountered SSH error when checking the second pod.")
 		framework.ExpectEqual(result.Code, 0, fmt.Sprintf("Expected grep exit code of 0, got %d", result.Code))
@@ -207,12 +207,12 @@ func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *f
 		CheckReadFromPath(f, secondPod, v1.PersistentVolumeFilesystem, false, volumePath, byteLen, seed)
 		err = c.CoreV1().Pods(secondPod.Namespace).Delete(context.TODO(), secondPod.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "when deleting the second pod")
-		err = e2epod.WaitForPodNotFoundInNamespace(f.ClientSet, secondPod.Name, f.Namespace.Name, f.Timeouts.PodDelete)
+		err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, secondPod.Name, f.Namespace.Name, f.Timeouts.PodDelete)
 		framework.ExpectNoError(err, "when waiting for the second pod to disappear")
 	}
 
 	ginkgo.By("Expecting the volume mount not to be found.")
-	result, err = e2essh.SSH(fmt.Sprintf("mount | grep %s | grep -v volume-subpaths", clientPod.UID), nodeIP, framework.TestContext.Provider)
+	result, err = e2essh.SSH(ctx, fmt.Sprintf("mount | grep %s | grep -v volume-subpaths", clientPod.UID), nodeIP, framework.TestContext.Provider)
 	e2essh.LogResult(result)
 	framework.ExpectNoError(err, "Encountered SSH error.")
 	gomega.Expect(result.Stdout).To(gomega.BeEmpty(), "Expected grep stdout to be empty (i.e. no mount found).")
@@ -220,7 +220,7 @@ func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *f
 
 	if checkSubpath {
 		ginkgo.By("Expecting the volume subpath mount not to be found.")
-		result, err = e2essh.SSH(fmt.Sprintf("cat /proc/self/mountinfo | grep %s | grep volume-subpaths", clientPod.UID), nodeIP, framework.TestContext.Provider)
+		result, err = e2essh.SSH(ctx, fmt.Sprintf("cat /proc/self/mountinfo | grep %s | grep volume-subpaths", clientPod.UID), nodeIP, framework.TestContext.Provider)
 		e2essh.LogResult(result)
 		framework.ExpectNoError(err, "Encountered SSH error.")
 		gomega.Expect(result.Stdout).To(gomega.BeEmpty(), "Expected grep stdout to be empty (i.e. no subpath mount found).")
@@ -230,42 +230,42 @@ func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *f
 }
 
 // TestVolumeUnmountsFromDeletedPod tests that a volume unmounts if the client pod was deleted while the kubelet was down.
-func TestVolumeUnmountsFromDeletedPod(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, volumePath string) {
-	TestVolumeUnmountsFromDeletedPodWithForceOption(c, f, clientPod, false, false, nil, volumePath)
+func TestVolumeUnmountsFromDeletedPod(ctx context.Context, c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, volumePath string) {
+	TestVolumeUnmountsFromDeletedPodWithForceOption(ctx, c, f, clientPod, false, false, nil, volumePath)
 }
 
 // TestVolumeUnmountsFromForceDeletedPod tests that a volume unmounts if the client pod was forcefully deleted while the kubelet was down.
-func TestVolumeUnmountsFromForceDeletedPod(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, volumePath string) {
-	TestVolumeUnmountsFromDeletedPodWithForceOption(c, f, clientPod, true, false, nil, volumePath)
+func TestVolumeUnmountsFromForceDeletedPod(ctx context.Context, c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, volumePath string) {
+	TestVolumeUnmountsFromDeletedPodWithForceOption(ctx, c, f, clientPod, true, false, nil, volumePath)
 }
 
 // TestVolumeUnmapsFromDeletedPodWithForceOption tests that a volume unmaps if the client pod was deleted while the kubelet was down.
 // forceDelete is true indicating whether the pod is forcefully deleted.
-func TestVolumeUnmapsFromDeletedPodWithForceOption(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, forceDelete bool, devicePath string) {
-	nodeIP, err := getHostAddress(c, clientPod)
+func TestVolumeUnmapsFromDeletedPodWithForceOption(ctx context.Context, c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, forceDelete bool, devicePath string) {
+	nodeIP, err := getHostAddress(ctx, c, clientPod)
 	framework.ExpectNoError(err, "Failed to get nodeIP.")
 	nodeIP = nodeIP + ":22"
 
 	// Creating command to check whether path exists
 	podDirectoryCmd := fmt.Sprintf("ls /var/lib/kubelet/pods/%s/volumeDevices/*/ | grep '.'", clientPod.UID)
-	if isSudoPresent(nodeIP, framework.TestContext.Provider) {
+	if isSudoPresent(ctx, nodeIP, framework.TestContext.Provider) {
 		podDirectoryCmd = fmt.Sprintf("sudo sh -c \"%s\"", podDirectoryCmd)
 	}
 	// Directories in the global directory have unpredictable names, however, device symlinks
 	// have the same name as pod.UID. So just find anything with pod.UID name.
 	globalBlockDirectoryCmd := fmt.Sprintf("find /var/lib/kubelet/plugins -name %s", clientPod.UID)
-	if isSudoPresent(nodeIP, framework.TestContext.Provider) {
+	if isSudoPresent(ctx, nodeIP, framework.TestContext.Provider) {
 		globalBlockDirectoryCmd = fmt.Sprintf("sudo sh -c \"%s\"", globalBlockDirectoryCmd)
 	}
 
 	ginkgo.By("Expecting the symlinks from PodDeviceMapPath to be found.")
-	result, err := e2essh.SSH(podDirectoryCmd, nodeIP, framework.TestContext.Provider)
+	result, err := e2essh.SSH(ctx, podDirectoryCmd, nodeIP, framework.TestContext.Provider)
 	e2essh.LogResult(result)
 	framework.ExpectNoError(err, "Encountered SSH error.")
 	framework.ExpectEqual(result.Code, 0, fmt.Sprintf("Expected grep exit code of 0, got %d", result.Code))
 
 	ginkgo.By("Expecting the symlinks from global map path to be found.")
-	result, err = e2essh.SSH(globalBlockDirectoryCmd, nodeIP, framework.TestContext.Provider)
+	result, err = e2essh.SSH(ctx, globalBlockDirectoryCmd, nodeIP, framework.TestContext.Provider)
 	e2essh.LogResult(result)
 	framework.ExpectNoError(err, "Encountered SSH error.")
 	framework.ExpectEqual(result.Code, 0, fmt.Sprintf("Expected find exit code of 0, got %d", result.Code))
@@ -273,19 +273,19 @@ func TestVolumeUnmapsFromDeletedPodWithForceOption(c clientset.Interface, f *fra
 	// This command is to make sure kubelet is started after test finishes no matter it fails or not.
 	ginkgo.DeferCleanup(KubeletCommand, KStart, c, clientPod)
 	ginkgo.By("Stopping the kubelet.")
-	KubeletCommand(KStop, c, clientPod)
+	KubeletCommand(ctx, KStop, c, clientPod)
 
 	ginkgo.By(fmt.Sprintf("Deleting Pod %q", clientPod.Name))
 	if forceDelete {
-		err = c.CoreV1().Pods(clientPod.Namespace).Delete(context.TODO(), clientPod.Name, *metav1.NewDeleteOptions(0))
+		err = c.CoreV1().Pods(clientPod.Namespace).Delete(ctx, clientPod.Name, *metav1.NewDeleteOptions(0))
 	} else {
-		err = c.CoreV1().Pods(clientPod.Namespace).Delete(context.TODO(), clientPod.Name, metav1.DeleteOptions{})
+		err = c.CoreV1().Pods(clientPod.Namespace).Delete(ctx, clientPod.Name, metav1.DeleteOptions{})
 	}
 	framework.ExpectNoError(err, "Failed to delete pod.")
 
 	ginkgo.By("Starting the kubelet and waiting for pod to delete.")
-	KubeletCommand(KStart, c, clientPod)
-	err = e2epod.WaitForPodNotFoundInNamespace(f.ClientSet, clientPod.Name, f.Namespace.Name, f.Timeouts.PodDelete)
+	KubeletCommand(ctx, KStart, c, clientPod)
+	err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, clientPod.Name, f.Namespace.Name, f.Timeouts.PodDelete)
 	framework.ExpectNoError(err, "Expected pod to be not found.")
 
 	if forceDelete {
@@ -295,13 +295,13 @@ func TestVolumeUnmapsFromDeletedPodWithForceOption(c clientset.Interface, f *fra
 	}
 
 	ginkgo.By("Expecting the symlink from PodDeviceMapPath not to be found.")
-	result, err = e2essh.SSH(podDirectoryCmd, nodeIP, framework.TestContext.Provider)
+	result, err = e2essh.SSH(ctx, podDirectoryCmd, nodeIP, framework.TestContext.Provider)
 	e2essh.LogResult(result)
 	framework.ExpectNoError(err, "Encountered SSH error.")
 	gomega.Expect(result.Stdout).To(gomega.BeEmpty(), "Expected grep stdout to be empty.")
 
 	ginkgo.By("Expecting the symlinks from global map path not to be found.")
-	result, err = e2essh.SSH(globalBlockDirectoryCmd, nodeIP, framework.TestContext.Provider)
+	result, err = e2essh.SSH(ctx, globalBlockDirectoryCmd, nodeIP, framework.TestContext.Provider)
 	e2essh.LogResult(result)
 	framework.ExpectNoError(err, "Encountered SSH error.")
 	gomega.Expect(result.Stdout).To(gomega.BeEmpty(), "Expected find stdout to be empty.")
@@ -310,17 +310,17 @@ func TestVolumeUnmapsFromDeletedPodWithForceOption(c clientset.Interface, f *fra
 }
 
 // TestVolumeUnmapsFromDeletedPod tests that a volume unmaps if the client pod was deleted while the kubelet was down.
-func TestVolumeUnmapsFromDeletedPod(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, devicePath string) {
-	TestVolumeUnmapsFromDeletedPodWithForceOption(c, f, clientPod, false, devicePath)
+func TestVolumeUnmapsFromDeletedPod(ctx context.Context, c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, devicePath string) {
+	TestVolumeUnmapsFromDeletedPodWithForceOption(ctx, c, f, clientPod, false, devicePath)
 }
 
 // TestVolumeUnmapsFromForceDeletedPod tests that a volume unmaps if the client pod was forcefully deleted while the kubelet was down.
-func TestVolumeUnmapsFromForceDeletedPod(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, devicePath string) {
-	TestVolumeUnmapsFromDeletedPodWithForceOption(c, f, clientPod, true, devicePath)
+func TestVolumeUnmapsFromForceDeletedPod(ctx context.Context, c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, devicePath string) {
+	TestVolumeUnmapsFromDeletedPodWithForceOption(ctx, c, f, clientPod, true, devicePath)
 }
 
 // RunInPodWithVolume runs a command in a pod with given claim mounted to /mnt directory.
-func RunInPodWithVolume(c clientset.Interface, t *framework.TimeoutContext, ns, claimName, command string) {
+func RunInPodWithVolume(ctx context.Context, c clientset.Interface, t *framework.TimeoutContext, ns, claimName, command string) {
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -358,14 +358,14 @@ func RunInPodWithVolume(c clientset.Interface, t *framework.TimeoutContext, ns, 
 			},
 		},
 	}
-	pod, err := c.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+	pod, err := c.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "Failed to create pod: %v", err)
 	ginkgo.DeferCleanup(e2epod.DeletePodOrFail, c, ns, pod.Name)
-	framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespaceTimeout(c, pod.Name, pod.Namespace, t.PodStartSlow))
+	framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, c, pod.Name, pod.Namespace, t.PodStartSlow))
 }
 
 // StartExternalProvisioner create external provisioner pod
-func StartExternalProvisioner(c clientset.Interface, ns string, externalPluginName string) *v1.Pod {
+func StartExternalProvisioner(ctx context.Context, c clientset.Interface, ns string, externalPluginName string) *v1.Pod {
 	podClient := c.CoreV1().Pods(ns)
 
 	provisionerPod := &v1.Pod{
@@ -426,21 +426,21 @@ func StartExternalProvisioner(c clientset.Interface, ns string, externalPluginNa
 			},
 		},
 	}
-	provisionerPod, err := podClient.Create(context.TODO(), provisionerPod, metav1.CreateOptions{})
+	provisionerPod, err := podClient.Create(ctx, provisionerPod, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "Failed to create %s pod: %v", provisionerPod.Name, err)
 
-	framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(c, provisionerPod))
+	framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, c, provisionerPod))
 
 	ginkgo.By("locating the provisioner pod")
-	pod, err := podClient.Get(context.TODO(), provisionerPod.Name, metav1.GetOptions{})
+	pod, err := podClient.Get(ctx, provisionerPod.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err, "Cannot locate the provisioner pod %v: %v", provisionerPod.Name, err)
 
 	return pod
 }
 
-func isSudoPresent(nodeIP string, provider string) bool {
+func isSudoPresent(ctx context.Context, nodeIP string, provider string) bool {
 	framework.Logf("Checking if sudo command is present")
-	sshResult, err := e2essh.SSH("sudo --version", nodeIP, provider)
+	sshResult, err := e2essh.SSH(ctx, "sudo --version", nodeIP, provider)
 	framework.ExpectNoError(err, "SSH to %q errored.", nodeIP)
 	if !strings.Contains(sshResult.Stderr, "command not found") {
 		return true
@@ -556,8 +556,8 @@ func GetSectorSize(f *framework.Framework, pod *v1.Pod, device string) int {
 }
 
 // findMountPoints returns all mount points on given node under specified directory.
-func findMountPoints(hostExec HostExec, node *v1.Node, dir string) []string {
-	result, err := hostExec.IssueCommandWithResult(fmt.Sprintf(`find %s -type d -exec mountpoint {} \; | grep 'is a mountpoint$' || true`, dir), node)
+func findMountPoints(ctx context.Context, hostExec HostExec, node *v1.Node, dir string) []string {
+	result, err := hostExec.IssueCommandWithResult(ctx, fmt.Sprintf(`find %s -type d -exec mountpoint {} \; | grep 'is a mountpoint$' || true`, dir), node)
 	framework.ExpectNoError(err, "Encountered HostExec error.")
 	var mountPoints []string
 	if err != nil {
@@ -572,16 +572,16 @@ func findMountPoints(hostExec HostExec, node *v1.Node, dir string) []string {
 }
 
 // FindVolumeGlobalMountPoints returns all volume global mount points on the node of given pod.
-func FindVolumeGlobalMountPoints(hostExec HostExec, node *v1.Node) sets.String {
-	return sets.NewString(findMountPoints(hostExec, node, "/var/lib/kubelet/plugins")...)
+func FindVolumeGlobalMountPoints(ctx context.Context, hostExec HostExec, node *v1.Node) sets.String {
+	return sets.NewString(findMountPoints(ctx, hostExec, node, "/var/lib/kubelet/plugins")...)
 }
 
 // CreateDriverNamespace creates a namespace for CSI driver installation.
 // The namespace is still tracked and ensured that gets deleted when test terminates.
-func CreateDriverNamespace(f *framework.Framework) *v1.Namespace {
+func CreateDriverNamespace(ctx context.Context, f *framework.Framework) *v1.Namespace {
 	ginkgo.By(fmt.Sprintf("Building a driver namespace object, basename %s", f.Namespace.Name))
 	// The driver namespace will be bound to the test namespace in the prefix
-	namespace, err := f.CreateNamespace(f.Namespace.Name, map[string]string{
+	namespace, err := f.CreateNamespace(ctx, f.Namespace.Name, map[string]string{
 		"e2e-framework":      f.BaseName,
 		"e2e-test-namespace": f.Namespace.Name,
 	})
@@ -589,7 +589,7 @@ func CreateDriverNamespace(f *framework.Framework) *v1.Namespace {
 
 	if framework.TestContext.VerifyServiceAccount {
 		ginkgo.By("Waiting for a default service account to be provisioned in namespace")
-		err = framework.WaitForDefaultServiceAccountInNamespace(f.ClientSet, namespace.Name)
+		err = framework.WaitForDefaultServiceAccountInNamespace(ctx, f.ClientSet, namespace.Name)
 		framework.ExpectNoError(err)
 	} else {
 		framework.Logf("Skipping waiting for service account")
@@ -598,11 +598,11 @@ func CreateDriverNamespace(f *framework.Framework) *v1.Namespace {
 }
 
 // WaitForGVRDeletion waits until a non-namespaced object has been deleted
-func WaitForGVRDeletion(c dynamic.Interface, gvr schema.GroupVersionResource, objectName string, poll, timeout time.Duration) error {
+func WaitForGVRDeletion(ctx context.Context, c dynamic.Interface, gvr schema.GroupVersionResource, objectName string, poll, timeout time.Duration) error {
 	framework.Logf("Waiting up to %v for %s %s to be deleted", timeout, gvr.Resource, objectName)
 
 	if successful := WaitUntil(poll, timeout, func() bool {
-		_, err := c.Resource(gvr).Get(context.TODO(), objectName, metav1.GetOptions{})
+		_, err := c.Resource(gvr).Get(ctx, objectName, metav1.GetOptions{})
 		if err != nil && apierrors.IsNotFound(err) {
 			framework.Logf("%s %v is not found and has been deleted", gvr.Resource, objectName)
 			return true
@@ -621,11 +621,11 @@ func WaitForGVRDeletion(c dynamic.Interface, gvr schema.GroupVersionResource, ob
 }
 
 // WaitForNamespacedGVRDeletion waits until a namespaced object has been deleted
-func WaitForNamespacedGVRDeletion(c dynamic.Interface, gvr schema.GroupVersionResource, ns, objectName string, poll, timeout time.Duration) error {
+func WaitForNamespacedGVRDeletion(ctx context.Context, c dynamic.Interface, gvr schema.GroupVersionResource, ns, objectName string, poll, timeout time.Duration) error {
 	framework.Logf("Waiting up to %v for %s %s to be deleted", timeout, gvr.Resource, objectName)
 
 	if successful := WaitUntil(poll, timeout, func() bool {
-		_, err := c.Resource(gvr).Namespace(ns).Get(context.TODO(), objectName, metav1.GetOptions{})
+		_, err := c.Resource(gvr).Namespace(ns).Get(ctx, objectName, metav1.GetOptions{})
 		if err != nil && apierrors.IsNotFound(err) {
 			framework.Logf("%s %s is not found in namespace %s and has been deleted", gvr.Resource, objectName, ns)
 			return true
@@ -645,6 +645,7 @@ func WaitForNamespacedGVRDeletion(c dynamic.Interface, gvr schema.GroupVersionRe
 
 // WaitUntil runs checkDone until a timeout is reached
 func WaitUntil(poll, timeout time.Duration, checkDone func() bool) bool {
+	// TODO (pohly): replace with gomega.Eventually
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
 		if checkDone() {
 			framework.Logf("WaitUntil finished successfully after %v", time.Since(start))
@@ -710,8 +711,8 @@ func ChangeFilePathGidInPod(f *framework.Framework, filePath, targetGid string, 
 }
 
 // DeleteStorageClass deletes the passed in StorageClass and catches errors other than "Not Found"
-func DeleteStorageClass(cs clientset.Interface, className string) error {
-	err := cs.StorageV1().StorageClasses().Delete(context.TODO(), className, metav1.DeleteOptions{})
+func DeleteStorageClass(ctx context.Context, cs clientset.Interface, className string) error {
+	err := cs.StorageV1().StorageClasses().Delete(ctx, className, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -59,7 +59,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 	f := framework.NewDefaultFramework("pv")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		c = f.ClientSet
 		ns = f.Namespace.Name
 		var err error
@@ -68,8 +68,8 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		// and the underlying storage driver and therefore don't pass
 		// with other kinds of clusters and drivers.
 		e2eskipper.SkipUnlessProviderIs("gce", "gke", "aws")
-		e2epv.SkipIfNoDefaultStorageClass(c)
-		defaultScName, err = e2epv.GetDefaultStorageClassName(c)
+		e2epv.SkipIfNoDefaultStorageClass(ctx, c)
+		defaultScName, err = e2epv.GetDefaultStorageClassName(ctx, c)
 		framework.ExpectNoError(err)
 
 		test := testsuites.StorageClassTest{
@@ -91,64 +91,64 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 			VolumeMode: &blockMode,
 		}, ns)
 
-		metricsGrabber, err = e2emetrics.NewMetricsGrabber(c, nil, f.ClientConfig(), true, false, true, false, false, false)
+		metricsGrabber, err = e2emetrics.NewMetricsGrabber(ctx, c, nil, f.ClientConfig(), true, false, true, false, false, false)
 
 		if err != nil {
 			framework.Failf("Error creating metrics grabber : %v", err)
 		}
 	})
 
-	ginkgo.AfterEach(func() {
-		newPvc, err := c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+	ginkgo.AfterEach(func(ctx context.Context) {
+		newPvc, err := c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		if err != nil {
 			framework.Logf("Failed to get pvc %s/%s: %v", pvc.Namespace, pvc.Name, err)
 		} else {
-			e2epv.DeletePersistentVolumeClaim(c, newPvc.Name, newPvc.Namespace)
+			e2epv.DeletePersistentVolumeClaim(ctx, c, newPvc.Name, newPvc.Namespace)
 			if newPvc.Spec.VolumeName != "" {
-				err = e2epv.WaitForPersistentVolumeDeleted(c, newPvc.Spec.VolumeName, 5*time.Second, 5*time.Minute)
+				err = e2epv.WaitForPersistentVolumeDeleted(ctx, c, newPvc.Spec.VolumeName, 5*time.Second, 5*time.Minute)
 				framework.ExpectNoError(err, "Persistent Volume %v not deleted by dynamic provisioner", newPvc.Spec.VolumeName)
 			}
 		}
 
 		if invalidSc != nil {
-			err := c.StorageV1().StorageClasses().Delete(context.TODO(), invalidSc.Name, metav1.DeleteOptions{})
+			err := c.StorageV1().StorageClasses().Delete(ctx, invalidSc.Name, metav1.DeleteOptions{})
 			framework.ExpectNoError(err, "Error deleting storageclass %v: %v", invalidSc.Name, err)
 			invalidSc = nil
 		}
 	})
 
-	provisioning := func(ephemeral bool) {
+	provisioning := func(ctx context.Context, ephemeral bool) {
 		if !metricsGrabber.HasControlPlanePods() {
 			e2eskipper.Skipf("Environment does not support getting controller-manager metrics - skipping")
 		}
 
 		ginkgo.By("Getting plugin name")
-		defaultClass, err := c.StorageV1().StorageClasses().Get(context.TODO(), defaultScName, metav1.GetOptions{})
+		defaultClass, err := c.StorageV1().StorageClasses().Get(ctx, defaultScName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "Error getting default storageclass: %v", err)
 		pluginName := defaultClass.Provisioner
 
-		controllerMetrics, err := metricsGrabber.GrabFromControllerManager()
+		controllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 
 		framework.ExpectNoError(err, "Error getting c-m metrics : %v", err)
 
 		storageOpMetrics := getControllerStorageMetrics(controllerMetrics, pluginName)
 
 		if !ephemeral {
-			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			framework.ExpectNotEqual(pvc, nil)
 		}
 
 		pod := makePod(ns, pvc, ephemeral)
-		pod, err = c.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		pod, err = c.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
 		framework.ExpectNoError(err, "Error starting pod %s", pod.Name)
 
-		framework.ExpectNoError(e2epod.DeletePodWithWait(c, pod))
+		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, c, pod))
 
-		updatedStorageMetrics := waitForDetachAndGrabMetrics(storageOpMetrics, metricsGrabber, pluginName)
+		updatedStorageMetrics := waitForDetachAndGrabMetrics(ctx, storageOpMetrics, metricsGrabber, pluginName)
 
 		framework.ExpectNotEqual(len(updatedStorageMetrics.latencyMetrics), 0, "Error fetching c-m updated storage metrics")
 		framework.ExpectNotEqual(len(updatedStorageMetrics.statusMetrics), 0, "Error fetching c-m updated storage metrics")
@@ -160,13 +160,13 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		}
 	}
 
-	provisioningError := func(ephemeral bool) {
+	provisioningError := func(ctx context.Context, ephemeral bool) {
 		if !metricsGrabber.HasControlPlanePods() {
 			e2eskipper.Skipf("Environment does not support getting controller-manager metrics - skipping")
 		}
 
 		ginkgo.By("Getting default storageclass")
-		defaultClass, err := c.StorageV1().StorageClasses().Get(context.TODO(), defaultScName, metav1.GetOptions{})
+		defaultClass, err := c.StorageV1().StorageClasses().Get(ctx, defaultScName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "Error getting default storageclass: %v", err)
 		pluginName := defaultClass.Provisioner
 
@@ -179,50 +179,50 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 				"invalidparam": "invalidvalue",
 			},
 		}
-		_, err = c.StorageV1().StorageClasses().Create(context.TODO(), invalidSc, metav1.CreateOptions{})
+		_, err = c.StorageV1().StorageClasses().Create(ctx, invalidSc, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Error creating new storageclass: %v", err)
 
 		pvc.Spec.StorageClassName = &invalidSc.Name
 		if !ephemeral {
-			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "failed to create PVC %s/%s", pvc.Namespace, pvc.Name)
 			framework.ExpectNotEqual(pvc, nil)
 		}
 
 		ginkgo.By("Creating a pod and expecting it to fail")
 		pod := makePod(ns, pvc, ephemeral)
-		pod, err = c.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		pod, err = c.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create Pod %s/%s", pod.Namespace, pod.Name)
 
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
 		framework.ExpectError(err)
 
 		framework.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
-		framework.ExpectNoError(e2epod.DeletePodWithWait(c, pod))
+		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, c, pod))
 
 		ginkgo.By("Checking failure metrics")
-		updatedControllerMetrics, err := metricsGrabber.GrabFromControllerManager()
+		updatedControllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 		framework.ExpectNoError(err, "failed to get controller manager metrics")
 		updatedStorageMetrics := getControllerStorageMetrics(updatedControllerMetrics, pluginName)
 
 		framework.ExpectNotEqual(len(updatedStorageMetrics.statusMetrics), 0, "Error fetching c-m updated storage metrics")
 	}
 
-	filesystemMode := func(isEphemeral bool) {
+	filesystemMode := func(ctx context.Context, isEphemeral bool) {
 		if !isEphemeral {
-			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			framework.ExpectNotEqual(pvc, nil)
 		}
 
 		pod := makePod(ns, pvc, isEphemeral)
-		pod, err = c.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		pod, err = c.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
 		framework.ExpectNoError(err, "Error starting pod ", pod.Name)
 
-		pod, err = c.CoreV1().Pods(ns).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		pod, err = c.CoreV1().Pods(ns).Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		pvcName := pvc.Name
@@ -245,11 +245,11 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		// Poll kubelet metrics waiting for the volume to be picked up
 		// by the volume stats collector
 		var kubeMetrics e2emetrics.KubeletMetrics
-		waitErr := wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
+		waitErr := wait.PollWithContext(ctx, 30*time.Second, 5*time.Minute, func(ctx context.Context) (bool, error) {
 			framework.Logf("Grabbing Kubelet metrics")
 			// Grab kubelet metrics from the node the pod was scheduled on
 			var err error
-			kubeMetrics, err = metricsGrabber.GrabFromKubelet(pod.Spec.NodeName)
+			kubeMetrics, err = metricsGrabber.GrabFromKubelet(ctx, pod.Spec.NodeName)
 			if err != nil {
 				framework.Logf("Error fetching kubelet metrics")
 				return false, err
@@ -270,12 +270,12 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		}
 
 		framework.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
-		framework.ExpectNoError(e2epod.DeletePodWithWait(c, pod))
+		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, c, pod))
 	}
 
-	blockmode := func(isEphemeral bool) {
+	blockmode := func(ctx context.Context, isEphemeral bool) {
 		if !isEphemeral {
-			pvcBlock, err = c.CoreV1().PersistentVolumeClaims(pvcBlock.Namespace).Create(context.TODO(), pvcBlock, metav1.CreateOptions{})
+			pvcBlock, err = c.CoreV1().PersistentVolumeClaims(pvcBlock.Namespace).Create(ctx, pvcBlock, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			framework.ExpectNotEqual(pvcBlock, nil)
 		}
@@ -286,13 +286,13 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 			DevicePath: "/mnt/" + pvcBlock.Name,
 		}}
 		pod.Spec.Containers[0].VolumeMounts = nil
-		pod, err = c.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		pod, err = c.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
 		framework.ExpectNoError(err, "Error starting pod ", pod.Name)
 
-		pod, err = c.CoreV1().Pods(ns).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		pod, err = c.CoreV1().Pods(ns).Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		// Verify volume stat metrics were collected for the referenced PVC
@@ -315,7 +315,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 			framework.Logf("Grabbing Kubelet metrics")
 			// Grab kubelet metrics from the node the pod was scheduled on
 			var err error
-			kubeMetrics, err = metricsGrabber.GrabFromKubelet(pod.Spec.NodeName)
+			kubeMetrics, err = metricsGrabber.GrabFromKubelet(ctx, pod.Spec.NodeName)
 			if err != nil {
 				framework.Logf("Error fetching kubelet metrics")
 				return false, err
@@ -336,27 +336,27 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		}
 
 		framework.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
-		framework.ExpectNoError(e2epod.DeletePodWithWait(c, pod))
+		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, c, pod))
 	}
 
-	totalTime := func(isEphemeral bool) {
+	totalTime := func(ctx context.Context, isEphemeral bool) {
 		if !isEphemeral {
-			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			framework.ExpectNotEqual(pvc, nil)
 		}
 
 		pod := makePod(ns, pvc, isEphemeral)
-		pod, err = c.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		pod, err = c.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
 		framework.ExpectNoError(err, "Error starting pod ", pod.Name)
 
-		pod, err = c.CoreV1().Pods(ns).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		pod, err = c.CoreV1().Pods(ns).Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
-		controllerMetrics, err := metricsGrabber.GrabFromControllerManager()
+		controllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 		if err != nil {
 			e2eskipper.Skipf("Could not get controller-manager metrics - skipping")
 		}
@@ -367,27 +367,27 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		framework.ExpectNoError(err, "Invalid metric in P/V Controller metrics: %q", metricKey)
 
 		framework.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
-		framework.ExpectNoError(e2epod.DeletePodWithWait(c, pod))
+		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, c, pod))
 	}
 
-	volumeManager := func(isEphemeral bool) {
+	volumeManager := func(ctx context.Context, isEphemeral bool) {
 		if !isEphemeral {
-			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			framework.ExpectNotEqual(pvc, nil)
 		}
 
 		pod := makePod(ns, pvc, isEphemeral)
-		pod, err = c.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		pod, err = c.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
 		framework.ExpectNoError(err, "Error starting pod ", pod.Name)
 
-		pod, err = c.CoreV1().Pods(ns).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		pod, err = c.CoreV1().Pods(ns).Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
-		kubeMetrics, err := metricsGrabber.GrabFromKubelet(pod.Spec.NodeName)
+		kubeMetrics, err := metricsGrabber.GrabFromKubelet(ctx, pod.Spec.NodeName)
 		framework.ExpectNoError(err)
 
 		// Metrics should have dimensions plugin_name and state available
@@ -397,12 +397,12 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		framework.ExpectNoError(err, "Invalid metric in Volume Manager metrics: %q", totalVolumesKey)
 
 		framework.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
-		framework.ExpectNoError(e2epod.DeletePodWithWait(c, pod))
+		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, c, pod))
 	}
 
-	adController := func(isEphemeral bool) {
+	adController := func(ctx context.Context, isEphemeral bool) {
 		if !isEphemeral {
-			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			framework.ExpectNotEqual(pvc, nil)
 		}
@@ -410,21 +410,21 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		pod := makePod(ns, pvc, isEphemeral)
 
 		// Get metrics
-		controllerMetrics, err := metricsGrabber.GrabFromControllerManager()
+		controllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 		if err != nil {
 			e2eskipper.Skipf("Could not get controller-manager metrics - skipping")
 		}
 
 		// Create pod
-		pod, err = c.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		pod, err = c.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
 		framework.ExpectNoError(err, "Error starting pod ", pod.Name)
-		pod, err = c.CoreV1().Pods(ns).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		pod, err = c.CoreV1().Pods(ns).Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		// Get updated metrics
-		updatedControllerMetrics, err := metricsGrabber.GrabFromControllerManager()
+		updatedControllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 		if err != nil {
 			e2eskipper.Skipf("Could not get controller-manager metrics - skipping")
 		}
@@ -440,7 +440,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		totalVolumesKey := "attachdetach_controller_total_volumes"
 		states := []string{"actual_state_of_world", "desired_state_of_world"}
 		dimensions := []string{"state", "plugin_name"}
-		waitForADControllerStatesMetrics(metricsGrabber, totalVolumesKey, dimensions, states)
+		waitForADControllerStatesMetrics(ctx, metricsGrabber, totalVolumesKey, dimensions, states)
 
 		// Total number of volumes in both ActualStateofWorld and DesiredStateOfWorld
 		// states should be higher or equal than it used to be
@@ -459,32 +459,32 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		}
 
 		framework.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
-		framework.ExpectNoError(e2epod.DeletePodWithWait(c, pod))
+		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, c, pod))
 	}
 
 	testAll := func(isEphemeral bool) {
 		ginkgo.It("should create prometheus metrics for volume provisioning and attach/detach", func(ctx context.Context) {
-			provisioning(isEphemeral)
+			provisioning(ctx, isEphemeral)
 		})
 		// TODO(mauriciopoppe): after CSIMigration is turned on we're no longer reporting
 		// the volume_provision metric (removed in #106609), issue to investigate the bug #106773
 		ginkgo.It("should create prometheus metrics for volume provisioning errors [Slow]", func(ctx context.Context) {
-			provisioningError(isEphemeral)
+			provisioningError(ctx, isEphemeral)
 		})
 		ginkgo.It("should create volume metrics with the correct FilesystemMode PVC ref", func(ctx context.Context) {
-			filesystemMode(isEphemeral)
+			filesystemMode(ctx, isEphemeral)
 		})
 		ginkgo.It("should create volume metrics with the correct BlockMode PVC ref", func(ctx context.Context) {
-			blockmode(isEphemeral)
+			blockmode(ctx, isEphemeral)
 		})
 		ginkgo.It("should create metrics for total time taken in volume operations in P/V Controller", func(ctx context.Context) {
-			totalTime(isEphemeral)
+			totalTime(ctx, isEphemeral)
 		})
 		ginkgo.It("should create volume metrics in Volume Manager", func(ctx context.Context) {
-			volumeManager(isEphemeral)
+			volumeManager(ctx, isEphemeral)
 		})
 		ginkgo.It("should create metrics for total number of volumes in A/D Controller", func(ctx context.Context) {
-			adController(isEphemeral)
+			adController(ctx, isEphemeral)
 		})
 	}
 
@@ -545,10 +545,10 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		// validator used to validate each metric's values, the length of metricValues
 		// should be 4, and the elements should be bound pv count, unbound pv count, bound
 		// pvc count, unbound pvc count in turn.
-		validator := func(metricValues []map[string]int64) {
+		validator := func(ctx context.Context, metricValues []map[string]int64) {
 			framework.ExpectEqual(len(metricValues), 4, "Wrong metric size: %d", len(metricValues))
 
-			controllerMetrics, err := metricsGrabber.GrabFromControllerManager()
+			controllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 			framework.ExpectNoError(err, "Error getting c-m metricValues: %v", err)
 
 			for i, metric := range e2emetrics {
@@ -566,7 +566,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 			}
 		}
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			if !metricsGrabber.HasControlPlanePods() {
 				e2eskipper.Skipf("Environment does not support getting controller-manager metrics - skipping")
 			}
@@ -575,7 +575,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 			pvc = e2epv.MakePersistentVolumeClaim(pvcConfig, ns)
 
 			// Initializes all original metric values.
-			controllerMetrics, err := metricsGrabber.GrabFromControllerManager()
+			controllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 			framework.ExpectNoError(err, "Error getting c-m metricValues: %v", err)
 			for _, metric := range e2emetrics {
 				originMetricValues = append(originMetricValues,
@@ -583,11 +583,11 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 			}
 		})
 
-		ginkgo.AfterEach(func() {
-			if err := e2epv.DeletePersistentVolume(c, pv.Name); err != nil {
+		ginkgo.AfterEach(func(ctx context.Context) {
+			if err := e2epv.DeletePersistentVolume(ctx, c, pv.Name); err != nil {
 				framework.Failf("Error deleting pv: %v", err)
 			}
-			if err := e2epv.DeletePersistentVolumeClaim(c, pvc.Name, pvc.Namespace); err != nil {
+			if err := e2epv.DeletePersistentVolumeClaim(ctx, c, pvc.Name, pvc.Namespace); err != nil {
 				framework.Failf("Error deleting pvc: %v", err)
 			}
 
@@ -596,45 +596,45 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		})
 
 		ginkgo.It("should create none metrics for pvc controller before creating any PV or PVC", func(ctx context.Context) {
-			validator([]map[string]int64{nil, nil, nil, nil})
+			validator(ctx, []map[string]int64{nil, nil, nil, nil})
 		})
 
 		ginkgo.It("should create unbound pv count metrics for pvc controller after creating pv only",
-			func() {
+			func(ctx context.Context) {
 				var err error
-				pv, err = e2epv.CreatePV(c, f.Timeouts, pv)
+				pv, err = e2epv.CreatePV(ctx, c, f.Timeouts, pv)
 				framework.ExpectNoError(err, "Error creating pv: %v", err)
-				waitForPVControllerSync(metricsGrabber, unboundPVKey, classKey)
-				validator([]map[string]int64{nil, {className: 1}, nil, nil})
+				waitForPVControllerSync(ctx, metricsGrabber, unboundPVKey, classKey)
+				validator(ctx, []map[string]int64{nil, {className: 1}, nil, nil})
 			})
 
 		ginkgo.It("should create unbound pvc count metrics for pvc controller after creating pvc only",
-			func() {
+			func(ctx context.Context) {
 				var err error
-				pvc, err = e2epv.CreatePVC(c, ns, pvc)
+				pvc, err = e2epv.CreatePVC(ctx, c, ns, pvc)
 				framework.ExpectNoError(err, "Error creating pvc: %v", err)
-				waitForPVControllerSync(metricsGrabber, unboundPVCKey, namespaceKey)
-				validator([]map[string]int64{nil, nil, nil, {ns: 1}})
+				waitForPVControllerSync(ctx, metricsGrabber, unboundPVCKey, namespaceKey)
+				validator(ctx, []map[string]int64{nil, nil, nil, {ns: 1}})
 			})
 
 		ginkgo.It("should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc",
-			func() {
+			func(ctx context.Context) {
 				var err error
-				pv, pvc, err = e2epv.CreatePVPVC(c, f.Timeouts, pvConfig, pvcConfig, ns, true)
+				pv, pvc, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfig, pvcConfig, ns, true)
 				framework.ExpectNoError(err, "Error creating pv pvc: %v", err)
-				waitForPVControllerSync(metricsGrabber, boundPVKey, classKey)
-				waitForPVControllerSync(metricsGrabber, boundPVCKey, namespaceKey)
-				validator([]map[string]int64{{className: 1}, nil, {ns: 1}, nil})
+				waitForPVControllerSync(ctx, metricsGrabber, boundPVKey, classKey)
+				waitForPVControllerSync(ctx, metricsGrabber, boundPVCKey, namespaceKey)
+				validator(ctx, []map[string]int64{{className: 1}, nil, {ns: 1}, nil})
 
 			})
 		ginkgo.It("should create total pv count metrics for with plugin and volume mode labels after creating pv",
-			func() {
+			func(ctx context.Context) {
 				var err error
 				dimensions := []string{pluginNameKey, volumeModeKey}
-				pv, err = e2epv.CreatePV(c, f.Timeouts, pv)
+				pv, err = e2epv.CreatePV(ctx, c, f.Timeouts, pv)
 				framework.ExpectNoError(err, "Error creating pv: %v", err)
-				waitForPVControllerSync(metricsGrabber, totalPVKey, pluginNameKey)
-				controllerMetrics, err := metricsGrabber.GrabFromControllerManager()
+				waitForPVControllerSync(ctx, metricsGrabber, totalPVKey, pluginNameKey)
+				controllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 				framework.ExpectNoError(err, "Error getting c-m metricValues: %v", err)
 				err = testutil.ValidateMetrics(testutil.Metrics(controllerMetrics), totalPVKey, dimensions...)
 				framework.ExpectNoError(err, "Invalid metric in Controller Manager metrics: %q", totalPVKey)
@@ -660,7 +660,7 @@ func newStorageControllerMetrics() *storageControllerMetrics {
 	}
 }
 
-func waitForDetachAndGrabMetrics(oldMetrics *storageControllerMetrics, metricsGrabber *e2emetrics.Grabber, pluginName string) *storageControllerMetrics {
+func waitForDetachAndGrabMetrics(ctx context.Context, oldMetrics *storageControllerMetrics, metricsGrabber *e2emetrics.Grabber, pluginName string) *storageControllerMetrics {
 	backoff := wait.Backoff{
 		Duration: 10 * time.Second,
 		Factor:   1.2,
@@ -674,7 +674,7 @@ func waitForDetachAndGrabMetrics(oldMetrics *storageControllerMetrics, metricsGr
 	}
 
 	verifyMetricFunc := func() (bool, error) {
-		updatedMetrics, err := metricsGrabber.GrabFromControllerManager()
+		updatedMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 
 		if err != nil {
 			framework.Logf("Error fetching controller-manager metrics")
@@ -698,7 +698,7 @@ func waitForDetachAndGrabMetrics(oldMetrics *storageControllerMetrics, metricsGr
 		return true, nil
 	}
 
-	waitErr := wait.ExponentialBackoff(backoff, verifyMetricFunc)
+	waitErr := wait.ExponentialBackoffWithContext(ctx, backoff, verifyMetricFunc)
 	framework.ExpectNoError(waitErr, "Unable to get updated metrics for plugin %s", pluginName)
 	return updatedStorageMetrics
 }
@@ -815,21 +815,21 @@ func findVolumeStatMetric(metricKeyName string, namespace string, pvcName string
 }
 
 // Wait for the count of a pv controller's metric specified by metricName and dimension bigger than zero.
-func waitForPVControllerSync(metricsGrabber *e2emetrics.Grabber, metricName, dimension string) {
+func waitForPVControllerSync(ctx context.Context, metricsGrabber *e2emetrics.Grabber, metricName, dimension string) {
 	backoff := wait.Backoff{
 		Duration: 10 * time.Second,
 		Factor:   1.2,
 		Steps:    21,
 	}
 	verifyMetricFunc := func() (bool, error) {
-		updatedMetrics, err := metricsGrabber.GrabFromControllerManager()
+		updatedMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 		if err != nil {
 			framework.Logf("Error fetching controller-manager metrics")
 			return false, err
 		}
 		return len(testutil.GetMetricValuesForLabel(testutil.Metrics(updatedMetrics), metricName, dimension)) > 0, nil
 	}
-	waitErr := wait.ExponentialBackoff(backoff, verifyMetricFunc)
+	waitErr := wait.ExponentialBackoffWithContext(ctx, backoff, verifyMetricFunc)
 	framework.ExpectNoError(waitErr, "Unable to get pv controller metrics")
 }
 
@@ -860,14 +860,14 @@ func getStatesMetrics(metricKey string, givenMetrics testutil.Metrics) map[strin
 	return states
 }
 
-func waitForADControllerStatesMetrics(metricsGrabber *e2emetrics.Grabber, metricName string, dimensions []string, stateNames []string) {
+func waitForADControllerStatesMetrics(ctx context.Context, metricsGrabber *e2emetrics.Grabber, metricName string, dimensions []string, stateNames []string) {
 	backoff := wait.Backoff{
 		Duration: 10 * time.Second,
 		Factor:   1.2,
 		Steps:    21,
 	}
 	verifyMetricFunc := func() (bool, error) {
-		updatedMetrics, err := metricsGrabber.GrabFromControllerManager()
+		updatedMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 		if err != nil {
 			e2eskipper.Skipf("Could not get controller-manager metrics - skipping")
 			return false, err
@@ -884,7 +884,7 @@ func waitForADControllerStatesMetrics(metricsGrabber *e2emetrics.Grabber, metric
 		}
 		return true, nil
 	}
-	waitErr := wait.ExponentialBackoff(backoff, verifyMetricFunc)
+	waitErr := wait.ExponentialBackoffWithContext(ctx, backoff, verifyMetricFunc)
 	framework.ExpectNoError(waitErr, "Unable to get A/D controller metrics")
 }
 

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -161,11 +161,11 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					Provisioner:    "kubernetes.io/gce-pd",
 					Parameters: map[string]string{
 						"type": "pd-ssd",
-						"zone": getRandomClusterZone(c),
+						"zone": getRandomClusterZone(ctx, c),
 					},
 					ClaimSize:    "1.5Gi",
 					ExpectedSize: "2Gi",
-					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+					PvCheck: func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(ctx, c, f.Timeouts, claim, e2epod.NodeSelection{})
 						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
@@ -183,7 +183,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					},
 					ClaimSize:    "1.5Gi",
 					ExpectedSize: "2Gi",
-					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+					PvCheck: func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(ctx, c, f.Timeouts, claim, e2epod.NodeSelection{})
 						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
@@ -199,11 +199,11 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					Provisioner:    "kubernetes.io/aws-ebs",
 					Parameters: map[string]string{
 						"type": "gp2",
-						"zone": getRandomClusterZone(c),
+						"zone": getRandomClusterZone(ctx, c),
 					},
 					ClaimSize:    "1.5Gi",
 					ExpectedSize: "2Gi",
-					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+					PvCheck: func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(ctx, c, f.Timeouts, claim, e2epod.NodeSelection{})
 						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
@@ -222,7 +222,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					},
 					ClaimSize:    "3.5Gi",
 					ExpectedSize: "4Gi", // 4 GiB is minimum for io1
-					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+					PvCheck: func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(ctx, c, f.Timeouts, claim, e2epod.NodeSelection{})
 						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
@@ -240,7 +240,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					},
 					ClaimSize:    "500Gi", // minimum for sc1
 					ExpectedSize: "500Gi",
-					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+					PvCheck: func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(ctx, c, f.Timeouts, claim, e2epod.NodeSelection{})
 						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
@@ -258,7 +258,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					},
 					ClaimSize:    "500Gi", // minimum for st1
 					ExpectedSize: "500Gi",
-					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+					PvCheck: func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(ctx, c, f.Timeouts, claim, e2epod.NodeSelection{})
 						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
@@ -276,7 +276,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					},
 					ClaimSize:    "1Gi",
 					ExpectedSize: "1Gi",
-					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+					PvCheck: func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(ctx, c, f.Timeouts, claim, e2epod.NodeSelection{})
 						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
@@ -293,7 +293,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					Parameters:     map[string]string{},
 					ClaimSize:      "1.5Gi",
 					ExpectedSize:   "2Gi",
-					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+					PvCheck: func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 						testsuites.PVWriteReadSingleNodeCheck(ctx, c, f.Timeouts, claim, e2epod.NodeSelection{})
 					},
 				},
@@ -308,7 +308,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					},
 					ClaimSize:    "1.5Gi",
 					ExpectedSize: "2Gi",
-					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+					PvCheck: func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 						testsuites.PVWriteReadSingleNodeCheck(ctx, c, f.Timeouts, claim, e2epod.NodeSelection{})
 					},
 				},
@@ -321,7 +321,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					Parameters:     map[string]string{},
 					ClaimSize:      "1.5Gi",
 					ExpectedSize:   "1.5Gi",
-					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+					PvCheck: func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 						testsuites.PVWriteReadSingleNodeCheck(ctx, c, f.Timeouts, claim, e2epod.NodeSelection{})
 					},
 				},
@@ -334,7 +334,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					Parameters:     map[string]string{},
 					ClaimSize:      "1Gi",
 					ExpectedSize:   "1Gi",
-					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+					PvCheck: func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 						testsuites.PVWriteReadSingleNodeCheck(ctx, c, f.Timeouts, claim, e2epod.NodeSelection{})
 					},
 				},
@@ -386,7 +386,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				},
 				ClaimSize:    "1Gi",
 				ExpectedSize: "1Gi",
-				PvCheck: func(claim *v1.PersistentVolumeClaim) {
+				PvCheck: func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 					volume := testsuites.PVWriteReadSingleNodeCheck(ctx, c, f.Timeouts, claim, e2epod.NodeSelection{})
 					gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
@@ -409,14 +409,14 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			pv := test.TestDynamicProvisioning(ctx)
 
 			ginkgo.By(fmt.Sprintf("waiting for the provisioned PV %q to enter phase %s", pv.Name, v1.VolumeReleased))
-			framework.ExpectNoError(e2epv.WaitForPersistentVolumePhase(v1.VolumeReleased, c, pv.Name, 1*time.Second, 30*time.Second))
+			framework.ExpectNoError(e2epv.WaitForPersistentVolumePhase(ctx, v1.VolumeReleased, c, pv.Name, 1*time.Second, 30*time.Second))
 
 			ginkgo.By(fmt.Sprintf("deleting the storage asset backing the PV %q", pv.Name))
-			framework.ExpectNoError(e2epv.DeletePDWithRetry(pv.Spec.GCEPersistentDisk.PDName))
+			framework.ExpectNoError(e2epv.DeletePDWithRetry(ctx, pv.Spec.GCEPersistentDisk.PDName))
 
 			ginkgo.By(fmt.Sprintf("deleting the PV %q", pv.Name))
-			framework.ExpectNoError(e2epv.DeletePersistentVolume(c, pv.Name), "Failed to delete PV ", pv.Name)
-			framework.ExpectNoError(e2epv.WaitForPersistentVolumeDeleted(c, pv.Name, 1*time.Second, 30*time.Second))
+			framework.ExpectNoError(e2epv.DeletePersistentVolume(ctx, c, pv.Name), "Failed to delete PV ", pv.Name)
+			framework.ExpectNoError(e2epv.WaitForPersistentVolumeDeleted(ctx, c, pv.Name, 1*time.Second, 30*time.Second))
 		})
 
 		ginkgo.It("should test that deleting a claim before the volume is provisioned deletes the volume.", func(ctx context.Context) {
@@ -438,7 +438,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			}
 
 			class := newStorageClass(test, ns, "race")
-			class, err := c.StorageV1().StorageClasses().Create(context.TODO(), class, metav1.CreateOptions{})
+			class, err := c.StorageV1().StorageClasses().Create(ctx, class, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			ginkgo.DeferCleanup(deleteStorageClass, c, class.Name)
 
@@ -451,13 +451,13 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					StorageClassName: &class.Name,
 					VolumeMode:       &test.VolumeMode,
 				}, ns)
-				tmpClaim, err := e2epv.CreatePVC(c, ns, claim)
+				tmpClaim, err := e2epv.CreatePVC(ctx, c, ns, claim)
 				framework.ExpectNoError(err)
-				framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(c, tmpClaim.Name, ns))
+				framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(ctx, c, tmpClaim.Name, ns))
 			}
 
 			ginkgo.By(fmt.Sprintf("Checking for residual PersistentVolumes associated with StorageClass %s", class.Name))
-			residualPVs, err = waitForProvisionedVolumesDeleted(c, class.Name)
+			residualPVs, err = waitForProvisionedVolumesDeleted(ctx, c, class.Name)
 			// Cleanup the test resources before breaking
 			ginkgo.DeferCleanup(deleteProvisionedVolumesAndDisks, c, residualPVs)
 			framework.ExpectNoError(err, "PersistentVolumes were not deleted as expected. %d remain", len(residualPVs))
@@ -473,7 +473,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			// is already deleted.
 			e2eskipper.SkipUnlessProviderIs("gce", "gke", "aws")
 			ginkgo.By("creating PD")
-			diskName, err := e2epv.CreatePDWithRetry()
+			diskName, err := e2epv.CreatePDWithRetry(ctx)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("creating PV")
@@ -510,26 +510,26 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					},
 				}
 			}
-			pv, err = c.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{})
+			pv, err = c.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("waiting for the PV to get Released")
-			err = e2epv.WaitForPersistentVolumePhase(v1.VolumeReleased, c, pv.Name, 2*time.Second, timeouts.PVReclaim)
+			err = e2epv.WaitForPersistentVolumePhase(ctx, v1.VolumeReleased, c, pv.Name, 2*time.Second, timeouts.PVReclaim)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("deleting the PD")
-			err = e2epv.DeletePVSource(&pv.Spec.PersistentVolumeSource)
+			err = e2epv.DeletePVSource(ctx, &pv.Spec.PersistentVolumeSource)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("changing the PV reclaim policy")
-			pv, err = c.CoreV1().PersistentVolumes().Get(context.TODO(), pv.Name, metav1.GetOptions{})
+			pv, err = c.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 			pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimDelete
-			pv, err = c.CoreV1().PersistentVolumes().Update(context.TODO(), pv, metav1.UpdateOptions{})
+			pv, err = c.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("waiting for the PV to get deleted")
-			err = e2epv.WaitForPersistentVolumeDeleted(c, pv.Name, 5*time.Second, timeouts.PVDelete)
+			err = e2epv.WaitForPersistentVolumeDeleted(ctx, c, pv.Name, 5*time.Second, timeouts.PVDelete)
 			framework.ExpectNoError(err)
 		})
 	})
@@ -545,11 +545,11 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				Name:      serviceAccountName,
 			}
 
-			err := e2eauth.BindClusterRole(c.RbacV1(), "system:persistent-volume-provisioner", ns, subject)
+			err := e2eauth.BindClusterRole(ctx, c.RbacV1(), "system:persistent-volume-provisioner", ns, subject)
 			framework.ExpectNoError(err)
 
 			roleName := "leader-locking-nfs-provisioner"
-			_, err = f.ClientSet.RbacV1().Roles(ns).Create(context.TODO(), &rbacv1.Role{
+			_, err = f.ClientSet.RbacV1().Roles(ns).Create(ctx, &rbacv1.Role{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: roleName,
 				},
@@ -561,16 +561,16 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			}, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "Failed to create leader-locking role")
 
-			err = e2eauth.BindRoleInNamespace(c.RbacV1(), roleName, ns, subject)
+			err = e2eauth.BindRoleInNamespace(ctx, c.RbacV1(), roleName, ns, subject)
 			framework.ExpectNoError(err)
 
-			err = e2eauth.WaitForAuthorizationUpdate(c.AuthorizationV1(),
+			err = e2eauth.WaitForAuthorizationUpdate(ctx, c.AuthorizationV1(),
 				serviceaccount.MakeUsername(ns, serviceAccountName),
 				"", "get", schema.GroupResource{Group: "storage.k8s.io", Resource: "storageclasses"}, true)
 			framework.ExpectNoError(err, "Failed to update authorization")
 
 			ginkgo.By("creating an external dynamic provisioner pod")
-			pod := utils.StartExternalProvisioner(c, ns, externalPluginName)
+			pod := utils.StartExternalProvisioner(ctx, c, ns, externalPluginName)
 			ginkgo.DeferCleanup(e2epod.DeletePodOrFail, c, ns, pod.Name)
 
 			ginkgo.By("creating a StorageClass")
@@ -601,7 +601,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 	ginkgo.Describe("DynamicProvisioner Default", func() {
 		ginkgo.It("should create and delete default persistent volumes [Slow]", func(ctx context.Context) {
 			e2eskipper.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 
 			ginkgo.By("creating a claim with no annotation")
 			test := testsuites.StorageClassTest{
@@ -625,9 +625,9 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 		// Modifying the default storage class can be disruptive to other tests that depend on it
 		ginkgo.It("should be disabled by changing the default annotation [Serial] [Disruptive]", func(ctx context.Context) {
 			e2eskipper.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 
-			scName, scErr := e2epv.GetDefaultStorageClassName(c)
+			scName, scErr := e2epv.GetDefaultStorageClassName(ctx, c)
 			framework.ExpectNoError(scErr)
 
 			test := testsuites.StorageClassTest{
@@ -637,24 +637,24 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			}
 
 			ginkgo.By("setting the is-default StorageClass annotation to false")
-			verifyDefaultStorageClass(c, scName, true)
+			verifyDefaultStorageClass(ctx, c, scName, true)
 			ginkgo.DeferCleanup(updateDefaultStorageClass, c, scName, "true")
-			updateDefaultStorageClass(c, scName, "false")
+			updateDefaultStorageClass(ctx, c, scName, "false")
 
 			ginkgo.By("creating a claim with default storageclass and expecting it to timeout")
 			claim := e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
 				ClaimSize:  test.ClaimSize,
 				VolumeMode: &test.VolumeMode,
 			}, ns)
-			claim, err := c.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), claim, metav1.CreateOptions{})
+			claim, err := c.CoreV1().PersistentVolumeClaims(ns).Create(ctx, claim, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			ginkgo.DeferCleanup(e2epv.DeletePersistentVolumeClaim, c, claim.Name, ns)
 
 			// The claim should timeout phase:Pending
-			err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, claim.Name, 2*time.Second, framework.ClaimProvisionShortTimeout)
+			err = e2epv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, c, ns, claim.Name, 2*time.Second, framework.ClaimProvisionShortTimeout)
 			framework.ExpectError(err)
 			framework.Logf(err.Error())
-			claim, err = c.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), claim.Name, metav1.GetOptions{})
+			claim, err = c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, claim.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(claim.Status.Phase, v1.ClaimPending)
 		})
@@ -662,9 +662,9 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 		// Modifying the default storage class can be disruptive to other tests that depend on it
 		ginkgo.It("should be disabled by removing the default annotation [Serial] [Disruptive]", func(ctx context.Context) {
 			e2eskipper.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
-			e2epv.SkipIfNoDefaultStorageClass(c)
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 
-			scName, scErr := e2epv.GetDefaultStorageClassName(c)
+			scName, scErr := e2epv.GetDefaultStorageClassName(ctx, c)
 			framework.ExpectNoError(scErr)
 
 			test := testsuites.StorageClassTest{
@@ -674,26 +674,26 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			}
 
 			ginkgo.By("removing the is-default StorageClass annotation")
-			verifyDefaultStorageClass(c, scName, true)
+			verifyDefaultStorageClass(ctx, c, scName, true)
 			ginkgo.DeferCleanup(updateDefaultStorageClass, c, scName, "true")
-			updateDefaultStorageClass(c, scName, "")
+			updateDefaultStorageClass(ctx, c, scName, "")
 
 			ginkgo.By("creating a claim with default storageclass and expecting it to timeout")
 			claim := e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
 				ClaimSize:  test.ClaimSize,
 				VolumeMode: &test.VolumeMode,
 			}, ns)
-			claim, err := c.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), claim, metav1.CreateOptions{})
+			claim, err := c.CoreV1().PersistentVolumeClaims(ns).Create(ctx, claim, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			defer func() {
-				framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(c, claim.Name, ns))
+				framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(ctx, c, claim.Name, ns))
 			}()
 
 			// The claim should timeout phase:Pending
-			err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, claim.Name, 2*time.Second, framework.ClaimProvisionShortTimeout)
+			err = e2epv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, c, ns, claim.Name, 2*time.Second, framework.ClaimProvisionShortTimeout)
 			framework.ExpectError(err)
 			framework.Logf(err.Error())
-			claim, err = c.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), claim.Name, metav1.GetOptions{})
+			claim, err = c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, claim.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(claim.Status.Phase, v1.ClaimPending)
 		})
@@ -720,11 +720,11 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				StorageClassName: &test.Class.Name,
 				VolumeMode:       &test.VolumeMode,
 			}, ns)
-			claim, err := c.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(context.TODO(), claim, metav1.CreateOptions{})
+			claim, err := c.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(ctx, claim, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			defer func() {
 				framework.Logf("deleting claim %q/%q", claim.Namespace, claim.Name)
-				err = c.CoreV1().PersistentVolumeClaims(claim.Namespace).Delete(context.TODO(), claim.Name, metav1.DeleteOptions{})
+				err = c.CoreV1().PersistentVolumeClaims(claim.Namespace).Delete(ctx, claim.Name, metav1.DeleteOptions{})
 				if err != nil && !apierrors.IsNotFound(err) {
 					framework.Failf("Error deleting claim %q. Error: %v", claim.Name, err)
 				}
@@ -735,7 +735,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			// key was not provisioned. If the event is not delivered, we check that the volume is not Bound for whole
 			// ClaimProvisionTimeout in the very same loop.
 			err = wait.Poll(time.Second, framework.ClaimProvisionTimeout, func() (bool, error) {
-				events, err := c.CoreV1().Events(claim.Namespace).List(context.TODO(), metav1.ListOptions{})
+				events, err := c.CoreV1().Events(claim.Namespace).List(ctx, metav1.ListOptions{})
 				if err != nil {
 					return false, fmt.Errorf("could not list PVC events in %s: %v", claim.Namespace, err)
 				}
@@ -745,7 +745,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					}
 				}
 
-				pvc, err := c.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(context.TODO(), claim.Name, metav1.GetOptions{})
+				pvc, err := c.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(ctx, claim.Name, metav1.GetOptions{})
 				if err != nil {
 					return true, err
 				}
@@ -765,14 +765,14 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 	})
 })
 
-func verifyDefaultStorageClass(c clientset.Interface, scName string, expectedDefault bool) {
-	sc, err := c.StorageV1().StorageClasses().Get(context.TODO(), scName, metav1.GetOptions{})
+func verifyDefaultStorageClass(ctx context.Context, c clientset.Interface, scName string, expectedDefault bool) {
+	sc, err := c.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	framework.ExpectEqual(storageutil.IsDefaultAnnotation(sc.ObjectMeta), expectedDefault)
 }
 
-func updateDefaultStorageClass(c clientset.Interface, scName string, defaultStr string) {
-	sc, err := c.StorageV1().StorageClasses().Get(context.TODO(), scName, metav1.GetOptions{})
+func updateDefaultStorageClass(ctx context.Context, c clientset.Interface, scName string, defaultStr string) {
+	sc, err := c.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 
 	if defaultStr == "" {
@@ -786,14 +786,14 @@ func updateDefaultStorageClass(c clientset.Interface, scName string, defaultStr 
 		sc.Annotations[storageutil.IsDefaultStorageClassAnnotation] = defaultStr
 	}
 
-	_, err = c.StorageV1().StorageClasses().Update(context.TODO(), sc, metav1.UpdateOptions{})
+	_, err = c.StorageV1().StorageClasses().Update(ctx, sc, metav1.UpdateOptions{})
 	framework.ExpectNoError(err)
 
 	expectedDefault := false
 	if defaultStr == "true" {
 		expectedDefault = true
 	}
-	verifyDefaultStorageClass(c, scName, expectedDefault)
+	verifyDefaultStorageClass(ctx, c, scName, expectedDefault)
 }
 
 func getDefaultPluginName() string {
@@ -872,13 +872,13 @@ func getStorageClass(
 
 // waitForProvisionedVolumesDelete is a polling wrapper to scan all PersistentVolumes for any associated to the test's
 // StorageClass.  Returns either an error and nil values or the remaining PVs and their count.
-func waitForProvisionedVolumesDeleted(c clientset.Interface, scName string) ([]*v1.PersistentVolume, error) {
+func waitForProvisionedVolumesDeleted(ctx context.Context, c clientset.Interface, scName string) ([]*v1.PersistentVolume, error) {
 	var remainingPVs []*v1.PersistentVolume
 
 	err := wait.Poll(10*time.Second, 300*time.Second, func() (bool, error) {
 		remainingPVs = []*v1.PersistentVolume{}
 
-		allPVs, err := c.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
+		allPVs, err := c.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -900,27 +900,27 @@ func waitForProvisionedVolumesDeleted(c clientset.Interface, scName string) ([]*
 }
 
 // deleteStorageClass deletes the passed in StorageClass and catches errors other than "Not Found"
-func deleteStorageClass(c clientset.Interface, className string) {
-	err := c.StorageV1().StorageClasses().Delete(context.TODO(), className, metav1.DeleteOptions{})
+func deleteStorageClass(ctx context.Context, c clientset.Interface, className string) {
+	err := c.StorageV1().StorageClasses().Delete(ctx, className, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		framework.ExpectNoError(err)
 	}
 }
 
 // deleteProvisionedVolumes [gce||gke only]  iteratively deletes persistent volumes and attached GCE PDs.
-func deleteProvisionedVolumesAndDisks(c clientset.Interface, pvs []*v1.PersistentVolume) {
+func deleteProvisionedVolumesAndDisks(ctx context.Context, c clientset.Interface, pvs []*v1.PersistentVolume) {
 	framework.Logf("Remaining PersistentVolumes:")
 	for i, pv := range pvs {
 		framework.Logf("\t%d) %s", i+1, pv.Name)
 	}
 	for _, pv := range pvs {
-		framework.ExpectNoError(e2epv.DeletePDWithRetry(pv.Spec.PersistentVolumeSource.GCEPersistentDisk.PDName))
-		framework.ExpectNoError(e2epv.DeletePersistentVolume(c, pv.Name))
+		framework.ExpectNoError(e2epv.DeletePDWithRetry(ctx, pv.Spec.PersistentVolumeSource.GCEPersistentDisk.PDName))
+		framework.ExpectNoError(e2epv.DeletePersistentVolume(ctx, c, pv.Name))
 	}
 }
 
-func getRandomClusterZone(c clientset.Interface) string {
-	zones, err := e2enode.GetClusterZones(c)
+func getRandomClusterZone(ctx context.Context, c clientset.Interface) string {
+	zones, err := e2enode.GetClusterZones(ctx, c)
 	zone := ""
 	framework.ExpectNoError(err)
 	if len(zones) != 0 {

--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -66,11 +66,11 @@ var _ = utils.SIGDescribe("Volumes", func() {
 					"third":  "this is the third file",
 				},
 			}
-			if _, err := cs.CoreV1().ConfigMaps(namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+			if _, err := cs.CoreV1().ConfigMaps(namespace.Name).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 				framework.Failf("unable to create test configmap: %v", err)
 			}
 			defer func() {
-				_ = cs.CoreV1().ConfigMaps(namespace.Name).Delete(context.TODO(), configMap.Name, metav1.DeleteOptions{})
+				_ = cs.CoreV1().ConfigMaps(namespace.Name).Delete(ctx, configMap.Name, metav1.DeleteOptions{})
 			}()
 
 			// Test one ConfigMap mounted several times to test #28502
@@ -110,7 +110,7 @@ var _ = utils.SIGDescribe("Volumes", func() {
 					ExpectedContent: "this is the second file",
 				},
 			}
-			e2evolume.TestVolumeClient(f, config, nil, "" /* fsType */, tests)
+			e2evolume.TestVolumeClient(ctx, f, config, nil, "" /* fsType */, tests)
 		})
 	})
 })

--- a/test/e2e/storage/vsphere/persistent_volumes-vsphere.go
+++ b/test/e2e/storage/vsphere/persistent_volumes-vsphere.go
@@ -62,7 +62,7 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere [Feature:vsphere]", func() 
 		4. Create a POD using the PVC.
 		5. Verify Disk and Attached to the node.
 	*/
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		e2eskipper.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		c = f.ClientSet
@@ -70,7 +70,7 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere [Feature:vsphere]", func() 
 		clientPod = nil
 		pvc = nil
 		pv = nil
-		nodeInfo = GetReadySchedulableRandomNodeInfo()
+		nodeInfo = GetReadySchedulableRandomNodeInfo(ctx)
 
 		volLabel = labels.Set{e2epv.VolumeSelectorKey: ns}
 		selector = metav1.SetAsLabelSelector(volLabel)
@@ -97,29 +97,29 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere [Feature:vsphere]", func() 
 			StorageClassName: &emptyStorageClass,
 		}
 		ginkgo.By("Creating the PV and PVC")
-		pv, pvc, err = e2epv.CreatePVPVC(c, f.Timeouts, pvConfig, pvcConfig, ns, false)
+		pv, pvc, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfig, pvcConfig, ns, false)
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(func() {
-			framework.ExpectNoError(e2epv.DeletePersistentVolume(c, pv.Name), "AfterEach: failed to delete PV ", pv.Name)
+			framework.ExpectNoError(e2epv.DeletePersistentVolume(ctx, c, pv.Name), "AfterEach: failed to delete PV ", pv.Name)
 		})
 		ginkgo.DeferCleanup(func() {
-			framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(c, pvc.Name, ns), "AfterEach: failed to delete PVC ", pvc.Name)
+			framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(ctx, c, pvc.Name, ns), "AfterEach: failed to delete PVC ", pvc.Name)
 		})
-		framework.ExpectNoError(e2epv.WaitOnPVandPVC(c, f.Timeouts, ns, pv, pvc))
+		framework.ExpectNoError(e2epv.WaitOnPVandPVC(ctx, c, f.Timeouts, ns, pv, pvc))
 
 		ginkgo.By("Creating the Client Pod")
-		clientPod, err = e2epod.CreateClientPod(c, ns, pvc)
+		clientPod, err = e2epod.CreateClientPod(ctx, c, ns, pvc)
 		framework.ExpectNoError(err)
 		node = clientPod.Spec.NodeName
 		ginkgo.DeferCleanup(func() {
-			framework.ExpectNoError(e2epod.DeletePodWithWait(c, clientPod), "AfterEach: failed to delete pod ", clientPod.Name)
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, c, clientPod), "AfterEach: failed to delete pod ", clientPod.Name)
 		})
 		ginkgo.DeferCleanup(func() {
-			framework.ExpectNoError(waitForVSphereDiskToDetach(volumePath, node), "wait for vsphere disk to detach")
+			framework.ExpectNoError(waitForVSphereDiskToDetach(ctx, volumePath, node), "wait for vsphere disk to detach")
 		})
 
 		ginkgo.By("Verify disk should be attached to the node")
-		isAttached, err := diskIsAttached(volumePath, node)
+		isAttached, err := diskIsAttached(ctx, volumePath, node)
 		framework.ExpectNoError(err)
 		if !isAttached {
 			framework.Failf("Disk %s is not attached with the node", volumePath)
@@ -128,11 +128,11 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere [Feature:vsphere]", func() 
 
 	ginkgo.It("should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach", func(ctx context.Context) {
 		ginkgo.By("Deleting the Claim")
-		framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)
+		framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(ctx, c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)
 		pvc = nil
 
 		ginkgo.By("Deleting the Pod")
-		framework.ExpectNoError(e2epod.DeletePodWithWait(c, clientPod), "Failed to delete pod ", clientPod.Name)
+		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, c, clientPod), "Failed to delete pod ", clientPod.Name)
 	})
 
 	/*
@@ -144,11 +144,11 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere [Feature:vsphere]", func() 
 	*/
 	ginkgo.It("should test that deleting the PV before the pod does not cause pod deletion to fail on vsphere volume detach", func(ctx context.Context) {
 		ginkgo.By("Deleting the Persistent Volume")
-		framework.ExpectNoError(e2epv.DeletePersistentVolume(c, pv.Name), "Failed to delete PV ", pv.Name)
+		framework.ExpectNoError(e2epv.DeletePersistentVolume(ctx, c, pv.Name), "Failed to delete PV ", pv.Name)
 		pv = nil
 
 		ginkgo.By("Deleting the pod")
-		framework.ExpectNoError(e2epod.DeletePodWithWait(c, clientPod), "Failed to delete pod ", clientPod.Name)
+		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, c, clientPod), "Failed to delete pod ", clientPod.Name)
 	})
 	/*
 		This test verifies that a volume mounted to a pod remains mounted after a kubelet restarts.
@@ -159,7 +159,7 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere [Feature:vsphere]", func() 
 	*/
 	ginkgo.It("should test that a file written to the vsphere volume mount before kubelet restart can be read after restart [Disruptive]", func(ctx context.Context) {
 		e2eskipper.SkipUnlessSSHKeyPresent()
-		utils.TestKubeletRestartsAndRestoresMount(c, f, clientPod, e2epod.VolumeMountPath1)
+		utils.TestKubeletRestartsAndRestoresMount(ctx, c, f, clientPod, e2epod.VolumeMountPath1)
 	})
 
 	/*
@@ -175,7 +175,7 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere [Feature:vsphere]", func() 
 	*/
 	ginkgo.It("should test that a vsphere volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]", func(ctx context.Context) {
 		e2eskipper.SkipUnlessSSHKeyPresent()
-		utils.TestVolumeUnmountsFromDeletedPod(c, f, clientPod, e2epod.VolumeMountPath1)
+		utils.TestVolumeUnmountsFromDeletedPod(ctx, c, f, clientPod, e2epod.VolumeMountPath1)
 	})
 
 	/*
@@ -188,13 +188,14 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere [Feature:vsphere]", func() 
 	*/
 	ginkgo.It("should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume", func(ctx context.Context) {
 		ginkgo.By("Deleting the Namespace")
-		err := c.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		err := c.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 
-		err = framework.WaitForNamespacesDeleted(c, []string{ns}, 3*time.Minute)
+		err = framework.WaitForNamespacesDeleted(ctx, c, []string{ns}, 3*time.Minute)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Verifying Persistent Disk detaches")
-		waitForVSphereDiskToDetach(volumePath, node)
+		err = waitForVSphereDiskToDetach(ctx, volumePath, node)
+		framework.ExpectNoError(err)
 	})
 })

--- a/test/e2e/storage/vsphere/pvc_label_selector.go
+++ b/test/e2e/storage/vsphere/pvc_label_selector.go
@@ -63,13 +63,13 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:vsphere][Feature:LabelSele
 		err        error
 		nodeInfo   *NodeInfo
 	)
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		e2eskipper.SkipUnlessProviderIs("vsphere")
 		c = f.ClientSet
 		ns = f.Namespace.Name
 		Bootstrap(f)
-		nodeInfo = GetReadySchedulableRandomNodeInfo()
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
+		nodeInfo = GetReadySchedulableRandomNodeInfo(ctx)
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, framework.TestContext.NodeSchedulableTimeout))
 		ssdlabels = make(map[string]string)
 		ssdlabels["volume-type"] = "ssd"
 		vvollabels = make(map[string]string)
@@ -78,38 +78,38 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:vsphere][Feature:LabelSele
 	})
 
 	ginkgo.Describe("Selector-Label Volume Binding:vsphere [Feature:vsphere]", func() {
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			ginkgo.By("Running clean up actions")
 			if framework.ProviderIs("vsphere") {
-				testCleanupVSpherePVClabelselector(c, ns, nodeInfo, volumePath, pvSsd, pvcSsd, pvcVvol)
+				testCleanupVSpherePVClabelselector(ctx, c, ns, nodeInfo, volumePath, pvSsd, pvcSsd, pvcVvol)
 			}
 		})
 		ginkgo.It("should bind volume with claim for given label", func(ctx context.Context) {
-			volumePath, pvSsd, pvcSsd, pvcVvol, err = testSetupVSpherePVClabelselector(c, nodeInfo, ns, ssdlabels, vvollabels)
+			volumePath, pvSsd, pvcSsd, pvcVvol, err = testSetupVSpherePVClabelselector(ctx, c, nodeInfo, ns, ssdlabels, vvollabels)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("wait for the pvcSsd to bind with pvSsd")
-			framework.ExpectNoError(e2epv.WaitOnPVandPVC(c, f.Timeouts, ns, pvSsd, pvcSsd))
+			framework.ExpectNoError(e2epv.WaitOnPVandPVC(ctx, c, f.Timeouts, ns, pvSsd, pvcSsd))
 
 			ginkgo.By("Verify status of pvcVvol is pending")
-			err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, c, ns, pvcVvol.Name, 3*time.Second, 300*time.Second)
+			err = e2epv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimPending, c, ns, pvcVvol.Name, 3*time.Second, 300*time.Second)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("delete pvcSsd")
-			framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(c, pvcSsd.Name, ns), "Failed to delete PVC ", pvcSsd.Name)
+			framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(ctx, c, pvcSsd.Name, ns), "Failed to delete PVC ", pvcSsd.Name)
 
 			ginkgo.By("verify pvSsd is deleted")
-			err = e2epv.WaitForPersistentVolumeDeleted(c, pvSsd.Name, 3*time.Second, 300*time.Second)
+			err = e2epv.WaitForPersistentVolumeDeleted(ctx, c, pvSsd.Name, 3*time.Second, 300*time.Second)
 			framework.ExpectNoError(err)
 			volumePath = ""
 
 			ginkgo.By("delete pvcVvol")
-			framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(c, pvcVvol.Name, ns), "Failed to delete PVC ", pvcVvol.Name)
+			framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(ctx, c, pvcVvol.Name, ns), "Failed to delete PVC ", pvcVvol.Name)
 		})
 	})
 })
 
-func testSetupVSpherePVClabelselector(c clientset.Interface, nodeInfo *NodeInfo, ns string, ssdlabels map[string]string, vvollabels map[string]string) (volumePath string, pvSsd *v1.PersistentVolume, pvcSsd *v1.PersistentVolumeClaim, pvcVvol *v1.PersistentVolumeClaim, err error) {
+func testSetupVSpherePVClabelselector(ctx context.Context, c clientset.Interface, nodeInfo *NodeInfo, ns string, ssdlabels map[string]string, vvollabels map[string]string) (volumePath string, pvSsd *v1.PersistentVolume, pvcSsd *v1.PersistentVolumeClaim, pvcVvol *v1.PersistentVolumeClaim, err error) {
 	ginkgo.By("creating vmdk")
 	volumePath = ""
 	volumePath, err = nodeInfo.VSphere.CreateVolume(&VolumeOptions{}, nodeInfo.DataCenterRef)
@@ -119,36 +119,36 @@ func testSetupVSpherePVClabelselector(c clientset.Interface, nodeInfo *NodeInfo,
 
 	ginkgo.By("creating the pv with label volume-type:ssd")
 	pvSsd = getVSpherePersistentVolumeSpec(volumePath, v1.PersistentVolumeReclaimDelete, ssdlabels)
-	pvSsd, err = c.CoreV1().PersistentVolumes().Create(context.TODO(), pvSsd, metav1.CreateOptions{})
+	pvSsd, err = c.CoreV1().PersistentVolumes().Create(ctx, pvSsd, metav1.CreateOptions{})
 	if err != nil {
 		return
 	}
 
 	ginkgo.By("creating pvc with label selector to match with volume-type:vvol")
 	pvcVvol = getVSpherePersistentVolumeClaimSpec(ns, vvollabels)
-	pvcVvol, err = c.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), pvcVvol, metav1.CreateOptions{})
+	pvcVvol, err = c.CoreV1().PersistentVolumeClaims(ns).Create(ctx, pvcVvol, metav1.CreateOptions{})
 	if err != nil {
 		return
 	}
 
 	ginkgo.By("creating pvc with label selector to match with volume-type:ssd")
 	pvcSsd = getVSpherePersistentVolumeClaimSpec(ns, ssdlabels)
-	pvcSsd, err = c.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), pvcSsd, metav1.CreateOptions{})
+	pvcSsd, err = c.CoreV1().PersistentVolumeClaims(ns).Create(ctx, pvcSsd, metav1.CreateOptions{})
 	return
 }
 
-func testCleanupVSpherePVClabelselector(c clientset.Interface, ns string, nodeInfo *NodeInfo, volumePath string, pvSsd *v1.PersistentVolume, pvcSsd *v1.PersistentVolumeClaim, pvcVvol *v1.PersistentVolumeClaim) {
+func testCleanupVSpherePVClabelselector(ctx context.Context, c clientset.Interface, ns string, nodeInfo *NodeInfo, volumePath string, pvSsd *v1.PersistentVolume, pvcSsd *v1.PersistentVolumeClaim, pvcVvol *v1.PersistentVolumeClaim) {
 	ginkgo.By("running testCleanupVSpherePVClabelselector")
 	if len(volumePath) > 0 {
 		nodeInfo.VSphere.DeleteVolume(volumePath, nodeInfo.DataCenterRef)
 	}
 	if pvcSsd != nil {
-		framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(c, pvcSsd.Name, ns), "Failed to delete PVC ", pvcSsd.Name)
+		framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(ctx, c, pvcSsd.Name, ns), "Failed to delete PVC ", pvcSsd.Name)
 	}
 	if pvcVvol != nil {
-		framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(c, pvcVvol.Name, ns), "Failed to delete PVC ", pvcVvol.Name)
+		framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(ctx, c, pvcVvol.Name, ns), "Failed to delete PVC ", pvcVvol.Name)
 	}
 	if pvSsd != nil {
-		framework.ExpectNoError(e2epv.DeletePersistentVolume(c, pvSsd.Name), "Failed to delete PV ", pvSsd.Name)
+		framework.ExpectNoError(e2epv.DeletePersistentVolume(ctx, c, pvSsd.Name), "Failed to delete PV ", pvSsd.Name)
 	}
 }

--- a/test/e2e/storage/vsphere/vsphere_scale.go
+++ b/test/e2e/storage/vsphere/vsphere_scale.go
@@ -74,7 +74,7 @@ var _ = utils.SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 		scNames           = []string{storageclass1, storageclass2, storageclass3, storageclass4}
 	)
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		e2eskipper.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
@@ -97,7 +97,7 @@ var _ = utils.SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 		datastoreName = GetAndExpectStringEnvVar(StorageClassDatastoreName)
 
 		var err error
-		nodes, err = e2enode.GetReadySchedulableNodes(client)
+		nodes, err = e2enode.GetReadySchedulableNodes(ctx, client)
 		framework.ExpectNoError(err)
 		if len(nodes.Items) < 2 {
 			e2eskipper.Skipf("Requires at least %d nodes (not %d)", 2, len(nodes.Items))
@@ -135,7 +135,7 @@ var _ = utils.SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 			case storageclass4:
 				scParams[Datastore] = datastoreName
 			}
-			sc, err = client.StorageV1().StorageClasses().Create(context.TODO(), getVSphereStorageClassSpec(scname, scParams, nil, ""), metav1.CreateOptions{})
+			sc, err = client.StorageV1().StorageClasses().Create(ctx, getVSphereStorageClassSpec(scname, scParams, nil, ""), metav1.CreateOptions{})
 			gomega.Expect(sc).NotTo(gomega.BeNil(), "Storage class is empty")
 			framework.ExpectNoError(err, "Failed to create storage class")
 			ginkgo.DeferCleanup(client.StorageV1().StorageClasses().Delete, scname, metav1.DeleteOptions{})
@@ -148,7 +148,7 @@ var _ = utils.SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 				volumeCountPerInstance = volumeCount
 			}
 			volumeCount = volumeCount - volumeCountPerInstance
-			go VolumeCreateAndAttach(client, f.Timeouts, namespace, scArrays, volumeCountPerInstance, volumesPerPod, nodeSelectorList, nodeVolumeMapChan)
+			go VolumeCreateAndAttach(ctx, client, f.Timeouts, namespace, scArrays, volumeCountPerInstance, volumesPerPod, nodeSelectorList, nodeVolumeMapChan)
 		}
 
 		// Get the list of all volumes attached to each node from the go routines by reading the data from the channel
@@ -157,20 +157,20 @@ var _ = utils.SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 				nodeVolumeMap[node] = append(nodeVolumeMap[node], volumeList...)
 			}
 		}
-		podList, err := client.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+		podList, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "Failed to list pods")
 		for _, pod := range podList.Items {
 			pvcClaimList = append(pvcClaimList, getClaimsForPod(&pod, volumesPerPod)...)
 			ginkgo.By("Deleting pod")
-			err = e2epod.DeletePodWithWait(client, &pod)
+			err = e2epod.DeletePodWithWait(ctx, client, &pod)
 			framework.ExpectNoError(err)
 		}
 		ginkgo.By("Waiting for volumes to be detached from the node")
-		err = waitForVSphereDisksToDetach(nodeVolumeMap)
+		err = waitForVSphereDisksToDetach(ctx, nodeVolumeMap)
 		framework.ExpectNoError(err)
 
 		for _, pvcClaim := range pvcClaimList {
-			err = e2epv.DeletePersistentVolumeClaim(client, pvcClaim, namespace)
+			err = e2epv.DeletePersistentVolumeClaim(ctx, client, pvcClaim, namespace)
 			framework.ExpectNoError(err)
 		}
 	})
@@ -188,7 +188,7 @@ func getClaimsForPod(pod *v1.Pod, volumesPerPod int) []string {
 }
 
 // VolumeCreateAndAttach peforms create and attach operations of vSphere persistent volumes at scale
-func VolumeCreateAndAttach(client clientset.Interface, timeouts *framework.TimeoutContext, namespace string, sc []*storagev1.StorageClass, volumeCountPerInstance int, volumesPerPod int, nodeSelectorList []*NodeSelector, nodeVolumeMapChan chan map[string][]string) {
+func VolumeCreateAndAttach(ctx context.Context, client clientset.Interface, timeouts *framework.TimeoutContext, namespace string, sc []*storagev1.StorageClass, volumeCountPerInstance int, volumesPerPod int, nodeSelectorList []*NodeSelector, nodeVolumeMapChan chan map[string][]string) {
 	defer ginkgo.GinkgoRecover()
 	nodeVolumeMap := make(map[string][]string)
 	nodeSelectorIndex := 0
@@ -199,26 +199,26 @@ func VolumeCreateAndAttach(client clientset.Interface, timeouts *framework.Timeo
 		pvclaims := make([]*v1.PersistentVolumeClaim, volumesPerPod)
 		for i := 0; i < volumesPerPod; i++ {
 			ginkgo.By("Creating PVC using the Storage Class")
-			pvclaim, err := e2epv.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", sc[index%len(sc)]))
+			pvclaim, err := e2epv.CreatePVC(ctx, client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", sc[index%len(sc)]))
 			framework.ExpectNoError(err)
 			pvclaims[i] = pvclaim
 		}
 
 		ginkgo.By("Waiting for claim to be in bound phase")
-		persistentvolumes, err := e2epv.WaitForPVClaimBoundPhase(client, pvclaims, timeouts.ClaimProvision)
+		persistentvolumes, err := e2epv.WaitForPVClaimBoundPhase(ctx, client, pvclaims, timeouts.ClaimProvision)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating pod to attach PV to the node")
 		nodeSelector := nodeSelectorList[nodeSelectorIndex%len(nodeSelectorList)]
 		// Create pod to attach Volume to Node
-		pod, err := e2epod.CreatePod(client, namespace, map[string]string{nodeSelector.labelKey: nodeSelector.labelValue}, pvclaims, false, "")
+		pod, err := e2epod.CreatePod(ctx, client, namespace, map[string]string{nodeSelector.labelKey: nodeSelector.labelValue}, pvclaims, false, "")
 		framework.ExpectNoError(err)
 
 		for _, pv := range persistentvolumes {
 			nodeVolumeMap[pod.Spec.NodeName] = append(nodeVolumeMap[pod.Spec.NodeName], pv.Spec.VsphereVolume.VolumePath)
 		}
 		ginkgo.By("Verify the volume is accessible and available in the pod")
-		verifyVSphereVolumesAccessible(client, pod, persistentvolumes)
+		verifyVSphereVolumesAccessible(ctx, client, pod, persistentvolumes)
 		nodeSelectorIndex++
 	}
 	nodeVolumeMapChan <- nodeVolumeMap

--- a/test/e2e/storage/vsphere/vsphere_statefulsets.go
+++ b/test/e2e/storage/vsphere/vsphere_statefulsets.go
@@ -74,84 +74,84 @@ var _ = utils.SIGDescribe("vsphere statefulset [Feature:vsphere]", func() {
 		scParameters := make(map[string]string)
 		scParameters["diskformat"] = "thin"
 		scSpec := getVSphereStorageClassSpec(storageclassname, scParameters, nil, "")
-		sc, err := client.StorageV1().StorageClasses().Create(context.TODO(), scSpec, metav1.CreateOptions{})
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(framework.IgnoreNotFound(client.StorageV1().StorageClasses().Delete), sc.Name, metav1.DeleteOptions{})
 
 		ginkgo.By("Creating statefulset")
 
-		statefulset := e2estatefulset.CreateStatefulSet(client, manifestPath, namespace)
+		statefulset := e2estatefulset.CreateStatefulSet(ctx, client, manifestPath, namespace)
 		ginkgo.DeferCleanup(e2estatefulset.DeleteAllStatefulSets, client, namespace)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
-		e2estatefulset.WaitForStatusReadyReplicas(client, statefulset, replicas)
-		framework.ExpectNoError(e2estatefulset.CheckMount(client, statefulset, mountPath))
-		ssPodsBeforeScaleDown := e2estatefulset.GetPodList(client, statefulset)
+		e2estatefulset.WaitForStatusReadyReplicas(ctx, client, statefulset, replicas)
+		framework.ExpectNoError(e2estatefulset.CheckMount(ctx, client, statefulset, mountPath))
+		ssPodsBeforeScaleDown := e2estatefulset.GetPodList(ctx, client, statefulset)
 		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(), fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
 		framework.ExpectEqual(len(ssPodsBeforeScaleDown.Items), int(replicas), "Number of Pods in the statefulset should match with number of replicas")
 
 		// Get the list of Volumes attached to Pods before scale down
 		volumesBeforeScaleDown := make(map[string]string)
 		for _, sspod := range ssPodsBeforeScaleDown.Items {
-			_, err := client.CoreV1().Pods(namespace).Get(context.TODO(), sspod.Name, metav1.GetOptions{})
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 			for _, volumespec := range sspod.Spec.Volumes {
 				if volumespec.PersistentVolumeClaim != nil {
-					volumePath := getvSphereVolumePathFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					volumePath := getvSphereVolumePathFromClaim(ctx, client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
 					volumesBeforeScaleDown[volumePath] = volumespec.PersistentVolumeClaim.ClaimName
 				}
 			}
 		}
 
 		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas-1))
-		_, scaledownErr := e2estatefulset.Scale(client, statefulset, replicas-1)
+		_, scaledownErr := e2estatefulset.Scale(ctx, client, statefulset, replicas-1)
 		framework.ExpectNoError(scaledownErr)
-		e2estatefulset.WaitForStatusReadyReplicas(client, statefulset, replicas-1)
+		e2estatefulset.WaitForStatusReadyReplicas(ctx, client, statefulset, replicas-1)
 
 		// After scale down, verify vsphere volumes are detached from deleted pods
 		ginkgo.By("Verify Volumes are detached from Nodes after Statefulsets is scaled down")
 		for _, sspod := range ssPodsBeforeScaleDown.Items {
-			_, err := client.CoreV1().Pods(namespace).Get(context.TODO(), sspod.Name, metav1.GetOptions{})
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
 			if err != nil {
 				if !apierrors.IsNotFound(err) {
 					framework.Failf("Error in getting Pod %s: %v", sspod.Name, err)
 				}
 				for _, volumespec := range sspod.Spec.Volumes {
 					if volumespec.PersistentVolumeClaim != nil {
-						vSpherediskPath := getvSphereVolumePathFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+						vSpherediskPath := getvSphereVolumePathFromClaim(ctx, client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
 						framework.Logf("Waiting for Volume: %q to detach from Node: %q", vSpherediskPath, sspod.Spec.NodeName)
-						framework.ExpectNoError(waitForVSphereDiskToDetach(vSpherediskPath, sspod.Spec.NodeName))
+						framework.ExpectNoError(waitForVSphereDiskToDetach(ctx, vSpherediskPath, sspod.Spec.NodeName))
 					}
 				}
 			}
 		}
 
 		ginkgo.By(fmt.Sprintf("Scaling up statefulsets to number of Replica: %v", replicas))
-		_, scaleupErr := e2estatefulset.Scale(client, statefulset, replicas)
+		_, scaleupErr := e2estatefulset.Scale(ctx, client, statefulset, replicas)
 		framework.ExpectNoError(scaleupErr)
-		e2estatefulset.WaitForStatusReplicas(client, statefulset, replicas)
-		e2estatefulset.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		e2estatefulset.WaitForStatusReplicas(ctx, client, statefulset, replicas)
+		e2estatefulset.WaitForStatusReadyReplicas(ctx, client, statefulset, replicas)
 
-		ssPodsAfterScaleUp := e2estatefulset.GetPodList(client, statefulset)
+		ssPodsAfterScaleUp := e2estatefulset.GetPodList(ctx, client, statefulset)
 		gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(), fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
 		framework.ExpectEqual(len(ssPodsAfterScaleUp.Items), int(replicas), "Number of Pods in the statefulset should match with number of replicas")
 
 		// After scale up, verify all vsphere volumes are attached to node VMs.
 		ginkgo.By("Verify all volumes are attached to Nodes after Statefulsets is scaled up")
 		for _, sspod := range ssPodsAfterScaleUp.Items {
-			err := e2epod.WaitTimeoutForPodReadyInNamespace(client, sspod.Name, statefulset.Namespace, framework.PodStartTimeout)
+			err := e2epod.WaitTimeoutForPodReadyInNamespace(ctx, client, sspod.Name, statefulset.Namespace, framework.PodStartTimeout)
 			framework.ExpectNoError(err)
-			pod, err := client.CoreV1().Pods(namespace).Get(context.TODO(), sspod.Name, metav1.GetOptions{})
+			pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 			for _, volumespec := range pod.Spec.Volumes {
 				if volumespec.PersistentVolumeClaim != nil {
-					vSpherediskPath := getvSphereVolumePathFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					vSpherediskPath := getvSphereVolumePathFromClaim(ctx, client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
 					framework.Logf("Verify Volume: %q is attached to the Node: %q", vSpherediskPath, sspod.Spec.NodeName)
 					// Verify scale up has re-attached the same volumes and not introduced new volume
 					if volumesBeforeScaleDown[vSpherediskPath] == "" {
 						framework.Failf("Volume: %q was not attached to the Node: %q before scale down", vSpherediskPath, sspod.Spec.NodeName)
 					}
-					isVolumeAttached, verifyDiskAttachedError := diskIsAttached(vSpherediskPath, sspod.Spec.NodeName)
+					isVolumeAttached, verifyDiskAttachedError := diskIsAttached(ctx, vSpherediskPath, sspod.Spec.NodeName)
 					if !isVolumeAttached {
 						framework.Failf("Volume: %q is not attached to the Node: %q", vSpherediskPath, sspod.Spec.NodeName)
 					}

--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -69,13 +69,13 @@ const (
 )
 
 // Wait until vsphere volumes are detached from the list of nodes or time out after 5 minutes
-func waitForVSphereDisksToDetach(nodeVolumes map[string][]string) error {
+func waitForVSphereDisksToDetach(ctx context.Context, nodeVolumes map[string][]string) error {
 	var (
 		detachTimeout  = 5 * time.Minute
 		detachPollTime = 10 * time.Second
 	)
-	waitErr := wait.Poll(detachPollTime, detachTimeout, func() (bool, error) {
-		attachedResult, err := disksAreAttached(nodeVolumes)
+	waitErr := wait.PollWithContext(ctx, detachPollTime, detachTimeout, func(ctx context.Context) (bool, error) {
+		attachedResult, err := disksAreAttached(ctx, nodeVolumes)
 		if err != nil {
 			return false, err
 		}
@@ -100,7 +100,7 @@ func waitForVSphereDisksToDetach(nodeVolumes map[string][]string) error {
 }
 
 // Wait until vsphere vmdk moves to expected state on the given node, or time out after 6 minutes
-func waitForVSphereDiskStatus(volumePath string, nodeName string, expectedState volumeState) error {
+func waitForVSphereDiskStatus(ctx context.Context, volumePath string, nodeName string, expectedState volumeState) error {
 	var (
 		currentState volumeState
 		timeout      = 6 * time.Minute
@@ -117,8 +117,8 @@ func waitForVSphereDiskStatus(volumePath string, nodeName string, expectedState 
 		volumeStateDetached: "detached from",
 	}
 
-	waitErr := wait.Poll(pollTime, timeout, func() (bool, error) {
-		diskAttached, err := diskIsAttached(volumePath, nodeName)
+	waitErr := wait.PollWithContext(ctx, pollTime, timeout, func(ctx context.Context) (bool, error) {
+		diskAttached, err := diskIsAttached(ctx, volumePath, nodeName)
 		if err != nil {
 			return true, err
 		}
@@ -141,13 +141,13 @@ func waitForVSphereDiskStatus(volumePath string, nodeName string, expectedState 
 }
 
 // Wait until vsphere vmdk is attached from the given node or time out after 6 minutes
-func waitForVSphereDiskToAttach(volumePath string, nodeName string) error {
-	return waitForVSphereDiskStatus(volumePath, nodeName, volumeStateAttached)
+func waitForVSphereDiskToAttach(ctx context.Context, volumePath string, nodeName string) error {
+	return waitForVSphereDiskStatus(ctx, volumePath, nodeName, volumeStateAttached)
 }
 
 // Wait until vsphere vmdk is detached from the given node or time out after 6 minutes
-func waitForVSphereDiskToDetach(volumePath string, nodeName string) error {
-	return waitForVSphereDiskStatus(volumePath, nodeName, volumeStateDetached)
+func waitForVSphereDiskToDetach(ctx context.Context, volumePath string, nodeName string) error {
+	return waitForVSphereDiskStatus(ctx, volumePath, nodeName, volumeStateDetached)
 }
 
 // function to create vsphere volume spec with given VMDK volume path, Reclaim Policy and labels
@@ -198,14 +198,14 @@ func getVSpherePersistentVolumeClaimSpec(namespace string, labels map[string]str
 }
 
 // function to write content to the volume backed by given PVC
-func writeContentToVSpherePV(client clientset.Interface, timeouts *framework.TimeoutContext, pvc *v1.PersistentVolumeClaim, expectedContent string) {
-	utils.RunInPodWithVolume(client, timeouts, pvc.Namespace, pvc.Name, "echo "+expectedContent+" > /mnt/test/data")
+func writeContentToVSpherePV(ctx context.Context, client clientset.Interface, timeouts *framework.TimeoutContext, pvc *v1.PersistentVolumeClaim, expectedContent string) {
+	utils.RunInPodWithVolume(ctx, client, timeouts, pvc.Namespace, pvc.Name, "echo "+expectedContent+" > /mnt/test/data")
 	framework.Logf("Done with writing content to volume")
 }
 
 // function to verify content is matching on the volume backed for given PVC
-func verifyContentOfVSpherePV(client clientset.Interface, timeouts *framework.TimeoutContext, pvc *v1.PersistentVolumeClaim, expectedContent string) {
-	utils.RunInPodWithVolume(client, timeouts, pvc.Namespace, pvc.Name, "grep '"+expectedContent+"' /mnt/test/data")
+func verifyContentOfVSpherePV(ctx context.Context, client clientset.Interface, timeouts *framework.TimeoutContext, pvc *v1.PersistentVolumeClaim, expectedContent string) {
+	utils.RunInPodWithVolume(ctx, client, timeouts, pvc.Namespace, pvc.Name, "grep '"+expectedContent+"' /mnt/test/data")
 	framework.Logf("Successfully verified content of the volume")
 }
 
@@ -373,12 +373,12 @@ func createEmptyFilesOnVSphereVolume(namespace string, podName string, filePaths
 }
 
 // verify volumes are attached to the node and are accessible in pod
-func verifyVSphereVolumesAccessible(c clientset.Interface, pod *v1.Pod, persistentvolumes []*v1.PersistentVolume) {
+func verifyVSphereVolumesAccessible(ctx context.Context, c clientset.Interface, pod *v1.Pod, persistentvolumes []*v1.PersistentVolume) {
 	nodeName := pod.Spec.NodeName
 	namespace := pod.Namespace
 	for index, pv := range persistentvolumes {
 		// Verify disks are attached to the node
-		isAttached, err := diskIsAttached(pv.Spec.VsphereVolume.VolumePath, nodeName)
+		isAttached, err := diskIsAttached(ctx, pv.Spec.VsphereVolume.VolumePath, nodeName)
 		framework.ExpectNoError(err)
 		if !isAttached {
 			framework.Failf("disk %v is not attached to the node: %v", pv.Spec.VsphereVolume.VolumePath, nodeName)
@@ -391,7 +391,7 @@ func verifyVSphereVolumesAccessible(c clientset.Interface, pod *v1.Pod, persiste
 }
 
 // verify volumes are created on one of the specified zones
-func verifyVolumeCreationOnRightZone(persistentvolumes []*v1.PersistentVolume, nodeName string, zones []string) {
+func verifyVolumeCreationOnRightZone(ctx context.Context, persistentvolumes []*v1.PersistentVolume, nodeName string, zones []string) {
 	for _, pv := range persistentvolumes {
 		volumePath := pv.Spec.VsphereVolume.VolumePath
 		// Extract datastoreName from the volume path in the pv spec
@@ -399,7 +399,7 @@ func verifyVolumeCreationOnRightZone(persistentvolumes []*v1.PersistentVolume, n
 		datastorePathObj, _ := getDatastorePathObjFromVMDiskPath(volumePath)
 		datastoreName := datastorePathObj.Datastore
 		nodeInfo := TestContext.NodeMapper.GetNodeInfo(nodeName)
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		// Get the datastore object reference from the datastore name
 		datastoreRef, err := nodeInfo.VSphere.GetDatastoreRefFromName(ctx, nodeInfo.DataCenterRef, datastoreName)
@@ -424,10 +424,10 @@ func verifyVolumeCreationOnRightZone(persistentvolumes []*v1.PersistentVolume, n
 }
 
 // Get vSphere Volume Path from PVC
-func getvSphereVolumePathFromClaim(client clientset.Interface, namespace string, claimName string) string {
-	pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), claimName, metav1.GetOptions{})
+func getvSphereVolumePathFromClaim(ctx context.Context, client clientset.Interface, namespace string, claimName string) string {
+	pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, claimName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	pv, err := client.CoreV1().PersistentVolumes().Get(context.TODO(), pvclaim.Spec.VolumeName, metav1.GetOptions{})
+	pv, err := client.CoreV1().PersistentVolumes().Get(ctx, pvclaim.Spec.VolumeName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	return pv.Spec.VsphereVolume.VolumePath
 }
@@ -601,8 +601,8 @@ func convertVolPathToDevicePath(ctx context.Context, dc *object.Datacenter, volP
 }
 
 // get .vmx file path for a virtual machine
-func getVMXFilePath(vmObject *object.VirtualMachine) (vmxPath string) {
-	ctx, cancel := context.WithCancel(context.Background())
+func getVMXFilePath(ctx context.Context, vmObject *object.VirtualMachine) (vmxPath string) {
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	var nodeVM mo.VirtualMachine
@@ -616,10 +616,10 @@ func getVMXFilePath(vmObject *object.VirtualMachine) (vmxPath string) {
 }
 
 // verify ready node count. Try up to 3 minutes. Return true if count is expected count
-func verifyReadyNodeCount(client clientset.Interface, expectedNodes int) bool {
+func verifyReadyNodeCount(ctx context.Context, client clientset.Interface, expectedNodes int) bool {
 	numNodes := 0
 	for i := 0; i < 36; i++ {
-		nodeList, err := e2enode.GetReadySchedulableNodes(client)
+		nodeList, err := e2enode.GetReadySchedulableNodes(ctx, client)
 		framework.ExpectNoError(err)
 
 		numNodes = len(nodeList.Items)
@@ -632,8 +632,8 @@ func verifyReadyNodeCount(client clientset.Interface, expectedNodes int) bool {
 }
 
 // poweroff nodeVM and confirm the poweroff state
-func poweroffNodeVM(nodeName string, vm *object.VirtualMachine) {
-	ctx, cancel := context.WithCancel(context.Background())
+func poweroffNodeVM(ctx context.Context, nodeName string, vm *object.VirtualMachine) {
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	framework.Logf("Powering off node VM %s", nodeName)
@@ -645,8 +645,8 @@ func poweroffNodeVM(nodeName string, vm *object.VirtualMachine) {
 }
 
 // poweron nodeVM and confirm the poweron state
-func poweronNodeVM(nodeName string, vm *object.VirtualMachine) {
-	ctx, cancel := context.WithCancel(context.Background())
+func poweronNodeVM(ctx context.Context, nodeName string, vm *object.VirtualMachine) {
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	framework.Logf("Powering on node VM %s", nodeName)
@@ -657,11 +657,11 @@ func poweronNodeVM(nodeName string, vm *object.VirtualMachine) {
 }
 
 // unregister a nodeVM from VC
-func unregisterNodeVM(nodeName string, vm *object.VirtualMachine) {
-	ctx, cancel := context.WithCancel(context.Background())
+func unregisterNodeVM(ctx context.Context, nodeName string, vm *object.VirtualMachine) {
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	poweroffNodeVM(nodeName, vm)
+	poweroffNodeVM(ctx, nodeName, vm)
 
 	framework.Logf("Unregistering node VM %s", nodeName)
 	err := vm.Unregister(ctx)
@@ -669,8 +669,8 @@ func unregisterNodeVM(nodeName string, vm *object.VirtualMachine) {
 }
 
 // register a nodeVM into a VC
-func registerNodeVM(nodeName, workingDir, vmxFilePath string, rpool *object.ResourcePool, host *object.HostSystem) {
-	ctx, cancel := context.WithCancel(context.Background())
+func registerNodeVM(ctx context.Context, nodeName, workingDir, vmxFilePath string, rpool *object.ResourcePool, host *object.HostSystem) {
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	framework.Logf("Registering node VM %s with vmx file path %s", nodeName, vmxFilePath)
@@ -690,12 +690,12 @@ func registerNodeVM(nodeName, workingDir, vmxFilePath string, rpool *object.Reso
 	vm, err := finder.VirtualMachine(ctx, vmPath)
 	framework.ExpectNoError(err)
 
-	poweronNodeVM(nodeName, vm)
+	poweronNodeVM(ctx, nodeName, vm)
 }
 
 // disksAreAttached takes map of node and it's volumes and returns map of node, its volumes and attachment state
-func disksAreAttached(nodeVolumes map[string][]string) (map[string]map[string]bool, error) {
-	ctx, cancel := context.WithCancel(context.Background())
+func disksAreAttached(ctx context.Context, nodeVolumes map[string][]string) (map[string]map[string]bool, error) {
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	disksAttached := make(map[string]map[string]bool)
@@ -711,7 +711,7 @@ func disksAreAttached(nodeVolumes map[string][]string) (map[string]map[string]bo
 	for vm, volumes := range vmVolumes {
 		volumeAttachedMap := make(map[string]bool)
 		for _, volume := range volumes {
-			attached, err := diskIsAttached(volume, vm)
+			attached, err := diskIsAttached(ctx, volume, vm)
 			if err != nil {
 				return nil, err
 			}
@@ -723,9 +723,9 @@ func disksAreAttached(nodeVolumes map[string][]string) (map[string]map[string]bo
 }
 
 // diskIsAttached returns if disk is attached to the VM using controllers supported by the plugin.
-func diskIsAttached(volPath string, nodeName string) (bool, error) {
+func diskIsAttached(ctx context.Context, volPath string, nodeName string) (bool, error) {
 	// Create context
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	nodeInfo := TestContext.NodeMapper.GetNodeInfo(nodeName)
 	Connect(ctx, nodeInfo.VSphere)
@@ -752,8 +752,8 @@ func getUUIDFromProviderID(providerID string) string {
 }
 
 // GetReadySchedulableNodeInfos returns NodeInfo objects for all nodes with Ready and schedulable state
-func GetReadySchedulableNodeInfos() []*NodeInfo {
-	nodeList, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+func GetReadySchedulableNodeInfos(ctx context.Context) []*NodeInfo {
+	nodeList, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
 	framework.ExpectNoError(err)
 	var nodesInfo []*NodeInfo
 	for _, node := range nodeList.Items {
@@ -768,18 +768,18 @@ func GetReadySchedulableNodeInfos() []*NodeInfo {
 // GetReadySchedulableRandomNodeInfo returns NodeInfo object for one of the Ready and Schedulable Node.
 // if multiple nodes are present with Ready and Schedulable state then one of the Node is selected randomly
 // and it's associated NodeInfo object is returned.
-func GetReadySchedulableRandomNodeInfo() *NodeInfo {
-	nodesInfo := GetReadySchedulableNodeInfos()
+func GetReadySchedulableRandomNodeInfo(ctx context.Context) *NodeInfo {
+	nodesInfo := GetReadySchedulableNodeInfos(ctx)
 	gomega.Expect(nodesInfo).NotTo(gomega.BeEmpty())
 	return nodesInfo[rand.Int()%len(nodesInfo)]
 }
 
 // invokeVCenterServiceControl invokes the given command for the given service
 // via service-control on the given vCenter host over SSH.
-func invokeVCenterServiceControl(command, service, host string) error {
+func invokeVCenterServiceControl(ctx context.Context, command, service, host string) error {
 	sshCmd := fmt.Sprintf("service-control --%s %s", command, service)
 	framework.Logf("Invoking command %v on vCenter host %v", sshCmd, host)
-	result, err := e2essh.SSH(sshCmd, host, framework.TestContext.Provider)
+	result, err := e2essh.SSH(ctx, sshCmd, host, framework.TestContext.Provider)
 	if err != nil || result.Code != 0 {
 		e2essh.LogResult(result)
 		return fmt.Errorf("couldn't execute command: %s on vCenter host: %v", sshCmd, err)
@@ -789,8 +789,8 @@ func invokeVCenterServiceControl(command, service, host string) error {
 
 // expectVolumeToBeAttached checks if the given Volume is attached to the given
 // Node, else fails.
-func expectVolumeToBeAttached(nodeName, volumePath string) {
-	isAttached, err := diskIsAttached(volumePath, nodeName)
+func expectVolumeToBeAttached(ctx context.Context, nodeName, volumePath string) {
+	isAttached, err := diskIsAttached(ctx, volumePath, nodeName)
 	framework.ExpectNoError(err)
 	if !isAttached {
 		framework.Failf("Volume: %s is not attached to the node: %v", volumePath, nodeName)
@@ -799,12 +799,12 @@ func expectVolumeToBeAttached(nodeName, volumePath string) {
 
 // expectVolumesToBeAttached checks if the given Volumes are attached to the
 // corresponding set of Nodes, else fails.
-func expectVolumesToBeAttached(pods []*v1.Pod, volumePaths []string) {
+func expectVolumesToBeAttached(ctx context.Context, pods []*v1.Pod, volumePaths []string) {
 	for i, pod := range pods {
 		nodeName := pod.Spec.NodeName
 		volumePath := volumePaths[i]
 		ginkgo.By(fmt.Sprintf("Verifying that volume %v is attached to node %v", volumePath, nodeName))
-		expectVolumeToBeAttached(nodeName, volumePath)
+		expectVolumeToBeAttached(ctx, nodeName, volumePath)
 	}
 }
 

--- a/test/e2e/storage/vsphere/vsphere_volume_diskformat.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_diskformat.go
@@ -69,12 +69,12 @@ var _ = utils.SIGDescribe("Volume Disk Format [Feature:vsphere]", func() {
 		nodeKeyValueLabel map[string]string
 		nodeLabelValue    string
 	)
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		e2eskipper.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
 		namespace = f.Namespace.Name
-		nodeName = GetReadySchedulableRandomNodeInfo().Name
+		nodeName = GetReadySchedulableRandomNodeInfo(ctx).Name
 		nodeLabelValue = "vsphere_e2e_" + string(uuid.NewUUID())
 		nodeKeyValueLabel = map[string]string{NodeLabelKey: nodeLabelValue}
 		e2enode.AddOrUpdateLabelOnNode(client, nodeName, NodeLabelKey, nodeLabelValue)
@@ -83,19 +83,19 @@ var _ = utils.SIGDescribe("Volume Disk Format [Feature:vsphere]", func() {
 
 	ginkgo.It("verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass", func(ctx context.Context) {
 		ginkgo.By("Invoking Test for diskformat: eagerzeroedthick")
-		invokeTest(f, client, namespace, nodeName, nodeKeyValueLabel, "eagerzeroedthick")
+		invokeTest(ctx, f, client, namespace, nodeName, nodeKeyValueLabel, "eagerzeroedthick")
 	})
 	ginkgo.It("verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass", func(ctx context.Context) {
 		ginkgo.By("Invoking Test for diskformat: zeroedthick")
-		invokeTest(f, client, namespace, nodeName, nodeKeyValueLabel, "zeroedthick")
+		invokeTest(ctx, f, client, namespace, nodeName, nodeKeyValueLabel, "zeroedthick")
 	})
 	ginkgo.It("verify disk format type - thin is honored for dynamically provisioned pv using storageclass", func(ctx context.Context) {
 		ginkgo.By("Invoking Test for diskformat: thin")
-		invokeTest(f, client, namespace, nodeName, nodeKeyValueLabel, "thin")
+		invokeTest(ctx, f, client, namespace, nodeName, nodeKeyValueLabel, "thin")
 	})
 })
 
-func invokeTest(f *framework.Framework, client clientset.Interface, namespace string, nodeName string, nodeKeyValueLabel map[string]string, diskFormat string) {
+func invokeTest(ctx context.Context, f *framework.Framework, client clientset.Interface, namespace string, nodeName string, nodeKeyValueLabel map[string]string, diskFormat string) {
 
 	framework.Logf("Invoking Test for DiskFomat: %s", diskFormat)
 	scParameters := make(map[string]string)
@@ -103,28 +103,28 @@ func invokeTest(f *framework.Framework, client clientset.Interface, namespace st
 
 	ginkgo.By("Creating Storage Class With DiskFormat")
 	storageClassSpec := getVSphereStorageClassSpec("thinsc", scParameters, nil, "")
-	storageclass, err := client.StorageV1().StorageClasses().Create(context.TODO(), storageClassSpec, metav1.CreateOptions{})
+	storageclass, err := client.StorageV1().StorageClasses().Create(ctx, storageClassSpec, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.DeferCleanup(framework.IgnoreNotFound(client.StorageV1().StorageClasses().Delete), storageclass.Name, metav1.DeleteOptions{})
 
 	ginkgo.By("Creating PVC using the Storage Class")
 	pvclaimSpec := getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass)
-	pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Create(context.TODO(), pvclaimSpec, metav1.CreateOptions{})
+	pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvclaimSpec, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.DeferCleanup(framework.IgnoreNotFound(client.CoreV1().PersistentVolumeClaims(namespace).Delete), pvclaimSpec.Name, metav1.DeleteOptions{})
 
 	ginkgo.By("Waiting for claim to be in bound phase")
-	err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, f.Timeouts.ClaimProvision)
+	err = e2epv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, f.Timeouts.ClaimProvision)
 	framework.ExpectNoError(err)
 
 	// Get new copy of the claim
-	pvclaim, err = client.CoreV1().PersistentVolumeClaims(pvclaim.Namespace).Get(context.TODO(), pvclaim.Name, metav1.GetOptions{})
+	pvclaim, err = client.CoreV1().PersistentVolumeClaims(pvclaim.Namespace).Get(ctx, pvclaim.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 
 	// Get the bound PV
-	pv, err := client.CoreV1().PersistentVolumes().Get(context.TODO(), pvclaim.Spec.VolumeName, metav1.GetOptions{})
+	pv, err := client.CoreV1().PersistentVolumes().Get(ctx, pvclaim.Spec.VolumeName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 
 	/*
@@ -134,37 +134,37 @@ func invokeTest(f *framework.Framework, client clientset.Interface, namespace st
 	ginkgo.By("Creating pod to attach PV to the node")
 	// Create pod to attach Volume to Node
 	podSpec := getVSpherePodSpecWithClaim(pvclaim.Name, nodeKeyValueLabel, "while true ; do sleep 2 ; done")
-	pod, err := client.CoreV1().Pods(namespace).Create(context.TODO(), podSpec, metav1.CreateOptions{})
+	pod, err := client.CoreV1().Pods(namespace).Create(ctx, podSpec, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Waiting for pod to be running")
-	gomega.Expect(e2epod.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(gomega.Succeed())
+	gomega.Expect(e2epod.WaitForPodNameRunningInNamespace(ctx, client, pod.Name, namespace)).To(gomega.Succeed())
 
-	isAttached, err := diskIsAttached(pv.Spec.VsphereVolume.VolumePath, nodeName)
+	isAttached, err := diskIsAttached(ctx, pv.Spec.VsphereVolume.VolumePath, nodeName)
 	if !isAttached {
 		framework.Failf("Volume: %s is not attached to the node: %v", pv.Spec.VsphereVolume.VolumePath, nodeName)
 	}
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Verify Disk Format")
-	framework.ExpectEqual(verifyDiskFormat(client, nodeName, pv.Spec.VsphereVolume.VolumePath, diskFormat), true, "DiskFormat Verification Failed")
+	framework.ExpectEqual(verifyDiskFormat(ctx, client, nodeName, pv.Spec.VsphereVolume.VolumePath, diskFormat), true, "DiskFormat Verification Failed")
 
 	var volumePaths []string
 	volumePaths = append(volumePaths, pv.Spec.VsphereVolume.VolumePath)
 
 	ginkgo.By("Delete pod and wait for volume to be detached from node")
-	deletePodAndWaitForVolumeToDetach(f, client, pod, nodeName, volumePaths)
+	deletePodAndWaitForVolumeToDetach(ctx, f, client, pod, nodeName, volumePaths)
 
 }
 
-func verifyDiskFormat(client clientset.Interface, nodeName string, pvVolumePath string, diskFormat string) bool {
+func verifyDiskFormat(ctx context.Context, client clientset.Interface, nodeName string, pvVolumePath string, diskFormat string) bool {
 	ginkgo.By("Verifying disk format")
 	eagerlyScrub := false
 	thinProvisioned := false
 	diskFound := false
 	pvvmdkfileName := filepath.Base(pvVolumePath) + filepath.Ext(pvVolumePath)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	nodeInfo := TestContext.NodeMapper.GetNodeInfo(nodeName)

--- a/test/e2e/storage/vsphere/vsphere_volume_disksize.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_disksize.go
@@ -71,25 +71,25 @@ var _ = utils.SIGDescribe("Volume Disk Size [Feature:vsphere]", func() {
 		expectedDiskSize := "1Mi"
 
 		ginkgo.By("Creating Storage Class")
-		storageclass, err := client.StorageV1().StorageClasses().Create(context.TODO(), getVSphereStorageClassSpec(diskSizeSCName, scParameters, nil, ""), metav1.CreateOptions{})
+		storageclass, err := client.StorageV1().StorageClasses().Create(ctx, getVSphereStorageClassSpec(diskSizeSCName, scParameters, nil, ""), metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(framework.IgnoreNotFound(client.StorageV1().StorageClasses().Delete), storageclass.Name, metav1.DeleteOptions{})
 
 		ginkgo.By("Creating PVC using the Storage Class")
-		pvclaim, err := e2epv.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, diskSize, storageclass))
+		pvclaim, err := e2epv.CreatePVC(ctx, client, namespace, getVSphereClaimSpecWithStorageClass(namespace, diskSize, storageclass))
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(e2epv.DeletePersistentVolumeClaim, client, pvclaim.Name, namespace)
 
 		ginkgo.By("Waiting for claim to be in bound phase")
-		err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
+		err = e2epv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Getting new copy of PVC")
-		pvclaim, err = client.CoreV1().PersistentVolumeClaims(pvclaim.Namespace).Get(context.TODO(), pvclaim.Name, metav1.GetOptions{})
+		pvclaim, err = client.CoreV1().PersistentVolumeClaims(pvclaim.Namespace).Get(ctx, pvclaim.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Getting PV created")
-		pv, err := client.CoreV1().PersistentVolumes().Get(context.TODO(), pvclaim.Spec.VolumeName, metav1.GetOptions{})
+		pv, err := client.CoreV1().PersistentVolumes().Get(ctx, pvclaim.Spec.VolumeName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Verifying if provisioned PV has the correct size")

--- a/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go
@@ -85,7 +85,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		policyName   string
 		tagPolicy    string
 	)
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		e2eskipper.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
@@ -94,7 +94,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		tagPolicy = GetAndExpectStringEnvVar(SPBMTagPolicy)
 		framework.Logf("framework: %+v", f)
 		scParameters = make(map[string]string)
-		_, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		_, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 	})
 
@@ -104,7 +104,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[PolicyHostFailuresToTolerate] = HostFailuresToTolerateCapabilityVal
 		scParameters[PolicyCacheReservation] = CacheReservationCapabilityVal
 		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
-		invokeValidPolicyTest(f, client, namespace, scParameters)
+		invokeValidPolicyTest(ctx, f, client, namespace, scParameters)
 	})
 
 	// Valid policy.
@@ -113,7 +113,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[PolicyDiskStripes] = "1"
 		scParameters[PolicyObjectSpaceReservation] = "30"
 		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
-		invokeValidPolicyTest(f, client, namespace, scParameters)
+		invokeValidPolicyTest(ctx, f, client, namespace, scParameters)
 	})
 
 	// Valid policy.
@@ -123,7 +123,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[PolicyObjectSpaceReservation] = ObjectSpaceReservationCapabilityVal
 		scParameters[Datastore] = vsanDatastore
 		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
-		invokeValidPolicyTest(f, client, namespace, scParameters)
+		invokeValidPolicyTest(ctx, f, client, namespace, scParameters)
 	})
 
 	// Valid policy.
@@ -132,7 +132,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[PolicyObjectSpaceReservation] = ObjectSpaceReservationCapabilityVal
 		scParameters[PolicyIopsLimit] = IopsLimitCapabilityVal
 		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
-		invokeValidPolicyTest(f, client, namespace, scParameters)
+		invokeValidPolicyTest(ctx, f, client, namespace, scParameters)
 	})
 
 	// Invalid VSAN storage capabilities parameters.
@@ -141,7 +141,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters["objectSpaceReserve"] = ObjectSpaceReservationCapabilityVal
 		scParameters[PolicyDiskStripes] = StripeWidthCapabilityVal
 		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
-		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
+		err := invokeInvalidPolicyTestNeg(ctx, client, namespace, scParameters)
 		framework.ExpectError(err)
 		errorMsg := "invalid option \\\"objectSpaceReserve\\\" for volume plugin kubernetes.io/vsphere-volume"
 		if !strings.Contains(err.Error(), errorMsg) {
@@ -156,7 +156,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[PolicyDiskStripes] = DiskStripesCapabilityInvalidVal
 		scParameters[PolicyCacheReservation] = CacheReservationCapabilityVal
 		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
-		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
+		err := invokeInvalidPolicyTestNeg(ctx, client, namespace, scParameters)
 		framework.ExpectError(err)
 		errorMsg := "Invalid value for " + PolicyDiskStripes + "."
 		if !strings.Contains(err.Error(), errorMsg) {
@@ -170,7 +170,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		ginkgo.By(fmt.Sprintf("Invoking test for VSAN policy hostFailuresToTolerate: %s", HostFailuresToTolerateCapabilityInvalidVal))
 		scParameters[PolicyHostFailuresToTolerate] = HostFailuresToTolerateCapabilityInvalidVal
 		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
-		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
+		err := invokeInvalidPolicyTestNeg(ctx, client, namespace, scParameters)
 		framework.ExpectError(err)
 		errorMsg := "Invalid value for " + PolicyHostFailuresToTolerate + "."
 		if !strings.Contains(err.Error(), errorMsg) {
@@ -186,7 +186,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[PolicyObjectSpaceReservation] = ObjectSpaceReservationCapabilityVal
 		scParameters[Datastore] = vmfsDatastore
 		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
-		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
+		err := invokeInvalidPolicyTestNeg(ctx, client, namespace, scParameters)
 		framework.ExpectError(err)
 		errorMsg := "The specified datastore: \\\"" + vmfsDatastore + "\\\" is not a VSAN datastore. " +
 			"The policy parameters will work only with VSAN Datastore."
@@ -200,7 +200,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[SpbmStoragePolicy] = policyName
 		scParameters[DiskFormat] = ThinDisk
 		framework.Logf("Invoking test for SPBM storage policy: %+v", scParameters)
-		invokeValidPolicyTest(f, client, namespace, scParameters)
+		invokeValidPolicyTest(ctx, f, client, namespace, scParameters)
 	})
 
 	ginkgo.It("verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy", func(ctx context.Context) {
@@ -209,9 +209,9 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[Datastore] = vsanDatastore
 		framework.Logf("Invoking test for SPBM storage policy: %+v", scParameters)
 		kubernetesClusterName := GetAndExpectStringEnvVar(KubernetesClusterName)
-		controlPlaneNode, err := getControlPlaneNode(client)
+		controlPlaneNode, err := getControlPlaneNode(ctx, client)
 		framework.ExpectNoError(err)
-		invokeStaleDummyVMTestWithStoragePolicy(client, controlPlaneNode, namespace, kubernetesClusterName, scParameters)
+		invokeStaleDummyVMTestWithStoragePolicy(ctx, client, controlPlaneNode, namespace, kubernetesClusterName, scParameters)
 	})
 
 	ginkgo.It("verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass", func(ctx context.Context) {
@@ -220,7 +220,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[Datastore] = vsanDatastore
 		scParameters[DiskFormat] = ThinDisk
 		framework.Logf("Invoking test for SPBM storage policy on a non-compatible datastore: %+v", scParameters)
-		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
+		err := invokeInvalidPolicyTestNeg(ctx, client, namespace, scParameters)
 		framework.ExpectError(err)
 		errorMsg := "User specified datastore is not compatible with the storagePolicy: \\\"" + tagPolicy + "\\\""
 		if !strings.Contains(err.Error(), errorMsg) {
@@ -233,7 +233,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[SpbmStoragePolicy] = BronzeStoragePolicy
 		scParameters[DiskFormat] = ThinDisk
 		framework.Logf("Invoking test for non-existing SPBM storage policy: %+v", scParameters)
-		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
+		err := invokeInvalidPolicyTestNeg(ctx, client, namespace, scParameters)
 		framework.ExpectError(err)
 		errorMsg := "no pbm profile found with name: \\\"" + BronzeStoragePolicy + "\\"
 		if !strings.Contains(err.Error(), errorMsg) {
@@ -248,7 +248,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[PolicyDiskStripes] = DiskStripesCapabilityVal
 		scParameters[DiskFormat] = ThinDisk
 		framework.Logf("Invoking test for SPBM storage policy and VSAN capabilities together: %+v", scParameters)
-		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
+		err := invokeInvalidPolicyTestNeg(ctx, client, namespace, scParameters)
 		framework.ExpectError(err)
 		errorMsg := "Cannot specify storage policy capabilities along with storage policy name. Please specify only one"
 		if !strings.Contains(err.Error(), errorMsg) {
@@ -257,77 +257,77 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 	})
 })
 
-func invokeValidPolicyTest(f *framework.Framework, client clientset.Interface, namespace string, scParameters map[string]string) {
+func invokeValidPolicyTest(ctx context.Context, f *framework.Framework, client clientset.Interface, namespace string, scParameters map[string]string) {
 	ginkgo.By("Creating Storage Class With storage policy params")
-	storageclass, err := client.StorageV1().StorageClasses().Create(context.TODO(), getVSphereStorageClassSpec("storagepolicysc", scParameters, nil, ""), metav1.CreateOptions{})
+	storageclass, err := client.StorageV1().StorageClasses().Create(ctx, getVSphereStorageClassSpec("storagepolicysc", scParameters, nil, ""), metav1.CreateOptions{})
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	ginkgo.DeferCleanup(framework.IgnoreNotFound(client.StorageV1().StorageClasses().Delete), storageclass.Name, metav1.DeleteOptions{})
 
 	ginkgo.By("Creating PVC using the Storage Class")
-	pvclaim, err := e2epv.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
+	pvclaim, err := e2epv.CreatePVC(ctx, client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	ginkgo.DeferCleanup(e2epv.DeletePersistentVolumeClaim, client, pvclaim.Name, namespace)
 
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
 	ginkgo.By("Waiting for claim to be in bound phase")
-	persistentvolumes, err := e2epv.WaitForPVClaimBoundPhase(client, pvclaims, f.Timeouts.ClaimProvision)
+	persistentvolumes, err := e2epv.WaitForPVClaimBoundPhase(ctx, client, pvclaims, f.Timeouts.ClaimProvision)
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Creating pod to attach PV to the node")
 	// Create pod to attach Volume to Node
-	pod, err := e2epod.CreatePod(client, namespace, nil, pvclaims, false, "")
+	pod, err := e2epod.CreatePod(ctx, client, namespace, nil, pvclaims, false, "")
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Verify the volume is accessible and available in the pod")
-	verifyVSphereVolumesAccessible(client, pod, persistentvolumes)
+	verifyVSphereVolumesAccessible(ctx, client, pod, persistentvolumes)
 
 	ginkgo.By("Deleting pod")
-	e2epod.DeletePodWithWait(client, pod)
+	framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, client, pod))
 
 	ginkgo.By("Waiting for volumes to be detached from the node")
-	waitForVSphereDiskToDetach(persistentvolumes[0].Spec.VsphereVolume.VolumePath, pod.Spec.NodeName)
+	framework.ExpectNoError(waitForVSphereDiskToDetach(ctx, persistentvolumes[0].Spec.VsphereVolume.VolumePath, pod.Spec.NodeName))
 }
 
-func invokeInvalidPolicyTestNeg(client clientset.Interface, namespace string, scParameters map[string]string) error {
+func invokeInvalidPolicyTestNeg(ctx context.Context, client clientset.Interface, namespace string, scParameters map[string]string) error {
 	ginkgo.By("Creating Storage Class With storage policy params")
-	storageclass, err := client.StorageV1().StorageClasses().Create(context.TODO(), getVSphereStorageClassSpec("storagepolicysc", scParameters, nil, ""), metav1.CreateOptions{})
+	storageclass, err := client.StorageV1().StorageClasses().Create(ctx, getVSphereStorageClassSpec("storagepolicysc", scParameters, nil, ""), metav1.CreateOptions{})
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	ginkgo.DeferCleanup(framework.IgnoreNotFound(client.StorageV1().StorageClasses().Delete), storageclass.Name, metav1.DeleteOptions{})
 
 	ginkgo.By("Creating PVC using the Storage Class")
-	pvclaim, err := e2epv.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
+	pvclaim, err := e2epv.CreatePVC(ctx, client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	ginkgo.DeferCleanup(e2epv.DeletePersistentVolumeClaim, client, pvclaim.Name, namespace)
 
 	ginkgo.By("Waiting for claim to be in bound phase")
-	err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
+	err = e2epv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
 	framework.ExpectError(err)
 
-	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(context.TODO(), metav1.ListOptions{})
+	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(ctx, metav1.ListOptions{})
 	framework.ExpectNoError(err)
 	return fmt.Errorf("Failure message: %+q", eventList.Items[0].Message)
 }
 
 // invokeStaleDummyVMTestWithStoragePolicy assumes control plane node is present on the datacenter specified in the workspace section of vsphere.conf file.
 // With in-tree VCP, when the volume is created using storage policy, shadow (dummy) VM is getting created and deleted to apply SPBM policy on the volume.
-func invokeStaleDummyVMTestWithStoragePolicy(client clientset.Interface, controlPlaneNode string, namespace string, clusterName string, scParameters map[string]string) {
+func invokeStaleDummyVMTestWithStoragePolicy(ctx context.Context, client clientset.Interface, controlPlaneNode string, namespace string, clusterName string, scParameters map[string]string) {
 	ginkgo.By("Creating Storage Class With storage policy params")
-	storageclass, err := client.StorageV1().StorageClasses().Create(context.TODO(), getVSphereStorageClassSpec("storagepolicysc", scParameters, nil, ""), metav1.CreateOptions{})
+	storageclass, err := client.StorageV1().StorageClasses().Create(ctx, getVSphereStorageClassSpec("storagepolicysc", scParameters, nil, ""), metav1.CreateOptions{})
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	ginkgo.DeferCleanup(framework.IgnoreNotFound(client.StorageV1().StorageClasses().Delete), storageclass.Name, metav1.DeleteOptions{})
 
 	ginkgo.By("Creating PVC using the Storage Class")
-	pvclaim, err := e2epv.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
+	pvclaim, err := e2epv.CreatePVC(ctx, client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
 	ginkgo.By("Expect claim to fail provisioning volume")
-	_, err = e2epv.WaitForPVClaimBoundPhase(client, pvclaims, 2*time.Minute)
+	_, err = e2epv.WaitForPVClaimBoundPhase(ctx, client, pvclaims, 2*time.Minute)
 	framework.ExpectError(err)
 
-	updatedClaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), pvclaim.Name, metav1.GetOptions{})
+	updatedClaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvclaim.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	vmName := clusterName + "-dynamic-pvc-" + string(updatedClaim.UID)
 	ginkgo.DeferCleanup(e2epv.DeletePersistentVolumeClaim, client, pvclaim.Name, namespace)
@@ -346,11 +346,11 @@ func invokeStaleDummyVMTestWithStoragePolicy(client clientset.Interface, control
 	}
 }
 
-func getControlPlaneNode(client clientset.Interface) (string, error) {
+func getControlPlaneNode(ctx context.Context, client clientset.Interface) (string, error) {
 	regKubeScheduler := regexp.MustCompile("kube-scheduler-.*")
 	regKubeControllerManager := regexp.MustCompile("kube-controller-manager-.*")
 
-	podList, err := client.CoreV1().Pods(metav1.NamespaceSystem).List(context.TODO(), metav1.ListOptions{})
+	podList, err := client.CoreV1().Pods(metav1.NamespaceSystem).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/storage/vsphere/vsphere_zone_support.go
+++ b/test/e2e/storage/vsphere/vsphere_zone_support.go
@@ -105,11 +105,11 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 		zoneD           string
 		invalidZone     string
 	)
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		e2eskipper.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
-		e2eskipper.SkipUnlessMultizone(client)
+		e2eskipper.SkipUnlessMultizone(ctx, client)
 		namespace = f.Namespace.Name
 		vsanDatastore1 = GetAndExpectStringEnvVar(VCPZoneVsanDatastore1)
 		vsanDatastore2 = GetAndExpectStringEnvVar(VCPZoneVsanDatastore2)
@@ -123,27 +123,27 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 		invalidZone = GetAndExpectStringEnvVar(VCPInvalidZone)
 		scParameters = make(map[string]string)
 		zones = make([]string, 0)
-		_, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		_, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 	})
 
 	ginkgo.It("Verify dynamically created pv with allowed zones specified in storage class, shows the right zone information on its labels", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with the following zones : %s", zoneA))
 		zones = append(zones, zoneA)
-		verifyPVZoneLabels(client, f.Timeouts, namespace, nil, zones)
+		verifyPVZoneLabels(ctx, client, f.Timeouts, namespace, nil, zones)
 	})
 
 	ginkgo.It("Verify dynamically created pv with multiple zones specified in the storage class, shows both the zones on its labels", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with the following zones : %s, %s", zoneA, zoneB))
 		zones = append(zones, zoneA)
 		zones = append(zones, zoneB)
-		verifyPVZoneLabels(client, f.Timeouts, namespace, nil, zones)
+		verifyPVZoneLabels(ctx, client, f.Timeouts, namespace, nil, zones)
 	})
 
 	ginkgo.It("Verify PVC creation with invalid zone specified in storage class fails", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with unknown zone : %s", invalidZone))
 		zones = append(zones, invalidZone)
-		err := verifyPVCCreationFails(client, namespace, nil, zones, "")
+		err := verifyPVCCreationFails(ctx, client, namespace, nil, zones, "")
 		framework.ExpectError(err)
 		errorMsg := "Failed to find a shared datastore matching zone [" + invalidZone + "]"
 		if !strings.Contains(err.Error(), errorMsg) {
@@ -154,28 +154,28 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 	ginkgo.It("Verify a pod is created and attached to a dynamically created PV, based on allowed zones specified in storage class ", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with zones :%s", zoneA))
 		zones = append(zones, zoneA)
-		verifyPVCAndPodCreationSucceeds(client, f.Timeouts, namespace, nil, zones, "")
+		verifyPVCAndPodCreationSucceeds(ctx, client, f.Timeouts, namespace, nil, zones, "")
 	})
 
 	ginkgo.It("Verify a pod is created and attached to a dynamically created PV, based on multiple zones specified in storage class ", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with zones :%s, %s", zoneA, zoneB))
 		zones = append(zones, zoneA)
 		zones = append(zones, zoneB)
-		verifyPVCAndPodCreationSucceeds(client, f.Timeouts, namespace, nil, zones, "")
+		verifyPVCAndPodCreationSucceeds(ctx, client, f.Timeouts, namespace, nil, zones, "")
 	})
 
 	ginkgo.It("Verify a pod is created and attached to a dynamically created PV, based on the allowed zones and datastore specified in storage class", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s and datastore :%s", zoneA, vsanDatastore1))
 		scParameters[Datastore] = vsanDatastore1
 		zones = append(zones, zoneA)
-		verifyPVCAndPodCreationSucceeds(client, f.Timeouts, namespace, scParameters, zones, "")
+		verifyPVCAndPodCreationSucceeds(ctx, client, f.Timeouts, namespace, scParameters, zones, "")
 	})
 
 	ginkgo.It("Verify PVC creation with incompatible datastore and zone combination specified in storage class fails", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s and datastore :%s", zoneC, vsanDatastore1))
 		scParameters[Datastore] = vsanDatastore1
 		zones = append(zones, zoneC)
-		err := verifyPVCCreationFails(client, namespace, scParameters, zones, "")
+		err := verifyPVCCreationFails(ctx, client, namespace, scParameters, zones, "")
 		errorMsg := "No matching datastores found in the kubernetes cluster for zone " + zoneC
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -186,21 +186,21 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s and storage policy :%s", zoneA, compatPolicy))
 		scParameters[SpbmStoragePolicy] = compatPolicy
 		zones = append(zones, zoneA)
-		verifyPVCAndPodCreationSucceeds(client, f.Timeouts, namespace, scParameters, zones, "")
+		verifyPVCAndPodCreationSucceeds(ctx, client, f.Timeouts, namespace, scParameters, zones, "")
 	})
 
 	ginkgo.It("Verify a pod is created on a non-Workspace zone and attached to a dynamically created PV, based on the allowed zones and storage policy specified in storage class", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s and storage policy :%s", zoneB, compatPolicy))
 		scParameters[SpbmStoragePolicy] = compatPolicy
 		zones = append(zones, zoneB)
-		verifyPVCAndPodCreationSucceeds(client, f.Timeouts, namespace, scParameters, zones, "")
+		verifyPVCAndPodCreationSucceeds(ctx, client, f.Timeouts, namespace, scParameters, zones, "")
 	})
 
 	ginkgo.It("Verify PVC creation with incompatible storagePolicy and zone combination specified in storage class fails", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s and storage policy :%s", zoneA, nonCompatPolicy))
 		scParameters[SpbmStoragePolicy] = nonCompatPolicy
 		zones = append(zones, zoneA)
-		err := verifyPVCCreationFails(client, namespace, scParameters, zones, "")
+		err := verifyPVCCreationFails(ctx, client, namespace, scParameters, zones, "")
 		errorMsg := "No compatible datastores found that satisfy the storage policy requirements"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -212,7 +212,7 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 		scParameters[SpbmStoragePolicy] = compatPolicy
 		scParameters[Datastore] = vsanDatastore1
 		zones = append(zones, zoneA)
-		verifyPVCAndPodCreationSucceeds(client, f.Timeouts, namespace, scParameters, zones, "")
+		verifyPVCAndPodCreationSucceeds(ctx, client, f.Timeouts, namespace, scParameters, zones, "")
 	})
 
 	ginkgo.It("Verify PVC creation with incompatible storage policy along with compatible zone and datastore combination specified in storage class fails", func(ctx context.Context) {
@@ -220,7 +220,7 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 		scParameters[SpbmStoragePolicy] = nonCompatPolicy
 		scParameters[Datastore] = vsanDatastore1
 		zones = append(zones, zoneA)
-		err := verifyPVCCreationFails(client, namespace, scParameters, zones, "")
+		err := verifyPVCCreationFails(ctx, client, namespace, scParameters, zones, "")
 		errorMsg := "User specified datastore is not compatible with the storagePolicy: \\\"" + nonCompatPolicy + "\\\"."
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -232,7 +232,7 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 		scParameters[SpbmStoragePolicy] = compatPolicy
 		scParameters[Datastore] = vsanDatastore2
 		zones = append(zones, zoneC)
-		err := verifyPVCCreationFails(client, namespace, scParameters, zones, "")
+		err := verifyPVCCreationFails(ctx, client, namespace, scParameters, zones, "")
 		errorMsg := "No matching datastores found in the kubernetes cluster for zone " + zoneC
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -241,7 +241,7 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 
 	ginkgo.It("Verify PVC creation fails if no zones are specified in the storage class (No shared datastores exist among all the nodes)", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with no zones"))
-		err := verifyPVCCreationFails(client, namespace, nil, nil, "")
+		err := verifyPVCCreationFails(ctx, client, namespace, nil, nil, "")
 		errorMsg := "No shared datastores found in the Kubernetes cluster"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -251,7 +251,7 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 	ginkgo.It("Verify PVC creation fails if only datastore is specified in the storage class (No shared datastores exist among all the nodes)", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with datastore :%s", vsanDatastore1))
 		scParameters[Datastore] = vsanDatastore1
-		err := verifyPVCCreationFails(client, namespace, scParameters, nil, "")
+		err := verifyPVCCreationFails(ctx, client, namespace, scParameters, nil, "")
 		errorMsg := "No shared datastores found in the Kubernetes cluster"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -261,7 +261,7 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 	ginkgo.It("Verify PVC creation fails if only storage policy is specified in the storage class (No shared datastores exist among all the nodes)", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with storage policy :%s", compatPolicy))
 		scParameters[SpbmStoragePolicy] = compatPolicy
-		err := verifyPVCCreationFails(client, namespace, scParameters, nil, "")
+		err := verifyPVCCreationFails(ctx, client, namespace, scParameters, nil, "")
 		errorMsg := "No shared datastores found in the Kubernetes cluster"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -272,7 +272,7 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 		ginkgo.By(fmt.Sprintf("Creating storage class with storage policy :%s and datastore :%s", compatPolicy, vsanDatastore1))
 		scParameters[SpbmStoragePolicy] = compatPolicy
 		scParameters[Datastore] = vsanDatastore1
-		err := verifyPVCCreationFails(client, namespace, scParameters, nil, "")
+		err := verifyPVCCreationFails(ctx, client, namespace, scParameters, nil, "")
 		errorMsg := "No shared datastores found in the Kubernetes cluster"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -282,7 +282,7 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 	ginkgo.It("Verify PVC creation fails if the availability zone specified in the storage class have no shared datastores under it.", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s", zoneC))
 		zones = append(zones, zoneC)
-		err := verifyPVCCreationFails(client, namespace, nil, zones, "")
+		err := verifyPVCCreationFails(ctx, client, namespace, nil, zones, "")
 		errorMsg := "No matching datastores found in the kubernetes cluster for zone " + zoneC
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -293,7 +293,7 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 		ginkgo.By(fmt.Sprintf("Creating storage class with the following zones :%s and %s", zoneA, zoneC))
 		zones = append(zones, zoneA)
 		zones = append(zones, zoneC)
-		err := verifyPVCCreationFails(client, namespace, nil, zones, "")
+		err := verifyPVCCreationFails(ctx, client, namespace, nil, zones, "")
 		errorMsg := "No matching datastores found in the kubernetes cluster for zone " + zoneC
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -304,7 +304,7 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 		ginkgo.By(fmt.Sprintf("Creating storage class with %s :%s and zone :%s", PolicyHostFailuresToTolerate, HostFailuresToTolerateCapabilityInvalidVal, zoneA))
 		scParameters[PolicyHostFailuresToTolerate] = HostFailuresToTolerateCapabilityInvalidVal
 		zones = append(zones, zoneA)
-		err := verifyPVCCreationFails(client, namespace, scParameters, zones, "")
+		err := verifyPVCCreationFails(ctx, client, namespace, scParameters, zones, "")
 		errorMsg := "Invalid value for " + PolicyHostFailuresToTolerate + "."
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -317,47 +317,47 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 		scParameters[PolicyIopsLimit] = IopsLimitCapabilityVal
 		scParameters[Datastore] = vsanDatastore1
 		zones = append(zones, zoneA)
-		verifyPVCAndPodCreationSucceeds(client, f.Timeouts, namespace, scParameters, zones, "")
+		verifyPVCAndPodCreationSucceeds(ctx, client, f.Timeouts, namespace, scParameters, zones, "")
 	})
 
 	ginkgo.It("Verify a pod is created and attached to a dynamically created PV, based on the allowed zones specified in storage class when the datastore under the zone is present in another datacenter", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s", zoneD))
 		zones = append(zones, zoneD)
-		verifyPVCAndPodCreationSucceeds(client, f.Timeouts, namespace, scParameters, zones, "")
+		verifyPVCAndPodCreationSucceeds(ctx, client, f.Timeouts, namespace, scParameters, zones, "")
 	})
 
 	ginkgo.It("Verify a pod is created and attached to a dynamically created PV, based on the allowed zones and datastore specified in storage class when there are multiple datastores with the same name under different zones across datacenters", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s and datastore name :%s", zoneD, localDatastore))
 		scParameters[Datastore] = localDatastore
 		zones = append(zones, zoneD)
-		verifyPVCAndPodCreationSucceeds(client, f.Timeouts, namespace, scParameters, zones, "")
+		verifyPVCAndPodCreationSucceeds(ctx, client, f.Timeouts, namespace, scParameters, zones, "")
 	})
 
 	ginkgo.It("Verify a pod is created and attached to a dynamically created PV with storage policy specified in storage class in waitForFirstConsumer binding mode", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with waitForFirstConsumer mode and storage policy :%s", compatPolicy))
 		scParameters[SpbmStoragePolicy] = compatPolicy
-		verifyPVCAndPodCreationSucceeds(client, f.Timeouts, namespace, scParameters, nil, storagev1.VolumeBindingWaitForFirstConsumer)
+		verifyPVCAndPodCreationSucceeds(ctx, client, f.Timeouts, namespace, scParameters, nil, storagev1.VolumeBindingWaitForFirstConsumer)
 	})
 
 	ginkgo.It("Verify a pod is created and attached to a dynamically created PV with storage policy specified in storage class in waitForFirstConsumer binding mode with allowedTopologies", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with waitForFirstConsumer mode, storage policy :%s and zone :%s", compatPolicy, zoneA))
 		scParameters[SpbmStoragePolicy] = compatPolicy
 		zones = append(zones, zoneA)
-		verifyPVCAndPodCreationSucceeds(client, f.Timeouts, namespace, scParameters, zones, storagev1.VolumeBindingWaitForFirstConsumer)
+		verifyPVCAndPodCreationSucceeds(ctx, client, f.Timeouts, namespace, scParameters, zones, storagev1.VolumeBindingWaitForFirstConsumer)
 	})
 
 	ginkgo.It("Verify a pod is created and attached to a dynamically created PV with storage policy specified in storage class in waitForFirstConsumer binding mode with multiple allowedTopologies", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with waitForFirstConsumer mode and zones : %s, %s", zoneA, zoneB))
 		zones = append(zones, zoneA)
 		zones = append(zones, zoneB)
-		verifyPVCAndPodCreationSucceeds(client, f.Timeouts, namespace, nil, zones, storagev1.VolumeBindingWaitForFirstConsumer)
+		verifyPVCAndPodCreationSucceeds(ctx, client, f.Timeouts, namespace, nil, zones, storagev1.VolumeBindingWaitForFirstConsumer)
 	})
 
 	ginkgo.It("Verify a PVC creation fails when multiple zones are specified in the storage class without shared datastores among the zones in waitForFirstConsumer binding mode", func(ctx context.Context) {
 		ginkgo.By(fmt.Sprintf("Creating storage class with waitForFirstConsumer mode and following zones :%s and %s", zoneA, zoneC))
 		zones = append(zones, zoneA)
 		zones = append(zones, zoneC)
-		err := verifyPodAndPvcCreationFailureOnWaitForFirstConsumerMode(client, namespace, nil, zones)
+		err := verifyPodAndPvcCreationFailureOnWaitForFirstConsumerMode(ctx, client, namespace, nil, zones)
 		framework.ExpectError(err)
 		errorMsg := "No matching datastores found in the kubernetes cluster for zone " + zoneC
 		if !strings.Contains(err.Error(), errorMsg) {
@@ -374,17 +374,17 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 			// nodeSelector set as zoneB
 			v1.LabelTopologyZone: zoneB,
 		}
-		verifyPodSchedulingFails(client, namespace, nodeSelectorMap, scParameters, zones, storagev1.VolumeBindingWaitForFirstConsumer)
+		verifyPodSchedulingFails(ctx, client, namespace, nodeSelectorMap, scParameters, zones, storagev1.VolumeBindingWaitForFirstConsumer)
 	})
 })
 
-func verifyPVCAndPodCreationSucceeds(client clientset.Interface, timeouts *framework.TimeoutContext, namespace string, scParameters map[string]string, zones []string, volumeBindingMode storagev1.VolumeBindingMode) {
-	storageclass, err := client.StorageV1().StorageClasses().Create(context.TODO(), getVSphereStorageClassSpec("zone-sc", scParameters, zones, volumeBindingMode), metav1.CreateOptions{})
+func verifyPVCAndPodCreationSucceeds(ctx context.Context, client clientset.Interface, timeouts *framework.TimeoutContext, namespace string, scParameters map[string]string, zones []string, volumeBindingMode storagev1.VolumeBindingMode) {
+	storageclass, err := client.StorageV1().StorageClasses().Create(ctx, getVSphereStorageClassSpec("zone-sc", scParameters, zones, volumeBindingMode), metav1.CreateOptions{})
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	ginkgo.DeferCleanup(client.StorageV1().StorageClasses().Delete, storageclass.Name, metav1.DeleteOptions{})
 
 	ginkgo.By("Creating PVC using the Storage Class")
-	pvclaim, err := e2epv.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
+	pvclaim, err := e2epv.CreatePVC(ctx, client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	ginkgo.DeferCleanup(e2epv.DeletePersistentVolumeClaim, client, pvclaim.Name, namespace)
 
@@ -394,39 +394,39 @@ func verifyPVCAndPodCreationSucceeds(client clientset.Interface, timeouts *frame
 	var persistentvolumes []*v1.PersistentVolume
 	// If WaitForFirstConsumer mode, verify pvc binding status after pod creation. For immediate mode, do now.
 	if volumeBindingMode != storagev1.VolumeBindingWaitForFirstConsumer {
-		persistentvolumes = waitForPVClaimBoundPhase(client, pvclaims, timeouts.ClaimProvision)
+		persistentvolumes = waitForPVClaimBoundPhase(ctx, client, pvclaims, timeouts.ClaimProvision)
 	}
 
 	ginkgo.By("Creating pod to attach PV to the node")
-	pod, err := e2epod.CreatePod(client, namespace, nil, pvclaims, false, "")
+	pod, err := e2epod.CreatePod(ctx, client, namespace, nil, pvclaims, false, "")
 	framework.ExpectNoError(err)
 
 	if volumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer {
-		persistentvolumes = waitForPVClaimBoundPhase(client, pvclaims, timeouts.ClaimProvision)
+		persistentvolumes = waitForPVClaimBoundPhase(ctx, client, pvclaims, timeouts.ClaimProvision)
 	}
 
 	if zones != nil {
 		ginkgo.By("Verify persistent volume was created on the right zone")
-		verifyVolumeCreationOnRightZone(persistentvolumes, pod.Spec.NodeName, zones)
+		verifyVolumeCreationOnRightZone(ctx, persistentvolumes, pod.Spec.NodeName, zones)
 	}
 
 	ginkgo.By("Verify the volume is accessible and available in the pod")
-	verifyVSphereVolumesAccessible(client, pod, persistentvolumes)
+	verifyVSphereVolumesAccessible(ctx, client, pod, persistentvolumes)
 
 	ginkgo.By("Deleting pod")
-	e2epod.DeletePodWithWait(client, pod)
+	framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, client, pod))
 
 	ginkgo.By("Waiting for volumes to be detached from the node")
-	waitForVSphereDiskToDetach(persistentvolumes[0].Spec.VsphereVolume.VolumePath, pod.Spec.NodeName)
+	framework.ExpectNoError(waitForVSphereDiskToDetach(ctx, persistentvolumes[0].Spec.VsphereVolume.VolumePath, pod.Spec.NodeName))
 }
 
-func verifyPodAndPvcCreationFailureOnWaitForFirstConsumerMode(client clientset.Interface, namespace string, scParameters map[string]string, zones []string) error {
-	storageclass, err := client.StorageV1().StorageClasses().Create(context.TODO(), getVSphereStorageClassSpec("zone-sc", scParameters, zones, storagev1.VolumeBindingWaitForFirstConsumer), metav1.CreateOptions{})
+func verifyPodAndPvcCreationFailureOnWaitForFirstConsumerMode(ctx context.Context, client clientset.Interface, namespace string, scParameters map[string]string, zones []string) error {
+	storageclass, err := client.StorageV1().StorageClasses().Create(ctx, getVSphereStorageClassSpec("zone-sc", scParameters, zones, storagev1.VolumeBindingWaitForFirstConsumer), metav1.CreateOptions{})
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	ginkgo.DeferCleanup(client.StorageV1().StorageClasses().Delete, storageclass.Name, metav1.DeleteOptions{})
 
 	ginkgo.By("Creating PVC using the Storage Class")
-	pvclaim, err := e2epv.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
+	pvclaim, err := e2epv.CreatePVC(ctx, client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	ginkgo.DeferCleanup(e2epv.DeletePersistentVolumeClaim, client, pvclaim.Name, namespace)
 
@@ -435,15 +435,15 @@ func verifyPodAndPvcCreationFailureOnWaitForFirstConsumerMode(client clientset.I
 
 	ginkgo.By("Creating a pod")
 	pod := e2epod.MakePod(namespace, nil, pvclaims, false, "")
-	pod, err = client.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	pod, err = client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	ginkgo.DeferCleanup(e2epod.DeletePodWithWait, client, pod)
 
 	ginkgo.By("Waiting for claim to be in bound phase")
-	err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
+	err = e2epv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
 	framework.ExpectError(err)
 
-	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(context.TODO(), metav1.ListOptions{})
+	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(ctx, metav1.ListOptions{})
 	framework.ExpectNoError(err)
 
 	// Look for PVC ProvisioningFailed event and return the message.
@@ -455,20 +455,20 @@ func verifyPodAndPvcCreationFailureOnWaitForFirstConsumerMode(client clientset.I
 	return nil
 }
 
-func waitForPVClaimBoundPhase(client clientset.Interface, pvclaims []*v1.PersistentVolumeClaim, timeout time.Duration) []*v1.PersistentVolume {
+func waitForPVClaimBoundPhase(ctx context.Context, client clientset.Interface, pvclaims []*v1.PersistentVolumeClaim, timeout time.Duration) []*v1.PersistentVolume {
 	ginkgo.By("Waiting for claim to be in bound phase")
-	persistentvolumes, err := e2epv.WaitForPVClaimBoundPhase(client, pvclaims, timeout)
+	persistentvolumes, err := e2epv.WaitForPVClaimBoundPhase(ctx, client, pvclaims, timeout)
 	framework.ExpectNoError(err)
 	return persistentvolumes
 }
 
-func verifyPodSchedulingFails(client clientset.Interface, namespace string, nodeSelector map[string]string, scParameters map[string]string, zones []string, volumeBindingMode storagev1.VolumeBindingMode) {
-	storageclass, err := client.StorageV1().StorageClasses().Create(context.TODO(), getVSphereStorageClassSpec("zone-sc", scParameters, zones, volumeBindingMode), metav1.CreateOptions{})
+func verifyPodSchedulingFails(ctx context.Context, client clientset.Interface, namespace string, nodeSelector map[string]string, scParameters map[string]string, zones []string, volumeBindingMode storagev1.VolumeBindingMode) {
+	storageclass, err := client.StorageV1().StorageClasses().Create(ctx, getVSphereStorageClassSpec("zone-sc", scParameters, zones, volumeBindingMode), metav1.CreateOptions{})
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	ginkgo.DeferCleanup(client.StorageV1().StorageClasses().Delete, storageclass.Name, metav1.DeleteOptions{})
 
 	ginkgo.By("Creating PVC using the Storage Class")
-	pvclaim, err := e2epv.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
+	pvclaim, err := e2epv.CreatePVC(ctx, client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	ginkgo.DeferCleanup(e2epv.DeletePersistentVolumeClaim, client, pvclaim.Name, namespace)
 
@@ -476,46 +476,46 @@ func verifyPodSchedulingFails(client clientset.Interface, namespace string, node
 	pvclaims = append(pvclaims, pvclaim)
 
 	ginkgo.By("Creating a pod")
-	pod, err := e2epod.CreateUnschedulablePod(client, namespace, nodeSelector, pvclaims, false, "")
+	pod, err := e2epod.CreateUnschedulablePod(ctx, client, namespace, nodeSelector, pvclaims, false, "")
 	framework.ExpectNoError(err)
 	ginkgo.DeferCleanup(e2epod.DeletePodWithWait, client, pod)
 }
 
-func verifyPVCCreationFails(client clientset.Interface, namespace string, scParameters map[string]string, zones []string, volumeBindingMode storagev1.VolumeBindingMode) error {
-	storageclass, err := client.StorageV1().StorageClasses().Create(context.TODO(), getVSphereStorageClassSpec("zone-sc", scParameters, zones, volumeBindingMode), metav1.CreateOptions{})
+func verifyPVCCreationFails(ctx context.Context, client clientset.Interface, namespace string, scParameters map[string]string, zones []string, volumeBindingMode storagev1.VolumeBindingMode) error {
+	storageclass, err := client.StorageV1().StorageClasses().Create(ctx, getVSphereStorageClassSpec("zone-sc", scParameters, zones, volumeBindingMode), metav1.CreateOptions{})
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	ginkgo.DeferCleanup(client.StorageV1().StorageClasses().Delete, storageclass.Name, metav1.DeleteOptions{})
 
 	ginkgo.By("Creating PVC using the Storage Class")
-	pvclaim, err := e2epv.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
+	pvclaim, err := e2epv.CreatePVC(ctx, client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	ginkgo.DeferCleanup(e2epv.DeletePersistentVolumeClaim, client, pvclaim.Name, namespace)
 
 	ginkgo.By("Waiting for claim to be in bound phase")
-	err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
+	err = e2epv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
 	framework.ExpectError(err)
 
-	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(context.TODO(), metav1.ListOptions{})
+	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(ctx, metav1.ListOptions{})
 	framework.ExpectNoError(err)
 
 	framework.Logf("Failure message : %+q", eventList.Items[0].Message)
 	return fmt.Errorf("Failure message: %+q", eventList.Items[0].Message)
 }
 
-func verifyPVZoneLabels(client clientset.Interface, timeouts *framework.TimeoutContext, namespace string, scParameters map[string]string, zones []string) {
-	storageclass, err := client.StorageV1().StorageClasses().Create(context.TODO(), getVSphereStorageClassSpec("zone-sc", nil, zones, ""), metav1.CreateOptions{})
+func verifyPVZoneLabels(ctx context.Context, client clientset.Interface, timeouts *framework.TimeoutContext, namespace string, scParameters map[string]string, zones []string) {
+	storageclass, err := client.StorageV1().StorageClasses().Create(ctx, getVSphereStorageClassSpec("zone-sc", nil, zones, ""), metav1.CreateOptions{})
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	ginkgo.DeferCleanup(client.StorageV1().StorageClasses().Delete, storageclass.Name, metav1.DeleteOptions{})
 
 	ginkgo.By("Creating PVC using the storage class")
-	pvclaim, err := e2epv.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
+	pvclaim, err := e2epv.CreatePVC(ctx, client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	ginkgo.DeferCleanup(e2epv.DeletePersistentVolumeClaim, client, pvclaim.Name, namespace)
 
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
 	ginkgo.By("Waiting for claim to be in bound phase")
-	persistentvolumes, err := e2epv.WaitForPVClaimBoundPhase(client, pvclaims, timeouts.ClaimProvision)
+	persistentvolumes, err := e2epv.WaitForPVClaimBoundPhase(ctx, client, pvclaims, timeouts.ClaimProvision)
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Verify zone information is present in the volume labels")

--- a/test/e2e/upgrades/apps/replicasets.go
+++ b/test/e2e/upgrades/apps/replicasets.go
@@ -49,24 +49,24 @@ type ReplicaSetUpgradeTest struct {
 func (ReplicaSetUpgradeTest) Name() string { return "[sig-apps] replicaset-upgrade" }
 
 // Setup creates a ReplicaSet and makes sure it's replicas ready.
-func (r *ReplicaSetUpgradeTest) Setup(f *framework.Framework) {
+func (r *ReplicaSetUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 	c := f.ClientSet
 	ns := f.Namespace.Name
 	nginxImage := imageutils.GetE2EImage(imageutils.Nginx)
 
 	ginkgo.By(fmt.Sprintf("Creating replicaset %s in namespace %s", rsName, ns))
 	replicaSet := newReplicaSet(rsName, ns, 1, map[string]string{"test": "upgrade"}, "nginx", nginxImage)
-	rs, err := c.AppsV1().ReplicaSets(ns).Create(context.TODO(), replicaSet, metav1.CreateOptions{})
+	rs, err := c.AppsV1().ReplicaSets(ns).Create(ctx, replicaSet, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.By(fmt.Sprintf("Waiting for replicaset %s to have all of its replicas ready", rsName))
-	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(c, ns, rsName))
+	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName))
 
 	r.UID = rs.UID
 }
 
 // Test checks whether the replicasets are the same after an upgrade.
-func (r *ReplicaSetUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+func (r *ReplicaSetUpgradeTest) Test(ctx context.Context, f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	c := f.ClientSet
 	ns := f.Namespace.Name
 	rsClient := c.AppsV1().ReplicaSets(ns)
@@ -77,14 +77,14 @@ func (r *ReplicaSetUpgradeTest) Test(f *framework.Framework, done <-chan struct{
 
 	// Verify the RS is the same (survives) after the upgrade
 	ginkgo.By(fmt.Sprintf("Checking UID to verify replicaset %s survives upgrade", rsName))
-	upgradedRS, err := rsClient.Get(context.TODO(), rsName, metav1.GetOptions{})
+	upgradedRS, err := rsClient.Get(ctx, rsName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	if upgradedRS.UID != r.UID {
 		framework.ExpectNoError(fmt.Errorf("expected same replicaset UID: %v got: %v", r.UID, upgradedRS.UID))
 	}
 
 	ginkgo.By(fmt.Sprintf("Waiting for replicaset %s to have all of its replicas ready after upgrade", rsName))
-	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(c, ns, rsName))
+	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName))
 
 	// Verify the upgraded RS is active by scaling up the RS to scaleNum and ensuring all pods are Ready
 	ginkgo.By(fmt.Sprintf("Scaling up replicaset %s to %d", rsName, scaleNum))
@@ -94,11 +94,11 @@ func (r *ReplicaSetUpgradeTest) Test(f *framework.Framework, done <-chan struct{
 	framework.ExpectNoError(err)
 
 	ginkgo.By(fmt.Sprintf("Waiting for replicaset %s to have all of its replicas ready after scaling", rsName))
-	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(c, ns, rsName))
+	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName))
 }
 
 // Teardown cleans up any remaining resources.
-func (r *ReplicaSetUpgradeTest) Teardown(f *framework.Framework) {
+func (r *ReplicaSetUpgradeTest) Teardown(ctx context.Context, f *framework.Framework) {
 	// rely on the namespace deletion to clean up everything
 }
 

--- a/test/e2e/upgrades/apps/statefulset.go
+++ b/test/e2e/upgrades/apps/statefulset.go
@@ -70,7 +70,7 @@ func (StatefulSetUpgradeTest) Skip(upgCtx upgrades.UpgradeContext) bool {
 }
 
 // Setup creates a StatefulSet and a HeadlessService. It verifies the basic SatefulSet properties
-func (t *StatefulSetUpgradeTest) Setup(f *framework.Framework) {
+func (t *StatefulSetUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 	ssName := "ss"
 	labels := map[string]string{
 		"foo": "bar",
@@ -86,49 +86,49 @@ func (t *StatefulSetUpgradeTest) Setup(f *framework.Framework) {
 	e2estatefulset.PauseNewPods(t.set)
 
 	ginkgo.By("Creating service " + headlessSvcName + " in namespace " + ns)
-	_, err := f.ClientSet.CoreV1().Services(ns).Create(context.TODO(), t.service, metav1.CreateOptions{})
+	_, err := f.ClientSet.CoreV1().Services(ns).Create(ctx, t.service, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 	*(t.set.Spec.Replicas) = 3
-	_, err = f.ClientSet.AppsV1().StatefulSets(ns).Create(context.TODO(), t.set, metav1.CreateOptions{})
+	_, err = f.ClientSet.AppsV1().StatefulSets(ns).Create(ctx, t.set, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Saturating stateful set " + t.set.Name)
-	e2estatefulset.Saturate(f.ClientSet, t.set)
-	t.verify(f)
-	t.restart(f)
-	t.verify(f)
+	e2estatefulset.Saturate(ctx, f.ClientSet, t.set)
+	t.verify(ctx, f)
+	t.restart(ctx, f)
+	t.verify(ctx, f)
 }
 
 // Test waits for the upgrade to complete and verifies the StatefulSet basic functionality
-func (t *StatefulSetUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+func (t *StatefulSetUpgradeTest) Test(ctx context.Context, f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	<-done
-	t.verify(f)
+	t.verify(ctx, f)
 }
 
 // Teardown deletes all StatefulSets
-func (t *StatefulSetUpgradeTest) Teardown(f *framework.Framework) {
-	e2estatefulset.DeleteAllStatefulSets(f.ClientSet, t.set.Name)
+func (t *StatefulSetUpgradeTest) Teardown(ctx context.Context, f *framework.Framework) {
+	e2estatefulset.DeleteAllStatefulSets(ctx, f.ClientSet, t.set.Name)
 }
 
-func (t *StatefulSetUpgradeTest) verify(f *framework.Framework) {
+func (t *StatefulSetUpgradeTest) verify(ctx context.Context, f *framework.Framework) {
 	ginkgo.By("Verifying statefulset mounted data directory is usable")
-	framework.ExpectNoError(e2estatefulset.CheckMount(f.ClientSet, t.set, "/data"))
+	framework.ExpectNoError(e2estatefulset.CheckMount(ctx, f.ClientSet, t.set, "/data"))
 
 	ginkgo.By("Verifying statefulset provides a stable hostname for each pod")
-	framework.ExpectNoError(e2estatefulset.CheckHostname(f.ClientSet, t.set))
+	framework.ExpectNoError(e2estatefulset.CheckHostname(ctx, f.ClientSet, t.set))
 
 	ginkgo.By("Verifying statefulset set proper service name")
 	framework.ExpectNoError(e2estatefulset.CheckServiceName(t.set, t.set.Spec.ServiceName))
 
 	cmd := "echo $(hostname) > /data/hostname; sync;"
 	ginkgo.By("Running " + cmd + " in all stateful pods")
-	framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(f.ClientSet, t.set, cmd))
+	framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, f.ClientSet, t.set, cmd))
 }
 
-func (t *StatefulSetUpgradeTest) restart(f *framework.Framework) {
+func (t *StatefulSetUpgradeTest) restart(ctx context.Context, f *framework.Framework) {
 	ginkgo.By("Restarting statefulset " + t.set.Name)
-	e2estatefulset.Restart(f.ClientSet, t.set)
-	e2estatefulset.WaitForRunningAndReady(f.ClientSet, *t.set.Spec.Replicas, t.set)
+	e2estatefulset.Restart(ctx, f.ClientSet, t.set)
+	e2estatefulset.WaitForRunningAndReady(ctx, f.ClientSet, *t.set.Spec.Replicas, t.set)
 }

--- a/test/e2e/upgrades/node/secrets.go
+++ b/test/e2e/upgrades/node/secrets.go
@@ -41,7 +41,7 @@ type SecretUpgradeTest struct {
 func (SecretUpgradeTest) Name() string { return "[sig-storage] [sig-api-machinery] secret-upgrade" }
 
 // Setup creates a secret and then verifies that a pod can consume it.
-func (t *SecretUpgradeTest) Setup(f *framework.Framework) {
+func (t *SecretUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 	secretName := "upgrade-secret"
 
 	ns := f.Namespace
@@ -58,30 +58,30 @@ func (t *SecretUpgradeTest) Setup(f *framework.Framework) {
 
 	ginkgo.By("Creating a secret")
 	var err error
-	if t.secret, err = f.ClientSet.CoreV1().Secrets(ns.Name).Create(context.TODO(), t.secret, metav1.CreateOptions{}); err != nil {
+	if t.secret, err = f.ClientSet.CoreV1().Secrets(ns.Name).Create(ctx, t.secret, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create test secret %s: %v", t.secret.Name, err)
 	}
 
 	ginkgo.By("Making sure the secret is consumable")
-	t.testPod(f)
+	t.testPod(ctx, f)
 }
 
 // Test waits for the upgrade to complete, and then verifies that a
 // pod can still consume the secret.
-func (t *SecretUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+func (t *SecretUpgradeTest) Test(ctx context.Context, f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	<-done
 	ginkgo.By("Consuming the secret after upgrade")
-	t.testPod(f)
+	t.testPod(ctx, f)
 }
 
 // Teardown cleans up any remaining resources.
-func (t *SecretUpgradeTest) Teardown(f *framework.Framework) {
+func (t *SecretUpgradeTest) Teardown(ctx context.Context, f *framework.Framework) {
 	// rely on the namespace deletion to clean up everything
 }
 
 // testPod creates a pod that consumes a secret and prints it out. The
 // output is then verified.
-func (t *SecretUpgradeTest) testPod(f *framework.Framework) {
+func (t *SecretUpgradeTest) testPod(ctx context.Context, f *framework.Framework) {
 	volumeName := "secret-volume"
 	volumeMountPath := "/etc/secret-volume"
 
@@ -145,8 +145,8 @@ func (t *SecretUpgradeTest) testPod(f *framework.Framework) {
 		"mode of file \"/etc/secret-volume/data\": -rw-r--r--",
 	}
 
-	e2eoutput.TestContainerOutput(f, "volume consume secrets", pod, 0, expectedOutput)
+	e2eoutput.TestContainerOutput(ctx, f, "volume consume secrets", pod, 0, expectedOutput)
 
 	expectedOutput = []string{"SECRET_DATA=keep it secret"}
-	e2eoutput.TestContainerOutput(f, "env consume secrets", pod, 1, expectedOutput)
+	e2eoutput.TestContainerOutput(ctx, f, "env consume secrets", pod, 1, expectedOutput)
 }

--- a/test/e2e/upgrades/upgrade.go
+++ b/test/e2e/upgrades/upgrade.go
@@ -19,6 +19,8 @@ limitations under the License.
 package upgrades
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -49,17 +51,17 @@ type Test interface {
 
 	// Setup should create and verify whatever objects need to
 	// exist before the upgrade disruption starts.
-	Setup(f *framework.Framework)
+	Setup(ctx context.Context, f *framework.Framework)
 
 	// Test will run during the upgrade. When the upgrade is
 	// complete, done will be closed and final validation can
 	// begin.
-	Test(f *framework.Framework, done <-chan struct{}, upgrade UpgradeType)
+	Test(ctx context.Context, f *framework.Framework, done <-chan struct{}, upgrade UpgradeType)
 
 	// Teardown should clean up any objects that are created that
 	// aren't already cleaned up by the framework. This will
 	// always be called, even if Setup failed.
-	Teardown(f *framework.Framework)
+	Teardown(ctx context.Context, f *framework.Framework)
 }
 
 // Skippable is an interface that an upgrade test can implement to be

--- a/test/e2e/windows/cpu_limits.go
+++ b/test/e2e/windows/cpu_limits.go
@@ -45,17 +45,17 @@ var _ = SIGDescribe("[Feature:Windows] Cpu Resources [Serial]", func() {
 		ginkgo.It("should not be exceeded after waiting 2 minutes", func(ctx context.Context) {
 			ginkgo.By("Creating one pod with limit set to '0.5'")
 			podsDecimal := newCPUBurnPods(1, powershellImage, "0.5", "1Gi")
-			e2epod.NewPodClient(f).CreateBatch(podsDecimal)
+			e2epod.NewPodClient(f).CreateBatch(ctx, podsDecimal)
 			ginkgo.By("Creating one pod with limit set to '500m'")
 			podsMilli := newCPUBurnPods(1, powershellImage, "500m", "1Gi")
-			e2epod.NewPodClient(f).CreateBatch(podsMilli)
+			e2epod.NewPodClient(f).CreateBatch(ctx, podsMilli)
 			ginkgo.By("Waiting 2 minutes")
 			time.Sleep(2 * time.Minute)
 			ginkgo.By("Ensuring pods are still running")
 			var allPods [](*v1.Pod)
 			for _, p := range podsDecimal {
 				pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(
-					context.TODO(),
+					ctx,
 					p.Name,
 					metav1.GetOptions{})
 				framework.ExpectNoError(err, "Error retrieving pod")
@@ -64,7 +64,7 @@ var _ = SIGDescribe("[Feature:Windows] Cpu Resources [Serial]", func() {
 			}
 			for _, p := range podsMilli {
 				pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(
-					context.TODO(),
+					ctx,
 					p.Name,
 					metav1.GetOptions{})
 				framework.ExpectNoError(err, "Error retrieving pod")
@@ -74,7 +74,7 @@ var _ = SIGDescribe("[Feature:Windows] Cpu Resources [Serial]", func() {
 			ginkgo.By("Ensuring cpu doesn't exceed limit by >5%")
 			for _, p := range allPods {
 				ginkgo.By("Gathering node summary stats")
-				nodeStats, err := e2ekubelet.GetStatsSummary(f.ClientSet, p.Spec.NodeName)
+				nodeStats, err := e2ekubelet.GetStatsSummary(ctx, f.ClientSet, p.Spec.NodeName)
 				framework.ExpectNoError(err, "Error grabbing node summary stats")
 				found := false
 				cpuUsage := float64(0)

--- a/test/e2e/windows/device_plugin.go
+++ b/test/e2e/windows/device_plugin.go
@@ -95,7 +95,7 @@ var _ = SIGDescribe("[Feature:GPUDevicePlugin] Device Plugin", func() {
 		}
 
 		sysNs := "kube-system"
-		_, err := cs.AppsV1().DaemonSets(sysNs).Create(context.TODO(), ds, metav1.CreateOptions{})
+		_, err := cs.AppsV1().DaemonSets(sysNs).Create(ctx, ds, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("creating Windows testing Pod")
@@ -104,10 +104,10 @@ var _ = SIGDescribe("[Feature:GPUDevicePlugin] Device Plugin", func() {
 		windowsPod.Spec.Containers[0].Resources.Limits = v1.ResourceList{
 			"microsoft.com/directx": resource.MustParse("1"),
 		}
-		windowsPod, err = cs.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), windowsPod, metav1.CreateOptions{})
+		windowsPod, err = cs.CoreV1().Pods(f.Namespace.Name).Create(ctx, windowsPod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		ginkgo.By("Waiting for the pod Running")
-		err = e2epod.WaitTimeoutForPodRunningInNamespace(cs, windowsPod.Name, f.Namespace.Name, testSlowMultiplier*framework.PodStartTimeout)
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, cs, windowsPod.Name, f.Namespace.Name, testSlowMultiplier*framework.PodStartTimeout)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("verifying device access in Windows testing Pod")

--- a/test/e2e/windows/dns.go
+++ b/test/e2e/windows/dns.go
@@ -42,7 +42,7 @@ var _ = SIGDescribe("[Feature:Windows] DNS", func() {
 
 		ginkgo.By("Getting the IP address of the internal Kubernetes service")
 
-		svc, err := f.ClientSet.CoreV1().Services("kube-system").Get(context.TODO(), "kube-dns", metav1.GetOptions{})
+		svc, err := f.ClientSet.CoreV1().Services("kube-system").Get(ctx, "kube-dns", metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Preparing a test DNS service with injected DNS names...")
@@ -60,7 +60,7 @@ var _ = SIGDescribe("[Feature:Windows] DNS", func() {
 		testPod.Spec.NodeSelector = map[string]string{
 			"kubernetes.io/os": "windows",
 		}
-		testPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), testPod, metav1.CreateOptions{})
+		testPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, testPod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("confirming that the pod has a windows label")
@@ -68,11 +68,11 @@ var _ = SIGDescribe("[Feature:Windows] DNS", func() {
 		framework.Logf("Created pod %v", testPod)
 		defer func() {
 			framework.Logf("Deleting pod %s...", testPod.Name)
-			if err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), testPod.Name, *metav1.NewDeleteOptions(0)); err != nil {
+			if err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, testPod.Name, *metav1.NewDeleteOptions(0)); err != nil {
 				framework.Failf("Failed to delete pod %s: %v", testPod.Name, err)
 			}
 		}()
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, testPod.Name, f.Namespace.Name), "failed to wait for pod %s to be running", testPod.Name)
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, testPod.Name, f.Namespace.Name), "failed to wait for pod %s to be running", testPod.Name)
 
 		// This isn't the best 'test' but it is a great diagnostic, see later test for the 'real' test.
 		ginkgo.By("Calling ipconfig to get debugging info for this pod's DNS and confirm that a dns server 1.1.1.1 can be injected, along with ")

--- a/test/e2e/windows/gmsa_full.go
+++ b/test/e2e/windows/gmsa_full.go
@@ -99,17 +99,17 @@ var _ = SIGDescribe("[Feature:Windows] GMSA Full [Serial] [Slow]", func() {
 			defer ginkgo.GinkgoRecover()
 
 			ginkgo.By("finding the worker node that fulfills this test's assumptions")
-			nodes := findPreconfiguredGmsaNodes(f.ClientSet)
+			nodes := findPreconfiguredGmsaNodes(ctx, f.ClientSet)
 			if len(nodes) != 1 {
 				e2eskipper.Skipf("Expected to find exactly one node with the %q label, found %d", gmsaFullNodeLabel, len(nodes))
 			}
 			node := nodes[0]
 
 			ginkgo.By("retrieving the contents of the GMSACredentialSpec custom resource manifest from the node")
-			crdManifestContents := retrieveCRDManifestFileContents(f, node)
+			crdManifestContents := retrieveCRDManifestFileContents(ctx, f, node)
 
 			ginkgo.By("deploying the GMSA webhook")
-			err := deployGmsaWebhook(f)
+			err := deployGmsaWebhook(ctx, f)
 			if err != nil {
 				framework.Failf(err.Error())
 			}
@@ -121,26 +121,26 @@ var _ = SIGDescribe("[Feature:Windows] GMSA Full [Serial] [Slow]", func() {
 			}
 
 			ginkgo.By("creating an RBAC role to grant use access to that GMSA resource")
-			rbacRoleName, err := createRBACRoleForGmsa(f)
+			rbacRoleName, err := createRBACRoleForGmsa(ctx, f)
 			if err != nil {
 				framework.Failf(err.Error())
 			}
 
 			ginkgo.By("creating a service account")
-			serviceAccountName := createServiceAccount(f)
+			serviceAccountName := createServiceAccount(ctx, f)
 
 			ginkgo.By("binding the RBAC role to the service account")
-			bindRBACRoleToServiceAccount(f, serviceAccountName, rbacRoleName)
+			bindRBACRoleToServiceAccount(ctx, f, serviceAccountName, rbacRoleName)
 
 			ginkgo.By("creating a pod using the GMSA cred spec")
-			podName := createPodWithGmsa(f, serviceAccountName)
+			podName := createPodWithGmsa(ctx, f, serviceAccountName)
 
 			// nltest /QUERY will only return successfully if there is a GMSA
 			// identity configured, _and_ it succeeds in contacting the AD controller
 			// and authenticating with it.
 			ginkgo.By("checking that nltest /QUERY returns successfully")
 			var output string
-			gomega.Eventually(func() bool {
+			gomega.Eventually(ctx, func() bool {
 				output, err = runKubectlExecInNamespace(f.Namespace.Name, podName, "nltest", "/QUERY")
 				if err != nil {
 					framework.Logf("unable to run command in container via exec: %s", err)
@@ -166,17 +166,17 @@ var _ = SIGDescribe("[Feature:Windows] GMSA Full [Serial] [Slow]", func() {
 			defer ginkgo.GinkgoRecover()
 
 			ginkgo.By("finding the worker node that fulfills this test's assumptions")
-			nodes := findPreconfiguredGmsaNodes(f.ClientSet)
+			nodes := findPreconfiguredGmsaNodes(ctx, f.ClientSet)
 			if len(nodes) != 1 {
 				e2eskipper.Skipf("Expected to find exactly one node with the %q label, found %d", gmsaFullNodeLabel, len(nodes))
 			}
 			node := nodes[0]
 
 			ginkgo.By("retrieving the contents of the GMSACredentialSpec custom resource manifest from the node")
-			crdManifestContents := retrieveCRDManifestFileContents(f, node)
+			crdManifestContents := retrieveCRDManifestFileContents(ctx, f, node)
 
 			ginkgo.By("deploying the GMSA webhook")
-			err := deployGmsaWebhook(f)
+			err := deployGmsaWebhook(ctx, f)
 			if err != nil {
 				framework.Failf(err.Error())
 			}
@@ -188,26 +188,26 @@ var _ = SIGDescribe("[Feature:Windows] GMSA Full [Serial] [Slow]", func() {
 			}
 
 			ginkgo.By("creating an RBAC role to grant use access to that GMSA resource")
-			rbacRoleName, err := createRBACRoleForGmsa(f)
+			rbacRoleName, err := createRBACRoleForGmsa(ctx, f)
 			if err != nil {
 				framework.Failf(err.Error())
 			}
 
 			ginkgo.By("creating a service account")
-			serviceAccountName := createServiceAccount(f)
+			serviceAccountName := createServiceAccount(ctx, f)
 
 			ginkgo.By("binding the RBAC role to the service account")
-			bindRBACRoleToServiceAccount(f, serviceAccountName, rbacRoleName)
+			bindRBACRoleToServiceAccount(ctx, f, serviceAccountName, rbacRoleName)
 
 			ginkgo.By("creating a pod using the GMSA cred spec")
-			podName := createPodWithGmsa(f, serviceAccountName)
+			podName := createPodWithGmsa(ctx, f, serviceAccountName)
 
 			ginkgo.By("getting the ip of GMSA domain")
 			gmsaDomainIP := getGmsaDomainIP(f, podName)
 
 			ginkgo.By("checking that file can be read and write from the remote folder successfully")
 			filePath := fmt.Sprintf("\\\\%s\\%s\\write-test-%s.txt", gmsaDomainIP, gmsaSharedFolder, string(uuid.NewUUID())[0:4])
-			gomega.Eventually(func() bool {
+			gomega.Eventually(ctx, func() bool {
 				// The filePath is a remote folder, do not change the format of it
 				_, _ = runKubectlExecInNamespace(f.Namespace.Name, podName, "--", "powershell.exe", "-Command", "echo 'This is a test file.' > "+filePath)
 				output, err := runKubectlExecInNamespace(f.Namespace.Name, podName, "powershell.exe", "--", "cat", filePath)
@@ -229,11 +229,11 @@ func isValidOutput(output string) bool {
 }
 
 // findPreconfiguredGmsaNode finds node with the gmsaFullNodeLabel label on it.
-func findPreconfiguredGmsaNodes(c clientset.Interface) []v1.Node {
+func findPreconfiguredGmsaNodes(ctx context.Context, c clientset.Interface) []v1.Node {
 	nodeOpts := metav1.ListOptions{
 		LabelSelector: gmsaFullNodeLabel,
 	}
-	nodes, err := c.CoreV1().Nodes().List(context.TODO(), nodeOpts)
+	nodes, err := c.CoreV1().Nodes().List(ctx, nodeOpts)
 	if err != nil {
 		framework.Failf("Unable to list nodes: %v", err)
 	}
@@ -245,7 +245,7 @@ func findPreconfiguredGmsaNodes(c clientset.Interface) []v1.Node {
 // on nodes with the gmsaFullNodeLabel label with that file's directory
 // mounted on it, and then exec-ing into that pod to retrieve the file's
 // contents.
-func retrieveCRDManifestFileContents(f *framework.Framework, node v1.Node) string {
+func retrieveCRDManifestFileContents(ctx context.Context, f *framework.Framework, node v1.Node) string {
 	podName := "retrieve-gmsa-crd-contents"
 	// we can't use filepath.Dir here since the test itself runs on a Linux machine
 	splitPath := strings.Split(gmsaCrdManifestPath, `\`)
@@ -283,7 +283,7 @@ func retrieveCRDManifestFileContents(f *framework.Framework, node v1.Node) strin
 			},
 		},
 	}
-	e2epod.NewPodClient(f).CreateSync(pod)
+	e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 	output, err := runKubectlExecInNamespace(f.Namespace.Name, podName, "cmd", "/S", "/C", fmt.Sprintf("type %s", gmsaCrdManifestPath))
 	if err != nil {
@@ -297,7 +297,7 @@ func retrieveCRDManifestFileContents(f *framework.Framework, node v1.Node) strin
 // deployGmsaWebhook deploys the GMSA webhook, and returns a cleanup function
 // to be called when done with testing, that removes the temp files it's created
 // on disks as well as the API resources it's created.
-func deployGmsaWebhook(f *framework.Framework) error {
+func deployGmsaWebhook(ctx context.Context, f *framework.Framework) error {
 	deployerName := "webhook-deployer"
 	deployerNamespace := f.Namespace.Name
 	webHookName := "gmsa-webhook"
@@ -317,8 +317,8 @@ func deployGmsaWebhook(f *framework.Framework) error {
 	})
 
 	// ensure the deployer has ability to approve certificatesigningrequests to install the webhook
-	s := createServiceAccount(f)
-	bindClusterRBACRoleToServiceAccount(f, s, "cluster-admin")
+	s := createServiceAccount(ctx, f)
+	bindClusterRBACRoleToServiceAccount(ctx, f, s, "cluster-admin")
 
 	installSteps := []string{
 		"echo \"@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing/\" >> /etc/apk/repositories",
@@ -357,11 +357,11 @@ func deployGmsaWebhook(f *framework.Framework) error {
 			},
 		},
 	}
-	e2epod.NewPodClient(f).CreateSync(pod)
+	e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 	// Wait for the Webhook deployment to become ready. The deployer pod takes a few seconds to initialize and create resources
 	err := waitForDeployment(func() (*appsv1.Deployment, error) {
-		return f.ClientSet.AppsV1().Deployments(webHookNamespace).Get(context.TODO(), webHookName, metav1.GetOptions{})
+		return f.ClientSet.AppsV1().Deployments(webHookNamespace).Get(ctx, webHookName, metav1.GetOptions{})
 	}, 10*time.Second, f.Timeouts.PodStart)
 	if err == nil {
 		framework.Logf("GMSA webhook successfully deployed")
@@ -370,7 +370,7 @@ func deployGmsaWebhook(f *framework.Framework) error {
 	}
 
 	// Dump deployer logs
-	logs, _ := e2epod.GetPodLogs(f.ClientSet, deployerNamespace, deployerName, deployerName)
+	logs, _ := e2epod.GetPodLogs(ctx, f.ClientSet, deployerNamespace, deployerName, deployerName)
 	framework.Logf("GMSA deployment logs:\n%s", logs)
 
 	return err
@@ -409,7 +409,7 @@ func createGmsaCustomResource(ns string, crdManifestContents string) error {
 // createRBACRoleForGmsa creates an RBAC cluster role to grant use
 // access to our test credential spec.
 // It returns the role's name, as well as a function to delete it when done.
-func createRBACRoleForGmsa(f *framework.Framework) (string, error) {
+func createRBACRoleForGmsa(ctx context.Context, f *framework.Framework) (string, error) {
 	roleName := f.Namespace.Name + "-rbac-role"
 
 	role := &rbacv1.ClusterRole{
@@ -427,7 +427,7 @@ func createRBACRoleForGmsa(f *framework.Framework) (string, error) {
 	}
 
 	ginkgo.DeferCleanup(framework.IgnoreNotFound(f.ClientSet.RbacV1().ClusterRoles().Delete), roleName, metav1.DeleteOptions{})
-	_, err := f.ClientSet.RbacV1().ClusterRoles().Create(context.TODO(), role, metav1.CreateOptions{})
+	_, err := f.ClientSet.RbacV1().ClusterRoles().Create(ctx, role, metav1.CreateOptions{})
 	if err != nil {
 		err = fmt.Errorf("unable to create RBAC cluster role %q: %w", roleName, err)
 	}
@@ -436,7 +436,7 @@ func createRBACRoleForGmsa(f *framework.Framework) (string, error) {
 }
 
 // createServiceAccount creates a service account, and returns its name.
-func createServiceAccount(f *framework.Framework) string {
+func createServiceAccount(ctx context.Context, f *framework.Framework) string {
 	accountName := f.Namespace.Name + "-sa-" + string(uuid.NewUUID())
 	account := &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
@@ -444,14 +444,14 @@ func createServiceAccount(f *framework.Framework) string {
 			Namespace: f.Namespace.Name,
 		},
 	}
-	if _, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Create(context.TODO(), account, metav1.CreateOptions{}); err != nil {
+	if _, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Create(ctx, account, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create service account %q: %v", accountName, err)
 	}
 	return accountName
 }
 
 // bindRBACRoleToServiceAccount binds the given RBAC cluster role to the given service account.
-func bindRBACRoleToServiceAccount(f *framework.Framework, serviceAccountName, rbacRoleName string) {
+func bindRBACRoleToServiceAccount(ctx context.Context, f *framework.Framework, serviceAccountName, rbacRoleName string) {
 	binding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      f.Namespace.Name + "-rbac-binding",
@@ -470,11 +470,11 @@ func bindRBACRoleToServiceAccount(f *framework.Framework, serviceAccountName, rb
 			Name:     rbacRoleName,
 		},
 	}
-	_, err := f.ClientSet.RbacV1().RoleBindings(f.Namespace.Name).Create(context.TODO(), binding, metav1.CreateOptions{})
+	_, err := f.ClientSet.RbacV1().RoleBindings(f.Namespace.Name).Create(ctx, binding, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 }
 
-func bindClusterRBACRoleToServiceAccount(f *framework.Framework, serviceAccountName, rbacRoleName string) {
+func bindClusterRBACRoleToServiceAccount(ctx context.Context, f *framework.Framework, serviceAccountName, rbacRoleName string) {
 	binding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      f.Namespace.Name + "-rbac-binding",
@@ -493,12 +493,12 @@ func bindClusterRBACRoleToServiceAccount(f *framework.Framework, serviceAccountN
 			Name:     rbacRoleName,
 		},
 	}
-	_, err := f.ClientSet.RbacV1().ClusterRoleBindings().Create(context.TODO(), binding, metav1.CreateOptions{})
+	_, err := f.ClientSet.RbacV1().ClusterRoleBindings().Create(ctx, binding, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 }
 
 // createPodWithGmsa creates a pod using the test GMSA cred spec, and returns its name.
-func createPodWithGmsa(f *framework.Framework, serviceAccountName string) string {
+func createPodWithGmsa(ctx context.Context, f *framework.Framework, serviceAccountName string) string {
 	podName := "pod-with-gmsa"
 	credSpecName := gmsaCustomResourceName
 
@@ -527,7 +527,7 @@ func createPodWithGmsa(f *framework.Framework, serviceAccountName string) string
 			},
 		},
 	}
-	e2epod.NewPodClient(f).CreateSync(pod)
+	e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 	return podName
 }

--- a/test/e2e/windows/gmsa_kubelet.go
+++ b/test/e2e/windows/gmsa_kubelet.go
@@ -95,7 +95,7 @@ var _ = SIGDescribe("[Feature:Windows] GMSA Kubelet [Slow]", func() {
 				}
 
 				ginkgo.By("creating a pod with correct GMSA specs")
-				e2epod.NewPodClient(f).CreateSync(pod)
+				e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 				ginkgo.By("checking the domain reported by nltest in the containers")
 				namespaceOption := fmt.Sprintf("--namespace=%s", f.Namespace.Name)
@@ -112,7 +112,7 @@ var _ = SIGDescribe("[Feature:Windows] GMSA Kubelet [Slow]", func() {
 					// even for bogus creds, `nltest /PARENTDOMAIN` simply returns the AD domain, which is enough for our purpose here.
 					// note that the "eventually" part seems to be needed to account for the fact that powershell containers
 					// are a bit slow to become responsive, even when docker reports them as running.
-					gomega.Eventually(func() bool {
+					gomega.Eventually(ctx, func() bool {
 						output, err = e2ekubectl.RunKubectl(f.Namespace.Name, "exec", namespaceOption, podName, containerOption, "--", "nltest", "/PARENTDOMAIN")
 						return err == nil
 					}, 1*time.Minute, 1*time.Second).Should(gomega.BeTrue())

--- a/test/e2e/windows/host_process.go
+++ b/test/e2e/windows/host_process.go
@@ -95,7 +95,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 	ginkgo.It("should run as a process on the host/node", func(ctx context.Context) {
 
 		ginkgo.By("selecting a Windows node")
-		targetNode, err := findWindowsNode(f)
+		targetNode, err := findWindowsNode(ctx, f)
 		framework.ExpectNoError(err, "Error finding Windows node")
 		framework.Logf("Using node: %v", targetNode.Name)
 
@@ -128,14 +128,14 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 			},
 		}
 
-		e2epod.NewPodClient(f).Create(pod)
+		e2epod.NewPodClient(f).Create(ctx, pod)
 
 		ginkgo.By("Waiting for pod to run")
-		e2epod.NewPodClient(f).WaitForFinish(podName, 3*time.Minute)
+		e2epod.NewPodClient(f).WaitForFinish(ctx, podName, 3*time.Minute)
 
 		ginkgo.By("Then ensuring pod finished running successfully")
 		p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(
-			context.TODO(),
+			ctx,
 			podName,
 			metav1.GetOptions{})
 
@@ -180,21 +180,21 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 			},
 		}
 
-		e2epod.NewPodClient(f).Create(pod)
+		e2epod.NewPodClient(f).Create(ctx, pod)
 
 		ginkgo.By("Waiting for pod to run")
-		e2epod.NewPodClient(f).WaitForFinish(podName, 3*time.Minute)
+		e2epod.NewPodClient(f).WaitForFinish(ctx, podName, 3*time.Minute)
 
 		ginkgo.By("Then ensuring pod finished running successfully")
 		p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(
-			context.TODO(),
+			ctx,
 			podName,
 			metav1.GetOptions{})
 
 		framework.ExpectNoError(err, "Error retrieving pod")
 
 		if p.Status.Phase != v1.PodSucceeded {
-			logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, "read-configuration")
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, podName, "read-configuration")
 			if err != nil {
 				framework.Logf("Error pulling logs: %v", err)
 			}
@@ -212,7 +212,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 		// See https://github.com/kubernetes/enhancements/blob/master/keps/sig-windows/1981-windows-privileged-container-support/README.md
 		// for more details.
 		ginkgo.By("Ensuring Windows nodes are running containerd v1.6.x")
-		windowsNode, err := findWindowsNode(f)
+		windowsNode, err := findWindowsNode(ctx, f)
 		framework.ExpectNoError(err, "error finding Windows node")
 		r, v, err := getNodeContainerRuntimeAndVersion(windowsNode)
 		framework.ExpectNoError(err, "error getting node container runtime and version")
@@ -418,14 +418,14 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 					},
 				},
 			}
-			e2epod.NewPodClient(f).Create(pod)
+			e2epod.NewPodClient(f).Create(ctx, pod)
 
 			ginkgo.By(fmt.Sprintf("Waiting for pod '%s' to run", podName))
-			e2epod.NewPodClient(f).WaitForFinish(podName, 3*time.Minute)
+			e2epod.NewPodClient(f).WaitForFinish(ctx, podName, 3*time.Minute)
 
 			ginkgo.By("Then ensuring pod finished running successfully")
 			p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(
-				context.TODO(),
+				ctx,
 				podName,
 				metav1.GetOptions{})
 
@@ -440,7 +440,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 						"involvedObject.namespace": f.Namespace.Name,
 					}.AsSelector().String(),
 				}
-				events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(context.TODO(), options)
+				events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, options)
 				framework.ExpectNoError(err, "Error getting events for failed pod")
 				for _, event := range events.Items {
 					framework.Logf("%s: %s", event.Reason, event.Message)
@@ -468,7 +468,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 				"validation-script": validation_script,
 			},
 		}
-		_, err := f.ClientSet.CoreV1().ConfigMaps(ns.Name).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		_, err := f.ClientSet.CoreV1().ConfigMaps(ns.Name).Create(ctx, configMap, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "unable to create create configmap")
 
 		ginkgo.By("Creating a secret containing test data")
@@ -485,7 +485,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 				"foo": []byte("bar"),
 			},
 		}
-		_, err = f.ClientSet.CoreV1().Secrets(ns.Name).Create(context.TODO(), secret, metav1.CreateOptions{})
+		_, err = f.ClientSet.CoreV1().Secrets(ns.Name).Create(ctx, secret, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "unable to create secret")
 
 		ginkgo.By("Creating a pod with a HostProcess container that uses various types of volume mounts")
@@ -493,18 +493,18 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 		podAndContainerName := "host-process-volume-mounts"
 		pod := makeTestPodWithVolumeMounts(podAndContainerName)
 
-		e2epod.NewPodClient(f).Create(pod)
+		e2epod.NewPodClient(f).Create(ctx, pod)
 
 		ginkgo.By("Waiting for pod to run")
-		e2epod.NewPodClient(f).WaitForFinish(podAndContainerName, 3*time.Minute)
+		e2epod.NewPodClient(f).WaitForFinish(ctx, podAndContainerName, 3*time.Minute)
 
-		logs, err := e2epod.GetPodLogs(f.ClientSet, ns.Name, podAndContainerName, podAndContainerName)
+		logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, ns.Name, podAndContainerName, podAndContainerName)
 		framework.ExpectNoError(err, "Error getting pod logs")
 		framework.Logf("Container logs: %s", logs)
 
 		ginkgo.By("Then ensuring pod finished running successfully")
 		p, err := f.ClientSet.CoreV1().Pods(ns.Name).Get(
-			context.TODO(),
+			ctx,
 			podAndContainerName,
 			metav1.GetOptions{})
 
@@ -514,12 +514,12 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 
 	ginkgo.It("metrics should report count of started and failed to start HostProcess containers", func(ctx context.Context) {
 		ginkgo.By("Selecting a Windows node")
-		targetNode, err := findWindowsNode(f)
+		targetNode, err := findWindowsNode(ctx, f)
 		framework.ExpectNoError(err, "Error finding Windows node")
 		framework.Logf("Using node: %v", targetNode.Name)
 
 		ginkgo.By("Getting initial kubelet metrics values")
-		beforeMetrics, err := getCurrentHostProcessMetrics(f, targetNode.Name)
+		beforeMetrics, err := getCurrentHostProcessMetrics(ctx, f, targetNode.Name)
 		framework.ExpectNoError(err, "Error getting initial kubelet metrics for node")
 		framework.Logf("Initial HostProcess container metrics -- StartedContainers: %v, StartedContainersErrors: %v, StartedInitContainers: %v, StartedInitContainersErrors: %v",
 			beforeMetrics.StartedContainersCount, beforeMetrics.StartedContainersErrorCount, beforeMetrics.StartedInitContainersCount, beforeMetrics.StartedInitContainersErrorCount)
@@ -565,8 +565,8 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 			},
 		}
 
-		e2epod.NewPodClient(f).Create(pod)
-		e2epod.NewPodClient(f).WaitForFinish(podName, 3*time.Minute)
+		e2epod.NewPodClient(f).Create(ctx, pod)
+		e2epod.NewPodClient(f).WaitForFinish(ctx, podName, 3*time.Minute)
 
 		ginkgo.By("Scheduling a pod with a HostProcess container that will fail")
 		podName = "host-process-metrics-pod-failing-container"
@@ -599,12 +599,12 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 			},
 		}
 
-		e2epod.NewPodClient(f).Create(pod)
-		e2epod.NewPodClient(f).WaitForFinish(podName, 3*time.Minute)
+		e2epod.NewPodClient(f).Create(ctx, pod)
+		e2epod.NewPodClient(f).WaitForFinish(ctx, podName, 3*time.Minute)
 
 		ginkgo.By("Getting subsequent kubelet metrics values")
 
-		afterMetrics, err := getCurrentHostProcessMetrics(f, targetNode.Name)
+		afterMetrics, err := getCurrentHostProcessMetrics(ctx, f, targetNode.Name)
 		framework.ExpectNoError(err, "Error getting subsequent kubelet metrics for node")
 		framework.Logf("Subsequent HostProcess container metrics -- StartedContainers: %v, StartedContainersErrors: %v, StartedInitContainers: %v, StartedInitContainersErrors: %v",
 			afterMetrics.StartedContainersCount, afterMetrics.StartedContainersErrorCount, afterMetrics.StartedInitContainersCount, afterMetrics.StartedInitContainersErrorCount)
@@ -620,7 +620,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 
 	ginkgo.It("container stats validation", func(ctx context.Context) {
 		ginkgo.By("selecting a Windows node")
-		targetNode, err := findWindowsNode(f)
+		targetNode, err := findWindowsNode(ctx, f)
 		framework.ExpectNoError(err, "Error finding Windows node")
 		framework.Logf("Using node: %v", targetNode.Name)
 
@@ -651,14 +651,14 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 			},
 		}
 
-		e2epod.NewPodClient(f).Create(pod)
+		e2epod.NewPodClient(f).Create(ctx, pod)
 
 		ginkgo.By("Waiting for the pod to start running")
 		timeout := 3 * time.Minute
-		e2epod.WaitForPodsRunningReady(f.ClientSet, f.Namespace.Name, 1, 0, timeout, make(map[string]string))
+		e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, 0, timeout, make(map[string]string))
 
 		ginkgo.By("Getting container stats for pod")
-		nodeStats, err := e2ekubelet.GetStatsSummary(f.ClientSet, targetNode.Name)
+		nodeStats, err := e2ekubelet.GetStatsSummary(ctx, f.ClientSet, targetNode.Name)
 		framework.ExpectNoError(err, "Error getting node stats")
 
 		statsChecked := false
@@ -700,7 +700,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 	ginkgo.It("should support querying api-server using in-cluster config", func(ctx context.Context) {
 		// This functionality is only support on containerd  v1.7+
 		ginkgo.By("Ensuring Windows nodes are running containerd v1.7+")
-		windowsNode, err := findWindowsNode(f)
+		windowsNode, err := findWindowsNode(ctx, f)
 		framework.ExpectNoError(err, "error finding Windows node")
 		r, v, err := getNodeContainerRuntimeAndVersion(windowsNode)
 		framework.ExpectNoError(err, "error getting node container runtime and version")
@@ -748,10 +748,10 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 		}
 
 		pc := e2epod.NewPodClient(f)
-		pc.Create(pod)
+		pc.Create(ctx, pod)
 
 		ginkgo.By("Waiting for pod to run")
-		e2epod.WaitForPodsRunningReady(f.ClientSet, f.Namespace.Name, 1, 0, 3*time.Minute, make(map[string]string))
+		e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, 0, 3*time.Minute, make(map[string]string))
 
 		ginkgo.By("Waiting for 60 seconds")
 		// We wait an additional 60 seconds after the pod is Running because the
@@ -760,7 +760,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 		time.Sleep(60 * time.Second)
 
 		ginkgo.By("Ensuring the test app was able to successfully query the api-server")
-		logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, "hpc-agnhost")
+		logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, podName, "hpc-agnhost")
 		framework.ExpectNoError(err, "Error getting pod logs")
 
 		framework.Logf("Logs: %s\n", logs)
@@ -779,7 +779,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 	ginkgo.It("should run as localgroup accounts", func(ctx context.Context) {
 		// This functionality is only supported on containerd v1.7+
 		ginkgo.By("Ensuring Windows nodes are running containerd v1.7+")
-		windowsNode, err := findWindowsNode(f)
+		windowsNode, err := findWindowsNode(ctx, f)
 		framework.ExpectNoError(err, "error finding Windows node")
 		r, v, err := getNodeContainerRuntimeAndVersion(windowsNode)
 		framework.ExpectNoError(err, "error getting node container runtime and version")
@@ -835,10 +835,10 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 			},
 		}
 
-		e2epod.NewPodClient(f).Create(pod)
+		e2epod.NewPodClient(f).Create(ctx, pod)
 
 		ginkgo.By("Waiting for pod to run")
-		e2epod.NewPodClient(f).WaitForFinish(podName, 3*time.Minute)
+		e2epod.NewPodClient(f).WaitForFinish(ctx, podName, 3*time.Minute)
 
 		ginkgo.By("Then ensuring pod finished running successfully")
 		p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(
@@ -854,7 +854,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 		// because all of the 'built-in' accounts that can be used with HostProcess
 		// are prefixed with this.
 		ginkgo.By("Then ensuring pod was not running as a system account")
-		logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, "localgroup-container")
+		logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, podName, "localgroup-container")
 		framework.ExpectNoError(err, "error retrieving container logs")
 		framework.Logf("Pod logs: %s", logs)
 		framework.ExpectEqual(
@@ -1005,10 +1005,10 @@ type HostProcessContainersMetrics struct {
 
 // getCurrentHostProcessMetrics returns a HostPRocessContainersMetrics object. Any metrics that do not have any
 // values reported will be set to 0.
-func getCurrentHostProcessMetrics(f *framework.Framework, nodeName string) (HostProcessContainersMetrics, error) {
+func getCurrentHostProcessMetrics(ctx context.Context, f *framework.Framework, nodeName string) (HostProcessContainersMetrics, error) {
 	var result HostProcessContainersMetrics
 
-	metrics, err := e2emetrics.GetKubeletMetrics(f.ClientSet, nodeName)
+	metrics, err := e2emetrics.GetKubeletMetrics(ctx, f.ClientSet, nodeName)
 	if err != nil {
 		return result, err
 	}

--- a/test/e2e/windows/hybrid_network.go
+++ b/test/e2e/windows/hybrid_network.go
@@ -58,44 +58,44 @@ var _ = SIGDescribe("Hybrid cluster network", func() {
 
 			linuxPod := createTestPod(f, linuxBusyBoxImage, linuxOS)
 			ginkgo.By("creating a linux pod and waiting for it to be running")
-			linuxPod = e2epod.NewPodClient(f).CreateSync(linuxPod)
+			linuxPod = e2epod.NewPodClient(f).CreateSync(ctx, linuxPod)
 
 			windowsPod := createTestPod(f, windowsBusyBoximage, windowsOS)
 
 			windowsPod.Spec.Containers[0].Args = []string{"test-webserver"}
 			ginkgo.By("creating a windows pod and waiting for it to be running")
-			windowsPod = e2epod.NewPodClient(f).CreateSync(windowsPod)
+			windowsPod = e2epod.NewPodClient(f).CreateSync(ctx, windowsPod)
 
 			ginkgo.By("verifying pod internal connectivity to the cluster dataplane")
 
 			ginkgo.By("checking connectivity from Linux to Windows")
-			assertConsistentConnectivity(f, linuxPod.ObjectMeta.Name, linuxOS, linuxCheck(windowsPod.Status.PodIP, 80))
+			assertConsistentConnectivity(ctx, f, linuxPod.ObjectMeta.Name, linuxOS, linuxCheck(windowsPod.Status.PodIP, 80))
 
 			ginkgo.By("checking connectivity from Windows to Linux")
-			assertConsistentConnectivity(f, windowsPod.ObjectMeta.Name, windowsOS, windowsCheck(linuxPod.Status.PodIP))
+			assertConsistentConnectivity(ctx, f, windowsPod.ObjectMeta.Name, windowsOS, windowsCheck(linuxPod.Status.PodIP))
 
 		})
 
 		ginkgo.It("should provide Internet connection for Linux containers using DNS [Feature:Networking-DNS]", func(ctx context.Context) {
 			linuxPod := createTestPod(f, linuxBusyBoxImage, linuxOS)
 			ginkgo.By("creating a linux pod and waiting for it to be running")
-			linuxPod = e2epod.NewPodClient(f).CreateSync(linuxPod)
+			linuxPod = e2epod.NewPodClient(f).CreateSync(ctx, linuxPod)
 
 			ginkgo.By("verifying pod external connectivity to the internet")
 
 			ginkgo.By("checking connectivity to 8.8.8.8 53 (google.com) from Linux")
-			assertConsistentConnectivity(f, linuxPod.ObjectMeta.Name, linuxOS, linuxCheck("8.8.8.8", 53))
+			assertConsistentConnectivity(ctx, f, linuxPod.ObjectMeta.Name, linuxOS, linuxCheck("8.8.8.8", 53))
 		})
 
 		ginkgo.It("should provide Internet connection for Windows containers using DNS [Feature:Networking-DNS]", func(ctx context.Context) {
 			windowsPod := createTestPod(f, windowsBusyBoximage, windowsOS)
 			ginkgo.By("creating a windows pod and waiting for it to be running")
-			windowsPod = e2epod.NewPodClient(f).CreateSync(windowsPod)
+			windowsPod = e2epod.NewPodClient(f).CreateSync(ctx, windowsPod)
 
 			ginkgo.By("verifying pod external connectivity to the internet")
 
 			ginkgo.By("checking connectivity to 8.8.8.8 53 (google.com) from Windows")
-			assertConsistentConnectivity(f, windowsPod.ObjectMeta.Name, windowsOS, windowsCheck("www.google.com"))
+			assertConsistentConnectivity(ctx, f, windowsPod.ObjectMeta.Name, windowsOS, windowsCheck("www.google.com"))
 		})
 
 	})
@@ -107,7 +107,7 @@ var (
 	timeoutSeconds = 10
 )
 
-func assertConsistentConnectivity(f *framework.Framework, podName string, os string, cmd []string) {
+func assertConsistentConnectivity(ctx context.Context, f *framework.Framework, podName string, os string, cmd []string) {
 	connChecker := func() error {
 		ginkgo.By(fmt.Sprintf("checking connectivity of %s-container in %s", os, podName))
 		// TODO, we should be retrying this similar to what is done in DialFromNode, in the test/e2e/networking/networking.go tests
@@ -117,8 +117,8 @@ func assertConsistentConnectivity(f *framework.Framework, podName string, os str
 		}
 		return err
 	}
-	gomega.Eventually(connChecker, duration, pollInterval).ShouldNot(gomega.HaveOccurred())
-	gomega.Consistently(connChecker, duration, pollInterval).ShouldNot(gomega.HaveOccurred())
+	gomega.Eventually(ctx, connChecker, duration, pollInterval).ShouldNot(gomega.HaveOccurred())
+	gomega.Consistently(ctx, connChecker, duration, pollInterval).ShouldNot(gomega.HaveOccurred())
 }
 
 func linuxCheck(address string, port int) []string {

--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -47,18 +47,18 @@ var _ = SIGDescribe("[Feature:Windows] Kubelet-Stats [Serial]", func() {
 			ginkgo.It("should return within 10 seconds", func(ctx context.Context) {
 
 				ginkgo.By("Selecting a Windows node")
-				targetNode, err := findWindowsNode(f)
+				targetNode, err := findWindowsNode(ctx, f)
 				framework.ExpectNoError(err, "Error finding Windows node")
 				framework.Logf("Using node: %v", targetNode.Name)
 
 				ginkgo.By("Scheduling 10 pods")
 				powershellImage := imageutils.GetConfig(imageutils.BusyBox)
 				pods := newKubeletStatsTestPods(10, powershellImage, targetNode.Name)
-				e2epod.NewPodClient(f).CreateBatch(pods)
+				e2epod.NewPodClient(f).CreateBatch(ctx, pods)
 
 				ginkgo.By("Waiting up to 3 minutes for pods to be running")
 				timeout := 3 * time.Minute
-				err = e2epod.WaitForPodsRunningReady(f.ClientSet, f.Namespace.Name, 10, 0, timeout, make(map[string]string))
+				err = e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 10, 0, timeout, make(map[string]string))
 				framework.ExpectNoError(err)
 
 				ginkgo.By("Getting kubelet stats 5 times and checking average duration")
@@ -67,7 +67,7 @@ var _ = SIGDescribe("[Feature:Windows] Kubelet-Stats [Serial]", func() {
 
 				for i := 0; i < iterations; i++ {
 					start := time.Now()
-					nodeStats, err := e2ekubelet.GetStatsSummary(f.ClientSet, targetNode.Name)
+					nodeStats, err := e2ekubelet.GetStatsSummary(ctx, f.ClientSet, targetNode.Name)
 					duration := time.Since(start)
 					totalDurationMs += duration.Milliseconds()
 
@@ -122,7 +122,7 @@ var _ = SIGDescribe("[Feature:Windows] Kubelet-Stats", func() {
 		ginkgo.Context("when windows is booted", func() {
 			ginkgo.It("should return bootid within 10 seconds", func(ctx context.Context) {
 				ginkgo.By("Selecting a Windows node")
-				targetNode, err := findWindowsNode(f)
+				targetNode, err := findWindowsNode(ctx, f)
 				framework.ExpectNoError(err, "Error finding Windows node")
 				framework.Logf("Using node: %v", targetNode.Name)
 
@@ -138,18 +138,18 @@ var _ = SIGDescribe("[Feature:Windows] Kubelet-Stats", func() {
 			ginkgo.It("should return within 10 seconds", func(ctx context.Context) {
 
 				ginkgo.By("Selecting a Windows node")
-				targetNode, err := findWindowsNode(f)
+				targetNode, err := findWindowsNode(ctx, f)
 				framework.ExpectNoError(err, "Error finding Windows node")
 				framework.Logf("Using node: %v", targetNode.Name)
 
 				ginkgo.By("Scheduling 3 pods")
 				powershellImage := imageutils.GetConfig(imageutils.BusyBox)
 				pods := newKubeletStatsTestPods(3, powershellImage, targetNode.Name)
-				e2epod.NewPodClient(f).CreateBatch(pods)
+				e2epod.NewPodClient(f).CreateBatch(ctx, pods)
 
 				ginkgo.By("Waiting up to 3 minutes for pods to be running")
 				timeout := 3 * time.Minute
-				err = e2epod.WaitForPodsRunningReady(f.ClientSet, f.Namespace.Name, 3, 0, timeout, make(map[string]string))
+				err = e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 3, 0, timeout, make(map[string]string))
 				framework.ExpectNoError(err)
 
 				ginkgo.By("Getting kubelet stats 1 time")
@@ -158,7 +158,7 @@ var _ = SIGDescribe("[Feature:Windows] Kubelet-Stats", func() {
 
 				for i := 0; i < iterations; i++ {
 					start := time.Now()
-					nodeStats, err := e2ekubelet.GetStatsSummary(f.ClientSet, targetNode.Name)
+					nodeStats, err := e2ekubelet.GetStatsSummary(ctx, f.ClientSet, targetNode.Name)
 					duration := time.Since(start)
 					totalDurationMs += duration.Milliseconds()
 
@@ -206,9 +206,9 @@ var _ = SIGDescribe("[Feature:Windows] Kubelet-Stats", func() {
 })
 
 // findWindowsNode finds a Windows node that is Ready and Schedulable
-func findWindowsNode(f *framework.Framework) (v1.Node, error) {
+func findWindowsNode(ctx context.Context, f *framework.Framework) (v1.Node, error) {
 	selector := labels.Set{"kubernetes.io/os": "windows"}.AsSelector()
-	nodeList, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	nodeList, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 
 	if err != nil {
 		return v1.Node{}, err

--- a/test/e2e/windows/reboot_node.go
+++ b/test/e2e/windows/reboot_node.go
@@ -44,7 +44,7 @@ var _ = SIGDescribe("[Feature:Windows] [Excluded:WindowsDocker] [MinimumKubeletV
 	ginkgo.It("should run as a reboot process on the host/node", func(ctx context.Context) {
 
 		ginkgo.By("selecting a Windows node")
-		targetNode, err := findWindowsNode(f)
+		targetNode, err := findWindowsNode(ctx, f)
 		framework.ExpectNoError(err, "Error finding Windows node")
 		framework.Logf("Using node: %v", targetNode.Name)
 
@@ -74,7 +74,7 @@ var _ = SIGDescribe("[Feature:Windows] [Excluded:WindowsDocker] [MinimumKubeletV
 		}
 		agnPod.Spec.Containers[0].Args = []string{"test-webserver"}
 		ginkgo.By("creating a windows pod and waiting for it to be running")
-		agnPod = e2epod.NewPodClient(f).CreateSync(agnPod)
+		agnPod = e2epod.NewPodClient(f).CreateSync(ctx, agnPod)
 
 		// Create Linux pod to ping the windows pod
 		linuxBusyBoxImage := imageutils.GetE2EImage(imageutils.Nginx)
@@ -107,16 +107,16 @@ var _ = SIGDescribe("[Feature:Windows] [Excluded:WindowsDocker] [MinimumKubeletV
 			},
 		}
 		ginkgo.By("Waiting for the Linux pod to run")
-		nginxPod = e2epod.NewPodClient(f).CreateSync(nginxPod)
+		nginxPod = e2epod.NewPodClient(f).CreateSync(ctx, nginxPod)
 
 		ginkgo.By("checking connectivity to 8.8.8.8 53 (google.com) from Linux")
-		assertConsistentConnectivity(f, nginxPod.ObjectMeta.Name, "linux", linuxCheck("8.8.8.8", 53))
+		assertConsistentConnectivity(ctx, f, nginxPod.ObjectMeta.Name, "linux", linuxCheck("8.8.8.8", 53))
 
 		ginkgo.By("checking connectivity to www.google.com from Windows")
-		assertConsistentConnectivity(f, agnPod.ObjectMeta.Name, "windows", windowsCheck("www.google.com"))
+		assertConsistentConnectivity(ctx, f, agnPod.ObjectMeta.Name, "windows", windowsCheck("www.google.com"))
 
 		ginkgo.By("checking connectivity from Linux to Windows for the first time")
-		assertConsistentConnectivity(f, nginxPod.ObjectMeta.Name, "linux", linuxCheck(agnPod.Status.PodIP, 80))
+		assertConsistentConnectivity(ctx, f, nginxPod.ObjectMeta.Name, "linux", linuxCheck(agnPod.Status.PodIP, 80))
 
 		initialRestartCount := podutil.GetExistingContainerStatus(agnPod.Status.ContainerStatuses, "windows-container").RestartCount
 
@@ -156,14 +156,14 @@ var _ = SIGDescribe("[Feature:Windows] [Excluded:WindowsDocker] [MinimumKubeletV
 			},
 		}
 
-		e2epod.NewPodClient(f).Create(pod)
+		e2epod.NewPodClient(f).Create(ctx, pod)
 
 		ginkgo.By("Waiting for pod to run")
-		e2epod.NewPodClient(f).WaitForFinish(podName, 3*time.Minute)
+		e2epod.NewPodClient(f).WaitForFinish(ctx, podName, 3*time.Minute)
 
 		ginkgo.By("Then ensuring pod finished running successfully")
 		p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(
-			context.TODO(),
+			ctx,
 			podName,
 			metav1.GetOptions{})
 
@@ -185,7 +185,7 @@ var _ = SIGDescribe("[Feature:Windows] [Excluded:WindowsDocker] [MinimumKubeletV
 					break FOR
 				}
 				ginkgo.By("Then checking existed agn-test-pod is running on the rebooted host")
-				agnPodOut, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), agnPod.Name, metav1.GetOptions{})
+				agnPodOut, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, agnPod.Name, metav1.GetOptions{})
 				if err == nil {
 					lastRestartCount := podutil.GetExistingContainerStatus(agnPodOut.Status.ContainerStatuses, "windows-container").RestartCount
 					restartCount = int(lastRestartCount - initialRestartCount)
@@ -197,10 +197,10 @@ var _ = SIGDescribe("[Feature:Windows] [Excluded:WindowsDocker] [MinimumKubeletV
 		ginkgo.By("Checking whether agn-test-pod is rebooted")
 		framework.ExpectEqual(restartCount, 1)
 
-		agnPodOut, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), agnPod.Name, metav1.GetOptions{})
+		agnPodOut, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, agnPod.Name, metav1.GetOptions{})
 		framework.ExpectEqual(agnPodOut.Status.Phase, v1.PodRunning)
 		framework.ExpectNoError(err, "getting pod info after reboot")
-		assertConsistentConnectivity(f, nginxPod.ObjectMeta.Name, "linux", linuxCheck(agnPodOut.Status.PodIP, 80))
+		assertConsistentConnectivity(ctx, f, nginxPod.ObjectMeta.Name, "linux", linuxCheck(agnPodOut.Status.PodIP, 80))
 
 		// create another host process pod to check system boot time
 		checkPod := &v1.Pod{
@@ -239,14 +239,14 @@ var _ = SIGDescribe("[Feature:Windows] [Excluded:WindowsDocker] [MinimumKubeletV
 			},
 		}
 
-		e2epod.NewPodClient(f).Create(checkPod)
+		e2epod.NewPodClient(f).Create(ctx, checkPod)
 
 		ginkgo.By("Waiting for pod to run")
-		e2epod.NewPodClient(f).WaitForFinish("check-reboot-pod", 3*time.Minute)
+		e2epod.NewPodClient(f).WaitForFinish(ctx, "check-reboot-pod", 3*time.Minute)
 
 		ginkgo.By("Then ensuring pod finished running successfully")
 		p, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(
-			context.TODO(),
+			ctx,
 			"check-reboot-pod",
 			metav1.GetOptions{})
 

--- a/test/e2e/windows/security_context.go
+++ b/test/e2e/windows/security_context.go
@@ -47,15 +47,15 @@ var _ = SIGDescribe("[Feature:Windows] SecurityContext", func() {
 	ginkgo.It("should be able create pods and run containers with a given username", func(ctx context.Context) {
 		ginkgo.By("Creating 2 pods: 1 with the default user, and one with a custom one.")
 		podDefault := runAsUserNamePod(nil)
-		e2eoutput.TestContainerOutput(f, "check default user", podDefault, 0, []string{"ContainerUser"})
+		e2eoutput.TestContainerOutput(ctx, f, "check default user", podDefault, 0, []string{"ContainerUser"})
 
 		podUserName := runAsUserNamePod(toPtr("ContainerAdministrator"))
-		e2eoutput.TestContainerOutput(f, "check set user", podUserName, 0, []string{"ContainerAdministrator"})
+		e2eoutput.TestContainerOutput(ctx, f, "check set user", podUserName, 0, []string{"ContainerAdministrator"})
 	})
 
 	ginkgo.It("should not be able to create pods with unknown usernames at Pod level", func(ctx context.Context) {
 		ginkgo.By("Creating a pod with an invalid username")
-		podInvalid := e2epod.NewPodClient(f).Create(runAsUserNamePod(toPtr("FooLish")))
+		podInvalid := e2epod.NewPodClient(f).Create(ctx, runAsUserNamePod(toPtr("FooLish")))
 
 		failedSandboxEventSelector := fields.Set{
 			"involvedObject.kind":      "Pod",
@@ -72,8 +72,8 @@ var _ = SIGDescribe("[Feature:Windows] SecurityContext", func() {
 		// Not all runtimes use the sandbox information.  This means the test needs to check if the pod
 		// sandbox failed or workload pod failed.
 		framework.Logf("Waiting for pod %s to enter the error state.", podInvalid.Name)
-		gomega.Eventually(func() bool {
-			failedSandbox, err := eventOccurred(f.ClientSet, podInvalid.Namespace, failedSandboxEventSelector, hcsschimError)
+		gomega.Eventually(ctx, func(ctx context.Context) bool {
+			failedSandbox, err := eventOccurred(ctx, f.ClientSet, podInvalid.Namespace, failedSandboxEventSelector, hcsschimError)
 			if err != nil {
 				framework.Logf("Error retrieving events for pod. Ignoring...")
 			}
@@ -83,7 +83,7 @@ var _ = SIGDescribe("[Feature:Windows] SecurityContext", func() {
 			}
 
 			framework.Logf("No Sandbox error found. Looking for failure in workload pods")
-			pod, err := e2epod.NewPodClient(f).Get(context.Background(), podInvalid.Name, metav1.GetOptions{})
+			pod, err := e2epod.NewPodClient(f).Get(ctx, podInvalid.Name, metav1.GetOptions{})
 			if err != nil {
 				framework.Logf("Error retrieving pod: %s", err)
 				return false
@@ -104,12 +104,12 @@ var _ = SIGDescribe("[Feature:Windows] SecurityContext", func() {
 		ginkgo.By("Creating a pod with an invalid username at container level and pod running as ContainerUser")
 		p := runAsUserNamePod(toPtr("FooLish"))
 		p.Spec.SecurityContext.WindowsOptions.RunAsUserName = toPtr("ContainerUser")
-		podInvalid := e2epod.NewPodClient(f).Create(p)
+		podInvalid := e2epod.NewPodClient(f).Create(ctx, p)
 
 		framework.Logf("Waiting for pod %s to enter the error state.", podInvalid.Name)
-		framework.ExpectNoError(e2epod.WaitForPodTerminatedInNamespace(f.ClientSet, podInvalid.Name, "", f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodTerminatedInNamespace(ctx, f.ClientSet, podInvalid.Name, "", f.Namespace.Name))
 
-		podInvalid, _ = e2epod.NewPodClient(f).Get(context.TODO(), podInvalid.Name, metav1.GetOptions{})
+		podInvalid, _ = e2epod.NewPodClient(f).Get(ctx, podInvalid.Name, metav1.GetOptions{})
 		podTerminatedReason := testutils.TerminatedContainers(podInvalid)[runAsUserNameContainerName]
 		if podTerminatedReason != "ContainerCannotRun" && podTerminatedReason != "StartError" {
 			framework.Failf("The container terminated reason was supposed to be: 'ContainerCannotRun' or 'StartError', not: '%q'", podTerminatedReason)
@@ -127,8 +127,8 @@ var _ = SIGDescribe("[Feature:Windows] SecurityContext", func() {
 			Command: []string{"cmd", "/S", "/C", "echo %username%"},
 		})
 
-		e2eoutput.TestContainerOutput(f, "check overridden username", pod, 0, []string{"ContainerUser"})
-		e2eoutput.TestContainerOutput(f, "check pod SecurityContext username", pod, 1, []string{"ContainerAdministrator"})
+		e2eoutput.TestContainerOutput(ctx, f, "check overridden username", pod, 0, []string{"ContainerUser"})
+		e2eoutput.TestContainerOutput(ctx, f, "check pod SecurityContext username", pod, 1, []string{"ContainerAdministrator"})
 	})
 
 	ginkgo.It("should ignore Linux Specific SecurityContext if set", func(ctx context.Context) {
@@ -147,11 +147,11 @@ var _ = SIGDescribe("[Feature:Windows] SecurityContext", func() {
 			SELinuxOptions: &v1.SELinuxOptions{Level: "s0:c24,c9"},
 			WindowsOptions: &v1.WindowsSecurityContextOptions{RunAsUserName: &containerUserName}}
 		windowsPodWithSELinux.Spec.Tolerations = []v1.Toleration{{Key: "os", Value: "Windows"}}
-		windowsPodWithSELinux, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(),
+		windowsPodWithSELinux, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx,
 			windowsPodWithSELinux, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		framework.Logf("Created pod %v", windowsPodWithSELinux)
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, windowsPodWithSELinux.Name,
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, windowsPodWithSELinux.Name,
 			f.Namespace.Name), "failed to wait for pod %s to be running", windowsPodWithSELinux.Name)
 	})
 
@@ -161,11 +161,11 @@ var _ = SIGDescribe("[Feature:Windows] SecurityContext", func() {
 		p := runAsUserNamePod(toPtr("ContainerAdministrator"))
 		p.Spec.SecurityContext.RunAsNonRoot = &trueVar
 
-		podInvalid, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), p, metav1.CreateOptions{})
+		podInvalid, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, p, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Error creating pod")
 
 		ginkgo.By("Waiting for pod to finish")
-		event, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(podInvalid)
+		event, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(ctx, podInvalid)
 		framework.ExpectNoError(err)
 		framework.ExpectNotEqual(event, nil, "event should not be empty")
 		framework.Logf("Got event: %v", event)
@@ -179,11 +179,11 @@ var _ = SIGDescribe("[Feature:Windows] SecurityContext", func() {
 		p := runAsUserNamePod(toPtr("CONTAINERADMINISTRATOR"))
 		p.Spec.SecurityContext.RunAsNonRoot = &trueVar
 
-		podInvalid, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), p, metav1.CreateOptions{})
+		podInvalid, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, p, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Error creating pod")
 
 		ginkgo.By("Waiting for pod to finish")
-		event, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(podInvalid)
+		event, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(ctx, podInvalid)
 		framework.ExpectNoError(err)
 		framework.ExpectNotEqual(event, nil, "event should not be empty")
 		framework.Logf("Got event: %v", event)
@@ -226,10 +226,10 @@ func toPtr(s string) *string {
 	return &s
 }
 
-func eventOccurred(c clientset.Interface, namespace, eventSelector, msg string) (bool, error) {
+func eventOccurred(ctx context.Context, c clientset.Interface, namespace, eventSelector, msg string) (bool, error) {
 	options := metav1.ListOptions{FieldSelector: eventSelector}
 
-	events, err := c.CoreV1().Events(namespace).List(context.TODO(), options)
+	events, err := c.CoreV1().Events(namespace).List(ctx, options)
 	if err != nil {
 		return false, fmt.Errorf("got error while getting events: %v", err)
 	}

--- a/test/e2e/windows/service.go
+++ b/test/e2e/windows/service.go
@@ -51,11 +51,11 @@ var _ = SIGDescribe("Services", func() {
 		ns := f.Namespace.Name
 
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-		nodeIP, err := e2enode.PickIP(jig.Client)
+		nodeIP, err := e2enode.PickIP(ctx, jig.Client)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("creating service " + serviceName + " with type=NodePort in namespace " + ns)
-		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeNodePort
 		})
 		framework.ExpectNoError(err)
@@ -69,20 +69,20 @@ var _ = SIGDescribe("Services", func() {
 				"kubernetes.io/os": "windows",
 			}
 		}
-		_, err = jig.Run(windowsNodeSelectorTweak)
+		_, err = jig.Run(ctx, windowsNodeSelectorTweak)
 		framework.ExpectNoError(err)
 
 		//using hybrid_network methods
 		ginkgo.By("creating Windows testing Pod")
 		testPod := createTestPod(f, windowsBusyBoximage, windowsOS)
-		testPod = e2epod.NewPodClient(f).CreateSync(testPod)
+		testPod = e2epod.NewPodClient(f).CreateSync(ctx, testPod)
 
 		ginkgo.By("verifying that pod has the correct nodeSelector")
 		// Admission controllers may sometimes do the wrong thing
 		framework.ExpectEqual(testPod.Spec.NodeSelector["kubernetes.io/os"], "windows")
 
 		ginkgo.By(fmt.Sprintf("checking connectivity Pod to curl http://%s:%d", nodeIP, nodePort))
-		assertConsistentConnectivity(f, testPod.ObjectMeta.Name, windowsOS, windowsCheck(fmt.Sprintf("http://%s", net.JoinHostPort(nodeIP, strconv.Itoa(nodePort)))))
+		assertConsistentConnectivity(ctx, f, testPod.ObjectMeta.Name, windowsOS, windowsCheck(fmt.Sprintf("http://%s", net.JoinHostPort(nodeIP, strconv.Itoa(nodePort)))))
 
 	})
 

--- a/test/e2e/windows/volumes.go
+++ b/test/e2e/windows/volumes.go
@@ -69,26 +69,26 @@ var _ = SIGDescribe("[Feature:Windows] Windows volume mounts ", func() {
 		ginkgo.It("container should have readOnly permissions on emptyDir", func(ctx context.Context) {
 
 			ginkgo.By("creating a container with readOnly permissions on emptyDir volume")
-			doReadOnlyTest(f, emptyDirSource, emptyDirVolumePath)
+			doReadOnlyTest(ctx, f, emptyDirSource, emptyDirVolumePath)
 
 			ginkgo.By("creating two containers, one with readOnly permissions the other with read-write permissions on emptyDir volume")
-			doReadWriteReadOnlyTest(f, emptyDirSource, emptyDirVolumePath)
+			doReadWriteReadOnlyTest(ctx, f, emptyDirSource, emptyDirVolumePath)
 		})
 
 		ginkgo.It("container should have readOnly permissions on hostMapPath", func(ctx context.Context) {
 
 			ginkgo.By("creating a container with readOnly permissions on hostMap volume")
-			doReadOnlyTest(f, hostMapSource, hostMapPath)
+			doReadOnlyTest(ctx, f, hostMapSource, hostMapPath)
 
 			ginkgo.By("creating two containers, one with readOnly permissions the other with read-write permissions on hostMap volume")
-			doReadWriteReadOnlyTest(f, hostMapSource, hostMapPath)
+			doReadWriteReadOnlyTest(ctx, f, hostMapSource, hostMapPath)
 		})
 
 	})
 
 })
 
-func doReadOnlyTest(f *framework.Framework, source v1.VolumeSource, volumePath string) {
+func doReadOnlyTest(ctx context.Context, f *framework.Framework, source v1.VolumeSource, volumePath string) {
 	var (
 		filePath = volumePath + "\\test-file.txt"
 		podName  = "pod-" + string(uuid.NewUUID())
@@ -98,7 +98,7 @@ func doReadOnlyTest(f *framework.Framework, source v1.VolumeSource, volumePath s
 		"kubernetes.io/os": "windows",
 	}
 
-	pod = e2epod.NewPodClient(f).CreateSync(pod)
+	pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
 	ginkgo.By("verifying that pod has the correct nodeSelector")
 	framework.ExpectEqual(pod.Spec.NodeSelector["kubernetes.io/os"], "windows")
 
@@ -109,7 +109,7 @@ func doReadOnlyTest(f *framework.Framework, source v1.VolumeSource, volumePath s
 	framework.ExpectEqual(stderr, "Access is denied.")
 }
 
-func doReadWriteReadOnlyTest(f *framework.Framework, source v1.VolumeSource, volumePath string) {
+func doReadWriteReadOnlyTest(ctx context.Context, f *framework.Framework, source v1.VolumeSource, volumePath string) {
 	var (
 		filePath        = volumePath + "\\test-file" + string(uuid.NewUUID())
 		podName         = "pod-" + string(uuid.NewUUID())
@@ -132,7 +132,7 @@ func doReadWriteReadOnlyTest(f *framework.Framework, source v1.VolumeSource, vol
 	}
 
 	pod.Spec.Containers = append(pod.Spec.Containers, rwcontainer)
-	pod = e2epod.NewPodClient(f).CreateSync(pod)
+	pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 	ginkgo.By("verifying that pod has the correct nodeSelector")
 	framework.ExpectEqual(pod.Spec.NodeSelector["kubernetes.io/os"], "windows")

--- a/test/e2e_kubeadm/bootstrap_token_test.go
+++ b/test/e2e_kubeadm/bootstrap_token_test.go
@@ -54,7 +54,7 @@ var _ = Describe("bootstrap token", func() {
 	ginkgo.It("should exist and be properly configured", func(ctx context.Context) {
 		secrets, err := f.ClientSet.CoreV1().
 			Secrets(kubeSystemNamespace).
-			List(context.TODO(), metav1.ListOptions{})
+			List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "error reading Secrets")
 
 		tokenNum := 0

--- a/test/e2e_kubeadm/controlplane_nodes_test.go
+++ b/test/e2e_kubeadm/controlplane_nodes_test.go
@@ -51,22 +51,22 @@ var _ = Describe("control-plane node", func() {
 	// in case you can skip this test with SKIP=multi-node
 	ginkgo.It("should be labelled and tainted [multi-node]", func(ctx context.Context) {
 		// get all control-plane nodes (and this implicitly checks that node are properly labeled)
-		controlPlanes := getControlPlaneNodes(f.ClientSet)
+		controlPlanes := getControlPlaneNodes(ctx, f.ClientSet)
 
 		// checks if there is at least one control-plane node
 		gomega.Expect(controlPlanes.Items).NotTo(gomega.BeEmpty(), "at least one node with label %s should exist. if you are running test on a single-node cluster, you can skip this test with SKIP=multi-node", controlPlaneLabel)
 
 		// checks that the control-plane nodes have the expected taints
 		for _, cp := range controlPlanes.Items {
-			e2enode.ExpectNodeHasTaint(f.ClientSet, cp.GetName(), &corev1.Taint{Key: controlPlaneLabel, Effect: corev1.TaintEffectNoSchedule})
+			e2enode.ExpectNodeHasTaint(ctx, f.ClientSet, cp.GetName(), &corev1.Taint{Key: controlPlaneLabel, Effect: corev1.TaintEffectNoSchedule})
 		}
 	})
 })
 
-func getControlPlaneNodes(c clientset.Interface) *corev1.NodeList {
+func getControlPlaneNodes(ctx context.Context, c clientset.Interface) *corev1.NodeList {
 	selector := labels.Set{controlPlaneLabel: ""}.AsSelector()
 	cpNodes, err := c.CoreV1().Nodes().
-		List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+		List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 	framework.ExpectNoError(err, "error reading control-plane nodes")
 	return cpNodes
 }

--- a/test/e2e_kubeadm/networking_test.go
+++ b/test/e2e_kubeadm/networking_test.go
@@ -89,7 +89,7 @@ var _ = Describe("networking [setup-networking]", func() {
 					netCC := cc["networking"].(map[interface{}]interface{})
 					if ps, ok := netCC["podSubnet"]; ok {
 						// Check that the pod CIDR allocated to the node(s) is within the kubeadm-config podCIDR.
-						nodes, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+						nodes, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 						framework.ExpectNoError(err, "error listing nodes")
 						for _, node := range nodes.Items {
 							if !subnetWithinSubnet(ps.(string), node.Spec.PodCIDR) {
@@ -114,7 +114,7 @@ var _ = Describe("networking [setup-networking]", func() {
 					if ss, ok := netCC["serviceSubnet"]; ok {
 						// Get the kubernetes service in the default namespace.
 						// Check that service CIDR allocated is within the serviceSubnet range.
-						svc, err := f.ClientSet.CoreV1().Services("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+						svc, err := f.ClientSet.CoreV1().Services("default").Get(ctx, "kubernetes", metav1.GetOptions{})
 						framework.ExpectNoError(err, "error getting Service %q from namespace %q", "kubernetes", "default")
 						if !ipWithinSubnet(ss.(string), svc.Spec.ClusterIP) {
 							framework.Failf("failed due to service(%v) cluster-IP %v not inside configured service subnet: %s", svc.Name, svc.Spec.ClusterIP, ss)
@@ -137,7 +137,7 @@ var _ = Describe("networking [setup-networking]", func() {
 				if _, ok := cc["networking"]; ok {
 					netCC := cc["networking"].(map[interface{}]interface{})
 					if ps, ok := netCC["podSubnet"]; ok {
-						nodes, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+						nodes, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 						framework.ExpectNoError(err, "error listing nodes")
 						// Check that the pod CIDRs allocated to the node(s) are within the kubeadm-config podCIDR.
 						var found bool

--- a/test/e2e_kubeadm/nodes_test.go
+++ b/test/e2e_kubeadm/nodes_test.go
@@ -49,7 +49,7 @@ var _ = Describe("nodes", func() {
 
 	ginkgo.It("should have CRI annotation", func(ctx context.Context) {
 		nodes, err := f.ClientSet.CoreV1().Nodes().
-			List(context.TODO(), metav1.ListOptions{})
+			List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "error reading nodes")
 
 		// Checks that the nodes have the CRI socket annotation

--- a/test/e2e_node/checkpoint_container.go
+++ b/test/e2e_node/checkpoint_container.go
@@ -42,7 +42,7 @@ const (
 )
 
 // proxyPostRequest performs a post on a node proxy endpoint given the nodename and rest client.
-func proxyPostRequest(c clientset.Interface, node, endpoint string, port int) (restclient.Result, error) {
+func proxyPostRequest(ctx context.Context, c clientset.Interface, node, endpoint string, port int) (restclient.Result, error) {
 	// proxy tends to hang in some cases when Node is not ready. Add an artificial timeout for this call. #22165
 	var result restclient.Result
 	finished := make(chan struct{}, 1)
@@ -52,13 +52,15 @@ func proxyPostRequest(c clientset.Interface, node, endpoint string, port int) (r
 			SubResource("proxy").
 			Name(fmt.Sprintf("%v:%v", node, port)).
 			Suffix(endpoint).
-			Do(context.TODO())
+			Do(ctx)
 
 		finished <- struct{}{}
 	}()
 	select {
 	case <-finished:
 		return result, nil
+	case <-ctx.Done():
+		return restclient.Result{}, nil
 	case <-time.After(proxyTimeout):
 		return restclient.Result{}, nil
 	}
@@ -70,7 +72,7 @@ var _ = SIGDescribe("Checkpoint Container [NodeFeature:CheckpointContainer]", fu
 	ginkgo.It("will checkpoint a container out of a pod", func(ctx context.Context) {
 		ginkgo.By("creating a target pod")
 		podClient := e2epod.NewPodClient(f)
-		pod := podClient.CreateSync(&v1.Pod{
+		pod := podClient.CreateSync(ctx, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "checkpoint-container-pod"},
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
@@ -85,7 +87,7 @@ var _ = SIGDescribe("Checkpoint Container [NodeFeature:CheckpointContainer]", fu
 		})
 
 		p, err := podClient.Get(
-			context.TODO(),
+			ctx,
 			pod.Name,
 			metav1.GetOptions{},
 		)
@@ -105,6 +107,7 @@ var _ = SIGDescribe("Checkpoint Container [NodeFeature:CheckpointContainer]", fu
 			pod.Spec.NodeName,
 		)
 		result, err := proxyPostRequest(
+			ctx,
 			f.ClientSet,
 			pod.Spec.NodeName,
 			fmt.Sprintf(

--- a/test/e2e_node/container_log_rotation_test.go
+++ b/test/e2e_node/container_log_rotation_test.go
@@ -45,13 +45,13 @@ var _ = SIGDescribe("ContainerLogRotation [Slow] [Serial] [Disruptive]", func() 
 	f := framework.NewDefaultFramework("container-log-rotation-test")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	ginkgo.Context("when a container generates a lot of log", func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			initialConfig.ContainerLogMaxFiles = testContainerLogMaxFiles
 			initialConfig.ContainerLogMaxSize = testContainerLogMaxSize
 		})
 
 		var logRotationPod *v1.Pod
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			ginkgo.By("create log container")
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -73,7 +73,7 @@ var _ = SIGDescribe("ContainerLogRotation [Slow] [Serial] [Disruptive]", func() 
 					},
 				},
 			}
-			logRotationPod = e2epod.NewPodClient(f).CreateSync(pod)
+			logRotationPod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
 			ginkgo.DeferCleanup(e2epod.NewPodClient(f).DeleteSync, logRotationPod.Name, metav1.DeleteOptions{}, time.Minute)
 		})
 
@@ -88,7 +88,7 @@ var _ = SIGDescribe("ContainerLogRotation [Slow] [Serial] [Disruptive]", func() 
 			framework.ExpectNoError(err)
 			logPath := resp.GetStatus().GetLogPath()
 			ginkgo.By("wait for container log being rotated to max file limit")
-			gomega.Eventually(func() (int, error) {
+			gomega.Eventually(ctx, func() (int, error) {
 				logs, err := kubelogs.GetAllLogs(logPath)
 				if err != nil {
 					return 0, err
@@ -96,7 +96,7 @@ var _ = SIGDescribe("ContainerLogRotation [Slow] [Serial] [Disruptive]", func() 
 				return len(logs), nil
 			}, rotationEventuallyTimeout, rotationPollInterval).Should(gomega.Equal(testContainerLogMaxFiles), "should eventually rotate to max file limit")
 			ginkgo.By("make sure container log number won't exceed max file limit")
-			gomega.Consistently(func() (int, error) {
+			gomega.Consistently(ctx, func() (int, error) {
 				logs, err := kubelogs.GetAllLogs(logPath)
 				if err != nil {
 					return 0, err

--- a/test/e2e_node/container_manager_test.go
+++ b/test/e2e_node/container_manager_test.go
@@ -86,7 +86,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 				runtimePids, err := getPidsForProcess(framework.TestContext.ContainerRuntimeProcessName, framework.TestContext.ContainerRuntimePidFile)
 				framework.ExpectNoError(err, "failed to get list of container runtime pids")
 				for _, pid := range runtimePids {
-					gomega.Eventually(func() error {
+					gomega.Eventually(ctx, func() error {
 						return validateOOMScoreAdjSetting(pid, -999)
 					}, 5*time.Minute, 30*time.Second).Should(gomega.BeNil())
 				}
@@ -95,7 +95,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 				kubeletPids, err := getPidsForProcess(kubeletProcessName, "")
 				framework.ExpectNoError(err, "failed to get list of kubelet pids")
 				framework.ExpectEqual(len(kubeletPids), 1, "expected only one kubelet process; found %d", len(kubeletPids))
-				gomega.Eventually(func() error {
+				gomega.Eventually(ctx, func() error {
 					return validateOOMScoreAdjSetting(kubeletPids[0], -999)
 				}, 5*time.Minute, 30*time.Second).Should(gomega.BeNil())
 			})
@@ -110,7 +110,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 
 					podClient := e2epod.NewPodClient(f)
 					podName := "besteffort" + string(uuid.NewUUID())
-					podClient.Create(&v1.Pod{
+					podClient.Create(ctx, &v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: podName,
 						},
@@ -126,7 +126,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 
 					var pausePids []int
 					ginkgo.By("checking infra container's oom-score-adj")
-					gomega.Eventually(func() error {
+					gomega.Eventually(ctx, func() error {
 						pausePids, err = getPidsForProcess("pause", "")
 						if err != nil {
 							return fmt.Errorf("failed to get list of pause pids: %v", err)
@@ -144,7 +144,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 					}, 2*time.Minute, time.Second*4).Should(gomega.BeNil())
 					var shPids []int
 					ginkgo.By("checking besteffort container's oom-score-adj")
-					gomega.Eventually(func() error {
+					gomega.Eventually(ctx, func() error {
 						shPids, err = getPidsForProcess("agnhost", "")
 						if err != nil {
 							return fmt.Errorf("failed to get list of serve hostname process pids: %v", err)
@@ -177,7 +177,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 			ginkgo.It("guaranteed container's oom-score-adj should be -998", func(ctx context.Context) {
 				podClient := e2epod.NewPodClient(f)
 				podName := "guaranteed" + string(uuid.NewUUID())
-				podClient.Create(&v1.Pod{
+				podClient.Create(ctx, &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: podName,
 					},
@@ -200,7 +200,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 					ngPids []int
 					err    error
 				)
-				gomega.Eventually(func() error {
+				gomega.Eventually(ctx, func() error {
 					ngPids, err = getPidsForProcess("nginx", "")
 					if err != nil {
 						return fmt.Errorf("failed to get list of nginx process pids: %v", err)
@@ -218,7 +218,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 			ginkgo.It("burstable container's oom-score-adj should be between [2, 1000)", func(ctx context.Context) {
 				podClient := e2epod.NewPodClient(f)
 				podName := "burstable" + string(uuid.NewUUID())
-				podClient.Create(&v1.Pod{
+				podClient.Create(ctx, &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: podName,
 					},
@@ -242,7 +242,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 					wsPids []int
 					err    error
 				)
-				gomega.Eventually(func() error {
+				gomega.Eventually(ctx, func() error {
 					wsPids, err = getPidsForProcess("agnhost", "")
 					if err != nil {
 						return fmt.Errorf("failed to get list of test-webserver process pids: %v", err)

--- a/test/e2e_node/cpu_manager_metrics_test.go
+++ b/test/e2e_node/cpu_manager_metrics_test.go
@@ -48,15 +48,15 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager]", func() {
 		var testPod *v1.Pod
 		var smtLevel int
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			var err error
 			if oldCfg == nil {
-				oldCfg, err = getCurrentKubeletConfig()
+				oldCfg, err = getCurrentKubeletConfig(ctx)
 				framework.ExpectNoError(err)
 			}
 
 			fullCPUsOnlyOpt := fmt.Sprintf("option=%s", cpumanager.FullPCPUsOnlyOption)
-			_, cpuAlloc, _ := getLocalNodeCPUDetails(f)
+			_, cpuAlloc, _ := getLocalNodeCPUDetails(ctx, f)
 			smtLevel = getSMTLevel()
 
 			// strict SMT alignment is trivially verified and granted on non-SMT systems
@@ -84,14 +84,14 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager]", func() {
 					options:                 cpuPolicyOptions,
 				},
 			)
-			updateKubeletConfig(f, newCfg, true)
+			updateKubeletConfig(ctx, f, newCfg, true)
 		})
 
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			if testPod != nil {
-				deletePodSyncByName(f, testPod.Name)
+				deletePodSyncByName(ctx, f, testPod.Name)
 			}
-			updateKubeletConfig(f, oldCfg, true)
+			updateKubeletConfig(ctx, f, oldCfg, true)
 		})
 
 		ginkgo.It("should report zero pinning counters after a fresh restart", func(ctx context.Context) {
@@ -116,7 +116,7 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager]", func() {
 
 		ginkgo.It("should report pinning failures when the cpumanager allocation is known to fail", func(ctx context.Context) {
 			ginkgo.By("Creating the test pod which will be rejected for SMTAlignmentError")
-			testPod = e2epod.NewPodClient(f).Create(makeGuaranteedCPUExclusiveSleeperPod("smt-align-err", 1))
+			testPod = e2epod.NewPodClient(f).Create(ctx, makeGuaranteedCPUExclusiveSleeperPod("smt-align-err", 1))
 
 			// we updated the kubelet config in BeforeEach, so we can assume we start fresh.
 			// being [Serial], we can also assume noone else but us is running pods.
@@ -139,7 +139,7 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager]", func() {
 
 		ginkgo.It("should not report any pinning failures when the cpumanager allocation is expected to succeed", func(ctx context.Context) {
 			ginkgo.By("Creating the test pod")
-			testPod = e2epod.NewPodClient(f).Create(makeGuaranteedCPUExclusiveSleeperPod("smt-align-ok", smtLevel))
+			testPod = e2epod.NewPodClient(f).Create(ctx, makeGuaranteedCPUExclusiveSleeperPod("smt-align-ok", smtLevel))
 
 			// we updated the kubelet config in BeforeEach, so we can assume we start fresh.
 			// being [Serial], we can also assume noone else but us is running pods.
@@ -162,10 +162,10 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager]", func() {
 	})
 })
 
-func getCPUManagerMetrics() (e2emetrics.KubeletMetrics, error) {
+func getCPUManagerMetrics(ctx context.Context) (e2emetrics.KubeletMetrics, error) {
 	// we are running out of good names, so we need to be unnecessarily specific to avoid clashes
 	ginkgo.By("getting CPU Manager metrics from the metrics API")
-	return e2emetrics.GrabKubeletMetricsWithoutProxy(framework.TestContext.NodeName+":10255", "/metrics")
+	return e2emetrics.GrabKubeletMetricsWithoutProxy(ctx, framework.TestContext.NodeName+":10255", "/metrics")
 }
 
 func makeGuaranteedCPUExclusiveSleeperPod(name string, cpus int) *v1.Pod {

--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -97,18 +97,18 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 		var v1alphaPodResources *kubeletpodresourcesv1alpha1.ListPodResourcesResponse
 		var v1PodResources *kubeletpodresourcesv1.ListPodResourcesResponse
 		var err error
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			ginkgo.By("Wait for node to be ready")
-			gomega.Eventually(func() bool {
-				nodes, err := e2enode.TotalReady(f.ClientSet)
+			gomega.Eventually(ctx, func(ctx context.Context) bool {
+				nodes, err := e2enode.TotalReady(ctx, f.ClientSet)
 				framework.ExpectNoError(err)
 				return nodes == 1
 			}, time.Minute, time.Second).Should(gomega.BeTrue())
 
-			v1alphaPodResources, err = getV1alpha1NodeDevices()
+			v1alphaPodResources, err = getV1alpha1NodeDevices(ctx)
 			framework.ExpectNoError(err, "should get node local podresources by accessing the (v1alpha) podresources API endpoint")
 
-			v1PodResources, err = getV1NodeDevices()
+			v1PodResources, err = getV1NodeDevices(ctx)
 			framework.ExpectNoError(err, "should get node local podresources by accessing the (v1) podresources API endpoint")
 
 			// Before we run the device plugin test, we need to ensure
@@ -137,30 +137,30 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 				}
 			}
 			dptemplate = dp.DeepCopy()
-			devicePluginPod = e2epod.NewPodClient(f).CreateSync(dp)
+			devicePluginPod = e2epod.NewPodClient(f).CreateSync(ctx, dp)
 
 			ginkgo.By("Waiting for devices to become available on the local node")
-			gomega.Eventually(func() bool {
-				node, ready := getLocalTestNode(f)
+			gomega.Eventually(ctx, func(ctx context.Context) bool {
+				node, ready := getLocalTestNode(ctx, f)
 				return ready && numberOfSampleResources(node) > 0
 			}, 5*time.Minute, framework.Poll).Should(gomega.BeTrue())
 			framework.Logf("Successfully created device plugin pod")
 
 			ginkgo.By("Waiting for the resource exported by the sample device plugin to become available on the local node")
-			gomega.Eventually(func() bool {
-				node, ready := getLocalTestNode(f)
+			gomega.Eventually(ctx, func(ctx context.Context) bool {
+				node, ready := getLocalTestNode(ctx, f)
 				return ready &&
 					numberOfDevicesCapacity(node, resourceName) == devsLen &&
 					numberOfDevicesAllocatable(node, resourceName) == devsLen
 			}, 30*time.Second, framework.Poll).Should(gomega.BeTrue())
 		})
 
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			ginkgo.By("Deleting the device plugin pod")
-			e2epod.NewPodClient(f).DeleteSync(devicePluginPod.Name, metav1.DeleteOptions{}, time.Minute)
+			e2epod.NewPodClient(f).DeleteSync(ctx, devicePluginPod.Name, metav1.DeleteOptions{}, time.Minute)
 
 			ginkgo.By("Deleting any Pods created by the test")
-			l, err := e2epod.NewPodClient(f).List(context.TODO(), metav1.ListOptions{})
+			l, err := e2epod.NewPodClient(f).List(ctx, metav1.ListOptions{})
 			framework.ExpectNoError(err)
 			for _, p := range l.Items {
 				if p.Namespace != f.Namespace.Name {
@@ -168,14 +168,14 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 				}
 
 				framework.Logf("Deleting pod: %s", p.Name)
-				e2epod.NewPodClient(f).DeleteSync(p.Name, metav1.DeleteOptions{}, 2*time.Minute)
+				e2epod.NewPodClient(f).DeleteSync(ctx, p.Name, metav1.DeleteOptions{}, 2*time.Minute)
 			}
 
 			restartKubelet(true)
 
 			ginkgo.By("Waiting for devices to become unavailable on the local node")
-			gomega.Eventually(func() bool {
-				node, ready := getLocalTestNode(f)
+			gomega.Eventually(ctx, func(ctx context.Context) bool {
+				node, ready := getLocalTestNode(ctx, f)
 				return ready && numberOfSampleResources(node) <= 0
 			}, 5*time.Minute, framework.Poll).Should(gomega.BeTrue())
 
@@ -184,15 +184,15 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 
 		ginkgo.It("Can schedule a pod that requires a device", func(ctx context.Context) {
 			podRECMD := "devs=$(ls /tmp/ | egrep '^Dev-[0-9]+$') && echo stub devices: $devs && sleep 60"
-			pod1 := e2epod.NewPodClient(f).CreateSync(makeBusyboxPod(resourceName, podRECMD))
+			pod1 := e2epod.NewPodClient(f).CreateSync(ctx, makeBusyboxPod(resourceName, podRECMD))
 			deviceIDRE := "stub devices: (Dev-[0-9]+)"
-			devID1 := parseLog(f, pod1.Name, pod1.Name, deviceIDRE)
+			devID1 := parseLog(ctx, f, pod1.Name, pod1.Name, deviceIDRE)
 			gomega.Expect(devID1).To(gomega.Not(gomega.Equal("")))
 
-			v1alphaPodResources, err = getV1alpha1NodeDevices()
+			v1alphaPodResources, err = getV1alpha1NodeDevices(ctx)
 			framework.ExpectNoError(err)
 
-			v1PodResources, err = getV1NodeDevices()
+			v1PodResources, err = getV1NodeDevices(ctx)
 			framework.ExpectNoError(err)
 
 			framework.Logf("v1alphaPodResources.PodResources:%+v\n", v1alphaPodResources.PodResources)
@@ -244,78 +244,78 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 
 		ginkgo.It("Keeps device plugin assignments across pod and kubelet restarts", func(ctx context.Context) {
 			podRECMD := "devs=$(ls /tmp/ | egrep '^Dev-[0-9]+$') && echo stub devices: $devs && sleep 60"
-			pod1 := e2epod.NewPodClient(f).CreateSync(makeBusyboxPod(resourceName, podRECMD))
+			pod1 := e2epod.NewPodClient(f).CreateSync(ctx, makeBusyboxPod(resourceName, podRECMD))
 			deviceIDRE := "stub devices: (Dev-[0-9]+)"
-			devID1 := parseLog(f, pod1.Name, pod1.Name, deviceIDRE)
+			devID1 := parseLog(ctx, f, pod1.Name, pod1.Name, deviceIDRE)
 			gomega.Expect(devID1).To(gomega.Not(gomega.Equal("")))
 
-			pod1, err := e2epod.NewPodClient(f).Get(context.TODO(), pod1.Name, metav1.GetOptions{})
+			pod1, err := e2epod.NewPodClient(f).Get(ctx, pod1.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 
-			ensurePodContainerRestart(f, pod1.Name, pod1.Name)
+			ensurePodContainerRestart(ctx, f, pod1.Name, pod1.Name)
 
 			ginkgo.By("Confirming that device assignment persists even after container restart")
-			devIDAfterRestart := parseLog(f, pod1.Name, pod1.Name, deviceIDRE)
+			devIDAfterRestart := parseLog(ctx, f, pod1.Name, pod1.Name, deviceIDRE)
 			framework.ExpectEqual(devIDAfterRestart, devID1)
 
 			ginkgo.By("Restarting Kubelet")
 			restartKubelet(true)
 
 			ginkgo.By("Wait for node to be ready again")
-			e2enode.WaitForAllNodesSchedulable(f.ClientSet, 5*time.Minute)
+			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)
 
 			ginkgo.By("Validating that assignment is kept")
-			ensurePodContainerRestart(f, pod1.Name, pod1.Name)
+			ensurePodContainerRestart(ctx, f, pod1.Name, pod1.Name)
 			ginkgo.By("Confirming that after a kubelet restart, fake-device assignment is kept")
-			devIDRestart1 := parseLog(f, pod1.Name, pod1.Name, deviceIDRE)
+			devIDRestart1 := parseLog(ctx, f, pod1.Name, pod1.Name, deviceIDRE)
 			framework.ExpectEqual(devIDRestart1, devID1)
 		})
 
 		ginkgo.It("Keeps device plugin assignments after the device plugin has been re-registered", func(ctx context.Context) {
 			podRECMD := "devs=$(ls /tmp/ | egrep '^Dev-[0-9]+$') && echo stub devices: $devs && sleep 60"
-			pod1 := e2epod.NewPodClient(f).CreateSync(makeBusyboxPod(resourceName, podRECMD))
+			pod1 := e2epod.NewPodClient(f).CreateSync(ctx, makeBusyboxPod(resourceName, podRECMD))
 			deviceIDRE := "stub devices: (Dev-[0-9]+)"
-			devID1 := parseLog(f, pod1.Name, pod1.Name, deviceIDRE)
+			devID1 := parseLog(ctx, f, pod1.Name, pod1.Name, deviceIDRE)
 			gomega.Expect(devID1).To(gomega.Not(gomega.Equal("")))
 
-			pod1, err := e2epod.NewPodClient(f).Get(context.TODO(), pod1.Name, metav1.GetOptions{})
+			pod1, err := e2epod.NewPodClient(f).Get(ctx, pod1.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Restarting Kubelet")
 			restartKubelet(true)
 
 			ginkgo.By("Wait for node to be ready again")
-			e2enode.WaitForAllNodesSchedulable(f.ClientSet, 5*time.Minute)
+			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)
 
 			ginkgo.By("Re-Register resources and delete the plugin pod")
 			gp := int64(0)
 			deleteOptions := metav1.DeleteOptions{
 				GracePeriodSeconds: &gp,
 			}
-			e2epod.NewPodClient(f).DeleteSync(devicePluginPod.Name, deleteOptions, time.Minute)
-			waitForContainerRemoval(devicePluginPod.Spec.Containers[0].Name, devicePluginPod.Name, devicePluginPod.Namespace)
+			e2epod.NewPodClient(f).DeleteSync(ctx, devicePluginPod.Name, deleteOptions, time.Minute)
+			waitForContainerRemoval(ctx, devicePluginPod.Spec.Containers[0].Name, devicePluginPod.Name, devicePluginPod.Namespace)
 
 			ginkgo.By("Recreating the plugin pod")
-			devicePluginPod = e2epod.NewPodClient(f).CreateSync(dptemplate)
+			devicePluginPod = e2epod.NewPodClient(f).CreateSync(ctx, dptemplate)
 
 			ginkgo.By("Confirming that after a kubelet and pod restart, fake-device assignment is kept")
-			ensurePodContainerRestart(f, pod1.Name, pod1.Name)
-			devIDRestart1 := parseLog(f, pod1.Name, pod1.Name, deviceIDRE)
+			ensurePodContainerRestart(ctx, f, pod1.Name, pod1.Name)
+			devIDRestart1 := parseLog(ctx, f, pod1.Name, pod1.Name, deviceIDRE)
 			framework.ExpectEqual(devIDRestart1, devID1)
 
 			ginkgo.By("Waiting for resource to become available on the local node after re-registration")
-			gomega.Eventually(func() bool {
-				node, ready := getLocalTestNode(f)
+			gomega.Eventually(ctx, func() bool {
+				node, ready := getLocalTestNode(ctx, f)
 				return ready &&
 					numberOfDevicesCapacity(node, resourceName) == devsLen &&
 					numberOfDevicesAllocatable(node, resourceName) == devsLen
 			}, 30*time.Second, framework.Poll).Should(gomega.BeTrue())
 
 			ginkgo.By("Creating another pod")
-			pod2 := e2epod.NewPodClient(f).CreateSync(makeBusyboxPod(resourceName, podRECMD))
+			pod2 := e2epod.NewPodClient(f).CreateSync(ctx, makeBusyboxPod(resourceName, podRECMD))
 
 			ginkgo.By("Checking that pod got a different fake device")
-			devID2 := parseLog(f, pod2.Name, pod2.Name, deviceIDRE)
+			devID2 := parseLog(ctx, f, pod2.Name, pod2.Name, deviceIDRE)
 
 			gomega.Expect(devID1).To(gomega.Not(gomega.Equal(devID2)))
 		})
@@ -347,16 +347,16 @@ func makeBusyboxPod(resourceName, cmd string) *v1.Pod {
 }
 
 // ensurePodContainerRestart confirms that pod container has restarted at least once
-func ensurePodContainerRestart(f *framework.Framework, podName string, contName string) {
+func ensurePodContainerRestart(ctx context.Context, f *framework.Framework, podName string, contName string) {
 	var initialCount int32
 	var currentCount int32
-	p, err := e2epod.NewPodClient(f).Get(context.TODO(), podName, metav1.GetOptions{})
+	p, err := e2epod.NewPodClient(f).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil || len(p.Status.ContainerStatuses) < 1 {
 		framework.Failf("ensurePodContainerRestart failed for pod %q: %v", podName, err)
 	}
 	initialCount = p.Status.ContainerStatuses[0].RestartCount
-	gomega.Eventually(func() bool {
-		p, err = e2epod.NewPodClient(f).Get(context.TODO(), podName, metav1.GetOptions{})
+	gomega.Eventually(ctx, func() bool {
+		p, err = e2epod.NewPodClient(f).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil || len(p.Status.ContainerStatuses) < 1 {
 			return false
 		}
@@ -367,8 +367,8 @@ func ensurePodContainerRestart(f *framework.Framework, podName string, contName 
 }
 
 // parseLog returns the matching string for the specified regular expression parsed from the container logs.
-func parseLog(f *framework.Framework, podName string, contName string, re string) string {
-	logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, contName)
+func parseLog(ctx context.Context, f *framework.Framework, podName string, contName string, re string) string {
+	logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, podName, contName)
 	if err != nil {
 		framework.Failf("GetPodLogs for pod %q failed: %v", podName, err)
 	}

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -139,7 +139,6 @@ func TestMain(m *testing.M) {
 const rootfs = "/rootfs"
 
 func TestE2eNode(t *testing.T) {
-
 	// Make sure we are not limited by sshd when it comes to open files
 	if err := rlimit.SetNumFiles(1000000); err != nil {
 		klog.Infof("failed to set rlimit on max file handles: %v", err)
@@ -195,7 +194,7 @@ func TestE2eNode(t *testing.T) {
 }
 
 // Setup the kubelet on the node
-var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
+var _ = ginkgo.SynchronizedBeforeSuite(func(ctx context.Context) []byte {
 	// Run system validation test.
 	gomega.Expect(validateSystem()).To(gomega.Succeed(), "system validation")
 
@@ -203,7 +202,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// This helps with debugging test flakes since it is hard to tell when a test failure is due to image pulling.
 	if framework.TestContext.PrepullImages {
 		klog.Infof("Pre-pulling images so that they are cached for the tests.")
-		updateImageAllowList()
+		updateImageAllowList(ctx)
 		err := PrePullAllImages()
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	}
@@ -223,7 +222,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	}
 
 	klog.Infof("Wait for the node to be ready")
-	waitForNodeReady()
+	waitForNodeReady(ctx)
 
 	// Reference common test to make the import valid.
 	commontest.CurrentSuite = commontest.NodeE2E
@@ -232,10 +231,10 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// Since the bearer token is generated randomly at run time,
 	// we need to distribute the bearer token to other processes to make them use the same token.
 	return []byte(framework.TestContext.BearerToken)
-}, func(token []byte) {
+}, func(ctx context.Context, token []byte) {
 	framework.TestContext.BearerToken = string(token)
 	// update test context with node configuration.
-	gomega.Expect(updateTestContext()).To(gomega.Succeed(), "update test context with node config.")
+	gomega.Expect(updateTestContext(ctx)).To(gomega.Succeed(), "update test context with node config.")
 })
 
 // Tear down the kubelet on the node
@@ -280,7 +279,7 @@ func maskLocksmithdOnCoreos() {
 	}
 }
 
-func waitForNodeReady() {
+func waitForNodeReady(ctx context.Context) {
 	const (
 		// nodeReadyTimeout is the time to wait for node to become ready.
 		nodeReadyTimeout = 2 * time.Minute
@@ -289,7 +288,7 @@ func waitForNodeReady() {
 	)
 	client, err := getAPIServerClient()
 	framework.ExpectNoError(err, "should be able to get apiserver client.")
-	gomega.Eventually(func() error {
+	gomega.Eventually(ctx, func() error {
 		node, err := getNode(client)
 		if err != nil {
 			return fmt.Errorf("failed to get node: %v", err)
@@ -302,9 +301,9 @@ func waitForNodeReady() {
 }
 
 // updateTestContext updates the test context with the node name.
-func updateTestContext() error {
+func updateTestContext(ctx context.Context) error {
 	setExtraEnvs()
-	updateImageAllowList()
+	updateImageAllowList(ctx)
 
 	client, err := getAPIServerClient()
 	if err != nil {
@@ -319,7 +318,7 @@ func updateTestContext() error {
 	// Update test context with current kubelet configuration.
 	// This assumes all tests which dynamically change kubelet configuration
 	// must: 1) run in serial; 2) restore kubelet configuration after test.
-	kubeletCfg, err := getCurrentKubeletConfig()
+	kubeletCfg, err := getCurrentKubeletConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get kubelet configuration: %v", err)
 	}

--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -77,9 +77,9 @@ var _ = SIGDescribe("InodeEviction [Slow] [Serial] [Disruptive][NodeFeature:Evic
 	pressureTimeout := 15 * time.Minute
 	inodesConsumed := uint64(200000)
 	ginkgo.Context(fmt.Sprintf(testContextFmt, expectedNodeCondition), func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			// Set the eviction threshold to inodesFree - inodesConsumed, so that using inodesConsumed causes an eviction.
-			summary := eventuallyGetSummary()
+			summary := eventuallyGetSummary(ctx)
 			inodesFree := *summary.Node.Fs.InodesFree
 			if inodesFree <= inodesConsumed {
 				e2eskipper.Skipf("Too few inodes free on the host for the InodeEviction test to run")
@@ -114,9 +114,9 @@ var _ = SIGDescribe("ImageGCNoEviction [Slow] [Serial] [Disruptive][NodeFeature:
 	expectedStarvedResource := resourceInodes
 	inodesConsumed := uint64(100000)
 	ginkgo.Context(fmt.Sprintf(testContextFmt, expectedNodeCondition), func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			// Set the eviction threshold to inodesFree - inodesConsumed, so that using inodesConsumed causes an eviction.
-			summary := eventuallyGetSummary()
+			summary := eventuallyGetSummary(ctx)
 			inodesFree := *summary.Node.Fs.InodesFree
 			if inodesFree <= inodesConsumed {
 				e2eskipper.Skipf("Too few inodes free on the host for the InodeEviction test to run")
@@ -144,9 +144,9 @@ var _ = SIGDescribe("MemoryAllocatableEviction [Slow] [Serial] [Disruptive][Node
 	expectedStarvedResource := v1.ResourceMemory
 	pressureTimeout := 10 * time.Minute
 	ginkgo.Context(fmt.Sprintf(testContextFmt, expectedNodeCondition), func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			// Set large system and kube reserved values to trigger allocatable thresholds far before hard eviction thresholds.
-			kubeReserved := getNodeCPUAndMemoryCapacity(f)[v1.ResourceMemory]
+			kubeReserved := getNodeCPUAndMemoryCapacity(ctx, f)[v1.ResourceMemory]
 			// The default hard eviction threshold is 250Mb, so Allocatable = Capacity - Reserved - 250Mb
 			// We want Allocatable = 50Mb, so set Reserved = Capacity - Allocatable - 250Mb = Capacity - 300Mb
 			kubeReserved.Sub(resource.MustParse("300Mi"))
@@ -179,8 +179,8 @@ var _ = SIGDescribe("LocalStorageEviction [Slow] [Serial] [Disruptive][NodeFeatu
 	expectedStarvedResource := v1.ResourceEphemeralStorage
 	ginkgo.Context(fmt.Sprintf(testContextFmt, expectedNodeCondition), func() {
 
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
-			summary := eventuallyGetSummary()
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			summary := eventuallyGetSummary(ctx)
 
 			diskConsumedByTest := resource.MustParse("4Gi")
 			availableBytesOnSystem := *(summary.Node.Fs.AvailableBytes)
@@ -217,9 +217,9 @@ var _ = SIGDescribe("LocalStorageSoftEviction [Slow] [Serial] [Disruptive][NodeF
 	expectedNodeCondition := v1.NodeDiskPressure
 	expectedStarvedResource := v1.ResourceEphemeralStorage
 	ginkgo.Context(fmt.Sprintf(testContextFmt, expectedNodeCondition), func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			diskConsumed := resource.MustParse("4Gi")
-			summary := eventuallyGetSummary()
+			summary := eventuallyGetSummary(ctx)
 			availableBytes := *(summary.Node.Fs.AvailableBytes)
 			if availableBytes <= uint64(diskConsumed.Value()) {
 				e2eskipper.Skipf("Too little disk free on the host for the LocalStorageSoftEviction test to run")
@@ -254,7 +254,7 @@ var _ = SIGDescribe("LocalStorageCapacityIsolationMemoryBackedVolumeEviction [Sl
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	evictionTestTimeout := 7 * time.Minute
 	ginkgo.Context(fmt.Sprintf(testContextFmt, "evictions due to pod local storage violations"), func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			// setting a threshold to 0% disables; non-empty map overrides default value (necessary due to omitempty)
 			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalMemoryAvailable): "0%"}
 			initialConfig.FeatureGates["SizeMemoryBackedVolumes"] = false
@@ -294,7 +294,7 @@ var _ = SIGDescribe("LocalStorageCapacityIsolationEviction [Slow] [Serial] [Disr
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	evictionTestTimeout := 10 * time.Minute
 	ginkgo.Context(fmt.Sprintf(testContextFmt, "evictions due to pod local storage violations"), func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			// setting a threshold to 0% disables; non-empty map overrides default value (necessary due to omitempty)
 			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalMemoryAvailable): "0%"}
 		})
@@ -353,9 +353,9 @@ var _ = SIGDescribe("PriorityMemoryEvictionOrdering [Slow] [Serial] [Disruptive]
 	highPriority := int32(999999999)
 
 	ginkgo.Context(fmt.Sprintf(testContextFmt, expectedNodeCondition), func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			memoryConsumed := resource.MustParse("600Mi")
-			summary := eventuallyGetSummary()
+			summary := eventuallyGetSummary(ctx)
 			availableBytes := *(summary.Node.Memory.AvailableBytes)
 			if availableBytes <= uint64(memoryConsumed.Value()) {
 				e2eskipper.Skipf("Too little memory free on the host for the PriorityMemoryEvictionOrdering test to run")
@@ -363,12 +363,12 @@ var _ = SIGDescribe("PriorityMemoryEvictionOrdering [Slow] [Serial] [Disruptive]
 			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalMemoryAvailable): fmt.Sprintf("%d", availableBytes-uint64(memoryConsumed.Value()))}
 			initialConfig.EvictionMinimumReclaim = map[string]string{}
 		})
-		ginkgo.BeforeEach(func() {
-			_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(context.TODO(), &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: highPriorityClassName}, Value: highPriority}, metav1.CreateOptions{})
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: highPriorityClassName}, Value: highPriority}, metav1.CreateOptions{})
 			framework.ExpectEqual(err == nil || apierrors.IsAlreadyExists(err), true)
 		})
-		ginkgo.AfterEach(func() {
-			err := f.ClientSet.SchedulingV1().PriorityClasses().Delete(context.TODO(), highPriorityClassName, metav1.DeleteOptions{})
+		ginkgo.AfterEach(func(ctx context.Context) {
+			err := f.ClientSet.SchedulingV1().PriorityClasses().Delete(ctx, highPriorityClassName, metav1.DeleteOptions{})
 			framework.ExpectNoError(err)
 		})
 		specs := []podEvictSpec{
@@ -411,9 +411,9 @@ var _ = SIGDescribe("PriorityLocalStorageEvictionOrdering [Slow] [Serial] [Disru
 	highPriority := int32(999999999)
 
 	ginkgo.Context(fmt.Sprintf(testContextFmt, expectedNodeCondition), func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			diskConsumed := resource.MustParse("4Gi")
-			summary := eventuallyGetSummary()
+			summary := eventuallyGetSummary(ctx)
 			availableBytes := *(summary.Node.Fs.AvailableBytes)
 			if availableBytes <= uint64(diskConsumed.Value()) {
 				e2eskipper.Skipf("Too little disk free on the host for the PriorityLocalStorageEvictionOrdering test to run")
@@ -421,12 +421,12 @@ var _ = SIGDescribe("PriorityLocalStorageEvictionOrdering [Slow] [Serial] [Disru
 			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalNodeFsAvailable): fmt.Sprintf("%d", availableBytes-uint64(diskConsumed.Value()))}
 			initialConfig.EvictionMinimumReclaim = map[string]string{}
 		})
-		ginkgo.BeforeEach(func() {
-			_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(context.TODO(), &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: highPriorityClassName}, Value: highPriority}, metav1.CreateOptions{})
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: highPriorityClassName}, Value: highPriority}, metav1.CreateOptions{})
 			framework.ExpectEqual(err == nil || apierrors.IsAlreadyExists(err), true)
 		})
-		ginkgo.AfterEach(func() {
-			err := f.ClientSet.SchedulingV1().PriorityClasses().Delete(context.TODO(), highPriorityClassName, metav1.DeleteOptions{})
+		ginkgo.AfterEach(func(ctx context.Context) {
+			err := f.ClientSet.SchedulingV1().PriorityClasses().Delete(ctx, highPriorityClassName, metav1.DeleteOptions{})
 			framework.ExpectNoError(err)
 		})
 		specs := []podEvictSpec{
@@ -468,19 +468,19 @@ var _ = SIGDescribe("PriorityPidEvictionOrdering [Slow] [Serial] [Disruptive][No
 	highPriority := int32(999999999)
 
 	ginkgo.Context(fmt.Sprintf(testContextFmt, expectedNodeCondition), func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			pidsConsumed := int64(10000)
-			summary := eventuallyGetSummary()
+			summary := eventuallyGetSummary(ctx)
 			availablePids := *(summary.Node.Rlimit.MaxPID) - *(summary.Node.Rlimit.NumOfRunningProcesses)
 			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalPIDAvailable): fmt.Sprintf("%d", availablePids-pidsConsumed)}
 			initialConfig.EvictionMinimumReclaim = map[string]string{}
 		})
-		ginkgo.BeforeEach(func() {
-			_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(context.TODO(), &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: highPriorityClassName}, Value: highPriority}, metav1.CreateOptions{})
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: highPriorityClassName}, Value: highPriority}, metav1.CreateOptions{})
 			framework.ExpectEqual(err == nil || apierrors.IsAlreadyExists(err), true)
 		})
-		ginkgo.AfterEach(func() {
-			err := f.ClientSet.SchedulingV1().PriorityClasses().Delete(context.TODO(), highPriorityClassName, metav1.DeleteOptions{})
+		ginkgo.AfterEach(func(ctx context.Context) {
+			err := f.ClientSet.SchedulingV1().PriorityClasses().Delete(ctx, highPriorityClassName, metav1.DeleteOptions{})
 			framework.ExpectNoError(err)
 		})
 		specs := []podEvictSpec{
@@ -503,9 +503,9 @@ var _ = SIGDescribe("PriorityPidEvictionOrdering [Slow] [Serial] [Disruptive][No
 	})
 
 	ginkgo.Context(fmt.Sprintf(testContextFmt, expectedNodeCondition)+"; PodDisruptionConditions enabled [NodeFeature:PodDisruptionConditions]", func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			pidsConsumed := int64(10000)
-			summary := eventuallyGetSummary()
+			summary := eventuallyGetSummary(ctx)
 			availablePids := *(summary.Node.Rlimit.MaxPID) - *(summary.Node.Rlimit.NumOfRunningProcesses)
 			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalPIDAvailable): fmt.Sprintf("%d", availablePids-pidsConsumed)}
 			initialConfig.EvictionMinimumReclaim = map[string]string{}
@@ -543,10 +543,10 @@ type podEvictSpec struct {
 //	It ensures that all pods with non-zero evictionPriority are eventually evicted.
 //
 // runEvictionTest then cleans up the testing environment by deleting provided pods, and ensures that expectedNodeCondition no longer exists
-func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expectedNodeCondition v1.NodeConditionType, expectedStarvedResource v1.ResourceName, logFunc func(), testSpecs []podEvictSpec) {
+func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expectedNodeCondition v1.NodeConditionType, expectedStarvedResource v1.ResourceName, logFunc func(ctx context.Context), testSpecs []podEvictSpec) {
 	// Place the remainder of the test within a context so that the kubelet config is set before and after the test.
 	ginkgo.Context("", func() {
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			// reduce memory usage in the allocatable cgroup to ensure we do not have MemoryPressure
 			reduceAllocatableMemoryUsageIfCgroupv1()
 			// Nodes do not immediately report local storage capacity
@@ -557,35 +557,35 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 			for _, spec := range testSpecs {
 				pods = append(pods, spec.pod)
 			}
-			e2epod.NewPodClient(f).CreateBatch(pods)
+			e2epod.NewPodClient(f).CreateBatch(ctx, pods)
 		})
 
 		ginkgo.It("should eventually evict all of the correct pods", func(ctx context.Context) {
 			ginkgo.By(fmt.Sprintf("Waiting for node to have NodeCondition: %s", expectedNodeCondition))
-			gomega.Eventually(func() error {
-				logFunc()
-				if expectedNodeCondition == noPressure || hasNodeCondition(f, expectedNodeCondition) {
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				logFunc(ctx)
+				if expectedNodeCondition == noPressure || hasNodeCondition(ctx, f, expectedNodeCondition) {
 					return nil
 				}
 				return fmt.Errorf("NodeCondition: %s not encountered", expectedNodeCondition)
 			}, pressureTimeout, evictionPollInterval).Should(gomega.BeNil())
 
 			ginkgo.By("Waiting for evictions to occur")
-			gomega.Eventually(func() error {
+			gomega.Eventually(ctx, func(ctx context.Context) error {
 				if expectedNodeCondition != noPressure {
-					if hasNodeCondition(f, expectedNodeCondition) {
+					if hasNodeCondition(ctx, f, expectedNodeCondition) {
 						framework.Logf("Node has %s", expectedNodeCondition)
 					} else {
 						framework.Logf("Node does NOT have %s", expectedNodeCondition)
 					}
 				}
-				logKubeletLatencyMetrics(kubeletmetrics.EvictionStatsAgeKey)
-				logFunc()
-				return verifyEvictionOrdering(f, testSpecs)
-			}, pressureTimeout, evictionPollInterval).Should(gomega.BeNil())
+				logKubeletLatencyMetrics(ctx, kubeletmetrics.EvictionStatsAgeKey)
+				logFunc(ctx)
+				return verifyEvictionOrdering(ctx, f, testSpecs)
+			}, pressureTimeout, evictionPollInterval).Should(gomega.Succeed())
 
 			ginkgo.By("checking for the expected pod conditions for evicted pods")
-			verifyPodConditions(f, testSpecs)
+			verifyPodConditions(ctx, f, testSpecs)
 
 			// We observe pressure from the API server.  The eviction manager observes pressure from the kubelet internal stats.
 			// This means the eviction manager will observe pressure before we will, creating a delay between when the eviction manager
@@ -594,30 +594,30 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 			time.Sleep(pressureDelay)
 
 			ginkgo.By(fmt.Sprintf("Waiting for NodeCondition: %s to no longer exist on the node", expectedNodeCondition))
-			gomega.Eventually(func() error {
-				logFunc()
-				logKubeletLatencyMetrics(kubeletmetrics.EvictionStatsAgeKey)
-				if expectedNodeCondition != noPressure && hasNodeCondition(f, expectedNodeCondition) {
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				logFunc(ctx)
+				logKubeletLatencyMetrics(ctx, kubeletmetrics.EvictionStatsAgeKey)
+				if expectedNodeCondition != noPressure && hasNodeCondition(ctx, f, expectedNodeCondition) {
 					return fmt.Errorf("Conditions haven't returned to normal, node still has %s", expectedNodeCondition)
 				}
 				return nil
 			}, pressureDisappearTimeout, evictionPollInterval).Should(gomega.BeNil())
 
 			ginkgo.By("checking for stable, pressure-free condition without unexpected pod failures")
-			gomega.Consistently(func() error {
-				if expectedNodeCondition != noPressure && hasNodeCondition(f, expectedNodeCondition) {
+			gomega.Consistently(ctx, func(ctx context.Context) error {
+				if expectedNodeCondition != noPressure && hasNodeCondition(ctx, f, expectedNodeCondition) {
 					return fmt.Errorf("%s disappeared and then reappeared", expectedNodeCondition)
 				}
-				logFunc()
-				logKubeletLatencyMetrics(kubeletmetrics.EvictionStatsAgeKey)
-				return verifyEvictionOrdering(f, testSpecs)
-			}, postTestConditionMonitoringPeriod, evictionPollInterval).Should(gomega.BeNil())
+				logFunc(ctx)
+				logKubeletLatencyMetrics(ctx, kubeletmetrics.EvictionStatsAgeKey)
+				return verifyEvictionOrdering(ctx, f, testSpecs)
+			}, postTestConditionMonitoringPeriod, evictionPollInterval).Should(gomega.Succeed())
 
 			ginkgo.By("checking for correctly formatted eviction events")
-			verifyEvictionEvents(f, testSpecs, expectedStarvedResource)
+			verifyEvictionEvents(ctx, f, testSpecs, expectedStarvedResource)
 		})
 
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			prePullImagesIfNeccecary := func() {
 				if expectedNodeCondition == v1.NodeDiskPressure && framework.TestContext.PrepullImages {
 					// The disk eviction test may cause the prepulled images to be evicted,
@@ -631,14 +631,14 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 			ginkgo.By("deleting pods")
 			for _, spec := range testSpecs {
 				ginkgo.By(fmt.Sprintf("deleting pod: %s", spec.pod.Name))
-				e2epod.NewPodClient(f).DeleteSync(spec.pod.Name, metav1.DeleteOptions{}, 10*time.Minute)
+				e2epod.NewPodClient(f).DeleteSync(ctx, spec.pod.Name, metav1.DeleteOptions{}, 10*time.Minute)
 			}
 
 			// In case a test fails before verifying that NodeCondition no longer exist on the node,
 			// we should wait for the NodeCondition to disappear
 			ginkgo.By(fmt.Sprintf("making sure NodeCondition %s no longer exists on the node", expectedNodeCondition))
-			gomega.Eventually(func() error {
-				if expectedNodeCondition != noPressure && hasNodeCondition(f, expectedNodeCondition) {
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				if expectedNodeCondition != noPressure && hasNodeCondition(ctx, f, expectedNodeCondition) {
 					return fmt.Errorf("Conditions haven't returned to normal, node still has %s", expectedNodeCondition)
 				}
 				return nil
@@ -650,8 +650,8 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 
 			// Ensure that the NodeCondition hasn't returned after pulling images
 			ginkgo.By(fmt.Sprintf("making sure NodeCondition %s doesn't exist again after pulling images", expectedNodeCondition))
-			gomega.Eventually(func() error {
-				if expectedNodeCondition != noPressure && hasNodeCondition(f, expectedNodeCondition) {
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				if expectedNodeCondition != noPressure && hasNodeCondition(ctx, f, expectedNodeCondition) {
 					return fmt.Errorf("Conditions haven't returned to normal, node still has %s", expectedNodeCondition)
 				}
 				return nil
@@ -659,7 +659,7 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 
 			ginkgo.By("making sure we can start a new pod after the test")
 			podName := "test-admit-pod"
-			e2epod.NewPodClient(f).CreateSync(&v1.Pod{
+			e2epod.NewPodClient(f).CreateSync(ctx, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: podName,
 				},
@@ -676,8 +676,8 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 
 			if ginkgo.CurrentSpecReport().Failed() {
 				if framework.TestContext.DumpLogsOnFailure {
-					logPodEvents(f)
-					logNodeEvents(f)
+					logPodEvents(ctx, f)
+					logNodeEvents(ctx, f)
 				}
 			}
 		})
@@ -686,9 +686,9 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 
 // verifyEvictionOrdering returns an error if all non-zero priority pods have not been evicted, nil otherwise
 // This function panics (via Expect) if eviction ordering is violated, or if a priority-zero pod fails.
-func verifyEvictionOrdering(f *framework.Framework, testSpecs []podEvictSpec) error {
+func verifyEvictionOrdering(ctx context.Context, f *framework.Framework, testSpecs []podEvictSpec) error {
 	// Gather current information
-	updatedPodList, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
+	updatedPodList, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -752,10 +752,10 @@ func verifyEvictionOrdering(f *framework.Framework, testSpecs []podEvictSpec) er
 	return fmt.Errorf("pods that should be evicted are still running: %#v", pendingPods)
 }
 
-func verifyPodConditions(f *framework.Framework, testSpecs []podEvictSpec) {
+func verifyPodConditions(ctx context.Context, f *framework.Framework, testSpecs []podEvictSpec) {
 	for _, spec := range testSpecs {
 		if spec.wantPodDisruptionCondition != nil {
-			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), spec.pod.Name, metav1.GetOptions{})
+			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, spec.pod.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Failed to get the recent pod object for name: %q", pod.Name)
 
 			cType := *spec.wantPodDisruptionCondition
@@ -767,7 +767,7 @@ func verifyPodConditions(f *framework.Framework, testSpecs []podEvictSpec) {
 	}
 }
 
-func verifyEvictionEvents(f *framework.Framework, testSpecs []podEvictSpec, expectedStarvedResource v1.ResourceName) {
+func verifyEvictionEvents(ctx context.Context, f *framework.Framework, testSpecs []podEvictSpec, expectedStarvedResource v1.ResourceName) {
 	for _, spec := range testSpecs {
 		pod := spec.pod
 		if spec.evictionPriority != 0 {
@@ -777,7 +777,7 @@ func verifyEvictionEvents(f *framework.Framework, testSpecs []podEvictSpec, expe
 				"involvedObject.namespace": f.Namespace.Name,
 				"reason":                   eviction.Reason,
 			}.AsSelector().String()
-			podEvictEvents, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{FieldSelector: selector})
+			podEvictEvents, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{FieldSelector: selector})
 			gomega.Expect(err).To(gomega.BeNil(), "Unexpected error getting events during eviction test: %v", err)
 			framework.ExpectEqual(len(podEvictEvents.Items), 1, "Expected to find 1 eviction event for pod %s, got %d", pod.Name, len(podEvictEvents.Items))
 			event := podEvictEvents.Items[0]
@@ -822,15 +822,15 @@ func verifyEvictionEvents(f *framework.Framework, testSpecs []podEvictSpec, expe
 }
 
 // Returns TRUE if the node has the node condition, FALSE otherwise
-func hasNodeCondition(f *framework.Framework, expectedNodeCondition v1.NodeConditionType) bool {
-	localNodeStatus := getLocalNode(f).Status
+func hasNodeCondition(ctx context.Context, f *framework.Framework, expectedNodeCondition v1.NodeConditionType) bool {
+	localNodeStatus := getLocalNode(ctx, f).Status
 	_, actualNodeCondition := testutils.GetNodeCondition(&localNodeStatus, expectedNodeCondition)
 	gomega.Expect(actualNodeCondition).NotTo(gomega.BeNil())
 	return actualNodeCondition.Status == v1.ConditionTrue
 }
 
-func logInodeMetrics() {
-	summary, err := getNodeSummary()
+func logInodeMetrics(ctx context.Context) {
+	summary, err := getNodeSummary(ctx)
 	if err != nil {
 		framework.Logf("Error getting summary: %v", err)
 		return
@@ -856,8 +856,8 @@ func logInodeMetrics() {
 	}
 }
 
-func logDiskMetrics() {
-	summary, err := getNodeSummary()
+func logDiskMetrics(ctx context.Context) {
+	summary, err := getNodeSummary(ctx)
 	if err != nil {
 		framework.Logf("Error getting summary: %v", err)
 		return
@@ -883,8 +883,8 @@ func logDiskMetrics() {
 	}
 }
 
-func logMemoryMetrics() {
-	summary, err := getNodeSummary()
+func logMemoryMetrics(ctx context.Context) {
+	summary, err := getNodeSummary(ctx)
 	if err != nil {
 		framework.Logf("Error getting summary: %v", err)
 		return
@@ -907,8 +907,8 @@ func logMemoryMetrics() {
 	}
 }
 
-func logPidMetrics() {
-	summary, err := getNodeSummary()
+func logPidMetrics(ctx context.Context) {
+	summary, err := getNodeSummary(ctx)
 	if err != nil {
 		framework.Logf("Error getting summary: %v", err)
 		return
@@ -918,9 +918,9 @@ func logPidMetrics() {
 	}
 }
 
-func eventuallyGetSummary() (s *kubeletstatsv1alpha1.Summary) {
-	gomega.Eventually(func() error {
-		summary, err := getNodeSummary()
+func eventuallyGetSummary(ctx context.Context) (s *kubeletstatsv1alpha1.Summary) {
+	gomega.Eventually(ctx, func() error {
+		summary, err := getNodeSummary(ctx)
 		if err != nil {
 			return err
 		}

--- a/test/e2e_node/garbage_collector_test.go
+++ b/test/e2e_node/garbage_collector_test.go
@@ -172,13 +172,13 @@ func containerGCTest(f *framework.Framework, test testRun) {
 	}
 
 	ginkgo.Context(fmt.Sprintf("Garbage Collection Test: %s", test.testName), func() {
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			realPods := getPods(test.testPods)
-			e2epod.NewPodClient(f).CreateBatch(realPods)
+			e2epod.NewPodClient(f).CreateBatch(ctx, realPods)
 			ginkgo.By("Making sure all containers restart the specified number of times")
-			gomega.Eventually(func() error {
+			gomega.Eventually(ctx, func(ctx context.Context) error {
 				for _, podSpec := range test.testPods {
-					err := verifyPodRestartCount(f, podSpec.podName, podSpec.numContainers, podSpec.restartCount)
+					err := verifyPodRestartCount(ctx, f, podSpec.podName, podSpec.numContainers, podSpec.restartCount)
 					if err != nil {
 						return err
 					}
@@ -187,12 +187,12 @@ func containerGCTest(f *framework.Framework, test testRun) {
 			}, setupDuration, runtimePollInterval).Should(gomega.BeNil())
 		})
 
-		ginkgo.It(fmt.Sprintf("Should eventually garbage collect containers when we exceed the number of dead containers per container"), func(ctx context.Context) {
+		ginkgo.It("Should eventually garbage collect containers when we exceed the number of dead containers per container", func(ctx context.Context) {
 			totalContainers := 0
 			for _, pod := range test.testPods {
 				totalContainers += pod.numContainers*2 + 1
 			}
-			gomega.Eventually(func() error {
+			gomega.Eventually(ctx, func() error {
 				total := 0
 				for _, pod := range test.testPods {
 					containerNames, err := pod.getContainerNames()
@@ -223,7 +223,7 @@ func containerGCTest(f *framework.Framework, test testRun) {
 
 			if maxPerPodContainer >= 2 && maxTotalContainers < 0 { // make sure constraints wouldn't make us gc old containers
 				ginkgo.By("Making sure the kubelet consistently keeps around an extra copy of each container.")
-				gomega.Consistently(func() error {
+				gomega.Consistently(ctx, func() error {
 					for _, pod := range test.testPods {
 						containerNames, err := pod.getContainerNames()
 						if err != nil {
@@ -246,14 +246,14 @@ func containerGCTest(f *framework.Framework, test testRun) {
 			}
 		})
 
-		ginkgo.AfterEach(func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			for _, pod := range test.testPods {
 				ginkgo.By(fmt.Sprintf("Deleting Pod %v", pod.podName))
-				e2epod.NewPodClient(f).DeleteSync(pod.podName, metav1.DeleteOptions{}, e2epod.DefaultPodDeletionTimeout)
+				e2epod.NewPodClient(f).DeleteSync(ctx, pod.podName, metav1.DeleteOptions{}, e2epod.DefaultPodDeletionTimeout)
 			}
 
 			ginkgo.By("Making sure all containers get cleaned up")
-			gomega.Eventually(func() error {
+			gomega.Eventually(ctx, func() error {
 				for _, pod := range test.testPods {
 					containerNames, err := pod.getContainerNames()
 					if err != nil {
@@ -267,8 +267,8 @@ func containerGCTest(f *framework.Framework, test testRun) {
 			}, garbageCollectDuration, runtimePollInterval).Should(gomega.BeNil())
 
 			if ginkgo.CurrentSpecReport().Failed() && framework.TestContext.DumpLogsOnFailure {
-				logNodeEvents(f)
-				logPodEvents(f)
+				logNodeEvents(ctx, f)
+				logPodEvents(ctx, f)
 			}
 		})
 	})
@@ -317,8 +317,8 @@ func getRestartingContainerCommand(path string, containerNum int, restarts int32
 	}
 }
 
-func verifyPodRestartCount(f *framework.Framework, podName string, expectedNumContainers int, expectedRestartCount int32) error {
-	updatedPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), podName, metav1.GetOptions{})
+func verifyPodRestartCount(ctx context.Context, f *framework.Framework, podName string, expectedNumContainers int, expectedRestartCount int32) error {
+	updatedPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/e2e_node/image_credential_provider.go
+++ b/test/e2e_node/image_credential_provider.go
@@ -63,6 +63,6 @@ var _ = SIGDescribe("ImageCredentialProvider [Feature:KubeletCredentialProviders
 		}
 
 		// CreateSync tests that the Pod is running and ready
-		podClient.CreateSync(pod)
+		podClient.CreateSync(ctx, pod)
 	})
 })

--- a/test/e2e_node/image_id_test.go
+++ b/test/e2e_node/image_id_test.go
@@ -52,11 +52,11 @@ var _ = SIGDescribe("ImageID [NodeFeature: ImageID]", func() {
 			},
 		}
 
-		pod := e2epod.NewPodClient(f).Create(podDesc)
+		pod := e2epod.NewPodClient(f).Create(ctx, podDesc)
 
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodNoLongerRunningInNamespace(
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodNoLongerRunningInNamespace(ctx,
 			f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout))
-		runningPod, err := e2epod.NewPodClient(f).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		runningPod, err := e2epod.NewPodClient(f).Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		status := runningPod.Status

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -72,7 +72,7 @@ var NodePrePullImageList = sets.NewString(
 // 1. the hard coded lists
 // 2. the ones passed in from framework.TestContext.ExtraEnvs
 // So this function needs to be called after the extra envs are applied.
-func updateImageAllowList() {
+func updateImageAllowList(ctx context.Context) {
 	// Union NodePrePullImageList and PrePulledImages into the framework image pre-pull list.
 	e2epod.ImagePrePullList = NodePrePullImageList.Union(commontest.PrePulledImages)
 	// Images from extra envs
@@ -82,7 +82,7 @@ func updateImageAllowList() {
 	} else {
 		e2epod.ImagePrePullList.Insert(sriovDevicePluginImage)
 	}
-	if gpuDevicePluginImage, err := getGPUDevicePluginImage(); err != nil {
+	if gpuDevicePluginImage, err := getGPUDevicePluginImage(ctx); err != nil {
 		klog.Errorln(err)
 	} else {
 		e2epod.ImagePrePullList.Insert(gpuDevicePluginImage)
@@ -213,8 +213,8 @@ func PrePullAllImages() error {
 }
 
 // getGPUDevicePluginImage returns the image of GPU device plugin.
-func getGPUDevicePluginImage() (string, error) {
-	ds, err := e2emanifest.DaemonSetFromURL(e2egpu.GPUDevicePluginDSYAML)
+func getGPUDevicePluginImage(ctx context.Context) (string, error) {
+	ds, err := e2emanifest.DaemonSetFromURL(ctx, e2egpu.GPUDevicePluginDSYAML)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse the device plugin image: %w", err)
 	}

--- a/test/e2e_node/lock_contention_linux_test.go
+++ b/test/e2e_node/lock_contention_linux_test.go
@@ -69,7 +69,7 @@ var _ = SIGDescribe("Lock contention [Slow] [Disruptive] [NodeSpecialFeature:Loc
 		ginkgo.By("verifying the kubelet is not healthy as there was a lock contention.")
 		// Once the lock is acquired, check if the kubelet is in healthy state or not.
 		// It should not be as the lock contention forces the kubelet to stop.
-		gomega.Eventually(func() bool {
+		gomega.Eventually(ctx, func() bool {
 			return kubeletHealthCheck(kubeletHealthCheckURL)
 		}, 10*time.Second, time.Second).Should(gomega.BeFalse())
 	})

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -68,7 +68,7 @@ var _ = SIGDescribe("Node Container Manager [Serial]", func() {
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	ginkgo.Describe("Validate Node Allocatable [NodeFeature:NodeAllocatable]", func() {
 		ginkgo.It("sets up the node and runs the test", func(ctx context.Context) {
-			framework.ExpectNoError(runTest(f))
+			framework.ExpectNoError(runTest(ctx, f))
 		})
 	})
 })
@@ -159,14 +159,14 @@ func convertSharesToWeight(shares int64) int64 {
 	return 1 + ((shares-2)*9999)/262142
 }
 
-func runTest(f *framework.Framework) error {
+func runTest(ctx context.Context, f *framework.Framework) error {
 	var oldCfg *kubeletconfig.KubeletConfiguration
 	subsystems, err := cm.GetCgroupSubsystems()
 	if err != nil {
 		return err
 	}
 	// Get current kubelet configuration
-	oldCfg, err = getCurrentKubeletConfig()
+	oldCfg, err = getCurrentKubeletConfig(ctx)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func runTest(f *framework.Framework) error {
 			startKubelet := stopKubelet()
 
 			// wait until the kubelet health check will fail
-			gomega.Eventually(func() bool {
+			gomega.Eventually(ctx, func() bool {
 				return kubeletHealthCheck(kubeletHealthCheckURL)
 			}, time.Minute, time.Second).Should(gomega.BeFalse())
 
@@ -201,7 +201,7 @@ func runTest(f *framework.Framework) error {
 			startKubelet()
 
 			// wait until the kubelet health check will succeed
-			gomega.Eventually(func() bool {
+			gomega.Eventually(ctx, func(ctx context.Context) bool {
 				return kubeletHealthCheck(kubeletHealthCheckURL)
 			}, 2*time.Minute, 5*time.Second).Should(gomega.BeTrue())
 		}
@@ -218,7 +218,7 @@ func runTest(f *framework.Framework) error {
 	startKubelet := stopKubelet()
 
 	// wait until the kubelet health check will fail
-	gomega.Eventually(func() bool {
+	gomega.Eventually(ctx, func() bool {
 		return kubeletHealthCheck(kubeletHealthCheckURL)
 	}, time.Minute, time.Second).Should(gomega.BeFalse())
 
@@ -228,7 +228,7 @@ func runTest(f *framework.Framework) error {
 	startKubelet()
 
 	// wait until the kubelet health check will succeed
-	gomega.Eventually(func() bool {
+	gomega.Eventually(ctx, func() bool {
 		return kubeletHealthCheck(kubeletHealthCheckURL)
 	}, 2*time.Minute, 5*time.Second).Should(gomega.BeTrue())
 
@@ -251,8 +251,8 @@ func runTest(f *framework.Framework) error {
 
 	// TODO: Update cgroupManager to expose a Status interface to get current Cgroup Settings.
 	// The node may not have updated capacity and allocatable yet, so check that it happens eventually.
-	gomega.Eventually(func() error {
-		nodeList, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	gomega.Eventually(ctx, func(ctx context.Context) error {
+		nodeList, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -306,7 +306,7 @@ func runTest(f *framework.Framework) error {
 			return fmt.Errorf("Unexpected memory allocatable value exposed by the node. Expected: %v, got: %v, capacity: %v", allocatableMemory, schedulerAllocatable[v1.ResourceMemory], capacity[v1.ResourceMemory])
 		}
 		return nil
-	}, time.Minute, 5*time.Second).Should(gomega.BeNil())
+	}, time.Minute, 5*time.Second).Should(gomega.Succeed())
 
 	cgroupPath := ""
 	if currentConfig.CgroupDriver == "systemd" {

--- a/test/e2e_node/pids_test.go
+++ b/test/e2e_node/pids_test.go
@@ -90,7 +90,7 @@ func makePodToVerifyPids(baseName string, pidsLimit resource.Quantity) *v1.Pod {
 func runPodPidsLimitTests(f *framework.Framework) {
 	ginkgo.It("should set pids.max for Pod", func(ctx context.Context) {
 		ginkgo.By("by creating a G pod")
-		pod := e2epod.NewPodClient(f).Create(&v1.Pod{
+		pod := e2epod.NewPodClient(f).Create(ctx, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod" + string(uuid.NewUUID()),
 				Namespace: f.Namespace.Name,
@@ -113,8 +113,8 @@ func runPodPidsLimitTests(f *framework.Framework) {
 		podUID := string(pod.UID)
 		ginkgo.By("checking if the expected pids settings were applied")
 		verifyPod := makePodToVerifyPids("pod"+podUID, resource.MustParse("1024"))
-		e2epod.NewPodClient(f).Create(verifyPod)
-		err := e2epod.WaitForPodSuccessInNamespace(f.ClientSet, verifyPod.Name, f.Namespace.Name)
+		e2epod.NewPodClient(f).Create(ctx, verifyPod)
+		err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, verifyPod.Name, f.Namespace.Name)
 		framework.ExpectNoError(err)
 	})
 }
@@ -124,7 +124,7 @@ var _ = SIGDescribe("PodPidsLimit [Serial]", func() {
 	f := framework.NewDefaultFramework("pids-limit-test")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	ginkgo.Context("With config updated with pids limits", func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			initialConfig.PodPidsLimit = int64(1024)
 		})
 		runPodPidsLimitTests(f)

--- a/test/e2e_node/pods_container_manager_test.go
+++ b/test/e2e_node/pods_container_manager_test.go
@@ -176,8 +176,8 @@ var _ = SIGDescribe("Kubelet Cgroup Manager", func() {
 				}
 				cgroupsToVerify := []string{burstableCgroup, bestEffortCgroup}
 				pod := makePodToVerifyCgroups(cgroupsToVerify)
-				e2epod.NewPodClient(f).Create(pod)
-				err := e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+				e2epod.NewPodClient(f).Create(ctx, pod)
+				err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 				framework.ExpectNoError(err)
 			})
 		})
@@ -194,7 +194,7 @@ var _ = SIGDescribe("Kubelet Cgroup Manager", func() {
 					podUID        string
 				)
 				ginkgo.By("Creating a Guaranteed pod in Namespace", func() {
-					guaranteedPod = e2epod.NewPodClient(f).Create(&v1.Pod{
+					guaranteedPod = e2epod.NewPodClient(f).Create(ctx, &v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "pod" + string(uuid.NewUUID()),
 							Namespace: f.Namespace.Name,
@@ -214,17 +214,17 @@ var _ = SIGDescribe("Kubelet Cgroup Manager", func() {
 				ginkgo.By("Checking if the pod cgroup was created", func() {
 					cgroupsToVerify := []string{"pod" + podUID}
 					pod := makePodToVerifyCgroups(cgroupsToVerify)
-					e2epod.NewPodClient(f).Create(pod)
-					err := e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+					e2epod.NewPodClient(f).Create(ctx, pod)
+					err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 					framework.ExpectNoError(err)
 				})
 				ginkgo.By("Checking if the pod cgroup was deleted", func() {
 					gp := int64(1)
-					err := e2epod.NewPodClient(f).Delete(context.TODO(), guaranteedPod.Name, metav1.DeleteOptions{GracePeriodSeconds: &gp})
+					err := e2epod.NewPodClient(f).Delete(ctx, guaranteedPod.Name, metav1.DeleteOptions{GracePeriodSeconds: &gp})
 					framework.ExpectNoError(err)
 					pod := makePodToVerifyCgroupRemoved("pod" + podUID)
-					e2epod.NewPodClient(f).Create(pod)
-					err = e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+					e2epod.NewPodClient(f).Create(ctx, pod)
+					err = e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 					framework.ExpectNoError(err)
 				})
 			})
@@ -239,7 +239,7 @@ var _ = SIGDescribe("Kubelet Cgroup Manager", func() {
 					bestEffortPod *v1.Pod
 				)
 				ginkgo.By("Creating a BestEffort pod in Namespace", func() {
-					bestEffortPod = e2epod.NewPodClient(f).Create(&v1.Pod{
+					bestEffortPod = e2epod.NewPodClient(f).Create(ctx, &v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "pod" + string(uuid.NewUUID()),
 							Namespace: f.Namespace.Name,
@@ -259,17 +259,17 @@ var _ = SIGDescribe("Kubelet Cgroup Manager", func() {
 				ginkgo.By("Checking if the pod cgroup was created", func() {
 					cgroupsToVerify := []string{"besteffort/pod" + podUID}
 					pod := makePodToVerifyCgroups(cgroupsToVerify)
-					e2epod.NewPodClient(f).Create(pod)
-					err := e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+					e2epod.NewPodClient(f).Create(ctx, pod)
+					err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 					framework.ExpectNoError(err)
 				})
 				ginkgo.By("Checking if the pod cgroup was deleted", func() {
 					gp := int64(1)
-					err := e2epod.NewPodClient(f).Delete(context.TODO(), bestEffortPod.Name, metav1.DeleteOptions{GracePeriodSeconds: &gp})
+					err := e2epod.NewPodClient(f).Delete(ctx, bestEffortPod.Name, metav1.DeleteOptions{GracePeriodSeconds: &gp})
 					framework.ExpectNoError(err)
 					pod := makePodToVerifyCgroupRemoved("besteffort/pod" + podUID)
-					e2epod.NewPodClient(f).Create(pod)
-					err = e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+					e2epod.NewPodClient(f).Create(ctx, pod)
+					err = e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 					framework.ExpectNoError(err)
 				})
 			})
@@ -284,7 +284,7 @@ var _ = SIGDescribe("Kubelet Cgroup Manager", func() {
 					burstablePod *v1.Pod
 				)
 				ginkgo.By("Creating a Burstable pod in Namespace", func() {
-					burstablePod = e2epod.NewPodClient(f).Create(&v1.Pod{
+					burstablePod = e2epod.NewPodClient(f).Create(ctx, &v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "pod" + string(uuid.NewUUID()),
 							Namespace: f.Namespace.Name,
@@ -304,17 +304,17 @@ var _ = SIGDescribe("Kubelet Cgroup Manager", func() {
 				ginkgo.By("Checking if the pod cgroup was created", func() {
 					cgroupsToVerify := []string{"burstable/pod" + podUID}
 					pod := makePodToVerifyCgroups(cgroupsToVerify)
-					e2epod.NewPodClient(f).Create(pod)
-					err := e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+					e2epod.NewPodClient(f).Create(ctx, pod)
+					err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 					framework.ExpectNoError(err)
 				})
 				ginkgo.By("Checking if the pod cgroup was deleted", func() {
 					gp := int64(1)
-					err := e2epod.NewPodClient(f).Delete(context.TODO(), burstablePod.Name, metav1.DeleteOptions{GracePeriodSeconds: &gp})
+					err := e2epod.NewPodClient(f).Delete(ctx, burstablePod.Name, metav1.DeleteOptions{GracePeriodSeconds: &gp})
 					framework.ExpectNoError(err)
 					pod := makePodToVerifyCgroupRemoved("burstable/pod" + podUID)
-					e2epod.NewPodClient(f).Create(pod)
-					err = e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+					e2epod.NewPodClient(f).Create(ctx, pod)
+					err = e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 					framework.ExpectNoError(err)
 				})
 			})

--- a/test/e2e_node/quota_lsci_test.go
+++ b/test/e2e_node/quota_lsci_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2enode
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -56,7 +57,7 @@ func runOneQuotaTest(f *framework.Framework, quotasRequested bool) {
 		priority = 1
 	}
 	ginkgo.Context(fmt.Sprintf(testContextFmt, fmt.Sprintf("use quotas for LSCI monitoring (quotas enabled: %v)", quotasRequested)), func() {
-		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			defer withFeatureGate(LSCIQuotaFeature, quotasRequested)()
 			// TODO: remove hardcoded kubelet volume directory path
 			// framework.TestContext.KubeVolumeDir is currently not populated for node e2e

--- a/test/e2e_node/resource_collector.go
+++ b/test/e2e_node/resource_collector.go
@@ -370,7 +370,7 @@ func getCadvisorPod() *v1.Pod {
 }
 
 // deletePodsSync deletes a list of pods and block until pods disappear.
-func deletePodsSync(f *framework.Framework, pods []*v1.Pod) {
+func deletePodsSync(ctx context.Context, f *framework.Framework, pods []*v1.Pod) {
 	var wg sync.WaitGroup
 	for i := range pods {
 		pod := pods[i]
@@ -379,12 +379,12 @@ func deletePodsSync(f *framework.Framework, pods []*v1.Pod) {
 			defer ginkgo.GinkgoRecover()
 			defer wg.Done()
 
-			err := e2epod.NewPodClient(f).Delete(context.TODO(), pod.ObjectMeta.Name, *metav1.NewDeleteOptions(30))
+			err := e2epod.NewPodClient(f).Delete(ctx, pod.ObjectMeta.Name, *metav1.NewDeleteOptions(30))
 			if apierrors.IsNotFound(err) {
 				framework.Failf("Unexpected error trying to delete pod %s: %v", pod.Name, err)
 			}
 
-			gomega.Expect(e2epod.WaitForPodToDisappear(f.ClientSet, f.Namespace.Name, pod.ObjectMeta.Name, labels.Everything(),
+			gomega.Expect(e2epod.WaitForPodToDisappear(ctx, f.ClientSet, f.Namespace.Name, pod.ObjectMeta.Name, labels.Everything(),
 				30*time.Second, 10*time.Minute)).NotTo(gomega.HaveOccurred())
 		}()
 	}

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -89,8 +89,8 @@ var _ = SIGDescribe("Container Runtime Conformance Test", func() {
 					defer os.Remove(configFile)
 
 					// checkContainerStatus checks whether the container status matches expectation.
-					checkContainerStatus := func() error {
-						status, err := container.GetStatus()
+					checkContainerStatus := func(ctx context.Context) error {
+						status, err := container.GetStatus(ctx)
 						if err != nil {
 							return fmt.Errorf("failed to get container status: %v", err)
 						}
@@ -116,7 +116,7 @@ var _ = SIGDescribe("Container Runtime Conformance Test", func() {
 							}
 						}
 						// Check pod phase
-						phase, err := container.GetPhase()
+						phase, err := container.GetPhase(ctx)
 						if err != nil {
 							return fmt.Errorf("failed to get pod phase: %v", err)
 						}
@@ -131,15 +131,15 @@ var _ = SIGDescribe("Container Runtime Conformance Test", func() {
 					for i := 1; i <= flakeRetry; i++ {
 						var err error
 						ginkgo.By("create the container")
-						container.Create()
+						container.Create(ctx)
 						ginkgo.By("check the container status")
 						for start := time.Now(); time.Since(start) < node.ContainerStatusRetryTimeout; time.Sleep(node.ContainerStatusPollInterval) {
-							if err = checkContainerStatus(); err == nil {
+							if err = checkContainerStatus(ctx); err == nil {
 								break
 							}
 						}
 						ginkgo.By("delete the container")
-						container.Delete()
+						_ = container.Delete(ctx)
 						if err == nil {
 							break
 						}

--- a/test/e2e_node/runtimeclass_test.go
+++ b/test/e2e_node/runtimeclass_test.go
@@ -114,11 +114,11 @@ var _ = SIGDescribe("Kubelet PodOverhead handling [LinuxOnly]", func() {
 							PodFixed: getResourceList("200m", "140Mi"),
 						},
 					}
-					_, err := f.ClientSet.NodeV1().RuntimeClasses().Create(context.TODO(), rc, metav1.CreateOptions{})
+					_, err := f.ClientSet.NodeV1().RuntimeClasses().Create(ctx, rc, metav1.CreateOptions{})
 					framework.ExpectNoError(err, "failed to create RuntimeClass resource")
 				})
 				ginkgo.By("Creating a Guaranteed pod with which has Overhead defined", func() {
-					guaranteedPod = e2epod.NewPodClient(f).CreateSync(&v1.Pod{
+					guaranteedPod = e2epod.NewPodClient(f).CreateSync(ctx, &v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							GenerateName: "pod-with-overhead-",
 							Namespace:    f.Namespace.Name,
@@ -140,8 +140,8 @@ var _ = SIGDescribe("Kubelet PodOverhead handling [LinuxOnly]", func() {
 				ginkgo.By("Checking if the pod cgroup was created appropriately", func() {
 					cgroupsToVerify := []string{"pod" + podUID}
 					pod := makePodToVerifyCgroupSize(cgroupsToVerify, "30000", "251658240")
-					pod = e2epod.NewPodClient(f).Create(pod)
-					err := e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+					pod = e2epod.NewPodClient(f).Create(ctx, pod)
+					err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 					framework.ExpectNoError(err)
 				})
 			})

--- a/test/e2e_node/seccompdefault_test.go
+++ b/test/e2e_node/seccompdefault_test.go
@@ -39,7 +39,7 @@ var _ = SIGDescribe("SeccompDefault [Serial] [Feature:SeccompDefault] [LinuxOnly
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.Context("with SeccompDefault enabled", func() {
-		tempSetCurrentKubeletConfig(f, func(cfg *kubeletconfig.KubeletConfiguration) {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, cfg *kubeletconfig.KubeletConfiguration) {
 			cfg.SeccompDefault = true
 		})
 
@@ -63,12 +63,12 @@ var _ = SIGDescribe("SeccompDefault [Serial] [Feature:SeccompDefault] [LinuxOnly
 
 		ginkgo.It("should use the default seccomp profile when unspecified", func(ctx context.Context) {
 			pod := newPod(nil)
-			e2eoutput.TestContainerOutput(f, "SeccompDefault", pod, 0, []string{"2"})
+			e2eoutput.TestContainerOutput(ctx, f, "SeccompDefault", pod, 0, []string{"2"})
 		})
 
 		ginkgo.It("should use unconfined when specified", func(ctx context.Context) {
 			pod := newPod(&v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}})
-			e2eoutput.TestContainerOutput(f, "SeccompDefault-unconfined", pod, 0, []string{"0"})
+			e2eoutput.TestContainerOutput(ctx, f, "SeccompDefault-unconfined", pod, 0, []string{"0"})
 		})
 	})
 })

--- a/test/e2e_node/security_context_test.go
+++ b/test/e2e_node/security_context_test.go
@@ -46,7 +46,7 @@ var _ = SIGDescribe("Security Context", func() {
 	ginkgo.Context("[NodeConformance][LinuxOnly] Container PID namespace sharing", func() {
 		ginkgo.It("containers in pods using isolated PID namespaces should all receive PID 1", func(ctx context.Context) {
 			ginkgo.By("Create a pod with isolated PID namespaces.")
-			e2epod.NewPodClient(f).CreateSync(&v1.Pod{
+			e2epod.NewPodClient(f).CreateSync(ctx, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "isolated-pid-ns-test-pod"},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -75,7 +75,7 @@ var _ = SIGDescribe("Security Context", func() {
 
 		ginkgo.It("processes in containers sharing a pod namespace should be able to see each other", func(ctx context.Context) {
 			ginkgo.By("Create a pod with shared PID namespace.")
-			e2epod.NewPodClient(f).CreateSync(&v1.Pod{
+			e2epod.NewPodClient(f).CreateSync(ctx, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "shared-pid-ns-test-pod"},
 				Spec: v1.PodSpec{
 					ShareProcessNamespace: &[]bool{true}[0],
@@ -123,20 +123,20 @@ var _ = SIGDescribe("Security Context", func() {
 				},
 			}
 		}
-		createAndWaitHostPidPod := func(podName string, hostPID bool) {
-			podClient.Create(makeHostPidPod(podName,
+		createAndWaitHostPidPod := func(ctx context.Context, podName string, hostPID bool) {
+			podClient.Create(ctx, makeHostPidPod(podName,
 				busyboxImage,
 				[]string{"sh", "-c", "pidof nginx || true"},
 				hostPID,
 			))
 
-			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+			podClient.WaitForSuccess(ctx, podName, framework.PodStartTimeout)
 		}
 
 		nginxPid := ""
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			nginxPodName := "nginx-hostpid-" + string(uuid.NewUUID())
-			podClient.CreateSync(makeHostPidPod(nginxPodName,
+			podClient.CreateSync(ctx, makeHostPidPod(nginxPodName,
 				imageutils.GetE2EImage(imageutils.Nginx),
 				nil,
 				true,
@@ -149,8 +149,8 @@ var _ = SIGDescribe("Security Context", func() {
 
 		ginkgo.It("should show its pid in the host PID namespace [NodeFeature:HostAccess]", func(ctx context.Context) {
 			busyboxPodName := "busybox-hostpid-" + string(uuid.NewUUID())
-			createAndWaitHostPidPod(busyboxPodName, true)
-			logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, busyboxPodName, busyboxPodName)
+			createAndWaitHostPidPod(ctx, busyboxPodName, true)
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, busyboxPodName, busyboxPodName)
 			if err != nil {
 				framework.Failf("GetPodLogs for pod %q failed: %v", busyboxPodName, err)
 			}
@@ -169,8 +169,8 @@ var _ = SIGDescribe("Security Context", func() {
 
 		ginkgo.It("should not show its pid in the non-hostpid containers [NodeFeature:HostAccess]", func(ctx context.Context) {
 			busyboxPodName := "busybox-non-hostpid-" + string(uuid.NewUUID())
-			createAndWaitHostPidPod(busyboxPodName, false)
-			logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, busyboxPodName, busyboxPodName)
+			createAndWaitHostPidPod(ctx, busyboxPodName, false)
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, busyboxPodName, busyboxPodName)
 			if err != nil {
 				framework.Failf("GetPodLogs for pod %q failed: %v", busyboxPodName, err)
 			}
@@ -203,14 +203,14 @@ var _ = SIGDescribe("Security Context", func() {
 				},
 			}
 		}
-		createAndWaitHostIPCPod := func(podName string, hostNetwork bool) {
-			podClient.Create(makeHostIPCPod(podName,
+		createAndWaitHostIPCPod := func(ctx context.Context, podName string, hostNetwork bool) {
+			podClient.Create(ctx, makeHostIPCPod(podName,
 				imageutils.GetE2EImage(imageutils.IpcUtils),
 				[]string{"sh", "-c", "ipcs -m | awk '{print $2}'"},
 				hostNetwork,
 			))
 
-			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+			podClient.WaitForSuccess(ctx, podName, framework.PodStartTimeout)
 		}
 
 		hostSharedMemoryID := ""
@@ -225,8 +225,8 @@ var _ = SIGDescribe("Security Context", func() {
 
 		ginkgo.It("should show the shared memory ID in the host IPC containers [NodeFeature:HostAccess]", func(ctx context.Context) {
 			ipcutilsPodName := "ipcutils-hostipc-" + string(uuid.NewUUID())
-			createAndWaitHostIPCPod(ipcutilsPodName, true)
-			logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, ipcutilsPodName, ipcutilsPodName)
+			createAndWaitHostIPCPod(ctx, ipcutilsPodName, true)
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, ipcutilsPodName, ipcutilsPodName)
 			if err != nil {
 				framework.Failf("GetPodLogs for pod %q failed: %v", ipcutilsPodName, err)
 			}
@@ -240,8 +240,8 @@ var _ = SIGDescribe("Security Context", func() {
 
 		ginkgo.It("should not show the shared memory ID in the non-hostIPC containers [NodeFeature:HostAccess]", func(ctx context.Context) {
 			ipcutilsPodName := "ipcutils-non-hostipc-" + string(uuid.NewUUID())
-			createAndWaitHostIPCPod(ipcutilsPodName, false)
-			logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, ipcutilsPodName, ipcutilsPodName)
+			createAndWaitHostIPCPod(ctx, ipcutilsPodName, false)
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, ipcutilsPodName, ipcutilsPodName)
 			if err != nil {
 				framework.Failf("GetPodLogs for pod %q failed: %v", ipcutilsPodName, err)
 			}
@@ -283,14 +283,14 @@ var _ = SIGDescribe("Security Context", func() {
 			}
 		}
 		listListeningPortsCommand := []string{"sh", "-c", "netstat -ln"}
-		createAndWaitHostNetworkPod := func(podName string, hostNetwork bool) {
-			podClient.Create(makeHostNetworkPod(podName,
+		createAndWaitHostNetworkPod := func(ctx context.Context, podName string, hostNetwork bool) {
+			podClient.Create(ctx, makeHostNetworkPod(podName,
 				busyboxImage,
 				listListeningPortsCommand,
 				hostNetwork,
 			))
 
-			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+			podClient.WaitForSuccess(ctx, podName, framework.PodStartTimeout)
 		}
 
 		listeningPort := ""
@@ -308,8 +308,8 @@ var _ = SIGDescribe("Security Context", func() {
 
 		ginkgo.It("should listen on same port in the host network containers [NodeFeature:HostAccess]", func(ctx context.Context) {
 			busyboxPodName := "busybox-hostnetwork-" + string(uuid.NewUUID())
-			createAndWaitHostNetworkPod(busyboxPodName, true)
-			logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, busyboxPodName, busyboxPodName)
+			createAndWaitHostNetworkPod(ctx, busyboxPodName, true)
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, busyboxPodName, busyboxPodName)
 			if err != nil {
 				framework.Failf("GetPodLogs for pod %q failed: %v", busyboxPodName, err)
 			}
@@ -322,8 +322,8 @@ var _ = SIGDescribe("Security Context", func() {
 
 		ginkgo.It("shouldn't show the same port in the non-hostnetwork containers [NodeFeature:HostAccess]", func(ctx context.Context) {
 			busyboxPodName := "busybox-non-hostnetwork-" + string(uuid.NewUUID())
-			createAndWaitHostNetworkPod(busyboxPodName, false)
-			logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, busyboxPodName, busyboxPodName)
+			createAndWaitHostNetworkPod(ctx, busyboxPodName, false)
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, busyboxPodName, busyboxPodName)
 			if err != nil {
 				framework.Failf("GetPodLogs for pod %q failed: %v", busyboxPodName, err)
 			}

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -290,11 +290,11 @@ func findSRIOVResource(node *v1.Node) (string, int64) {
 	return "", 0
 }
 
-func validatePodAlignment(f *framework.Framework, pod *v1.Pod, envInfo *testEnvInfo) {
+func validatePodAlignment(ctx context.Context, f *framework.Framework, pod *v1.Pod, envInfo *testEnvInfo) {
 	for _, cnt := range pod.Spec.Containers {
 		ginkgo.By(fmt.Sprintf("validating the container %s on Gu pod %s", cnt.Name, pod.Name))
 
-		logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, cnt.Name)
+		logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, cnt.Name)
 		framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]", cnt.Name, pod.Name)
 
 		framework.Logf("got pod logs: %v", logs)
@@ -307,13 +307,13 @@ func validatePodAlignment(f *framework.Framework, pod *v1.Pod, envInfo *testEnvI
 }
 
 // validatePodAligmentWithPodScope validates whether all pod's CPUs are affined to the same NUMA node.
-func validatePodAlignmentWithPodScope(f *framework.Framework, pod *v1.Pod, envInfo *testEnvInfo) error {
+func validatePodAlignmentWithPodScope(ctx context.Context, f *framework.Framework, pod *v1.Pod, envInfo *testEnvInfo) error {
 	// Mapping between CPU IDs and NUMA node IDs.
 	podsNUMA := make(map[int]int)
 
 	ginkgo.By(fmt.Sprintf("validate pod scope alignment for %s pod", pod.Name))
 	for _, cnt := range pod.Spec.Containers {
-		logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, cnt.Name)
+		logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, cnt.Name)
 		framework.ExpectNoError(err, "NUMA alignment failed for container [%s] of pod [%s]", cnt.Name, pod.Name)
 		envMap, err := makeEnvMap(logs)
 		framework.ExpectNoError(err, "NUMA alignment failed for container [%s] of pod [%s]", cnt.Name, pod.Name)
@@ -336,10 +336,10 @@ func validatePodAlignmentWithPodScope(f *framework.Framework, pod *v1.Pod, envIn
 	return nil
 }
 
-func runTopologyManagerPolicySuiteTests(f *framework.Framework) {
+func runTopologyManagerPolicySuiteTests(ctx context.Context, f *framework.Framework) {
 	var cpuCap, cpuAlloc int64
 
-	cpuCap, cpuAlloc, _ = getLocalNodeCPUDetails(f)
+	cpuCap, cpuAlloc, _ = getLocalNodeCPUDetails(ctx, f)
 	ginkgo.By(fmt.Sprintf("checking node CPU capacity (%d) and allocatable CPUs (%d)", cpuCap, cpuAlloc))
 
 	// Albeit even the weakest CI machines usually have 2 cpus, let's be extra careful and
@@ -349,10 +349,10 @@ func runTopologyManagerPolicySuiteTests(f *framework.Framework) {
 	}
 
 	ginkgo.By("running a non-Gu pod")
-	runNonGuPodTest(f, cpuCap)
+	runNonGuPodTest(ctx, f, cpuCap)
 
 	ginkgo.By("running a Gu pod")
-	runGuPodTest(f, 1)
+	runGuPodTest(ctx, f, 1)
 
 	// Skip rest of the tests if CPU allocatable < 3.
 	if cpuAlloc < 3 {
@@ -360,16 +360,16 @@ func runTopologyManagerPolicySuiteTests(f *framework.Framework) {
 	}
 
 	ginkgo.By("running multiple Gu and non-Gu pods")
-	runMultipleGuNonGuPods(f, cpuCap, cpuAlloc)
+	runMultipleGuNonGuPods(ctx, f, cpuCap, cpuAlloc)
 
 	ginkgo.By("running a Gu pod requesting multiple CPUs")
-	runMultipleCPUGuPod(f)
+	runMultipleCPUGuPod(ctx, f)
 
 	ginkgo.By("running a Gu pod with multiple containers requesting integer CPUs")
-	runMultipleCPUContainersGuPod(f)
+	runMultipleCPUContainersGuPod(ctx, f)
 
 	ginkgo.By("running multiple Gu pods")
-	runMultipleGuPods(f)
+	runMultipleGuPods(ctx, f)
 }
 
 // waitForAllContainerRemoval waits until all the containers on a given pod are really gone.
@@ -377,11 +377,11 @@ func runTopologyManagerPolicySuiteTests(f *framework.Framework) {
 // In these cases, we need to make sure the tests clean up after themselves to make sure each test runs in
 // a pristine environment. The only way known so far to do that is to introduce this wait.
 // Worth noting, however, that this makes the test runtime much bigger.
-func waitForAllContainerRemoval(podName, podNS string) {
+func waitForAllContainerRemoval(ctx context.Context, podName, podNS string) {
 	rs, _, err := getCRIClient()
 	framework.ExpectNoError(err)
-	gomega.Eventually(func() bool {
-		containers, err := rs.ListContainers(context.Background(), &runtimeapi.ContainerFilter{
+	gomega.Eventually(ctx, func(ctx context.Context) bool {
+		containers, err := rs.ListContainers(ctx, &runtimeapi.ContainerFilter{
 			LabelSelector: map[string]string{
 				types.KubernetesPodNameLabel:      podName,
 				types.KubernetesPodNamespaceLabel: podNS,
@@ -394,14 +394,14 @@ func waitForAllContainerRemoval(podName, podNS string) {
 	}, 2*time.Minute, 1*time.Second).Should(gomega.BeTrue())
 }
 
-func runTopologyManagerPositiveTest(f *framework.Framework, numPods int, ctnAttrs, initCtnAttrs []tmCtnAttribute, envInfo *testEnvInfo) {
+func runTopologyManagerPositiveTest(ctx context.Context, f *framework.Framework, numPods int, ctnAttrs, initCtnAttrs []tmCtnAttribute, envInfo *testEnvInfo) {
 	podMap := make(map[string]*v1.Pod)
 
 	for podID := 0; podID < numPods; podID++ {
 		podName := fmt.Sprintf("gu-pod-%d", podID)
 		framework.Logf("creating pod %s attrs %v", podName, ctnAttrs)
 		pod := makeTopologyManagerTestPod(podName, ctnAttrs, initCtnAttrs)
-		pod = e2epod.NewPodClient(f).CreateSync(pod)
+		pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
 		framework.Logf("created pod %s", podName)
 		podMap[podName] = pod
 	}
@@ -410,20 +410,20 @@ func runTopologyManagerPositiveTest(f *framework.Framework, numPods int, ctnAttr
 	// we can do a menaingful validation only when using the single-numa node policy
 	if envInfo.policy == topologymanager.PolicySingleNumaNode {
 		for _, pod := range podMap {
-			validatePodAlignment(f, pod, envInfo)
+			validatePodAlignment(ctx, f, pod, envInfo)
 		}
 		if envInfo.scope == podScopeTopology {
 			for _, pod := range podMap {
-				err := validatePodAlignmentWithPodScope(f, pod, envInfo)
+				err := validatePodAlignmentWithPodScope(ctx, f, pod, envInfo)
 				framework.ExpectNoError(err)
 			}
 		}
 	}
 
-	deletePodsAsync(f, podMap)
+	deletePodsAsync(ctx, f, podMap)
 }
 
-func deletePodsAsync(f *framework.Framework, podMap map[string]*v1.Pod) {
+func deletePodsAsync(ctx context.Context, f *framework.Framework, podMap map[string]*v1.Pod) {
 	var wg sync.WaitGroup
 	for _, pod := range podMap {
 		wg.Add(1)
@@ -431,27 +431,27 @@ func deletePodsAsync(f *framework.Framework, podMap map[string]*v1.Pod) {
 			defer ginkgo.GinkgoRecover()
 			defer wg.Done()
 
-			deletePodSyncByName(f, podName)
-			waitForAllContainerRemoval(podName, podNS)
+			deletePodSyncByName(ctx, f, podName)
+			waitForAllContainerRemoval(ctx, podName, podNS)
 		}(pod.Namespace, pod.Name)
 	}
 	wg.Wait()
 }
 
-func runTopologyManagerNegativeTest(f *framework.Framework, ctnAttrs, initCtnAttrs []tmCtnAttribute, envInfo *testEnvInfo) {
+func runTopologyManagerNegativeTest(ctx context.Context, f *framework.Framework, ctnAttrs, initCtnAttrs []tmCtnAttribute, envInfo *testEnvInfo) {
 	podName := "gu-pod"
 	framework.Logf("creating pod %s attrs %v", podName, ctnAttrs)
 	pod := makeTopologyManagerTestPod(podName, ctnAttrs, initCtnAttrs)
 
-	pod = e2epod.NewPodClient(f).Create(pod)
-	err := e2epod.WaitForPodCondition(f.ClientSet, f.Namespace.Name, pod.Name, "Failed", 30*time.Second, func(pod *v1.Pod) (bool, error) {
+	pod = e2epod.NewPodClient(f).Create(ctx, pod)
+	err := e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "Failed", 30*time.Second, func(pod *v1.Pod) (bool, error) {
 		if pod.Status.Phase != v1.PodPending {
 			return true, nil
 		}
 		return false, nil
 	})
 	framework.ExpectNoError(err)
-	pod, err = e2epod.NewPodClient(f).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+	pod, err = e2epod.NewPodClient(f).Get(ctx, pod.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 
 	if pod.Status.Phase != v1.PodFailed {
@@ -461,7 +461,7 @@ func runTopologyManagerNegativeTest(f *framework.Framework, ctnAttrs, initCtnAtt
 		framework.Failf("pod %s failed for wrong reason: %q", pod.Name, pod.Status.Reason)
 	}
 
-	deletePodSyncByName(f, pod.Name)
+	deletePodSyncByName(ctx, f, pod.Name)
 }
 
 func isTopologyAffinityError(pod *v1.Pod) bool {
@@ -498,20 +498,20 @@ type sriovData struct {
 	resourceAmount int64
 }
 
-func setupSRIOVConfigOrFail(f *framework.Framework, configMap *v1.ConfigMap) *sriovData {
-	sd := createSRIOVConfigOrFail(f, configMap)
+func setupSRIOVConfigOrFail(ctx context.Context, f *framework.Framework, configMap *v1.ConfigMap) *sriovData {
+	sd := createSRIOVConfigOrFail(ctx, f, configMap)
 
-	e2enode.WaitForNodeToBeReady(f.ClientSet, framework.TestContext.NodeName, 5*time.Minute)
+	e2enode.WaitForNodeToBeReady(ctx, f.ClientSet, framework.TestContext.NodeName, 5*time.Minute)
 
-	sd.pod = createSRIOVPodOrFail(f)
+	sd.pod = createSRIOVPodOrFail(ctx, f)
 	return sd
 }
 
-func createSRIOVConfigOrFail(f *framework.Framework, configMap *v1.ConfigMap) *sriovData {
+func createSRIOVConfigOrFail(ctx context.Context, f *framework.Framework, configMap *v1.ConfigMap) *sriovData {
 	var err error
 
 	ginkgo.By(fmt.Sprintf("Creating configMap %v/%v", metav1.NamespaceSystem, configMap.Name))
-	if _, err = f.ClientSet.CoreV1().ConfigMaps(metav1.NamespaceSystem).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+	if _, err = f.ClientSet.CoreV1().ConfigMaps(metav1.NamespaceSystem).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 	}
 
@@ -521,7 +521,7 @@ func createSRIOVConfigOrFail(f *framework.Framework, configMap *v1.ConfigMap) *s
 	}
 	serviceAccount := readServiceAccountV1OrDie(data)
 	ginkgo.By(fmt.Sprintf("Creating serviceAccount %v/%v", metav1.NamespaceSystem, serviceAccount.Name))
-	if _, err = f.ClientSet.CoreV1().ServiceAccounts(metav1.NamespaceSystem).Create(context.TODO(), serviceAccount, metav1.CreateOptions{}); err != nil {
+	if _, err = f.ClientSet.CoreV1().ServiceAccounts(metav1.NamespaceSystem).Create(ctx, serviceAccount, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create test serviceAccount %s: %v", serviceAccount.Name, err)
 	}
 
@@ -531,15 +531,15 @@ func createSRIOVConfigOrFail(f *framework.Framework, configMap *v1.ConfigMap) *s
 	}
 }
 
-func createSRIOVPodOrFail(f *framework.Framework) *v1.Pod {
+func createSRIOVPodOrFail(ctx context.Context, f *framework.Framework) *v1.Pod {
 	dp := getSRIOVDevicePluginPod()
 	dp.Spec.NodeName = framework.TestContext.NodeName
 
 	ginkgo.By("Create SRIOV device plugin pod")
-	dpPod, err := f.ClientSet.CoreV1().Pods(metav1.NamespaceSystem).Create(context.TODO(), dp, metav1.CreateOptions{})
+	dpPod, err := f.ClientSet.CoreV1().Pods(metav1.NamespaceSystem).Create(ctx, dp, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
-	if err = e2epod.WaitForPodCondition(f.ClientSet, metav1.NamespaceSystem, dp.Name, "Ready", 120*time.Second, testutils.PodRunningReady); err != nil {
+	if err = e2epod.WaitForPodCondition(ctx, f.ClientSet, metav1.NamespaceSystem, dp.Name, "Ready", 120*time.Second, testutils.PodRunningReady); err != nil {
 		framework.Logf("SRIOV Pod %v took too long to enter running/ready: %v", dp.Name, err)
 	}
 	framework.ExpectNoError(err)
@@ -549,12 +549,12 @@ func createSRIOVPodOrFail(f *framework.Framework) *v1.Pod {
 
 // waitForSRIOVResources waits until enough SRIOV resources are avaailable, expecting to complete within the timeout.
 // if exits successfully, updates the sriovData with the resources which were found.
-func waitForSRIOVResources(f *framework.Framework, sd *sriovData) {
+func waitForSRIOVResources(ctx context.Context, f *framework.Framework, sd *sriovData) {
 	sriovResourceName := ""
 	var sriovResourceAmount int64
 	ginkgo.By("Waiting for devices to become available on the local node")
-	gomega.Eventually(func() bool {
-		node := getLocalNode(f)
+	gomega.Eventually(ctx, func(ctx context.Context) bool {
+		node := getLocalNode(ctx, f)
 		sriovResourceName, sriovResourceAmount = findSRIOVResource(node)
 		return sriovResourceAmount > minSriovResource
 	}, 2*time.Minute, framework.Poll).Should(gomega.BeTrue())
@@ -564,7 +564,7 @@ func waitForSRIOVResources(f *framework.Framework, sd *sriovData) {
 	framework.Logf("Detected SRIOV allocatable devices name=%q amount=%d", sd.resourceName, sd.resourceAmount)
 }
 
-func deleteSRIOVPodOrFail(f *framework.Framework, sd *sriovData) {
+func deleteSRIOVPodOrFail(ctx context.Context, f *framework.Framework, sd *sriovData) {
 	var err error
 	gp := int64(0)
 	deleteOptions := metav1.DeleteOptions{
@@ -572,12 +572,12 @@ func deleteSRIOVPodOrFail(f *framework.Framework, sd *sriovData) {
 	}
 
 	ginkgo.By(fmt.Sprintf("Delete SRIOV device plugin pod %s/%s", sd.pod.Namespace, sd.pod.Name))
-	err = f.ClientSet.CoreV1().Pods(sd.pod.Namespace).Delete(context.TODO(), sd.pod.Name, deleteOptions)
+	err = f.ClientSet.CoreV1().Pods(sd.pod.Namespace).Delete(ctx, sd.pod.Name, deleteOptions)
 	framework.ExpectNoError(err)
-	waitForAllContainerRemoval(sd.pod.Name, sd.pod.Namespace)
+	waitForAllContainerRemoval(ctx, sd.pod.Name, sd.pod.Namespace)
 }
 
-func removeSRIOVConfigOrFail(f *framework.Framework, sd *sriovData) {
+func removeSRIOVConfigOrFail(ctx context.Context, f *framework.Framework, sd *sriovData) {
 	var err error
 	gp := int64(0)
 	deleteOptions := metav1.DeleteOptions{
@@ -585,25 +585,25 @@ func removeSRIOVConfigOrFail(f *framework.Framework, sd *sriovData) {
 	}
 
 	ginkgo.By(fmt.Sprintf("Deleting configMap %v/%v", metav1.NamespaceSystem, sd.configMap.Name))
-	err = f.ClientSet.CoreV1().ConfigMaps(metav1.NamespaceSystem).Delete(context.TODO(), sd.configMap.Name, deleteOptions)
+	err = f.ClientSet.CoreV1().ConfigMaps(metav1.NamespaceSystem).Delete(ctx, sd.configMap.Name, deleteOptions)
 	framework.ExpectNoError(err)
 
 	ginkgo.By(fmt.Sprintf("Deleting serviceAccount %v/%v", metav1.NamespaceSystem, sd.serviceAccount.Name))
-	err = f.ClientSet.CoreV1().ServiceAccounts(metav1.NamespaceSystem).Delete(context.TODO(), sd.serviceAccount.Name, deleteOptions)
+	err = f.ClientSet.CoreV1().ServiceAccounts(metav1.NamespaceSystem).Delete(ctx, sd.serviceAccount.Name, deleteOptions)
 	framework.ExpectNoError(err)
 }
 
-func teardownSRIOVConfigOrFail(f *framework.Framework, sd *sriovData) {
-	deleteSRIOVPodOrFail(f, sd)
-	removeSRIOVConfigOrFail(f, sd)
+func teardownSRIOVConfigOrFail(ctx context.Context, f *framework.Framework, sd *sriovData) {
+	deleteSRIOVPodOrFail(ctx, f, sd)
+	removeSRIOVConfigOrFail(ctx, f, sd)
 }
 
-func runTMScopeResourceAlignmentTestSuite(f *framework.Framework, configMap *v1.ConfigMap, reservedSystemCPUs, policy string, numaNodes, coreCount int) {
+func runTMScopeResourceAlignmentTestSuite(ctx context.Context, f *framework.Framework, configMap *v1.ConfigMap, reservedSystemCPUs, policy string, numaNodes, coreCount int) {
 	threadsPerCore := getSMTLevel()
-	sd := setupSRIOVConfigOrFail(f, configMap)
+	sd := setupSRIOVConfigOrFail(ctx, f, configMap)
 	var ctnAttrs, initCtnAttrs []tmCtnAttribute
 
-	waitForSRIOVResources(f, sd)
+	waitForSRIOVResources(ctx, f, sd)
 
 	envInfo := &testEnvInfo{
 		numaNodes:         numaNodes,
@@ -631,7 +631,7 @@ func runTMScopeResourceAlignmentTestSuite(f *framework.Framework, configMap *v1.
 			deviceLimit:   "1",
 		},
 	}
-	runTopologyManagerPositiveTest(f, 2, ctnAttrs, initCtnAttrs, envInfo)
+	runTopologyManagerPositiveTest(ctx, f, 2, ctnAttrs, initCtnAttrs, envInfo)
 
 	numCores := threadsPerCore * coreCount
 	coresReq := fmt.Sprintf("%dm", numCores*1000)
@@ -652,7 +652,7 @@ func runTMScopeResourceAlignmentTestSuite(f *framework.Framework, configMap *v1.
 			deviceLimit:   "1",
 		},
 	}
-	runTopologyManagerNegativeTest(f, ctnAttrs, initCtnAttrs, envInfo)
+	runTopologyManagerNegativeTest(ctx, f, ctnAttrs, initCtnAttrs, envInfo)
 
 	// The Topology Manager with pod scope should calculate how many CPUs it needs to admit a pod basing on two requests:
 	// the maximum of init containers' demand for CPU and sum of app containers' requests for CPU.
@@ -693,15 +693,15 @@ func runTMScopeResourceAlignmentTestSuite(f *framework.Framework, configMap *v1.
 			deviceLimit:   "1",
 		},
 	}
-	runTopologyManagerPositiveTest(f, 2, ctnAttrs, initCtnAttrs, envInfo)
+	runTopologyManagerPositiveTest(ctx, f, 2, ctnAttrs, initCtnAttrs, envInfo)
 
-	teardownSRIOVConfigOrFail(f, sd)
+	teardownSRIOVConfigOrFail(ctx, f, sd)
 }
 
-func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, sd *sriovData, reservedSystemCPUs, policy string, numaNodes, coreCount int) {
+func runTopologyManagerNodeAlignmentSuiteTests(ctx context.Context, f *framework.Framework, sd *sriovData, reservedSystemCPUs, policy string, numaNodes, coreCount int) {
 	threadsPerCore := getSMTLevel()
 
-	waitForSRIOVResources(f, sd)
+	waitForSRIOVResources(ctx, f, sd)
 
 	envInfo := &testEnvInfo{
 		numaNodes:         numaNodes,
@@ -724,7 +724,7 @@ func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, sd *sriov
 			deviceLimit:   "1",
 		},
 	}
-	runTopologyManagerPositiveTest(f, 1, ctnAttrs, initCtnAttrs, envInfo)
+	runTopologyManagerPositiveTest(ctx, f, 1, ctnAttrs, initCtnAttrs, envInfo)
 
 	ginkgo.By(fmt.Sprintf("Successfully admit one guaranteed pod with 2 cores, 1 %s device", sd.resourceName))
 	ctnAttrs = []tmCtnAttribute{
@@ -737,7 +737,7 @@ func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, sd *sriov
 			deviceLimit:   "1",
 		},
 	}
-	runTopologyManagerPositiveTest(f, 1, ctnAttrs, initCtnAttrs, envInfo)
+	runTopologyManagerPositiveTest(ctx, f, 1, ctnAttrs, initCtnAttrs, envInfo)
 
 	if reservedSystemCPUs != "" {
 		// to avoid false negatives, we have put reserved CPUs in such a way there is at least a NUMA node
@@ -755,7 +755,7 @@ func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, sd *sriov
 				deviceLimit:   "1",
 			},
 		}
-		runTopologyManagerPositiveTest(f, 1, ctnAttrs, initCtnAttrs, envInfo)
+		runTopologyManagerPositiveTest(ctx, f, 1, ctnAttrs, initCtnAttrs, envInfo)
 	}
 
 	if sd.resourceAmount > 1 {
@@ -772,7 +772,7 @@ func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, sd *sriov
 				deviceLimit:   "1",
 			},
 		}
-		runTopologyManagerPositiveTest(f, 2, ctnAttrs, initCtnAttrs, envInfo)
+		runTopologyManagerPositiveTest(ctx, f, 2, ctnAttrs, initCtnAttrs, envInfo)
 
 		ginkgo.By(fmt.Sprintf("Successfully admit two guaranteed pods, each with 2 cores, 1 %s device", sd.resourceName))
 		ctnAttrs = []tmCtnAttribute{
@@ -785,7 +785,7 @@ func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, sd *sriov
 				deviceLimit:   "1",
 			},
 		}
-		runTopologyManagerPositiveTest(f, 2, ctnAttrs, initCtnAttrs, envInfo)
+		runTopologyManagerPositiveTest(ctx, f, 2, ctnAttrs, initCtnAttrs, envInfo)
 
 		// testing more complex conditions require knowledge about the system cpu+bus topology
 	}
@@ -811,7 +811,7 @@ func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, sd *sriov
 				deviceLimit:   "1",
 			},
 		}
-		runTopologyManagerPositiveTest(f, 1, ctnAttrs, initCtnAttrs, envInfo)
+		runTopologyManagerPositiveTest(ctx, f, 1, ctnAttrs, initCtnAttrs, envInfo)
 
 		ginkgo.By(fmt.Sprintf("Successfully admit two guaranteed pods, each with two containers, each with 1 core, 1 %s device", sd.resourceName))
 		ctnAttrs = []tmCtnAttribute{
@@ -832,7 +832,7 @@ func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, sd *sriov
 				deviceLimit:   "1",
 			},
 		}
-		runTopologyManagerPositiveTest(f, 2, ctnAttrs, initCtnAttrs, envInfo)
+		runTopologyManagerPositiveTest(ctx, f, 2, ctnAttrs, initCtnAttrs, envInfo)
 
 		ginkgo.By(fmt.Sprintf("Successfully admit two guaranteed pods, each with two containers, both with with 2 cores, one with 1 %s device", sd.resourceName))
 		ctnAttrs = []tmCtnAttribute{
@@ -850,7 +850,7 @@ func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, sd *sriov
 				cpuLimit:   "2000m",
 			},
 		}
-		runTopologyManagerPositiveTest(f, 2, ctnAttrs, initCtnAttrs, envInfo)
+		runTopologyManagerPositiveTest(ctx, f, 2, ctnAttrs, initCtnAttrs, envInfo)
 	}
 
 	// this is the only policy that can guarantee reliable rejects
@@ -869,7 +869,7 @@ func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, sd *sriov
 				deviceLimit:   "1",
 			},
 		}
-		runTopologyManagerNegativeTest(f, ctnAttrs, initCtnAttrs, envInfo)
+		runTopologyManagerNegativeTest(ctx, f, ctnAttrs, initCtnAttrs, envInfo)
 	}
 }
 
@@ -885,7 +885,7 @@ func runTopologyManagerTests(f *framework.Framework) {
 	}
 
 	ginkgo.It("run Topology Manager policy test suite", func(ctx context.Context) {
-		oldCfg, err = getCurrentKubeletConfig()
+		oldCfg, err = getCurrentKubeletConfig(ctx)
 		framework.ExpectNoError(err)
 
 		scope := containerScopeTopology
@@ -895,9 +895,9 @@ func runTopologyManagerTests(f *framework.Framework) {
 			framework.Logf("Configuring topology Manager policy to %s", policy)
 
 			newCfg, _ := configureTopologyManagerInKubelet(oldCfg, policy, scope, nil, 0)
-			updateKubeletConfig(f, newCfg, true)
+			updateKubeletConfig(ctx, f, newCfg, true)
 			// Run the tests
-			runTopologyManagerPolicySuiteTests(f)
+			runTopologyManagerPolicySuiteTests(ctx, f)
 		}
 	})
 
@@ -906,10 +906,10 @@ func runTopologyManagerTests(f *framework.Framework) {
 
 		configMap := getSRIOVDevicePluginConfigMap(framework.TestContext.SriovdpConfigMapFile)
 
-		oldCfg, err = getCurrentKubeletConfig()
+		oldCfg, err = getCurrentKubeletConfig(ctx)
 		framework.ExpectNoError(err)
 
-		sd := setupSRIOVConfigOrFail(f, configMap)
+		sd := setupSRIOVConfigOrFail(ctx, f, configMap)
 		ginkgo.DeferCleanup(teardownSRIOVConfigOrFail, f, sd)
 
 		scope := containerScopeTopology
@@ -919,9 +919,9 @@ func runTopologyManagerTests(f *framework.Framework) {
 			framework.Logf("Configuring topology Manager policy to %s", policy)
 
 			newCfg, reservedSystemCPUs := configureTopologyManagerInKubelet(oldCfg, policy, scope, configMap, numaNodes)
-			updateKubeletConfig(f, newCfg, true)
+			updateKubeletConfig(ctx, f, newCfg, true)
 
-			runTopologyManagerNodeAlignmentSuiteTests(f, sd, reservedSystemCPUs, policy, numaNodes, coreCount)
+			runTopologyManagerNodeAlignmentSuiteTests(ctx, f, sd, reservedSystemCPUs, policy, numaNodes, coreCount)
 		}
 	})
 
@@ -930,22 +930,22 @@ func runTopologyManagerTests(f *framework.Framework) {
 
 		configMap := getSRIOVDevicePluginConfigMap(framework.TestContext.SriovdpConfigMapFile)
 
-		oldCfg, err = getCurrentKubeletConfig()
+		oldCfg, err = getCurrentKubeletConfig(ctx)
 		framework.ExpectNoError(err)
 
 		policy := topologymanager.PolicySingleNumaNode
 		scope := podScopeTopology
 
 		newCfg, reservedSystemCPUs := configureTopologyManagerInKubelet(oldCfg, policy, scope, configMap, numaNodes)
-		updateKubeletConfig(f, newCfg, true)
+		updateKubeletConfig(ctx, f, newCfg, true)
 
-		runTMScopeResourceAlignmentTestSuite(f, configMap, reservedSystemCPUs, policy, numaNodes, coreCount)
+		runTMScopeResourceAlignmentTestSuite(ctx, f, configMap, reservedSystemCPUs, policy, numaNodes, coreCount)
 	})
 
-	ginkgo.AfterEach(func() {
+	ginkgo.AfterEach(func(ctx context.Context) {
 		if oldCfg != nil {
 			// restore kubelet config
-			updateKubeletConfig(f, oldCfg, true)
+			updateKubeletConfig(ctx, f, oldCfg, true)
 		}
 	})
 }

--- a/test/e2e_node/volume_manager_test.go
+++ b/test/e2e_node/volume_manager_test.go
@@ -44,7 +44,7 @@ var _ = SIGDescribe("Kubelet Volume Manager", func() {
 				)
 				ginkgo.By("Creating a pod with a memory backed volume that exits success without restart", func() {
 					volumeName = "memory-volume"
-					memoryBackedPod = e2epod.NewPodClient(f).Create(&v1.Pod{
+					memoryBackedPod = e2epod.NewPodClient(f).Create(ctx, &v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "pod" + string(uuid.NewUUID()),
 							Namespace: f.Namespace.Name,
@@ -74,7 +74,7 @@ var _ = SIGDescribe("Kubelet Volume Manager", func() {
 							},
 						},
 					})
-					err := e2epod.WaitForPodSuccessInNamespace(f.ClientSet, memoryBackedPod.Name, f.Namespace.Name)
+					err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, memoryBackedPod.Name, f.Namespace.Name)
 					framework.ExpectNoError(err)
 				})
 				ginkgo.By("Verifying the memory backed volume was removed from node", func() {
@@ -83,7 +83,7 @@ var _ = SIGDescribe("Kubelet Volume Manager", func() {
 					for i := 0; i < 10; i++ {
 						// need to create a new verification pod on each pass since updates
 						//to the HostPath volume aren't propogated to the pod
-						pod := e2epod.NewPodClient(f).Create(&v1.Pod{
+						pod := e2epod.NewPodClient(f).Create(ctx, &v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "pod" + string(uuid.NewUUID()),
 								Namespace: f.Namespace.Name,
@@ -115,9 +115,9 @@ var _ = SIGDescribe("Kubelet Volume Manager", func() {
 								},
 							},
 						})
-						err = e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+						err = e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
 						gp := int64(1)
-						e2epod.NewPodClient(f).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &gp})
+						_ = e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &gp})
 						if err == nil {
 							break
 						}

--- a/test/integration/framework/perf_utils.go
+++ b/test/integration/framework/perf_utils.go
@@ -58,7 +58,7 @@ func NewIntegrationTestNodePreparerWithNodeSpec(client clientset.Interface, coun
 }
 
 // PrepareNodes prepares countToStrategy test nodes.
-func (p *IntegrationTestNodePreparer) PrepareNodes(nextNodeIndex int) error {
+func (p *IntegrationTestNodePreparer) PrepareNodes(ctx context.Context, nextNodeIndex int) error {
 	numNodes := 0
 	for _, v := range p.countToStrategy {
 		numNodes += v.Count
@@ -89,7 +89,7 @@ func (p *IntegrationTestNodePreparer) PrepareNodes(nextNodeIndex int) error {
 	for i := 0; i < numNodes; i++ {
 		var err error
 		for retry := 0; retry < retries; retry++ {
-			_, err = p.client.CoreV1().Nodes().Create(context.TODO(), baseNode, metav1.CreateOptions{})
+			_, err = p.client.CoreV1().Nodes().Create(ctx, baseNode, metav1.CreateOptions{})
 			if err == nil {
 				break
 			}
@@ -106,7 +106,7 @@ func (p *IntegrationTestNodePreparer) PrepareNodes(nextNodeIndex int) error {
 	index := nextNodeIndex
 	for _, v := range p.countToStrategy {
 		for i := 0; i < v.Count; i, index = i+1, index+1 {
-			if err := testutils.DoPrepareNode(p.client, &nodes.Items[index], v.Strategy); err != nil {
+			if err := testutils.DoPrepareNode(ctx, p.client, &nodes.Items[index], v.Strategy); err != nil {
 				klog.Errorf("Aborting node preparation: %v", err)
 				return err
 			}
@@ -116,7 +116,7 @@ func (p *IntegrationTestNodePreparer) PrepareNodes(nextNodeIndex int) error {
 }
 
 // CleanupNodes deletes existing test nodes.
-func (p *IntegrationTestNodePreparer) CleanupNodes() error {
+func (p *IntegrationTestNodePreparer) CleanupNodes(ctx context.Context) error {
 	// TODO(#93794): make CleanupNodes only clean up the nodes created by this
 	// IntegrationTestNodePreparer to make this more intuitive.
 	nodes, err := waitListAllNodes(p.client)
@@ -125,7 +125,7 @@ func (p *IntegrationTestNodePreparer) CleanupNodes() error {
 	}
 	var errRet error
 	for i := range nodes.Items {
-		if err := p.client.CoreV1().Nodes().Delete(context.TODO(), nodes.Items[i].Name, metav1.DeleteOptions{}); err != nil {
+		if err := p.client.CoreV1().Nodes().Delete(ctx, nodes.Items[i].Name, metav1.DeleteOptions{}); err != nil {
 			klog.Errorf("Error while deleting Node: %v", err)
 			errRet = err
 		}

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -687,11 +687,11 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 			if err != nil {
 				b.Fatalf("op %d: %v", opIndex, err)
 			}
-			if err := nodePreparer.PrepareNodes(nextNodeIndex); err != nil {
+			if err := nodePreparer.PrepareNodes(ctx, nextNodeIndex); err != nil {
 				b.Fatalf("op %d: %v", opIndex, err)
 			}
 			b.Cleanup(func() {
-				nodePreparer.CleanupNodes()
+				_ = nodePreparer.CleanupNodes(ctx)
 			})
 			nextNodeIndex += concreteOp.Count
 
@@ -742,7 +742,7 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 					go collector.run(collectorCtx)
 				}
 			}
-			if err := createPods(b, namespace, concreteOp, client); err != nil {
+			if err := createPods(ctx, b, namespace, concreteOp, client); err != nil {
 				b.Fatalf("op %d: %v", opIndex, err)
 			}
 			if concreteOp.SkipWaitToCompletion {
@@ -958,7 +958,7 @@ func getNodePreparer(prefix string, cno *createNodesOp, clientset clientset.Inte
 	), nil
 }
 
-func createPods(b *testing.B, namespace string, cpo *createPodsOp, clientset clientset.Interface) error {
+func createPods(ctx context.Context, b *testing.B, namespace string, cpo *createPodsOp, clientset clientset.Interface) error {
 	strategy, err := getPodStrategy(cpo)
 	if err != nil {
 		return err
@@ -967,7 +967,7 @@ func createPods(b *testing.B, namespace string, cpo *createPodsOp, clientset cli
 	config := testutils.NewTestPodCreatorConfig()
 	config.AddStrategy(namespace, cpo.Count, strategy)
 	podCreator := testutils.NewTestPodCreator(clientset, config)
-	return podCreator.CreatePods()
+	return podCreator.CreatePods(ctx)
 }
 
 // waitUntilPodsScheduledInNamespace blocks until all pods in the given

--- a/test/utils/crd/crd_util.go
+++ b/test/utils/crd/crd_util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package crd
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/utils/pointer"
@@ -31,7 +32,7 @@ import (
 )
 
 // CleanCrdFn declares the clean up function needed to remove the CRD
-type CleanCrdFn func() error
+type CleanCrdFn func(ctx context.Context) error
 
 // TestCrd holds all the pieces needed to test with the CRD
 type TestCrd struct {
@@ -111,7 +112,7 @@ func CreateMultiVersionTestCRD(f *framework.Framework, group string, opts ...Opt
 	testcrd.APIExtensionClient = apiExtensionClient
 	testcrd.Crd = crd
 	testcrd.DynamicClients = resourceClients
-	testcrd.CleanUp = func() error {
+	testcrd.CleanUp = func(ctx context.Context) error {
 		err := fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
 		if err != nil {
 			framework.Failf("failed to delete CustomResourceDefinition(%s): %v", name, err)

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -65,17 +65,17 @@ func removePtr(replicas *int32) int32 {
 	return *replicas
 }
 
-func WaitUntilPodIsScheduled(c clientset.Interface, name, namespace string, timeout time.Duration) (*v1.Pod, error) {
+func WaitUntilPodIsScheduled(ctx context.Context, c clientset.Interface, name, namespace string, timeout time.Duration) (*v1.Pod, error) {
 	// Wait until it's scheduled
-	p, err := c.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{ResourceVersion: "0"})
+	p, err := c.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{ResourceVersion: "0"})
 	if err == nil && p.Spec.NodeName != "" {
 		return p, nil
 	}
 	pollingPeriod := 200 * time.Millisecond
 	startTime := time.Now()
-	for startTime.Add(timeout).After(time.Now()) {
+	for startTime.Add(timeout).After(time.Now()) && ctx.Err() == nil {
 		time.Sleep(pollingPeriod)
-		p, err := c.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{ResourceVersion: "0"})
+		p, err := c.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{ResourceVersion: "0"})
 		if err == nil && p.Spec.NodeName != "" {
 			return p, nil
 		}
@@ -83,13 +83,13 @@ func WaitUntilPodIsScheduled(c clientset.Interface, name, namespace string, time
 	return nil, fmt.Errorf("timed out after %v when waiting for pod %v/%v to start", timeout, namespace, name)
 }
 
-func RunPodAndGetNodeName(c clientset.Interface, pod *v1.Pod, timeout time.Duration) (string, error) {
+func RunPodAndGetNodeName(ctx context.Context, c clientset.Interface, pod *v1.Pod, timeout time.Duration) (string, error) {
 	name := pod.Name
 	namespace := pod.Namespace
 	if err := CreatePodWithRetries(c, namespace, pod); err != nil {
 		return "", err
 	}
-	p, err := WaitUntilPodIsScheduled(c, name, namespace, timeout)
+	p, err := WaitUntilPodIsScheduled(ctx, c, name, namespace, timeout)
 	if err != nil {
 		return "", err
 	}
@@ -173,8 +173,8 @@ type RCConfig struct {
 	LogFunc func(fmt string, args ...interface{})
 	// If set those functions will be used to gather data from Nodes - in integration tests where no
 	// kubelets are running those variables should be nil.
-	NodeDumpFunc      func(c clientset.Interface, nodeNames []string, logFunc func(fmt string, args ...interface{}))
-	ContainerDumpFunc func(c clientset.Interface, ns string, logFunc func(ftm string, args ...interface{}))
+	NodeDumpFunc      func(ctx context.Context, c clientset.Interface, nodeNames []string, logFunc func(fmt string, args ...interface{}))
+	ContainerDumpFunc func(ctx context.Context, c clientset.Interface, ns string, logFunc func(ftm string, args ...interface{}))
 
 	// Names of the secrets and configmaps to mount.
 	SecretNames    []string
@@ -288,16 +288,16 @@ func Diff(oldPods []*v1.Pod, curPods []*v1.Pod) PodDiff {
 // and will wait for all pods it spawns to become "Running".
 // It's the caller's responsibility to clean up externally (i.e. use the
 // namespace lifecycle for handling Cleanup).
-func RunDeployment(config DeploymentConfig) error {
+func RunDeployment(ctx context.Context, config DeploymentConfig) error {
 	err := config.create()
 	if err != nil {
 		return err
 	}
-	return config.start()
+	return config.start(ctx)
 }
 
-func (config *DeploymentConfig) Run() error {
-	return RunDeployment(*config)
+func (config *DeploymentConfig) Run(ctx context.Context) error {
+	return RunDeployment(ctx, *config)
 }
 
 func (config *DeploymentConfig) GetKind() schema.GroupKind {
@@ -374,16 +374,16 @@ func (config *DeploymentConfig) create() error {
 // and waits until all the pods it launches to reach the "Running" state.
 // It's the caller's responsibility to clean up externally (i.e. use the
 // namespace lifecycle for handling Cleanup).
-func RunReplicaSet(config ReplicaSetConfig) error {
+func RunReplicaSet(ctx context.Context, config ReplicaSetConfig) error {
 	err := config.create()
 	if err != nil {
 		return err
 	}
-	return config.start()
+	return config.start(ctx)
 }
 
-func (config *ReplicaSetConfig) Run() error {
-	return RunReplicaSet(*config)
+func (config *ReplicaSetConfig) Run(ctx context.Context) error {
+	return RunReplicaSet(ctx, *config)
 }
 
 func (config *ReplicaSetConfig) GetKind() schema.GroupKind {
@@ -456,16 +456,16 @@ func (config *ReplicaSetConfig) create() error {
 // and will wait for all pods it spawns to become "Running".
 // It's the caller's responsibility to clean up externally (i.e. use the
 // namespace lifecycle for handling Cleanup).
-func RunJob(config JobConfig) error {
+func RunJob(ctx context.Context, config JobConfig) error {
 	err := config.create()
 	if err != nil {
 		return err
 	}
-	return config.start()
+	return config.start(ctx)
 }
 
-func (config *JobConfig) Run() error {
-	return RunJob(*config)
+func (config *JobConfig) Run(ctx context.Context) error {
+	return RunJob(ctx, *config)
 }
 
 func (config *JobConfig) GetKind() schema.GroupKind {
@@ -530,16 +530,16 @@ func (config *JobConfig) create() error {
 // and will wait for all pods it spawns to become "Running".
 // It's the caller's responsibility to clean up externally (i.e. use the
 // namespace lifecycle for handling Cleanup).
-func RunRC(config RCConfig) error {
+func RunRC(ctx context.Context, config RCConfig) error {
 	err := config.create()
 	if err != nil {
 		return err
 	}
-	return config.start()
+	return config.start(ctx)
 }
 
-func (config *RCConfig) Run() error {
-	return RunRC(*config)
+func (config *RCConfig) Run(ctx context.Context) error {
+	return RunRC(ctx, *config)
 }
 
 func (config *RCConfig) GetName() string {
@@ -776,7 +776,7 @@ func ComputeRCStartupStatus(pods []*v1.Pod, expected int) RCStartupStatus {
 	return startupStatus
 }
 
-func (config *RCConfig) start() error {
+func (config *RCConfig) start(ctx context.Context) error {
 	// Don't force tests to fail if they don't care about containers restarting.
 	var maxContainerFailures int
 	if config.MaxContainerFailures == nil {
@@ -824,11 +824,11 @@ func (config *RCConfig) start() error {
 
 		if startupStatus.FailedContainers > maxContainerFailures {
 			if config.NodeDumpFunc != nil {
-				config.NodeDumpFunc(config.Client, startupStatus.ContainerRestartNodes.List(), config.RCConfigLog)
+				config.NodeDumpFunc(ctx, config.Client, startupStatus.ContainerRestartNodes.List(), config.RCConfigLog)
 			}
 			if config.ContainerDumpFunc != nil {
 				// Get the logs from the failed containers to help diagnose what caused them to fail
-				config.ContainerDumpFunc(config.Client, config.Namespace, config.RCConfigLog)
+				config.ContainerDumpFunc(ctx, config.Client, config.Namespace, config.RCConfigLog)
 			}
 			return fmt.Errorf("%d containers failed which is more than allowed %d", startupStatus.FailedContainers, maxContainerFailures)
 		}
@@ -858,7 +858,7 @@ func (config *RCConfig) start() error {
 	if oldRunning != config.Replicas {
 		// List only pods from a given replication controller.
 		options := metav1.ListOptions{LabelSelector: label.String()}
-		if pods, err := config.Client.CoreV1().Pods(config.Namespace).List(context.TODO(), options); err == nil {
+		if pods, err := config.Client.CoreV1().Pods(config.Namespace).List(ctx, options); err == nil {
 			for _, pod := range pods.Items {
 				config.RCConfigLog("Pod %s\t%s\t%s\t%s", pod.Name, pod.Spec.NodeName, pod.Status.Phase, pod.DeletionTimestamp)
 			}
@@ -946,8 +946,8 @@ type CountToStrategy struct {
 }
 
 type TestNodePreparer interface {
-	PrepareNodes(nextNodeIndex int) error
-	CleanupNodes() error
+	PrepareNodes(ctx context.Context, nextNodeIndex int) error
+	CleanupNodes(ctx context.Context) error
 }
 
 type PrepareNodeStrategy interface {
@@ -955,12 +955,12 @@ type PrepareNodeStrategy interface {
 	PreparePatch(node *v1.Node) []byte
 	// Create or modify any objects that depend on the node before the test starts.
 	// Caller will re-try when http.StatusConflict error is returned.
-	PrepareDependentObjects(node *v1.Node, client clientset.Interface) error
+	PrepareDependentObjects(ctx context.Context, node *v1.Node, client clientset.Interface) error
 	// Clean up any node modifications after the test finishes.
-	CleanupNode(node *v1.Node) *v1.Node
+	CleanupNode(ctx context.Context, node *v1.Node) *v1.Node
 	// Clean up any objects that depend on the node after the test finishes.
 	// Caller will re-try when http.StatusConflict error is returned.
-	CleanupDependentObjects(nodeName string, client clientset.Interface) error
+	CleanupDependentObjects(ctx context.Context, nodeName string, client clientset.Interface) error
 }
 
 type TrivialNodePrepareStrategy struct{}
@@ -971,16 +971,16 @@ func (*TrivialNodePrepareStrategy) PreparePatch(*v1.Node) []byte {
 	return []byte{}
 }
 
-func (*TrivialNodePrepareStrategy) CleanupNode(node *v1.Node) *v1.Node {
+func (*TrivialNodePrepareStrategy) CleanupNode(ctx context.Context, node *v1.Node) *v1.Node {
 	nodeCopy := *node
 	return &nodeCopy
 }
 
-func (*TrivialNodePrepareStrategy) PrepareDependentObjects(node *v1.Node, client clientset.Interface) error {
+func (*TrivialNodePrepareStrategy) PrepareDependentObjects(ctx context.Context, node *v1.Node, client clientset.Interface) error {
 	return nil
 }
 
-func (*TrivialNodePrepareStrategy) CleanupDependentObjects(nodeName string, client clientset.Interface) error {
+func (*TrivialNodePrepareStrategy) CleanupDependentObjects(ctx context.Context, nodeName string, client clientset.Interface) error {
 	return nil
 }
 
@@ -1009,7 +1009,7 @@ func (s *LabelNodePrepareStrategy) PreparePatch(*v1.Node) []byte {
 	return []byte(patch)
 }
 
-func (s *LabelNodePrepareStrategy) CleanupNode(node *v1.Node) *v1.Node {
+func (s *LabelNodePrepareStrategy) CleanupNode(ctx context.Context, node *v1.Node) *v1.Node {
 	nodeCopy := node.DeepCopy()
 	if node.Labels != nil && len(node.Labels[s.LabelKey]) != 0 {
 		delete(nodeCopy.Labels, s.LabelKey)
@@ -1017,11 +1017,11 @@ func (s *LabelNodePrepareStrategy) CleanupNode(node *v1.Node) *v1.Node {
 	return nodeCopy
 }
 
-func (*LabelNodePrepareStrategy) PrepareDependentObjects(node *v1.Node, client clientset.Interface) error {
+func (*LabelNodePrepareStrategy) PrepareDependentObjects(ctx context.Context, node *v1.Node, client clientset.Interface) error {
 	return nil
 }
 
-func (*LabelNodePrepareStrategy) CleanupDependentObjects(nodeName string, client clientset.Interface) error {
+func (*LabelNodePrepareStrategy) CleanupDependentObjects(ctx context.Context, nodeName string, client clientset.Interface) error {
 	return nil
 }
 
@@ -1069,7 +1069,7 @@ func (s *NodeAllocatableStrategy) PreparePatch(node *v1.Node) []byte {
 	return patch
 }
 
-func (s *NodeAllocatableStrategy) CleanupNode(node *v1.Node) *v1.Node {
+func (s *NodeAllocatableStrategy) CleanupNode(ctx context.Context, node *v1.Node) *v1.Node {
 	nodeCopy := node.DeepCopy()
 	for name := range s.NodeAllocatable {
 		delete(nodeCopy.Status.Allocatable, name)
@@ -1077,7 +1077,7 @@ func (s *NodeAllocatableStrategy) CleanupNode(node *v1.Node) *v1.Node {
 	return nodeCopy
 }
 
-func (s *NodeAllocatableStrategy) createCSINode(nodeName string, client clientset.Interface) error {
+func (s *NodeAllocatableStrategy) createCSINode(ctx context.Context, nodeName string, client clientset.Interface) error {
 	csiNode := &storagev1.CSINode{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
@@ -1099,7 +1099,7 @@ func (s *NodeAllocatableStrategy) createCSINode(nodeName string, client clientse
 		csiNode.Spec.Drivers = append(csiNode.Spec.Drivers, d)
 	}
 
-	_, err := client.StorageV1().CSINodes().Create(context.TODO(), csiNode, metav1.CreateOptions{})
+	_, err := client.StorageV1().CSINodes().Create(ctx, csiNode, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		// Something created CSINode instance after we checked it did not exist.
 		// Make the caller to re-try PrepareDependentObjects by returning Conflict error
@@ -1108,7 +1108,7 @@ func (s *NodeAllocatableStrategy) createCSINode(nodeName string, client clientse
 	return err
 }
 
-func (s *NodeAllocatableStrategy) updateCSINode(csiNode *storagev1.CSINode, client clientset.Interface) error {
+func (s *NodeAllocatableStrategy) updateCSINode(ctx context.Context, csiNode *storagev1.CSINode, client clientset.Interface) error {
 	for driverName, allocatable := range s.CsiNodeAllocatable {
 		found := false
 		for i, driver := range csiNode.Spec.Drivers {
@@ -1129,23 +1129,23 @@ func (s *NodeAllocatableStrategy) updateCSINode(csiNode *storagev1.CSINode, clie
 	}
 	csiNode.Annotations[v1.MigratedPluginsAnnotationKey] = strings.Join(s.MigratedPlugins, ",")
 
-	_, err := client.StorageV1().CSINodes().Update(context.TODO(), csiNode, metav1.UpdateOptions{})
+	_, err := client.StorageV1().CSINodes().Update(ctx, csiNode, metav1.UpdateOptions{})
 	return err
 }
 
-func (s *NodeAllocatableStrategy) PrepareDependentObjects(node *v1.Node, client clientset.Interface) error {
-	csiNode, err := client.StorageV1().CSINodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+func (s *NodeAllocatableStrategy) PrepareDependentObjects(ctx context.Context, node *v1.Node, client clientset.Interface) error {
+	csiNode, err := client.StorageV1().CSINodes().Get(ctx, node.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return s.createCSINode(node.Name, client)
+			return s.createCSINode(ctx, node.Name, client)
 		}
 		return err
 	}
-	return s.updateCSINode(csiNode, client)
+	return s.updateCSINode(ctx, csiNode, client)
 }
 
-func (s *NodeAllocatableStrategy) CleanupDependentObjects(nodeName string, client clientset.Interface) error {
-	csiNode, err := client.StorageV1().CSINodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+func (s *NodeAllocatableStrategy) CleanupDependentObjects(ctx context.Context, nodeName string, client clientset.Interface) error {
+	csiNode, err := client.StorageV1().CSINodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
@@ -1160,7 +1160,7 @@ func (s *NodeAllocatableStrategy) CleanupDependentObjects(nodeName string, clien
 			}
 		}
 	}
-	return s.updateCSINode(csiNode, client)
+	return s.updateCSINode(ctx, csiNode, client)
 }
 
 // UniqueNodeLabelStrategy sets a unique label for each node.
@@ -1182,7 +1182,7 @@ func (s *UniqueNodeLabelStrategy) PreparePatch(*v1.Node) []byte {
 	return []byte(patch)
 }
 
-func (s *UniqueNodeLabelStrategy) CleanupNode(node *v1.Node) *v1.Node {
+func (s *UniqueNodeLabelStrategy) CleanupNode(ctx context.Context, node *v1.Node) *v1.Node {
 	nodeCopy := node.DeepCopy()
 	if node.Labels != nil && len(node.Labels[s.LabelKey]) != 0 {
 		delete(nodeCopy.Labels, s.LabelKey)
@@ -1190,22 +1190,22 @@ func (s *UniqueNodeLabelStrategy) CleanupNode(node *v1.Node) *v1.Node {
 	return nodeCopy
 }
 
-func (*UniqueNodeLabelStrategy) PrepareDependentObjects(node *v1.Node, client clientset.Interface) error {
+func (*UniqueNodeLabelStrategy) PrepareDependentObjects(ctx context.Context, node *v1.Node, client clientset.Interface) error {
 	return nil
 }
 
-func (*UniqueNodeLabelStrategy) CleanupDependentObjects(nodeName string, client clientset.Interface) error {
+func (*UniqueNodeLabelStrategy) CleanupDependentObjects(ctx context.Context, nodeName string, client clientset.Interface) error {
 	return nil
 }
 
-func DoPrepareNode(client clientset.Interface, node *v1.Node, strategy PrepareNodeStrategy) error {
+func DoPrepareNode(ctx context.Context, client clientset.Interface, node *v1.Node, strategy PrepareNodeStrategy) error {
 	var err error
 	patch := strategy.PreparePatch(node)
 	if len(patch) == 0 {
 		return nil
 	}
 	for attempt := 0; attempt < retries; attempt++ {
-		if _, err = client.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.MergePatchType, []byte(patch), metav1.PatchOptions{}); err == nil {
+		if _, err = client.CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, []byte(patch), metav1.PatchOptions{}); err == nil {
 			break
 		}
 		if !apierrors.IsConflict(err) {
@@ -1218,7 +1218,7 @@ func DoPrepareNode(client clientset.Interface, node *v1.Node, strategy PrepareNo
 	}
 
 	for attempt := 0; attempt < retries; attempt++ {
-		if err = strategy.PrepareDependentObjects(node, client); err == nil {
+		if err = strategy.PrepareDependentObjects(ctx, node, client); err == nil {
 			break
 		}
 		if !apierrors.IsConflict(err) {
@@ -1232,19 +1232,19 @@ func DoPrepareNode(client clientset.Interface, node *v1.Node, strategy PrepareNo
 	return nil
 }
 
-func DoCleanupNode(client clientset.Interface, nodeName string, strategy PrepareNodeStrategy) error {
+func DoCleanupNode(ctx context.Context, client clientset.Interface, nodeName string, strategy PrepareNodeStrategy) error {
 	var err error
 	for attempt := 0; attempt < retries; attempt++ {
 		var node *v1.Node
-		node, err = client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		node, err = client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("skipping cleanup of Node: failed to get Node %v: %v", nodeName, err)
 		}
-		updatedNode := strategy.CleanupNode(node)
+		updatedNode := strategy.CleanupNode(ctx, node)
 		if apiequality.Semantic.DeepEqual(node, updatedNode) {
 			return nil
 		}
-		if _, err = client.CoreV1().Nodes().Update(context.TODO(), updatedNode, metav1.UpdateOptions{}); err == nil {
+		if _, err = client.CoreV1().Nodes().Update(ctx, updatedNode, metav1.UpdateOptions{}); err == nil {
 			break
 		}
 		if !apierrors.IsConflict(err) {
@@ -1257,7 +1257,7 @@ func DoCleanupNode(client clientset.Interface, nodeName string, strategy Prepare
 	}
 
 	for attempt := 0; attempt < retries; attempt++ {
-		err = strategy.CleanupDependentObjects(nodeName, client)
+		err = strategy.CleanupDependentObjects(ctx, nodeName, client)
 		if err == nil {
 			break
 		}
@@ -1272,7 +1272,7 @@ func DoCleanupNode(client clientset.Interface, nodeName string, strategy Prepare
 	return nil
 }
 
-type TestPodCreateStrategy func(client clientset.Interface, namespace string, podCount int) error
+type TestPodCreateStrategy func(ctx context.Context, client clientset.Interface, namespace string, podCount int) error
 
 type CountToPodStrategy struct {
 	Count    int
@@ -1304,10 +1304,10 @@ func NewTestPodCreator(client clientset.Interface, config *TestPodCreatorConfig)
 	}
 }
 
-func (c *TestPodCreator) CreatePods() error {
+func (c *TestPodCreator) CreatePods(ctx context.Context) error {
 	for ns, v := range *(c.Config) {
 		for _, countToStrategy := range v {
-			if err := countToStrategy.Strategy(c.Client, ns, countToStrategy.Count); err != nil {
+			if err := countToStrategy.Strategy(ctx, c.Client, ns, countToStrategy.Count); err != nil {
 				return err
 			}
 		}
@@ -1342,7 +1342,7 @@ func makeCreatePod(client clientset.Interface, namespace string, podTemplate *v1
 	return nil
 }
 
-func CreatePod(client clientset.Interface, namespace string, podCount int, podTemplate *v1.Pod) error {
+func CreatePod(ctx context.Context, client clientset.Interface, namespace string, podCount int, podTemplate *v1.Pod) error {
 	var createError error
 	lock := sync.Mutex{}
 	createPodFunc := func(i int) {
@@ -1354,14 +1354,14 @@ func CreatePod(client clientset.Interface, namespace string, podCount int, podTe
 	}
 
 	if podCount < 30 {
-		workqueue.ParallelizeUntil(context.TODO(), podCount, podCount, createPodFunc)
+		workqueue.ParallelizeUntil(ctx, podCount, podCount, createPodFunc)
 	} else {
-		workqueue.ParallelizeUntil(context.TODO(), 30, podCount, createPodFunc)
+		workqueue.ParallelizeUntil(ctx, 30, podCount, createPodFunc)
 	}
 	return createError
 }
 
-func CreatePodWithPersistentVolume(client clientset.Interface, namespace string, claimTemplate *v1.PersistentVolumeClaim, factory volumeFactory, podTemplate *v1.Pod, count int, bindVolume bool) error {
+func CreatePodWithPersistentVolume(ctx context.Context, client clientset.Interface, namespace string, claimTemplate *v1.PersistentVolumeClaim, factory volumeFactory, podTemplate *v1.Pod, count int, bindVolume bool) error {
 	var createError error
 	lock := sync.Mutex{}
 	createPodFunc := func(i int) {
@@ -1400,7 +1400,7 @@ func CreatePodWithPersistentVolume(client clientset.Interface, namespace string,
 		}
 
 		// We need to update statuses separately, as creating pv/pvc resets status to the default one.
-		if _, err := client.CoreV1().PersistentVolumeClaims(namespace).UpdateStatus(context.TODO(), pvc, metav1.UpdateOptions{}); err != nil {
+		if _, err := client.CoreV1().PersistentVolumeClaims(namespace).UpdateStatus(ctx, pvc, metav1.UpdateOptions{}); err != nil {
 			lock.Lock()
 			defer lock.Unlock()
 			createError = fmt.Errorf("error updating PVC status: %s", err)
@@ -1414,7 +1414,7 @@ func CreatePodWithPersistentVolume(client clientset.Interface, namespace string,
 			return
 		}
 		// We need to update statuses separately, as creating pv/pvc resets status to the default one.
-		if _, err := client.CoreV1().PersistentVolumes().UpdateStatus(context.TODO(), pv, metav1.UpdateOptions{}); err != nil {
+		if _, err := client.CoreV1().PersistentVolumes().UpdateStatus(ctx, pv, metav1.UpdateOptions{}); err != nil {
 			lock.Lock()
 			defer lock.Unlock()
 			createError = fmt.Errorf("error updating PV status: %s", err)
@@ -1442,9 +1442,9 @@ func CreatePodWithPersistentVolume(client clientset.Interface, namespace string,
 	}
 
 	if count < 30 {
-		workqueue.ParallelizeUntil(context.TODO(), count, count, createPodFunc)
+		workqueue.ParallelizeUntil(ctx, count, count, createPodFunc)
 	} else {
-		workqueue.ParallelizeUntil(context.TODO(), 30, count, createPodFunc)
+		workqueue.ParallelizeUntil(ctx, 30, count, createPodFunc)
 	}
 	return createError
 }
@@ -1472,8 +1472,8 @@ func createController(client clientset.Interface, controllerName, namespace stri
 }
 
 func NewCustomCreatePodStrategy(podTemplate *v1.Pod) TestPodCreateStrategy {
-	return func(client clientset.Interface, namespace string, podCount int) error {
-		return CreatePod(client, namespace, podCount, podTemplate)
+	return func(ctx context.Context, client clientset.Interface, namespace string, podCount int) error {
+		return CreatePod(ctx, client, namespace, podCount, podTemplate)
 	}
 }
 
@@ -1481,8 +1481,8 @@ func NewCustomCreatePodStrategy(podTemplate *v1.Pod) TestPodCreateStrategy {
 type volumeFactory func(uniqueID int) *v1.PersistentVolume
 
 func NewCreatePodWithPersistentVolumeStrategy(claimTemplate *v1.PersistentVolumeClaim, factory volumeFactory, podTemplate *v1.Pod) TestPodCreateStrategy {
-	return func(client clientset.Interface, namespace string, podCount int) error {
-		return CreatePodWithPersistentVolume(client, namespace, claimTemplate, factory, podTemplate, podCount, true /* bindVolume */)
+	return func(ctx context.Context, client clientset.Interface, namespace string, podCount int) error {
+		return CreatePodWithPersistentVolume(ctx, client, namespace, claimTemplate, factory, podTemplate, podCount, true /* bindVolume */)
 	}
 }
 
@@ -1501,7 +1501,7 @@ func makeUnboundPersistentVolumeClaim(storageClass string) *v1.PersistentVolumeC
 }
 
 func NewCreatePodWithPersistentVolumeWithFirstConsumerStrategy(factory volumeFactory, podTemplate *v1.Pod) TestPodCreateStrategy {
-	return func(client clientset.Interface, namespace string, podCount int) error {
+	return func(ctx context.Context, client clientset.Interface, namespace string, podCount int) error {
 		volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
 		storageClass := &storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1522,7 +1522,7 @@ func NewCreatePodWithPersistentVolumeWithFirstConsumerStrategy(factory volumeFac
 			return pv
 		}
 
-		return CreatePodWithPersistentVolume(client, namespace, claimTemplate, factoryWithStorageClass, podTemplate, podCount, false /* bindVolume */)
+		return CreatePodWithPersistentVolume(ctx, client, namespace, claimTemplate, factoryWithStorageClass, podTemplate, podCount, false /* bindVolume */)
 	}
 }
 
@@ -1537,7 +1537,7 @@ func NewSimpleCreatePodStrategy() TestPodCreateStrategy {
 }
 
 func NewSimpleWithControllerCreatePodStrategy(controllerName string) TestPodCreateStrategy {
-	return func(client clientset.Interface, namespace string, podCount int) error {
+	return func(ctx context.Context, client clientset.Interface, namespace string, podCount int) error {
 		basePod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: controllerName + "-pod-",
@@ -1548,7 +1548,7 @@ func NewSimpleWithControllerCreatePodStrategy(controllerName string) TestPodCrea
 		if err := createController(client, controllerName, namespace, podCount, basePod); err != nil {
 			return err
 		}
-		return CreatePod(client, namespace, podCount, basePod)
+		return CreatePod(ctx, client, namespace, podCount, basePod)
 	}
 }
 
@@ -1739,7 +1739,7 @@ type DaemonConfig struct {
 	Timeout time.Duration
 }
 
-func (config *DaemonConfig) Run() error {
+func (config *DaemonConfig) Run(ctx context.Context) error {
 	if config.Image == "" {
 		config.Image = "registry.k8s.io/pause:3.9"
 	}
@@ -1775,7 +1775,7 @@ func (config *DaemonConfig) Run() error {
 	var err error
 	for i := 0; i < retries; i++ {
 		// Wait for all daemons to be running
-		nodes, err = config.Client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
+		nodes, err = config.Client.CoreV1().Nodes().List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 		if err == nil {
 			break
 		} else if i+1 == retries {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Ginkgo can tell code to stop running by canceling the context that Ginkgo provides to callbacks when those accept one. This can be used to stop immediately when aborting manually via CTRL-C and to clean up properly in case of a timeout, because cleanup code then runs after the main test has stopped with a new context.

#### Special notes for your reviewer:

I started eliminating context.TODO in provisioning.go and then branched out from there: any function which had context.TODO needed an explicit context. The minimal goal for this PR is to clean up all code in test/e2e/framework because then further PRs probably can be more localized.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
