### PR TITLE
[windows-test] check nil in MetricsEqualIgnoreTimestamp

### DIFF
--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -1722,7 +1722,13 @@ func CreateTestPVC(capacity string, accessModes []v1.PersistentVolumeAccessMode)
 	return &claim
 }
 
-func MetricsEqualIgnoreTimestamp(a *volume.Metrics, b *volume.Metrics) bool {
+func MetricsEqualIgnoreTimestamp(a, b *volume.Metrics) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
 	available := a.Available == b.Available
 	capacity := a.Capacity == b.Capacity
 	used := a.Used == b.Used


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test


#### What this PR does / why we need it:
Failure cluster [df4d0b863f0818b642f0](https://go.k8s.io/triage#df4d0b863f0818b642f0)


#### Which issue(s) this PR fixes:
Fixes None

#### Special notes for your reviewer:

```
=== RUN   TestGetMetricsBlockInvalid
--- FAIL: TestGetMetricsBlockInvalid (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x28 pc=0xf65636]

goroutine 13 [running]:
testing.tRunner.func1.2({0x10f46a0, 0x1f41390})
	C:/Program Files/Go/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
	C:/Program Files/Go/src/testing/testing.go:1392 +0x39f
panic({0x10f46a0, 0x1f41390})
	C:/Program Files/Go/src/runtime/panic.go:838 +0x207
k8s.io/kubernetes/pkg/volume/testing.MetricsEqualIgnoreTimestamp(...)
	C:/kubernetes/pkg/volume/testing/testing.go:1720
k8s.io/kubernetes/pkg/volume_test.TestGetMetricsBlockInvalid(0xc000341380)
	C:/kubernetes/pkg/volume/metrics_block_test.go:30 +0x76
testing.tRunner(0xc000341380, 0x13a3548)
	C:/Program Files/Go/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
	C:/Program Files/Go/src/testing/testing.go:1486 +0x35f

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
#### Recent failures:
[2022/9/30 19:14:17 ci-kubernetes-unit-windows-master](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1575806220697079808)
[2022/9/30 07:13:20 ci-kubernetes-unit-windows-master](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1575624787730894848)
[2022/9/29 19:13:20 ci-kubernetes-unit-windows-master](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1575443590820139008)
[2022/9/29 07:13:19 ci-kubernetes-unit-windows-master](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1575262393833885696)
[2022/9/28 19:12:36 ci-kubernetes-unit-windows-master](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1575081019504070656)
