### PR TITLE
rollout restart: Change error message to more descriptive

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go
@@ -18,7 +18,6 @@ package rollout
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -183,7 +182,8 @@ func (o RestartOptions) RunRestart() error {
 		}
 
 		if string(patch.Patch) == "{}" || len(patch.Patch) == 0 {
-			allErrs = append(allErrs, fmt.Errorf("failed to create patch for %v: empty patch", info.Name))
+			allErrs = append(allErrs, fmt.Errorf("failed to create patch for %v: if restart has already been triggered within the past second, please wait before attempting to trigger another", info.Name))
+			continue
 		}
 
 		obj, err := resource.NewHelper(info.Client, info.Mapping).

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart_test.go
@@ -88,7 +88,7 @@ func TestRolloutRestartError(t *testing.T) {
 				case p == "/namespaces/test/deployments/nginx-deployment" && (m == "GET" || m == "PATCH"):
 					responseDeployment := &appsv1.Deployment{}
 					responseDeployment.Name = deploymentName
-					body := ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(encoder, responseDeployment))))
+					body := io.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(encoder, responseDeployment))))
 					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: body}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`rollout restart` command calculates patches according to the
`kubectl.kubernetes.io/restartedAt` annotation whose time format is
RFC3339. That is sufficient for users. However, if automated scripts
execute `rollout restart` in multiple times within second, commands fails
by returning an error "empty patch".

This PR changes error message to more descriptive format to warn users
that rollout restart does not work subsequent execution within second.


#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1268

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
changing the error message of kubectl rollout restart when subsequent kubectl rollout restart commands are executed within a second
```