### PR TITLE
[Flaky test] fix floating point precision error in TestDifferentWidths

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -834,7 +834,7 @@ func TestDifferentWidths(t *testing.T) {
 		concurrencyLimit:            6,
 		evalDuration:                time.Second * 20,
 		expectedFair:                []bool{true},
-		expectedFairnessMargin:      []float64{0.15},
+		expectedFairnessMargin:      []float64{0.155},
 		expectAllRequests:           true,
 		evalInqueueMetrics:          true,
 		evalExecutingMetrics:        true,


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>


#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

I noticed this test flakying in several of my PRs. Here's an example: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/113147/pull-kubernetes-unit/1582531708157169664

It seems like the test fails because of a floating point precision error when comparing the calculated difference in average to the expected margin. Naively opening a PR that just rounds the average to 2 decimal points to fix the flaky test but open to other alternatives.  

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #106579

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
