### PR TITLE
pvc storage request warning for fractional byte value

### DIFF
--- a/pkg/api/persistentvolumeclaim/util.go
+++ b/pkg/api/persistentvolumeclaim/util.go
@@ -19,7 +19,6 @@ package persistentvolumeclaim
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/apis/core"
@@ -161,13 +160,12 @@ func GetWarningsForPersistentVolumeClaim(pv *core.PersistentVolumeClaim) []strin
 		return nil
 	}
 	storageValue := pv.Spec.Resources.Requests[core.ResourceStorage]
-	return warningsForPersistentVolumeClaimResources(field.NewPath("spec").Child("Resources").Child("Requests").Key(core.ResourceStorage.String()), storageValue)
-}
-
-func warningsForPersistentVolumeClaimResources(fieldPath *field.Path, storageValue resource.Quantity) []string {
 	var warnings []string
 	if storageValue.MilliValue()%int64(1000) != int64(0) {
-		warnings = append(warnings, fmt.Sprintf("%s: fractional byte value %q is invalid, must be an integer", fieldPath.String(), storageValue.String()))
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: fractional byte value %q is invalid, must be an integer",
+			field.NewPath("spec").Child("resources").Child("requests").Key(core.ResourceStorage.String()),
+			storageValue.String()))
 	}
 	return warnings
 }

--- a/pkg/api/persistentvolumeclaim/util.go
+++ b/pkg/api/persistentvolumeclaim/util.go
@@ -159,13 +159,24 @@ func GetWarningsForPersistentVolumeClaim(pv *core.PersistentVolumeClaim) []strin
 	if pv == nil {
 		return nil
 	}
-	storageValue := pv.Spec.Resources.Requests[core.ResourceStorage]
+
+	return GetWarningsForPersistentVolumeClaimSpec(field.NewPath("spec"), pv.Spec)
+}
+
+func GetWarningsForPersistentVolumeClaimSpec(fieldPath *field.Path, pvSpec core.PersistentVolumeClaimSpec) []string {
+
 	var warnings []string
-	if storageValue.MilliValue()%int64(1000) != int64(0) {
+	requestValue := pvSpec.Resources.Requests[core.ResourceStorage]
+	if requestValue.MilliValue()%int64(1000) != int64(0) {
 		warnings = append(warnings, fmt.Sprintf(
 			"%s: fractional byte value %q is invalid, must be an integer",
-			field.NewPath("spec").Child("resources").Child("requests").Key(core.ResourceStorage.String()),
-			storageValue.String()))
+			fieldPath.Child("resources").Child("requests").Key(core.ResourceStorage.String()), requestValue.String()))
+	}
+	limitValue := pvSpec.Resources.Limits[core.ResourceStorage]
+	if limitValue.MilliValue()%int64(1000) != int64(0) {
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: fractional byte value %q is invalid, must be an integer",
+			fieldPath.Child("resources").Child("limits").Key(core.ResourceStorage.String()), limitValue.String()))
 	}
 	return warnings
 }

--- a/pkg/api/persistentvolumeclaim/util_test.go
+++ b/pkg/api/persistentvolumeclaim/util_test.go
@@ -411,11 +411,14 @@ func TestWarnings(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "200Mi no warning",
+			name: "200Mi requests no warning",
 			template: &core.PersistentVolumeClaim{
 				Spec: core.PersistentVolumeClaimSpec{
 					Resources: core.ResourceRequirements{
 						Requests: core.ResourceList{
+							core.ResourceStorage: resource.MustParse("200Mi"),
+						},
+						Limits: core.ResourceList{
 							core.ResourceStorage: resource.MustParse("200Mi"),
 						},
 					},
@@ -431,11 +434,15 @@ func TestWarnings(t *testing.T) {
 						Requests: core.ResourceList{
 							core.ResourceStorage: resource.MustParse("200m"),
 						},
+						Limits: core.ResourceList{
+							core.ResourceStorage: resource.MustParse("100m"),
+						},
 					},
 				},
 			},
 			expected: []string{
 				`spec.resources.requests[storage]: fractional byte value "200m" is invalid, must be an integer`,
+				`spec.resources.limits[storage]: fractional byte value "100m" is invalid, must be an integer`,
 			},
 		},
 		{

--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	nodeapi "k8s.io/kubernetes/pkg/api/node"
+	pvcutil "k8s.io/kubernetes/pkg/api/persistentvolumeclaim"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/pods"
 )
