### PR TITLE
FilterLatency tracing for APIServerTracing

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/tracing"
 	netutils "k8s.io/utils/net"
 )
 
@@ -302,6 +303,7 @@ func TestAuthenticationAuditAnnotationsDefaultChain(t *testing.T) {
 		RequestTimeout:        10 * time.Second,
 		LongRunningFunc:       func(_ *http.Request, _ *request.RequestInfo) bool { return false },
 		lifecycleSignals:      newLifecycleSignals(),
+		TracerProvider:        tracing.NewNoopTracerProvider(),
 	}
 
 	h := DefaultBuildHandlerChain(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig instrumentation
/priority important-soon

#### What this PR does / why we need it:

Part of https://github.com/kubernetes/kubernetes/issues/113170, which is a beta requirement for the API Server tracing KEP: https://github.com/kubernetes/enhancements/issues/647

This was requested here: https://github.com/kubernetes/enhancements/issues/647#issuecomment-1078834288 to measure "request filter processing -- for filters like authorization, priority and fairness and other, how much time we spent in each".

#### Special notes for your reviewer:

Rather than explicitly keep a reference to the current span in the `requestFilterRecord` struct, we store and retrieve it from the current context.  This minimizes the amount of tracking we have to do.

#### Does this PR introduce a user-facing change?

```release-note
API Server tracing now includes the latency of authorization, priorityandfairness, impersonation, audit, and authentication filters.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/bddca24910fb349e2eb0ac1c822c77f0f32fe9c6/keps/sig-instrumentation/647-apiserver-tracing/README.md
```
