### PR TITLE
Allow Setting Kubelet ReadOnly Listen Address.

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -377,6 +377,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 	fs.Var(cliflag.NewColonSeparatedMultimapStringString(&c.StaticPodURLHeader), "manifest-url-header", "Comma-separated list of HTTP headers to use when accessing the url provided to --manifest-url. Multiple headers with the same name will be added in the same order provided. This flag can be repeatedly invoked. For example: --manifest-url-header 'a:hello,b:again,c:world' --manifest-url-header 'b:beautiful'")
 	fs.Var(&utilflag.IPVar{Val: &c.Address}, "address", "The IP address for the Kubelet to serve on (set to '0.0.0.0' or '::' for listening in all interfaces and IP families)")
 	fs.Int32Var(&c.Port, "port", c.Port, "The port for the Kubelet to serve on.")
+	fs.Var(&utilflag.IPVar{Val: &c.ReadOnlyBindAddress}, "read-only-bind-address", "The address used for the read-only API to serve on. Defaults to the value passed to --address. Has no effect if the read only port is disabled. (set to '0.0.0.0' or '::' for listening in all interfaces and IP families)")
 	fs.Int32Var(&c.ReadOnlyPort, "read-only-port", c.ReadOnlyPort, "The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable)")
 
 	// runtime flags

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1193,7 +1193,11 @@ func startKubelet(k kubelet.Bootstrap, podCfg *config.PodConfig, kubeCfg *kubele
 		go k.ListenAndServe(kubeCfg, kubeDeps.TLSOptions, kubeDeps.Auth, kubeDeps.TracerProvider)
 	}
 	if kubeCfg.ReadOnlyPort > 0 {
-		go k.ListenAndServeReadOnly(netutils.ParseIPSloppy(kubeCfg.Address), uint(kubeCfg.ReadOnlyPort))
+		bindAddress := netutils.ParseIPSloppy(kubeCfg.Address)
+		if kubeCfg.ReadOnlyBindAddress != "" {
+			bindAddress = netutils.ParseIPSloppy(kubeCfg.ReadOnlyBindAddress)
+		}
+		go k.ListenAndServeReadOnly(bindAddress, uint(kubeCfg.ReadOnlyPort))
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPodResources) {
 		go k.ListenAndServePodResources()

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -57316,6 +57316,13 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 							Format:      "int32",
 						},
 					},
+					"readOnlyBindAddress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "readOnlyBindAddress is the address for the Kubelet to serve on with no authentication/authorization. Defaults to the secure serving address if not set. Default: \"\"",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"readOnlyPort": {
 						SchemaProps: spec.SchemaProps{
 							Description: "readOnlyPort is the read-only port for the Kubelet to serve on with no authentication/authorization. The port number must be between 1 and 65535, inclusive. Setting this field to 0 disables the read-only service. Default: 0 (disabled)",

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -255,6 +255,7 @@ var (
 		"Port",
 		"ProtectKernelDefaults",
 		"ProviderID",
+		"ReadOnlyBindAddress",
 		"ReadOnlyPort",
 		"RegisterNode",
 		"RegistryBurst",

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -108,6 +108,10 @@ type KubeletConfiguration struct {
 	// readOnlyPort is the read-only port for the Kubelet to serve on with
 	// no authentication/authorization (set to 0 to disable)
 	ReadOnlyPort int32
+	// readOnlyBindAddress is the address for the Kubelet to serve on with
+	// no authentication/authorization (set to '0.0.0.0' or '::' to serve on all interfaces and IP families).
+	// Defaults to the value of the Address field if not set.
+	ReadOnlyBindAddress string
 	// volumePluginDir is the full path of the directory in which to search
 	// for additional third party volume plugins.
 	VolumePluginDir string

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -353,6 +353,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	out.StaticPodURLHeader = *(*map[string][]string)(unsafe.Pointer(&in.StaticPodURLHeader))
 	out.Address = in.Address
 	out.Port = in.Port
+	out.ReadOnlyBindAddress = in.ReadOnlyBindAddress
 	out.ReadOnlyPort = in.ReadOnlyPort
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
@@ -535,6 +536,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	out.Address = in.Address
 	out.Port = in.Port
 	out.ReadOnlyPort = in.ReadOnlyPort
+	out.ReadOnlyBindAddress = in.ReadOnlyBindAddress
 	out.VolumePluginDir = in.VolumePluginDir
 	out.ProviderID = in.ProviderID
 	out.TLSCertFile = in.TLSCertFile

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -130,6 +130,11 @@ type KubeletConfiguration struct {
 	// Default: 10250
 	// +optional
 	Port int32 `json:"port,omitempty"`
+	// readOnlyBindAddress is the address for the Kubelet to serve on with
+	// no authentication/authorization. Defaults to the value of the Address field if not set.
+	// Default: ""
+	// +optional
+	ReadOnlyBindAddress string `json:"readOnlyBindAddress,omitempty"`
 	// readOnlyPort is the read-only port for the Kubelet to serve on with
 	// no authentication/authorization.
 	// The port number must be between 1 and 65535, inclusive.


### PR DESCRIPTION
Add one of the following kinds:
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change

#### What this PR does / why we need it:
The Kubelet's read-only port (customarily 10255) can be overridden via config file or command line. However, the bind address for the readonly server is always the same as the secure serving address.

It may be useful to restrict the read-only port to the loopback interface, but there is no way to do so independently of the secure serving address.

Add a config item and flag to control the readonly address. Defaults to the secure serving address if not set.

#### Special notes for your reviewer:

WIP. Needs updates to tests, kubeadm, etc.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

Add a new flag and field to KubeletConfiguration that allows setting the readonly port bind address independently of the
secure server address. 

New flag: --read-only-bind-address.
KubeletConfiguration item: ReadOnlyBindAddress. 

The value of --read-only-bind-address defaults to the server bind address (`--server`) if not set. 

The readonly bind address is only used if the read only server is enabled by setting --read-only-port != 0.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
