### PR TITLE
apiserver identity: use persistent names for lease objects

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"reflect"
 	"strconv"
 	"time"
@@ -515,6 +516,14 @@ func labelAPIServerHeartbeat(lease *coordinationapiv1.Lease) error {
 	}
 	// This label indicates that kube-apiserver owns this identity lease object
 	lease.Labels[IdentityLeaseComponentLabelKey] = KubeAPIServer
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+
+	// convenience label to easily map a lease object to a specific apiserver
+	lease.Labels[apiv1.LabelHostname] = hostname
 	return nil
 }
 

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -476,7 +476,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 			leaseName := m.GenericAPIServer.APIServerID
 			holderIdentity := m.GenericAPIServer.APIServerID + "_" + string(uuid.NewUUID())
 
-			controller := lease.NewControllerWithLeaseName(
+			controller := lease.NewController(
 				clock.RealClock{},
 				kubeClient,
 				holderIdentity,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -833,6 +833,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		kubeCfg.NodeLeaseDurationSeconds,
 		klet.onRepeatedHeartbeatFailure,
 		renewInterval,
+		string(klet.nodeName),
 		v1.NamespaceNodeLease,
 		util.SetNodeOwnerFunc(klet.heartbeatClient, string(klet.nodeName)))
 

--- a/staging/src/k8s.io/component-helpers/apimachinery/lease/controller.go
+++ b/staging/src/k8s.io/component-helpers/apimachinery/lease/controller.go
@@ -72,28 +72,7 @@ type controller struct {
 }
 
 // NewController constructs and returns a controller
-func NewController(clock clock.Clock, client clientset.Interface, holderIdentity string, leaseDurationSeconds int32, onRepeatedHeartbeatFailure func(), renewInterval time.Duration, leaseNamespace string, newLeasePostProcessFunc ProcessLeaseFunc) Controller {
-	var leaseClient coordclientset.LeaseInterface
-	if client != nil {
-		leaseClient = client.CoordinationV1().Leases(leaseNamespace)
-	}
-	return &controller{
-		client:                     client,
-		leaseClient:                leaseClient,
-		holderIdentity:             holderIdentity,
-		leaseName:                  holderIdentity,
-		leaseNamespace:             leaseNamespace,
-		leaseDurationSeconds:       leaseDurationSeconds,
-		renewInterval:              renewInterval,
-		clock:                      clock,
-		onRepeatedHeartbeatFailure: onRepeatedHeartbeatFailure,
-		newLeasePostProcessFunc:    newLeasePostProcessFunc,
-	}
-}
-
-// NewControllerWithLeaseName is a copy of NewController but accepts a leaseName parameter.
-// Use this constructor in cases when the lease name and holder identity should be different.
-func NewControllerWithLeaseName(clock clock.Clock, client clientset.Interface, holderIdentity string, leaseDurationSeconds int32, onRepeatedHeartbeatFailure func(), renewInterval time.Duration, leaseName, leaseNamespace string, newLeasePostProcessFunc ProcessLeaseFunc) Controller {
+func NewController(clock clock.Clock, client clientset.Interface, holderIdentity string, leaseDurationSeconds int32, onRepeatedHeartbeatFailure func(), renewInterval time.Duration, leaseName, leaseNamespace string, newLeasePostProcessFunc ProcessLeaseFunc) Controller {
 	var leaseClient coordclientset.LeaseInterface
 	if client != nil {
 		leaseClient = client.CoordinationV1().Leases(leaseNamespace)
@@ -174,7 +153,7 @@ func (c *controller) backoffEnsureLease() (*coordinationv1.Lease, bool) {
 // ensureLease creates the lease if it does not exist. Returns the lease and
 // a bool (true if this call created the lease), or any error that occurs.
 func (c *controller) ensureLease() (*coordinationv1.Lease, bool, error) {
-	lease, err := c.leaseClient.Get(context.TODO(), c.holderIdentity, metav1.GetOptions{})
+	lease, err := c.leaseClient.Get(context.TODO(), c.leaseName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		// lease does not exist, create it.
 		leaseToCreate, err := c.newLease(nil)

--- a/staging/src/k8s.io/component-helpers/apimachinery/lease/controller_test.go
+++ b/staging/src/k8s.io/component-helpers/apimachinery/lease/controller_test.go
@@ -59,6 +59,7 @@ func TestNewNodeLease(t *testing.T) {
 			desc: "nil base without node",
 			controller: &controller{
 				client:               fake.NewSimpleClientset(),
+				leaseName:            node.Name,
 				holderIdentity:       node.Name,
 				leaseDurationSeconds: 10,
 				clock:                fakeClock,
@@ -80,6 +81,7 @@ func TestNewNodeLease(t *testing.T) {
 			desc: "nil base with node",
 			controller: &controller{
 				client:               fake.NewSimpleClientset(node),
+				leaseName:            node.Name,
 				holderIdentity:       node.Name,
 				leaseDurationSeconds: 10,
 				clock:                fakeClock,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR updates the naming format for kube-apiserver Leases to use a format that persists even after a restart. The new format uses a hash of the hostname, so only apiservers using different hostnames will have unique identities. The holder identity of each Lease remains unique per start-up. This reduces system churn when lease objects are garbage collected, but still allows  operators to identify when lease ownership is churning. 

To support this change, the `NewController` constructor was updated for the lease controller to allow for overriding the lease name when it differs from the holder identity.     

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Update the Lease identity naming format for the APIServerIdentity feature to use a persistent name  
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
