### PR TITLE
Remove unused RBAC rule from system:kubelet-api-admin

### DIFF
--- a/cluster/addons/rbac/kubelet-api-auth/kubelet-api-admin-role.yaml
+++ b/cluster/addons/rbac/kubelet-api-auth/kubelet-api-admin-role.yaml
@@ -13,6 +13,5 @@ rules:
   - nodes/log
   - nodes/stats
   - nodes/metrics
-  - nodes/spec
   verbs:
   - "*"

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -384,7 +384,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 				// Allow all API calls to the nodes
 				rbacv1helpers.NewRule("proxy").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
-				rbacv1helpers.NewRule("*").Groups(legacyGroup).Resources("nodes/proxy", "nodes/metrics", "nodes/spec", "nodes/stats", "nodes/log").RuleOrDie(),
+				rbacv1helpers.NewRule("*").Groups(legacyGroup).Resources("nodes/proxy", "nodes/metrics", "nodes/stats", "nodes/log").RuleOrDie(),
 			},
 		},
 		{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -914,7 +914,6 @@ items:
     - nodes/log
     - nodes/metrics
     - nodes/proxy
-    - nodes/spec
     - nodes/stats
     verbs:
     - '*'


### PR DESCRIPTION
Commit cd54bd94e90dbf10a7e4f8a85a26cd036d589c57 
removes the handlers for /spec from the kubelet server.

Cleanup the RBAC rules as well.

/kind cleanup


#### Does this PR introduce a user-facing change?

```release-note
Remove unused rule for `nodes/spec` from `ClusterRole system:kubelet-api-admin` 
```
