### PR TITLE
Introduce the ResourceExhausted Pod condition into the API types

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2434,6 +2434,10 @@ const (
 	// disruption (such as preemption, eviction API or garbage-collection).
 	// The constant is to be renamed once the name is accepted within the KEP-3329.
 	AlphaNoCompatGuaranteeDisruptionTarget PodConditionType = "DisruptionTarget"
+	// ResourceExhausted indicates the pod is about to be deleted due to either
+	// exceeding its ephemeral storage limits or running an OOM killed container.
+	// The constant is to be renamed once the name is accepted within the KEP-3329.
+	AlphaNoCompatGuaranteeResourceExhausted = "ResourceExhausted"
 )
 
 // PodCondition represents pod's condition

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2434,8 +2434,10 @@ const (
 	// disruption (such as preemption, eviction API or garbage-collection).
 	// The constant is to be renamed once the name is accepted within the KEP-3329.
 	AlphaNoCompatGuaranteeDisruptionTarget PodConditionType = "DisruptionTarget"
-	// ResourceExhausted indicates the pod is about to be deleted due to either
-	// exceeding its ephemeral storage limits or running an OOM killed container.
+	// ResourceExhausted indicates the pod is in the Failed phase or is about to
+	// transition into the Failed phase (and is about to be deleted) due to either:
+	// - exceeding its ephemeral storage limits; or
+	// - running an OOM killed container when the pod's .spec.restartPolicy=Never.
 	// The constant is to be renamed once the name is accepted within the KEP-3329.
 	AlphaNoCompatGuaranteeResourceExhausted = "ResourceExhausted"
 )

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2658,8 +2658,10 @@ const (
 	// disruption (such as preemption, eviction API or garbage-collection).
 	// The constant is to be renamed once the name is accepted within the KEP-3329.
 	AlphaNoCompatGuaranteeDisruptionTarget PodConditionType = "DisruptionTarget"
-	// ResourceExhausted indicates the pod is about to be deleted due to either
-	// exceeding its ephemeral storage limits or running an OOM killed container.
+	// ResourceExhausted indicates the pod is in the Failed phase or is about to
+	// transition into the Failed phase (and is about to be deleted) due to either:
+	// - exceeding its ephemeral storage limits; or
+	// - running an OOM killed container when the pod's .spec.restartPolicy=Never.
 	// The constant is to be renamed once the name is accepted within the KEP-3329.
 	AlphaNoCompatGuaranteeResourceExhausted = "ResourceExhausted"
 )

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2658,6 +2658,10 @@ const (
 	// disruption (such as preemption, eviction API or garbage-collection).
 	// The constant is to be renamed once the name is accepted within the KEP-3329.
 	AlphaNoCompatGuaranteeDisruptionTarget PodConditionType = "DisruptionTarget"
+	// ResourceExhausted indicates the pod is about to be deleted due to either
+	// exceeding its ephemeral storage limits or running an OOM killed container.
+	// The constant is to be renamed once the name is accepted within the KEP-3329.
+	AlphaNoCompatGuaranteeResourceExhausted = "ResourceExhausted"
 )
 
 // These are reasons for a pod's transition to a condition.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In order to decouple the API changes from the kubelet implementation in the PR (and thus to speed up the acceptance / review process):
https://github.com/kubernetes/kubernetes/pull/112360

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
- Tracking issue: https://github.com/kubernetes/enhancements/issues/3329

#### Special notes for your reviewer:

The new Pod condition follows the same naming convention as for the previously added pod condition: DisruptionTarget. 
For now we use the "Alpha" prefix in case the feature does not get fully promoted to Beta in this release cycle.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
 ```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures 
```
