### PR TITLE
kubectl explain --output plaintext

### DIFF
--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 	github.com/fatih/camelcase v1.0.0
 	github.com/fvbommel/sortorder v1.0.1
+	github.com/go-openapi/jsonreference v0.20.0
 	github.com/google/gnostic v0.5.7-v3refs
 	github.com/google/go-cmp v0.5.9
 	github.com/jonboulle/clockwork v0.2.2
@@ -52,7 +53,6 @@ require (
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
-	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
@@ -128,11 +128,11 @@ func (o *ExplainOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 
 	// Only openapi v3 needs the discovery client.
 	if o.EnableOpenAPIV3 {
-		clientset, err := f.KubernetesClientSet()
+		discoveryClient, err := f.ToDiscoveryClient()
 		if err != nil {
 			return err
 		}
-		o.DiscoveryClient = clientset.DiscoveryClient
+		o.DiscoveryClient = discoveryClient
 	}
 
 	o.args = args

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/explain.go
@@ -37,8 +37,13 @@ func PrintModelDescription(
 	recursive bool,
 	outputFormat string,
 ) error {
+	generator := NewGenerator()
+	if err := registerBuiltinTemplates(generator); err != nil {
+		return fmt.Errorf("error parsing builtin templates. Please file a bug on GitHub: %w", err)
+	}
+
 	return printModelDescriptionWithGenerator(
-		NewGenerator(), fieldsPath, w, client, gvr, recursive, outputFormat)
+		generator, fieldsPath, w, client, gvr, recursive, outputFormat)
 }
 
 // Factored out for testability

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/explain.go
@@ -43,7 +43,7 @@ func PrintModelDescription(
 
 // Factored out for testability
 func printModelDescriptionWithGenerator(
-	generator *generator,
+	generator Generator,
 	fieldsPath []string,
 	w io.Writer,
 	client openapi.Client,

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/funcs.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/funcs.go
@@ -35,6 +35,193 @@ func WithBuiltinTemplateFuncs(tmpl *template.Template) *template.Template {
 			res, err := json.Marshal(obj)
 			return string(res), err
 		},
+		"toPrettyJson": func(obj any) (string, error) {
+			res, err := json.MarshalIndent(obj, "", "    ")
+			if err != nil {
+				return "", err
+			}
+			return string(res), err
+		},
+		"fail": func(message string) (string, error) {
+			return "", errors.New(message)
+		},
+		"wrap": func(l int, s string) (string, error) {
+			buf := bytes.NewBuffer(nil)
+			writer := term.NewWordWrapWriter(buf, uint(l))
+			_, err := writer.Write([]byte(s))
+			if err != nil {
+				return "", err
+			}
+			return buf.String(), nil
+		},
+		"split": func(s string, sep string) []string {
+			return strings.Split(s, sep)
+		},
+		"join": func(sep string, strs ...string) string {
+			return strings.Join(strs, sep)
+		},
+		"include": func(name string, data interface{}) (string, error) {
+			buf := bytes.NewBuffer(nil)
+			if err := tmpl.ExecuteTemplate(buf, name, data); err != nil {
+				return "", err
+			}
+			return buf.String(), nil
+		},
+		"ternary": func(a, b any, condition bool) any {
+			if condition {
+				return a
+			}
+			return b
+		},
+		"first": func(list any) (any, error) {
+			if list == nil {
+				return nil, errors.New("list is empty")
+			}
+
+			tp := reflect.TypeOf(list).Kind()
+			switch tp {
+			case reflect.Slice, reflect.Array:
+				l2 := reflect.ValueOf(list)
+
+				l := l2.Len()
+				if l == 0 {
+					return nil, errors.New("list is empty")
+				}
+
+				return l2.Index(0).Interface(), nil
+			default:
+				return nil, fmt.Errorf("first cannot be used on type: %T", list)
+			}
+		},
+		"last": func(list any) (any, error) {
+			if list == nil {
+				return nil, errors.New("list is empty")
+			}
+
+			tp := reflect.TypeOf(list).Kind()
+			switch tp {
+			case reflect.Slice, reflect.Array:
+				l2 := reflect.ValueOf(list)
+
+				l := l2.Len()
+				if l == 0 {
+					return nil, errors.New("list is empty")
+				}
+
+				return l2.Index(l - 1).Interface(), nil
+			default:
+				return nil, fmt.Errorf("last cannot be used on type: %T", list)
+			}
+		},
+		"indent": func(amount int, str string) string {
+			pad := strings.Repeat(" ", amount)
+			return pad + strings.Replace(str, "\n", "\n"+pad, -1)
+		},
+		"dict": func(keysAndValues ...any) (map[string]any, error) {
+			if len(keysAndValues)%2 != 0 {
+				return nil, errors.New("expected even # of arguments")
+			}
+
+			res := map[string]any{}
+			for i := 0; i+1 < len(keysAndValues); i = i + 2 {
+				if key, ok := keysAndValues[i].(string); ok {
+					res[key] = keysAndValues[i+1]
+				} else {
+					return nil, fmt.Errorf("key of type %T is not a string as expected", key)
+				}
+			}
+
+			return res, nil
+		},
+		"contains": func(list any, value any) bool {
+			if list == nil {
+				return false
+			}
+
+			val := reflect.ValueOf(list)
+			switch val.Kind() {
+			case reflect.Array:
+			case reflect.Slice:
+				for i := 0; i < val.Len(); i++ {
+					cur := val.Index(i)
+					if cur.CanInterface() && reflect.DeepEqual(cur.Interface(), value) {
+						return true
+					}
+				}
+				return false
+			default:
+				return false
+			}
+			return false
+		},
+		"set": func(dict map[string]any, keysAndValues ...any) (any, error) {
+			if len(keysAndValues)%2 != 0 {
+				return nil, errors.New("expected even number of arguments")
+			}
+
+			copyDict := make(map[string]any, len(dict))
+			for k, v := range dict {
+				copyDict[k] = v
+			}
+
+			for i := 0; i < len(keysAndValues); i += 2 {
+				key, ok := keysAndValues[i].(string)
+				if !ok {
+					return nil, errors.New("keys must be strings")
+				}
+
+				copyDict[key] = keysAndValues[i+1]
+			}
+
+			return copyDict, nil
+		},
+		"add": func(value, operand int) int {
+			return value + operand
+		},
+		"sub": func(value, operand int) int {
+			return value - operand
+		},
+		"mul": func(value, operand int) int {
+			return value * operand
+		},
+		"resolveRef": func(refAny any, document map[string]any) map[string]any {
+			refString, ok := refAny.(string)
+			if !ok {
+				// if passed nil, or wrong type just treat the same
+				// way as unresolved reference (makes for easier templates)
+				return nil
+			}
+
+			// Resolve field path encoded by the ref
+			ref, err := jsonreference.New(refString)
+			if err != nil {
+				// Unrecognized ref format.
+				return nil
+			}
+
+			if !ref.HasFragmentOnly {
+				// Downloading is not supported. Treat as not found
+				return nil
+			}
+
+			fragment := ref.GetURL().Fragment
+			components := strings.Split(fragment, "/")
+			cur := document
+
+			for _, k := range components {
+				if len(k) == 0 {
+					// first component is usually empty (#/components/) , etc
+					continue
+				}
+
+				next, ok := cur[k].(map[string]any)
+				if !ok {
+					return nil
+				}
+
+				cur = next
+			}
+			return cur
+		},
 	})
 }
