### PR TITLE
To avoid the staticpod cannot be created after kl.syncTerminated fails

### DIFF
--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -960,7 +960,7 @@ func (p *podWorkers) managePodLoop(podUpdates <-chan podWork) {
 			// when the context is cancelled we expect an update to already be queued
 			klog.V(2).InfoS("Sync exited with context cancellation error", "pod", klog.KObj(pod), "podUID", pod.UID, "updateType", update.WorkType)
 
-		case err != nil:
+		case err != nil && update.WorkType != TerminatedPodWork:
 			// we will queue a retry
 			klog.ErrorS(err, "Error syncing pod, skipping", "pod", klog.KObj(pod), "podUID", pod.UID)
 


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
When we modify staticpod yaml, the new pod will be blocked before deleting the old pod(#104743). If kl.syncTerminated fails when deleting the old pod, the old pod won't be deleted anymore, and then the new pod won't be create anymore, and it is an irreparable problem unless you restart kubelet. But when executing kl.syncTerminated, the containers of the old pod have be deleted successfully in kl.syncTerminatingPod, kl.syncTerminated just deal the unmount valume and cgroups (when set cgroupsPerQOS true), they don't affect the creation of new pods. This situation should not block the operation of the new pod.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

/release-note-none
/priority backlog
/triage accepted
