### PR TITLE
actually resolve the computations for buckets for static analysis

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -49,19 +49,19 @@ var clientCertificateExpirationHistogram = metrics.NewHistogram(
 		Help:      "Distribution of the remaining lifetime on the certificate used to authenticate a request.",
 		Buckets: []float64{
 			0,
-			(30 * time.Minute).Seconds(),
-			(1 * time.Hour).Seconds(),
-			(2 * time.Hour).Seconds(),
-			(6 * time.Hour).Seconds(),
-			(12 * time.Hour).Seconds(),
-			(24 * time.Hour).Seconds(),
-			(2 * 24 * time.Hour).Seconds(),
-			(4 * 24 * time.Hour).Seconds(),
-			(7 * 24 * time.Hour).Seconds(),
-			(30 * 24 * time.Hour).Seconds(),
-			(3 * 30 * 24 * time.Hour).Seconds(),
-			(6 * 30 * 24 * time.Hour).Seconds(),
-			(12 * 30 * 24 * time.Hour).Seconds(),
+			1800,     // 30 minutes
+			3600,     // 1 hour
+			7200,     // 2 hours
+			21600,    // 6 hours
+			43200,    // 12 hours
+			86400,    // 1 day
+			172800,   // 2 days
+			345600,   // 4 days
+			604800,   // 1 week
+			2592000,  // 1 month
+			7776000,  // 3 months
+			15552000, // 6 months
+			31104000, // 1 year
 		},
 		StabilityLevel: metrics.ALPHA,
 	},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Static analysis chokes on the buckets here because of the method evaluation. But this is literally the only spot we do this, in [other spots](https://github.com/kubernetes/kubernetes/blob/release-1.25/pkg/kubelet/certificate/kubelet.go#L69-L88) we actually just hardcode the buckets. This PR makes this more consistent and amenable to static analysis.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```