### PR TITLE
Removes test of deprecated --dry-run value

### DIFF
--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -101,7 +101,6 @@ run_kubectl_apply_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{${id_field:?}}}:{{end}}" ''
 
   # apply dry-run
-  kubectl apply --dry-run=true -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
   kubectl apply --dry-run=client -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
   kubectl apply --dry-run=server -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
   # No pod exists


### PR DESCRIPTION
* Removes `kubectl apply` integration test which tests a deprecated `--dry-run=true` flag value.

/kind bug

```release-note
NONE
```