### PR TITLE
Log request method & path with timeout errors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/finisher/finisher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/finisher/finisher_test.go
@@ -225,13 +225,13 @@ func TestFinishRequestWithPostTimeoutTracker(t *testing.T) {
 
 			var resultGot *result
 			postTimeoutLoggerCompletedCh := make(chan struct{})
-			decoratedPostTimeoutLogger := func(timedOutAt time.Time, r *result) {
+			decoratedPostTimeoutLogger := func(ctx context.Context, timedOutAt time.Time, r *result) {
 				defer func() {
 					resultGot = r
 					close(postTimeoutLoggerCompletedCh)
 				}()
 
-				logPostTimeoutResult(timedOutAt, r)
+				logPostTimeoutResult(ctx, timedOutAt, r)
 			}
 
 			_, err := finishRequest(ctx, resultFn, test.postTimeoutWait, decoratedPostTimeoutLogger)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

I was just debugging an API server with leaking go-routines, and saw lots of these logs:
```
FinishRequest: post-timeout activity, waited for 5m0.000182551s, child goroutine has not returned yet
```

This is error is not particularly useful, as it doesn't tell me anything about the request that's timing out. This PR includes the request verb & path in the log.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig api-machinery