### PR TITLE
memorymanager: fix the bug of numa node grouping change

### DIFF
--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -114,7 +114,7 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 
 	machineState := s.GetMachineState()
 	bestHint := &hint
-	// topology manager returned the hint with NUMA affinity nil
+	// topology manager returned the hint with NUMA affinity nil.
 	// we should use the default NUMA affinity calculated the same way as for the topology manager
 	if hint.NUMANodeAffinity == nil {
 		defaultHint, err := p.getDefaultHint(machineState, pod, requestedResources)
@@ -128,19 +128,17 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 		bestHint = defaultHint
 	}
 
-	// topology manager returns the hint that does not satisfy completely the container request
-	// we should extend this hint to the one who will satisfy the request and include the current hint
-	if !isAffinitySatisfyRequest(machineState, bestHint.NUMANodeAffinity, requestedResources) {
-		extendedHint, err := p.extendTopologyManagerHint(machineState, pod, requestedResources, bestHint.NUMANodeAffinity)
-		if err != nil {
-			return err
-		}
-
-		if !extendedHint.Preferred && bestHint.Preferred {
-			return fmt.Errorf("[memorymanager] failed to find the extended preferred hint")
-		}
-		bestHint = extendedHint
+	// topology manager returns the hint that does not satisfy completely the container request and numa node grouping rules
+	// we should extend this hint to the one who will satisfy all requirements above and include the current hint
+	extendedHint, err := p.extendTopologyManagerHint(machineState, pod, requestedResources, bestHint.NUMANodeAffinity)
+	if err != nil {
+		return err
 	}
+
+	if !extendedHint.Preferred && bestHint.Preferred {
+		return fmt.Errorf("[memorymanager] failed to find the extended preferred hint")
+	}
+	bestHint = extendedHint
 
 	var containerBlocks []state.Block
 	maskBits := bestHint.NUMANodeAffinity.GetBits()
@@ -722,27 +720,6 @@ func (p *staticPolicy) getDefaultHint(machineState state.NUMANodeMap, pod *v1.Po
 
 	// hints for all memory types should be the same, so we will check hints only for regular memory type
 	return findBestHint(hints[string(v1.ResourceMemory)]), nil
-}
-
-func isAffinitySatisfyRequest(machineState state.NUMANodeMap, mask bitmask.BitMask, requestedResources map[v1.ResourceName]uint64) bool {
-	totalFreeSize := map[v1.ResourceName]uint64{}
-	for _, nodeID := range mask.GetBits() {
-		for resourceName := range requestedResources {
-			if _, ok := totalFreeSize[resourceName]; !ok {
-				totalFreeSize[resourceName] = 0
-			}
-			totalFreeSize[resourceName] += machineState[nodeID].MemoryMap[resourceName].Free
-		}
-	}
-
-	// verify that for all memory types the node mask has enough resources
-	for resourceName, requestedSize := range requestedResources {
-		if totalFreeSize[resourceName] < requestedSize {
-			return false
-		}
-	}
-
-	return true
 }
 
 // extendTopologyManagerHint extends the topology manager hint, in case when it does not satisfy to the container request

--- a/pkg/kubelet/cm/memorymanager/policy_static_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_test.go
@@ -1762,6 +1762,139 @@ func TestStaticPolicyAllocate(t *testing.T) {
 			pod:          getPod("pod1", "container1", requirementsGuaranteed),
 			topologyHint: &topologymanager.TopologyHint{Preferred: true},
 		},
+		{
+			description: "should succeed when NUMA affinity provided under the topology manager hint satisfies container requirements and should not change the current grouping algorithm",
+			assignments: state.ContainerMemoryAssignments{
+				"pod1": map[string][]state.Block{
+					"container1": {
+						{
+							NUMAAffinity: []int{0, 1},
+							Type:         v1.ResourceMemory,
+							Size:         2 * gb,
+						},
+					},
+				},
+			},
+			expectedAssignments: state.ContainerMemoryAssignments{
+				"pod1": map[string][]state.Block{
+					"container1": {
+						{
+							NUMAAffinity: []int{0, 1},
+							Type:         v1.ResourceMemory,
+							Size:         2 * gb,
+						},
+					},
+				},
+				"pod2": map[string][]state.Block{
+					"container2": {
+						{
+							NUMAAffinity: []int{0, 1},
+							Type:         v1.ResourceMemory,
+							Size:         gb,
+						},
+						{
+							NUMAAffinity: []int{0, 1},
+							Type:         hugepages1Gi,
+							Size:         gb,
+						},
+					},
+				},
+			},
+			machineState: state.NUMANodeMap{
+				0: &state.NUMANodeState{
+					MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+						v1.ResourceMemory: {
+							Allocatable:    1.5 * gb,
+							Free:           0,
+							Reserved:       1.5 * gb,
+							SystemReserved: 512 * mb,
+							TotalMemSize:   2 * gb,
+						},
+						hugepages1Gi: {
+							Allocatable:    gb,
+							Free:           gb,
+							Reserved:       0,
+							SystemReserved: 0,
+							TotalMemSize:   gb,
+						},
+					},
+					Cells:               []int{0, 1},
+					NumberOfAssignments: 1,
+				},
+				1: &state.NUMANodeState{
+					MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+						v1.ResourceMemory: {
+							Allocatable:    1.5 * gb,
+							Free:           gb,
+							Reserved:       0.5 * gb,
+							SystemReserved: 512 * mb,
+							TotalMemSize:   2 * gb,
+						},
+						hugepages1Gi: {
+							Allocatable:    gb,
+							Free:           gb,
+							Reserved:       0,
+							SystemReserved: 0,
+							TotalMemSize:   gb,
+						},
+					},
+					Cells:               []int{0, 1},
+					NumberOfAssignments: 1,
+				},
+			},
+			expectedMachineState: state.NUMANodeMap{
+				0: &state.NUMANodeState{
+					MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+						v1.ResourceMemory: {
+							Allocatable:    1.5 * gb,
+							Free:           0,
+							Reserved:       1.5 * gb,
+							SystemReserved: 512 * mb,
+							TotalMemSize:   2 * gb,
+						},
+						hugepages1Gi: {
+							Allocatable:    gb,
+							Free:           0,
+							Reserved:       gb,
+							SystemReserved: 0,
+							TotalMemSize:   gb,
+						},
+					},
+					Cells:               []int{0, 1},
+					NumberOfAssignments: 3,
+				},
+				1: &state.NUMANodeState{
+					MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+						v1.ResourceMemory: {
+							Allocatable:    1.5 * gb,
+							Free:           0,
+							Reserved:       1.5 * gb,
+							SystemReserved: 512 * mb,
+							TotalMemSize:   2 * gb,
+						},
+						hugepages1Gi: {
+							Allocatable:    gb,
+							Free:           gb,
+							Reserved:       0,
+							SystemReserved: 0,
+							TotalMemSize:   gb,
+						},
+					},
+					Cells:               []int{0, 1},
+					NumberOfAssignments: 3,
+				},
+			},
+			systemReserved: systemReservedMemory{
+				0: map[v1.ResourceName]uint64{
+					v1.ResourceMemory: 512 * mb,
+				},
+				1: map[v1.ResourceName]uint64{
+					v1.ResourceMemory: 512 * mb,
+				},
+			},
+			pod:          getPod("pod2", "container2", requirementsGuaranteed),
+			topologyHint: &topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(1), Preferred: false},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
In the func Allocate , call Topology Manager to get the aligned affinity across all hint providers, then in the func updateMachineState, machineState[nodeID].Cells value will be overwritten without any verification related to node grouping as done in the func calculateHints.This will cause that kubelet fails to restart


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #113035 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

