### PR TITLE
Fix linter finding in staging/src/k8s.io/apiserver

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,7 +13,7 @@ issues:
         - ineffassign
     # TODO(oscr) Remove these excluded directories and fix findings. Due to large amount of findings in different components
     # with different owners it's hard to fix everything in a single pr. This will therefore be done in multiple prs.
-    - path: (pkg/volume/*|test/*|cmd/kubeadm/*|azure/*|pkg/cmd/wait*|request/bearertoken/*|metrics/*|filters/*)
+    - path: (pkg/volume/*|test/*|cmd/kubeadm/*|azure/*|pkg/cmd/wait*)
       linters:
         - gocritic
 
@@ -36,8 +36,8 @@ linters-settings: # please keep this alphabetized
       original-url: k8s.io/klog/hack/tools
   gocritic:
     enabled-checks:
-      - equalFold
       - boolExprSimplify
+      - equalFold
   staticcheck:
     checks: [
       "all",

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
@@ -45,7 +45,7 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.R
 		return nil, false, nil
 	}
 	parts := strings.SplitN(auth, " ", 3)
-	if len(parts) < 2 || strings.ToLower(parts[0]) != "bearer" {
+	if len(parts) < 2 || !strings.EqualFold(parts[0], "bearer") {
 		return nil, false, nil
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit.go
@@ -69,7 +69,7 @@ func getAuthMethods(req *http.Request) string {
 
 	auth := strings.TrimSpace(req.Header.Get("Authorization"))
 	parts := strings.Split(auth, " ")
-	if len(parts) > 1 && strings.ToLower(parts[0]) == "bearer" {
+	if len(parts) > 1 && strings.EqualFold(parts[0], "bearer") {
 		authMethods = append(authMethods, "bearer")
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -631,7 +631,7 @@ func cleanVerb(verb, suggestedVerb string, request *http.Request) string {
 
 // getVerbIfWatch additionally ensures that GET or List would be transformed to WATCH
 func getVerbIfWatch(req *http.Request) string {
-	if strings.ToUpper(req.Method) == "GET" || strings.ToUpper(req.Method) == "LIST" {
+	if strings.EqualFold(req.Method, "GET") || strings.EqualFold(req.Method, "LIST") {
 		// see apimachinery/pkg/runtime/conversion.go Convert_Slice_string_To_bool
 		if values := req.URL.Query()["watch"]; len(values) > 0 {
 			if value := strings.ToLower(values[0]); value != "0" && value != "false" {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Removes some of the gocritic excluded folders and fixes the following findings in `staging/src/k8s.io/apiserver` 

```
staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:634:5: equalFold: consider replacing with strings.EqualFold(req.Method, "GET") (gocritic)
	if strings.ToUpper(req.Method) == "GET" || strings.ToUpper(req.Method) == "LIST" {
	   ^
staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit.go:72:23: equalFold: consider replacing with strings.EqualFold(parts[0], "bearer") (gocritic)
	if len(parts) > 1 && strings.ToLower(parts[0]) == "bearer" {
	                   
staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go:48:23: equalFold: consider replacing with !strings.EqualFold(parts[0], "bearer") (gocritic)
        if len(parts) < 2 || strings.ToLower(parts[0]) != "bearer" {
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```