### PR TITLE
kmsv2: implement expire cache with clock 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
@@ -109,7 +109,7 @@ type KMSConfiguration struct {
 	// name is the name of the KMS plugin to be used.
 	Name string
 	// cachesize is the maximum number of secrets which are cached in memory. The default value is 1000.
-	// Set to a negative value to disable caching.
+	// Set to a negative value to disable caching. This field is only allowed for KMS v1 providers.
 	// +optional
 	CacheSize *int32
 	// endpoint is the gRPC server listening address, for example "unix:///var/run/kms-provider.sock".

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults.go
@@ -39,11 +39,12 @@ func SetDefaults_KMSConfiguration(obj *KMSConfiguration) {
 		obj.Timeout = defaultTimeout
 	}
 
-	if obj.CacheSize == nil {
-		obj.CacheSize = &defaultCacheSize
-	}
-
 	if obj.APIVersion == "" {
 		obj.APIVersion = defaultAPIVersion
+	}
+
+	// cacheSize is relevant only for kms v1
+	if obj.CacheSize == nil && obj.APIVersion == "v1" {
+		obj.CacheSize = &defaultCacheSize
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults_test.go
@@ -55,8 +55,9 @@ func TestKMSProviderTimeoutDefaults(t *testing.T) {
 
 func TestKMSProviderCacheDefaults(t *testing.T) {
 	var (
-		zero int32 = 0
-		ten  int32 = 10
+		zero     int32 = 0
+		ten      int32 = 10
+		negative int32 = -1
 	)
 
 	testCases := []struct {
@@ -78,6 +79,21 @@ func TestKMSProviderCacheDefaults(t *testing.T) {
 			desc: "positive cache size supplied",
 			in:   &KMSConfiguration{CacheSize: &ten},
 			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &ten, APIVersion: defaultAPIVersion},
+		},
+		{
+			desc: "negative cache size supplied",
+			in:   &KMSConfiguration{CacheSize: &negative},
+			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &negative, APIVersion: defaultAPIVersion},
+		},
+		{
+			desc: "cache size not supplied but API version is v2",
+			in:   &KMSConfiguration{APIVersion: "v2"},
+			want: &KMSConfiguration{Timeout: defaultTimeout, APIVersion: "v2"},
+		},
+		{
+			desc: "cache size not supplied with API version v1",
+			in:   &KMSConfiguration{APIVersion: "v1"},
+			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &defaultCacheSize, APIVersion: defaultAPIVersion},
 		},
 	}
 
@@ -104,8 +120,13 @@ func TestKMSProviderAPIVersionDefaults(t *testing.T) {
 		},
 		{
 			desc: "apiVersion supplied",
+			in:   &KMSConfiguration{Timeout: &v1.Duration{Duration: 1 * time.Minute}, APIVersion: "v1"},
+			want: &KMSConfiguration{Timeout: &v1.Duration{Duration: 1 * time.Minute}, CacheSize: &defaultCacheSize, APIVersion: "v1"},
+		},
+		{
+			desc: "apiVersion v2 supplied, cache size not defaulted",
 			in:   &KMSConfiguration{Timeout: &v1.Duration{Duration: 1 * time.Minute}, APIVersion: "v2"},
-			want: &KMSConfiguration{Timeout: &v1.Duration{Duration: 1 * time.Minute}, CacheSize: &defaultCacheSize, APIVersion: "v2"},
+			want: &KMSConfiguration{Timeout: &v1.Duration{Duration: 1 * time.Minute}, APIVersion: "v2"},
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
@@ -109,7 +109,7 @@ type KMSConfiguration struct {
 	// name is the name of the KMS plugin to be used.
 	Name string `json:"name"`
 	// cachesize is the maximum number of secrets which are cached in memory. The default value is 1000.
-	// Set to a negative value to disable caching.
+	// Set to a negative value to disable caching. This field is only allowed for KMS v1 providers.
 	// +optional
 	CacheSize *int32 `json:"cachesize,omitempty"`
 	// endpoint is the gRPC server listening address, for example "unix:///var/run/kms-provider.sock".

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation.go
@@ -195,7 +195,13 @@ func validateKMSConfiguration(c *config.KMSConfiguration, fieldPath *field.Path,
 
 func validateKMSCacheSize(c *config.KMSConfiguration, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if *c.CacheSize == 0 {
+
+	// In defaulting, we set the cache size to the default value only when API version is v1.
+	// So, for v2 API version, we expect the cache size field to be nil.
+	if c.APIVersion != "v1" && c.CacheSize != nil {
+		allErrs = append(allErrs, field.Invalid(fieldPath, *c.CacheSize, "cachesize is not supported in v2"))
+	}
+	if c.APIVersion == "v1" && *c.CacheSize == 0 {
 		allErrs = append(allErrs, field.Invalid(fieldPath, *c.CacheSize, fmt.Sprintf(nonZeroErrFmt, "cachesize")))
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation_test.go
@@ -185,7 +185,6 @@ func TestStructure(t *testing.T) {
 									Name:       "foo",
 									Endpoint:   "unix:///tmp/kms-provider-2.socket",
 									Timeout:    &metav1.Duration{Duration: 3 * time.Second},
-									CacheSize:  &cacheSize,
 									APIVersion: "v2",
 								},
 							},
@@ -210,7 +209,6 @@ func TestStructure(t *testing.T) {
 									Name:       "foo",
 									Endpoint:   "unix:///tmp/kms-provider-1.socket",
 									Timeout:    &metav1.Duration{Duration: 3 * time.Second},
-									CacheSize:  &cacheSize,
 									APIVersion: "v2",
 								},
 							},
@@ -219,7 +217,6 @@ func TestStructure(t *testing.T) {
 									Name:       "foo",
 									Endpoint:   "unix:///tmp/kms-provider-2.socket",
 									Timeout:    &metav1.Duration{Duration: 3 * time.Second},
-									CacheSize:  &cacheSize,
 									APIVersion: "v2",
 								},
 							},
@@ -244,7 +241,6 @@ func TestStructure(t *testing.T) {
 									Name:       "foo",
 									Endpoint:   "unix:///tmp/kms-provider-1.socket",
 									Timeout:    &metav1.Duration{Duration: 3 * time.Second},
-									CacheSize:  &cacheSize,
 									APIVersion: "v2",
 								},
 							},
@@ -258,7 +254,6 @@ func TestStructure(t *testing.T) {
 									Name:       "foo",
 									Endpoint:   "unix:///tmp/kms-provider-2.socket",
 									Timeout:    &metav1.Duration{Duration: 3 * time.Second},
-									CacheSize:  &cacheSize,
 									APIVersion: "v2",
 								},
 							},
@@ -297,7 +292,6 @@ func TestStructure(t *testing.T) {
 									Name:       "foo",
 									Endpoint:   "unix:///tmp/kms-provider-2.socket",
 									Timeout:    &metav1.Duration{Duration: 3 * time.Second},
-									CacheSize:  &cacheSize,
 									APIVersion: "v2",
 								},
 							},
@@ -539,20 +533,27 @@ func TestKMSProviderCacheSize(t *testing.T) {
 	}{
 		{
 			desc: "valid positive cache size",
-			in:   &config.KMSConfiguration{CacheSize: &positiveCacheSize},
+			in:   &config.KMSConfiguration{APIVersion: "v1", CacheSize: &positiveCacheSize},
 			want: field.ErrorList{},
 		},
 		{
 			desc: "invalid zero cache size",
-			in:   &config.KMSConfiguration{CacheSize: &zeroCacheSize},
+			in:   &config.KMSConfiguration{APIVersion: "v1", CacheSize: &zeroCacheSize},
 			want: field.ErrorList{
 				field.Invalid(cacheField, int32(0), fmt.Sprintf(nonZeroErrFmt, "cachesize")),
 			},
 		},
 		{
 			desc: "valid negative caches size",
-			in:   &config.KMSConfiguration{CacheSize: &negativeCacheSize},
+			in:   &config.KMSConfiguration{APIVersion: "v1", CacheSize: &negativeCacheSize},
 			want: field.ErrorList{},
+		},
+		{
+			desc: "cache size set with v2 provider",
+			in:   &config.KMSConfiguration{CacheSize: &positiveCacheSize, APIVersion: "v2"},
+			want: field.ErrorList{
+				field.Invalid(cacheField, positiveCacheSize, "cachesize is not supported in v2"),
+			},
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -598,7 +598,7 @@ func kmsPrefixTransformer(ctx context.Context, config *apiserverconfig.KMSConfig
 
 		// using AES-GCM by default for encrypting data with KMSv2
 		transformer := value.PrefixTransformer{
-			Transformer: envelopekmsv2.NewEnvelopeTransformer(envelopeService, probe.getCurrentKeyID, int(*config.CacheSize), aestransformer.NewGCMTransformer),
+			Transformer: envelopekmsv2.NewEnvelopeTransformer(envelopeService, probe.getCurrentKeyID, aestransformer.NewGCMTransformer),
 			Prefix:      []byte(kmsTransformerPrefixV2 + kmsName + ":"),
 		}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/aes-cbc-first.yaml
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/aes-cbc-first.yaml
@@ -18,7 +18,6 @@ resources:
           apiVersion: v2
           name: testproviderv2
           endpoint: unix:///tmp/testprovider.sock
-          cachesize: 10
       - identity: {}
       - secretbox:
           keys:

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/aes-gcm-first.yaml
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/aes-gcm-first.yaml
@@ -22,7 +22,6 @@ resources:
           apiVersion: v2
           name: testproviderv2
           endpoint: unix:///tmp/testprovider.sock
-          cachesize: 10
       - aescbc:
           keys:
             - name: key1

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/identity-first.yaml
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/identity-first.yaml
@@ -20,7 +20,6 @@ resources:
           apiVersion: v2
           name: testproviderv2
           endpoint: unix:///tmp/testprovider.sock
-          cachesize: 10
       - aescbc:
           keys:
             - name: key1

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kms-first.yaml
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kms-first.yaml
@@ -12,7 +12,6 @@ resources:
           apiVersion: v2
           name: testproviderv2
           endpoint: unix:///tmp/testprovider.sock
-          cachesize: 10
       - secretbox:
           keys:
             - name: key1

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kmsv2-first.yaml
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kmsv2-first.yaml
@@ -8,7 +8,6 @@ resources:
           apiVersion: v2
           name: testproviderv2
           endpoint: unix:///tmp/testprovider.sock
-          cachesize: 10
       - kms:
           name: testprovider
           endpoint: unix:///tmp/testprovider.sock

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/secret-box-first.yaml
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/secret-box-first.yaml
@@ -22,7 +22,6 @@ resources:
           apiVersion: v2
           name: testproviderv2
           endpoint: unix:///tmp/testprovider.sock
-          cachesize: 10
       - identity: {}
       - aesgcm:
           keys:

--- a/staging/src/k8s.io/apiserver/pkg/server/options/testdata/encryption-configs/multiple-kms-v2-providers.yaml
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/testdata/encryption-configs/multiple-kms-v2-providers.yaml
@@ -7,12 +7,10 @@ resources:
       - kms:
           apiVersion: v2
           name: kms-provider-1
-          cachesize: 1000
           endpoint: unix:///@provider1.sock
       - kms:
           apiVersion: v2
           name: kms-provider-2
-          cachesize: 1000
           endpoint: unix:///@provider2.sock
       - kms:
           apiVersion: v2

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/cache.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kmsv2 transforms values for storage at rest using a Envelope v2 provider
+package kmsv2
+
+import (
+	"encoding/base64"
+	"time"
+
+	utilcache "k8s.io/apimachinery/pkg/util/cache"
+	"k8s.io/apiserver/pkg/storage/value"
+	"k8s.io/utils/clock"
+)
+
+type simpleCache struct {
+	cache *utilcache.Expiring
+	ttl   time.Duration
+}
+
+func newSimpleCache(clock clock.Clock, ttl time.Duration) *simpleCache {
+	return &simpleCache{
+		cache: utilcache.NewExpiringWithClock(clock),
+		ttl:   ttl,
+	}
+}
+
+// given a key, return the transformer, or nil if it does not exist in the cache
+func (c *simpleCache) get(key []byte) value.Transformer {
+	record, ok := c.cache.Get(base64.StdEncoding.EncodeToString(key))
+	if !ok {
+		return nil
+	}
+	return record.(value.Transformer)
+}
+
+// set caches the record for the key
+func (c *simpleCache) set(key []byte, transformer value.Transformer) {
+	if len(key) == 0 {
+		panic("key must not be empty")
+	}
+	if transformer == nil {
+		panic("transformer must not be nil")
+	}
+	c.cache.Set(base64.StdEncoding.EncodeToString(key), transformer, c.ttl)
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/cache_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kmsv2 transforms values for storage at rest using a Envelope v2 provider
+package kmsv2
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apiserver/pkg/storage/value"
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+func TestSimpleCacheSetError(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	cache := newSimpleCache(fakeClock, time.Second)
+
+	tests := []struct {
+		name        string
+		key         []byte
+		transformer value.Transformer
+	}{
+		{
+			name:        "empty key",
+			key:         []byte{},
+			transformer: nil,
+		},
+		{
+			name:        "nil transformer",
+			key:         []byte("key"),
+			transformer: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("The code did not panic")
+				}
+			}()
+			cache.set(test.key, test.transformer)
+		})
+	}
+}

--- a/test/integration/controlplane/transformation/kmsv2_transformation_test.go
+++ b/test/integration/controlplane/transformation/kmsv2_transformation_test.go
@@ -125,7 +125,6 @@ resources:
     - kms:
        apiVersion: v2
        name: kms-provider
-       cachesize: 1000
        endpoint: unix:///@kms-provider.sock
 `
 
@@ -229,7 +228,6 @@ resources:
     - kms:
        apiVersion: v2
        name: kms-provider
-       cachesize: 1000
        endpoint: unix:///@kms-provider.sock
 `
 	pluginMock, err := kmsv2mock.NewBase64Plugin("@kms-provider.sock")
@@ -442,7 +440,6 @@ resources:
     - kms:
        apiVersion: v2
        name: kms-provider
-       cachesize: 1000
        endpoint: unix:///@kms-provider.sock
 `
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
- Use expiring cache for KMS v2
  - The default TTL for cache entry is set to 1h

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #111920

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
cacheSize field in EncryptionConfiguration is not supported for KMSv2 provider
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3299-kms-v2-improvements
```
