### PR TITLE
Set default test timeouts first, only then modify the required ones

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1905,9 +1905,9 @@ func (v *azureFileVolume) DeleteVolume() {
 }
 
 func (a *azureDiskDriver) GetTimeouts() *framework.TimeoutContext {
-	return &framework.TimeoutContext{
-		PodStart:  time.Minute * 15,
-		PodDelete: time.Minute * 15,
-		PVDelete:  time.Minute * 20,
-	}
+	timeouts := framework.NewTimeoutContextWithDefaults()
+	timeouts.PodStart = time.Minute * 15
+	timeouts.PodDelete = time.Minute * 15
+	timeouts.PVDelete = time.Minute * 20
+	return timeouts
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind failing-test
/kind flake
/kind regression

#### What this PR does / why we need it:
This was found in OpenShift CI https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/openshift-origin-27416-ci-4.12-upgrade-from-stable-4.11-e2e-azure-sdn-upgrade/1582968138251636736 the ClaimTimeout is 0s as per the error:
```
"PVC \"pvc-nv5q2\" did not become Bound: PersistentVolumeClaims [pvc-nv5q2] not all in phase Bound within 0s",
```

This is followup to https://github.com/kubernetes/kubernetes/pull/111034/


#### Special notes for your reviewer:
/assign @jsafrane @bertinatto 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/hold
for testing... 