### PR TITLE
kubelet: fix nil crash in allocateRemainingFrom

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -564,14 +564,14 @@ func (m *ManagerImpl) devicesToAllocate(podUID, contName, resource string, requi
 		return false
 	}
 
-	// Allocates from reusableDevices list first.
-	if allocateRemainingFrom(reusableDevices) {
-		return allocated, nil
-	}
-
 	// Needs to allocate additional devices.
 	if m.allocatedDevices[resource] == nil {
 		m.allocatedDevices[resource] = sets.NewString()
+	}
+
+	// Allocates from reusableDevices list first.
+	if allocateRemainingFrom(reusableDevices) {
+		return allocated, nil
 	}
 
 	// Gets Devices in use.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
[allocateRemainingFrom](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/devicemanager/manager.go#L555) uses `allocatedDevices` which needs to be allocated. The function calls allocateRemainingFrom before the nil check. Reverse the order of operations so the set is allocated prior to calling allocateRemainingFrom.

#### Which issue(s) this PR fixes:
Fixes #112936

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubelet: Fixes a startup crash in devicemanager
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
