### PR TITLE
fix: port name validation prompt is incorrect

### DIFF
--- a/vendor/sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/util/validation/validation.go
+++ b/vendor/sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/util/validation/validation.go
@@ -336,7 +336,7 @@ func IsValidPortName(port string) []string {
 		errs = append(errs, "must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)")
 	}
 	if !portNameOneLetterRegexp.MatchString(port) {
-		errs = append(errs, "must contain at least one letter or number (a-z, 0-9)")
+		errs = append(errs, "must contain at least one letter (a-z)")
 	}
 	if strings.Contains(port, "--") {
 		errs = append(errs, "must not contain consecutive hyphens")


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
the port name validation prompt is incorrect: must contains at least one letter, not letter or number.
![image](https://user-images.githubusercontent.com/6092586/197106545-3dbf1822-2f29-42a4-8abe-7b714dbe9828.png)
![image](https://user-images.githubusercontent.com/6092586/197106667-8a5fa37d-129b-4ca0-92d9-c0305cf13114.png)


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
fix: modify the port name validation prompt
```

