### PR TITLE
Automatically recreate PVC for pending STS pod

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	apps "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"

--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -114,7 +114,7 @@ func (om *realStatefulPodControlObjectManager) UpdateClaim(claim *v1.PersistentV
 
 func (spc *StatefulPodControl) CreateStatefulPod(ctx context.Context, set *apps.StatefulSet, pod *v1.Pod) error {
 	// Create the Pod's PVCs prior to creating the Pod
-	if err := spc.createPersistentVolumeClaims(set, pod); err != nil {
+	if err := spc.CreatePersistentVolumeClaims(set, pod); err != nil {
 		spc.recordPodEvent("create", set, pod, err)
 		return err
 	}
@@ -150,7 +150,7 @@ func (spc *StatefulPodControl) UpdateStatefulPod(set *apps.StatefulSet, pod *v1.
 		if !storageMatches(set, pod) {
 			updateStorage(set, pod)
 			consistent = false
-			if err := spc.createPersistentVolumeClaims(set, pod); err != nil {
+			if err := spc.CreatePersistentVolumeClaims(set, pod); err != nil {
 				spc.recordPodEvent("update", set, pod, err)
 				return err
 			}
@@ -315,11 +315,11 @@ func (spc *StatefulPodControl) recordClaimEvent(verb string, set *apps.StatefulS
 	}
 }
 
-// createPersistentVolumeClaims creates all of the required PersistentVolumeClaims for pod, which must be a member of
+// CreatePersistentVolumeClaims creates all of the required PersistentVolumeClaims for pod, which must be a member of
 // set. If all of the claims for Pod are successfully created, the returned error is nil. If creation fails, this method
 // may be called again until no error is returned, indicating the PersistentVolumeClaims for pod are consistent with
 // set's Spec.
-func (spc *StatefulPodControl) createPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) error {
+func (spc *StatefulPodControl) CreatePersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) error {
 	var errs []error
 	for _, claim := range getPersistentVolumeClaims(set, pod) {
 		pvc, err := spc.objectMgr.GetClaim(claim.Namespace, claim.Name)

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -453,15 +453,8 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 				set.Namespace,
 				set.Name,
 				replicas[i].Name)
-			if err := ssc.podControl.createPersistentVolumeClaims(set, replicas[i]); err != nil {
+			if err := ssc.podControl.createMissingPersistentVolumeClaims(set, replicas[i]); err != nil {
 				return &status, err
-			}
-			if utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC) {
-				// Set PVC policy as much as is possible at this point.
-				if err := ssc.podControl.UpdatePodClaimForRetentionPolicy(set, replicas[i]); err != nil {
-					ssc.podControl.recordPodEvent("update", set, replicas[i], err)
-					return &status, err
-				}
 			}
 		}
 		// If we find a Pod that is currently terminating, we must wait until graceful deletion

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -453,8 +453,15 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 				set.Namespace,
 				set.Name,
 				replicas[i].Name)
-			if err := ssc.podControl.CreatePersistentVolumeClaims(set, replicas[i]); err != nil {
+			if err := ssc.podControl.createPersistentVolumeClaims(set, replicas[i]); err != nil {
 				return &status, err
+			}
+			if utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC) {
+				// Set PVC policy as much as is possible at this point.
+				if err := ssc.podControl.UpdatePodClaimForRetentionPolicy(set, replicas[i]); err != nil {
+					ssc.podControl.recordPodEvent("update", set, replicas[i], err)
+					return &status, err
+				}
 			}
 		}
 		// If we find a Pod that is currently terminating, we must wait until graceful deletion

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -2441,7 +2441,7 @@ func (om *fakeObjectManager) DeletePod(pod *v1.Pod) error {
 	return nil // Not found, no error in deleting.
 }
 
-func (om *fakeObjectManager) CreatePersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) error {
+func (om *fakeObjectManager) createPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) error {
 	for _, claim := range getPersistentVolumeClaims(set, pod) {
 		om.claimsIndexer.Update(&claim)
 	}

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -2441,13 +2441,6 @@ func (om *fakeObjectManager) DeletePod(pod *v1.Pod) error {
 	return nil // Not found, no error in deleting.
 }
 
-func (om *fakeObjectManager) createPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) error {
-	for _, claim := range getPersistentVolumeClaims(set, pod) {
-		om.claimsIndexer.Update(&claim)
-	}
-	return nil
-}
-
 func (om *fakeObjectManager) CreateClaim(claim *v1.PersistentVolumeClaim) error {
 	om.claimsIndexer.Update(claim)
 	return nil

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -413,6 +413,11 @@ func isCreated(pod *v1.Pod) bool {
 	return pod.Status.Phase != ""
 }
 
+// isPending returns true if pod has a Phase of PodPending
+func isPending(pod *v1.Pod) bool {
+	return pod.Status.Phase == v1.PodPending
+}
+
 // isFailed returns true if pod has a Phase of PodFailed
 func isFailed(pod *v1.Pod) bool {
 	return pod.Status.Phase == v1.PodFailed

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
@@ -1346,6 +1347,92 @@ var _ = SIGDescribe("StatefulSet", func() {
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})
 			framework.ExpectNoError(err)
 		})
+	})
+
+	ginkgo.It("PVC should be recreated when pod is pending due to missing PVC [Feature:AutomaticPVCRecreation]", func() {
+		// This test must be run in an environment that will allow the test pod to be scheduled on a node with local volumes
+		ssName := "test-ss"
+		headlessSvcName := "test"
+		// Define StatefulSet Labels
+		ssPodLabels := map[string]string{
+			"name": "sample-pod",
+			"pod":  WebserverImageName,
+		}
+
+		statefulPodMounts := []v1.VolumeMount{{Name: "datadir", MountPath: "/data/"}}
+		ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, statefulPodMounts, nil, ssPodLabels)
+		e2epv.SkipIfNoDefaultStorageClass(c)
+		ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
+		_, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Confirming PVC exists")
+		err = verifyStatefulSetPVCsExist(c, ss, []int{0})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Confirming Pod is ready")
+		e2estatefulset.WaitForStatusReadyReplicas(c, ss, 1)
+		podName := getStatefulSetPodNameAtIndex(0, ss)
+		pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+
+		nodeName := pod.Spec.NodeName
+		node, err := c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+
+		oldData, err := json.Marshal(node)
+		framework.ExpectNoError(err)
+
+		node.Spec.Unschedulable = true
+
+		newData, err := json.Marshal(node)
+		framework.ExpectNoError(err)
+
+		// cordon node, to make sure pod does not get scheduled to the node until the pvc is deleted
+		patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})
+		framework.ExpectNoError(err)
+		ginkgo.By("Cordoning Node")
+		_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+		framework.ExpectNoError(err)
+
+		// wait for the node to be patched
+		time.Sleep(5 * time.Second)
+		node, err = c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(node.Spec.Unschedulable, true)
+
+		ginkgo.By("Deleting Pod")
+		err = c.CoreV1().Pods(ns).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		framework.ExpectNoError(err)
+
+		// wait for the pod to be recreated
+		time.Sleep(10 * time.Second)
+		_, err = c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+
+		pvcList, err := c.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: klabels.Everything().String()})
+		framework.ExpectNoError(err)
+		pvcName := pvcList.Items[0].Name
+
+		ginkgo.By("Deleting PVC")
+		err = c.CoreV1().PersistentVolumeClaims(ns).Delete(context.TODO(), pvcName, metav1.DeleteOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Uncordoning Node")
+		// uncordon node, by reverting patch
+		revertPatchBytes, err := strategicpatch.CreateTwoWayMergePatch(newData, oldData, v1.Node{})
+		framework.ExpectNoError(err)
+		_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.StrategicMergePatchType, revertPatchBytes, metav1.PatchOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Confirming PVC recreated")
+		err = verifyStatefulSetPVCsExist(c, ss, []int{0})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Confirming Pod is ready after being recreated")
+		e2estatefulset.WaitForStatusReadyReplicas(c, ss, 1)
+		_, err = c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
 	})
 })
 

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -1349,99 +1349,113 @@ var _ = SIGDescribe("StatefulSet", func() {
 		})
 	})
 
