### PR TITLE
migrate usage of `merge` to `MergeBuckets` for static analysis

### DIFF
--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -61,7 +61,7 @@ var (
 			Subsystem: kubeProxySubsystem,
 			Name:      "network_programming_duration_seconds",
 			Help:      "In Cluster Network Programming Latency in seconds",
-			Buckets: merge(
+			Buckets: metrics.MergeBuckets(
 				metrics.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
 				metrics.LinearBuckets(1, 1, 59),      // 1s, 2s, 3s, ... 59s
 				metrics.LinearBuckets(60, 5, 12),     // 60s, 65s, 70s, ... 115s
@@ -185,12 +185,4 @@ func RegisterMetrics() {
 // SinceInSeconds gets the time since the specified start in seconds.
 func SinceInSeconds(start time.Time) float64 {
 	return time.Since(start).Seconds()
-}
-
-func merge(slices ...[]float64) []float64 {
-	result := make([]float64, 1)
-	for _, s := range slices {
-		result = append(result, s...)
-	}
-	return result
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

This centralizes the logic for merging buckets into component-base so that we can reliably perform static analysis on metrics that do this. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
