### PR TITLE
Promote List, Patch and Delete LimitRange test to Conformance - +3 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2393,6 +2393,16 @@
     validate the pod resources are applied to the Limitrange
   release: v1.18
   file: test/e2e/scheduling/limit_range.go
+- testname: LimitRange, list, patch and delete a LimitRange by collection
+  codename: '[sig-scheduling] LimitRange should list, patch and delete a LimitRange
+    by collection [Conformance]'
+  description: When two limitRanges are created in different namespaces, both MUST
+    succeed. Listing limitRanges across all namespaces with a labelSelector MUST find
+    both limitRanges. When patching the first limitRange it MUST succeed and the fields
+    MUST equal the new values. When deleting the limitRange by collection with a labelSelector
+    it MUST delete only one limitRange.
+  release: v1.26
+  file: test/e2e/scheduling/limit_range.go
 - testname: Scheduler, resource limits
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates resource limits
     of pods that are allowed to run  [Conformance]'

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -226,7 +226,17 @@ var _ = SIGDescribe("LimitRange", func() {
 		framework.ExpectNoError(err)
 	})
 
-	ginkgo.It("should list, patch and delete a LimitRange by collection", func() {
+	/*
+		Release: v1.26
+		Testname: LimitRange, list, patch and delete a LimitRange by collection
+		Description: When two limitRanges are created in different namespaces,
+		both MUST succeed. Listing limitRanges across all namespaces with a
+		labelSelector MUST find both limitRanges. When patching the first limitRange
+		it MUST succeed and the fields MUST equal the new values. When deleting
+		the limitRange by collection with a labelSelector it MUST delete only one
+		limitRange.
+	*/
+	framework.ConformanceIt("should list, patch and delete a LimitRange by collection", func() {
 
 		ns := f.Namespace.Name
 		lrClient := f.ClientSet.CoreV1().LimitRanges(ns)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- patchCoreV1NamespacedLimitRange
- listCoreV1LimitRangeForAllNamespaces
- deleteCoreV1CollectionNamespacedLimitRange

**Which issue(s) this PR fixes:**
Fixes #112429

**Testgrid Link:** 
[testgrid-link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.list,.patch.and.delete.a.LimitRange.by.collection)

**Special notes for your reviewer:**
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance