### PR TITLE
flake: wait for crd ready in kubectl apply script

### DIFF
--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -351,6 +351,7 @@ __EOF__
   # First pass, custom resource fails, but crd apply succeeds.
   output_message=$(! kubectl apply -f hack/testdata/multi-resource-4.yaml 2>&1 "${kube_flags[@]:?}")
   kube::test::if_has_string "${output_message}" 'no matches for kind "Widget" in version "example.com/v1"'
+  kubectl wait --timeout=2s --for=condition=Established=true crd/widgets.example.com
   output_message=$(! kubectl get widgets foo 2>&1 "${kube_flags[@]:?}")
   kube::test::if_has_string "${output_message}" 'widgets.example.com "foo" not found'
   kube::test::get_object_assert 'crds widgets.example.com' "{{${id_field}}}" 'widgets.example.com'


### PR DESCRIPTION
Fixes flaky kubectl apply integration test: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-integration/1582306882633076736
/kind flake

See more in https://github.com/kubernetes/kubernetes/pull/113150#issuecomment-1283534001

```
�(Bmessage:customresourcedefinition.apiextensions.k8s.io/widgets.example.com created
error: resource mapping not found for name: "foo" namespace: "" from "hack/testdata/multi-resource-4.yaml": no matches for kind "Widget" in version "example.com/v1"
ensure CRDs are installed first
has:no matches for kind "Widget" in version "example.com/v1"
�[31mFAIL!
�(Bmessage:error: the server doesn't have a resource type "widgets"
has not:widgets.example.com "foo" not found
```

After the first apply, crd is created and cr is not. However, the `kubectl get widgets foo` failed for crd not available; the expected error message would be the cr is not found.

So I add a wait before the `kubectl get` to avoid crd not ready.

/cc @apelisse  @seans3 @lavalamp

```release-note
None
```