### PR TITLE
order the output for stable metrics since we're supporting more than just stable now

### DIFF
--- a/test/instrumentation/metric.go
+++ b/test/instrumentation/metric.go
@@ -53,6 +53,11 @@ type byFQName []metric
 
 func (ms byFQName) Len() int { return len(ms) }
 func (ms byFQName) Less(i, j int) bool {
+	if ms[i].StabilityLevel < ms[j].StabilityLevel {
+		return true
+	} else if ms[i].StabilityLevel > ms[j].StabilityLevel {
+		return false
+	}
 	return ms[i].buildFQName() < ms[j].buildFQName()
 }
 func (ms byFQName) Swap(i, j int) {

--- a/test/instrumentation/testdata/pkg/kubelet/metrics/metrics.go
+++ b/test/instrumentation/testdata/pkg/kubelet/metrics/metrics.go
@@ -469,7 +469,7 @@ var (
 			Subsystem:      KubeletSubsystem,
 			Name:           RunningContainersKey,
 			Help:           "Number of containers currently running",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"container_state"},
 	)

--- a/test/instrumentation/testdata/test-stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/test-stable-metrics-list.yaml
@@ -39,14 +39,13 @@
   type: Summary
   stabilityLevel: BETA
   maxAge: 120000000000
-- name: multiline
+- name: running_containers
   subsystem: kubelet
-  help: Cumulative number of pod preemptions by preemption resource asdf asdf asdf
-    asdfas dfasdf
-  type: Counter
-  stabilityLevel: STABLE
+  help: Number of containers currently running
+  type: Gauge
+  stabilityLevel: BETA
   labels:
-  - preemption_signal
+  - container_state
 - name: runtime_operations_duration_seconds
   subsystem: kubelet
   help: Duration in seconds of runtime operations. Broken down by operation type.
@@ -69,43 +68,6 @@
   - 119.20928955078125
   - 298.0232238769531
   - 745.0580596923828
-- name: summary_metric_test
-  subsystem: kubelet
-  help: Cumulative number of device plugin registrations. Broken down by resource
-    name.
-  type: Summary
-  stabilityLevel: STABLE
-- name: summary_vec_metric_test
-  subsystem: kubelet
-  help: Duration in seconds to serve a device plugin Allocation request. Broken down
-    by resource name.
-  type: Summary
-  stabilityLevel: STABLE
-  labels:
-  - resource_name
-  objectives:
-    0.5: 0.5
-    0.75: 0.75
-  ageBuckets: 5
-  bufCap: 500
-  maxAge: 600000000000
-- name: test_histogram_metric
-  subsystem: kubelet
-  help: Interval in seconds between relisting in PLEG.
-  type: Histogram
-  stabilityLevel: STABLE
-  buckets:
-  - 0.005
-  - 0.01
-  - 0.025
-  - 0.05
-  - 0.1
-  - 0.25
-  - 0.5
-  - 1
-  - 2.5
-  - 5
-  - 10
 - name: priority_level_seat_utilization
   subsystem: subsystem
   namespace: namespace
@@ -157,3 +119,48 @@
   constLabels:
     phase: blah
     somestring: executing
+- name: multiline
+  subsystem: kubelet
+  help: Cumulative number of pod preemptions by preemption resource asdf asdf asdf
+    asdfas dfasdf
+  type: Counter
+  stabilityLevel: STABLE
+  labels:
+  - preemption_signal
+- name: summary_metric_test
+  subsystem: kubelet
+  help: Cumulative number of device plugin registrations. Broken down by resource
+    name.
+  type: Summary
+  stabilityLevel: STABLE
+- name: summary_vec_metric_test
+  subsystem: kubelet
+  help: Duration in seconds to serve a device plugin Allocation request. Broken down
+    by resource name.
+  type: Summary
+  stabilityLevel: STABLE
+  labels:
+  - resource_name
+  objectives:
+    0.5: 0.5
+    0.75: 0.75
+  ageBuckets: 5
+  bufCap: 500
+  maxAge: 600000000000
+- name: test_histogram_metric
+  subsystem: kubelet
+  help: Interval in seconds between relisting in PLEG.
+  type: Histogram
+  stabilityLevel: STABLE
+  buckets:
+  - 0.005
+  - 0.01
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  - 10


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Previously, we only supported stable metrics for API review. Since we're going to introduce new stability classes, we should also order by them, so that we have sane groupings of metrics in our output.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:

- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/3466
```
