### PR TITLE
WIP: unittests: Fixes unit tests for Windows (time)

### DIFF
--- a/pkg/kubelet/pluginmanager/cache/actual_state_of_world_test.go
+++ b/pkg/kubelet/pluginmanager/cache/actual_state_of_world_test.go
@@ -119,9 +119,13 @@ func Test_ASW_RemovePlugin_Positive(t *testing.T) {
 func Test_ASW_PluginExistsWithCorrectTimestamp_Negative_WrongTimestamp(t *testing.T) {
 	// First, add a plugin
 	asw := NewActualStateOfWorld()
+	// On Windows, time.Now() is not as precise, which means that 2 consecutive calls may
+	// return the same timestamp. This would cause the test to fail, since they would have
+	// the same timestamp.
+	timestamp := time.Now().Add(-time.Second)
 	pluginInfo := PluginInfo{
 		SocketPath: "/var/lib/kubelet/device-plugins/test-plugin.sock",
-		Timestamp:  time.Now(),
+		Timestamp:  timestamp,
 		Handler:    nil,
 		Name:       "test",
 	}

--- a/pkg/kubelet/pluginmanager/cache/desired_state_of_world_test.go
+++ b/pkg/kubelet/pluginmanager/cache/desired_state_of_world_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -70,6 +71,10 @@ func Test_DSW_AddOrUpdatePlugin_Positive_ExistingPlugin(t *testing.T) {
 		t.Fatalf("Expected\n%s\nin desired state of world, but got\n%v\n", socketPath, dswPlugins[0])
 	}
 	oldTimestamp := dswPlugins[0].Timestamp
+	// On Windows, time.Now() is not as precise, which means that 2 consecutive calls may
+	// return the same timestamp. This would cause the test to fail, since they would have
+	// the same timestamp. Sleeping will cause in different times.
+	time.Sleep(time.Millisecond)
 
 	// Adding the plugin again so that the timestamp will be updated
 	err = dsw.AddOrUpdatePlugin(socketPath)

--- a/pkg/kubelet/pluginmanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/pluginmanager/reconciler/reconciler_test.go
@@ -191,7 +191,10 @@ func Test_Run_Positive_Register(t *testing.T) {
 	pluginName := fmt.Sprintf("example-plugin")
 	p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
 	require.NoError(t, p.Serve("v1beta1", "v1beta2"))
-	timestampBeforeRegistration := time.Now()
+	// On Windows, time.Now() is not as precise, which means that 2 consecutive calls may
+	// return the same timestamp. This would cause the test to fail, since they would have
+	// the same timestamp.
+	timestampBeforeRegistration := time.Now().Add(-time.Millisecond)
 	dsw.AddOrUpdatePlugin(socketPath)
 	waitForRegistration(t, socketPath, timestampBeforeRegistration, asw)
 
@@ -237,7 +240,10 @@ func Test_Run_Positive_RegisterThenUnregister(t *testing.T) {
 	pluginName := fmt.Sprintf("example-plugin")
 	p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
 	require.NoError(t, p.Serve("v1beta1", "v1beta2"))
-	timestampBeforeRegistration := time.Now()
+	// On Windows, time.Now() is not as precise, which means that 2 consecutive calls may
+	// return the same timestamp. This would cause the test to fail, since they would have
+	// the same timestamp.
+	timestampBeforeRegistration := time.Now().Add(-time.Millisecond)
 	dsw.AddOrUpdatePlugin(socketPath)
 	waitForRegistration(t, socketPath, timestampBeforeRegistration, asw)
 
@@ -293,11 +299,14 @@ func Test_Run_Positive_ReRegister(t *testing.T) {
 	pluginName := fmt.Sprintf("example-plugin2")
 	p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
 	require.NoError(t, p.Serve("v1beta1", "v1beta2"))
-	timestampBeforeRegistration := time.Now()
+	// On Windows, time.Now() is not as precise, which means that 2 consecutive calls may
+	// return the same timestamp. This would cause the test to fail, since they would have
+	// the same timestamp.
+	timestampBeforeRegistration := time.Now().Add(-time.Millisecond)
 	dsw.AddOrUpdatePlugin(socketPath)
 	waitForRegistration(t, socketPath, timestampBeforeRegistration, asw)
 
-	timeStampBeforeReRegistration := time.Now()
+	timeStampBeforeReRegistration := time.Now().Add(-time.Microsecond)
 	// Add the plugin again to update the timestamp
 	dsw.AddOrUpdatePlugin(socketPath)
 	// This should trigger a deregistration and a regitration

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -170,6 +170,10 @@ func (pl *TestPlugin) Less(*framework.QueuedPodInfo, *framework.QueuedPodInfo) b
 }
 
 func (pl *TestPlugin) Score(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) (int64, *framework.Status) {
+	// NOTE: The tests expect some non-zero latency to occur while running these methods. On Windows, time.Now()
+	// is not as precise, 2 consecutive calls may return the same timestamp, resulting in 0 time delta / latency,
+	// causing the tests to fail.
+	time.Sleep(time.Millisecond)
 	return 0, framework.NewStatus(framework.Code(pl.inj.ScoreStatus), injectReason)
 }
 
@@ -178,6 +182,7 @@ func (pl *TestPlugin) ScoreExtensions() framework.ScoreExtensions {
 }
 
 func (pl *TestPlugin) PreFilter(ctx context.Context, state *framework.CycleState, p *v1.Pod) (*framework.PreFilterResult, *framework.Status) {
+	time.Sleep(time.Millisecond)
 	return nil, framework.NewStatus(framework.Code(pl.inj.PreFilterStatus), injectReason)
 }
 
@@ -194,28 +199,35 @@ func (pl *TestPlugin) PostFilter(_ context.Context, _ *framework.CycleState, _ *
 }
 
 func (pl *TestPlugin) PreScore(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
+	time.Sleep(time.Millisecond)
 	return framework.NewStatus(framework.Code(pl.inj.PreScoreStatus), injectReason)
 }
 
 func (pl *TestPlugin) Reserve(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) *framework.Status {
+	time.Sleep(time.Millisecond)
 	return framework.NewStatus(framework.Code(pl.inj.ReserveStatus), injectReason)
 }
 
 func (pl *TestPlugin) Unreserve(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) {
+	time.Sleep(time.Millisecond)
 }
 
 func (pl *TestPlugin) PreBind(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) *framework.Status {
+	time.Sleep(time.Millisecond)
 	return framework.NewStatus(framework.Code(pl.inj.PreBindStatus), injectReason)
 }
 
 func (pl *TestPlugin) PostBind(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) {
+	time.Sleep(time.Millisecond)
 }
 
 func (pl *TestPlugin) Permit(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
+	time.Sleep(time.Millisecond)
 	return framework.NewStatus(framework.Code(pl.inj.PermitStatus), injectReason), time.Duration(0)
 }
 
 func (pl *TestPlugin) Bind(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) *framework.Status {
+	time.Sleep(time.Millisecond)
 	return framework.NewStatus(framework.Code(pl.inj.BindStatus), injectReason)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/sig windows

/priority important-soon

#### What this PR does / why we need it:

Currently, there are some unit tests that are failing on Windows due to various reasons:

- time.Now() is not as precise on Windows, which means that 2 consecutive calls may return the same timestamp.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related: https://github.com/kubernetes/kubernetes/issues/51540

#### Special notes for your reviewer:

Windows clock resolution issue: https://github.com/golang/go/issues/8687
Originally proposed in (+ discussions on the topic): https://github.com/kubernetes/kubernetes/pull/110263 , https://github.com/kubernetes/kubernetes/pull/110403 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
