### PR TITLE
Promote Read, Replace ReplicationController scale endpoints Conformance - +2 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -903,6 +903,14 @@
     Pod or delete and replace it with a new Pod
   release: v1.13
   file: test/e2e/apps/rc.go
+- testname: Replication Controller, get and update ReplicationController scale
+  codename: '[sig-apps] ReplicationController should get and update a ReplicationController
+    scale [Conformance]'
+  description: A ReplicationController is created which MUST succeed. It MUST succeed
+    when reading the ReplicationController scale. When updating the ReplicationController
+    scale it MUST succeed and the field MUST equal the new value.
+  release: v1.26
+  file: test/e2e/apps/rc.go
 - testname: Replication Controller, release pods
   codename: '[sig-apps] ReplicationController should release no longer matching pods
     [Conformance]'

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -392,7 +392,14 @@ var _ = SIGDescribe("ReplicationController", func() {
 		})
 	})
 
-	ginkgo.It("should get and update a ReplicationController scale", func() {
+	/*
+		Release: v1.26
+		Testname: Replication Controller, get and update ReplicationController scale
+		Description: A ReplicationController is created which MUST succeed. It MUST
+		succeed when reading the ReplicationController scale. When updating the
+		ReplicationController scale it MUST succeed and the field MUST equal the new value.
+	*/
+	framework.ConformanceIt("should get and update a ReplicationController scale", func() {
 		rcClient := f.ClientSet.CoreV1().ReplicationControllers(ns)
 		rcName := "e2e-rc-" + utilrand.String(5)
 		initialRCReplicaCount := int32(1)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- readCoreV1NamespacedReplicationControllerScale
- replaceCoreV1NamespacedReplicationControllerScale

**Which issue(s) this PR fixes:**
Fixes #112585

**Testgrid Link:** 
[testgrid-link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.get.and.update.a.ReplicationController.scale)

**Special notes for your reviewer:**
Adds +2 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance