### PR TITLE
add unit tests for apiserverleasegc controller

### DIFF
--- a/pkg/controlplane/controller/apiserverleasegc/gc_controller_test.go
+++ b/pkg/controlplane/controller/apiserverleasegc/gc_controller_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserverleasegc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/pointer"
+)
+
+func Test_Controller(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	tests := []struct {
+		name          string
+		lease         *coordinationv1.Lease
+		expectDeleted bool
+	}{
+		{
+			name: "lease not expired",
+			lease: &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-12345",
+					Namespace: metav1.NamespaceSystem,
+					Labels: map[string]string{
+						"k8s.io/component": "kube-apiserver",
+					},
+				},
+				Spec: coordinationv1.LeaseSpec{
+					HolderIdentity:       pointer.StringPtr("kube-apiserver-12345"),
+					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now()},
+				},
+			},
+			expectDeleted: false,
+		},
+		{
+			name: "expired lease but with a different component label",
+			lease: &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-12345",
+					Namespace: metav1.NamespaceSystem,
+					Labels: map[string]string{
+						"k8s.io/component": "kube-controller-manager",
+					},
+				},
+				Spec: coordinationv1.LeaseSpec{
+					HolderIdentity:       pointer.StringPtr("kube-apiserver-12345"),
+					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now().Add(-time.Minute)},
+				},
+			},
+			expectDeleted: false,
+		},
+		{
+			name: "lease expired due to expired renew time",
+			lease: &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-12345",
+					Namespace: metav1.NamespaceSystem,
+					Labels: map[string]string{
+						"k8s.io/component": "kube-apiserver",
+					},
+				},
+				Spec: coordinationv1.LeaseSpec{
+					HolderIdentity:       pointer.StringPtr("kube-apiserver-12345"),
+					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now().Add(-time.Minute)},
+				},
+			},
+			expectDeleted: true,
+		},
+		{
+			name: "lease expired due to nil renew time",
+			lease: &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-12345",
+					Namespace: metav1.NamespaceSystem,
+					Labels: map[string]string{
+						"k8s.io/component": "kube-apiserver",
+					},
+				},
+				Spec: coordinationv1.LeaseSpec{
+					HolderIdentity:       pointer.StringPtr("kube-apiserver-12345"),
+					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					RenewTime:            nil,
+				},
+			},
+			expectDeleted: true,
+		},
+		{
+			name: "lease expired due to nil lease duration seconds",
+			lease: &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-12345",
+					Namespace: metav1.NamespaceSystem,
+					Labels: map[string]string{
+						"k8s.io/component": "kube-apiserver",
+					},
+				},
+				Spec: coordinationv1.LeaseSpec{
+					HolderIdentity:       pointer.StringPtr("kube-apiserver-12345"),
+					LeaseDurationSeconds: nil,
+					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now().Add(-time.Minute)},
+				},
+			},
+			expectDeleted: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(test.lease)
+			controller := NewAPIServerLeaseGC(clientset, 100*time.Millisecond, metav1.NamespaceSystem, "k8s.io/component=kube-apiserver")
+			go controller.Run(nil)
+
+			time.Sleep(1 * time.Second)
+
+			_, err := clientset.CoordinationV1().Leases(test.lease.Namespace).Get(context.TODO(), test.lease.Name, metav1.GetOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if apierrors.IsNotFound(err) && !test.expectDeleted {
+				t.Errorf("lease was not deleted")
+			}
+
+			if err == nil && test.expectDeleted {
+				t.Error("lease was not deleted")
+			}
+		})
+	}
+}

--- a/pkg/controlplane/controller/apiserverleasegc/gc_controller_test.go
+++ b/pkg/controlplane/controller/apiserverleasegc/gc_controller_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+// Test_Controller validates the garbage collection logic for the apiserverleasegc controller.
 func Test_Controller(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	tests := []struct {
@@ -134,7 +135,7 @@ func Test_Controller(t *testing.T) {
 			controller := NewAPIServerLeaseGC(clientset, 100*time.Millisecond, metav1.NamespaceSystem, "k8s.io/component=kube-apiserver")
 			go controller.Run(nil)
 
-			time.Sleep(1 * time.Second)
+			time.Sleep(time.Second)
 
 			_, err := clientset.CoordinationV1().Leases(test.lease.Namespace).Get(context.TODO(), test.lease.Name, metav1.GetOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:

As part of test-hardening required for promoting APIServerIdentity feature to Beta in v1.26. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
