### PR TITLE
kubectl-e2e: the event rendering may have 3 or 4 whitespaces

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1942,7 +1942,7 @@ metadata:
 	})
 
 	ginkgo.Describe("Kubectl events", func() {
-		ginkgo.It("should show event when pod is created ", func() {
+		ginkgo.It("should show event when pod is created", func() {
 			podName := "e2e-test-httpd-pod"
 			ginkgo.By("running the image " + httpdImage)
 			e2ekubectl.RunKubectlOrDie(ns, "run", podName, "--image="+httpdImage, podRunningTimeoutArg, "--labels=run="+podName)
@@ -1957,7 +1957,9 @@ metadata:
 			ginkgo.By("show started event for this pod")
 			events := e2ekubectl.RunKubectlOrDie(ns, "alpha", "events", "--for=pod/"+podName)
 
-			if !strings.Contains(events, fmt.Sprintf("Normal   Scheduled   Pod/%s", podName)) {
+			// replace multi spaces into single white space
+			eventsStr := strings.Join(strings.Fields(strings.TrimSpace(events)), " ")
+			if !strings.Contains(string(eventsStr), fmt.Sprintf("Normal Scheduled Pod/%s", podName)) {
 				framework.Failf("failed to list expected event")
 			}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind flake


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes https://storage.googleapis.com/k8s-triage/index.html?test=should%20show%20event%20when%20pod%20is%20created#65db77e2bd13e82720b8

#### Special notes for your reviewer:
Failed case: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-flaky-repro/1582606702572736512
```
Kubernetes e2e suite: [It] [sig-cli] Kubectl client Kubectl events should show event when pod is created  expand_less | 12s
-- | --
{Oct 19 05:58:54.973: failed to list expected event failed vendor/github.com/onsi/ginkgo/v2/internal/node.go:436 }

```

When pod is not started or started with some warning event, the output may have different number of whitespaces.
```
Oct 18 20:50:56.142: INFO: stdout: "LAST SEEN   TYPE      REASON        OBJECT                   MESSAGE\n11s         Normal    Scheduled     Pod/e2e-test-httpd-pod   Successfully assigned kubectl-4657/e2e-test-httpd-pod to bootstrap-e2e-minion-group-53pg\n9s          Warning   FailedMount   Pod/e2e-test-httpd-pod   MountVolume.SetUp failed for volume \"kube-api-access-jxzn8\" : failed to sync configmap cache: timed out waiting for the condition\n8s          Normal    Pulled        Pod/e2e-test-httpd-pod   Container image \"registry.k8s.io/e2e-test-images/httpd:2.4.38-2\" already present on machine\n8s          Normal    Created       Pod/e2e-test-httpd-pod   Created container e2e-test-httpd-pod\n8s          Normal    Started       Pod/e2e-test-httpd-pod   Started container e2e-test-httpd-pod\n"

LAST SEEN   TYPE      REASON        OBJECT                   MESSAGE
5s          Normal    Scheduled     Pod/e2e-test-httpd-pod   Successfully assigned kubectl-3173/e2e-test-httpd-pod to bootstrap-e2e-minion-group-g1nh
4s          Warning   FailedMount   Pod/e2e-test-httpd-pod   MountVolume.SetUp failed for volume "kube-api-access-nffj7" : failed to sync configmap cache: timed out waiting for the condition
2s          Normal    Pulled        Pod/e2e-test-httpd-pod   Container image "registry.k8s.io/e2e-test-images/httpd:2.4.38-2" already present on machine
2s          Normal    Created       Pod/e2e-test-httpd-pod   Created container e2e-test-httpd-pod
2s          Normal    Started       Pod/e2e-test-httpd-pod   Started container e2e-test-httpd-pod
```
When there is no warning event, the case pass.
This case is focus on `kubectl alpha event` and should not flake for pod startup warnings.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
