### PR TITLE
Make root approvers list non-recursive, shift from individuals to sig/subproject aliases

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 reviewers:
   - alisondy
   - cblecker

--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 approvers:
   - release-engineering-approvers
   - release-managers

--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -6,16 +6,16 @@ options:
 approvers:
   - release-engineering-approvers
   - release-managers
-  - ramrodo # 1.26 Release Notes Lead
-  - csantanapr # 1.25 Release Notes Lead
   - AuraSinis # 1.24 Release Notes Lead
   - cici37 # 1.23 Release Notes Lead
+  - csantanapr # 1.25 Release Notes Lead
+  - ramrodo # 1.26 Release Notes Lead
 reviewers:
   - release-managers
-  - ramrodo # 1.26 Release Notes Lead
   - AnaMMedina21 # 1.26 Release Notes Shadow
   - harshanarayana # 1.26 Release Notes Shadow
   - laxmikantbpandhare # 1.26 Release Notes Shadow
+  - ramrodo # 1.26 Release Notes Lead
   - sayantani11 # 1.26 Release Notes Shadow
 labels:
   - sig/release

--- a/LICENSES/OWNERS
+++ b/LICENSES/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 approvers:
   - dep-approvers

--- a/OWNERS
+++ b/OWNERS
@@ -2,24 +2,18 @@
 
 filters:
   ".*":
-    reviewers:
-      - dchen1107
-      - lavalamp
-      - smarterclayton
-      - thockin
-      - wojtek-t
-      - liggitt
-    approvers:
-      - dchen1107
-      - lavalamp
-      - smarterclayton
-      - thockin
-      - wojtek-t
-      - liggitt
+    reviewers: []
+    approvers: []
     emeritus_approvers:
-      - brendandburns
       - bgrant0607
+      - brendandburns
+      - dchen1107
       - jbeda
+      - lavalamp
+      - liggitt
+      - smarterclayton
+      - thockin
+      - wojtek-t
   # go.{mod,sum} files relate to go dependencies, and should be reviewed by the
   # dep-approvers
   "go\\.(mod|sum)$":

--- a/OWNERS
+++ b/OWNERS
@@ -2,8 +2,12 @@
 
 filters:
   ".*":
-    reviewers: []
-    approvers: []
+    reviewers:
+      - dep-reviewers
+      - sig-architecture-approvers
+    approvers:
+      - dep-approvers # for go.mod/go.sum
+      - sig-architecture-approvers # for OWNERS_ALIASES and other root files
     emeritus_approvers:
       - bgrant0607
       - brendandburns

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,4 +1,6 @@
 aliases:
+  # Note: sig-architecture-approvers has approval on root files (including go.mod/go.sum) until https://github.com/kubernetes/test-infra/pull/21398 is resolved.
+  # People with approve rights via this alias should defer dependency update PRs to dep-approvers.
   sig-architecture-approvers:
     - dims
     - derekwaynecarr
@@ -462,6 +464,8 @@ aliases:
     - jayunit100
     - jsturtevant
     - marosset
+  # Note: dep-approvers has approval on root files (including OWNERS_ALIASES) until https://github.com/kubernetes/test-infra/pull/21398 is resolved.
+  # People with approve rights via this alias should defer updates of root files other than go.mod/go.sum to dep-approvers.
   dep-approvers:
     - BenTheElder
     - cblecker

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 reviewers:
   - bentheelder
   - cblecker

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -11,10 +11,12 @@ reviewers:
   - jeremyrickard # SIG Technical Lead / RelEng subproject owner
   #- justaugustus # SIG Chair / RelEng subproject owner / Release Manager - approvals only
   - lavalamp
+  - liggitt
   - palnabarun # Release Manager
   - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
   - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
   - spiffxp
+  - thockin
   - Verolop # Release Manager
   - xmudrii # Release Manager
 approvers:
@@ -23,8 +25,10 @@ approvers:
   - dims
   - justaugustus
   - lavalamp
+  - liggitt
   - mikedanese
   - spiffxp
+  - thockin
 emeritus_approvers:
   - fejta
   - jbeda

