### PR TITLE
node: e2e: device plugins: Deflake e2e tests

### DIFF
--- a/test/e2e_node/container_log_rotation_test.go
+++ b/test/e2e_node/container_log_rotation_test.go
@@ -80,10 +80,10 @@ var _ = SIGDescribe("ContainerLogRotation [Slow] [Serial] [Disruptive]", func() 
 		ginkgo.It("should be rotated and limited to a fixed amount of files", func(ctx context.Context) {
 
 			ginkgo.By("get container log path")
-			framework.ExpectEqual(len(logRotationPod.Status.ContainerStatuses), 1)
+			framework.ExpectEqual(len(logRotationPod.Status.ContainerStatuses), 1, "log rotation pod should have one container")
 			id := kubecontainer.ParseContainerID(logRotationPod.Status.ContainerStatuses[0].ContainerID).ID
 			r, _, err := getCRIClient()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "should connect to CRI and obtain runtime service clients and image service client")
 			resp, err := r.ContainerStatus(context.Background(), id, false)
 			framework.ExpectNoError(err)
 			logPath := resp.GetStatus().GetLogPath()

--- a/test/e2e_node/container_log_rotation_test.go
+++ b/test/e2e_node/container_log_rotation_test.go
@@ -74,12 +74,7 @@ var _ = SIGDescribe("ContainerLogRotation [Slow] [Serial] [Disruptive]", func() 
 				},
 			}
 			logRotationPod = e2epod.NewPodClient(f).CreateSync(pod)
-		})
-
-		ginkgo.AfterEach(func() {
-			ginkgo.By("Deleting the log-rotation pod")
-			framework.Logf("Deleting pod: %s", logRotationPod.Name)
-			e2epod.NewPodClient(f).DeleteSync(logRotationPod.Name, metav1.DeleteOptions{}, time.Minute)
+			ginkgo.DeferCleanup(e2epod.NewPodClient(f).DeleteSync, logRotationPod.Name, metav1.DeleteOptions{}, time.Minute)
 		})
 
 		ginkgo.It("should be rotated and limited to a fixed amount of files", func(ctx context.Context) {

--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -106,16 +106,16 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			}, time.Minute, time.Second).Should(gomega.BeTrue())
 
 			v1alphaPodResources, err = getV1alpha1NodeDevices()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "should get node local podresources by accessing the (v1alpha) podresources API endpoint")
 
 			v1PodResources, err = getV1NodeDevices()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "should get node local podresources by accessing the (v1) podresources API endpoint")
 
 			// Before we run the device plugin test, we need to ensure
 			// that the cluster is in a clean state and there are no
 			// pods running on this node.
-			framework.ExpectEqual(len(v1alphaPodResources.PodResources), 0)
-			framework.ExpectEqual(len(v1PodResources.PodResources), 0)
+			gomega.Expect(v1alphaPodResources.PodResources).To(gomega.BeEmpty(), "should have no pod resources")
+			gomega.Expect(v1PodResources.PodResources).To(gomega.BeEmpty(), "should have no pod resources")
 
 			ginkgo.By("Scheduling a sample device plugin pod")
 			data, err := e2etestfiles.Read(SampleDevicePluginDSYAML)

--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -94,7 +94,9 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 		// and then use the same here
 		devsLen := int64(2)
 		var devicePluginPod, dptemplate *v1.Pod
-
+		var v1alphaPodResources *kubeletpodresourcesv1alpha1.ListPodResourcesResponse
+		var v1PodResources *kubeletpodresourcesv1.ListPodResourcesResponse
+		var err error
 		ginkgo.BeforeEach(func() {
 			ginkgo.By("Wait for node to be ready")
 			gomega.Eventually(func() bool {
@@ -102,6 +104,18 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 				framework.ExpectNoError(err)
 				return nodes == 1
 			}, time.Minute, time.Second).Should(gomega.BeTrue())
+
+			v1alphaPodResources, err = getV1alpha1NodeDevices()
+			framework.ExpectNoError(err)
+
+			v1PodResources, err = getV1NodeDevices()
+			framework.ExpectNoError(err)
+
+			// Before we run the device plugin test, we need to ensure
+			// that the cluster is in a clean state and there are no
+			// pods running on this node.
+			framework.ExpectEqual(len(v1alphaPodResources.PodResources), 0)
+			framework.ExpectEqual(len(v1PodResources.PodResources), 0)
 
 			ginkgo.By("Scheduling a sample device plugin pod")
 			data, err := e2etestfiles.Read(SampleDevicePluginDSYAML)
@@ -175,10 +189,10 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			devID1 := parseLog(f, pod1.Name, pod1.Name, deviceIDRE)
 			gomega.Expect(devID1).To(gomega.Not(gomega.Equal("")))
 
-			v1alphaPodResources, err := getV1alpha1NodeDevices()
+			v1alphaPodResources, err = getV1alpha1NodeDevices()
 			framework.ExpectNoError(err)
 
-			v1PodResources, err := getV1NodeDevices()
+			v1PodResources, err = getV1NodeDevices()
 			framework.ExpectNoError(err)
 
 			framework.Logf("v1alphaPodResources.PodResources:%+v\n", v1alphaPodResources.PodResources)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
Some node e2e tests check for expected number of pods running
on the node to verify the correct state of that node after running
 test scenarios. An example of such a check is in the device plugin
 end to end test here:
https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/device_plugin_test.go#L189-L190.
    
 If the node is not left in a clean state after an e2e test finishes
 running, it can lead to flaky tests because the node might have
 unexpected pods running on the node.
    
 In order to avoid that, we make sure that the test pods are
 cleaned up after the test runs in case log rotation e2e tests.
  
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #112612

#### Special notes for your reviewer:
Related PR that was used to debug the issue: https://github.com/kubernetes/kubernetes/pull/113165

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->