### PR TITLE
e2e: skip AllNodesReady when the test skipped framework initialization

### DIFF
--- a/test/e2e/framework/node/init/init.go
+++ b/test/e2e/framework/node/init/init.go
@@ -30,6 +30,12 @@ func init() {
 	framework.NewFrameworkExtensions = append(framework.NewFrameworkExtensions,
 		func(f *framework.Framework) {
 			ginkgo.AfterEach(func() {
+				if f.ClientSet == nil {
+					// Test didn't reach f.BeforeEach, most
+					// likely because the test got
+					// skipped. Nothing to check...
+					return
+				}
 				e2enode.AllNodesReady(f.ClientSet, 3*time.Minute)
 			})
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind regression

#### What this PR does / why we need it:

This addresses a problem caused by
https://github.com/kubernetes/kubernetes/pull/112043: because the AfterEach which invokes AllNodesReady always runs, including tests that skipped early, those tests ran into a nil pointer access. This increased the size of log files. The tests still worked.

#### Which issue(s) this PR fixes:
Fixes #112996

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

