### PR TITLE
Reduce QOS cgroup update latency when creating multiple pods

### DIFF
--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
@@ -57,6 +59,7 @@ type qosContainerManagerImpl struct {
 	getNodeAllocatable func() v1.ResourceList
 	cgroupRoot         CgroupName
 	qosReserved        map[v1.ResourceName]int64
+	group              singleflight.Group
 }
 
 func NewQOSContainerManager(subsystems *CgroupSubsystems, cgroupRoot CgroupName, nodeConfig NodeConfig, cgroupManager CgroupManager) (QOSContainerManager, error) {
@@ -303,81 +306,92 @@ func (m *qosContainerManagerImpl) setMemoryQoS(configs map[v1.PodQOSClass]*Cgrou
 }
 
 func (m *qosContainerManagerImpl) UpdateCgroups() error {
-	m.Lock()
-	defer m.Unlock()
+	_, err, _ := m.group.Do("qos", func() (interface{}, error) {
+		m.Lock()
+		defer m.Unlock()
 
-	qosConfigs := map[v1.PodQOSClass]*CgroupConfig{
-		v1.PodQOSGuaranteed: {
-			Name:               m.qosContainersInfo.Guaranteed,
-			ResourceParameters: &ResourceConfig{},
-		},
-		v1.PodQOSBurstable: {
-			Name:               m.qosContainersInfo.Burstable,
-			ResourceParameters: &ResourceConfig{},
-		},
-		v1.PodQOSBestEffort: {
-			Name:               m.qosContainersInfo.BestEffort,
-			ResourceParameters: &ResourceConfig{},
-		},
-	}
+		// All update requests made until this point will wait for the current call.
+		// activePods callback is called after Forget, this ensures that pods
+		// added/removed before UpdateCgroups call are taken into account
+		// New update requests after Forget will trigger a new function invocation
+		// that will wait until the mutex that we acquired above is released
+		m.group.Forget("qos")
 
-	// update the qos level cgroup settings for cpu shares
-	if err := m.setCPUCgroupConfig(qosConfigs); err != nil {
-		return err
-	}
+		qosConfigs := map[v1.PodQOSClass]*CgroupConfig{
+			v1.PodQOSGuaranteed: {
+				Name:               m.qosContainersInfo.Guaranteed,
+				ResourceParameters: &ResourceConfig{},
+			},
+			v1.PodQOSBurstable: {
+				Name:               m.qosContainersInfo.Burstable,
+				ResourceParameters: &ResourceConfig{},
+			},
+			v1.PodQOSBestEffort: {
+				Name:               m.qosContainersInfo.BestEffort,
+				ResourceParameters: &ResourceConfig{},
+			},
+		}
 
-	// update the qos level cgroup settings for huge pages (ensure they remain unbounded)
-	if err := m.setHugePagesConfig(qosConfigs); err != nil {
-		return err
-	}
+		// update the qos level cgroup settings for cpu shares
+		if err := m.setCPUCgroupConfig(qosConfigs); err != nil {
+			return nil, err
+		}
 
-	// update the qos level cgrougs v2 settings of memory qos if feature enabled
-	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) &&
-		libcontainercgroups.IsCgroup2UnifiedMode() {
-		m.setMemoryQoS(qosConfigs)
-	}
+		// update the qos level cgroup settings for huge pages (ensure they remain unbounded)
+		if err := m.setHugePagesConfig(qosConfigs); err != nil {
+			return nil, err
+		}
 
-	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.QOSReserved) {
-		for resource, percentReserve := range m.qosReserved {
-			switch resource {
-			case v1.ResourceMemory:
-				m.setMemoryReserve(qosConfigs, percentReserve)
+		// update the qos level cgrougs v2 settings of memory qos if feature enabled
+		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) &&
+			libcontainercgroups.IsCgroup2UnifiedMode() {
+			m.setMemoryQoS(qosConfigs)
+		}
+
+		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.QOSReserved) {
+			for resource, percentReserve := range m.qosReserved {
+				switch resource {
+				case v1.ResourceMemory:
+					m.setMemoryReserve(qosConfigs, percentReserve)
+				}
+			}
+
+			updateSuccess := true
+			for _, config := range qosConfigs {
+				err := m.cgroupManager.Update(config)
+				if err != nil {
+					updateSuccess = false
+				}
+			}
+			if updateSuccess {
+				klog.V(4).InfoS("Updated QoS cgroup configuration")
+				return nil, nil
+			}
+
+			// If the resource can adjust the ResourceConfig to increase likelihood of
+			// success, call the adjustment function here.  Otherwise, the Update() will
+			// be called again with the same values.
+			for resource, percentReserve := range m.qosReserved {
+				switch resource {
+				case v1.ResourceMemory:
+					m.retrySetMemoryReserve(qosConfigs, percentReserve)
+				}
 			}
 		}
 
-		updateSuccess := true
 		for _, config := range qosConfigs {
 			err := m.cgroupManager.Update(config)
 			if err != nil {
-				updateSuccess = false
+				klog.ErrorS(err, "Failed to update QoS cgroup configuration")
+				return nil, err
 			}
 		}
-		if updateSuccess {
-			klog.V(4).InfoS("Updated QoS cgroup configuration")
-			return nil
-		}
 
-		// If the resource can adjust the ResourceConfig to increase likelihood of
-		// success, call the adjustment function here.  Otherwise, the Update() will
-		// be called again with the same values.
-		for resource, percentReserve := range m.qosReserved {
-			switch resource {
-			case v1.ResourceMemory:
-				m.retrySetMemoryReserve(qosConfigs, percentReserve)
-			}
-		}
-	}
+		klog.V(4).InfoS("Updated QoS cgroup configuration")
+		return nil, nil
+	})
 
