### PR TITLE
HostProcess containers metrics e2e test fixes

### DIFF
--- a/test/e2e/windows/host_process.go
+++ b/test/e2e/windows/host_process.go
@@ -520,6 +520,8 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 
 		ginkgo.By("Scheduling a pod with a HostProcess init container that will fail")
 
+		badUserName := "bad-user-name"
+
 		podName := "host-process-metrics-pod-failing-init-container"
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -535,6 +537,11 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 				HostNetwork: true,
 				InitContainers: []v1.Container{
 					{
+						SecurityContext: &v1.SecurityContext{
+							WindowsOptions: &v1.WindowsSecurityContextOptions{
+								RunAsUserName: &badUserName,
+							},
+						},
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
 						Name:    "failing-init-container",
 						Command: []string{"foobar.exe"},
@@ -571,6 +578,11 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 				HostNetwork: true,
 				Containers: []v1.Container{
 					{
+						SecurityContext: &v1.SecurityContext{
+							WindowsOptions: &v1.WindowsSecurityContextOptions{
+								RunAsUserName: &badUserName,
+							},
+						},
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
 						Name:    "failing-container",
 						Command: []string{"foobar.exe"},


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind cleanup
/area test
/sig windows
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixing an issue where there the e2e test that validates that kubelet metrics around starting / failed HostProcess containers is acting differently on containerd v1.6.x vs v1.7 due to known differences.
These updates ensure the failure mode for starting containers that are expected to not start is consistent across containerd versions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
