### PR TITLE
resourcequota: use contextual logging

### DIFF
--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/rest"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/quota/v1/install"
 )
@@ -123,7 +124,8 @@ func setupQuotaController(t *testing.T, kubeClient kubernetes.Interface, lister 
 		InformersStarted:          alwaysStarted,
 		InformerFactory:           informerFactory,
 	}
-	qc, err := NewController(resourceQuotaControllerOptions)
+	_, ctx := ktesting.NewTestContext(t)
+	qc, err := NewController(ctx, resourceQuotaControllerOptions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -976,7 +978,8 @@ func TestAddQuota(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		qc.addQuota(tc.quota)
+		logger, _ := ktesting.NewTestContext(t)
+		qc.addQuota(logger, tc.quota)
 		if tc.expectedPriority {
 			if e, a := 1, qc.missingUsageQueue.Len(); e != a {
 				t.Errorf("%s: expected %v, got %v", tc.name, e, a)
@@ -1075,7 +1078,8 @@ func TestDiscoverySync(t *testing.T) {
 	// The 1s sleep in the test allows GetQuotableResources and
 	// resyncMonitors to run ~5 times to ensure the changes to the
 	// fakeDiscoveryClient are picked up.
-	go qc.Sync(fakeDiscoveryClient.ServerPreferredNamespacedResources, 200*time.Millisecond, stopSync)
+	_, ctx := ktesting.NewTestContext(t)
+	go qc.Sync(ctx, fakeDiscoveryClient.ServerPreferredNamespacedResources, 200*time.Millisecond)
 
 	// Wait until the sync discovers the initial resources
 	time.Sleep(1 * time.Second)

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/controller"
 	replicationcontroller "k8s.io/kubernetes/pkg/controller/replication"
@@ -75,7 +76,8 @@ func TestQuota(t *testing.T) {
 	ns2 := framework.CreateNamespaceOrDie(clientset, "non-quotaed", t)
 	defer framework.DeleteNamespaceOrDie(clientset, ns2, t)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	informers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
@@ -102,14 +104,14 @@ func TestQuota(t *testing.T) {
 		InformersStarted:          informersStarted,
 		Registry:                  generic.NewRegistry(qc.Evaluators()),
 	}
-	resourceQuotaController, err := resourcequotacontroller.NewController(resourceQuotaControllerOptions)
+	resourceQuotaController, err := resourcequotacontroller.NewController(ctx, resourceQuotaControllerOptions)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	go resourceQuotaController.Run(ctx, 2)
 
 	// Periodically the quota controller to detect new resource types
-	go resourceQuotaController.Sync(discoveryFunc, 30*time.Second, ctx.Done())
+	go resourceQuotaController.Sync(ctx, discoveryFunc, 30*time.Second)
 
 	informers.Start(ctx.Done())
 	close(informersStarted)
@@ -304,7 +306,8 @@ plugins:
 	ns := framework.CreateNamespaceOrDie(clientset, "quota", t)
 	defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	informers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
@@ -331,14 +334,14 @@ plugins:
 		InformersStarted:          informersStarted,
 		Registry:                  generic.NewRegistry(qc.Evaluators()),
 	}
-	resourceQuotaController, err := resourcequotacontroller.NewController(resourceQuotaControllerOptions)
+	resourceQuotaController, err := resourcequotacontroller.NewController(ctx, resourceQuotaControllerOptions)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	go resourceQuotaController.Run(ctx, 2)
 
 	// Periodically the quota controller to detect new resource types
-	go resourceQuotaController.Sync(discoveryFunc, 30*time.Second, ctx.Done())
+	go resourceQuotaController.Sync(ctx, discoveryFunc, 30*time.Second)
 
 	informers.Start(ctx.Done())
 	close(informersStarted)
@@ -430,7 +433,8 @@ plugins:
 	ns := framework.CreateNamespaceOrDie(clientset, "quota", t)
 	defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	informers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
@@ -457,14 +461,14 @@ plugins:
 		InformersStarted:          informersStarted,
 		Registry:                  generic.NewRegistry(qc.Evaluators()),
 	}
-	resourceQuotaController, err := resourcequotacontroller.NewController(resourceQuotaControllerOptions)
+	resourceQuotaController, err := resourcequotacontroller.NewController(ctx, resourceQuotaControllerOptions)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	go resourceQuotaController.Run(ctx, 2)
 
 	// Periodically the quota controller to detect new resource types
-	go resourceQuotaController.Sync(discoveryFunc, 30*time.Second, ctx.Done())
+	go resourceQuotaController.Sync(ctx, discoveryFunc, 30*time.Second)
 
 	informers.Start(ctx.Done())
 	close(informersStarted)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update the resourcequota controller to use contextual logging.

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/enhancements/issues/3077

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Migrated the ResourceQuota controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
