### PR TITLE
Use custom resource status validator in ValidateStatusUpdate

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/validator.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/validator.go
@@ -119,7 +119,7 @@ func (a customResourceValidator) ValidateStatusUpdate(ctx context.Context, obj, 
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, validation.ValidateObjectMetaAccessorUpdate(objAccessor, oldAccessor, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, apiservervalidation.ValidateCustomResource(nil, u.UnstructuredContent(), a.schemaValidator)...)
+	allErrs = append(allErrs, apiservervalidation.ValidateCustomResource(nil, u.UnstructuredContent(), a.statusSchemaValidator)...)
 	allErrs = append(allErrs, a.ValidateScaleStatus(ctx, u, scale)...)
 
 	return allErrs


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When digging through the apiextensions code, I noticed that status schema validator isn't actually used for validation (instead, the regular schema validator is used). It doesn't appear like this causes any issues/any bugs, but it certainly seems like a code smell.

#### Special notes for your reviewer:

If we _don't_ want to use this specific status validator, I can adapt this PR to remove references to the status validator instead.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
