### PR TITLE
Promote job metrics

### DIFF
--- a/pkg/controller/job/metrics/metrics.go
+++ b/pkg/controller/job/metrics/metrics.go
@@ -37,7 +37,7 @@ var (
 			Subsystem:      JobControllerSubsystem,
 			Name:           "job_sync_duration_seconds",
 			Help:           "The time it took to sync a job",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.STABLE,
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 		},
 		[]string{"completion_mode", "result", "action"},
@@ -49,9 +49,9 @@ var (
 	JobSyncNum = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      JobControllerSubsystem,
-			Name:           "job_sync_total",
+			Name:           "job_syncs_total",
 			Help:           "The number of job syncs",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.STABLE,
 		},
 		[]string{"completion_mode", "result", "action"},
 	)
@@ -64,9 +64,9 @@ var (
 	JobFinishedNum = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      JobControllerSubsystem,
-			Name:           "job_finished_total",
-			Help:           "The number of finished job",
-			StabilityLevel: metrics.ALPHA,
+			Name:           "jobs_finished_total",
+			Help:           "The number of finished jobs",
+			StabilityLevel: metrics.STABLE,
 		},
 		[]string{"completion_mode", "result", "reason"},
 	)
@@ -80,9 +80,10 @@ var (
 	//   result:          failed, succeeded
 	JobPodsFinished = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Subsystem: JobControllerSubsystem,
-			Name:      "job_pods_finished_total",
-			Help:      "The number of finished Pods that are fully tracked",
+			Subsystem:      JobControllerSubsystem,
+			Name:           "job_pods_finished_total",
+			Help:           "The number of finished Pods that are fully tracked",
+			StabilityLevel: metrics.STABLE,
 		},
 		[]string{"completion_mode", "result"})
 

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -15,6 +15,57 @@
   - 128
   - 256
   - 512
+- name: job_pods_finished_total
+  subsystem: job_controller
+  help: The number of finished Pods that are fully tracked
+  type: Counter
+  stabilityLevel: STABLE
+  labels:
+  - completion_mode
+  - result
+- name: job_sync_duration_seconds
+  subsystem: job_controller
+  help: The time it took to sync a job
+  type: Histogram
+  stabilityLevel: STABLE
+  labels:
+  - action
+  - completion_mode
+  - result
+  buckets:
+  - 0.001
+  - 0.002
+  - 0.004
+  - 0.008
+  - 0.016
+  - 0.032
+  - 0.064
+  - 0.128
+  - 0.256
+  - 0.512
+  - 1.024
+  - 2.048
+  - 4.096
+  - 8.192
+  - 16.384
+- name: job_syncs_total
+  subsystem: job_controller
+  help: The number of job syncs
+  type: Counter
+  stabilityLevel: STABLE
+  labels:
+  - action
+  - completion_mode
+  - result
+- name: jobs_finished_total
+  subsystem: job_controller
+  help: The number of finished jobs
+  type: Counter
+  stabilityLevel: STABLE
+  labels:
+  - completion_mode
+  - reason
+  - result
 - name: evictions_total
   subsystem: node_collector
   help: Number of Node evictions that happened since current instance of NodeController


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps

#### What this PR does / why we need it:
This should've been promoted along with the new cronjob controller, as part of https://github.com/kubernetes/enhancements/issues/2214

#### Special notes for your reviewer:
/assign @alculquicondor 

#### Does this PR introduce a user-facing change?
```release-note
Promote  job-related metrics to stable to follow IndexedJobs GA, the following metrics had their name updated to match metrics API guidelines:
- job_sync_total -> job_syncs_total
- job_finished_total -> jobs_finished_total
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2214
```
