### PR TITLE
Add liggitt to dep-approvers alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -473,6 +473,7 @@ aliases:
     - thockin
     - sttts
     - soltysh
+    - liggitt
   dep-reviewers:
     - logicalhan
   feature-approvers:


### PR DESCRIPTION
/kind cleanup
/area code-organization
/sig architecture

doh, forgot I wasn't in the dep-approvers alias when completing https://github.com/kubernetes/kubernetes/pull/112952

```release-note
NONE
```

/assign @dims @johnbelamaric @derekwaynecarr 