### PR TITLE
client-go: raw data options for fetching openapiv3

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -175,14 +175,14 @@ func TestOpenAPIDiskCache(t *testing.T) {
 	for k, v := range paths {
 		i++
 
-		_, err = v.Schema()
+		_, err = v.SchemaJSON()
 		assert.NoError(t, err)
 
 		path := "/openapi/v3/" + strings.TrimPrefix(k, "/")
 		assert.Equal(t, 1, fakeServer.RequestCounters[path])
 
 		// Ensure schema call is served from memory
-		_, err = v.Schema()
+		_, err = v.SchemaJSON()
 		assert.NoError(t, err)
 		assert.Equal(t, 1, fakeServer.RequestCounters[path])
 
@@ -196,7 +196,7 @@ func TestOpenAPIDiskCache(t *testing.T) {
 		}
 
 		// Ensure schema call is still served from disk
-		_, err = newPaths[k].Schema()
+		_, err = newPaths[k].SchemaJSON()
 		assert.NoError(t, err)
 		assert.Equal(t, 1+i, fakeServer.RequestCounters["/openapi/v3"])
 		assert.Equal(t, 1, fakeServer.RequestCounters[path])

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
@@ -416,7 +416,7 @@ func TestOpenAPIMemCache(t *testing.T) {
 	require.NoError(t, err)
 
 	for k, v := range paths {
-		original, err := v.Schema()
+		original, err := v.SchemaPB()
 		if !assert.NoError(t, err) {
 			continue
 		}
@@ -426,7 +426,7 @@ func TestOpenAPIMemCache(t *testing.T) {
 			continue
 		}
 
-		schemaAgain, err := pathsAgain[k].Schema()
+		schemaAgain, err := pathsAgain[k].SchemaPB()
 		if !assert.NoError(t, err) {
 			continue
 		}
@@ -442,7 +442,7 @@ func TestOpenAPIMemCache(t *testing.T) {
 			continue
 		}
 
-		schemaAgain, err = pathsAgain[k].Schema()
+		schemaAgain, err = pathsAgain[k].SchemaPB()
 		if !assert.NoError(t, err) {
 			continue
 		}

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -577,25 +577,29 @@ func TestGetOpenAPISchemaV3(t *testing.T) {
 	}
 
 	for k, v := range paths {
-		actual, err := v.Schema()
+		actual, err := v.SchemaPB()
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		expected := testV3Specs[k]
-		if !golangproto.Equal(expected, actual) {
+		expectedPB, err := golangproto.Marshal(expected)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(expectedPB, actual) {
 			t.Fatalf("expected \n%v\n\ngot:\n%v", expected, actual)
 		}
 
 		// Ensure that fetching schema once again does not return same instance
-		actualAgain, err := v.Schema()
+		actualAgain, err := v.SchemaPB()
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		if reflect.ValueOf(actual).Pointer() == reflect.ValueOf(actualAgain).Pointer() {
 			t.Fatal("expected schema not to be cached")
-		} else if !golangproto.Equal(actual, actualAgain) {
+		} else if !reflect.DeepEqual(expectedPB, actualAgain) {
 			t.Fatal("expected schema values to be equal")
 		}
 	}

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -594,7 +594,9 @@ func TestGetOpenAPISchemaV3(t *testing.T) {
 				}
 
 				expected := testV3Specs[k]
-				if contentType == runtime.ContentTypeJSON {
+				switch contentType {
+
+				case runtime.ContentTypeJSON:
 					var actualSpec spec3.OpenAPI
 
 					if err := json.Unmarshal(actual, &actualSpec); err != nil {
@@ -606,7 +608,7 @@ func TestGetOpenAPISchemaV3(t *testing.T) {
 					// Our test server parses the files in directly as gnostic
 					// which retains empty maps/lists, etc.
 					require.EqualValues(t, expected, &actualSpec)
-				} else {
+				case openapi.ContentTypeOpenAPIV3PB:
 					// Convert to JSON then to gnostic then to PB for comparison
 					expectedJSON, err := json.Marshal(expected)
 					if err != nil {
@@ -625,6 +627,8 @@ func TestGetOpenAPISchemaV3(t *testing.T) {
 					if !reflect.DeepEqual(expectedPB, actual) {
 						t.Fatalf("expected equal values: %v", cmp.Diff(expectedPB, actual))
 					}
+				default:
+					panic(fmt.Errorf("unrecognized content type: %v", contentType))
 				}
 
 				// Ensure that fetching schema once again does not return same instance

--- a/staging/src/k8s.io/client-go/openapi/cached/groupversion.go
+++ b/staging/src/k8s.io/client-go/openapi/cached/groupversion.go
@@ -19,15 +19,19 @@ package cached
 import (
 	"sync"
 
-	openapi_v3 "github.com/google/gnostic/openapiv3"
 	"k8s.io/client-go/openapi"
 )
 
 type groupversion struct {
 	delegate openapi.GroupVersion
-	once     sync.Once
-	doc      *openapi_v3.Document
-	err      error
+
+	jsonOnce  sync.Once
+	jsonBytes []byte
+	jsonErr   error
+
+	pbOnce  sync.Once
+	pbBytes []byte
+	pbErr   error
 }
 
 func newGroupVersion(delegate openapi.GroupVersion) *groupversion {
@@ -36,10 +40,18 @@ func newGroupVersion(delegate openapi.GroupVersion) *groupversion {
 	}
 }
 
-func (g *groupversion) Schema() (*openapi_v3.Document, error) {
-	g.once.Do(func() {
-		g.doc, g.err = g.delegate.Schema()
+func (g *groupversion) SchemaPB() ([]byte, error) {
+	g.pbOnce.Do(func() {
+		g.pbBytes, g.pbErr = g.delegate.SchemaPB()
 	})
 
-	return g.doc, g.err
+	return g.pbBytes, g.pbErr
+}
+
+func (g *groupversion) SchemaJSON() ([]byte, error) {
+	g.jsonOnce.Do(func() {
+		g.jsonBytes, g.jsonErr = g.delegate.SchemaJSON()
+	})
+
+	return g.jsonBytes, g.jsonErr
 }

--- a/staging/src/k8s.io/client-go/openapi/groupversion.go
+++ b/staging/src/k8s.io/client-go/openapi/groupversion.go
@@ -38,14 +38,9 @@ func newGroupVersion(client *client, item handler3.OpenAPIV3DiscoveryGroupVersio
 }
 
 func (g *groupversion) Schema(contentType string) ([]byte, error) {
-	data, err := g.client.restClient.Get().
+	return g.client.restClient.Get().
 		RequestURI(g.item.ServerRelativeURL).
 		SetHeader("Accept", contentType).
 		Do(context.TODO()).
 		Raw()
-
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
 }

--- a/staging/src/k8s.io/client-go/openapi/groupversion.go
+++ b/staging/src/k8s.io/client-go/openapi/groupversion.go
@@ -22,13 +22,10 @@ import (
 	"k8s.io/kube-openapi/pkg/handler3"
 )
 
-const openAPIV3mimePb = "application/com.github.proto-openapi.spec.v3@v1.0+protobuf"
-const jsonMime = "application/json"
+const ContentTypeOpenAPIV3PB = "application/com.github.proto-openapi.spec.v3@v1.0+protobuf"
 
 type GroupVersion interface {
-	// Raw data types
-	SchemaJSON() ([]byte, error)
-	SchemaPB() ([]byte, error)
+	Schema(contentType string) ([]byte, error)
 }
 
 type groupversion struct {
@@ -40,23 +37,10 @@ func newGroupVersion(client *client, item handler3.OpenAPIV3DiscoveryGroupVersio
 	return &groupversion{client: client, item: item}
 }
 
-func (g *groupversion) SchemaPB() ([]byte, error) {
+func (g *groupversion) Schema(contentType string) ([]byte, error) {
 	data, err := g.client.restClient.Get().
 		RequestURI(g.item.ServerRelativeURL).
-		SetHeader("Accept", openAPIV3mimePb).
-		Do(context.TODO()).
-		Raw()
-
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
-}
-
-func (g *groupversion) SchemaJSON() ([]byte, error) {
-	data, err := g.client.restClient.Get().
-		RequestURI(g.item.ServerRelativeURL).
-		SetHeader("Accept", jsonMime).
+		SetHeader("Accept", contentType).
 		Do(context.TODO()).
 		Raw()
 

--- a/staging/src/k8s.io/client-go/util/testing/fake_openapi_handler.go
+++ b/staging/src/k8s.io/client-go/util/testing/fake_openapi_handler.go
@@ -27,14 +27,13 @@ import (
 	"strings"
 	"sync"
 
-	openapi_v3 "github.com/google/gnostic/openapiv3"
 	"k8s.io/kube-openapi/pkg/handler3"
 	"k8s.io/kube-openapi/pkg/spec3"
 )
 
 type FakeOpenAPIServer struct {
 	HttpServer      *httptest.Server
-	ServedDocuments map[string]*openapi_v3.Document
+	ServedDocuments map[string]*spec3.OpenAPI
 	RequestCounters map[string]int
 }
 
@@ -62,7 +61,7 @@ func NewFakeOpenAPIV3Server(specsPath string) (*FakeOpenAPIServer, error) {
 	}
 
 	grouped := make(map[string][]byte)
-	var testV3Specs = make(map[string]*openapi_v3.Document)
+	var testV3Specs = make(map[string]*spec3.OpenAPI)
 
 	addSpec := func(path string) {
 		file, err := os.Open(path)
@@ -97,11 +96,8 @@ func NewFakeOpenAPIV3Server(specsPath string) (*FakeOpenAPIServer, error) {
 		if err != nil {
 			return nil, err
 		}
-		gnosticSpec, err := openapi_v3.ParseDocument(jsonSpec)
-		if err != nil {
-			return nil, err
-		}
-		testV3Specs[gv] = gnosticSpec
+
+		testV3Specs[gv] = spec
 		openAPIVersionedService.UpdateGroupVersion(gv, spec)
 	}
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

blocks https://github.com/kubernetes/kubernetes/pull/113024

remove serialized types from openapiv3 client

API was introduced this summer for kubectl. Implementation plans changed, and now instead kubectl needs raw JSON data. Don't see any usages of original in open source community, so opting to remove.


#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3515-kubectl-explain-openapiv3
```