-	for _, config := range qosConfigs {
-		err := m.cgroupManager.Update(config)
-		if err != nil {
-			klog.ErrorS(err, "Failed to update QoS cgroup configuration")
-			return err
-		}
-	}
-
-	klog.V(4).InfoS("Updated QoS cgroup configuration")
-	return nil
+	return err
 }
 
 type qosContainerManagerNoop struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When creating many pods (60+) on a node that is using systemd as a cgroup driver, there is added latency due to the way go-systemd and systemd behave. This addresses the issue by processing all QoS cgroup update requests in batches rather than one-by-one.

Below are the the results of tests done with k-bench on a single node cluster, with 100 pods created and 3 runs. 
The pod startup total latency on the server (measured as the difference between StartedAt and CreationTimestamp) is reduced to 3 seconds, down from 5 seconds.

<details>
<summary>Before</summary>

```
time="2022-07-19T11:27:32.473" level=info msg="**********************************************************************************************"
time="2022-07-19T11:27:32.473" level=info msg="**************************************** Pod Results ****************************************"
time="2022-07-19T11:27:32.473" level=info msg="**********************************************************************************************"
time="2022-07-19T11:27:32.473" level=info msg="------------------------------------ Pod Operation Summary -----------------------------------"
time="2022-07-19T11:27:32.473" level=info msg="Number of valid pod creation requests:             100       "
time="2022-07-19T11:27:32.473" level=info msg="Number of created pods:                            100       "
time="2022-07-19T11:27:32.473" level=info msg="Number of scheduled pods:                          100       "
time="2022-07-19T11:27:32.473" level=info msg="Number of initialized pods:                        100       "
time="2022-07-19T11:27:32.473" level=info msg="Number of started pods:                            100       "
time="2022-07-19T11:27:32.473" level=info msg="Number of running pods:                            100       "
time="2022-07-19T11:27:32.473" level=info msg="Pod creation throughput (pods/minutes):            983.50745 "
time="2022-07-19T11:27:32.473" level=info msg="Pod creation (client) average latency:             3.1747003 "
time="2022-07-19T11:27:32.473" level=info msg="--------------------------------- Pod Startup Latencies (ms) ---------------------------------"
time="2022-07-19T11:27:32.473" level=info msg="                                                   median     min        max        99%       "
time="2022-07-19T11:27:32.473" level=info msg="Pod creation latency stats (server):               0          0          0          0         "
time="2022-07-19T11:27:32.473" level=info msg="Pod scheduling latency stats (server):             0          0          0          0         "
time="2022-07-19T11:27:32.473" level=info msg="Pod image pulling latency stats (server):          2000       0          5000       5000      "
time="2022-07-19T11:27:32.473" level=info msg="Pod starting latency stats (server):               0          0          1000       1000      "
time="2022-07-19T11:27:32.473" level=info msg="Pod startup total latency (server):                2000       0          6000       5000      "
time="2022-07-19T11:27:32.474" level=info msg="Pod client-server e2e latency:                     3455.778   1381.443   6647.575   6644.716  "
time="2022-07-19T11:27:32.474" level=info msg="Pod scheduling latency stats (client):             11.499     1.358      17.873     16.61     "
time="2022-07-19T11:27:32.474" level=info msg="Pod initialization latency on kubelet (client):    150.965    9.574      487.309    480.966   "
time="2022-07-19T11:27:32.474" level=info msg="Pod starting latency stats (client):               2856.468   908.87396  5766.564   5737.752  "
time="2022-07-19T11:27:32.474" level=info msg="Pod startup total latency (client):                3050.3071  1040.531   6201.9307  6182.595  "
time="2022-07-19T11:27:32.474" level=info msg="--------------------------------- Pod API Call Latencies (ms) --------------------------------"
time="2022-07-19T11:27:32.474" level=info msg="                                                   median     min        max        99%       "
time="2022-07-19T11:27:32.474" level=info msg="delete pod latency:                                202.632    45.358     725.845    456.32602 "
time="2022-07-19T11:27:32.474" level=info msg="create pod latency:                                145.482    57.504     173.078    172.251   "
time="2022-07-19T11:27:32.474" level=info msg="Pod Creation Success Rate: 100 %"
time="2022-07-19T11:27:32.474" level=info msg="Benchmark run completed."
time="2022-07-19T11:30:27.090" level=info msg="**********************************************************************************************"
time="2022-07-19T11:30:27.090" level=info msg="**************************************** Pod Results ****************************************"
time="2022-07-19T11:30:27.090" level=info msg="**********************************************************************************************"
time="2022-07-19T11:30:27.090" level=info msg="------------------------------------ Pod Operation Summary -----------------------------------"
time="2022-07-19T11:30:27.090" level=info msg="Number of valid pod creation requests:             100       "
time="2022-07-19T11:30:27.090" level=info msg="Number of created pods:                            100       "
time="2022-07-19T11:30:27.091" level=info msg="Number of scheduled pods:                          100       "
time="2022-07-19T11:30:27.091" level=info msg="Number of initialized pods:                        100       "
time="2022-07-19T11:30:27.091" level=info msg="Number of started pods:                            100       "
time="2022-07-19T11:30:27.091" level=info msg="Number of running pods:                            100       "
time="2022-07-19T11:30:27.091" level=info msg="Pod creation throughput (pods/minutes):            1021.037  "
time="2022-07-19T11:30:27.091" level=info msg="Pod creation (client) average latency:             3.0919125 "
time="2022-07-19T11:30:27.091" level=info msg="--------------------------------- Pod Startup Latencies (ms) ---------------------------------"
time="2022-07-19T11:30:27.091" level=info msg="                                                   median     min        max        99%       "
time="2022-07-19T11:30:27.091" level=info msg="Pod creation latency stats (server):               0          0          0          0         "
time="2022-07-19T11:30:27.091" level=info msg="Pod scheduling latency stats (server):             0          0          0          0         "
time="2022-07-19T11:30:27.091" level=info msg="Pod image pulling latency stats (server):          2000       1000       5000       5000      "
time="2022-07-19T11:30:27.091" level=info msg="Pod starting latency stats (server):               0          0          1000       1000      "
time="2022-07-19T11:30:27.091" level=info msg="Pod startup total latency (server):                3000       1000       5000       5000      "
time="2022-07-19T11:30:27.091" level=info msg="Pod client-server e2e latency:                     3920.4219  1744.209   6154.9053  6154.5474 "
time="2022-07-19T11:30:27.091" level=info msg="Pod scheduling latency stats (client):             7.971      0.521      65.245     42.017    "
time="2022-07-19T11:30:27.091" level=info msg="Pod initialization latency on kubelet (client):    220.989    79.153     569.816    561.029   "
time="2022-07-19T11:30:27.091" level=info msg="Pod starting latency stats (client):               2707.777   589.88904  4667.413   4661.589  "
time="2022-07-19T11:30:27.091" level=info msg="Pod startup total latency (client):                2938.189   835.619    5148.065   5145.3857 "
time="2022-07-19T11:30:27.091" level=info msg="--------------------------------- Pod API Call Latencies (ms) --------------------------------"
time="2022-07-19T11:30:27.091" level=info msg="                                                   median     min        max        99%       "
time="2022-07-19T11:30:27.091" level=info msg="create pod latency:                                223.087    116.387    268.913    260.633   "
time="2022-07-19T11:30:27.091" level=info msg="delete pod latency:                                202.79102  45.247     433.24     381.586   "
time="2022-07-19T11:30:27.091" level=info msg="Pod Creation Success Rate: 100 %"
time="2022-07-19T11:30:27.091" level=info msg="Benchmark run completed."
time="2022-07-19T11:33:14.534" level=info msg="**********************************************************************************************"
time="2022-07-19T11:33:14.535" level=info msg="**************************************** Pod Results ****************************************"
time="2022-07-19T11:33:14.535" level=info msg="**********************************************************************************************"
time="2022-07-19T11:33:14.535" level=info msg="------------------------------------ Pod Operation Summary -----------------------------------"
time="2022-07-19T11:33:14.535" level=info msg="Number of valid pod creation requests:             100       "
time="2022-07-19T11:33:14.535" level=info msg="Number of created pods:                            100       "
time="2022-07-19T11:33:14.535" level=info msg="Number of scheduled pods:                          99        "
time="2022-07-19T11:33:14.535" level=info msg="Number of initialized pods:                        100       "
time="2022-07-19T11:33:14.535" level=info msg="Number of started pods:                            100       "
time="2022-07-19T11:33:14.535" level=info msg="Number of running pods:                            100       "
time="2022-07-19T11:33:14.535" level=info msg="Pod creation throughput (pods/minutes):            934.3367  "
time="2022-07-19T11:33:14.535" level=info msg="Pod creation (client) average latency:             3.3856149 "
time="2022-07-19T11:33:14.535" level=info msg="--------------------------------- Pod Startup Latencies (ms) ---------------------------------"
time="2022-07-19T11:33:14.535" level=info msg="                                                   median     min        max        99%       "
time="2022-07-19T11:33:14.535" level=info msg="Pod creation latency stats (server):               0          0          0          0         "
time="2022-07-19T11:33:14.535" level=info msg="Pod scheduling latency stats (server):             0          0          0          0         "
time="2022-07-19T11:33:14.535" level=info msg="Pod image pulling latency stats (server):          2000       0          5000       5000      "
time="2022-07-19T11:33:14.535" level=info msg="Pod starting latency stats (server):               0          0          1000       1000      "
time="2022-07-19T11:33:14.535" level=info msg="Pod startup total latency (server):                3000       0          6000       6000      "
time="2022-07-19T11:33:14.535" level=info msg="Pod client-server e2e latency:                     3637.699   1194.562   6615.043   6580.267  "
time="2022-07-19T11:33:14.535" level=info msg="Pod scheduling latency stats (client):             7.739      0.001      17.327     17.327    "
time="2022-07-19T11:33:14.535" level=info msg="Pod initialization latency on kubelet (client):    194.948    80.911     545.484    545.484   "
time="2022-07-19T11:33:14.535" level=info msg="Pod starting latency stats (client):               3054.752   699.206    5648.997   5614.9214 "
time="2022-07-19T11:33:14.535" level=info msg="Pod startup total latency (client):                3210.834   801.905    6132.14    6098.298  "
time="2022-07-19T11:33:14.535" level=info msg="--------------------------------- Pod API Call Latencies (ms) --------------------------------"
time="2022-07-19T11:33:14.535" level=info msg="                                                   median     min        max        99%       "
time="2022-07-19T11:33:14.535" level=info msg="create pod latency:                                162.046    47.705     209.82301  193.40701 "
time="2022-07-19T11:33:14.535" level=info msg="delete pod latency:                                203.462    47.792     500.202    211.44499 "
time="2022-07-19T11:33:14.535" level=info msg="Pod Creation Success Rate: 100 %"
time="2022-07-19T11:33:14.535" level=info msg="Benchmark run completed."
```

