### PR TITLE
Promote replaceCoreV1NamespacedServiceAccount test to Conformance - +1 Endpoint

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1083,6 +1083,12 @@
     ServiceAccount will be deleted and MUST find a deleted watch event.
   release: v1.19
   file: test/e2e/auth/service_accounts.go
+- testname: ServiceAccount, update a ServiceAccount
+  codename: '[sig-auth] ServiceAccounts should update a ServiceAccount [Conformance]'
+  description: A ServiceAccount is created which MUST succeed. When updating the ServiceAccount
+    it MUST succeed and the field MUST equal the new value.
+  release: v1.26
+  file: test/e2e/auth/service_accounts.go
 - testname: Kubectl, guestbook application
   codename: '[sig-cli] Kubectl client Guestbook application should create and stop
     a working application  [Conformance]'

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -800,7 +800,14 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		framework.Logf("Reconciled root ca configmap in namespace %q", f.Namespace.Name)
 	})
 
-	ginkgo.It("should update a ServiceAccount", func() {
+	/*
+		Release: v1.26
+		Testname: ServiceAccount, update a ServiceAccount
+		Description: A ServiceAccount is created which MUST succeed. When
+		updating the ServiceAccount it MUST succeed and the field MUST equal
+		the new value.
+	*/
+	framework.ConformanceIt("should update a ServiceAccount", func() {
 		saClient := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name)
 		saName := "e2e-sa-" + utilrand.String(5)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceCoreV1NamespacedServiceAccount

**Which issue(s) this PR fixes:**
Fixes #112822

**Testgrid Link:** 
[testgrid-link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should%20update%20a%20ServiceAccount)

**Special notes for your reviewer:**
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance