### PR TITLE
hack/tools enable additional linter gocritic in golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,14 +7,20 @@ issues:
   max-same-issues: 0
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
-    # exclude ineffassing linter for generated files for conversion
+    # exclude ineffassign linter for generated files for conversion
     - path: conversion\.go
       linters:
         - ineffassign
+    # TODO(oscr) Remove these excluded directories and fix findings. Due to large amount of findings in different components
+    # with different owners it's hard to fix everything in a single pr. This will therefore be done in multiple prs.
+    - path: (pkg/volume/*|test/*|cmd/kubeadm/*|azure/*|pkg/cmd/wait*|request/bearertoken/*|metrics/*|filters/*)
+      linters:
+        - gocritic
 
 linters:
   disable-all: true
   enable: # please keep this alphabetized
+    - gocritic
     - ineffassign
     - logcheck
     - staticcheck
@@ -28,6 +34,10 @@ linters-settings: # please keep this alphabetized
       path: _output/local/bin/logcheck.so
       description: structured logging checker
       original-url: k8s.io/klog/hack/tools
+  gocritic:
+    enabled-checks:
+      - equalFold
+      - boolExprSimplify
   staticcheck:
     checks: [
       "all",

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/scheme.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/scheme.go
@@ -41,7 +41,7 @@ func (dynamicCodec) Decode(data []byte, gvk *schema.GroupVersionKind, obj runtim
 		return nil, nil, err
 	}
 
-	if strings.ToLower(gvk.Kind) == "status" && gvk.Version == "v1" && (gvk.Group == "" || gvk.Group == "meta.k8s.io") {
+	if strings.EqualFold(gvk.Kind, "status") && gvk.Version == "v1" && (gvk.Group == "" || gvk.Group == "meta.k8s.io") {
 		if _, ok := obj.(*metav1.Status); !ok {
 			obj = &metav1.Status{}
 			err := json.Unmarshal(data, obj)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Enables linter [gocritic](https://golangci-lint.run/usage/linters/#gocritic) with two checks enabled for a subset of the project. 

My goal is to remove the exclusions in follow up prs, but I'm trying to keep the prs small to make them easier to merge. 

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```