### PR TITLE
Image Version Bump in Manifest for Node Perf Test tf-wide-deep

### DIFF
--- a/test/e2e_node/perf/workloads/tf_wide_deep.go
+++ b/test/e2e_node/perf/workloads/tf_wide_deep.go
@@ -56,7 +56,7 @@ func (w tfWideDeepWorkload) PodSpec() v1.PodSpec {
 			},
 		},
 		Command: []string{"/bin/sh"},
-		Args:    []string{"-c", "python ./data_download.py && time -p python ./wide_deep.py --model_type=wide_deep --train_epochs=300 --epochs_between_evals=300 --batch_size=32561"},
+		Args:    []string{"-c", "time -p python ./wide_deep.py --model_type=wide_deep --train_epochs=300 --epochs_between_evals=300 --batch_size=32561"},
 	}
 	containers = append(containers, ctn)
 

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -255,7 +255,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[NginxNew] = Config{list.PromoterE2eRegistry, "nginx", "1.15-2"}
 	configs[NodePerfNpbEp] = Config{list.PromoterE2eRegistry, "node-perf/npb-ep", "1.2"}
 	configs[NodePerfNpbIs] = Config{list.PromoterE2eRegistry, "node-perf/npb-is", "1.2"}
-	configs[NodePerfTfWideDeep] = Config{list.PromoterE2eRegistry, "node-perf/tf-wide-deep", "1.2"}
+	configs[NodePerfTfWideDeep] = Config{list.PromoterE2eRegistry, "node-perf/tf-wide-deep", "1.3"}
 	configs[Nonewprivs] = Config{list.PromoterE2eRegistry, "nonewprivs", "1.3"}
 	configs[NonRoot] = Config{list.PromoterE2eRegistry, "nonroot", "1.2"}
 	// Pause - when these values are updated, also update cmd/kubelet/app/options/container_runtime.go


### PR DESCRIPTION
Bumped version of tf-wide-deep image to 1.3 in test manifest, and removed the data download from the tf-wide-deep pod spec command, since it is now done at image-build time.

### The image has been promoted.

The promoted image has been tested via local runs of this kind:

`make test-e2e-node FOCUS='Node Performance Testing \[Serial\] \[Slow\] Run node performance testing with pre-defined workloads TensorFlow workload' SKIP="QQQQQ"`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR is expected to fix the failing test [here](https://prow.k8s.io/?job=ci-kubernetes-node-kubelet-containerd-performance-test) as was the previous PR.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #109295

#### Special notes for your reviewer:

Did full test using the real e2e_node binary and the test machinery like this:

`make test-e2e-node FOCUS='Node Performance Testing \[Serial\] \[Slow\] Run node performance testing with pre-defined workloads TensorFlow workload' SKIP="QQQQQ"`

- image has been promoted and is found at the expected prod registry url
- local containerd cleared out
- local test was rerun pulling from the new prod registry
- **local test** using that new registry **passes**

```
> ctr -n k8s.io i ls | grep -i tf
REF                                                                                                                                            TYPE                                                      DIGEST                                                                  SIZE      PLATFORMS                                                                    LABELS
registry.k8s.io/e2e-test-images/node-perf/tf-wide-deep:1.3                                                                                     application/vnd.docker.distribution.manifest.list.v2+json sha256:91ab3b5ee22441c99370944e2e2cb32670db62db433611b4e3780bdee6a8e5a1 203.6 MiB linux/amd64                                                                  io.cri-containerd.image=managed
registry.k8s.io/e2e-test-images/node-perf/tf-wide-deep@sha256:91ab3b5ee22441c99370944e2e2cb32670db62db433611b4e3780bdee6a8e5a1                 application/vnd.docker.distribution.manifest.list.v2+json sha256:91ab3b5ee22441c99370944e2e2cb32670db62db433611b4e3780bdee6a8e5a1 203.6 MiB linux/amd64                                                                  io.cri-containerd.image=managed
>
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
