### PR TITLE
Kubectl debug; add --security-context-from=(container)

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -547,6 +547,14 @@ func (o *DebugOptions) generateDebugContainer(pod *corev1.Pod) (*corev1.Pod, *co
 		if ec.SecurityContext == nil {
 			return nil, nil, fmt.Errorf("Container for SecurityContext not found")
 		}
+	} else {
+		// If the POD has runAsNonRoot:true a securityContext MUST be specified.
+		// Otherwise a non-runnable ephemeral container is created.
+		if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsNonRoot != nil {
+			if *pod.Spec.SecurityContext.RunAsNonRoot {
+				return nil, nil, fmt.Errorf("Must have a SecurityContext when POD has runAsNonRoot:true")
+			}
+		}
 	}
 
 	if o.ArgsOnly {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Makes it possible to inject an ephemeral container with `kubectl debug` when the POD has securityContext `runAsNonRoot: true`.

#### Which issue(s) this PR fixes:

Fixes #113006

#### Special notes for your reviewer:

The rationale for copying the securityContext from an existing container is that a common use-case is when you _could_ have debugged from an existing container (security wise) if it just had the tools (like a shell). (and it was simple :smile: )

To debug the example from #113006 do;
```
pod=$(kubectl get pods -l app=alpine-noroot -o name | head -1)
kubectl debug --container adebug --image docker.io/library/alpine:latest --security-context-from=alpine $pod -it -- sh
(works)
```


#### Does this PR introduce a user-facing change?

```release-note
Add `--security-context-from=(container)` for kubectl debug
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

