### PR TITLE
Replace deprecated pointer conversions in scheduler

### DIFF
--- a/pkg/scheduler/apis/config/v1/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins_test.go
@@ -240,8 +240,8 @@ func TestMergePlugins(t *testing.T) {
 			customPlugins: &v1.Plugins{
 				Filter: v1.PluginSet{
 					Enabled: []v1.Plugin{
-						{Name: "Plugin1", Weight: pointer.Int32Ptr(2)},
-						{Name: "Plugin3", Weight: pointer.Int32Ptr(3)},
+						{Name: "Plugin1", Weight: pointer.Int32(2)},
+						{Name: "Plugin3", Weight: pointer.Int32(3)},
 					},
 				},
 			},
@@ -257,9 +257,9 @@ func TestMergePlugins(t *testing.T) {
 			expectedPlugins: &v1.Plugins{
 				Filter: v1.PluginSet{
 					Enabled: []v1.Plugin{
-						{Name: "Plugin1", Weight: pointer.Int32Ptr(2)},
+						{Name: "Plugin1", Weight: pointer.Int32(2)},
 						{Name: "Plugin2"},
-						{Name: "Plugin3", Weight: pointer.Int32Ptr(3)},
+						{Name: "Plugin3", Weight: pointer.Int32(3)},
 					},
 				},
 			},
@@ -269,8 +269,8 @@ func TestMergePlugins(t *testing.T) {
 			customPlugins: &v1.Plugins{
 				Filter: v1.PluginSet{
 					Enabled: []v1.Plugin{
-						{Name: "Plugin2", Weight: pointer.Int32Ptr(2)},
-						{Name: "Plugin1", Weight: pointer.Int32Ptr(1)},
+						{Name: "Plugin2", Weight: pointer.Int32(2)},
+						{Name: "Plugin1", Weight: pointer.Int32(1)},
 					},
 				},
 			},
@@ -286,8 +286,8 @@ func TestMergePlugins(t *testing.T) {
 			expectedPlugins: &v1.Plugins{
 				Filter: v1.PluginSet{
 					Enabled: []v1.Plugin{
-						{Name: "Plugin1", Weight: pointer.Int32Ptr(1)},
-						{Name: "Plugin2", Weight: pointer.Int32Ptr(2)},
+						{Name: "Plugin1", Weight: pointer.Int32(1)},
+						{Name: "Plugin2", Weight: pointer.Int32(2)},
 						{Name: "Plugin3"},
 					},
 				},
@@ -299,9 +299,9 @@ func TestMergePlugins(t *testing.T) {
 				Filter: v1.PluginSet{
 					Enabled: []v1.Plugin{
 						{Name: "Plugin1"},
-						{Name: "Plugin2", Weight: pointer.Int32Ptr(2)},
+						{Name: "Plugin2", Weight: pointer.Int32(2)},
 						{Name: "Plugin3"},
-						{Name: "Plugin2", Weight: pointer.Int32Ptr(4)},
+						{Name: "Plugin2", Weight: pointer.Int32(4)},
 					},
 				},
 			},
@@ -318,9 +318,9 @@ func TestMergePlugins(t *testing.T) {
 				Filter: v1.PluginSet{
 					Enabled: []v1.Plugin{
 						{Name: "Plugin1"},
-						{Name: "Plugin2", Weight: pointer.Int32Ptr(4)},
+						{Name: "Plugin2", Weight: pointer.Int32(4)},
 						{Name: "Plugin3"},
-						{Name: "Plugin2", Weight: pointer.Int32Ptr(2)},
+						{Name: "Plugin2", Weight: pointer.Int32(2)},
 					},
 				},
 			},

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -102,7 +102,7 @@ func setDefaults_KubeSchedulerProfile(prof *configv1.KubeSchedulerProfile) {
 // SetDefaults_KubeSchedulerConfiguration sets additional defaults
 func SetDefaults_KubeSchedulerConfiguration(obj *configv1.KubeSchedulerConfiguration) {
 	if obj.Parallelism == nil {
-		obj.Parallelism = pointer.Int32Ptr(16)
+		obj.Parallelism = pointer.Int32(16)
 	}
 
 	if len(obj.Profiles) == 0 {
@@ -111,7 +111,7 @@ func SetDefaults_KubeSchedulerConfiguration(obj *configv1.KubeSchedulerConfigura
 	// Only apply a default scheduler name when there is a single profile.
 	// Validation will ensure that every profile has a non-empty unique name.
 	if len(obj.Profiles) == 1 && obj.Profiles[0].SchedulerName == nil {
-		obj.Profiles[0].SchedulerName = pointer.StringPtr(v1.DefaultSchedulerName)
+		obj.Profiles[0].SchedulerName = pointer.String(v1.DefaultSchedulerName)
 	}
 
 	// Add the default set of plugins and apply the configuration.
@@ -172,22 +172,22 @@ func SetDefaults_KubeSchedulerConfiguration(obj *configv1.KubeSchedulerConfigura
 
 func SetDefaults_DefaultPreemptionArgs(obj *configv1.DefaultPreemptionArgs) {
 	if obj.MinCandidateNodesPercentage == nil {
-		obj.MinCandidateNodesPercentage = pointer.Int32Ptr(10)
+		obj.MinCandidateNodesPercentage = pointer.Int32(10)
 	}
 	if obj.MinCandidateNodesAbsolute == nil {
-		obj.MinCandidateNodesAbsolute = pointer.Int32Ptr(100)
+		obj.MinCandidateNodesAbsolute = pointer.Int32(100)
 	}
 }
 
 func SetDefaults_InterPodAffinityArgs(obj *configv1.InterPodAffinityArgs) {
 	if obj.HardPodAffinityWeight == nil {
-		obj.HardPodAffinityWeight = pointer.Int32Ptr(1)
+		obj.HardPodAffinityWeight = pointer.Int32(1)
 	}
 }
 
 func SetDefaults_VolumeBindingArgs(obj *configv1.VolumeBindingArgs) {
 	if obj.BindTimeoutSeconds == nil {
-		obj.BindTimeoutSeconds = pointer.Int64Ptr(600)
+		obj.BindTimeoutSeconds = pointer.Int64(600)
 	}
 	if len(obj.Shape) == 0 && feature.DefaultFeatureGate.Enabled(features.VolumeCapacityPriority) {
 		obj.Shape = []configv1.UtilizationShapePoint{

--- a/pkg/scheduler/apis/config/v1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1/defaults_test.go
@@ -46,8 +46,8 @@ var pluginConfigs = []configv1.PluginConfig{
 					Kind:       "DefaultPreemptionArgs",
 					APIVersion: "kubescheduler.config.k8s.io/v1",
 				},
-				MinCandidateNodesPercentage: pointer.Int32Ptr(10),
-				MinCandidateNodesAbsolute:   pointer.Int32Ptr(100),
+				MinCandidateNodesPercentage: pointer.Int32(10),
+				MinCandidateNodesAbsolute:   pointer.Int32(100),
 			}},
 	},
 	{
@@ -58,7 +58,7 @@ var pluginConfigs = []configv1.PluginConfig{
 					Kind:       "InterPodAffinityArgs",
 					APIVersion: "kubescheduler.config.k8s.io/v1",
 				},
-				HardPodAffinityWeight: pointer.Int32Ptr(1),
+				HardPodAffinityWeight: pointer.Int32(1),
 			}},
 	},
 	{
@@ -110,7 +110,7 @@ var pluginConfigs = []configv1.PluginConfig{
 				Kind:       "VolumeBindingArgs",
 				APIVersion: "kubescheduler.config.k8s.io/v1",
 			},
-			BindTimeoutSeconds: pointer.Int64Ptr(600),
+			BindTimeoutSeconds: pointer.Int64(600),
 		}},
 	},
 }
@@ -126,13 +126,13 @@ func TestSchedulerDefaults(t *testing.T) {
 			name:   "empty config",
 			config: &configv1.KubeSchedulerConfiguration{},
 			expected: &configv1.KubeSchedulerConfiguration{
-				Parallelism: pointer.Int32Ptr(16),
+				Parallelism: pointer.Int32(16),
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
 					EnableProfiling:           &enable,
 					EnableContentionProfiling: &enable,
 				},
 				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-					LeaderElect:       pointer.BoolPtr(true),
+					LeaderElect:       pointer.Bool(true),
 					LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
 					RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
 					RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
@@ -146,13 +146,13 @@ func TestSchedulerDefaults(t *testing.T) {
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
-				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
+				PodInitialBackoffSeconds: pointer.Int64(1),
+				PodMaxBackoffSeconds:     pointer.Int64(10),
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:       getDefaultPlugins(),
 						PluginConfig:  pluginConfigs,
-						SchedulerName: pointer.StringPtr("default-scheduler"),
+						SchedulerName: pointer.String("default-scheduler"),
 					},
 				},
 			},
@@ -163,13 +163,13 @@ func TestSchedulerDefaults(t *testing.T) {
 				Profiles: []configv1.KubeSchedulerProfile{{}},
 			},
 			expected: &configv1.KubeSchedulerConfiguration{
-				Parallelism: pointer.Int32Ptr(16),
+				Parallelism: pointer.Int32(16),
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
 					EnableProfiling:           &enable,
 					EnableContentionProfiling: &enable,
 				},
 				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-					LeaderElect:       pointer.BoolPtr(true),
+					LeaderElect:       pointer.Bool(true),
 					LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
 					RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
 					RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
@@ -183,11 +183,11 @@ func TestSchedulerDefaults(t *testing.T) {
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
-				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
+				PodInitialBackoffSeconds: pointer.Int64(1),
+				PodMaxBackoffSeconds:     pointer.Int64(10),
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
-						SchedulerName: pointer.StringPtr("default-scheduler"),
+						SchedulerName: pointer.String("default-scheduler"),
 						Plugins:       getDefaultPlugins(),
 						PluginConfig:  pluginConfigs},
 				},
@@ -196,7 +196,7 @@ func TestSchedulerDefaults(t *testing.T) {
 		{
 			name: "two profiles",
 			config: &configv1.KubeSchedulerConfiguration{
-				Parallelism: pointer.Int32Ptr(16),
+				Parallelism: pointer.Int32(16),
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						PluginConfig: []configv1.PluginConfig{
@@ -204,7 +204,7 @@ func TestSchedulerDefaults(t *testing.T) {
 						},
 					},
 					{
-						SchedulerName: pointer.StringPtr("custom-scheduler"),
+						SchedulerName: pointer.String("custom-scheduler"),
 						Plugins: &configv1.Plugins{
 							Bind: configv1.PluginSet{
 								Enabled: []configv1.Plugin{
@@ -219,13 +219,13 @@ func TestSchedulerDefaults(t *testing.T) {
 				},
 			},
 			expected: &configv1.KubeSchedulerConfiguration{
-				Parallelism: pointer.Int32Ptr(16),
+				Parallelism: pointer.Int32(16),
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
 					EnableProfiling:           &enable,
 					EnableContentionProfiling: &enable,
 				},
 				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-					LeaderElect:       pointer.BoolPtr(true),
+					LeaderElect:       pointer.Bool(true),
 					LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
 					RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
 					RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
@@ -239,8 +239,8 @@ func TestSchedulerDefaults(t *testing.T) {
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
-				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
+				PodInitialBackoffSeconds: pointer.Int64(1),
+				PodMaxBackoffSeconds:     pointer.Int64(10),
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins: getDefaultPlugins(),
@@ -254,8 +254,8 @@ func TestSchedulerDefaults(t *testing.T) {
 											Kind:       "DefaultPreemptionArgs",
 											APIVersion: "kubescheduler.config.k8s.io/v1",
 										},
-										MinCandidateNodesPercentage: pointer.Int32Ptr(10),
-										MinCandidateNodesAbsolute:   pointer.Int32Ptr(100),
+										MinCandidateNodesPercentage: pointer.Int32(10),
+										MinCandidateNodesAbsolute:   pointer.Int32(100),
 									}},
 							},
 							{
@@ -266,7 +266,7 @@ func TestSchedulerDefaults(t *testing.T) {
 											Kind:       "InterPodAffinityArgs",
 											APIVersion: "kubescheduler.config.k8s.io/v1",
 										},
-										HardPodAffinityWeight: pointer.Int32Ptr(1),
+										HardPodAffinityWeight: pointer.Int32(1),
 									}},
 							},
 							{
@@ -318,13 +318,13 @@ func TestSchedulerDefaults(t *testing.T) {
 										Kind:       "VolumeBindingArgs",
 										APIVersion: "kubescheduler.config.k8s.io/v1",
 									},
-									BindTimeoutSeconds: pointer.Int64Ptr(600),
+									BindTimeoutSeconds: pointer.Int64(600),
 								}},
 							},
 						},
 					},
 					{
-						SchedulerName: pointer.StringPtr("custom-scheduler"),
+						SchedulerName: pointer.String("custom-scheduler"),
 						Plugins: &configv1.Plugins{
 							MultiPoint: configv1.PluginSet{
 								Enabled: []configv1.Plugin{
@@ -367,16 +367,16 @@ func TestSchedulerDefaults(t *testing.T) {
 		{
 			name: "Prallelism with no port",
 			config: &configv1.KubeSchedulerConfiguration{
-				Parallelism: pointer.Int32Ptr(16),
+				Parallelism: pointer.Int32(16),
 			},
 			expected: &configv1.KubeSchedulerConfiguration{
-				Parallelism: pointer.Int32Ptr(16),
+				Parallelism: pointer.Int32(16),
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
 					EnableProfiling:           &enable,
 					EnableContentionProfiling: &enable,
 				},
 				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-					LeaderElect:       pointer.BoolPtr(true),
+					LeaderElect:       pointer.Bool(true),
 					LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
 					RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
 					RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
@@ -390,13 +390,13 @@ func TestSchedulerDefaults(t *testing.T) {
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
-				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
+				PodInitialBackoffSeconds: pointer.Int64(1),
+				PodMaxBackoffSeconds:     pointer.Int64(10),
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:       getDefaultPlugins(),
 						PluginConfig:  pluginConfigs,
-						SchedulerName: pointer.StringPtr("default-scheduler"),
+						SchedulerName: pointer.String("default-scheduler"),
 					},
 				},
 			},
@@ -404,16 +404,16 @@ func TestSchedulerDefaults(t *testing.T) {
 		{
 			name: "set non default parallelism",
 			config: &configv1.KubeSchedulerConfiguration{
-				Parallelism: pointer.Int32Ptr(8),
+				Parallelism: pointer.Int32(8),
 			},
 			expected: &configv1.KubeSchedulerConfiguration{
-				Parallelism: pointer.Int32Ptr(8),
+				Parallelism: pointer.Int32(8),
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
 					EnableProfiling:           &enable,
 					EnableContentionProfiling: &enable,
 				},
 				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-					LeaderElect:       pointer.BoolPtr(true),
+					LeaderElect:       pointer.Bool(true),
 					LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
 					RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
 					RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
@@ -427,13 +427,13 @@ func TestSchedulerDefaults(t *testing.T) {
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
-				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
+				PodInitialBackoffSeconds: pointer.Int64(1),
+				PodMaxBackoffSeconds:     pointer.Int64(10),
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:       getDefaultPlugins(),
 						PluginConfig:  pluginConfigs,
-						SchedulerName: pointer.StringPtr("default-scheduler"),
+						SchedulerName: pointer.String("default-scheduler"),
 					},
 				},
 			},
@@ -441,16 +441,16 @@ func TestSchedulerDefaults(t *testing.T) {
 		{
 			name: "set non default global percentageOfNodesToScore",
 			config: &configv1.KubeSchedulerConfiguration{
-				PercentageOfNodesToScore: pointer.Int32Ptr(50),
+				PercentageOfNodesToScore: pointer.Int32(50),
 			},
 			expected: &configv1.KubeSchedulerConfiguration{
-				Parallelism: pointer.Int32Ptr(16),
+				Parallelism: pointer.Int32(16),
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
 					EnableProfiling:           &enable,
 					EnableContentionProfiling: &enable,
 				},
 				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-					LeaderElect:       pointer.BoolPtr(true),
+					LeaderElect:       pointer.Bool(true),
 					LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
 					RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
 					RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
@@ -463,14 +463,14 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32Ptr(50),
-				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
-				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
+				PercentageOfNodesToScore: pointer.Int32(50),
+				PodInitialBackoffSeconds: pointer.Int64(1),
+				PodMaxBackoffSeconds:     pointer.Int64(10),
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:       getDefaultPlugins(),
 						PluginConfig:  pluginConfigs,
-						SchedulerName: pointer.StringPtr("default-scheduler"),
+						SchedulerName: pointer.String("default-scheduler"),
 					},
 				},
 			},
@@ -480,18 +480,18 @@ func TestSchedulerDefaults(t *testing.T) {
 			config: &configv1.KubeSchedulerConfiguration{
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
-						PercentageOfNodesToScore: pointer.Int32Ptr(50),
+						PercentageOfNodesToScore: pointer.Int32(50),
 					},
 				},
 			},
 			expected: &configv1.KubeSchedulerConfiguration{
-				Parallelism: pointer.Int32Ptr(16),
+				Parallelism: pointer.Int32(16),
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
 					EnableProfiling:           &enable,
 					EnableContentionProfiling: &enable,
 				},
 				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-					LeaderElect:       pointer.BoolPtr(true),
+					LeaderElect:       pointer.Bool(true),
 					LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
 					RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
 					RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
@@ -505,14 +505,14 @@ func TestSchedulerDefaults(t *testing.T) {
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
-				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
+				PodInitialBackoffSeconds: pointer.Int64(1),
+				PodMaxBackoffSeconds:     pointer.Int64(10),
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:                  getDefaultPlugins(),
 						PluginConfig:             pluginConfigs,
-						SchedulerName:            pointer.StringPtr("default-scheduler"),
-						PercentageOfNodesToScore: pointer.Int32Ptr(50),
+						SchedulerName:            pointer.String("default-scheduler"),
+						PercentageOfNodesToScore: pointer.Int32(50),
 					},
 				},
 			},
@@ -520,21 +520,21 @@ func TestSchedulerDefaults(t *testing.T) {
 		{
 			name: "set non default global and profile percentageOfNodesToScore",
 			config: &configv1.KubeSchedulerConfiguration{
-				PercentageOfNodesToScore: pointer.Int32Ptr(10),
+				PercentageOfNodesToScore: pointer.Int32(10),
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
-						PercentageOfNodesToScore: pointer.Int32Ptr(50),
+						PercentageOfNodesToScore: pointer.Int32(50),
 					},
 				},
 			},
 			expected: &configv1.KubeSchedulerConfiguration{
-				Parallelism: pointer.Int32Ptr(16),
+				Parallelism: pointer.Int32(16),
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
 					EnableProfiling:           &enable,
 					EnableContentionProfiling: &enable,
 				},
 				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-					LeaderElect:       pointer.BoolPtr(true),
+					LeaderElect:       pointer.Bool(true),
 					LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
 					RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
 					RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
@@ -547,15 +547,15 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32Ptr(10),
-				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
-				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
+				PercentageOfNodesToScore: pointer.Int32(10),
+				PodInitialBackoffSeconds: pointer.Int64(1),
+				PodMaxBackoffSeconds:     pointer.Int64(10),
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:                  getDefaultPlugins(),
 						PluginConfig:             pluginConfigs,
-						SchedulerName:            pointer.StringPtr("default-scheduler"),
-						PercentageOfNodesToScore: pointer.Int32Ptr(50),
+						SchedulerName:            pointer.String("default-scheduler"),
+						PercentageOfNodesToScore: pointer.Int32(50),
 					},
 				},
 			},
