### PR TITLE
Fix after the pod workers delete pod syncTerminated failed ,kubelet cann't start a new pod with the same namespacedname

### DIFF
--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -936,6 +936,7 @@ func (p *podWorkers) managePodLoop(podUpdates <-chan podWork) {
 			switch {
 			case update.WorkType == TerminatedPodWork:
 				err = p.syncTerminatedPodFn(ctx, pod, status)
+				klog.V(2).InfoS("The static pod syncTerminated failed", "pod", klog.KObj(pod), "podUID", pod.UID, "updateType", update.WorkType, "err", err)
 
 			case update.WorkType == TerminatingPodWork:
 				var gracePeriod *int64

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -936,7 +936,10 @@ func (p *podWorkers) managePodLoop(podUpdates <-chan podWork) {
 			switch {
 			case update.WorkType == TerminatedPodWork:
 				err = p.syncTerminatedPodFn(ctx, pod, status)
-				klog.V(2).InfoS("The static pod syncTerminated failed", "pod", klog.KObj(pod), "podUID", pod.UID, "updateType", update.WorkType, "err", err)
+				if status, ok := p.podSyncStatuses[pod.UID]; ok && err != nil {
+					klog.V(2).InfoS("The pod syncTerminated failed, set status.finished to cleanup pod information", "pod", klog.KObj(pod), "podUID", pod.UID, "updateType", update.WorkType, "err", err)
+					status.finished = true
+				}
 
 			case update.WorkType == TerminatingPodWork:
 				var gracePeriod *int64


### PR DESCRIPTION
fix-113091

#### What type of PR is this?

/kind bug 

#### What this PR does / why we need it:

when delete a pod , the pod worker will Terminate and cleanup the pod information;
if syncTerminatedPodFn returned error such as umount the pod volumes failed or delete cgroups failed, 
the pod was put to workQueue and expected to retry synchronization , And the pod status.finished was **false**;
but the pod was deleted, and  the syncLoopIteration  configCh will never receive a message  to  dispatch the pods for the config change to the appropriate  handler callback for the event type;
so the old pod info was stored in pod worker map 'startedStaticPodsByFullname' and cann't be cleanup;
(the 'startedStaticPodsByFullname' map use pod.Name + "_" + pod.Namespace as pod keys).
on the other hand，the housekeeping timer could not cleanup the pod infomations because of the pod status.finished was **false**, 

so a new pod with the same namespacedname cann't start, because the map 'startedStaticPodsByFullname' store the old pod information with the same key.

This PR set pod **status.finished= true** when pod worker call syncTerminatedPodFn return an error , so that the housekeeping timer will cleanup the pod information, the new pod the same namespacedname  can start successfully

#### Which issue(s) this PR fixes:

Fixes #113091
Fixes https://github.com/kubernetes/kubernetes/issues/113091

#### Special notes for your reviewer:

/cc  @smarterclayton
/cc  @ehashman

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```