### PR TITLE
test dualstack services with assigned clusterIPs

### DIFF
--- a/test/integration/dualstack/dualstack_test.go
+++ b/test/integration/dualstack/dualstack_test.go
@@ -82,6 +82,14 @@ func TestCreateServiceSingleStackIPv4(t *testing.T) {
 			expectError:        false,
 		},
 		{
+			name:               "Type ClusterIP - Client Allocated IP - Default IP Family - Policy Single Stack",
+			serviceType:        v1.ServiceTypeClusterIP,
+			clusterIPs:         []string{"10.0.0.16"},
+			ipFamilies:         nil,
+			expectedIPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+			expectError:        false,
+		},
+		{
 			name:               "Type ClusterIP - Server Allocated IP - Default IP Family - Policy Prefer Dual Stack",
 			serviceType:        v1.ServiceTypeClusterIP,
 			clusterIPs:         []string{},
@@ -218,10 +226,9 @@ func TestCreateServiceSingleStackIPv4(t *testing.T) {
 					Name: fmt.Sprintf("svc-test-%d", i), // use different services for each test
 				},
 				Spec: v1.ServiceSpec{
-					Type:           tc.serviceType,
-					ClusterIPs:     tc.clusterIPs,
-					IPFamilies:     tc.ipFamilies,
-					IPFamilyPolicy: &tc.ipFamilyPolicy,
+					Type:       tc.serviceType,
+					ClusterIPs: tc.clusterIPs,
+					IPFamilies: tc.ipFamilies,
 					Ports: []v1.ServicePort{
 						{
 							Port:       443,
@@ -229,6 +236,14 @@ func TestCreateServiceSingleStackIPv4(t *testing.T) {
 						},
 					},
 				},
+			}
+
+			if len(tc.ipFamilyPolicy) > 0 {
+				svc.Spec.IPFamilyPolicy = &tc.ipFamilyPolicy
+			}
+
+			if len(tc.clusterIPs) > 0 {
+				svc.Spec.ClusterIP = tc.clusterIPs[0]
 			}
 
 			// create the service
@@ -510,6 +525,47 @@ func TestCreateServiceDualStackIPv4IPv6(t *testing.T) {
 			expectError:        false,
 		},
 		{
+			name:               "Type ClusterIP - Client Allocated IP - IPv4 Family",
+			serviceType:        v1.ServiceTypeClusterIP,
+			clusterIPs:         []string{"10.0.0.16"},
+			ipFamilies:         nil,
+			expectedIPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+			expectError:        false,
+		},
+		{
+			name:               "Type ClusterIP - Client Allocated IP - IPv6 Family",
+			serviceType:        v1.ServiceTypeClusterIP,
+			clusterIPs:         []string{"2001:db8:1::16"},
+			ipFamilies:         nil,
+			expectedIPFamilies: []v1.IPFamily{v1.IPv6Protocol},
+			expectError:        false,
+		},
+		{
+			name:               "Type ClusterIP - Client Allocated IP - IPv4 IPv6 Family ",
+			serviceType:        v1.ServiceTypeClusterIP,
+			clusterIPs:         []string{"10.0.0.17", "2001:db8:1::17"},
+			ipFamilies:         nil,
+			expectedIPFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+			expectError:        true,
+		},
+		{
+			name:               "Type ClusterIP - Client Allocated IP - IPv4 IPv6 Family ",
+			serviceType:        v1.ServiceTypeClusterIP,
+			clusterIPs:         []string{"10.0.0.17", "2001:db8:1::17"},
+			ipFamilies:         nil,
+			ipFamilyPolicy:     v1.IPFamilyPolicyPreferDualStack,
+			expectedIPFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+			expectError:        false,
+		},
+		{
+			name:               "Type ClusterIP - Client Allocated IP - IPv4 IPv6 Family ",
+			serviceType:        v1.ServiceTypeClusterIP,
+			clusterIPs:         []string{"10.0.0.18", "2001:db8:1::18"},
+			ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+			expectedIPFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+			expectError:        true,
+		},
+		{
 			name:               "Type ClusterIP - Server Allocated IP - Default IP Family - Policy Prefer Dual Stack",
 			serviceType:        v1.ServiceTypeClusterIP,
 			clusterIPs:         []string{},
@@ -647,10 +703,9 @@ func TestCreateServiceDualStackIPv4IPv6(t *testing.T) {
 					Name: fmt.Sprintf("svc-test-%d", i), // use different services for each test
 				},
 				Spec: v1.ServiceSpec{
-					Type:           tc.serviceType,
-					ClusterIPs:     tc.clusterIPs,
-					IPFamilies:     tc.ipFamilies,
-					IPFamilyPolicy: &tc.ipFamilyPolicy,
+					Type:       tc.serviceType,
+					ClusterIPs: tc.clusterIPs,
+					IPFamilies: tc.ipFamilies,
 					Ports: []v1.ServicePort{
 						{
 							Port:       443,
@@ -658,6 +713,14 @@ func TestCreateServiceDualStackIPv4IPv6(t *testing.T) {
 						},
 					},
 				},
+			}
+
+			if len(tc.ipFamilyPolicy) > 0 {
+				svc.Spec.IPFamilyPolicy = &tc.ipFamilyPolicy
+			}
+
+			if len(tc.clusterIPs) > 0 {
+				svc.Spec.ClusterIP = tc.clusterIPs[0]
 			}
 
 			// create a service


### PR DESCRIPTION
/kind cleanup

`spec.IPFamily` and `spec.IPFamilyPolicy` control the ClusterIP family allocation.
However, a user can configure single-stack services without those fields, if the ClusterIP is statically assigned, so service creation is backwards compatible with single-stack services.
DualStack Services always require to set those fields.
Add a few test cases to assert this behavior and avoid regressions 
```release-note
NONE
```
