### PR TITLE
Fix SELinux PodSecurity message when only user or role are set

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/policy/check_seLinuxOptions.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_seLinuxOptions.go
@@ -137,12 +137,12 @@ func seLinuxOptions_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec)
 				pluralize("type", "types", len(badTypes)),
 				joinQuote(badTypes.List()),
 			))
-			if setUser {
-				badData = append(badData, "user may not be set")
-			}
-			if setRole {
-				badData = append(badData, "role may not be set")
-			}
+		}
+		if setUser {
+			badData = append(badData, "user may not be set")
+		}
+		if setRole {
+			badData = append(badData, "role may not be set")
 		}
 
 		return CheckResult{

--- a/staging/src/k8s.io/pod-security-admission/policy/check_seLinuxOptions_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_seLinuxOptions_test.go
@@ -118,6 +118,42 @@ func TestSELinuxOptions(t *testing.T) {
 			expectReason: `seLinuxOptions`,
 			expectDetail: `containers "d", "e", "f" set forbidden securityContext.seLinuxOptions: type "bar"; user may not be set; role may not be set`,
 		},
+		{
+			name: "bad type",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "bad",
+					},
+				},
+			}},
+			expectReason: `seLinuxOptions`,
+			expectDetail: `pod set forbidden securityContext.seLinuxOptions: type "bad"`,
+		},
+		{
+			name: "bad user",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SELinuxOptions: &corev1.SELinuxOptions{
+						User: "bad",
+					},
+				},
+			}},
+			expectReason: `seLinuxOptions`,
+			expectDetail: `pod set forbidden securityContext.seLinuxOptions: user may not be set`,
+		},
+		{
+			name: "bad role",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SELinuxOptions: &corev1.SELinuxOptions{
+						Role: "bad",
+					},
+				},
+			}},
+			expectReason: `seLinuxOptions`,
+			expectDetail: `pod set forbidden securityContext.seLinuxOptions: role may not be set`,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes the explanatory message about a SELinux violation when only the user and/or role are set incorrectly.

#### Which issue(s) this PR fixes:
Fixes #113109

#### Special notes for your reviewer:

This does not change the security characteristics of the admission plugin... the request was correctly rejected even without this fix. This makes the message explain why correctly.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @tallclair 