### PR TITLE
Promote cronjob_job_creation_skew metric to stable

### DIFF
--- a/pkg/controller/cronjob/metrics/metrics.go
+++ b/pkg/controller/cronjob/metrics/metrics.go
@@ -29,9 +29,9 @@ var (
 	CronJobCreationSkew = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem:      CronJobControllerSubsystem,
-			Name:           "cronjob_job_creation_skew_duration_seconds",
+			Name:           "job_creation_skew_duration_seconds",
 			Help:           "Time between when a cronjob is scheduled to be run, and when the corresponding job is created",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.STABLE,
 			Buckets:        metrics.ExponentialBuckets(1, 2, 10),
 		},
 	)

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -1,3 +1,20 @@
+- name: job_creation_skew_duration_seconds
+  subsystem: cronjob_controller
+  help: Time between when a cronjob is scheduled to be run, and when the corresponding
+    job is created
+  type: Histogram
+  stabilityLevel: STABLE
+  buckets:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+  - 512
 - name: evictions_total
   subsystem: node_collector
   help: Number of Node evictions that happened since current instance of NodeController


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps

#### What this PR does / why we need it:
This should've been promoted along with the new cronjob controller, as part of https://github.com/kubernetes/enhancements/issues/19

#### Special notes for your reviewer:
/assign @atiratree 

#### Does this PR introduce a user-facing change?
```release-note
Promote cronjob_job_creation_skew metric to stable to follow the cronjob v2 controller, the following metrics had their name updated to match metrics API guidelines:
- cronjob_job_creation_skew_duration_seconds -> job_creation_skew_duration_seconds
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/19
```