--- a/cluster/OWNERS
+++ b/cluster/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 reviewers:
   - bentheelder
   - cheftako

--- a/cluster/OWNERS
+++ b/cluster/OWNERS
@@ -8,14 +8,18 @@ reviewers:
   - cheftako
   - dims
   - justaugustus
+  - liggitt
   - mikedanese
   - spiffxp
+  - wojtek-t
 approvers:
   - bentheelder
   - cheftako
   - dims
+  - liggitt
   - mikedanese
   - spiffxp
+  - wojtek-t
 emeritus_approvers:
   - eparis
   - roberthbailey # 2019-03-08

--- a/cmd/OWNERS
+++ b/cmd/OWNERS
@@ -7,11 +7,17 @@ reviewers:
   - dchen1107
   - dims
   - lavalamp
+  - liggitt
   - mikedanese
+  - smarterclayton
   - thockin
+  - wojtek-t
 approvers:
   - dchen1107
   - dims
   - lavalamp
+  - liggitt
   - mikedanese
+  - smarterclayton
   - thockin
+  - wojtek-t

--- a/cmd/OWNERS
+++ b/cmd/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 reviewers:
   - dchen1107
   - lavalamp

--- a/cmd/OWNERS
+++ b/cmd/OWNERS
@@ -5,13 +5,13 @@ options:
   no_parent_owners: true
 reviewers:
   - dchen1107
+  - dims
   - lavalamp
   - mikedanese
   - thockin
-  - dims
 approvers:
   - dchen1107
+  - dims
   - lavalamp
   - mikedanese
   - thockin
-  - dims

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 reviewers:
   - smarterclayton
   - thockin

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 reviewers:
   - bentheelder
   - cblecker

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -6,16 +6,22 @@ options:
 reviewers:
   - bentheelder
   - cblecker
+  - dchen1107
   - hwdef
   - justaugustus
   - lavalamp
+  - liggitt
   - mikedanese
   - SataQiu
+  - smarterclayton
   - spiffxp
   - sttts
+  - thockin
+  - wojtek-t
 approvers:
   - bentheelder
   - cblecker
+  - dchen1107
   - deads2k
   - dims # for local-up-cluster related files
   - enj # for sig-auth related stuff like cert testdata
@@ -24,9 +30,12 @@ approvers:
   - mikedanese
   - pwittrock
   - SataQiu
+  - smarterclayton
   - soltysh # for sig-cli related stuff
   - spiffxp
   - sttts
+  - thockin
+  - wojtek-t
 emeritus_approvers:
   - eparis
   - fejta

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -9,10 +9,10 @@ reviewers:
   - hwdef
   - justaugustus
   - lavalamp
+  - mikedanese
   - SataQiu
   - spiffxp
   - sttts
-  - mikedanese
 approvers:
   - bentheelder
   - cblecker
@@ -21,12 +21,12 @@ approvers:
   - enj # for sig-auth related stuff like cert testdata
   - lavalamp
   - liggitt
+  - mikedanese
   - pwittrock
   - SataQiu
   - soltysh # for sig-cli related stuff
   - spiffxp
   - sttts
-  - mikedanese
 emeritus_approvers:
   - eparis
   - fejta

--- a/hack/update-vendor.sh
+++ b/hack/update-vendor.sh
@@ -419,6 +419,9 @@ rm -f "vendor/OWNERS"
 cat <<__EOF__ > "vendor/OWNERS"
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 approvers:
 - dep-approvers
 reviewers:

--- a/logo/OWNERS
+++ b/logo/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 reviewers:
   - thockin
 approvers:

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 reviewers:
   - dchen1107
   - dims

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -7,13 +7,17 @@ reviewers:
   - dchen1107
   - dims
   - lavalamp
+  - liggitt
   - smarterclayton
   - thockin
+  - wojtek-t
 approvers:
   - dchen1107
   - dims
   - lavalamp
+  - liggitt
   - smarterclayton
   - thockin
+  - wojtek-t
 emeritus_approvers:
   - brendandburns

--- a/plugin/OWNERS
+++ b/plugin/OWNERS
@@ -4,13 +4,13 @@ options:
   # make root approval non-recursive
   no_parent_owners: true
 reviewers:
