### PR TITLE
kubectl apply: Deprecate --prune-whitelist in favor of --prune-allowlist

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -49,12 +49,14 @@ import (
 	dynamicfakeclient "k8s.io/client-go/dynamic/fake"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
+	testing2 "k8s.io/client-go/testing"
 	"k8s.io/client-go/util/csaupgrade"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/openapi"
 	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/strings/slices"
 )
 
 var (
@@ -712,6 +714,250 @@ func TestApplyPruneObjects(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApplyPruneObjectsWithAllowlist(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+
+	// Read ReplicationController from the file we will use to apply. This one will not be pruned because it exists in the file.
+	rc := readUnstructuredFromFile(t, filenameRC)
+	err := setLastAppliedConfigAnnotation(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create another ReplicationController that can be pruned
+	rc2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "ReplicationController",
+			"apiVersion": "v1",
+			"metadata": map[string]interface{}{
+				"name":      "test-rc2",
+				"namespace": "test",
+				"uid":       "uid-rc2",
+			},
+		},
+	}
+	err = setLastAppliedConfigAnnotation(rc2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a ConfigMap that can be pruned
+	cm := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "ConfigMap",
+			"apiVersion": "v1",
+			"metadata": map[string]interface{}{
+				"name":      "test-cm",
+				"namespace": "test",
+				"uid":       "uid-cm",
+			},
+		},
+	}
+	err = setLastAppliedConfigAnnotation(cm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a ConfigMap without a UID. Resources without a UID will not be pruned.
+	cmNoUID := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "ConfigMap",
+			"apiVersion": "v1",
+			"metadata": map[string]interface{}{
+				"name":      "test-cm-nouid",
+				"namespace": "test",
+			},
+		},
+	}
+	err = setLastAppliedConfigAnnotation(cmNoUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a ConfigMap without a last applied annotation. Resources without a last applied annotation will not be pruned.
+	cmNoLastApplied := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "ConfigMap",
+			"apiVersion": "v1",
+			"metadata": map[string]interface{}{
+				"name":      "test-cm-nolastapplied",
+				"namespace": "test",
+				"uid":       "uid-cm-nolastapplied",
+			},
+		},
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := map[string]struct {
+		currentResources        []runtime.Object
+		pruneAllowlist          []string
+		expectedPrunedResources []string
+		expectedOutputs         []string
+	}{
+		"prune without allowlist should delete resources that are not in the specified file": {
+			currentResources:        []runtime.Object{rc, rc2, cm},
+			expectedPrunedResources: []string{"test/test-cm", "test/test-rc2"},
+			expectedOutputs: []string{
+				"replicationcontroller/test-rc unchanged",
+				"configmap/test-cm pruned",
+				"replicationcontroller/test-rc2 pruned",
+			},
+		},
+		"prune with allowlist should delete only matching resources": {
+			currentResources:        []runtime.Object{rc, rc2, cm},
+			pruneAllowlist:          []string{"core/v1/ConfigMap"},
+			expectedPrunedResources: []string{"test/test-cm"},
+			expectedOutputs: []string{
+				"replicationcontroller/test-rc unchanged",
+				"configmap/test-cm pruned",
+			},
+		},
+		"prune with allowlist specifying the same resource type multiple times should not fail": {
+			currentResources:        []runtime.Object{rc, rc2, cm},
+			pruneAllowlist:          []string{"core/v1/ConfigMap", "core/v1/ConfigMap"},
+			expectedPrunedResources: []string{"test/test-cm"},
+			expectedOutputs: []string{
+				"replicationcontroller/test-rc unchanged",
+				"configmap/test-cm pruned",
+			},
+		},
+		"prune with allowlist should not delete resources that exist in the specified file": {
+			currentResources:        []runtime.Object{rc, rc2, cm},
+			pruneAllowlist:          []string{"core/v1/ReplicationController"},
+			expectedPrunedResources: []string{"test/test-rc2"},
+			expectedOutputs: []string{
+				"replicationcontroller/test-rc unchanged",
+				"replicationcontroller/test-rc2 pruned",
+			},
+		},
+		"prune with allowlist specifying multiple resource types should delete matching resources": {
+			currentResources:        []runtime.Object{rc, rc2, cm},
+			pruneAllowlist:          []string{"core/v1/ConfigMap", "core/v1/ReplicationController"},
+			expectedPrunedResources: []string{"test/test-cm", "test/test-rc2"},
+			expectedOutputs: []string{
+				"replicationcontroller/test-rc unchanged",
+				"configmap/test-cm pruned",
+				"replicationcontroller/test-rc2 pruned",
+			},
+		},
+		"prune should not delete resources that are missing a UID": {
+			currentResources:        []runtime.Object{rc, cm, cmNoUID},
+			expectedPrunedResources: []string{"test/test-cm"},
+			expectedOutputs: []string{
+				"replicationcontroller/test-rc unchanged",
+				"configmap/test-cm pruned",
+			},
+		},
+		"prune should not delete resources that are missing the last applied config annotation": {
+			currentResources:        []runtime.Object{rc, cm, cmNoLastApplied},
+			expectedPrunedResources: []string{"test/test-cm"},
+			expectedOutputs: []string{
+				"replicationcontroller/test-rc unchanged",
+				"configmap/test-cm pruned",
+			},
+		},
+	}
+
+	for testCaseName, tc := range testCases {
+		for _, testingOpenAPISchema := range testingOpenAPISchemas {
+			t.Run(testCaseName, func(t *testing.T) {
+				tf := cmdtesting.NewTestFactory().WithNamespace("test")
+				defer tf.Cleanup()
+
+				tf.UnstructuredClient = &fake.RESTClient{
+					NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+					Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+						switch p, m := req.URL.Path, req.Method; {
+						case p == "/namespaces/test/replicationcontrollers/test-rc" && m == "GET":
+							encoded := runtime.EncodeOrDie(unstructured.UnstructuredJSONScheme, rc)
+							bodyRC := io.NopCloser(strings.NewReader(encoded))
+							return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, nil
+						case p == "/namespaces/test/replicationcontrollers/test-rc" && m == "PATCH":
+							encoded := runtime.EncodeOrDie(unstructured.UnstructuredJSONScheme, rc)
+							bodyRC := io.NopCloser(strings.NewReader(encoded))
+							return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, nil
+						default:
+							t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+							return nil, nil
+						}
+					}),
+				}
+				tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
+				tf.FakeOpenAPIGetter = testingOpenAPISchema.OpenAPIGetter
+				tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+				for _, resource := range tc.currentResources {
+					if err := tf.FakeDynamicClient.Tracker().Add(resource); err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+				cmd := NewCmdApply("kubectl", tf, ioStreams)
+				cmd.Flags().Set("filename", filenameRC)
+				cmd.Flags().Set("prune", "true")
+				cmd.Flags().Set("namespace", "test")
+				cmd.Flags().Set("all", "true")
+				for _, allow := range tc.pruneAllowlist {
+					cmd.Flags().Set("prune-allowlist", allow)
+				}
+				cmd.Run(cmd, []string{})
+
+				if errBuf.String() != "" {
+					t.Fatalf("unexpected error output: %s", errBuf.String())
+				}
+
+				actualOutput := buf.String()
+				for _, expectedOutput := range tc.expectedOutputs {
+					if !strings.Contains(actualOutput, expectedOutput) {
+						t.Fatalf("expected output to contain %q, but it did not. Actual Output:\n%s", expectedOutput, actualOutput)
+					}
+				}
+
+				var prunedResources []string
+				for _, action := range tf.FakeDynamicClient.Actions() {
+					if action.GetVerb() == "delete" {
+						deleteAction := action.(testing2.DeleteAction)
+						prunedResources = append(prunedResources, deleteAction.GetNamespace()+"/"+deleteAction.GetName())
+					}
+				}
+
+				// Make sure nothing unexpected was pruned
+				for _, resource := range prunedResources {
+					if !slices.Contains(tc.expectedPrunedResources, resource) {
+						t.Fatalf("expected %s not to be pruned, but it was", resource)
+					}
+				}
+
+				// Make sure everything that was expected to be pruned was pruned
+				for _, resource := range tc.expectedPrunedResources {
+					if !slices.Contains(prunedResources, resource) {
+						t.Fatalf("expected %s to be pruned, but it was not", resource)
+					}
+				}
+
+			})
+		}
+	}
+}
+
+func setLastAppliedConfigAnnotation(obj runtime.Object) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	annotations := accessor.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+		accessor.SetAnnotations(annotations)
+	}
+	annotations[corev1.LastAppliedConfigAnnotation] = runtime.EncodeOrDie(unstructured.NewJSONFallbackEncoder(codec), obj)
+	accessor.SetAnnotations(annotations)
+	return nil
 }
 
 // Tests that apply of object in need of CSA migration results in a call