-	ginkgo.It("PVC should be recreated when pod is pending due to missing PVC [Disruptive][Serial]", func() {
-		ssName := "test-ss"
-		headlessSvcName := "test"
-		// Define StatefulSet Labels
-		ssPodLabels := map[string]string{
-			"name": "sample-pod",
-			"pod":  WebserverImageName,
+	ginkgo.Describe("Automatically recreate PVC for pending pod when PVC is missing", func() {
+		ssName := "ss"
+		labels := map[string]string{
+			"foo": "bar",
+			"baz": "blah",
 		}
+		headlessSvcName := "test"
+		var statefulPodMounts []v1.VolumeMount
+		var ss *appsv1.StatefulSet
 
-		readyNode, err := e2enode.GetReadySchedulableWorkerNode(c)
-		framework.ExpectNoError(err)
-		hostLabel := "kubernetes.io/hostname"
-		hostLabelVal := readyNode.Labels[hostLabel]
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			statefulPodMounts = []v1.VolumeMount{{Name: "datadir", MountPath: "/data/"}}
+			ss = e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, statefulPodMounts, nil, labels)
+		})
 
-		statefulPodMounts := []v1.VolumeMount{{Name: "datadir", MountPath: "/data/"}}
-		ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, statefulPodMounts, nil, ssPodLabels)
-		ss.Spec.Template.Spec.NodeSelector = map[string]string{hostLabel: hostLabelVal} // force the pod on a specific node
-
-		e2epv.SkipIfNoDefaultStorageClass(c)
-		ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
-		_, err = c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Confirming PVC exists")
-		err = verifyStatefulSetPVCsExist(c, ss, []int{0})
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Confirming Pod is ready")
-		e2estatefulset.WaitForStatusReadyReplicas(c, ss, 1)
-		podName := getStatefulSetPodNameAtIndex(0, ss)
-		pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
-
-		nodeName := pod.Spec.NodeName
-		framework.ExpectEqual(nodeName, readyNode.Name)
-		node, err := c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
-
-		oldData, err := json.Marshal(node)
-		framework.ExpectNoError(err)
-
-		node.Spec.Unschedulable = true
-
-		newData, err := json.Marshal(node)
-		framework.ExpectNoError(err)
-
-		// cordon node, to make sure pod does not get scheduled to the node until the pvc is deleted
-		patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})
-		framework.ExpectNoError(err)
-		ginkgo.By("Cordoning Node")
-		_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
-		framework.ExpectNoError(err)
-		cordoned := true
-
-		defer func() {
-			if cordoned {
-				uncordonNode(c, oldData, newData, nodeName)
+		ginkgo.AfterEach(func(ctx context.Context) {
+			if ginkgo.CurrentSpecReport().Failed() {
+				e2eoutput.DumpDebugInfo(ctx, c, ns)
 			}
-		}()
+			framework.Logf("Deleting all statefulset in ns %v", ns)
+			e2estatefulset.DeleteAllStatefulSets(ctx, c, ns)
+		})
 
-		// wait for the node to be unschedulable
-		e2enode.WaitForNodeSchedulable(c, nodeName, 10*time.Second, false)
+		ginkgo.It("PVC should be recreated when pod is pending due to missing PVC [Disruptive][Serial]", func(ctx context.Context) {
+			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 
-		ginkgo.By("Deleting Pod")
-		err = c.CoreV1().Pods(ns).Delete(context.TODO(), podName, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+			readyNode, err := e2enode.GetRandomReadySchedulableNode(ctx, c)
+			framework.ExpectNoError(err)
+			hostLabel := "kubernetes.io/hostname"
+			hostLabelVal := readyNode.Labels[hostLabel]
 
-		// wait for the pod to be recreated
-		e2estatefulset.WaitForStatusCurrentReplicas(c, ss, 1)
-		_, err = c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+			ss.Spec.Template.Spec.NodeSelector = map[string]string{hostLabel: hostLabelVal} // force the pod on a specific node
+			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
+			_, err = c.AppsV1().StatefulSets(ns).Create(context.TODO(), ss, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
 
-		pvcList, err := c.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: klabels.Everything().String()})
-		framework.ExpectNoError(err)
-		framework.ExpectEqual(len(pvcList.Items), 1)
-		pvcName := pvcList.Items[0].Name
+			ginkgo.By("Confirming PVC exists")
+			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})
+			framework.ExpectNoError(err)
 
-		ginkgo.By("Deleting PVC")
-		err = c.CoreV1().PersistentVolumeClaims(ns).Delete(context.TODO(), pvcName, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+			ginkgo.By("Confirming Pod is ready")
+			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 1)
+			podName := getStatefulSetPodNameAtIndex(0, ss)
+			pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
 
-		uncordonNode(c, oldData, newData, nodeName)
-		cordoned = false
+			nodeName := pod.Spec.NodeName
+			framework.ExpectEqual(nodeName, readyNode.Name)
+			node, err := c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
 
-		ginkgo.By("Confirming PVC recreated")
-		err = verifyStatefulSetPVCsExist(c, ss, []int{0})
-		framework.ExpectNoError(err)
+			oldData, err := json.Marshal(node)
+			framework.ExpectNoError(err)
 
-		ginkgo.By("Confirming Pod is ready after being recreated")
-		e2estatefulset.WaitForStatusReadyReplicas(c, ss, 1)
-		pod, err = c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
-		framework.ExpectEqual(pod.Spec.NodeName, readyNode.Name) // confirm the pod was scheduled back to the original node
+			node.Spec.Unschedulable = true
+
+			newData, err := json.Marshal(node)
+			framework.ExpectNoError(err)
+
+			// cordon node, to make sure pod does not get scheduled to the node until the pvc is deleted
+			patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})
+			framework.ExpectNoError(err)
+			ginkgo.By("Cordoning Node")
+			_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+			framework.ExpectNoError(err)
+			cordoned := true
+
+			defer func() {
+				if cordoned {
+					uncordonNode(c, oldData, newData, nodeName)
+				}
+			}()
+
+			// wait for the node to be unschedulable
+			e2enode.WaitForNodeSchedulable(c, nodeName, 10*time.Second, false)
+
+			ginkgo.By("Deleting Pod")
+			err = c.CoreV1().Pods(ns).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+
+			// wait for the pod to be recreated
+			e2estatefulset.WaitForStatusCurrentReplicas(c, ss, 1)
+			_, err = c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			pvcList, err := c.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: klabels.Everything().String()})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(len(pvcList.Items), 1)
+			pvcName := pvcList.Items[0].Name
+
+			ginkgo.By("Deleting PVC")
+			err = c.CoreV1().PersistentVolumeClaims(ns).Delete(context.TODO(), pvcName, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+
+			uncordonNode(c, oldData, newData, nodeName)
+			cordoned = false
+
+			ginkgo.By("Confirming PVC recreated")
+			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Confirming Pod is ready after being recreated")
+			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 1)
+			pod, err = c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(pod.Spec.NodeName, readyNode.Name) // confirm the pod was scheduled back to the original node
+		})
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
See https://github.com/kubernetes/kubernetes/issues/113139 for details on the bug. Currently the workaround is to delete the pending pod so that the pvc gets recreated with the pod. But we want to automate this so that we don't need manual intervention.

This change is based on https://github.com/mucahitkurt/kubernetes/commit/1ab4b97b8b63228ea25fc541233df15eb0e3d598

there was some discussion on that change ^ here https://github.com/kubernetes/kubernetes/issues/74374

If a pod is pending, the code will check the informer for the pod's PVCs and if a PVC is not found, it will recreate it. since it is using the informer, this won't make a call directly to the api server each time to see if a pvc exists. 
#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/113139

#### Special notes for your reviewer:
I tested this on an AWS cluster, following the error case I described in the issue. It recreated the pvc as expected.

I also created an e2e test for this. It will cordon a node and delete the pod, then delete the pvc. The pvc should then be recreated with my change allowing the pod to be rescheduled. 


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
PVCs will automatically be recreated if they are missing for a pending Pod.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