-  - dims
   - dchen1107
+  - dims
   - lavalamp
   - thockin
 approvers:
-  - dims
   - dchen1107
+  - dims
   - lavalamp
   - thockin
 emeritus_approvers:

--- a/plugin/OWNERS
+++ b/plugin/OWNERS
@@ -7,12 +7,18 @@ reviewers:
   - dchen1107
   - dims
   - lavalamp
+  - liggitt
+  - smarterclayton
   - thockin
+  - wojtek-t
 approvers:
   - dchen1107
   - dims
   - lavalamp
+  - liggitt
+  - smarterclayton
   - thockin
+  - wojtek-t
 emeritus_approvers:
   - davidopp
   - brendandburns

--- a/plugin/OWNERS
+++ b/plugin/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 reviewers:
   - dims
   - dchen1107

--- a/staging/OWNERS
+++ b/staging/OWNERS
@@ -4,11 +4,16 @@ options:
   # make root approval non-recursive
   no_parent_owners: true
 approvers:
+  - dchen1107
   - dims
   - lavalamp
+  - liggitt
   - smarterclayton
+  - thockin
+  - wojtek-t
 reviewers:
   - caesarxuchao
+  - dchen1107
   - deads2k
   - dims
   - lavalamp
@@ -16,4 +21,5 @@ reviewers:
   - mikedanese
   - smarterclayton
   - sttts
+  - thockin
   - wojtek-t

--- a/staging/OWNERS
+++ b/staging/OWNERS
@@ -8,12 +8,12 @@ approvers:
   - lavalamp
   - smarterclayton
 reviewers:
+  - caesarxuchao
+  - deads2k
   - dims
   - lavalamp
-  - smarterclayton
-  - wojtek-t
-  - deads2k
-  - caesarxuchao
-  - mikedanese
   - liggitt
+  - mikedanese
+  - smarterclayton
   - sttts
+  - wojtek-t

--- a/staging/OWNERS
+++ b/staging/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 approvers:
   - dims
   - lavalamp

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 reviewers:
   - aojea
   - neolit123

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -5,8 +5,8 @@ options:
   no_parent_owners: true
 reviewers:
   - aojea
-  - neolit123
   - johnSchnake
+  - neolit123
   - SataQiu
 approvers:
   - andrewsykim
@@ -15,13 +15,13 @@ approvers:
   - bowei # for test/e2e/{dns*,network}.go
   - caseydavenport # for test/e2e/{dns*,network}.go
   - cblecker
-  - dims
-  - MrHohn
   - deads2k
+  - dims
   - enj
   - janetkuo
   - liggitt
   - mikedanese
+  - MrHohn
   - msau42
   - neolit123
   - oomichi

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -5,9 +5,15 @@ options:
   no_parent_owners: true
 reviewers:
   - aojea
+  - dchen1107
   - johnSchnake
+  - lavalamp
+  - liggitt
   - neolit123
   - SataQiu
+  - smarterclayton
+  - thockin
+  - wojtek-t
 approvers:
   - andrewsykim
   - aojea
@@ -15,10 +21,12 @@ approvers:
   - bowei # for test/e2e/{dns*,network}.go
   - caseydavenport # for test/e2e/{dns*,network}.go
   - cblecker
+  - dchen1107
   - deads2k
   - dims
   - enj
   - janetkuo
+  - lavalamp
   - liggitt
   - mikedanese
   - MrHohn
@@ -32,6 +40,8 @@ approvers:
   - smarterclayton
   - soltysh
   - sttts
+  - thockin
+  - wojtek-t
 emeritus_approvers:
   - eparis
   - foxish

--- a/third_party/OWNERS
+++ b/third_party/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 reviewers:
   - dims
   - lavalamp

--- a/vendor/OWNERS
+++ b/vendor/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
 approvers:
 - dep-approvers
 reviewers:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Restructures root approvers to be limited to files in the root directory (primarily OWNERS_ALIASES and dependency-related files).

Moves current root approvers down into relevant subdir OWNERS files.

Best reviewed commit by commit

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/112867

```release-note
NONE
```