--- a/staging/src/k8s.io/kubectl/pkg/util/slice/slice.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/slice/slice.go
@@ -36,3 +36,22 @@ func ContainsString(slice []string, s string, modifier func(s string) string) bo
 	}
 	return false
 }
+
+// ToSet returns a single slice containing the unique values from one or more slices. The order of the items in the
+// result is not guaranteed.
+func ToSet[T comparable](slices ...[]T) []T {
+	if len(slices) == 0 {
+		return nil
+	}
+	m := map[T]struct{}{}
+	for _, slice := range slices {
+		for _, value := range slice {
+			m[value] = struct{}{}
+		}
+	}
+	result := []T{}
+	for k := range m {
+		result = append(result, k)
+	}
+	return result
+}

--- a/staging/src/k8s.io/kubectl/pkg/util/slice/slice_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/slice/slice_test.go
@@ -18,6 +18,7 @@ package slice
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -27,5 +28,46 @@ func TestSortInts64(t *testing.T) {
 	SortInts64(src)
 	if !reflect.DeepEqual(src, expected) {
 		t.Errorf("func Ints64 didnt sort correctly, %v !- %v", src, expected)
+	}
+}
+
+func TestToSet(t *testing.T) {
+	testCases := map[string]struct {
+		input    [][]string
+		expected []string
+	}{
+		"nil should be returned if no slices are passed to the function": {
+			input:    [][]string{},
+			expected: nil,
+		},
+		"empty slice should be returned if an empty slice is passed to the function": {
+			input:    [][]string{{}},
+			expected: []string{},
+		},
+		"a single slice with no duplicates should have the same values": {
+			input:    [][]string{{"a", "b", "c"}},
+			expected: []string{"a", "b", "c"},
+		},
+		"duplicates should be removed from a single slice": {
+			input:    [][]string{{"a", "b", "a", "c", "b"}},
+			expected: []string{"a", "b", "c"},
+		},
+		"multiple slices with no duplicates should be combined": {
+			input:    [][]string{{"a", "b", "c"}, {"d", "e", "f"}},
+			expected: []string{"a", "b", "c", "d", "e", "f"},
+		},
+		"duplicates should be removed from multiple slices": {
+			input:    [][]string{{"a", "b", "c"}, {"d", "b", "e"}, {"e", "f", "a"}},
+			expected: []string{"a", "b", "c", "d", "e", "f"},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := ToSet(tc.input...)
+			sort.Strings(actual) // Sort is needed to compare the output because ToSet is non-deterministic
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("wrong output. Actual=%v, Expected=%v", actual, tc.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Changes in kubectl apply --prune to support k8s [Inclusive Naming Initiative](https://www.cncf.io/announcements/2021/10/13/inclusive-naming-initiative-announces-new-community-resources-for-a-more-inclusive-future/):
* Deprecated the --prune-whitelist flag.
* Deprecated the PruneWhitelist field on ApplyFlags struct.
* Removed PruneWhitelist field (not used anywhere) from ApplyOptions struct.
* Added --prune-allowlist flag.
* Added PruneAllowlist field on ApplyFlags struct.
* Added unit tests for prune with allowlist

This commit also fixes a bug where the command would fail if you specified the same GVK multiple times for --allow-whitelist. Now it only attempts to prune the unique set of allowed GVKs.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Added a `--prune-allowlist` flag that can be used with `kubectl apply --prune`. This flag replaces and functions the same as the `--prune-whitelist` flag, which has been deprecated.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
