### PR TITLE
Replaces path.Operation with filepath.Operation (staging)

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -115,7 +114,7 @@ func ShortenConfig(config *Config) {
 // FlattenConfig changes the config object into a self-contained config (useful for making secrets)
 func FlattenConfig(config *Config) error {
 	for key, authInfo := range config.AuthInfos {
-		baseDir, err := MakeAbs(path.Dir(authInfo.LocationOfOrigin), "")
+		baseDir, err := MakeAbs(filepath.Dir(authInfo.LocationOfOrigin), "")
 		if err != nil {
 			return err
 		}
@@ -130,7 +129,7 @@ func FlattenConfig(config *Config) error {
 		config.AuthInfos[key] = authInfo
 	}
 	for key, cluster := range config.Clusters {
-		baseDir, err := MakeAbs(path.Dir(cluster.LocationOfOrigin), "")
+		baseDir, err := MakeAbs(filepath.Dir(cluster.LocationOfOrigin), "")
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/config.go
@@ -19,7 +19,6 @@ package clientcmd
 import (
 	"errors"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -148,7 +147,7 @@ func NewDefaultPathOptions() *PathOptions {
 		EnvVar:           RecommendedConfigPathEnvVar,
 		ExplicitFileFlag: RecommendedConfigPathFlag,
 
-		GlobalFileSubpath: path.Join(RecommendedHomeDir, RecommendedFileName),
+		GlobalFileSubpath: filepath.Join(RecommendedHomeDir, RecommendedFileName),
 
 		LoadingRules: NewDefaultClientConfigLoadingRules(),
 	}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -539,13 +538,13 @@ func TestResolveRelativePaths(t *testing.T) {
 
 	configDir1, _ := os.MkdirTemp("", "")
 	defer os.RemoveAll(configDir1)
-	configFile1 := path.Join(configDir1, ".kubeconfig")
+	configFile1 := filepath.Join(configDir1, ".kubeconfig")
 	configDir1, _ = filepath.Abs(configDir1)
 
 	configDir2, _ := os.MkdirTemp("", "")
 	defer os.RemoveAll(configDir2)
 	configDir2, _ = os.MkdirTemp(configDir2, "")
-	configFile2 := path.Join(configDir2, ".kubeconfig")
+	configFile2 := filepath.Join(configDir2, ".kubeconfig")
 	configDir2, _ = filepath.Abs(configDir2)
 
 	WriteToFile(pathResolutionConfig1, configFile1)
@@ -564,11 +563,11 @@ func TestResolveRelativePaths(t *testing.T) {
 	for key, cluster := range mergedConfig.Clusters {
 		if key == "relative-server-1" {
 			foundClusterCount++
-			matchStringArg(path.Join(configDir1, pathResolutionConfig1.Clusters["relative-server-1"].CertificateAuthority), cluster.CertificateAuthority, t)
+			matchStringArg(filepath.Join(configDir1, pathResolutionConfig1.Clusters["relative-server-1"].CertificateAuthority), cluster.CertificateAuthority, t)
 		}
 		if key == "relative-server-2" {
 			foundClusterCount++
-			matchStringArg(path.Join(configDir2, pathResolutionConfig2.Clusters["relative-server-2"].CertificateAuthority), cluster.CertificateAuthority, t)
+			matchStringArg(filepath.Join(configDir2, pathResolutionConfig2.Clusters["relative-server-2"].CertificateAuthority), cluster.CertificateAuthority, t)
 		}
 		if key == "absolute-server-1" {
 			foundClusterCount++
@@ -587,13 +586,13 @@ func TestResolveRelativePaths(t *testing.T) {
 	for key, authInfo := range mergedConfig.AuthInfos {
 		if key == "relative-user-1" {
 			foundAuthInfoCount++
-			matchStringArg(path.Join(configDir1, pathResolutionConfig1.AuthInfos["relative-user-1"].ClientCertificate), authInfo.ClientCertificate, t)
-			matchStringArg(path.Join(configDir1, pathResolutionConfig1.AuthInfos["relative-user-1"].ClientKey), authInfo.ClientKey, t)
+			matchStringArg(filepath.Join(configDir1, pathResolutionConfig1.AuthInfos["relative-user-1"].ClientCertificate), authInfo.ClientCertificate, t)
+			matchStringArg(filepath.Join(configDir1, pathResolutionConfig1.AuthInfos["relative-user-1"].ClientKey), authInfo.ClientKey, t)
 		}
 		if key == "relative-user-2" {
 			foundAuthInfoCount++
-			matchStringArg(path.Join(configDir2, pathResolutionConfig2.AuthInfos["relative-user-2"].ClientCertificate), authInfo.ClientCertificate, t)
-			matchStringArg(path.Join(configDir2, pathResolutionConfig2.AuthInfos["relative-user-2"].ClientKey), authInfo.ClientKey, t)
+			matchStringArg(filepath.Join(configDir2, pathResolutionConfig2.AuthInfos["relative-user-2"].ClientCertificate), authInfo.ClientCertificate, t)
+			matchStringArg(filepath.Join(configDir2, pathResolutionConfig2.AuthInfos["relative-user-2"].ClientKey), authInfo.ClientKey, t)
 		}
 		if key == "absolute-user-1" {
 			foundAuthInfoCount++
@@ -607,7 +606,7 @@ func TestResolveRelativePaths(t *testing.T) {
 		}
 		if key == "relative-cmd-1" {
 			foundAuthInfoCount++
-			matchStringArg(path.Join(configDir1, pathResolutionConfig1.AuthInfos[key].Exec.Command), authInfo.Exec.Command, t)
+			matchStringArg(filepath.Join(configDir1, pathResolutionConfig1.AuthInfos[key].Exec.Command), authInfo.Exec.Command, t)
 		}
 		if key == "absolute-cmd-1" {
 			foundAuthInfoCount++

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -118,8 +119,8 @@ func setupOutputWriter(dir string, defaultWriter io.Writer, filename string, fil
 	if len(dir) == 0 || dir == "-" {
 		return defaultWriter
 	}
-	fullFile := path.Join(dir, filename) + fileExtension
-	parent := path.Dir(fullFile)
+	fullFile := filepath.Join(dir, filename) + fileExtension
+	parent := filepath.Dir(fullFile)
 	cmdutil.CheckErr(os.MkdirAll(parent, 0755))
 
 	file, err := os.Create(fullFile)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
@@ -18,7 +18,7 @@ package clusterinfo
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -60,7 +60,7 @@ func TestSetupOutputWriterFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	fullPath := path.Join(dir, file) + extension
+	fullPath := filepath.Join(dir, file) + extension
 	defer os.RemoveAll(dir)
 
 	_, _, buf, _ := genericiooptions.NewTestIOStreams()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
@@ -19,7 +19,7 @@ package config
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -415,7 +415,7 @@ func TestEmptyTokenAndCertAllowed(t *testing.T) {
 	defer utiltesting.CloseAndRemove(t, fakeCertFile)
 	expectedConfig := newRedFederalCowHammerConfig()
 	authInfo := clientcmdapi.NewAuthInfo()
-	authInfo.ClientCertificate = path.Base(fakeCertFile.Name())
+	authInfo.ClientCertificate = filepath.Base(fakeCertFile.Name())
 	expectedConfig.AuthInfos["another-user"] = authInfo
 
 	test := configCommandTest{
@@ -660,7 +660,7 @@ func TestCAClearsInsecure(t *testing.T) {
 	clusterInfoWithInsecure.InsecureSkipTLSVerify = true
 
 	clusterInfoWithCA := clientcmdapi.NewCluster()
-	clusterInfoWithCA.CertificateAuthority = path.Base(fakeCAFile.Name())
+	clusterInfoWithCA.CertificateAuthority = filepath.Base(fakeCAFile.Name())
 
 	startingConfig := newRedFederalCowHammerConfig()
 	startingConfig.Clusters["another-cluster"] = clusterInfoWithInsecure

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"unicode/utf8"
 
@@ -320,7 +320,7 @@ func handleConfigMapFromFileSources(configMap *corev1.ConfigMap, fileSources []s
 				return fmt.Errorf("error listing files in %s: %v", filePath, err)
 			}
 			for _, item := range fileList {
-				itemPath := path.Join(filePath, item.Name())
+				itemPath := filepath.Join(filePath, item.Name())
 				if item.Type().IsRegular() {
 					keyName = item.Name()
 					err = addKeyFromFileToConfigMap(configMap, keyName, itemPath)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -349,7 +349,7 @@ func handleSecretFromFileSources(secret *corev1.Secret, fileSources []string) er
 				return fmt.Errorf("error listing files in %s: %v", filePath, err)
 			}
 			for _, item := range fileList {
-				itemPath := path.Join(filePath, item.Name())
+				itemPath := filepath.Join(filePath, item.Name())
 				if item.Type().IsRegular() {
 					keyName = item.Name()
 					if err := addKeyFromFileToSecret(secret, keyName, itemPath); err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls_test.go
@@ -18,7 +18,7 @@ package create
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -197,8 +197,8 @@ func write(path, contents string, t *testing.T) {
 }
 
 func writeKeyPair(tmpDirPath, key, cert string, t *testing.T) (keyPath, certPath string) {
-	keyPath = path.Join(tmpDirPath, "tls.key")
-	certPath = path.Join(tmpDirPath, "tls.cert")
+	keyPath = filepath.Join(tmpDirPath, "tls.key")
+	certPath = filepath.Join(tmpDirPath, "tls.cert")
 	write(keyPath, key, t)
 	write(certPath, cert, t)
 	return

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -130,7 +129,7 @@ func TestDiffVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fcontent, err := os.ReadFile(path.Join(diff.Dir.Name, obj.Name()))
+	fcontent, err := os.ReadFile(filepath.Join(diff.Dir.Name, obj.Name()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +200,7 @@ func TestDiffer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fcontent, err := os.ReadFile(path.Join(diff.From.Dir.Name, obj.Name()))
+	fcontent, err := os.ReadFile(filepath.Join(diff.From.Dir.Name, obj.Name()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +209,7 @@ func TestDiffer(t *testing.T) {
 		t.Fatalf("File has %q, expected %q", string(fcontent), econtent)
 	}
 
-	fcontent, err = os.ReadFile(path.Join(diff.To.Dir.Name, obj.Name()))
+	fcontent, err = os.ReadFile(filepath.Join(diff.To.Dir.Name, obj.Name()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,12 +285,12 @@ metadata:
 				t.Fatal(err)
 			}
 
-			actualFromContent, _ := os.ReadFile(path.Join(diff.From.Dir.Name, obj.Name()))
+			actualFromContent, _ := os.ReadFile(filepath.Join(diff.From.Dir.Name, obj.Name()))
 			if string(actualFromContent) != tc.expectedFromContent {
 				t.Fatalf("File has %q, expected %q", string(actualFromContent), tc.expectedFromContent)
 			}
 
-			actualToContent, _ := os.ReadFile(path.Join(diff.To.Dir.Name, obj.Name()))
+			actualToContent, _ := os.ReadFile(filepath.Join(diff.To.Dir.Name, obj.Name()))
 			if string(actualToContent) != tc.expectedToContent {
 				t.Fatalf("File has %q, expected %q", string(actualToContent), tc.expectedToContent)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

/sig windows
/priority important-soon

#### What this PR does / why we need it:

The path module has a few different functions: Clean, Split, Join, Ext, Dir, Base, IsAbs. These functions do not take into account the OS-specific path separator, meaning that they won't behave as intended on Windows.

For example, Dir is supposed to return all but the last element of the path. For the path ``C:\some\dir\somewhere``, it is supposed to return ``C:\some\dir\``, however, it returns ``.``.

Instead of these functions, the ones in filepath should be used instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #110600

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
