### PR TITLE
Promote ardaguclu to approver for sig-cli related stuff

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -183,6 +183,7 @@ aliases:
   # - wgliang
 
   sig-cli-maintainers:
+    - ardaguclu
     - apelisse
     - brianpursley
     - deads2k
@@ -200,8 +201,8 @@ aliases:
   # - monopole
   # - smarterclayton
   sig-cli-reviewers:
+    - ardaguclu
     - brianpursley
-    - dougsland
     - eddiezane
     - KnVerey
     - seans3


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli

#### What this PR does / why we need it:
@ardaguclu has consistently proven good judgement and quality of his contributions over the past few releases, so we've decided to promote him to approver.

I've also noticed that we have Doug in reviewers, but he wasn't around for a while now, so I'm removing him. 

#### Special notes for your reviewer:
/assign @eddiezane @KnVerey @seans3 
for sig-cli approval

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
