### PR TITLE
Add metric for terminated pods with tracking finalizer

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -246,6 +246,7 @@ func (jm *Controller) resolveControllerRef(namespace string, controllerRef *meta
 // When a pod is created, enqueue the controller that manages it and update its expectations.
 func (jm *Controller) addPod(obj interface{}) {
 	pod := obj.(*v1.Pod)
+	recordFinishedPodWithTrackingFinalizer(nil, pod)
 	if pod.DeletionTimestamp != nil {
 		// on a restart of the controller, it's possible a new pod shows up in a state that
 		// is already pending deletion. Prevent the pod from being a creation observation.
@@ -288,6 +289,7 @@ func (jm *Controller) addPod(obj interface{}) {
 func (jm *Controller) updatePod(old, cur interface{}) {
 	curPod := cur.(*v1.Pod)
 	oldPod := old.(*v1.Pod)
+	recordFinishedPodWithTrackingFinalizer(oldPod, curPod)
 	if curPod.ResourceVersion == oldPod.ResourceVersion {
 		// Periodic resync will send update events for all known pods.
 		// Two different versions of the same pod will always have different RVs.
@@ -362,6 +364,9 @@ func (jm *Controller) updatePod(old, cur interface{}) {
 // obj could be an *v1.Pod, or a DeleteFinalStateUnknown marker item.
 func (jm *Controller) deletePod(obj interface{}, final bool) {
 	pod, ok := obj.(*v1.Pod)
+	if final {
+		recordFinishedPodWithTrackingFinalizer(pod, nil)
+	}
 
 	// When a delete is dropped, the relist will notice a pod in the store not
 	// in the list, leading to the insertion of a tombstone object which contains
@@ -1671,15 +1676,6 @@ func removeTrackingAnnotationPatch(job *batch.Job) []byte {
 	}
 	patchBytes, _ := json.Marshal(patch)
 	return patchBytes
-}
-
-func hasJobTrackingFinalizer(pod *v1.Pod) bool {
-	for _, fin := range pod.Finalizers {
-		if fin == batch.JobTrackingFinalizer {
-			return true
-		}
-	}
-	return false
 }
 
 type uncountedTerminatedPods struct {

--- a/pkg/controller/job/metrics/metrics.go
+++ b/pkg/controller/job/metrics/metrics.go
@@ -83,6 +83,18 @@ var (
 			Help:      "The number of finished Pods that are fully tracked",
 		},
 		[]string{"completion_mode", "result"})
+
+	// TerminatedPodsWithTrackingFinalizer records the addition and removal of
+	// terminated pods that have the finalizer batch.kubernetes.io/job-tracking,
+	// regardless of whether they are owned by a Job.
+	TerminatedPodsTrackingFinalizerTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem: JobControllerSubsystem,
+			Name:      "terminated_pods_tracking_finalizer_total",
+			Help: `The number of terminated pods (phase=Failed|Succeeded)
+that have the finalizer batch.kubernetes.io/job-tracking
+The event label can be "add" or "delete".`,
+		}, []string{"event"})
 )
 
 const (
@@ -109,6 +121,11 @@ const (
 
 	Succeeded = "succeeded"
 	Failed    = "failed"
+
+	// Possible values for "event"  label in the terminated_pods_tracking_finalizer
+	// metric.
+	Add    = "add"
+	Delete = "delete"
 )
 
 var registerMetrics sync.Once
@@ -120,5 +137,6 @@ func Register() {
 		legacyregistry.MustRegister(JobSyncNum)
 		legacyregistry.MustRegister(JobFinishedNum)
 		legacyregistry.MustRegister(JobPodsFinished)
+		legacyregistry.MustRegister(TerminatedPodsTrackingFinalizerTotal)
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

/sig apps
/sig instrumentation

#### What this PR does / why we need it:

Add a counter metric to keep track of terminated Pods as they get and loose the tracking finalizer.

#### Which issue(s) this PR fixes:

Part of kubernetes/enhancements#2307

#### Special notes for your reviewer:

The KEP originally proposed a gauge, but it proved to be difficult to test whether the controller saw finalizers at all.
A counter with an event label (with values add and remove) can be used to construct a gauge.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
New metric job_controller_terminated_pods_tracking_finalizer can be used to monitor whether the job controller is removing Pod finalizers from terminated Pods after accounting them in Job status.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: git.k8s.io/enhancements/sig-apps/2307-job-tracking-without-lingering-pods
- [Usage]: https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-tracking-with-finalizers
```
