### PR TITLE
add support for timing histograms and const labels

### DIFF
--- a/test/instrumentation/metric.go
+++ b/test/instrumentation/metric.go
@@ -21,10 +21,11 @@ import (
 )
 
 const (
-	counterMetricType   = "Counter"
-	gaugeMetricType     = "Gauge"
-	histogramMetricType = "Histogram"
-	summaryMetricType   = "Summary"
+	counterMetricType    = "Counter"
+	gaugeMetricType      = "Gauge"
+	histogramMetricType  = "Histogram"
+	summaryMetricType    = "Summary"
+	timingRatioHistogram = "TimingRatioHistogram"
 )
 
 type metric struct {
@@ -41,6 +42,7 @@ type metric struct {
 	AgeBuckets        uint32              `yaml:"ageBuckets,omitempty"`
 	BufCap            uint32              `yaml:"bufCap,omitempty"`
 	MaxAge            int64               `yaml:"maxAge,omitempty"`
+	ConstLabels       map[string]string   `yaml:"constLabels,omitempty"`
 }
 
 func (m metric) buildFQName() string {

--- a/test/instrumentation/testdata/pkg/kubelet/metrics/metrics.go
+++ b/test/instrumentation/testdata/pkg/kubelet/metrics/metrics.go
@@ -63,6 +63,16 @@ const (
 	RunPodSandboxErrorsKey   = "run_podsandbox_errors_total"
 )
 
+const (
+	requestKind         = "request_kind"
+	priorityLevel       = "priority_level"
+	flowSchema          = "flow_schema"
+	phase               = "phase"
+	LabelNamePhase      = "phase"
+	LabelValueWaiting   = "waiting"
+	LabelValueExecuting = "executing"
+)
+
 var (
 	defObjectives = map[float64]float64{0.5: 0.5, 0.75: 0.75}
 	testBuckets   = []float64{0, 0.5, 1.0}
@@ -130,6 +140,35 @@ var (
 			Buckets:        metrics.DefBuckets,
 			StabilityLevel: metrics.ALPHA,
 		},
+	)
+	// PriorityLevelExecutionSeatsGaugeVec creates observers of seats occupied throughout execution for priority levels
+	PriorityLevelExecutionSeatsGaugeVec = metrics.NewTimingHistogramVec(
+		&metrics.TimingHistogramOpts{
+			Namespace: "namespace",
+			Subsystem: "subsystem",
+			Name:      "priority_level_seat_utilization",
+			Help:      "Observations, at the end of every nanosecond, of utilization of seats for any stage of execution (but only initial stage for WATCHes)",
+			// Buckets for both 0.99 and 1.0 mean PromQL's histogram_quantile will reveal saturation
+			Buckets:        []float64{0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1},
+			ConstLabels:    map[string]string{phase: "executing"},
+			StabilityLevel: metrics.BETA,
+		},
+		[]string{"priorityLevel"},
+	)
+
+	// PriorityLevelExecutionSeatsGaugeVec creates observers of seats occupied throughout execution for priority levels
+	TestConstLabels = metrics.NewTimingHistogramVec(
+		&metrics.TimingHistogramOpts{
+			Namespace: "test",
+			Subsystem: "const",
+			Name:      "label",
+			Help:      "Observations, at the end of every nanosecond, of utilization of seats for any stage of execution (but only initial stage for WATCHes)",
+			// Buckets for both 0.99 and 1.0 mean PromQL's histogram_quantile will reveal saturation
+			Buckets:        []float64{0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1},
+			ConstLabels:    map[string]string{"somestring": "executing", phase: "blah"},
+			StabilityLevel: metrics.BETA,
+		},
+		[]string{"priorityLevel"},
 	)
 	// PLEGRelistDuration is a Histogram that tracks the duration (in seconds) it takes for relisting pods in the Kubelet's
 	// Pod Lifecycle Event Generator (PLEG).

--- a/test/instrumentation/testdata/test-stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/test-stable-metrics-list.yaml
@@ -85,3 +85,54 @@
   - 2.5
   - 5
   - 10
+- name: priority_level_seat_utilization
+  subsystem: subsystem
+  namespace: namespace
+  help: Observations, at the end of every nanosecond, of utilization of seats for
+    any stage of execution (but only initial stage for WATCHes)
+  type: TimingRatioHistogram
+  stabilityLevel: BETA
+  labels:
+  - priorityLevel
+  buckets:
+  - 0
+  - 0.1
+  - 0.2
+  - 0.3
+  - 0.4
+  - 0.5
+  - 0.6
+  - 0.7
+  - 0.8
+  - 0.9
+  - 0.95
+  - 0.99
+  - 1
+  constLabels:
+    phase: executing
+- name: label
+  subsystem: const
+  namespace: test
+  help: Observations, at the end of every nanosecond, of utilization of seats for
+    any stage of execution (but only initial stage for WATCHes)
+  type: TimingRatioHistogram
+  stabilityLevel: BETA
+  labels:
+  - priorityLevel
+  buckets:
+  - 0
+  - 0.1
+  - 0.2
+  - 0.3
+  - 0.4
+  - 0.5
+  - 0.6
+  - 0.7
+  - 0.8
+  - 0.9
+  - 0.95
+  - 0.99
+  - 1
+  constLabels:
+    phase: blah
+    somestring: executing


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add support for timing histograms and const labels. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
