### PR TITLE
Fix APF width estimate for creating service account's token

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
@@ -410,6 +410,33 @@ func TestWorkEstimator(t *testing.T) {
 			finalSeatsExpected:        3,
 			additionalLatencyExpected: 5 * time.Millisecond,
 		},
+		{
+			name:       "creating token for service account",
+			requestURI: "http://server/api/v1/namespaces/foo/serviceaccounts/default/token",
+			requestInfo: &apirequest.RequestInfo{
+				Verb:        "create",
+				APIGroup:    "v1",
+				Resource:    "serviceaccounts",
+				Subresource: "token",
+			},
+			watchCount:                5777,
+			initialSeatsExpected:      minimumSeats,
+			finalSeatsExpected:        0,
+			additionalLatencyExpected: 0,
+		},
+		{
+			name:       "creating service account",
+			requestURI: "http://server/api/v1/namespaces/foo/serviceaccounts",
+			requestInfo: &apirequest.RequestInfo{
+				Verb:     "create",
+				APIGroup: "v1",
+				Resource: "serviceaccounts",
+			},
+			watchCount:                1000,
+			initialSeatsExpected:      1,
+			finalSeatsExpected:        maximumSeats,
+			additionalLatencyExpected: 50 * time.Millisecond,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Creating token for service account does not modify serviceaccount and does not produce any event. Because of that it shouldn't be considered as such request, example:
```
"HTTP" verb="POST" URI="/api/v1/namespaces/kube-system/serviceaccounts/default/token" latency="266.784506ms" userAgent="kubelet/v1.25.1" apf_pl="system" apf_fs="system-nodes" apf_iseats=1 apf_fseats=10 apf_additionalLatency="258.5ms" fl_priorityandfairness="256.272604ms" apf_execution_time="10.256749ms" resp=201
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix cost estimation of token creation request for service account in Priority and Fairness.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
