### PR TITLE
Fix bug in which APIServerTracing did not work with some egress selectors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/tracing.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/tracing.go
@@ -101,11 +101,12 @@ func (o *TracingOptions) ApplyTo(es *egressselector.EgressSelector, c *server.Co
 		if err != nil {
 			return err
 		}
-
-		otelDialer := func(ctx context.Context, addr string) (net.Conn, error) {
-			return egressDialer(ctx, "tcp", addr)
+		if egressDialer != nil {
+			otelDialer := func(ctx context.Context, addr string) (net.Conn, error) {
+				return egressDialer(ctx, "tcp", addr)
+			}
+			opts = append(opts, otlptracegrpc.WithDialOption(grpc.WithContextDialer(otelDialer)))
 		}
-		opts = append(opts, otlptracegrpc.WithDialOption(grpc.WithContextDialer(otelDialer)))
 	}
 
 	resourceOpts := []resource.Option{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig instrumentation
/priority important-soon

#### What this PR does / why we need it:

Prevent the APIServer from panicking when an egress selector without a dialer is used.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/112976

#### Testing

I verified that test case added causes the API Server to panic as described in https://github.com/kubernetes/kubernetes/issues/112976, and that it no longer panics when the fix is applied.

#### Does this PR introduce a user-facing change?
```release-note
Fixed an issue where the APIServer would panic on startup if an egress selector without a controlplane configuration is specified when using APIServerTracing
```

/assign @logicalhan 