### PR TITLE
kubeadm: Inherit `dry-run` flags for each sub-phases

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/addons.go
+++ b/cmd/kubeadm/app/cmd/phases/init/addons.go
@@ -127,6 +127,7 @@ func getAddonPhaseFlags(name string) []string {
 		options.KubeconfigPath,
 		options.KubernetesVersion,
 		options.ImageRepository,
+		options.DryRun,
 	}
 	if name == "all" || name == "kube-proxy" {
 		flags = append(flags,

--- a/cmd/kubeadm/app/cmd/phases/init/bootstraptoken.go
+++ b/cmd/kubeadm/app/cmd/phases/init/bootstraptoken.go
@@ -56,6 +56,7 @@ func NewBootstrapTokenPhase() workflow.Phase {
 			options.CfgPath,
 			options.KubeconfigPath,
 			options.SkipTokenPrint,
+			options.DryRun,
 		},
 		Run: runBootstrapToken,
 	}

--- a/cmd/kubeadm/app/cmd/phases/init/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs.go
@@ -123,6 +123,7 @@ func getCertPhaseFlags(name string) []string {
 		options.CertificatesDir,
 		options.CfgPath,
 		options.KubernetesVersion,
+		options.DryRun,
 	}
 	if name == "all" || name == "apiserver" {
 		flags = append(flags,

--- a/cmd/kubeadm/app/cmd/phases/init/etcd.go
+++ b/cmd/kubeadm/app/cmd/phases/init/etcd.go
@@ -72,6 +72,7 @@ func getEtcdPhaseFlags() []string {
 		options.CfgPath,
 		options.ImageRepository,
 		options.Patches,
+		options.DryRun,
 	}
 	return flags
 }

--- a/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
@@ -105,6 +105,7 @@ func getKubeConfigPhaseFlags(name string) []string {
 		options.CfgPath,
 		options.KubeconfigDir,
 		options.KubernetesVersion,
+		options.DryRun,
 	}
 	if name == "all" || name == kubeadmconstants.KubeletKubeConfigFileName {
 		flags = append(flags,

--- a/cmd/kubeadm/app/cmd/phases/init/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubelet.go
@@ -49,6 +49,7 @@ func NewKubeletStartPhase() workflow.Phase {
 			options.NodeCRISocket,
 			options.NodeName,
 			options.Patches,
+			options.DryRun,
 		},
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/init/kubeletfinalize.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubeletfinalize.go
@@ -51,14 +51,14 @@ func NewKubeletFinalizePhase() workflow.Phase {
 			{
 				Name:           "all",
 				Short:          "Run all kubelet-finalize phases",
-				InheritFlags:   []string{options.CfgPath, options.CertificatesDir},
+				InheritFlags:   []string{options.CfgPath, options.CertificatesDir, options.DryRun},
 				Example:        kubeletFinalizePhaseExample,
 				RunAllSiblings: true,
 			},
 			{
 				Name:         "experimental-cert-rotation",
 				Short:        "Enable kubelet client certificate rotation",
-				InheritFlags: []string{options.CfgPath, options.CertificatesDir},
+				InheritFlags: []string{options.CfgPath, options.CertificatesDir, options.DryRun},
 				Run:          runKubeletFinalizeCertRotation,
 			},
 		},

--- a/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
@@ -44,6 +44,7 @@ func NewMarkControlPlanePhase() workflow.Phase {
 		InheritFlags: []string{
 			options.NodeName,
 			options.CfgPath,
+			options.DryRun,
 		},
 		Run: runMarkControlPlane,
 	}

--- a/cmd/kubeadm/app/cmd/phases/init/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/init/preflight.go
@@ -47,6 +47,7 @@ func NewPreflightPhase() workflow.Phase {
 		InheritFlags: []string{
 			options.CfgPath,
 			options.IgnorePreflightErrors,
+			options.DryRun,
 		},
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/init/uploadcerts.go
+++ b/cmd/kubeadm/app/cmd/phases/init/uploadcerts.go
@@ -41,6 +41,7 @@ func NewUploadCertsPhase() workflow.Phase {
 			options.UploadCerts,
 			options.CertificateKey,
 			options.SkipCertificateKeyPrint,
+			options.DryRun,
 		},
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/init/uploadconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/uploadconfig.go
@@ -97,6 +97,7 @@ func getUploadConfigPhaseFlags() []string {
 	return []string{
 		options.CfgPath,
 		options.KubeconfigPath,
+		options.DryRun,
 	}
 }
 

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -48,6 +48,9 @@ func getControlPlaneJoinPhaseFlags(name string) []string {
 	if name != "mark-control-plane" {
 		flags = append(flags, options.APIServerAdvertiseAddress)
 	}
+	if name != "update-status" {
+		flags = append(flags, options.DryRun)
+	}
 	return flags
 }
 

--- a/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
@@ -81,6 +81,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.TokenStr,
 			options.CertificateKey,
 			options.Patches,
+			options.DryRun,
 		}
 	case "download-certs":
 		flags = []string{
@@ -93,6 +94,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.TLSBootstrapToken,
 			options.TokenStr,
 			options.CertificateKey,
+			options.DryRun,
 		}
 	case "certs":
 		flags = []string{
@@ -118,6 +120,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.TLSBootstrapToken,
 			options.TokenStr,
 			options.CertificateKey,
+			options.DryRun,
 		}
 	case "control-plane":
 		flags = []string{
@@ -126,6 +129,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.CfgPath,
 			options.ControlPlane,
 			options.Patches,
+			options.DryRun,
 		}
 	default:
 		flags = []string{}

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -77,6 +77,7 @@ func NewKubeletStartPhase() workflow.Phase {
 			options.TLSBootstrapToken,
 			options.TokenStr,
 			options.Patches,
+			options.DryRun,
 		},
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/join/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/join/preflight.go
@@ -76,6 +76,7 @@ func NewPreflightPhase() workflow.Phase {
 			options.TokenDiscoveryCAHash,
 			options.TokenDiscoverySkipCAHash,
 			options.CertificateKey,
+			options.DryRun,
 		},
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -49,6 +49,7 @@ func NewCleanupNodePhase() workflow.Phase {
 			options.CertificatesDir,
 			options.NodeCRISocket,
 			options.CleanupTmpDir,
+			options.DryRun,
 		},
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/reset/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/preflight.go
@@ -40,6 +40,7 @@ func NewPreflightPhase() workflow.Phase {
 		InheritFlags: []string{
 			options.IgnorePreflightErrors,
 			options.ForceReset,
+			options.DryRun,
 		},
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember.go
@@ -44,6 +44,7 @@ func NewRemoveETCDMemberPhase() workflow.Phase {
 		Run:   runRemoveETCDMemberPhase,
 		InheritFlags: []string{
 			options.KubeconfigPath,
+			options.DryRun,
 		},
 	}
 }


### PR DESCRIPTION
- The sub-phases like `kubeadm reset phase cleanup-node` which could be run independently would be able to support the `dry-run` mode as well.

- Consistent with the sub-phases which support the `dry-run` mode already, such as `kubeadm init phase control-plane apiserver --dry-run`.

- Prepare for the day when each of those sub-phases could be run independently.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/sig cluster-lifecycle


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: sub-phases are now able to support the dry-run mode, e.g. kubeadm reset phase cleanup-node --dry-run
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