-

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/funcs.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/funcs.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"text/template"
+
+	"github.com/go-openapi/jsonreference"
+	"k8s.io/kubectl/pkg/util/term"
+)
+
+func WithBuiltinTemplateFuncs(tmpl *template.Template) *template.Template {
+	return tmpl.Funcs(map[string]interface{}{
+		"toJson": func(obj any) (string, error) {
+			res, err := json.Marshal(obj)
+			return string(res), err
+		},
+	})
+}
+

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/funcs_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/funcs_test.go
@@ -1,0 +1,358 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2_test
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	v2 "k8s.io/kubectl/pkg/explain/v2"
+)
+
+func TestFuncs(t *testing.T) {
+	testcases := []struct {
+		Name     string
+		FuncName string
+		Source   string
+		Context  any
+		Expect   string
+		Error    string
+	}{
+		{
+			Name:     "err",
+			FuncName: "fail",
+			Source:   `{{fail .}}`,
+			Context:  "this is a test",
+			Error:    "this is a test",
+		},
+		{
+			Name:     "basic",
+			FuncName: "wrap",
+			Source:   `{{wrap 3 .}}`,
+			Context:  "this is a really good test",
+			Expect:   "this\nis\na\nreally\ngood\ntest",
+		},
+		{
+			Name:     "basic",
+			FuncName: "split",
+			Source:   `{{split . "/"}}`,
+			Context:  "this/is/a/slash/separated/thing",
+			Expect:   "[this is a slash separated thing]",
+		},
+		{
+			Name:     "basic",
+			FuncName: "join",
+			Source:   `{{join "/" "this" "is" "a" "slash" "separated" "thing"}}`,
+			Expect:   "this/is/a/slash/separated/thing",
+		},
+		{
+			Name:     "basic",
+			FuncName: "include",
+			Source:   `{{define "myTemplate"}}{{.}}{{end}}{{$var := include "myTemplate" .}}{{$var}}`,
+			Context:  "hello, world!",
+			Expect:   "hello, world!",
+		},
+		{
+			Name:     "nil",
+			FuncName: "first",
+			Source:   `{{first .}}`,
+			Context:  nil,
+			Error:    "list is empty",
+		},
+		{
+			Name:     "empty",
+			FuncName: "first",
+			Source:   `{{first .}}`,
+			Context:  []string{},
+			Error:    "list is empty",
+		},
+		{
+			Name:     "basic",
+			FuncName: "first",
+			Source:   `{{first .}}`,
+			Context:  []string{"first", "second", "third"},
+			Expect:   "first",
+		},
+		{
+			Name:     "wrongtype",
+			FuncName: "first",
+			Source:   `{{first .}}`,
+			Context:  "test",
+			Error:    "first cannot be used on type: string",
+		},
+		{
+			Name:     "nil",
+			FuncName: "last",
+			Source:   `{{last .}}`,
+			Context:  nil,
+			Error:    "list is empty",
+		},
+		{
+			Name:     "empty",
+			FuncName: "last",
+			Source:   `{{last .}}`,
+			Context:  []string{},
+			Error:    "list is empty",
+		},
+		{
+			Name:     "basic",
+			FuncName: "last",
+			Source:   `{{last .}}`,
+			Context:  []string{"first", "second", "third"},
+			Expect:   "third",
+		},
+		{
+			Name:     "wrongtype",
+			FuncName: "last",
+			Source:   `{{last .}}`,
+			Context:  "test",
+			Error:    "last cannot be used on type: string",
+		},
+		{
+			Name:     "none",
+			FuncName: "indent",
+			Source:   `{{indent 0 .}}`,
+			Context:  "this is a string",
+			Expect:   "this is a string",
+		},
+		{
+			Name:     "some",
+			FuncName: "indent",
+			Source:   `{{indent 2 .}}`,
+			Context:  "this is a string",
+			Expect:   "  this is a string",
+		},
+		{
+			Name:     "empty",
+			FuncName: "dict",
+			Source:   `{{dict | toJson}}`,
+			Expect:   "{}",
+		},
+		{
+			Name:     "single value",
+			FuncName: "dict",
+			Source:   `{{dict "key" "value" | toJson}}`,
+			Expect:   `{"key":"value"}`,
+		},
+		{
+			Name:     "twoValues",
+			FuncName: "dict",
+			Source:   `{{dict "key1" "val1" "key2" "val2" | toJson}}`,
+			Expect:   `{"key1":"val1","key2":"val2"}`,
+		},
+		{
+			Name:     "oddNumberArgs",
+			FuncName: "dict",
+			Source:   `{{dict "key1" 1 "key2" | toJson}}`,
+			Error:    "error calling dict: expected even # of arguments",
+		},
+		{
+			Name:     "IntegerValue",
+			FuncName: "dict",
+			Source:   `{{dict "key1" 1 | toJson}}`,
+			Expect:   `{"key1":1}`,
+		},
+		{
+			Name:     "MixedValues",
+			FuncName: "dict",
+			Source:   `{{dict "key1" 1 "key2" "val2" "key3" (dict "key1" "val1") | toJson}}`,
+			Expect:   `{"key1":1,"key2":"val2","key3":{"key1":"val1"}}`,
+		},
+		{
+			Name:     "nil",
+			FuncName: "contains",
+			Source:   `{{contains . "value"}}`,
+			Context:  nil,
+			Expect:   `false`,
+		},
+		{
+			Name:     "empty",
+			FuncName: "contains",
+			Source:   `{{contains . "value"}}`,
+			Context:  []string{},
+			Expect:   `false`,
+		},
+		{
+			Name:     "basic",
+			FuncName: "contains",
+			Source:   `{{contains . "value"}}`,
+			Context:  []string{"value"},
+			Expect:   `true`,
+		},
+		{
+			Name:     "struct",
+			FuncName: "contains",
+			Source:   `{{contains $.haystack $.needle}}`,
+			Context: map[string]any{
+				"needle": schema.GroupVersionKind{"testgroup.k8s.io", "v1", "Kind"},
+				"haystack": []schema.GroupVersionKind{
+					{"randomgroup.k8s.io", "v1", "OtherKind"},
+					{"testgroup.k8s.io", "v1", "OtherKind"},
+					{"testgroup.k8s.io", "v1", "Kind"},
+				},
+			},
+			Expect: `true`,
+		},
+		{
+			Name:     "nil",
+			FuncName: "set",
+			Source:   `{{set nil "key" "value" | toJson}}`,
+			Expect:   `{"key":"value"}`,
+		},
+		{
+			Name:     "empty",
+			FuncName: "set",
+			Source:   `{{set (dict) "key" "value" | toJson}}`,
+			Expect:   `{"key":"value"}`,
+		},
+		{
+			Name:     "OddArgs",
+			FuncName: "set",
+			Source:   `{{set (dict) "key" "value" "key2" | toJson}}`,
+			Error:    `expected even number of arguments`,
+		},
+		{
+			Name:     "NonStringKey",
+			FuncName: "set",
+			Source:   `{{set (dict) 1 "value" | toJson}}`,
+			Error:    `keys must be strings`,
+		},
+		{
+			Name:     "NilKey",
+			FuncName: "set",
+			Source:   `{{set (dict) nil "value" | toJson}}`,
+			Error:    `keys must be strings`,
+		},
+		{
+			Name:     "NilValue",
+			FuncName: "set",
+			Source:   `{{set (dict) "key" nil | toJson}}`,
+			Expect:   `{"key":null}`,
+		},
+		{
+			Name:     "OverwriteKey",
+			FuncName: "set",
+			Source:   `{{set (dict "key1" "val1" "key2" "val2") "key1" nil | toJson}}`,
+			Expect:   `{"key1":null,"key2":"val2"}`,
+		},
+		{
+			Name:     "OverwriteKeyWithLefover",
+			FuncName: "set",
+			Source:   `{{set (dict "key1" "val1" "key2" "val2" "key3" "val3") "key1" nil | toJson}}`,
+			Expect:   `{"key1":null,"key2":"val2","key3":"val3"}`,
+		},
+		{
+			Name:     "basic",
+			FuncName: "add",
+			Source:   `{{add 1 2}}`,
+			Expect:   `3`,
+		},
+		{
+			Name:     "basic",
+			FuncName: "sub",
+			Source:   `{{sub 1 2}}`,
+			Expect:   `-1`,
+		},
+		{
+			Name:     "basic",
+			FuncName: "mul",
+			Source:   `{{mul 2 3}}`,
+			Expect:   `6`,
+		},
+		{
+			Name:     "basic",
+			FuncName: "resolveRef",
+			Source:   `{{resolveRef "#/components/schemas/myTypeName" . | toJson}}`,
+			Context: map[string]any{
+				"components": map[string]any{
+					"schemas": map[string]any{
+						"myTypeName": map[string]any{
+							"key": "val",
+						},
+					},
+				},
+			},
+			Expect: `{"key":"val"}`,
+		},
+		{
+			Name:     "basicNameWithDots",
+			FuncName: "resolveRef",
+			Source:   `{{resolveRef "#/components/schemas/myTypeName.with.dots" . | toJson}}`,
+			Context: map[string]any{
+				"components": map[string]any{
+					"schemas": map[string]any{
+						"myTypeName.with.dots": map[string]any{
+							"key": "val",
+						},
+					},
+				},
+			},
+			Expect: `{"key":"val"}`,
+		},
+		{
+			Name:     "notFound",
+			FuncName: "resolveRef",
+			Source:   `{{resolveRef "#/components/schemas/otherTypeName" . | toJson}}`,
+			Context: map[string]any{
+				"components": map[string]any{
+					"schemas": map[string]any{
+						"myTypeName": map[string]any{
+							"key": "val",
+						},
+					},
+				},
+			},
+			Expect: `null`,
+		},
+		{
+			Name:     "url",
+			FuncName: "resolveRef",
+			Source:   `{{resolveRef "http://swagger.com/swagger.json#/components/schemas/myTypeName" . | toJson}}`,
+			Context: map[string]any{
+				"components": map[string]any{
+					"schemas": map[string]any{
+						"myTypeName": map[string]any{
+							"key": "val",
+						},
+					},
+				},
+			},
+			Expect: `null`,
+		},
+	}
+
+	for _, tcase := range testcases {
+		t.Run(tcase.FuncName+"/"+tcase.Name, func(t *testing.T) {
+
+			tmpl, err := v2.WithBuiltinTemplateFuncs(template.New("me")).Parse(tcase.Source)
+			require.NoError(t, err)
+
+			buf := bytes.NewBuffer(nil)
+			err = tmpl.Execute(buf, tcase.Context)
+
+			if len(tcase.Error) > 0 {
+				require.ErrorContains(t, err, tcase.Error)
+			} else if output := buf.String(); len(tcase.Expect) > 0 {
+				require.NoError(t, err)
+				require.Contains(t, output, tcase.Expect)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/template.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/template.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"embed"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed templates/*.tmpl
+var rawBuiltinTemplates embed.FS
+
+func registerBuiltinTemplates(gen Generator) error {
+	files, err := rawBuiltinTemplates.ReadDir("templates")
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range files {
+		contents, err := rawBuiltinTemplates.ReadFile("templates/" + entry.Name())
+		if err != nil {
+			return err
+		}
+
+		err = gen.AddTemplate(
+			strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name())),
+			string(contents))
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/template_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/template_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+// Ensure that the templates are embededd correctly.
+func TestRegisterBuitinTemplates(t *testing.T) {
+	myGenerator := NewGenerator().(*generator)
+	err := registerBuiltinTemplates(myGenerator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Show that generator now as a named template for each file in the `templates`
+	// directory.
+	files, err := os.ReadDir("templates")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, templateFile := range files {
+		name := templateFile.Name()
+		ext := path.Ext(name)
+		if ext != "tmpl" {
+			continue
+		}
+
+		name = strings.TrimSuffix(name, ext)
+		if _, ok := myGenerator.templates[name]; !ok {
+			t.Fatalf("missing template: %v", name)
+		}
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/apiextensions.k8s.io_v1.json
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/apiextensions.k8s.io_v1.json
@@ -1,0 +1,2812 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Kubernetes", "version": "v1.26.0" },
+  "paths": {
+    "/apis/apiextensions.k8s.io/v1/": {
+      "get": {
+        "tags": ["apiextensions_v1"],
+        "description": "get available resources",
+        "operationId": "getApiextensionsV1APIResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/apis/apiextensions.k8s.io/v1/customresourcedefinitions": {
+      "get": {
+        "tags": ["apiextensions_v1"],
+        "description": "list or watch objects of kind CustomResourceDefinition",
+        "operationId": "listApiextensionsV1CustomResourceDefinition",
+        "parameters": [
+          {
+            "name": "allowWatchBookmarks",
+            "in": "query",
+            "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+            "schema": { "type": "boolean", "uniqueItems": true }
+          },
+          {
+            "name": "continue",
+            "in": "query",
+            "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "fieldSelector",
+            "in": "query",
+            "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "labelSelector",
+            "in": "query",
+            "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+            "schema": { "type": "integer", "uniqueItems": true }
+          },
+          {
+            "name": "resourceVersion",
+            "in": "query",
+            "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "resourceVersionMatch",
+            "in": "query",
+            "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "timeoutSeconds",
+            "in": "query",
+            "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+            "schema": { "type": "integer", "uniqueItems": true }
+          },
+          {
+            "name": "watch",
+            "in": "query",
+            "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+            "schema": { "type": "boolean", "uniqueItems": true }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        },
+        "x-kubernetes-action": "list",
+        "x-kubernetes-group-version-kind": {
+          "group": "apiextensions.k8s.io",
+          "version": "v1",
+          "kind": "CustomResourceDefinition"
+        }
+      },
+      "post": {
+        "tags": ["apiextensions_v1"],
+        "description": "create a CustomResourceDefinition",
+        "operationId": "createApiextensionsV1CustomResourceDefinition",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "fieldManager",
+            "in": "query",
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "fieldValidation",
+            "in": "query",
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields, provided that the `ServerSideFieldValidation` feature gate is also enabled. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23 and is the default behavior when the `ServerSideFieldValidation` feature gate is disabled. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default when the `ServerSideFieldValidation` feature gate is enabled. - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "schema": { "type": "string", "uniqueItems": true }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        },
+        "x-kubernetes-action": "post",
+        "x-kubernetes-group-version-kind": {
+          "group": "apiextensions.k8s.io",
+          "version": "v1",
+          "kind": "CustomResourceDefinition"
+        }
+      },
+      "delete": {
+        "tags": ["apiextensions_v1"],
+        "description": "delete collection of CustomResourceDefinition",
+        "operationId": "deleteApiextensionsV1CollectionCustomResourceDefinition",
+        "parameters": [
+          {
+            "name": "continue",
+            "in": "query",
+            "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "fieldSelector",
+            "in": "query",
+            "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "gracePeriodSeconds",
+            "in": "query",
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "schema": { "type": "integer", "uniqueItems": true }
+          },
+          {
+            "name": "labelSelector",
+            "in": "query",
+            "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+            "schema": { "type": "integer", "uniqueItems": true }
+          },
+          {
+            "name": "orphanDependents",
+            "in": "query",
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "schema": { "type": "boolean", "uniqueItems": true }
+          },
+          {
+            "name": "propagationPolicy",
+            "in": "query",
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "resourceVersion",
+            "in": "query",
+            "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "resourceVersionMatch",
+            "in": "query",
+            "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "timeoutSeconds",
+            "in": "query",
+            "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+            "schema": { "type": "integer", "uniqueItems": true }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        },
+        "x-kubernetes-action": "deletecollection",
+        "x-kubernetes-group-version-kind": {
+          "group": "apiextensions.k8s.io",
+          "version": "v1",
+          "kind": "CustomResourceDefinition"
+        }
+      },
+      "parameters": [
+        {
+          "name": "pretty",
+          "in": "query",
+          "description": "If 'true', then the output is pretty printed.",
+          "schema": { "type": "string", "uniqueItems": true }
+        }
+      ]
+    },
+    "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}": {
+      "get": {
+        "tags": ["apiextensions_v1"],
+        "description": "read the specified CustomResourceDefinition",
+        "operationId": "readApiextensionsV1CustomResourceDefinition",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        },
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "apiextensions.k8s.io",
+          "version": "v1",
+          "kind": "CustomResourceDefinition"
+        }
+      },
+      "put": {
+        "tags": ["apiextensions_v1"],
+        "description": "replace the specified CustomResourceDefinition",
+        "operationId": "replaceApiextensionsV1CustomResourceDefinition",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "fieldManager",
+            "in": "query",
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "fieldValidation",
+            "in": "query",
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields, provided that the `ServerSideFieldValidation` feature gate is also enabled. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23 and is the default behavior when the `ServerSideFieldValidation` feature gate is disabled. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default when the `ServerSideFieldValidation` feature gate is enabled. - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "schema": { "type": "string", "uniqueItems": true }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        },
+        "x-kubernetes-action": "put",
+        "x-kubernetes-group-version-kind": {
+          "group": "apiextensions.k8s.io",
+          "version": "v1",
+          "kind": "CustomResourceDefinition"
+        }
+      },
+      "delete": {
+        "tags": ["apiextensions_v1"],
+        "description": "delete a CustomResourceDefinition",
+        "operationId": "deleteApiextensionsV1CustomResourceDefinition",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "gracePeriodSeconds",
+            "in": "query",
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "schema": { "type": "integer", "uniqueItems": true }
+          },
+          {
+            "name": "orphanDependents",
+            "in": "query",
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "schema": { "type": "boolean", "uniqueItems": true }
+          },
+          {
+            "name": "propagationPolicy",
+            "in": "query",
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "schema": { "type": "string", "uniqueItems": true }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        },
+        "x-kubernetes-action": "delete",
+        "x-kubernetes-group-version-kind": {
+          "group": "apiextensions.k8s.io",
+          "version": "v1",
+          "kind": "CustomResourceDefinition"
+        }
+      },
+      "patch": {
+        "tags": ["apiextensions_v1"],
+        "description": "partially update the specified CustomResourceDefinition",
+        "operationId": "patchApiextensionsV1CustomResourceDefinition",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "fieldManager",
+            "in": "query",
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "fieldValidation",
+            "in": "query",
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields, provided that the `ServerSideFieldValidation` feature gate is also enabled. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23 and is the default behavior when the `ServerSideFieldValidation` feature gate is disabled. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default when the `ServerSideFieldValidation` feature gate is enabled. - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+            "schema": { "type": "boolean", "uniqueItems": true }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/apply-patch+yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/strategic-merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        },
+        "x-kubernetes-action": "patch",
+        "x-kubernetes-group-version-kind": {
+          "group": "apiextensions.k8s.io",
+          "version": "v1",
+          "kind": "CustomResourceDefinition"
+        }
+      },
+      "parameters": [
+        {
+          "name": "name",
+          "in": "path",
+          "description": "name of the CustomResourceDefinition",
+          "required": true,
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "pretty",
+          "in": "query",
+          "description": "If 'true', then the output is pretty printed.",
+          "schema": { "type": "string", "uniqueItems": true }
+        }
+      ]
+    },
+    "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}/status": {
+      "get": {
+        "tags": ["apiextensions_v1"],
+        "description": "read status of the specified CustomResourceDefinition",
+        "operationId": "readApiextensionsV1CustomResourceDefinitionStatus",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        },
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "apiextensions.k8s.io",
+          "version": "v1",
+          "kind": "CustomResourceDefinition"
+        }
+      },
+      "put": {
+        "tags": ["apiextensions_v1"],
+        "description": "replace status of the specified CustomResourceDefinition",
+        "operationId": "replaceApiextensionsV1CustomResourceDefinitionStatus",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "fieldManager",
+            "in": "query",
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "fieldValidation",
+            "in": "query",
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields, provided that the `ServerSideFieldValidation` feature gate is also enabled. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23 and is the default behavior when the `ServerSideFieldValidation` feature gate is disabled. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default when the `ServerSideFieldValidation` feature gate is enabled. - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "schema": { "type": "string", "uniqueItems": true }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        },
+        "x-kubernetes-action": "put",
+        "x-kubernetes-group-version-kind": {
+          "group": "apiextensions.k8s.io",
+          "version": "v1",
+          "kind": "CustomResourceDefinition"
+        }
+      },
+      "patch": {
+        "tags": ["apiextensions_v1"],
+        "description": "partially update status of the specified CustomResourceDefinition",
+        "operationId": "patchApiextensionsV1CustomResourceDefinitionStatus",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "fieldManager",
+            "in": "query",
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "fieldValidation",
+            "in": "query",
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields, provided that the `ServerSideFieldValidation` feature gate is also enabled. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23 and is the default behavior when the `ServerSideFieldValidation` feature gate is disabled. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default when the `ServerSideFieldValidation` feature gate is enabled. - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "schema": { "type": "string", "uniqueItems": true }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+            "schema": { "type": "boolean", "uniqueItems": true }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/apply-patch+yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/strategic-merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        },
+        "x-kubernetes-action": "patch",
+        "x-kubernetes-group-version-kind": {
+          "group": "apiextensions.k8s.io",
+          "version": "v1",
+          "kind": "CustomResourceDefinition"
+        }
+      },
+      "parameters": [
+        {
+          "name": "name",
+          "in": "path",
+          "description": "name of the CustomResourceDefinition",
+          "required": true,
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "pretty",
+          "in": "query",
+          "description": "If 'true', then the output is pretty printed.",
+          "schema": { "type": "string", "uniqueItems": true }
+        }
+      ]
+    },
+    "/apis/apiextensions.k8s.io/v1/watch/customresourcedefinitions": {
+      "get": {
+        "tags": ["apiextensions_v1"],
+        "description": "watch individual changes to a list of CustomResourceDefinition. deprecated: use the 'watch' parameter with a list operation instead.",
+        "operationId": "watchApiextensionsV1CustomResourceDefinitionList",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        },
+        "x-kubernetes-action": "watchlist",
+        "x-kubernetes-group-version-kind": {
+          "group": "apiextensions.k8s.io",
+          "version": "v1",
+          "kind": "CustomResourceDefinition"
+        }
+      },
+      "parameters": [
+        {
+          "name": "allowWatchBookmarks",
+          "in": "query",
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "schema": { "type": "boolean", "uniqueItems": true }
+        },
+        {
+          "name": "continue",
+          "in": "query",
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "fieldSelector",
+          "in": "query",
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "labelSelector",
+          "in": "query",
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "schema": { "type": "integer", "uniqueItems": true }
+        },
+        {
+          "name": "pretty",
+          "in": "query",
+          "description": "If 'true', then the output is pretty printed.",
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "resourceVersion",
+          "in": "query",
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "resourceVersionMatch",
+          "in": "query",
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "timeoutSeconds",
+          "in": "query",
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "schema": { "type": "integer", "uniqueItems": true }
+        },
+        {
+          "name": "watch",
+          "in": "query",
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "schema": { "type": "boolean", "uniqueItems": true }
+        }
+      ]
+    },
+    "/apis/apiextensions.k8s.io/v1/watch/customresourcedefinitions/{name}": {
+      "get": {
+        "tags": ["apiextensions_v1"],
+        "description": "watch changes to an object of kind CustomResourceDefinition. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+        "operationId": "watchApiextensionsV1CustomResourceDefinition",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        },
+        "x-kubernetes-action": "watch",
+        "x-kubernetes-group-version-kind": {
+          "group": "apiextensions.k8s.io",
+          "version": "v1",
+          "kind": "CustomResourceDefinition"
+        }
+      },
+      "parameters": [
+        {
+          "name": "allowWatchBookmarks",
+          "in": "query",
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "schema": { "type": "boolean", "uniqueItems": true }
+        },
+        {
+          "name": "continue",
+          "in": "query",
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "fieldSelector",
+          "in": "query",
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "labelSelector",
+          "in": "query",
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "schema": { "type": "integer", "uniqueItems": true }
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "description": "name of the CustomResourceDefinition",
+          "required": true,
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "pretty",
+          "in": "query",
+          "description": "If 'true', then the output is pretty printed.",
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "resourceVersion",
+          "in": "query",
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "resourceVersionMatch",
+          "in": "query",
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "schema": { "type": "string", "uniqueItems": true }
+        },
+        {
+          "name": "timeoutSeconds",
+          "in": "query",
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "schema": { "type": "integer", "uniqueItems": true }
+        },
+        {
+          "name": "watch",
+          "in": "query",
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "schema": { "type": "boolean", "uniqueItems": true }
+        }
+      ]
+    }
+  },
+  "components": {
+    "schemas": {
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition": {
+        "description": "CustomResourceColumnDefinition specifies a column for server side printing.",
+        "type": "object",
+        "required": ["name", "type", "jsonPath"],
+        "properties": {
+          "description": {
+            "description": "description is a human readable description of this column.",
+            "type": "string"
+          },
+          "format": {
+            "description": "format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.",
+            "type": "string"
+          },
+          "jsonPath": {
+            "description": "jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.",
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "description": "name is a human readable name for the column.",
+            "type": "string",
+            "default": ""
+          },
+          "priority": {
+            "description": "priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "description": "type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceConversion": {
+        "description": "CustomResourceConversion describes how to convert different versions of a CR.",
+        "type": "object",
+        "required": ["strategy"],
+        "properties": {
+          "strategy": {
+            "description": "strategy specifies how custom resources are converted between versions. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information\n  is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhook to be set.",
+            "type": "string",
+            "default": ""
+          },
+          "webhook": {
+            "description": "webhook describes how to call the conversion webhook. Required when `strategy` is set to `Webhook`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookConversion"
+              }
+            ]
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition": {
+        "description": "CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format \u003c.spec.name\u003e.\u003c.spec.group\u003e.",
+        "type": "object",
+        "required": ["spec"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+              }
+            ]
+          },
+          "spec": {
+            "description": "spec describes how the user wants the resources to appear",
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec"
+              }
+            ]
+          },
+          "status": {
+            "description": "status indicates the actual state of the CustomResourceDefinition",
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus"
+              }
+            ]
+          }
+        },
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "apiextensions.k8s.io",
+            "kind": "CustomResourceDefinition",
+            "version": "v1"
+          }
+        ]
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition": {
+        "description": "CustomResourceDefinitionCondition contains details for the current condition of this pod.",
+        "type": "object",
+        "required": ["type", "status"],
+        "properties": {
+          "lastTransitionTime": {
+            "description": "lastTransitionTime last time the condition transitioned from one status to another.",
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ]
+          },
+          "message": {
+            "description": "message is a human-readable message indicating details about last transition.",
+            "type": "string"
+          },
+          "reason": {
+            "description": "reason is a unique, one-word, CamelCase reason for the condition's last transition.",
+            "type": "string"
+          },
+          "status": {
+            "description": "status is the status of the condition. Can be True, False, Unknown.",
+            "type": "string",
+            "default": ""
+          },
+          "type": {
+            "description": "type is the type of the condition. Types include Established, NamesAccepted and Terminating.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList": {
+        "description": "CustomResourceDefinitionList is a list of CustomResourceDefinition objects.",
+        "type": "object",
+        "required": ["items"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "items": {
+            "description": "items list individual CustomResourceDefinition objects",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+                }
+              ]
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+              }
+            ]
+          }
+        },
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "apiextensions.k8s.io",
+            "kind": "CustomResourceDefinitionList",
+            "version": "v1"
+          }
+        ]
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames": {
+        "description": "CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition",
+        "type": "object",
+        "required": ["plural", "kind"],
+        "properties": {
+          "categories": {
+            "description": "categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.",
+            "type": "array",
+            "items": { "type": "string", "default": "" }
+          },
+          "kind": {
+            "description": "kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.",
+            "type": "string",
+            "default": ""
+          },
+          "listKind": {
+            "description": "listKind is the serialized kind of the list for this resource. Defaults to \"`kind`List\".",
+            "type": "string"
+          },
+          "plural": {
+            "description": "plural is the plural name of the resource to serve. The custom resources are served under `/apis/\u003cgroup\u003e/\u003cversion\u003e/.../\u003cplural\u003e`. Must match the name of the CustomResourceDefinition (in the form `\u003cnames.plural\u003e.\u003cgroup\u003e`). Must be all lowercase.",
+            "type": "string",
+            "default": ""
+          },
+          "shortNames": {
+            "description": "shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get \u003cshortname\u003e`. It must be all lowercase.",
+            "type": "array",
+            "items": { "type": "string", "default": "" }
+          },
+          "singular": {
+            "description": "singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec": {
+        "description": "CustomResourceDefinitionSpec describes how a user wants their resource to appear",
+        "type": "object",
+        "required": ["group", "names", "scope", "versions"],
+        "properties": {
+          "conversion": {
+            "description": "conversion defines conversion settings for the CRD.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceConversion"
+              }
+            ]
+          },
+          "group": {
+            "description": "group is the API group of the defined custom resource. The custom resources are served under `/apis/\u003cgroup\u003e/...`. Must match the name of the CustomResourceDefinition (in the form `\u003cnames.plural\u003e.\u003cgroup\u003e`).",
+            "type": "string",
+            "default": ""
+          },
+          "names": {
+            "description": "names specify the resource and kind names for the custom resource.",
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames"
+              }
+            ]
+          },
+          "preserveUnknownFields": {
+            "description": "preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning for details.",
+            "type": "boolean"
+          },
+          "scope": {
+            "description": "scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`.",
+            "type": "string",
+            "default": ""
+          },
+          "versions": {
+            "description": "versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA \u003e beta \u003e alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus": {
+        "description": "CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition",
+        "type": "object",
+        "properties": {
+          "acceptedNames": {
+            "description": "acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec.",
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames"
+              }
+            ]
+          },
+          "conditions": {
+            "description": "conditions indicate state for particular aspects of a CustomResourceDefinition",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition"
+                }
+              ]
+            },
+            "x-kubernetes-list-map-keys": ["type"],
+            "x-kubernetes-list-type": "map"
+          },
+          "storedVersions": {
+            "description": "storedVersions lists all versions of CustomResources that were ever persisted. Tracking these versions allows a migration path for stored versions in etcd. The field is mutable so a migration controller can finish a migration to another version (ensuring no old objects are left in storage), and then remove the rest of the versions from this list. Versions may not be removed from `spec.versions` while they exist in this list.",
+            "type": "array",
+            "items": { "type": "string", "default": "" }
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion": {
+        "description": "CustomResourceDefinitionVersion describes a version for CRD.",
+        "type": "object",
+        "required": ["name", "served", "storage"],
+        "properties": {
+          "additionalPrinterColumns": {
+            "description": "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition"
+                }
+              ]
+            }
+          },
+          "deprecated": {
+            "description": "deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.",
+            "type": "boolean"
+          },
+          "deprecationWarning": {
+            "description": "deprecationWarning overrides the default warning returned to API clients. May only be set when `deprecated` is true. The default warning indicates this version is deprecated and recommends use of the newest served version of equal or greater stability, if one exists.",
+            "type": "string"
+          },
+          "name": {
+            "description": "name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/\u003cgroup\u003e/\u003cversion\u003e/...` if `served` is true.",
+            "type": "string",
+            "default": ""
+          },
+          "schema": {
+            "description": "schema describes the schema used for validation, pruning, and defaulting of this version of the custom resource.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation"
+              }
+            ]
+          },
+          "served": {
+            "description": "served is a flag enabling/disabling this version from being served via REST APIs",
+            "type": "boolean",
+            "default": false
+          },
+          "storage": {
+            "description": "storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.",
+            "type": "boolean",
+            "default": false
+          },
+          "subresources": {
+            "description": "subresources specify what subresources this version of the defined custom resource have.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresources"
+              }
+            ]
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceScale": {
+        "description": "CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.",
+        "type": "object",
+        "required": ["specReplicasPath", "statusReplicasPath"],
+        "properties": {
+          "labelSelectorPath": {
+            "description": "labelSelectorPath defines the JSON path inside of a custom resource that corresponds to Scale `status.selector`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status` or `.spec`. Must be set to work with HorizontalPodAutoscaler. The field pointed by this JSON path must be a string field (not a complex selector struct) which contains a serialized label selector in string form. More info: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions#scale-subresource If there is no value under the given path in the custom resource, the `status.selector` value in the `/scale` subresource will default to the empty string.",
+            "type": "string"
+          },
+          "specReplicasPath": {
+            "description": "specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.",
+            "type": "string",
+            "default": ""
+          },
+          "statusReplicasPath": {
+            "description": "statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceStatus": {
+        "description": "CustomResourceSubresourceStatus defines how to serve the status subresource for CustomResources. Status is represented by the `.status` JSON path inside of a CustomResource. When set, * exposes a /status subresource for the custom resource * PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza * PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza",
+        "type": "object"
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresources": {
+        "description": "CustomResourceSubresources defines the status and scale subresources for CustomResources.",
+        "type": "object",
+        "properties": {
+          "scale": {
+            "description": "scale indicates the custom resource should serve a `/scale` subresource that returns an `autoscaling/v1` Scale object.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceScale"
+              }
+            ]
+          },
+          "status": {
+            "description": "status indicates the custom resource should serve a `/status` subresource. When enabled: 1. requests to the custom resource primary endpoint ignore changes to the `status` stanza of the object. 2. requests to the custom resource `/status` subresource ignore changes to anything other than the `status` stanza of the object.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceStatus"
+              }
+            ]
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation": {
+        "description": "CustomResourceValidation is a list of validation methods for CustomResources.",
+        "type": "object",
+        "properties": {
+          "openAPIV3Schema": {
+            "description": "openAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+              }
+            ]
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ExternalDocumentation": {
+        "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+        "type": "object",
+        "properties": {
+          "description": { "type": "string" },
+          "url": { "type": "string" }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON": {
+        "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil."
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps": {
+        "description": "JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).",
+        "type": "object",
+        "properties": {
+          "$ref": { "type": "string" },
+          "$schema": { "type": "string" },
+          "additionalItems": {
+            "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool"
+          },
+          "additionalProperties": {
+            "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool"
+          },
+          "allOf": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+                }
+              ]
+            }
+          },
+          "anyOf": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+                }
+              ]
+            }
+          },
+          "default": {
+            "description": "default is a default value for undefined object fields. Defaulting is a beta feature under the CustomResourceDefaulting feature gate. Defaulting requires spec.preserveUnknownFields to be false.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
+              }
+            ]
+          },
+          "definitions": {
+            "type": "object",
+            "additionalProperties": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+                }
+              ]
+            }
+          },
+          "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrStringArray"
+                }
+              ]
+            }
+          },
+          "description": { "type": "string" },
+          "enum": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
+                }
+              ]
+            }
+          },
+          "example": {
+            "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
+          },
+          "exclusiveMaximum": { "type": "boolean" },
+          "exclusiveMinimum": { "type": "boolean" },
+          "externalDocs": {
+            "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ExternalDocumentation"
+          },
+          "format": {
+            "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:\n\n- bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\d{3}[- ]?\\d{2}[- ]?\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
+            "type": "string"
+          },
+          "id": { "type": "string" },
+          "items": {
+            "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrArray"
+          },
+          "maxItems": { "type": "integer", "format": "int64" },
+          "maxLength": { "type": "integer", "format": "int64" },
+          "maxProperties": { "type": "integer", "format": "int64" },
+          "maximum": { "type": "number", "format": "double" },
+          "minItems": { "type": "integer", "format": "int64" },
+          "minLength": { "type": "integer", "format": "int64" },
+          "minProperties": { "type": "integer", "format": "int64" },
+          "minimum": { "type": "number", "format": "double" },
+          "multipleOf": { "type": "number", "format": "double" },
+          "not": {
+            "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+          },
+          "nullable": { "type": "boolean" },
+          "oneOf": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+                }
+              ]
+            }
+          },
+          "pattern": { "type": "string" },
+          "patternProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+                }
+              ]
+            }
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+                }
+              ]
+            }
+          },
+          "required": {
+            "type": "array",
+            "items": { "type": "string", "default": "" }
+          },
+          "title": { "type": "string" },
+          "type": { "type": "string" },
+          "uniqueItems": { "type": "boolean" },
+          "x-kubernetes-embedded-resource": {
+            "description": "x-kubernetes-embedded-resource defines that the value is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta. The type must be object. It is allowed to further restrict the embedded object. kind, apiVersion and metadata are validated automatically. x-kubernetes-preserve-unknown-fields is allowed to be true, but does not have to be if the object is fully specified (up to kind, apiVersion, metadata).",
+            "type": "boolean"
+          },
+          "x-kubernetes-int-or-string": {
+            "description": "x-kubernetes-int-or-string specifies that this value is either an integer or a string. If this is true, an empty type is allowed and type as child of anyOf is permitted if following one of the following patterns:\n\n1) anyOf:\n   - type: integer\n   - type: string\n2) allOf:\n   - anyOf:\n     - type: integer\n     - type: string\n   - ... zero or more",
+            "type": "boolean"
+          },
+          "x-kubernetes-list-map-keys": {
+            "description": "x-kubernetes-list-map-keys annotates an array with the x-kubernetes-list-type `map` by specifying the keys used as the index of the map.\n\nThis tag MUST only be used on lists that have the \"x-kubernetes-list-type\" extension set to \"map\". Also, the values specified for this attribute must be a scalar typed field of the child structure (no nesting is supported).\n\nThe properties specified must either be required or have a default value, to ensure those properties are present for all list items.",
+            "type": "array",
+            "items": { "type": "string", "default": "" }
+          },
+          "x-kubernetes-list-type": {
+            "description": "x-kubernetes-list-type annotates an array to further describe its topology. This extension must only be used on lists and may have 3 possible values:\n\n1) `atomic`: the list is treated as a single entity, like a scalar.\n     Atomic lists will be entirely replaced when updated. This extension\n     may be used on any type of list (struct, scalar, ...).\n2) `set`:\n     Sets are lists that must not have multiple items with the same value. Each\n     value must be a scalar, an object with x-kubernetes-map-type `atomic` or an\n     array with x-kubernetes-list-type `atomic`.\n3) `map`:\n     These lists are like maps in that their elements have a non-index key\n     used to identify them. Order is preserved upon merge. The map tag\n     must only be used on a list with elements of type object.\nDefaults to atomic for arrays.",
+            "type": "string"
+          },
+          "x-kubernetes-map-type": {
+            "description": "x-kubernetes-map-type annotates an object to further describe its topology. This extension must only be used when type is object and may have 2 possible values:\n\n1) `granular`:\n     These maps are actual maps (key-value pairs) and each fields are independent\n     from each other (they can each be manipulated by separate actors). This is\n     the default behaviour for all maps.\n2) `atomic`: the list is treated as a single entity, like a scalar.\n     Atomic maps will be entirely replaced when updated.",
+            "type": "string"
+          },
+          "x-kubernetes-preserve-unknown-fields": {
+            "description": "x-kubernetes-preserve-unknown-fields stops the API server decoding step from pruning fields which are not specified in the validation schema. This affects fields recursively, but switches back to normal pruning behaviour if nested properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden.",
+            "type": "boolean"
+          },
+          "x-kubernetes-validations": {
+            "description": "x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule"
+                }
+              ]
+            },
+            "x-kubernetes-list-map-keys": ["rule"],
+            "x-kubernetes-list-type": "map",
+            "x-kubernetes-patch-merge-key": "rule",
+            "x-kubernetes-patch-strategy": "merge"
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrArray": {
+        "description": "JSONSchemaPropsOrArray represents a value that can either be a JSONSchemaProps or an array of JSONSchemaProps. Mainly here for serialization purposes."
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool": {
+        "description": "JSONSchemaPropsOrBool represents JSONSchemaProps or a boolean value. Defaults to true for the boolean property."
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrStringArray": {
+        "description": "JSONSchemaPropsOrStringArray represents a JSONSchemaProps or a string array."
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ServiceReference": {
+        "description": "ServiceReference holds a reference to Service.legacy.k8s.io",
+        "type": "object",
+        "required": ["namespace", "name"],
+        "properties": {
+          "name": {
+            "description": "name is the name of the service. Required",
+            "type": "string",
+            "default": ""
+          },
+          "namespace": {
+            "description": "namespace is the namespace of the service. Required",
+            "type": "string",
+            "default": ""
+          },
+          "path": {
+            "description": "path is an optional URL path at which the webhook will be contacted.",
+            "type": "string"
+          },
+          "port": {
+            "description": "port is an optional service port at which the webhook will be contacted. `port` should be a valid port number (1-65535, inclusive). Defaults to 443 for backward compatibility.",
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule": {
+        "description": "ValidationRule describes a validation rule written in the CEL expression language.",
+        "type": "object",
+        "required": ["rule"],
+        "properties": {
+          "message": {
+            "description": "Message represents the message displayed when validation fails. The message is required if the Rule contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\"",
+            "type": "string"
+          },
+          "rule": {
+            "description": "Rule represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec The Rule is scoped to the location of the x-kubernetes-validations extension in the schema. The `self` variable in the CEL expression is bound to the scoped value. Example: - Rule scoped to the root of a resource with a status subresource: {\"rule\": \"self.status.actual \u003c= self.spec.maxDesired\"}\n\nIf the Rule is scoped to an object with properties, the accessible properties of the object are field selectable via `self.field` and field presence can be checked via `has(self.field)`. Null valued fields are treated as absent fields in CEL expressions. If the Rule is scoped to an object with additionalProperties (i.e. a map) the value of the map are accessible via `self[mapKey]`, map containment can be checked via `mapKey in self` and all entries of the map are accessible via CEL macros and functions such as `self.all(...)`. If the Rule is scoped to an array, the elements of the array are accessible via `self[i]` and also by macros and functions. If the Rule is scoped to a scalar, `self` is bound to the scalar value. Examples: - Rule scoped to a map of objects: {\"rule\": \"self.components['Widget'].priority \u003c 10\"} - Rule scoped to a list of integers: {\"rule\": \"self.values.all(value, value \u003e= 0 \u0026\u0026 value \u003c 100)\"} - Rule scoped to a string value: {\"rule\": \"self.startsWith('kube')\"}\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object and from any x-kubernetes-embedded-resource annotated objects. No other metadata properties are accessible.\n\nUnknown data preserved in custom resources via x-kubernetes-preserve-unknown-fields is not accessible in CEL expressions. This includes: - Unknown field values that are preserved by object schemas with x-kubernetes-preserve-unknown-fields. - Object properties where the property schema is of an \"unknown type\". An \"unknown type\" is recursively defined as:\n  - A schema with no type and x-kubernetes-preserve-unknown-fields set to true\n  - An array where the items schema is of an \"unknown type\"\n  - An object where the additionalProperties schema is of an \"unknown type\"\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Rule accessing a property named \"namespace\": {\"rule\": \"self.__namespace__ \u003e 0\"}\n  - Rule accessing a property named \"x-prop\": {\"rule\": \"self.x__dash__prop \u003e 0\"}\n  - Rule accessing a property named \"redact__d\": {\"rule\": \"self.redact__underscores__d \u003e 0\"}\n\nEquality on arrays with x-kubernetes-list-type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig": {
+        "description": "WebhookClientConfig contains the information to make a TLS connection with the webhook.",
+        "type": "object",
+        "properties": {
+          "caBundle": {
+            "description": "caBundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.",
+            "type": "string",
+            "format": "byte"
+          },
+          "service": {
+            "description": "service is a reference to the service for this webhook. Either service or url must be specified.\n\nIf the webhook is running within the cluster, then you should use `service`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ServiceReference"
+              }
+            ]
+          },
+          "url": {
+            "description": "url gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.\n\nThe `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.\n\nPlease note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.\n\nThe scheme must be \"https\"; the URL must begin with \"https://\".\n\nA path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.\n\nAttempting to use a user or basic auth e.g. \"user:password@\" is not allowed. Fragments (\"#...\") and query parameters (\"?...\") are not allowed, either.",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookConversion": {
+        "description": "WebhookConversion describes how to call a conversion webhook",
+        "type": "object",
+        "required": ["conversionReviewVersions"],
+        "properties": {
+          "clientConfig": {
+            "description": "clientConfig is the instructions for how to call the webhook if strategy is `Webhook`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig"
+              }
+            ]
+          },
+          "conversionReviewVersions": {
+            "description": "conversionReviewVersions is an ordered list of preferred `ConversionReview` versions the Webhook expects. The API server will use the first version in the list which it supports. If none of the versions specified in this list are supported by API server, conversion will fail for the custom resource. If a persisted Webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail.",
+            "type": "array",
+            "items": { "type": "string", "default": "" }
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
+        "description": "APIResource specifies the name of a resource and whether it is namespaced.",
+        "type": "object",
+        "required": ["name", "singularName", "namespaced", "kind", "verbs"],
+        "properties": {
+          "categories": {
+            "description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
+            "type": "array",
+            "items": { "type": "string", "default": "" }
+          },
+          "group": {
+            "description": "group is the preferred group of the resource.  Empty implies the group of the containing resource list. For subresources, this may have a different value, for example: Scale\".",
+            "type": "string"
+          },
+          "kind": {
+            "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "description": "name is the plural name of the resource.",
+            "type": "string",
+            "default": ""
+          },
+          "namespaced": {
+            "description": "namespaced indicates if a resource is namespaced or not.",
+            "type": "boolean",
+            "default": false
+          },
+          "shortNames": {
+            "description": "shortNames is a list of suggested short names of the resource.",
+            "type": "array",
+            "items": { "type": "string", "default": "" }
+          },
+          "singularName": {
+            "description": "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
+            "type": "string",
+            "default": ""
+          },
+          "storageVersionHash": {
+            "description": "The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates.",
+            "type": "string"
+          },
+          "verbs": {
+            "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
+            "type": "array",
+            "items": { "type": "string", "default": "" }
+          },
+          "version": {
+            "description": "version is the preferred version of the resource.  Empty implies the version of the containing resource list For subresources, this may have a different value, for example: v1 (while inside a v1beta1 version of the core resource's group)\".",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+        "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+        "type": "object",
+        "required": ["groupVersion", "resources"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "groupVersion": {
+            "description": "groupVersion is the group and version this APIResourceList is for.",
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "resources": {
+            "description": "resources contains the name of the resources and if they are namespaced.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
+                }
+              ]
+            }
+          }
+        },
+        "x-kubernetes-group-version-kind": [
+          { "group": "", "kind": "APIResourceList", "version": "v1" }
+        ]
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+        "description": "DeleteOptions may be provided when deleting an API object.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "dryRun": {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "type": "array",
+            "items": { "type": "string", "default": "" }
+          },
+          "gracePeriodSeconds": {
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "orphanDependents": {
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "type": "boolean"
+          },
+          "preconditions": {
+            "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+              }
+            ]
+          },
+          "propagationPolicy": {
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "type": "string"
+          }
+        },
+        "x-kubernetes-group-version-kind": [
+          { "group": "", "kind": "DeleteOptions", "version": "v1" },
+          {
+            "group": "admission.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "admission.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "admissionregistration.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "admissionregistration.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "apiextensions.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "apiextensions.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "apiregistration.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "apiregistration.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          { "group": "apps", "kind": "DeleteOptions", "version": "v1" },
+          { "group": "apps", "kind": "DeleteOptions", "version": "v1beta1" },
+          { "group": "apps", "kind": "DeleteOptions", "version": "v1beta2" },
+          {
+            "group": "authentication.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "authentication.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "authentication.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "authorization.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "authorization.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          { "group": "autoscaling", "kind": "DeleteOptions", "version": "v1" },
+          { "group": "autoscaling", "kind": "DeleteOptions", "version": "v2" },
+          {
+            "group": "autoscaling",
+            "kind": "DeleteOptions",
+            "version": "v2beta1"
+          },
+          {
+            "group": "autoscaling",
+            "kind": "DeleteOptions",
+            "version": "v2beta2"
+          },
+          { "group": "batch", "kind": "DeleteOptions", "version": "v1" },
+          { "group": "batch", "kind": "DeleteOptions", "version": "v1beta1" },
+          {
+            "group": "certificates.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "certificates.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "coordination.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "coordination.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "discovery.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "discovery.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "events.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "events.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "extensions",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta2"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta3"
+          },
+          {
+            "group": "imagepolicy.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "internal.apiserver.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "networking.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "networking.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "networking.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          { "group": "node.k8s.io", "kind": "DeleteOptions", "version": "v1" },
+          {
+            "group": "node.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "node.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          { "group": "policy", "kind": "DeleteOptions", "version": "v1" },
+          { "group": "policy", "kind": "DeleteOptions", "version": "v1beta1" },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "scheduling.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "scheduling.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "scheduling.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "storage.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "storage.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "storage.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          }
+        ]
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+        "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+        "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+        "type": "object",
+        "properties": {
+          "continue": {
+            "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+            "type": "string"
+          },
+          "remainingItemCount": {
+            "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "resourceVersion": {
+            "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+            "type": "string"
+          },
+          "selfLink": {
+            "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+        "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+            "type": "string"
+          },
+          "fieldsType": {
+            "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+            "type": "string"
+          },
+          "fieldsV1": {
+            "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+              }
+            ]
+          },
+          "manager": {
+            "description": "Manager is an identifier of the workflow managing these fields.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+            "type": "string"
+          },
+          "subresource": {
+            "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+            "type": "string"
+          },
+          "time": {
+            "description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ]
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+        "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+            "type": "object",
+            "additionalProperties": { "type": "string", "default": "" }
+          },
+          "creationTimestamp": {
+            "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ]
+          },
+          "deletionGracePeriodSeconds": {
+            "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "deletionTimestamp": {
+            "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ]
+          },
+          "finalizers": {
+            "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+            "type": "array",
+            "items": { "type": "string", "default": "" },
+            "x-kubernetes-patch-strategy": "merge"
+          },
+          "generateName": {
+            "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+            "type": "string"
+          },
+          "generation": {
+            "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "labels": {
+            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+            "type": "object",
+            "additionalProperties": { "type": "string", "default": "" }
+          },
+          "managedFields": {
+            "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+                }
+              ]
+            }
+          },
+          "name": {
+            "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+            "type": "string"
+          },
+          "namespace": {
+            "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+            "type": "string"
+          },
+          "ownerReferences": {
+            "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+                }
+              ]
+            },
+            "x-kubernetes-patch-merge-key": "uid",
+            "x-kubernetes-patch-strategy": "merge"
+          },
+          "resourceVersion": {
+            "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+            "type": "string"
+          },
+          "selfLink": {
+            "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+            "type": "string"
+          },
+          "uid": {
+            "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+        "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+        "type": "object",
+        "required": ["apiVersion", "kind", "name", "uid"],
+        "properties": {
+          "apiVersion": {
+            "description": "API version of the referent.",
+            "type": "string",
+            "default": ""
+          },
+          "blockOwnerDeletion": {
+            "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+            "type": "boolean"
+          },
+          "controller": {
+            "description": "If true, this reference points to the managing controller.",
+            "type": "boolean"
+          },
+          "kind": {
+            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+            "type": "string",
+            "default": ""
+          },
+          "uid": {
+            "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+            "type": "string",
+            "default": ""
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
+        "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
+        "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+        "type": "object",
+        "properties": {
+          "resourceVersion": {
+            "description": "Specifies the target ResourceVersion",
+            "type": "string"
+          },
+          "uid": {
+            "description": "Specifies the target UID.",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+        "description": "Status is a return value for calls that don't return other objects.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "code": {
+            "description": "Suggested HTTP return code for this status, 0 if not set.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "details": {
+            "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
+              }
+            ]
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "message": {
+            "description": "A human-readable description of the status of this operation.",
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+              }
+            ]
+          },
+          "reason": {
+            "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+            "type": "string"
+          },
+          "status": {
+            "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+            "type": "string"
+          }
+        },
+        "x-kubernetes-group-version-kind": [
+          { "group": "", "kind": "Status", "version": "v1" }
+        ]
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
+        "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+        "type": "object",
+        "properties": {
+          "field": {
+            "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+            "type": "string"
+          },
+          "message": {
+            "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+            "type": "string"
+          },
+          "reason": {
+            "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+        "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+        "type": "object",
+        "properties": {
+          "causes": {
+            "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+                }
+              ]
+            }
+          },
+          "group": {
+            "description": "The group attribute of the resource associated with the status StatusReason.",
+            "type": "string"
+          },
+          "kind": {
+            "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+            "type": "string"
+          },
+          "retryAfterSeconds": {
+            "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "uid": {
+            "description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+        "type": "string",
+        "format": "date-time"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+        "description": "Event represents a single event to a watched resource.",
+        "type": "object",
+        "required": ["type", "object"],
+        "properties": {
+          "object": {
+            "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.runtime.RawExtension"
+              }
+            ]
+          },
+          "type": { "type": "string", "default": "" }
+        },
+        "x-kubernetes-group-version-kind": [
+          { "group": "", "kind": "WatchEvent", "version": "v1" },
+          {
+            "group": "admission.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "admission.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "admissionregistration.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "admissionregistration.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "apiextensions.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "apiextensions.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "apiregistration.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "apiregistration.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          { "group": "apps", "kind": "WatchEvent", "version": "v1" },
+          { "group": "apps", "kind": "WatchEvent", "version": "v1beta1" },
+          { "group": "apps", "kind": "WatchEvent", "version": "v1beta2" },
+          {
+            "group": "authentication.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "authentication.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "authentication.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "authorization.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "authorization.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          { "group": "autoscaling", "kind": "WatchEvent", "version": "v1" },
+          { "group": "autoscaling", "kind": "WatchEvent", "version": "v2" },
+          {
+            "group": "autoscaling",
+            "kind": "WatchEvent",
+            "version": "v2beta1"
+          },
+          {
+            "group": "autoscaling",
+            "kind": "WatchEvent",
+            "version": "v2beta2"
+          },
+          { "group": "batch", "kind": "WatchEvent", "version": "v1" },
+          { "group": "batch", "kind": "WatchEvent", "version": "v1beta1" },
+          {
+            "group": "certificates.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "certificates.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "coordination.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "coordination.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "discovery.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "discovery.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          { "group": "events.k8s.io", "kind": "WatchEvent", "version": "v1" },
+          {
+            "group": "events.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          { "group": "extensions", "kind": "WatchEvent", "version": "v1beta1" },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta2"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta3"
+          },
+          {
+            "group": "imagepolicy.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "internal.apiserver.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "networking.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "networking.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "networking.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          { "group": "node.k8s.io", "kind": "WatchEvent", "version": "v1" },
+          {
+            "group": "node.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "node.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          { "group": "policy", "kind": "WatchEvent", "version": "v1" },
+          { "group": "policy", "kind": "WatchEvent", "version": "v1beta1" },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "scheduling.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "scheduling.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "scheduling.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          { "group": "storage.k8s.io", "kind": "WatchEvent", "version": "v1" },
+          {
+            "group": "storage.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "storage.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          }
+        ]
+      },
+      "io.k8s.apimachinery.pkg.runtime.RawExtension": {
+        "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package:\n\n\ttype MyAPIObject struct {\n\t\truntime.TypeMeta `json:\",inline\"`\n\t\tMyPlugin runtime.Object `json:\"myPlugin\"`\n\t}\n\n\ttype PluginA struct {\n\t\tAOption string `json:\"aOption\"`\n\t}\n\n// External package:\n\n\ttype MyAPIObject struct {\n\t\truntime.TypeMeta `json:\",inline\"`\n\t\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n\t}\n\n\ttype PluginA struct {\n\t\tAOption string `json:\"aOption\"`\n\t}\n\n// On the wire, the JSON will look something like this:\n\n\t{\n\t\t\"kind\":\"MyAPIObject\",\n\t\t\"apiVersion\":\"v1\",\n\t\t\"myPlugin\": {\n\t\t\t\"kind\":\"PluginA\",\n\t\t\t\"aOption\":\"foo\",\n\t\t},\n\t}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "BearerToken": {
+        "type": "apiKey",
+        "description": "Bearer Token authentication",
+        "name": "authorization",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
@@ -1,0 +1,250 @@
+{{- /* Determine if Path for requested GVR is at /api or /apis based on emptiness of group */ -}}
+{{- $prefix := (ternary "/api" (join "" "/apis/" $.GVR.Group) (not $.GVR.Group)) -}}
+
+{{- /* Search both cluster-scoped and namespaced-scoped paths for the GVR to find its GVK */ -}}
+{{- /* Looks for path /apis/<group>/<version>/<resource> or /apis/<group>/<version>/<version>/namespaces/{namespace}/<resource> */ -}}
+{{- $clusterScopedSearchPath :=  join "/" $prefix $.GVR.Version $.GVR.Resource -}}
+{{- $namespaceScopedSearchPath := join "/" $prefix $.GVR.Version "namespaces" "\\{namespace\\}" $.GVR.Resource -}}
+{{- $path := or (index $.Document "paths" $clusterScopedSearchPath) (index $.Document "paths" $clusterScopedSearchPath) -}}
+
+{{- /* Pull GVK from operation */ -}}
+{{- with $gvk := and $path (index $path "get" "x-kubernetes-group-version-kind") -}}
+    {{- if $gvk.group -}}
+        GROUP:      {{ $gvk.group }}{{"\n" -}}
+    {{- end -}}
+    KIND:       {{ $gvk.kind}}{{"\n" -}}
+    VERSION:    {{ $gvk.version }}{{"\n" -}}
+    {{- "\n" -}}
+
+    {{- with include "schema" (dict "gvk" $gvk "Document" $.Document "FieldPath" $.FieldPath "Recursive" $.Recursive) -}}
+        {{- . -}}
+    {{- else -}}
+        error: GVK {{$gvk}} not found in OpenAPI schema
+    {{- end -}}
+{{- else -}}
+    error: GVR ({{$.GVR.String}}) not found in OpenAPI schema
+{{- end -}}
+{{- "\n" -}}
+
+{{- /*
+Finds a schema with the given GVK and prints its explain output or empty string
+if GVK was not found
+
+Takes dictionary as argument with keys:
+    gvk: openapiv3 JSON schema
+    Document: entire doc
+    FieldPath: field path to follow
+    Recursive: print recursive
+*/ -}}
+{{- define "schema" -}}
+    {{- /* Find definition with this GVK by filtering out the components/schema with the given x-kubernetes-group-version-kind */ -}}
+    {{- range index $.Document "components" "schemas" -}}
+        {{- if contains (index . "x-kubernetes-group-version-kind") $.gvk -}}
+            {{- with include "output" (set $ "schema" .) -}}
+                {{- . -}}
+            {{- else -}}
+                error: field "{{$.FieldPath}}" does not exist
+            {{- end -}}
+            {{- break -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{- /*
+Follows FieldPath until the FieldPath is empty. Then prints field name and field 
+list of resultant schema. If field path is not found. Prints nothing.
+Example output:
+
+FIELD: spec
+
+DESCRIPTION:
+    <template "description">
+
+FIELDS:
+    <template "fieldList">
+
+Takes dictionary as argument with keys:
+    schema: openapiv3 JSON schema
+    history: map[string]int
+    Document: entire doc
+    FieldPath: field path to follow
+    Recursive: print recursive
+*/ -}}
+{{- define "output" -}}
+    {{- $refString := or (index $.schema "$ref") "" -}}
+    {{- $nextContext := set $ "history" (set $.history $refString 1) -}}
+    {{- $resolved := or (resolveRef $refString $.Document) $.schema -}}
+    {{- if not $.FieldPath -}}
+        DESCRIPTION:{{- "\n" -}}
+        {{- or (include "description" (dict "schema" $resolved "Document" $.Document)) "<empty>" | wrap 76 | indent 4 -}}{{- "\n" -}}
+        {{- with include "fieldList" (dict "schema" $resolved "level" 1 "Document" $.Document "Recursive" $.Recursive) -}}
+            FIELDS:{{- "\n" -}}
+            {{- . -}}
+        {{- end -}}
+    {{- else if and $refString (index $.history $refString) -}}
+        {{- /* Stop and do nothing. Hit a cycle */ -}}
+    {{- else if and $resolved.properties (index $resolved.properties (first $.FieldPath)) -}}
+        {{- /* Schema has this property directly. Traverse to next schema */ -}}
+        {{- $subschema := index $resolved.properties (first $.FieldPath) -}}
+        {{- if eq 1 (len $.FieldPath) -}}
+            {{- /* TODO: The original explain would say RESOURCE instead of FIELD here under some circumstances */ -}}
+            FIELD: {{first $.FieldPath}} <{{ template "typeGuess" (dict "schema" $subschema) }}>{{"\n"}}
+            {{- "\n" -}}
+        {{- end -}}
+        {{- template "output" (set $nextContext "history" (dict) "FieldPath" (slice $.FieldPath 1) "schema" $subschema ) -}}
+    {{- else if $resolved.items -}}
+        {{- /* If the schema is an array then traverse the array item fields */ -}}
+        {{- template "output" (set $nextContext "schema" $resolved.items) -}}
+    {{- else if $resolved.additionalProperties -}}
+        {{- /* If the schema is a map then traverse the map item fields */ -}}
+        {{- template "output" (set $nextContext "schema" $resolved.additionalProperties) -}}
+    {{- else -}}
+        {{- /* Last thing to try is all the alternatives in the allOf case */ -}}
+        {{- /* Stop when one of the alternatives has an output at all */ -}}
+        {{- range $index, $subschema := $resolved.allOf -}}
+            {{- with include "output" (set $nextContext "schema" $subschema) -}}
+                {{- . -}}
+                {{- break -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{- /*
+Prints list of fields of a given open api schema in following form:
+
+field1 <type> -required-
+    DESCRIPTION
+
+field2 <type> -required-
+    DESCRIPTION
+
+or if Recursive is enabled:
+field1 <type> -required-
+    subfield1 <type>
+        subsubfield1 <type>
+        subsubfield2 <type>
+    subfield2 <type>
+field2 <type> -required-
+    subfield1 <type>
+    subfield2 <type>
+
+Follows refs for field traversal. If there are cycles in the schema, they are
+detected and traversal ends.
+
+Takes dictionary as argument with keys:
+    schema: openapiv3 JSON schema
+    level: indentation level
+    history: map[string]int containing all ref names so far
+    Document: entire doc
+    Recursive: print recursive
+*/ -}}
+{{- define "fieldList" -}}
+    {{- /* Resolve schema if it is a ref */}}
+    {{- /* If this is a ref seen before, then ignore it */}}
+    {{- $refString := or (index $.schema "$ref") "" }}
+    {{- if and $refString (index (or $.history (dict)) $refString) -}}
+        {{- /* Do nothing for cycle */}}
+    {{- else -}}
+        {{- $nextContext := set $ "history" (set $.history $refString 1) -}}
+        {{- $resolved := or (resolveRef $refString $.Document) $.schema -}}
+        {{- range $k, $v := $resolved.properties -}}
+            {{- template "fieldDetail" (dict "name" $k "schema" $resolved "short" $.Recursive "level" $.level) -}}
+            {{- if $.Recursive -}}
+                {{- /* Check if we already know about this element */}}
+                {{- template "fieldList" (set $nextContext "schema" $v "level" (add $.level 1)) -}}
+            {{- end -}}
+        {{- end -}}
+        {{- range $resolved.allOf -}}
+            {{- template "fieldList" (set $nextContext "schema" .)}}
+        {{- end -}}
+        {{- if $resolved.items}}{{- template "fieldList" (set $nextContext "schema" $resolved.items)}}{{end}}
+        {{- if $resolved.additionalProperties}}{{- template "fieldList" (set $nextContext "schema" $resolved.additionalProperties)}}{{end}}
+    {{- end -}}
+{{- end -}}
+
+
+{{- /*
+
+Prints a single field of the given schema
+Optionally prints in a one-line style
+
+Takes dictionary as argument with keys:
+    schema: openapiv3 JSON schema which contains the field
+    name: name of field
+    short: limit printing to a single-line summary
+    level: indentation amount
+*/ -}}
+{{- define "fieldDetail" -}}
+    {{- $level := or $.level 0 -}}
+    {{- $indentAmount := mul $level 2 -}}
+    {{- $fieldSchema := index $.schema.properties $.name -}}
+    {{- $.name | indent $indentAmount -}}{{"\t"}}<{{ template "typeGuess" (dict "schema" $fieldSchema) }}>
+    {{- if contains $.schema.required $.name}} -required-{{- end -}}
+    {{- "\n" -}}
+    {{- if not $.short -}}
+        {{- or $fieldSchema.description "<no description>" | wrap (sub 78 $indentAmount) | indent (add $indentAmount 2) -}}{{- "\n" -}}
+        {{- "\n" -}}
+    {{- end -}}
+{{- end -}}
+
+{{- /*
+
+Prints the description of the given OpenAPI v3 schema. Also walks through all
+sibling schemas to the provided schema and prints the description of those schemas
+too
+
+Takes dictionary as argument with keys:
+    schema: openapiv3 JSON schema
+    Document: document to resolve refs within
+*/ -}}
+{{- define "description" -}}
+    {{- with or (resolveRef (index $.schema "$ref") $.Document) $.schema -}}
+        {{- if .description -}}
+            {{- .description -}}
+            {{- "\n" -}}
+        {{- end -}}
+        {{- range .allOf -}}
+            {{- template "description" (set $ "schema" .)}}
+        {{- end -}}
+        {{- if .items -}}
+            {{- template "description" (set $ "schema" .items) -}}
+        {{- end -}}
+        {{- if .additionalProperties -}}
+            {{- template "description" (set $ "schema" .additionalProperties) -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{- /* Renders a shortstring representing an interpretation of what is the "type"
+        of a subschema e.g.:
+
+        `string` `number`, `Object`, `[]Object`, `map[string]string`, etc.
+
+    Serves as a more helpful type hint than raw typical openapi `type` field
+
+Takes dictionary as argument with keys:
+    schema: openapiv3 JSON schema
+*/ -}}
+{{- define "typeGuess" -}}
+    {{- with $.schema -}}
+        {{- if .items -}}
+            []{{template "typeGuess" (dict "schema" .items)}}
+        {{- else if .additionalProperties -}}
+            map[string]{{template "typeGuess" (dict "schema" .additionalProperties)}}
+        {{- else if and .allOf (not .properties) (eq (len .allOf) 1) -}}
+            {{- /* If allOf has a single element and there are no direct
+                properties on the schema, defer to the allOf */ -}}
+            {{- template "typeGuess" (dict "schema" (first .allOf)) -}}
+        {{- else if index . "$ref"}}
+            {{- /* Parse the #!/components/schemas/io.k8s.Kind string into just the Kind name */ -}}
+            {{- $ref := index . "$ref" -}}
+            {{- $name := split $ref "/" | last -}}
+            {{- or (split $name "." | last) "Object" -}}
+        {{- else -}}
+            {{- or .type "Object" -}}
+        {{- end -}}
+    {{- else -}}
+        {{- fail "expected schema argument to subtemplate 'typeguess'" -}}
+    {{- end -}}
+{{- end -}}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
@@ -1,0 +1,547 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates_test
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	v2 "k8s.io/kubectl/pkg/explain/v2"
+)
+
+var (
+	//go:embed plaintext.tmpl
+	plaintextSource string
+
+	//go:embed apiextensions.k8s.io_v1.json
+	apiextensionsJSON string
+
+	apiExtensionsV1OpenAPI map[string]interface{} = func() map[string]interface{} {
+		var res map[string]interface{}
+		utilruntime.Must(json.Unmarshal([]byte(apiextensionsJSON), &res))
+		return res
+	}()
+
+	apiExtensionsV1OpenAPISpec spec3.OpenAPI = func() spec3.OpenAPI {
+		var res spec3.OpenAPI
+		utilruntime.Must(json.Unmarshal([]byte(apiextensionsJSON), &res))
+		return res
+	}()
+)
+
+type testCase struct {
+	// test case name
+	Name string
+	// if empty uses main template
+	Subtemplate string
+	// context to render withi
+	Context any
+	// checks to perform on rendered output
+	Checks []check
+}
+
+type check interface {
+	doCheck(output string) error
+}
+
+type checkError string
+
+func (c checkError) doCheck(output string) error {
+	if !strings.Contains(output, "error: "+string(c)) {
+		return fmt.Errorf("expected error: '%v' in string:\n%v", string(c), output)
+	}
+	return nil
+}
+
+type checkContains string
+
+func (c checkContains) doCheck(output string) error {
+	if !strings.Contains(output, string(c)) {
+		return fmt.Errorf("expected substring: '%v' in string:\n%v", string(c), output)
+	}
+	return nil
+}
+
+type checkEquals string
+
+func (c checkEquals) doCheck(output string) error {
+	if output != string(c) {
+		return fmt.Errorf("output is not equal to expectation:\n%v", cmp.Diff(string(c), output))
+	}
+	return nil
+}
+
+func MapDict[K comparable, V any, N any](accum map[K]V, mapper func(V) N) map[K]N {
+	res := make(map[K]N, len(accum))
+	for k, v := range accum {
+		res[k] = mapper(v)
+	}
+	return res
+}
+
+func ReduceDict[K comparable, V any, N any](val map[K]V, accum N, mapper func(N, K, V) N) N {
+	for k, v := range val {
+		accum = mapper(accum, k, v)
+	}
+	return accum
+}
+
+func TestPlaintext(t *testing.T) {
+	testcases := []testCase{
+		{
+			// Test case where resource being rendered is not found in OpenAPI schema
+			Name: "ResourceNotFound",
+			Context: v2.TemplateContext{
+				Document:  apiExtensionsV1OpenAPI,
+				GVR:       schema.GroupVersionResource{},
+				FieldPath: nil,
+				Recursive: false,
+			},
+			Checks: []check{
+				checkError("GVR (/, Resource=) not found in OpenAPI schema\n"),
+			},
+		},
+		{
+			// Test basic ability to find a GVR and print its description
+			Name: "SchemaFound",
+			Context: v2.TemplateContext{
+				Document: apiExtensionsV1OpenAPI,
+				GVR: schema.GroupVersionResource{
+					Group:    "apiextensions.k8s.io",
+					Version:  "v1",
+					Resource: "customresourcedefinitions",
+				},
+				FieldPath: nil,
+				Recursive: false,
+			},
+			Checks: []check{
+				checkContains("CustomResourceDefinition represents a resource that should be exposed"),
+			},
+		},
+		{
+			// Test that shows trying to find a non-existent field path of an existing
+			// schema
+			Name: "SchemaFieldPathNotFound",
+			Context: v2.TemplateContext{
+				Document: apiExtensionsV1OpenAPI,
+				GVR: schema.GroupVersionResource{
+					Group:    "apiextensions.k8s.io",
+					Version:  "v1",
+					Resource: "customresourcedefinitions",
+				},
+				FieldPath: []string{"does", "not", "exist"},
+				Recursive: false,
+			},
+			Checks: []check{
+				checkError(`field "[does not exist]" does not exist`),
+			},
+		},
+		{
+			// Test traversing a single level for scalar field path
+			Name: "SchemaFieldPathShallow",
+			Context: v2.TemplateContext{
+				Document: apiExtensionsV1OpenAPI,
+				GVR: schema.GroupVersionResource{
+					Group:    "apiextensions.k8s.io",
+					Version:  "v1",
+					Resource: "customresourcedefinitions",
+				},
+				FieldPath: []string{"kind"},
+				Recursive: false,
+			},
+			Checks: []check{
+				checkContains("FIELD: kind <string>"),
+			},
+		},
+		{
+			// Test traversing a multiple levels for scalar field path
+			Name: "SchemaFieldPathDeep",
+			Context: v2.TemplateContext{
+				Document: apiExtensionsV1OpenAPI,
+				GVR: schema.GroupVersionResource{
+					Group:    "apiextensions.k8s.io",
+					Version:  "v1",
+					Resource: "customresourcedefinitions",
+				},
+				FieldPath: []string{"spec", "names", "singular"},
+				Recursive: false,
+			},
+			Checks: []check{
+				checkContains("FIELD: singular <string>"),
+			},
+		},
+		{
+			// Test traversing a multiple levels for scalar field path
+			// through an array field
+			Name: "SchemaFieldPathViaList",
+			Context: v2.TemplateContext{
+				Document: apiExtensionsV1OpenAPI,
+				GVR: schema.GroupVersionResource{
+					Group:    "apiextensions.k8s.io",
+					Version:  "v1",
+					Resource: "customresourcedefinitions",
+				},
+				FieldPath: []string{"spec", "versions", "name"},
+				Recursive: false,
+			},
+			Checks: []check{
+				checkContains("FIELD: name <string>"),
+			},
+		},
+		{
+			// Test traversing a multiple levels for scalar field path
+			// through a map[string]T field.
+			Name: "SchemaFieldPathViaMap",
+			Context: v2.TemplateContext{
+				Document: apiExtensionsV1OpenAPI,
+				GVR: schema.GroupVersionResource{
+					Group:    "apiextensions.k8s.io",
+					Version:  "v1",
+					Resource: "customresourcedefinitions",
+				},
+				FieldPath: []string{"spec", "versions", "schema", "openAPIV3Schema", "properties", "default"},
+				Recursive: false,
+			},
+			Checks: []check{
+				checkContains("default is a default value for undefined object fields"),
+			},
+		},
+		{
+			// Shows that walking through a recursively specified schema is A-OK!
+			Name: "SchemaFieldPathRecursive",
+			Context: v2.TemplateContext{
+				Document: apiExtensionsV1OpenAPI,
+				GVR: schema.GroupVersionResource{
+					Group:    "apiextensions.k8s.io",
+					Version:  "v1",
+					Resource: "customresourcedefinitions",
+				},
+				FieldPath: []string{"spec", "versions", "schema", "openAPIV3Schema", "properties", "properties", "properties", "properties", "properties", "default"},
+				Recursive: false,
+			},
+			Checks: []check{
+				checkContains("default is a default value for undefined object fields"),
+			},
+		},
+		{
+			// Shows that all fields are included
+			Name: "SchemaAllFields",
+			Context: v2.TemplateContext{
+				Document: apiExtensionsV1OpenAPI,
+				GVR: schema.GroupVersionResource{
+					Group:    "apiextensions.k8s.io",
+					Version:  "v1",
+					Resource: "customresourcedefinitions",
+				},
+				FieldPath: []string{"spec", "versions", "schema"},
+				Recursive: false,
+			},
+			Checks: ReduceDict(apiExtensionsV1OpenAPISpec.Components.Schemas["io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation"].Properties, []check{}, func(checks []check, k string, v spec.Schema) []check {
+				return append(checks, checkContains(k), checkContains(v.Description))
+			}),
+		},
+		{
+			// Shows that all fields are included
+			Name: "SchemaAllFieldsRecursive",
+			Context: v2.TemplateContext{
+				Document: apiExtensionsV1OpenAPI,
+				GVR: schema.GroupVersionResource{
+					Group:    "apiextensions.k8s.io",
+					Version:  "v1",
+					Resource: "customresourcedefinitions",
+				},
+				FieldPath: []string{"spec", "versions", "schema"},
+				Recursive: true,
+			},
+			Checks: ReduceDict(apiExtensionsV1OpenAPISpec.Components.Schemas["io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation"].Properties, []check{}, func(checks []check, k string, v spec.Schema) []check {
+				return append(checks, checkContains(k))
+			}),
+		},
+		{
+			// Shows that the typeguess template works with scalars
+			Name:        "Scalar",
+			Subtemplate: "typeGuess",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type": "string",
+				},
+			},
+			Checks: []check{
+				checkEquals("string"),
+			},
+		},
+		{
+			// Shows that the typeguess template behaves correctly given an
+			// array with unknown items
+			Name:        "ArrayUnknown",
+			Subtemplate: "typeGuess",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"description": "a cool field",
+					"type":        "array",
+				},
+			},
+			Checks: []check{
+				checkEquals("array"),
+			},
+		},
+		{
+			// Shows that the typeguess template works with scalars
+			Name:        "ArrayOfScalar",
+			Subtemplate: "typeGuess",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"description": "a cool field",
+					"type":        "array",
+					"items": map[string]any{
+						"type": "number",
+					},
+				},
+			},
+			Checks: []check{
+				checkEquals("[]number"),
+			},
+		},
+		{
+			// Shows that the typeguess template works with arrays containing
+			// a items which are a schema specified by a single-element allOf
+			// pointing to a $ref
+			Name:        "ArrayOfAllOfRef",
+			Subtemplate: "typeGuess",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"description": "a cool field",
+					"type":        "array",
+					"items": map[string]any{
+						"type": "object",
+						"allOf": []map[string]any{
+							{
+								"$ref": "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation",
+							},
+						},
+					},
+				},
+			},
+			Checks: []check{
+				checkEquals("[]CustomResourceValidation"),
+			},
+		},
+		{
+			// Shows that the typeguess template works with arrays containing
+			// a items which are a schema pointing to a $ref
+			Name:        "ArrayOfRef",
+			Subtemplate: "typeGuess",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"description": "a cool field",
+					"type":        "array",
+					"items": map[string]any{
+						"type": "object",
+						"$ref": "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation",
+					},
+				},
+			},
+			Checks: []check{
+				checkEquals("[]CustomResourceValidation"),
+			},
+		},
+		{
+			// Shows that the typeguess template works with arrays of maps of scalars
+			Name:        "ArrayOfMap",
+			Subtemplate: "typeGuess",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"description": "a cool field",
+					"type":        "array",
+					"items": map[string]any{
+						"type": "object",
+						"additionalProperties": map[string]any{
+							"type": "string",
+						},
+					},
+				},
+			},
+			Checks: []check{
+				checkEquals("[]map[string]string"),
+			},
+		},
+		{
+			// Shows that the typeguess template works with maps of arrays of scalars
+			Name:        "MapOfArrayOfScalar",
+			Subtemplate: "typeGuess",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"description": "a cool field",
+					"type":        "object",
+					"additionalProperties": map[string]any{
+						"type": "array",
+						"items": map[string]any{
+							"type": "string",
+						},
+					},
+				},
+			},
+			Checks: []check{
+				checkEquals("map[string][]string"),
+			},
+		},
+		{
+			// Shows that the typeguess template works with maps of ref types
+			Name:        "MapOfRef",
+			Subtemplate: "typeGuess",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"description": "a cool field",
+					"type":        "object",
+					"additionalProperties": map[string]any{
+						"type": "string",
+						"allOf": []map[string]any{
+							{
+								"$ref": "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation",
+							},
+						},
+					},
+				},
+			},
+			Checks: []check{
+				checkEquals("map[string]CustomResourceValidation"),
+			},
+		},
+		{
+			// Shows that the typeguess template prints `Object` if there
+			// is absolutely no type information
+			Name:        "Unknown",
+			Subtemplate: "typeGuess",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"description": "a cool field",
+				},
+			},
+			Checks: []check{
+				checkEquals("Object"),
+			},
+		},
+		{
+			Name:        "Required",
+			Subtemplate: "fieldDetail",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "object",
+					"description": "a description that should not be printed",
+					"properties": map[string]any{
+						"thefield": map[string]any{
+							"type":        "string",
+							"description": "a description that should not be printed",
+						},
+					},
+					"required": []string{"thefield"},
+				},
+				"name":  "thefield",
+				"short": true,
+			},
+			Checks: []check{
+				checkEquals("thefield\t<string> -required-\n"),
+			},
+		},
+		{
+			Name:        "Description",
+			Subtemplate: "fieldDetail",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "object",
+					"description": "a description that should not be printed",
+					"properties": map[string]any{
+						"thefield": map[string]any{
+							"type":        "string",
+							"description": "a description that should be printed",
+						},
+					},
+					"required": []string{"thefield"},
+				},
+				"name":  "thefield",
+				"short": false,
+			},
+			Checks: []check{
+				checkEquals("thefield\t<string> -required-\n  a description that should be printed\n\n"),
+			},
+		},
+		{
+			Name:        "Indent",
+			Subtemplate: "fieldDetail",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "object",
+					"description": "a description that should not be printed",
+					"properties": map[string]any{
+						"thefield": map[string]any{
+							"type":        "string",
+							"description": "a description that should not be printed",
+						},
+					},
+					"required": []string{"thefield"},
+				},
+				"name":  "thefield",
+				"short": true,
+				"level": 5,
+			},
+			Checks: []check{
+				checkEquals("          thefield\t<string> -required-\n"),
+			},
+		},
+	}
+
+	tmpl, err := v2.WithBuiltinTemplateFuncs(template.New("")).Parse(plaintextSource)
+	require.NoError(t, err)
+
+	for _, tcase := range testcases {
+		testName := tcase.Name
+		if len(tcase.Subtemplate) > 0 {
+			testName = tcase.Subtemplate + "/" + testName
+		}
+
+		t.Run(testName, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			if len(tcase.Subtemplate) == 0 {
+				tmpl.Execute(buf, tcase.Context)
+			} else {
+				tmpl.ExecuteTemplate(buf, tcase.Subtemplate, tcase.Context)
+			}
+			require.NoError(t, err)
+
+			output := buf.String()
+			for _, check := range tcase.Checks {
+				err = check.doCheck(output)
+
+				if err != nil {
+					t.Log("test failed on output:\n" + output)
+					require.NoError(t, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implements plaintext output for kubectl explain to be similar to the current output with the same amount or more information (still does not display new v3 fields, forthcoming).

#### Special notes for your reviewer:

Depends on #113024

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds alpha --output plaintext protected by environment variable `KUBECTL_EXPLAIN_OPENAPIV3`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3515-kubectl-explain-openapiv3
```