</details>

<details>
<summary>After</summary>

```
time="2022-07-19T11:39:22.202" level=info msg="**********************************************************************************************"
time="2022-07-19T11:39:22.202" level=info msg="**************************************** Pod Results ****************************************"
time="2022-07-19T11:39:22.202" level=info msg="**********************************************************************************************"
time="2022-07-19T11:39:22.202" level=info msg="------------------------------------ Pod Operation Summary -----------------------------------"
time="2022-07-19T11:39:22.202" level=info msg="Number of valid pod creation requests:             100       "
time="2022-07-19T11:39:22.202" level=info msg="Number of created pods:                            100       "
time="2022-07-19T11:39:22.202" level=info msg="Number of scheduled pods:                          0         "
time="2022-07-19T11:39:22.202" level=info msg="Number of initialized pods:                        88        "
time="2022-07-19T11:39:22.202" level=info msg="Number of started pods:                            100       "
time="2022-07-19T11:39:22.203" level=info msg="Number of running pods:                            100       "
time="2022-07-19T11:39:22.203" level=info msg="Pod creation throughput (pods/minutes):            936.3858  "
time="2022-07-19T11:39:22.203" level=info msg="Pod creation (client) average latency:             2.76927   "
time="2022-07-19T11:39:22.203" level=info msg="--------------------------------- Pod Startup Latencies (ms) ---------------------------------"
time="2022-07-19T11:39:22.203" level=info msg="                                                   median     min        max        99%       "
time="2022-07-19T11:39:22.203" level=info msg="Pod creation latency stats (server):               0          0          0          0         "
time="2022-07-19T11:39:22.203" level=info msg="Pod scheduling latency stats (server):             0          0          1000       1000      "
time="2022-07-19T11:39:22.203" level=info msg="Pod image pulling latency stats (server):          3000       1000       3000       3000      "
time="2022-07-19T11:39:22.203" level=info msg="Pod starting latency stats (server):               0          0          2000       2000      "
time="2022-07-19T11:39:22.203" level=info msg="Pod startup total latency (server):                3000       1000       3000       3000      "
time="2022-07-19T11:39:22.203" level=info msg="Pod client-server e2e latency:                     5365.912   2166.451   5555.488   5546.6987 "
time="2022-07-19T11:39:22.203" level=info msg="Pod scheduling latency stats (client):             ---        ---        ---        ---       "
time="2022-07-19T11:39:22.203" level=info msg="Pod initialization latency on kubelet (client):    ---        ---        ---        ---       "
time="2022-07-19T11:39:22.203" level=info msg="Pod starting latency stats (client):               3211.691   464.229    3387.74    3387.74   "
time="2022-07-19T11:39:22.203" level=info msg="Pod startup total latency (client):                3203.807   0.002      3387.741   3379.607  "
time="2022-07-19T11:39:22.203" level=info msg="--------------------------------- Pod API Call Latencies (ms) --------------------------------"
time="2022-07-19T11:39:22.203" level=info msg="                                                   median     min        max        99%       "
time="2022-07-19T11:39:22.203" level=info msg="create pod latency:                                174.427    79.999     235.50499  235.198   "
time="2022-07-19T11:39:22.203" level=info msg="delete pod latency:                                202.396    47.391     238.23     220.315   "
time="2022-07-19T11:39:22.203" level=info msg="Pod Creation Success Rate: 100 %"
time="2022-07-19T11:39:22.203" level=info msg="Benchmark run completed."
time="2022-07-19T11:43:25.316" level=info msg="**********************************************************************************************"
time="2022-07-19T11:43:25.316" level=info msg="**************************************** Pod Results ****************************************"
time="2022-07-19T11:43:25.316" level=info msg="**********************************************************************************************"
time="2022-07-19T11:43:25.316" level=info msg="------------------------------------ Pod Operation Summary -----------------------------------"
time="2022-07-19T11:43:25.316" level=info msg="Number of valid pod creation requests:             100       "
time="2022-07-19T11:43:25.316" level=info msg="Number of created pods:                            100       "
time="2022-07-19T11:43:25.316" level=info msg="Number of scheduled pods:                          0         "
time="2022-07-19T11:43:25.316" level=info msg="Number of initialized pods:                        100       "
time="2022-07-19T11:43:25.316" level=info msg="Number of started pods:                            100       "
time="2022-07-19T11:43:25.316" level=info msg="Number of running pods:                            100       "
time="2022-07-19T11:43:25.316" level=info msg="Pod creation throughput (pods/minutes):            965.09406 "
time="2022-07-19T11:43:25.316" level=info msg="Pod creation (client) average latency:             2.5098753 "
time="2022-07-19T11:43:25.316" level=info msg="--------------------------------- Pod Startup Latencies (ms) ---------------------------------"
time="2022-07-19T11:43:25.316" level=info msg="                                                   median     min        max        99%       "
time="2022-07-19T11:43:25.316" level=info msg="Pod creation latency stats (server):               0          0          0          0         "
time="2022-07-19T11:43:25.316" level=info msg="Pod scheduling latency stats (server):             0          0          0          0         "
time="2022-07-19T11:43:25.316" level=info msg="Pod image pulling latency stats (server):          2000       0          2000       2000      "
time="2022-07-19T11:43:25.316" level=info msg="Pod starting latency stats (server):               1000       0          1000       1000      "
time="2022-07-19T11:43:25.316" level=info msg="Pod startup total latency (server):                3000       1000       3000       3000      "
time="2022-07-19T11:43:25.316" level=info msg="Pod client-server e2e latency:                     5105.85    2421.942   5241.074   5231.061  "
time="2022-07-19T11:43:25.316" level=info msg="Pod scheduling latency stats (client):             ---        ---        ---        ---       "
time="2022-07-19T11:43:25.316" level=info msg="Pod initialization latency on kubelet (client):    ---        ---        ---        ---       "
time="2022-07-19T11:43:25.316" level=info msg="Pod starting latency stats (client):               3108.5042  425.572    3243.498   3234.603  "
time="2022-07-19T11:43:25.316" level=info msg="Pod startup total latency (client):                3108.5051  425.574    3243.499   3234.613  "
time="2022-07-19T11:43:25.316" level=info msg="--------------------------------- Pod API Call Latencies (ms) --------------------------------"
time="2022-07-19T11:43:25.316" level=info msg="                                                   median     min        max        99%       "
time="2022-07-19T11:43:25.316" level=info msg="create pod latency:                                141.106    85.861     179.797    179.788   "
time="2022-07-19T11:43:25.316" level=info msg="delete pod latency:                                203.028    46.158     482.775    465.185   "
time="2022-07-19T11:43:25.316" level=info msg="Pod Creation Success Rate: 100 %"
time="2022-07-19T11:43:25.317" level=info msg="Benchmark run completed."
time="2022-07-19T11:48:18.174" level=info msg="**********************************************************************************************"
time="2022-07-19T11:48:18.174" level=info msg="**************************************** Pod Results ****************************************"
time="2022-07-19T11:48:18.174" level=info msg="**********************************************************************************************"
time="2022-07-19T11:48:18.174" level=info msg="------------------------------------ Pod Operation Summary -----------------------------------"
time="2022-07-19T11:48:18.174" level=info msg="Number of valid pod creation requests:             100       "
time="2022-07-19T11:48:18.174" level=info msg="Number of created pods:                            100       "
time="2022-07-19T11:48:18.174" level=info msg="Number of scheduled pods:                          0         "
time="2022-07-19T11:48:18.174" level=info msg="Number of initialized pods:                        95        "
time="2022-07-19T11:48:18.174" level=info msg="Number of started pods:                            100       "
time="2022-07-19T11:48:18.174" level=info msg="Number of running pods:                            100       "
time="2022-07-19T11:48:18.174" level=info msg="Pod creation throughput (pods/minutes):            1249.7874 "
time="2022-07-19T11:48:18.174" level=info msg="Pod creation (client) average latency:             1.6006274 "
time="2022-07-19T11:48:18.174" level=info msg="--------------------------------- Pod Startup Latencies (ms) ---------------------------------"
time="2022-07-19T11:48:18.174" level=info msg="                                                   median     min        max        99%       "
time="2022-07-19T11:48:18.174" level=info msg="Pod creation latency stats (server):               0          0          0          0         "
time="2022-07-19T11:48:18.174" level=info msg="Pod scheduling latency stats (server):             0          0          0          0         "
time="2022-07-19T11:48:18.174" level=info msg="Pod image pulling latency stats (server):          3000       0          3000       3000      "
time="2022-07-19T11:48:18.175" level=info msg="Pod starting latency stats (server):               0          0          1000       1000      "
time="2022-07-19T11:48:18.175" level=info msg="Pod startup total latency (server):                3000       1000       3000       3000      "
time="2022-07-19T11:48:18.175" level=info msg="Pod client-server e2e latency:                     4487.1377  2086.833   4943.2646  4935.205  "
time="2022-07-19T11:48:18.175" level=info msg="Pod scheduling latency stats (client):             ---        ---        ---        ---       "
time="2022-07-19T11:48:18.175" level=info msg="Pod initialization latency on kubelet (client):    ---        ---        ---        ---       "
time="2022-07-19T11:48:18.175" level=info msg="Pod starting latency stats (client):               2422.707   111.743    2856.786   2856.786  "
time="2022-07-19T11:48:18.175" level=info msg="Pod startup total latency (client):                2400.408   0.001      2856.7869  2848.832  "
time="2022-07-19T11:48:18.175" level=info msg="--------------------------------- Pod API Call Latencies (ms) --------------------------------"
time="2022-07-19T11:48:18.175" level=info msg="                                                   median     min        max        99%       "
time="2022-07-19T11:48:18.175" level=info msg="create pod latency:                                342.484    72.707     400.17798  398.826   "
time="2022-07-19T11:48:18.175" level=info msg="delete pod latency:                                202.428    47.42      308.586    219.938   "
time="2022-07-19T11:48:18.175" level=info msg="Pod Creation Success Rate: 100 %"
time="2022-07-19T11:48:18.175" level=info msg="Benchmark run completed."
```

</details>

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
