### PR TITLE
minor fix to ContainsString

### DIFF
--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -43,9 +43,14 @@ func SortStrings(s []string) []string {
 // If a modifier func is provided, it is called with the slice item before the comparation.
 func ContainsString(slice []string, s string, modifier func(s string) string) bool {
 	for _, item := range slice {
-		if item == s {
-			return true
+		if modifier == nil {
+			if item == s {
+				return true
+			}
+			continue
 		}
+
+		// modifer present
 		if modifier != nil && modifier(item) == s {
 			return true
 		}

--- a/pkg/util/slice/slice_test.go
+++ b/pkg/util/slice/slice_test.go
@@ -64,24 +64,60 @@ func TestSortStrings(t *testing.T) {
 }
 
 func TestContainsString(t *testing.T) {
-	src := []string{"aa", "bb", "cc"}
-	if !ContainsString(src, "bb", nil) {
-		t.Errorf("ContainsString didn't find the string as expected")
+	testCases := []struct {
+		name           string
+		expectedResult bool
+		strings        []string
+		find           string
+		modifier       func(s string) string
+	}{
+		{
+			name:           "string-existent-no-modifier",
+			expectedResult: true,
+			strings:        []string{"foo", "bar", "baz"},
+			find:           "foo",
+			modifier:       nil,
+		},
+		{
+			name:           "string-non-existent-no-modifier",
+			expectedResult: false,
+			strings:        []string{"foo", "bar", "baz"},
+			find:           "not-foo",
+			modifier:       nil,
+		},
+		{
+			name:           "string-existent-via-modifier",
+			expectedResult: true,
+			strings:        []string{"foo", "bar", "baz"},
+			find:           "foo-baz",
+			modifier: func(in string) string {
+				if in == "foo" {
+					return "foo-baz"
+				}
+				return "something-else"
+			},
+		},
+		{
+			name:           "string-existent-but-not-with-modifier",
+			expectedResult: false,
+			strings:        []string{"foo", "bar", "baz"},
+			find:           "foo",
+			modifier: func(in string) string {
+				if in == "foo" {
+					return "foo-baz"
+				}
+				return "something-else"
+			},
+		},
 	}
 
-	modifier := func(s string) string {
-		if s == "cc" {
-			return "ee"
-		}
-		return s
-	}
-	if !ContainsString(src, "ee", modifier) {
-		t.Errorf("ContainsString didn't find the string by modifier")
-	}
-
-	src = make([]string, 0)
-	if ContainsString(src, "", nil) {
-		t.Errorf("The result returned is not the expected result")
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			res := ContainsString(testCase.strings, testCase.find, testCase.modifier)
+			if res != testCase.expectedResult {
+				t.Fatalf("test:%v failed expected %v got %v", testCase.name, testCase.expectedResult, res)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`ContainString()` does not work as advertised. And the reason we don't see an issue out of it is nobody is using the `modifier` yet. 
#### Which issue(s) this PR fixes:

An issue was not filed against this behavior. Let me know if we need to file one

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A