### PR TITLE
unparameterize 'webhook' from conversion metrics since it's the only one

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/converter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/converter.go
@@ -37,7 +37,7 @@ type CRConverterFactory struct {
 
 // converterMetricFactorySingleton protects us from reregistration of metrics on repeated
 // apiextensions-apiserver runs.
-var converterMetricFactorySingleton = newConverterMertricFactory()
+var converterMetricFactorySingleton = newConverterMetricFactory()
 
 // NewCRConverterFactory creates a new CRConverterFactory
 func NewCRConverterFactory(serviceResolver webhook.ServiceResolver, authResolverWrapper webhook.AuthenticationInfoResolverWrapper) (*CRConverterFactory, error) {
@@ -66,7 +66,7 @@ func (m *CRConverterFactory) NewConverter(crd *apiextensionsv1.CustomResourceDef
 		if err != nil {
 			return nil, nil, err
 		}
-		converter, err = converterMetricFactorySingleton.addMetrics("webhook", crd.Name, converter)
+		converter, err = converterMetricFactorySingleton.addMetrics(crd.Name, converter)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/metrics.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/metrics.go
@@ -17,7 +17,6 @@ limitations under the License.
 package conversion
 
 import (
-	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -40,7 +39,7 @@ type converterMetricFactory struct {
 	factoryLock sync.Mutex
 }
 
-func newConverterMertricFactory() *converterMetricFactory {
+func newConverterMetricFactory() *converterMetricFactory {
 	return &converterMetricFactory{durations: map[string]*metrics.HistogramVec{}, factoryLock: sync.Mutex{}}
 }
 
@@ -52,15 +51,15 @@ type converterMetric struct {
 	crdName   string
 }
 
-func (c *converterMetricFactory) addMetrics(converterName string, crdName string, converter crConverterInterface) (crConverterInterface, error) {
+func (c *converterMetricFactory) addMetrics(crdName string, converter crConverterInterface) (crConverterInterface, error) {
 	c.factoryLock.Lock()
 	defer c.factoryLock.Unlock()
-	metric, exists := c.durations[converterName]
+	metric, exists := c.durations["webhook"]
 	if !exists {
 		metric = metrics.NewHistogramVec(
 			&metrics.HistogramOpts{
-				Name:           fmt.Sprintf("apiserver_crd_%s_conversion_duration_seconds", converterName),
-				Help:           fmt.Sprintf("CRD %s conversion duration in seconds", converterName),
+				Name:           "apiserver_crd_webhook_conversion_duration_seconds",
+				Help:           "CRD webhook conversion duration in seconds",
 				Buckets:        latencyBuckets,
 				StabilityLevel: metrics.ALPHA,
 			},
@@ -69,7 +68,7 @@ func (c *converterMetricFactory) addMetrics(converterName string, crdName string
 		if err != nil {
 			return nil, err
 		}
-		c.durations[converterName] = metric
+		c.durations["webhook"] = metric
 	}
 	return &converterMetric{latencies: metric, delegate: converter, crdName: crdName}, nil
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Currently static analysis chokes on this metric due to the dynamic construction of the metric name. However, this function is actually only ever called a single time, which means we don't have to parameterize 'webhook' as a part of the function call. This PR simplifies the code and allows it to be parsed via static analysis.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

Snippet of static analysis choking:

```
./staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/metrics.go:62:5: Non string attribute is not supported
```