### PR TITLE
e2e storage: proxy workarounds

### DIFF
--- a/test/e2e/storage/drivers/proxy/io.go
+++ b/test/e2e/storage/drivers/proxy/io.go
@@ -17,6 +17,7 @@ limitations under the License.
 package proxy
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io"
 
@@ -66,9 +67,23 @@ func (p PodDirIO) Mkdir(path string) error {
 }
 
 func (p PodDirIO) CreateFile(path string, content io.Reader) error {
-	_, stderr, err := p.execute([]string{"dd", "of=" + path}, content)
+	// Piping the content into dd via stdin turned out to be unreliable.
+	// Sometimes dd would stop after writing zero bytes, without an error
+	// from ExecWithOptions (reported as
+	// https://github.com/kubernetes/kubernetes/issues/112834).
+	//
+	// Therefore the content is now encoded inside the command itself.
+	data, err := io.ReadAll(content)
 	if err != nil {
-		return fmt.Errorf("dd of=%s: stderr=%q, %v", path, stderr, err)
+		return fmt.Errorf("read content: %v", err)
+	}
+	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
+	base64.StdEncoding.Encode(encoded, data)
+	_, stderr, err := p.execute([]string{"sh", "-c", fmt.Sprintf(`base64 -d >'%s' <<EOF
+%s
+EOF`, path, string(encoded))}, nil)
+	if err != nil {
+		return fmt.Errorf("decoding into %q: stderr=%q, %v", path, stderr, err)
 	}
 	return nil
 }
@@ -90,7 +105,7 @@ func (p PodDirIO) RemoveAll(path string) error {
 }
 
 func (p PodDirIO) execute(command []string, stdin io.Reader) (string, string, error) {
-	stdout, stderr, err := e2epod.ExecWithOptions(framework.ExecOptions{
+	stdout, stderr, err := e2epod.ExecWithOptions(p.F, e2epod.ExecOptions{
 		Command:       command,
 		Namespace:     p.Namespace,
 		PodName:       p.PodName,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

The new `CreateFile` turned out to suffer from some unreliable stdin handling. Logging the output of `dd` revealed that not all input data got written.

#### Special notes for your reviewer:

Currently only affects https://github.com/kubernetes/kubernetes/pull/111023

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
