### PR TITLE
Remove unuseful multi scheduler testcases

### DIFF
--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -188,11 +188,6 @@ func TestMultipleSchedulers(t *testing.T) {
 	// 5. create a scheduler with name "foo-scheduler"
 	// 6. **check point-2**:
 	//     - testPodWithAnnotationFitsFoo should be scheduled
-	// 7. stop default scheduler
-	// 8. create 2 pods: testPodNoAnnotation2 and testPodWithAnnotationFitsDefault2
-	//    - note: these two pods belong to default scheduler which no longer exists
-	// 9. **check point-3**:
-	//     - testPodNoAnnotation2 and testPodWithAnnotationFitsDefault2 should NOT be scheduled
 
 	// 1. create and start default-scheduler
 	testCtx := initTest(t, "multi-scheduler")
@@ -279,52 +274,6 @@ func TestMultipleSchedulers(t *testing.T) {
 	} else {
 		t.Logf("Test MultiScheduler: %s Pod scheduled", testPodFitsFoo.Name)
 	}
-
-	//	7. delete the pods that were scheduled by the default scheduler, and stop the default scheduler
-	if err := deletePod(testCtx.ClientSet, testPod.Name, testCtx.NS.Name); err != nil {
-		t.Errorf("Failed to delete pod: %v", err)
-	}
-	if err := deletePod(testCtx.ClientSet, testPodFitsDefault.Name, testCtx.NS.Name); err != nil {
-		t.Errorf("Failed to delete pod: %v", err)
-	}
-
-	// The rest of this test assumes that closing StopEverything will cause the
-	// scheduler thread to stop immediately.  It won't, and in fact it will often
-	// schedule 1 more pod before finally exiting.  Comment out until we fix that.
-	//
-	// See https://github.com/kubernetes/kubernetes/issues/23715 for more details.
-
-	/*
-		close(schedulerConfig.StopEverything)
-
-		//	8. create 2 pods: testPodNoAnnotation2 and testPodWithAnnotationFitsDefault2
-		//		- note: these two pods belong to default scheduler which no longer exists
-		podWithNoAnnotation2 := createPod("pod-with-no-annotation2", nil)
-		podWithAnnotationFitsDefault2 := createPod("pod-with-annotation-fits-default2", schedulerAnnotationFitsDefault)
-		testPodNoAnnotation2, err := clientSet.CoreV1().Pods(ns.Name).Create(podWithNoAnnotation2)
-		if err != nil {
-			t.Fatalf("Failed to create pod: %v", err)
-		}
-		testPodWithAnnotationFitsDefault2, err := clientSet.CoreV1().Pods(ns.Name).Create(podWithAnnotationFitsDefault2)
-		if err != nil {
-			t.Fatalf("Failed to create pod: %v", err)
-		}
-
-		//	9. **check point-3**:
-		//		- testPodNoAnnotation2 and testPodWithAnnotationFitsDefault2 should NOT be scheduled
-		err = wait.Poll(time.Second, time.Second*5, testutils.PodScheduled(clientSet, testPodNoAnnotation2.Namespace, testPodNoAnnotation2.Name))
-		if err == nil {
-			t.Errorf("Test MultiScheduler: %s Pod got scheduled, %v", testPodNoAnnotation2.Name, err)
-		} else {
-			t.Logf("Test MultiScheduler: %s Pod not scheduled", testPodNoAnnotation2.Name)
-		}
-		err = wait.Poll(time.Second, time.Second*5, testutils.PodScheduled(clientSet, testPodWithAnnotationFitsDefault2.Namespace, testPodWithAnnotationFitsDefault2.Name))
-		if err == nil {
-			t.Errorf("Test MultiScheduler: %s Pod got scheduled, %v", testPodWithAnnotationFitsDefault2.Name, err)
-		} else {
-			t.Logf("Test MultiScheduler: %s Pod scheduled", testPodWithAnnotationFitsDefault2.Name)
-		}
-	*/
 }
 
 func TestMultipleSchedulingProfiles(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: kerthcet <kerthcet@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig scheduling

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
The test case used to have race problem, currently we support multi-profiles in scheduler, multi-schedulers is not recommended.
So I'd like to remove this directly.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
