### PR TITLE
Make STS available replicas optional

### DIFF
--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -987,8 +987,7 @@
           }
         },
         "required": [
-          "replicas",
-          "availableReplicas"
+          "replicas"
         ],
         "type": "object"
       },

--- a/pkg/apis/apps/types.go
+++ b/pkg/apis/apps/types.go
@@ -246,6 +246,7 @@ type StatefulSetStatus struct {
 
 	// Total number of available pods (ready for at least minReadySeconds) targeted by this statefulset.
 	// This is a beta field and requires enabling StatefulSetMinReadySeconds feature gate.
+	// +optional
 	AvailableReplicas int32
 }
 

--- a/staging/src/k8s.io/api/apps/v1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1/generated.proto
@@ -748,6 +748,7 @@ message StatefulSetStatus {
 
   // Total number of available pods (ready for at least minReadySeconds) targeted by this statefulset.
   // This is a beta field and enabled/disabled by StatefulSetMinReadySeconds feature gate.
+  // +optional
   optional int32 availableReplicas = 11;
 }
 

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -272,6 +272,7 @@ type StatefulSetStatus struct {
 
 	// Total number of available pods (ready for at least minReadySeconds) targeted by this statefulset.
 	// This is a beta field and enabled/disabled by StatefulSetMinReadySeconds feature gate.
+	// +optional
 	AvailableReplicas int32 `json:"availableReplicas" protobuf:"varint,11,opt,name=availableReplicas"`
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta1/generated.proto
@@ -502,6 +502,7 @@ message StatefulSetStatus {
 
   // Total number of available pods (ready for at least minReadySeconds) targeted by this StatefulSet.
   // This is a beta field and enabled/disabled by StatefulSetMinReadySeconds feature gate.
+  // +optional
   optional int32 availableReplicas = 11;
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -310,6 +310,7 @@ type StatefulSetStatus struct {
 
 	// Total number of available pods (ready for at least minReadySeconds) targeted by this StatefulSet.
 	// This is a beta field and enabled/disabled by StatefulSetMinReadySeconds feature gate.
+	// +optional
 	AvailableReplicas int32 `json:"availableReplicas" protobuf:"varint,11,opt,name=availableReplicas"`
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -790,6 +790,7 @@ message StatefulSetStatus {
 
   // Total number of available pods (ready for at least minReadySeconds) targeted by this StatefulSet.
   // This is a beta field and enabled/disabled by StatefulSetMinReadySeconds feature gate.
+  // +optional
   optional int32 availableReplicas = 11;
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -320,6 +320,7 @@ type StatefulSetStatus struct {
 
 	// Total number of available pods (ready for at least minReadySeconds) targeted by this StatefulSet.
 	// This is a beta field and enabled/disabled by StatefulSetMinReadySeconds feature gate.
+	// +optional
 	AvailableReplicas int32 `json:"availableReplicas" protobuf:"varint,11,opt,name=availableReplicas"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/109210

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes a 1.22 regression in published openapi: make STS available replicas optional again
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
Make STS available replicas optional again.
```
