### PR TITLE
Fix Makefile help target

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -307,11 +307,15 @@ clean:
 	hack/make-rules/clean.sh
 endif
 
+
 # TODO(thockin): Remove this in v1.29.
 .PHONY: generated_files
 generated_files:
 	echo "'make generated_files' is deprecated.  Please use hack/update-codegen.sh instead."
+ifneq ($(PRINT_HELP), y)
 	false
+endif
+
 
 define VET_HELP_INFO
 # Run 'go vet'.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

On the main branch `make help` will fail with the following error message
```
make help
(...omitted output ...)
---------------------------------------------------------------------------------
generated_files
'make generated_files' is deprecated.  Please use hack/update-codegen.sh instead.
make[1]: *** [Makefile:314: generated_files] Error 1
make: *** [Makefile:497: help] Error 2
```

This pr fixes this by adding a condition. This changes fixes `make help` and gives the following output
```
---------------------------------------------------------------------------------
generated_files
'make generated_files' is deprecated.  Please use hack/update-codegen.sh instead.
---------------------------------------------------------------------------------
```

But still fails `make generated_files` like before
```
make generated_files
'make generated_files' is deprecated.  Please use hack/update-codegen.sh instead.
make: *** [Makefile:315: generated_files] Error 1
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
