### PR TITLE
fix metric labels in cloud-provider metrics since it breaks static analysis

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/metrics/azure_metrics.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/metrics/azure_metrics.go
@@ -39,8 +39,8 @@ var (
 		"source",          // Operation source(optional)
 	}
 
-	apiMetrics       = registerAPIMetrics(metricLabels...)
-	operationMetrics = registerOperationMetrics(metricLabels...)
+	apiMetrics       = registerAPIMetrics()
+	operationMetrics = registerOperationMetrics()
 )
 
 // apiCallMetrics is the metrics measuring the performance of a single API call
@@ -109,7 +109,7 @@ func (mc *MetricContext) CountFailedOperation() {
 }
 
 // registerAPIMetrics registers the API metrics.
-func registerAPIMetrics(attributes ...string) *apiCallMetrics {
+func registerAPIMetrics() *apiCallMetrics {
 	metrics := &apiCallMetrics{
 		latency: metrics.NewHistogramVec(
 			&metrics.HistogramOpts{
@@ -119,7 +119,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 				Buckets:        []float64{.1, .25, .5, 1, 2.5, 5, 10, 15, 25, 50, 120, 300, 600, 1200},
 				StabilityLevel: metrics.ALPHA,
 			},
-			attributes,
+			metricLabels,
 		),
 		errors: metrics.NewCounterVec(
 			&metrics.CounterOpts{
@@ -128,7 +128,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 				Help:           "Number of errors for an Azure API call",
 				StabilityLevel: metrics.ALPHA,
 			},
-			attributes,
+			metricLabels,
 		),
 		rateLimitedCount: metrics.NewCounterVec(
 			&metrics.CounterOpts{
@@ -137,7 +137,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 				Help:           "Number of rate limited Azure API calls",
 				StabilityLevel: metrics.ALPHA,
 			},
-			attributes,
+			metricLabels,
 		),
 		throttledCount: metrics.NewCounterVec(
 			&metrics.CounterOpts{
@@ -146,7 +146,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 				Help:           "Number of throttled Azure API calls",
 				StabilityLevel: metrics.ALPHA,
 			},
-			attributes,
+			metricLabels,
 		),
 	}
 
@@ -159,7 +159,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 }
 
 // registerOperationMetrics registers the operation metrics.
-func registerOperationMetrics(attributes ...string) *operationCallMetrics {
+func registerOperationMetrics() *operationCallMetrics {
 	metrics := &operationCallMetrics{
 		operationLatency: metrics.NewHistogramVec(
 			&metrics.HistogramOpts{
@@ -169,7 +169,7 @@ func registerOperationMetrics(attributes ...string) *operationCallMetrics {
 				StabilityLevel: metrics.ALPHA,
 				Buckets:        []float64{0.1, 0.2, 0.5, 1, 10, 20, 30, 40, 50, 60, 100, 200, 300},
 			},
-			attributes,
+			metricLabels,
 		),
 		operationFailureCount: metrics.NewCounterVec(
 			&metrics.CounterOpts{
@@ -178,7 +178,7 @@ func registerOperationMetrics(attributes ...string) *operationCallMetrics {
 				Help:           "Number of failed Azure service operations",
 				StabilityLevel: metrics.ALPHA,
 			},
-			attributes,
+			metricLabels,
 		),
 	}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/metrics.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/metrics.go
@@ -46,7 +46,7 @@ var (
 		"version", // API version.
 	}
 
-	apiMetrics = registerAPIMetrics(metricLabels...)
+	apiMetrics = registerAPIMetrics()
 )
 
 type metricContext struct {
@@ -84,7 +84,7 @@ func newGenericMetricContext(prefix, request, region, zone, version string) *met
 }
 
 // registerApiMetrics adds metrics definitions for a category of API calls.
-func registerAPIMetrics(attributes ...string) *apiCallMetrics {
+func registerAPIMetrics() *apiCallMetrics {
 	metrics := &apiCallMetrics{
 		latency: metrics.NewHistogramVec(
 			&metrics.HistogramOpts{
@@ -92,7 +92,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 				Help:           "Latency of a GCE API call",
 				StabilityLevel: metrics.ALPHA,
 			},
-			attributes,
+			metricLabels,
 		),
 		errors: metrics.NewCounterVec(
 			&metrics.CounterOpts{
@@ -100,7 +100,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 				Help:           "Number of errors for an API call",
 				StabilityLevel: metrics.ALPHA,
 			},
-			attributes,
+			metricLabels,
 		),
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is a no-opt change. We're passing around a variable in a very weird way currently. 


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

Snippet of the static analysis failure:

```
./staging/src/k8s.io/legacy-cloud-providers/azure/metrics/azure_metrics.go:122:4: couldn't find variable for labels
./staging/src/k8s.io/legacy-cloud-providers/azure/metrics/azure_metrics.go:131:4: couldn't find variable for labels
./staging/src/k8s.io/legacy-cloud-providers/azure/metrics/azure_metrics.go:140:4: couldn't find variable for labels
./staging/src/k8s.io/legacy-cloud-providers/azure/metrics/azure_metrics.go:149:4: couldn't find variable for labels
./staging/src/k8s.io/legacy-cloud-providers/azure/metrics/azure_metrics.go:172:4: couldn't find variable for labels
./staging/src/k8s.io/legacy-cloud-providers/azure/metrics/azure_metrics.go:181:4: couldn't find variable for labels
./staging/src/k8s.io/legacy-cloud-providers/gce/metrics.go:95:4: couldn't find variable for labels
./staging/src/k8s.io/legacy-cloud-providers/gce/metrics.go:103:4: couldn't find variable for labels
```
