### PR TITLE
test: remove flaky pod update test in CSIInlineVolumes e2e

### DIFF
--- a/test/e2e/storage/csi_inline.go
+++ b/test/e2e/storage/csi_inline.go
@@ -200,13 +200,6 @@ var _ = utils.SIGDescribe("CSIInlineVolumes", func() {
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(patchedPod.Annotations["patched"], "true", "patched object should have the applied annotation")
 
-		ginkgo.By("updating")
-		podToUpdate := patchedPod.DeepCopy()
-		podToUpdate.Annotations["updated"] = "true"
-		updatedPod, err := client.Update(context.TODO(), podToUpdate, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
-		framework.ExpectEqual(updatedPod.Annotations["updated"], "true", "updated object should have the applied annotation")
-
 		ginkgo.By("deleting")
 		err = client.Delete(context.TODO(), createdPod.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

The `should support CSIVolumeSource in Pod API` update test fails occasionally with:
`the object has been modified; please apply your changes to the latest version and try again`
for example: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce/1567089187251818496
job history: https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-cos-master-default

So we either need to implement some retry logic for the update test, or just remove it. IMO, it doesn't add value in testing the CSIInlineVolumes feature, so I have removed it in this PR.

This flake needs to be resolved before these tests can be promoted to conformance in https://github.com/kubernetes/kubernetes/pull/111724

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

/cc @jsafrane @gnufied @msau42 @xing-yang
/priority important-soon
/triage accepted
/sig storage

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

