### PR TITLE
add unit tests for storageversiongc controller

### DIFF
--- a/pkg/controller/storageversiongc/gc_controller_test.go
+++ b/pkg/controller/storageversiongc/gc_controller_test.go
@@ -1,0 +1,426 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversiongc
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+func setupController(clientset kubernetes.Interface) {
+	informerFactory := informers.NewSharedInformerFactory(clientset, 100*time.Millisecond)
+	leaseInformer := informerFactory.Coordination().V1().Leases()
+	storageVersionInformer := informerFactory.Internal().V1alpha1().StorageVersions()
+
+	controller := NewStorageVersionGC(clientset, leaseInformer, storageVersionInformer)
+	go controller.Run(context.Background())
+	informerFactory.Start(nil)
+}
+
+func Test_StorageVersionUpdatedWithAllEncodingVersionsEqualOnLeaseDeletion(t *testing.T) {
+	lease1 := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-1",
+			Namespace: metav1.NamespaceSystem,
+			Labels: map[string]string{
+				"k8s.io/component": "kube-apiserver",
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: utilpointer.StringPtr("kube-apiserver-1"),
+		},
+	}
+	lease2 := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-2",
+			Namespace: metav1.NamespaceSystem,
+			Labels: map[string]string{
+				"k8s.io/component": "kube-apiserver",
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: utilpointer.StringPtr("kube-apiserver-2"),
+		},
+	}
+	lease3 := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-3",
+			Namespace: metav1.NamespaceSystem,
+			Labels: map[string]string{
+				"k8s.io/component": "kube-apiserver",
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: utilpointer.StringPtr("kube-apiserver-3"),
+		},
+	}
+
+	storageVersion := &apiserverinternalv1alpha1.StorageVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "k8s.test.resources",
+		},
+		Status: apiserverinternalv1alpha1.StorageVersionStatus{
+			StorageVersions: []apiserverinternalv1alpha1.ServerStorageVersion{
+				{
+					APIServerID:       "kube-apiserver-1",
+					EncodingVersion:   "v1",
+					DecodableVersions: []string{"v1"},
+				},
+				{
+					APIServerID:       "kube-apiserver-2",
+					EncodingVersion:   "v2",
+					DecodableVersions: []string{"v2"},
+				},
+				{
+					APIServerID:       "kube-apiserver-3",
+					EncodingVersion:   "v2",
+					DecodableVersions: []string{"v2"},
+				},
+			},
+			CommonEncodingVersion: utilpointer.String("v1"),
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(lease1, lease2, lease3, storageVersion)
+	setupController(clientset)
+
+	// Delete the lease object and verify that storage version status is updated
+	if err := clientset.CoordinationV1().Leases(metav1.NamespaceSystem).Delete(context.Background(), "kube-apiserver-1", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("error deleting lease object: %v", err)
+	}
+
+	// add a delay to ensure controller had a chance to reconcile
+	time.Sleep(2 * time.Second)
+
+	storageVersion, err := clientset.InternalV1alpha1().StorageVersions().Get(context.Background(), "k8s.test.resources", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting StorageVersion: %v", err)
+	}
+
+	expectedServerStorageVersions := []apiserverinternalv1alpha1.ServerStorageVersion{
+		{
+			APIServerID:       "kube-apiserver-2",
+			EncodingVersion:   "v2",
+			DecodableVersions: []string{"v2"},
+		},
+		{
+			APIServerID:       "kube-apiserver-3",
+			EncodingVersion:   "v2",
+			DecodableVersions: []string{"v2"},
+		},
+	}
+
+	if !reflect.DeepEqual(storageVersion.Status.StorageVersions, expectedServerStorageVersions) {
+		t.Error("unexpected storage version object")
+		t.Logf("got: %+v", storageVersion)
+		t.Logf("expected: %+v", expectedServerStorageVersions)
+	}
+
+	if *storageVersion.Status.CommonEncodingVersion != "v2" {
+		t.Errorf("unexpected common encoding version")
+		t.Logf("got: %q", *storageVersion.Status.CommonEncodingVersion)
+		t.Logf("expected: %q", "v2")
+	}
+
+	if len(storageVersion.Status.Conditions) != 1 {
+		t.Errorf("expected 1 condition, got: %d", len(storageVersion.Status.Conditions))
+	}
+
+	if storageVersion.Status.Conditions[0].Type != apiserverinternalv1alpha1.AllEncodingVersionsEqual {
+		t.Errorf("expected condition type 'AllEncodingVersionsEqual', got: %q", storageVersion.Status.Conditions[0].Type)
+	}
+
+	if storageVersion.Status.Conditions[0].Status != apiserverinternalv1alpha1.ConditionTrue {
+		t.Errorf("expected condition status 'True', got: %q", storageVersion.Status.Conditions[0].Status)
+	}
+}
+
+func Test_StorageVersionUpdatedWithDifferentEncodingVersionsOnLeaseDeletion(t *testing.T) {
+	lease1 := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-1",
+			Namespace: metav1.NamespaceSystem,
+			Labels: map[string]string{
+				"k8s.io/component": "kube-apiserver",
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: utilpointer.StringPtr("kube-apiserver-1"),
+		},
+	}
+	lease2 := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-2",
+			Namespace: metav1.NamespaceSystem,
+			Labels: map[string]string{
+				"k8s.io/component": "kube-apiserver",
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: utilpointer.StringPtr("kube-apiserver-2"),
+		},
+	}
+	lease3 := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-3",
+			Namespace: metav1.NamespaceSystem,
+			Labels: map[string]string{
+				"k8s.io/component": "kube-apiserver",
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: utilpointer.StringPtr("kube-apiserver-3"),
+		},
+	}
+
+	storageVersion := &apiserverinternalv1alpha1.StorageVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "k8s.test.resources",
+		},
+		Status: apiserverinternalv1alpha1.StorageVersionStatus{
+			StorageVersions: []apiserverinternalv1alpha1.ServerStorageVersion{
+				{
+					APIServerID:       "kube-apiserver-1",
+					EncodingVersion:   "v1",
+					DecodableVersions: []string{"v1"},
+				},
+				{
+					APIServerID:       "kube-apiserver-3",
+					EncodingVersion:   "v2",
+					DecodableVersions: []string{"v2"},
+				},
+			},
+			CommonEncodingVersion: utilpointer.String("v1"),
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(lease1, lease2, lease3, storageVersion)
+	setupController(clientset)
+
+	// Delete the lease object and verify that storage version status is updated
+	if err := clientset.CoordinationV1().Leases(metav1.NamespaceSystem).Delete(context.Background(), "kube-apiserver-2", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("error deleting lease object: %v", err)
+	}
+
+	// add a delay to ensure controller had a chance to reconcile
+	time.Sleep(2 * time.Second)
+
+	storageVersion, err := clientset.InternalV1alpha1().StorageVersions().Get(context.Background(), "k8s.test.resources", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting StorageVersion: %v", err)
+	}
+
+	expectedServerStorageVersions := []apiserverinternalv1alpha1.ServerStorageVersion{
+		{
+			APIServerID:       "kube-apiserver-1",
+			EncodingVersion:   "v1",
+			DecodableVersions: []string{"v1"},
+		},
+		{
+			APIServerID:       "kube-apiserver-3",
+			EncodingVersion:   "v2",
+			DecodableVersions: []string{"v2"},
+		},
+	}
+
+	if !reflect.DeepEqual(storageVersion.Status.StorageVersions, expectedServerStorageVersions) {
+		t.Error("unexpected storage version object")
+		t.Logf("got: %+v", storageVersion)
+		t.Logf("expected: %+v", expectedServerStorageVersions)
+	}
+
+	if *storageVersion.Status.CommonEncodingVersion != "v1" {
+		t.Errorf("unexpected common encoding version")
+		t.Logf("got: %q", *storageVersion.Status.CommonEncodingVersion)
+		t.Logf("expected: %q", "v1")
+	}
+}
+
+func Test_StorageVersionContainsInvalidLeaseID(t *testing.T) {
+	lease1 := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-1",
+			Namespace: metav1.NamespaceSystem,
+			Labels: map[string]string{
+				"k8s.io/component": "kube-apiserver",
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: utilpointer.StringPtr("kube-apiserver-1"),
+		},
+	}
+	lease2 := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-2",
+			Namespace: metav1.NamespaceSystem,
+			Labels: map[string]string{
+				"k8s.io/component": "kube-apiserver",
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: utilpointer.StringPtr("kube-apiserver-2"),
+		},
+	}
+	lease3 := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-3",
+			Namespace: metav1.NamespaceSystem,
+			Labels: map[string]string{
+				"k8s.io/component": "kube-apiserver",
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: utilpointer.StringPtr("kube-apiserver-3"),
+		},
+	}
+
+	storageVersion := &apiserverinternalv1alpha1.StorageVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "k8s.test.resources",
+		},
+		Status: apiserverinternalv1alpha1.StorageVersionStatus{
+			StorageVersions: []apiserverinternalv1alpha1.ServerStorageVersion{
+				{
+					APIServerID:       "kube-apiserver-1",
+					EncodingVersion:   "v1",
+					DecodableVersions: []string{"v1"},
+				},
+				{
+					APIServerID:       "kube-apiserver-2",
+					EncodingVersion:   "v2",
+					DecodableVersions: []string{"v2"},
+				},
+				{
+					APIServerID:       "kube-apiserver-3",
+					EncodingVersion:   "v2",
+					DecodableVersions: []string{"v2"},
+				},
+				{
+					APIServerID:       "kube-apiserver-4", // doesn't exist
+					EncodingVersion:   "v2",
+					DecodableVersions: []string{"v1"},
+				},
+			},
+			CommonEncodingVersion: utilpointer.String("v1"),
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(lease1, lease2, lease3, storageVersion)
+	setupController(clientset)
+
+	// add a delay to ensure controller had a chance to reconcile
+	time.Sleep(2 * time.Second)
+
+	storageVersion, err := clientset.InternalV1alpha1().StorageVersions().Get(context.Background(), "k8s.test.resources", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting StorageVersion: %v", err)
+	}
+
+	expectedServerStorageVersions := []apiserverinternalv1alpha1.ServerStorageVersion{
+		{
+			APIServerID:       "kube-apiserver-1",
+			EncodingVersion:   "v1",
+			DecodableVersions: []string{"v1"},
+		},
+		{
+			APIServerID:       "kube-apiserver-2",
+			EncodingVersion:   "v2",
+			DecodableVersions: []string{"v2"},
+		},
+		{
+			APIServerID:       "kube-apiserver-3",
+			EncodingVersion:   "v2",
+			DecodableVersions: []string{"v2"},
+		},
+	}
+
+	if !reflect.DeepEqual(storageVersion.Status.StorageVersions, expectedServerStorageVersions) {
+		t.Error("unexpected storage version object")
+		t.Logf("got: %+v", storageVersion)
+		t.Logf("expected: %+v", expectedServerStorageVersions)
+	}
+
+	if len(storageVersion.Status.Conditions) != 1 {
+		t.Errorf("expected 1 condition, got: %d", len(storageVersion.Status.Conditions))
+	}
+
+	if storageVersion.Status.Conditions[0].Type != apiserverinternalv1alpha1.AllEncodingVersionsEqual {
+		t.Errorf("expected condition type 'AllEncodingVersionsEqual', got: %q", storageVersion.Status.Conditions[0].Type)
+	}
+
+	if storageVersion.Status.Conditions[0].Status != apiserverinternalv1alpha1.ConditionFalse {
+		t.Errorf("expected condition status 'True', got: %q", storageVersion.Status.Conditions[0].Status)
+	}
+}
+
+func Test_StorageVersionDeletedOnLeaseDeletion(t *testing.T) {
+	lease1 := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-1",
+			Namespace: metav1.NamespaceSystem,
+			Labels: map[string]string{
+				"k8s.io/component": "kube-apiserver",
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: utilpointer.StringPtr("kube-apiserver-1"),
+		},
+	}
+
+	storageVersion := &apiserverinternalv1alpha1.StorageVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "k8s.test.resources",
+		},
+		Status: apiserverinternalv1alpha1.StorageVersionStatus{
+			StorageVersions: []apiserverinternalv1alpha1.ServerStorageVersion{
+				{
+					APIServerID:       "kube-apiserver-1",
+					EncodingVersion:   "v1",
+					DecodableVersions: []string{"v1"},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(lease1, storageVersion)
+	setupController(clientset)
+
+	// Delete the lease object and verify that storage version status is updated
+	if err := clientset.CoordinationV1().Leases(metav1.NamespaceSystem).Delete(context.Background(), "kube-apiserver-1", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("error deleting lease object: %v", err)
+	}
+
+	// add a delay to ensure controller had a chance to reconcile
+	time.Sleep(2 * time.Second)
+
+	// expect deleted
+	_, err := clientset.InternalV1alpha1().StorageVersions().Get(context.Background(), "k8s.test.resources", metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected IsNotFound error, got: %v", err)
+	}
+}

--- a/pkg/controller/storageversiongc/gc_controller_test.go
+++ b/pkg/controller/storageversiongc/gc_controller_test.go
@@ -42,47 +42,29 @@ func setupController(clientset kubernetes.Interface) {
 	informerFactory.Start(nil)
 }
 
+func newKubeApiserverLease(name, holderIdentity string) *coordinationv1.Lease {
+	return &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceSystem,
+			Labels: map[string]string{
+				"k8s.io/component": "kube-apiserver",
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: utilpointer.StringPtr(holderIdentity),
+		},
+	}
+}
+
 // Test_StorageVersionUpdatedWithAllEncodingVersionsEqualOnLeaseDeletion validates that
 // status.serverStorageVersions is updated when a kube-apiserver Lease is deleted.
 // If the remaining Leases agree on a new encoding version, status.commonEncodingVersion
 // should reflect the newly agreed version.
 func Test_StorageVersionUpdatedWithAllEncodingVersionsEqualOnLeaseDeletion(t *testing.T) {
-	lease1 := &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver-1",
-			Namespace: metav1.NamespaceSystem,
-			Labels: map[string]string{
-				"k8s.io/component": "kube-apiserver",
-			},
-		},
-		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: utilpointer.StringPtr("kube-apiserver-1"),
-		},
-	}
-	lease2 := &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver-2",
-			Namespace: metav1.NamespaceSystem,
-			Labels: map[string]string{
-				"k8s.io/component": "kube-apiserver",
-			},
-		},
-		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: utilpointer.StringPtr("kube-apiserver-2"),
-		},
-	}
-	lease3 := &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver-3",
-			Namespace: metav1.NamespaceSystem,
-			Labels: map[string]string{
-				"k8s.io/component": "kube-apiserver",
-			},
-		},
-		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: utilpointer.StringPtr("kube-apiserver-3"),
-		},
-	}
+	lease1 := newKubeApiserverLease("kube-apiserver-1", "kube-apiserver-1")
+	lease2 := newKubeApiserverLease("kube-apiserver-2", "kube-apiserver-2")
+	lease3 := newKubeApiserverLease("kube-apiserver-3", "kube-apiserver-3")
 
 	storageVersion := &apiserverinternalv1alpha1.StorageVersion{
 		ObjectMeta: metav1.ObjectMeta{
@@ -169,42 +151,9 @@ func Test_StorageVersionUpdatedWithAllEncodingVersionsEqualOnLeaseDeletion(t *te
 // If the remaining Leases do not agree on a new encoding version, status.commonEncodingVersion
 // should remain unchanged.
 func Test_StorageVersionUpdatedWithDifferentEncodingVersionsOnLeaseDeletion(t *testing.T) {
-	lease1 := &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver-1",
-			Namespace: metav1.NamespaceSystem,
-			Labels: map[string]string{
-				"k8s.io/component": "kube-apiserver",
-			},
-		},
-		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: utilpointer.StringPtr("kube-apiserver-1"),
-		},
-	}
-	lease2 := &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver-2",
-			Namespace: metav1.NamespaceSystem,
-			Labels: map[string]string{
-				"k8s.io/component": "kube-apiserver",
-			},
-		},
-		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: utilpointer.StringPtr("kube-apiserver-2"),
-		},
-	}
-	lease3 := &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver-3",
-			Namespace: metav1.NamespaceSystem,
-			Labels: map[string]string{
-				"k8s.io/component": "kube-apiserver",
-			},
-		},
-		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: utilpointer.StringPtr("kube-apiserver-3"),
-		},
-	}
+	lease1 := newKubeApiserverLease("kube-apiserver-1", "kube-apiserver-1")
+	lease2 := newKubeApiserverLease("kube-apiserver-2", "kube-apiserver-2")
+	lease3 := newKubeApiserverLease("kube-apiserver-3", "kube-apiserver-3")
 
 	storageVersion := &apiserverinternalv1alpha1.StorageVersion{
 		ObjectMeta: metav1.ObjectMeta{
@@ -272,42 +221,9 @@ func Test_StorageVersionUpdatedWithDifferentEncodingVersionsOnLeaseDeletion(t *t
 // Test_StorageVersionContainsInvalidLeaseID validates that status.serverStorageVersions
 // only contains the holder identity from kube-apiserver Leases that exist.
 func Test_StorageVersionContainsInvalidLeaseID(t *testing.T) {
-	lease1 := &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver-1",
-			Namespace: metav1.NamespaceSystem,
-			Labels: map[string]string{
-				"k8s.io/component": "kube-apiserver",
-			},
-		},
-		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: utilpointer.StringPtr("kube-apiserver-1"),
-		},
-	}
-	lease2 := &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver-2",
-			Namespace: metav1.NamespaceSystem,
-			Labels: map[string]string{
-				"k8s.io/component": "kube-apiserver",
-			},
-		},
-		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: utilpointer.StringPtr("kube-apiserver-2"),
-		},
-	}
-	lease3 := &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver-3",
-			Namespace: metav1.NamespaceSystem,
-			Labels: map[string]string{
-				"k8s.io/component": "kube-apiserver",
-			},
-		},
-		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: utilpointer.StringPtr("kube-apiserver-3"),
-		},
-	}
+	lease1 := newKubeApiserverLease("kube-apiserver-1", "kube-apiserver-1")
+	lease2 := newKubeApiserverLease("kube-apiserver-2", "kube-apiserver-2")
+	lease3 := newKubeApiserverLease("kube-apiserver-3", "kube-apiserver-3")
 
 	storageVersion := &apiserverinternalv1alpha1.StorageVersion{
 		ObjectMeta: metav1.ObjectMeta{
@@ -391,18 +307,7 @@ func Test_StorageVersionContainsInvalidLeaseID(t *testing.T) {
 // Test_StorageVersionDeletedOnLeaseDeletion validates that a StorageVersion
 // object is deleted if there are no kube-apiserver Leases.
 func Test_StorageVersionDeletedOnLeaseDeletion(t *testing.T) {
-	lease1 := &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver-1",
-			Namespace: metav1.NamespaceSystem,
-			Labels: map[string]string{
-				"k8s.io/component": "kube-apiserver",
-			},
-		},
-		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: utilpointer.StringPtr("kube-apiserver-1"),
-		},
-	}
+	lease1 := newKubeApiserverLease("kube-apiserver-1", "kube-apiserver-1")
 
 	storageVersion := &apiserverinternalv1alpha1.StorageVersion{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/storageversiongc/gc_controller_test.go
+++ b/pkg/controller/storageversiongc/gc_controller_test.go
@@ -42,6 +42,10 @@ func setupController(clientset kubernetes.Interface) {
 	informerFactory.Start(nil)
 }
 
+// Test_StorageVersionUpdatedWithAllEncodingVersionsEqualOnLeaseDeletion validates that
+// status.serverStorageVersions is updated when a kube-apiserver Lease is deleted.
+// If the remaining Leases agree on a new encoding version, status.commonEncodingVersion
+// should reflect the newly agreed version.
 func Test_StorageVersionUpdatedWithAllEncodingVersionsEqualOnLeaseDeletion(t *testing.T) {
 	lease1 := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
@@ -160,6 +164,10 @@ func Test_StorageVersionUpdatedWithAllEncodingVersionsEqualOnLeaseDeletion(t *te
 	}
 }
 
+// Test_StorageVersionUpdatedWithDifferentEncodingVersionsOnLeaseDeletion validates that
+// status.serverStorageVersions is updated when a kube-apiserver Lease is deleted.
+// If the remaining Leases do not agree on a new encoding version, status.commonEncodingVersion
+// should remain unchanged.
 func Test_StorageVersionUpdatedWithDifferentEncodingVersionsOnLeaseDeletion(t *testing.T) {
 	lease1 := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
@@ -261,6 +269,8 @@ func Test_StorageVersionUpdatedWithDifferentEncodingVersionsOnLeaseDeletion(t *t
 	}
 }
 
+// Test_StorageVersionContainsInvalidLeaseID validates that status.serverStorageVersions
+// only contains the holder identity from kube-apiserver Leases that exist.
 func Test_StorageVersionContainsInvalidLeaseID(t *testing.T) {
 	lease1 := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
@@ -378,6 +388,8 @@ func Test_StorageVersionContainsInvalidLeaseID(t *testing.T) {
 	}
 }
 
+// Test_StorageVersionDeletedOnLeaseDeletion validates that a StorageVersion
+// object is deleted if there are no kube-apiserver Leases.
 func Test_StorageVersionDeletedOnLeaseDeletion(t *testing.T) {
 	lease1 := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

As part of test-hardening required for promoting StorageVersionAPI feature to Beta in v1.26.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