@@ -582,43 +582,43 @@ func TestPluginArgsDefaults(t *testing.T) {
 			name: "DefaultPreemptionArgs empty",
 			in:   &configv1.DefaultPreemptionArgs{},
 			want: &configv1.DefaultPreemptionArgs{
-				MinCandidateNodesPercentage: pointer.Int32Ptr(10),
-				MinCandidateNodesAbsolute:   pointer.Int32Ptr(100),
+				MinCandidateNodesPercentage: pointer.Int32(10),
+				MinCandidateNodesAbsolute:   pointer.Int32(100),
 			},
 		},
 		{
 			name: "DefaultPreemptionArgs with value",
 			in: &configv1.DefaultPreemptionArgs{
-				MinCandidateNodesPercentage: pointer.Int32Ptr(50),
+				MinCandidateNodesPercentage: pointer.Int32(50),
 			},
 			want: &configv1.DefaultPreemptionArgs{
-				MinCandidateNodesPercentage: pointer.Int32Ptr(50),
-				MinCandidateNodesAbsolute:   pointer.Int32Ptr(100),
+				MinCandidateNodesPercentage: pointer.Int32(50),
+				MinCandidateNodesAbsolute:   pointer.Int32(100),
 			},
 		},
 		{
 			name: "InterPodAffinityArgs empty",
 			in:   &configv1.InterPodAffinityArgs{},
 			want: &configv1.InterPodAffinityArgs{
-				HardPodAffinityWeight: pointer.Int32Ptr(1),
+				HardPodAffinityWeight: pointer.Int32(1),
 			},
 		},
 		{
 			name: "InterPodAffinityArgs explicit 0",
 			in: &configv1.InterPodAffinityArgs{
-				HardPodAffinityWeight: pointer.Int32Ptr(0),
+				HardPodAffinityWeight: pointer.Int32(0),
 			},
 			want: &configv1.InterPodAffinityArgs{
-				HardPodAffinityWeight: pointer.Int32Ptr(0),
+				HardPodAffinityWeight: pointer.Int32(0),
 			},
 		},
 		{
 			name: "InterPodAffinityArgs with value",
 			in: &configv1.InterPodAffinityArgs{
-				HardPodAffinityWeight: pointer.Int32Ptr(5),
+				HardPodAffinityWeight: pointer.Int32(5),
 			},
 			want: &configv1.InterPodAffinityArgs{
-				HardPodAffinityWeight: pointer.Int32Ptr(5),
+				HardPodAffinityWeight: pointer.Int32(5),
 			},
 		},
 		{
@@ -735,7 +735,7 @@ func TestPluginArgsDefaults(t *testing.T) {
 			},
 			in: &configv1.VolumeBindingArgs{},
 			want: &configv1.VolumeBindingArgs{
-				BindTimeoutSeconds: pointer.Int64Ptr(600),
+				BindTimeoutSeconds: pointer.Int64(600),
 			},
 		},
 		{
@@ -745,7 +745,7 @@ func TestPluginArgsDefaults(t *testing.T) {
 			},
 			in: &configv1.VolumeBindingArgs{},
 			want: &configv1.VolumeBindingArgs{
-				BindTimeoutSeconds: pointer.Int64Ptr(600),
+				BindTimeoutSeconds: pointer.Int64(600),
 				Shape: []configv1.UtilizationShapePoint{
 					{Utilization: 0, Score: 0},
 					{Utilization: 100, Score: 10},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Change the functions in scheduler that convert `int, int32, int64, float, string, bool` to pointers from `IntPtr, Int32Ptr, Int64Ptr, FloatPtr, BoolPtr, StringPtr` to `Int, Int32, Int64, Float, String, Bool`. 

`IntPtr/Int32Ptr/Int64Ptr/FloatPtr/StringPtr/BoolPtr` are deprecated in `utils.pointer`. For example,  https://github.com/kubernetes/utils/blob/cfd413dd9e8559bc69d4abd23c12d666a59971c4/pointer/pointer.go#L56)
```
// IntPtr is a function variable referring to Int.
// Deprecated: Use Int instead.
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Replacement the deprecated functions in other kubernetes code can be done in separate PRs. 
https://github.com/kubernetes/kubernetes/issues/113177

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
