### PR TITLE
Add capability for tests with multiple PVs with the same VolumeHandle

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -149,6 +149,7 @@ func InitHostPathCSIDriver() storageframework.TestDriver {
 		storageframework.CapOnlineExpansion:     true,
 		storageframework.CapSingleNodeVolume:    true,
 		storageframework.CapReadWriteOncePod:    true,
+		storageframework.CapMultiplePVsSameID:   true,
 
 		// This is needed for the
 		// testsuites/volumelimits.go `should support volume limits`
@@ -487,10 +488,11 @@ func InitMockCSIDriver(driverOpts CSIMockDriverOpts) MockCSITestDriver {
 				"", // Default fsType
 			),
 			Capabilities: map[storageframework.Capability]bool{
-				storageframework.CapPersistence:  false,
-				storageframework.CapFsGroup:      false,
-				storageframework.CapExec:         false,
-				storageframework.CapVolumeLimits: true,
+				storageframework.CapPersistence:       false,
+				storageframework.CapFsGroup:           false,
+				storageframework.CapExec:              false,
+				storageframework.CapVolumeLimits:      true,
+				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
 		manifests:              driverManifests,
@@ -807,6 +809,7 @@ func InitGcePDCSIDriver() storageframework.TestDriver {
 				storageframework.CapNodeExpansion:       true,
 				storageframework.CapSnapshotDataSource:  true,
 				storageframework.CapReadWriteOncePod:    true,
+				storageframework.CapMultiplePVsSameID:   true,
 			},
 			RequiredAccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 			TopologyKeys:        []string{GCEPDCSIZoneTopologyKey},

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -105,10 +105,11 @@ func InitNFSDriver() storageframework.TestDriver {
 			SupportedMountOption: sets.NewString("relatime"),
 			RequiredMountOption:  sets.NewString("vers=4.1"),
 			Capabilities: map[storageframework.Capability]bool{
-				storageframework.CapPersistence: true,
-				storageframework.CapExec:        true,
-				storageframework.CapRWX:         true,
-				storageframework.CapMultiPODs:   true,
+				storageframework.CapPersistence:       true,
+				storageframework.CapExec:              true,
+				storageframework.CapRWX:               true,
+				storageframework.CapMultiPODs:         true,
+				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
 	}
@@ -249,12 +250,13 @@ func InitISCSIDriver() storageframework.TestDriver {
 			),
 			TopologyKeys: []string{v1.LabelHostname},
 			Capabilities: map[storageframework.Capability]bool{
-				storageframework.CapPersistence: true,
-				storageframework.CapFsGroup:     true,
-				storageframework.CapBlock:       true,
-				storageframework.CapExec:        true,
-				storageframework.CapMultiPODs:   true,
-				storageframework.CapTopology:    true,
+				storageframework.CapPersistence:       true,
+				storageframework.CapFsGroup:           true,
+				storageframework.CapBlock:             true,
+				storageframework.CapExec:              true,
+				storageframework.CapMultiPODs:         true,
+				storageframework.CapTopology:          true,
+				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
 	}
@@ -431,11 +433,12 @@ func InitRbdDriver() storageframework.TestDriver {
 				"ext4",
 			),
 			Capabilities: map[storageframework.Capability]bool{
-				storageframework.CapPersistence: true,
-				storageframework.CapFsGroup:     true,
-				storageframework.CapBlock:       true,
-				storageframework.CapExec:        true,
-				storageframework.CapMultiPODs:   true,
+				storageframework.CapPersistence:       true,
+				storageframework.CapFsGroup:           true,
+				storageframework.CapBlock:             true,
+				storageframework.CapExec:              true,
+				storageframework.CapMultiPODs:         true,
+				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
 	}
@@ -559,10 +562,11 @@ func InitCephFSDriver() storageframework.TestDriver {
 				"", // Default fsType
 			),
 			Capabilities: map[storageframework.Capability]bool{
-				storageframework.CapPersistence: true,
-				storageframework.CapExec:        true,
-				storageframework.CapRWX:         true,
-				storageframework.CapMultiPODs:   true,
+				storageframework.CapPersistence:       true,
+				storageframework.CapExec:              true,
+				storageframework.CapRWX:               true,
+				storageframework.CapMultiPODs:         true,
+				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
 	}
@@ -662,10 +666,11 @@ func InitHostPathDriver() storageframework.TestDriver {
 			),
 			TopologyKeys: []string{v1.LabelHostname},
 			Capabilities: map[storageframework.Capability]bool{
-				storageframework.CapPersistence:      true,
-				storageframework.CapMultiPODs:        true,
-				storageframework.CapSingleNodeVolume: true,
-				storageframework.CapTopology:         true,
+				storageframework.CapPersistence:       true,
+				storageframework.CapMultiPODs:         true,
+				storageframework.CapSingleNodeVolume:  true,
+				storageframework.CapTopology:          true,
+				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
 	}
@@ -737,10 +742,11 @@ func InitHostPathSymlinkDriver() storageframework.TestDriver {
 			),
 			TopologyKeys: []string{v1.LabelHostname},
 			Capabilities: map[storageframework.Capability]bool{
-				storageframework.CapPersistence:      true,
-				storageframework.CapMultiPODs:        true,
-				storageframework.CapSingleNodeVolume: true,
-				storageframework.CapTopology:         true,
+				storageframework.CapPersistence:       true,
+				storageframework.CapMultiPODs:         true,
+				storageframework.CapSingleNodeVolume:  true,
+				storageframework.CapTopology:          true,
+				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
 	}
@@ -966,8 +972,9 @@ func InitGcePdDriver() storageframework.TestDriver {
 				storageframework.CapNodeExpansion:       true,
 				// GCE supports volume limits, but the test creates large
 				// number of volumes and times out test suites.
-				storageframework.CapVolumeLimits: false,
-				storageframework.CapTopology:     true,
+				storageframework.CapVolumeLimits:      false,
+				storageframework.CapTopology:          true,
+				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
 	}
@@ -998,8 +1005,9 @@ func InitWindowsGcePdDriver() storageframework.TestDriver {
 				storageframework.CapMultiPODs:           true,
 				// GCE supports volume limits, but the test creates large
 				// number of volumes and times out test suites.
-				storageframework.CapVolumeLimits: false,
-				storageframework.CapTopology:     true,
+				storageframework.CapVolumeLimits:      false,
+				storageframework.CapTopology:          true,
+				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
 	}
@@ -1136,12 +1144,13 @@ func InitVSphereDriver() storageframework.TestDriver {
 			),
 			TopologyKeys: []string{v1.LabelFailureDomainBetaZone},
 			Capabilities: map[storageframework.Capability]bool{
-				storageframework.CapPersistence: true,
-				storageframework.CapFsGroup:     true,
-				storageframework.CapExec:        true,
-				storageframework.CapMultiPODs:   true,
-				storageframework.CapTopology:    true,
-				storageframework.CapBlock:       true,
+				storageframework.CapPersistence:       true,
+				storageframework.CapFsGroup:           true,
+				storageframework.CapExec:              true,
+				storageframework.CapMultiPODs:         true,
+				storageframework.CapTopology:          true,
+				storageframework.CapBlock:             true,
+				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
 	}
@@ -1282,8 +1291,9 @@ func InitAzureDiskDriver() storageframework.TestDriver {
 				storageframework.CapMultiPODs:   true,
 				// Azure supports volume limits, but the test creates large
 				// number of volumes and times out test suites.
-				storageframework.CapVolumeLimits: false,
-				storageframework.CapTopology:     true,
+				storageframework.CapVolumeLimits:      false,
+				storageframework.CapTopology:          true,
+				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
 	}
@@ -1431,8 +1441,9 @@ func InitAwsDriver() storageframework.TestDriver {
 				storageframework.CapOnlineExpansion:     true,
 				// AWS supports volume limits, but the test creates large
 				// number of volumes and times out test suites.
-				storageframework.CapVolumeLimits: false,
-				storageframework.CapTopology:     true,
+				storageframework.CapVolumeLimits:      false,
+				storageframework.CapTopology:          true,
+				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
 	}
@@ -1551,21 +1562,23 @@ type localVolume struct {
 var (
 	// capabilities
 	defaultLocalVolumeCapabilities = map[storageframework.Capability]bool{
-		storageframework.CapPersistence:      true,
-		storageframework.CapFsGroup:          true,
-		storageframework.CapBlock:            false,
-		storageframework.CapExec:             true,
-		storageframework.CapMultiPODs:        true,
-		storageframework.CapSingleNodeVolume: true,
+		storageframework.CapPersistence:       true,
+		storageframework.CapFsGroup:           true,
+		storageframework.CapBlock:             false,
+		storageframework.CapExec:              true,
+		storageframework.CapMultiPODs:         true,
+		storageframework.CapSingleNodeVolume:  true,
+		storageframework.CapMultiplePVsSameID: true,
 	}
 	localVolumeCapabitilies = map[utils.LocalVolumeType]map[storageframework.Capability]bool{
 		utils.LocalVolumeBlock: {
-			storageframework.CapPersistence:      true,
-			storageframework.CapFsGroup:          true,
-			storageframework.CapBlock:            true,
-			storageframework.CapExec:             true,
-			storageframework.CapMultiPODs:        true,
-			storageframework.CapSingleNodeVolume: true,
+			storageframework.CapPersistence:       true,
+			storageframework.CapFsGroup:           true,
+			storageframework.CapBlock:             true,
+			storageframework.CapExec:              true,
+			storageframework.CapMultiPODs:         true,
+			storageframework.CapSingleNodeVolume:  true,
+			storageframework.CapMultiplePVsSameID: true,
 		},
 	}
 	// fstype
@@ -1796,6 +1809,7 @@ func InitAzureFileDriver() storageframework.TestDriver {
 				storageframework.CapMultiPODs:           true,
 				storageframework.CapControllerExpansion: true,
 				storageframework.CapNodeExpansion:       true,
+				storageframework.CapMultiplePVsSameID:   true,
 			},
 		},
 	}

--- a/test/e2e/storage/framework/testdriver.go
+++ b/test/e2e/storage/framework/testdriver.go
@@ -190,6 +190,16 @@ const (
 	// - csi-attacher:v3.3.0+
 	// - csi-resizer:v1.3.0+
 	CapReadWriteOncePod Capability = "readWriteOncePod"
+
+	// The driver can handle two PersistentVolumes with the same VolumeHandle (= volume_id in CSI spec).
+	// This capability is highly recommended for volumes that support ReadWriteMany access mode,
+	// because creating multiple PVs for the same VolumeHandle is frequently used to share a single
+	// volume among multiple namespaces.
+	// Note that this capability needs to be disabled only for CSI drivers that break CSI boundary and
+	// inspect Kubernetes PersistentVolume objects. A CSI driver that implements only CSI and does not
+	// talk to Kubernetes API server in any way should keep this capability enabled, because
+	// they will see the same NodeStage / NodePublish requests as if only one PV existed.
+	CapMultiplePVsSameID Capability = "multiplePVsSameID"
 )
 
 // DriverInfo represents static information about a TestDriver.

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -530,6 +530,10 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 			e2eskipper.Skipf("skipping multiple PV mount test for block mode")
 		}
 
+		if !dInfo.Capabilities[storageframework.CapMultiplePVsSameID] {
+			e2eskipper.Skipf("this driver does not support multiple PVs with the same volumeHandle")
+		}
+
 		init()
 		defer cleanup()
 


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Some CSI drivers do not like multiple PVs with the same VolumeHandle and test `should mount multiple PV pointing to the same storage on the same node` fails for them. Make the tests opt-in, i.e. add test capability `multiplePVsSameID` that's disabled by default.

I enabled the capability for all known test drivers we have in-tree - the test was enabled until now and it passed in all volume plugins / CSI driver tests we have in Kubernetes CI.

The test was added in https://github.com/kubernetes/kubernetes/pull/107065, testing Kubernetes ability to handle such scenario (two PVs with the same VolumeHandle mounted to the same node).

#### Which issue(s) this PR fixes:
Helps with https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/1913

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

cc @kubernetes/sig-storage-pr-reviews 
