### PR TITLE
Add watch cache metric with store size estimation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -135,6 +135,17 @@ var (
 		},
 		[]string{"resource"},
 	)
+
+	WatchCacheStoreSize = compbasemetrics.NewGaugeVec(
+		&compbasemetrics.GaugeOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "store_size",
+			Help:           "Total estimated size of watch cache's store broken by resource type.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"resource"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -153,6 +164,7 @@ func Register() {
 		legacyregistry.MustRegister(watchCacheCapacityDecreaseTotal)
 		legacyregistry.MustRegister(WatchCacheCapacity)
 		legacyregistry.MustRegister(WatchCacheInitializations)
+		legacyregistry.MustRegister(WatchCacheStoreSize)
 	})
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR adds a metric apiserver_watch_cache_store_size which aims to help understanding:
* memory consumption by the watch cache's store (excluding cyclic buffer for now), per resource type
   * this is useful when debugging high memory usage of kube-apiserver
* estimate of size for data we store in etcd, per resource type
   * useful for estimating e.g. risk of hitting issues like "too many data to list in 1m timeout"


It uses the storage codec to estimate size.

The potential risk is a resource consumption by additional serialization. We need some benchmarks to understand the performance impact (EDIT: See https://github.com/kubernetes/kubernetes/pull/113249#issuecomment-1288656541 for performance benchmark).

Preferably we can use size of data from etcd, but it's quite hard to pass it from etcd's storage to watch cache (especially in List call where result must be e.g. []v1.Pod and it's quite hard to store this information in v1.Pod).

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
A new metric 'apiserver_watch_cache_store_size' has been added that exposes estimated memory consumption by watch cache for a given resource type.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