@@ -150,6 +151,9 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 		}
 		if v.Glusterfs != nil {
 			warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.25, this feature will be removed soon after in a subsequent release", fieldPath.Child("spec", "volumes").Index(i).Child("glusterfs")))
+		}
+		if v.Ephemeral != nil && v.Ephemeral.VolumeClaimTemplate != nil {
+			warnings = append(warnings, pvcutil.GetWarningsForPersistentVolumeClaimSpec(fieldPath.Child("spec", "volumes").Index(i).Child("ephemeral").Child("volumeClaimTemplate").Child("spec"), v.Ephemeral.VolumeClaimTemplate.Spec)...)
 		}
 	}
 

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -459,6 +459,36 @@ func TestWarnings(t *testing.T) {
 			},
 			expected: []string{},
 		},
+		{
+			name: "pod with ephemeral volume source 200Mi",
+			template: &api.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: api.PodSpec{Volumes: []api.Volume{
+					{Name: "ephemeral-volume", VolumeSource: api.VolumeSource{Ephemeral: &api.EphemeralVolumeSource{
+						VolumeClaimTemplate: &api.PersistentVolumeClaimTemplate{
+							Spec: api.PersistentVolumeClaimSpec{Resources: api.ResourceRequirements{
+								Requests: api.ResourceList{api.ResourceStorage: resource.MustParse("200Mi")}}},
+						},
+					}}}}},
+			},
+			expected: []string{},
+		},
+		{
+			name: "pod with ephemeral volume source 200m",
+			template: &api.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: api.PodSpec{Volumes: []api.Volume{
+					{Name: "ephemeral-volume", VolumeSource: api.VolumeSource{Ephemeral: &api.EphemeralVolumeSource{
+						VolumeClaimTemplate: &api.PersistentVolumeClaimTemplate{
+							Spec: api.PersistentVolumeClaimSpec{Resources: api.ResourceRequirements{
+								Requests: api.ResourceList{api.ResourceStorage: resource.MustParse("200m")}}},
+						},
+					}}}}},
+			},
+			expected: []string{
+				`spec.volumes[0].ephemeral.volumeClaimTemplate.spec.resources.requests[storage]: fractional byte value "200m" is invalid, must be an integer`,
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/registry/core/persistentvolumeclaim/strategy.go
+++ b/pkg/registry/core/persistentvolumeclaim/strategy.go
@@ -86,7 +86,7 @@ func (persistentvolumeclaimStrategy) Validate(ctx context.Context, obj runtime.O
 
 // WarningsOnCreate returns warnings for the creation of the given object.
 func (persistentvolumeclaimStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
-	return nil
+	return pvcutil.GetWarningsForPersistentVolumeClaim(obj.(*api.PersistentVolumeClaim))
 }
 
 // Canonicalize normalizes the object after validation.
@@ -128,7 +128,7 @@ func (persistentvolumeclaimStrategy) ValidateUpdate(ctx context.Context, obj, ol
 
 // WarningsOnUpdate returns warnings for the given update.
 func (persistentvolumeclaimStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
-	return nil
+	return pvcutil.GetWarningsForPersistentVolumeClaim(obj.(*api.PersistentVolumeClaim))
 }
 
 func (persistentvolumeclaimStrategy) AllowUnconditionalUpdate() bool {

--- a/test/e2e/framework/.import-restrictions
+++ b/test/e2e/framework/.import-restrictions
@@ -8,6 +8,7 @@ rules:
       - k8s.io/kubernetes/pkg/api/v1/service
       - k8s.io/kubernetes/pkg/api/pod
       - k8s.io/kubernetes/pkg/api/node
+      - k8s.io/kubernetes/pkg/api/persistentvolumeclaim
       - k8s.io/kubernetes/pkg/apis/apps
       - k8s.io/kubernetes/pkg/apis/apps/validation
       - k8s.io/kubernetes/pkg/apis/autoscaling


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
xref https://github.com/kubernetes/kubernetes/issues/94313

In https://github.com/kubernetes/kubernetes/issues/94626
- Add warnings for known bad values
- - PVC, PV, PVC template in statefulset and inline ephemeral volume
- - - fractional byte storage requests  

#### Special notes for your reviewer:
I followed #101688

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
