### PR TITLE
remove invalid handling for fsVomule when mount volume

### DIFF
--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -948,10 +948,11 @@ func (oe *operationExecutor) MountVolume(
 		// Creates a map to device if a volume is attached
 		generatedOperations, err = oe.operationGenerator.GenerateMapVolumeFunc(
 			waitForAttachTimeout, volumeToMount, actualStateOfWorld)
+		if err != nil {
+			return err
+		}
 	}
-	if err != nil {
-		return err
-	}
+
 	// Avoid executing mount/map from multiple pods referencing the
 	// same volume in parallel
 	podName := nestedpendingoperations.EmptyUniquePodName


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
For fsVolume, there is no err of GenerateMountVolumeFunc, so remove error handling.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

