### PR TITLE
kubeadm: enable etcd's learner mode when joining etcd members

### DIFF
--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -33,7 +33,7 @@ const (
 	PublicKeysECDSA = "PublicKeysECDSA"
 	// RootlessControlPlane is expected to be in alpha in v1.22
 	RootlessControlPlane = "RootlessControlPlane"
-	// EtcdLearnerMode is expected to be in alpha in v1.26
+	// EtcdLearnerMode is expected to be in alpha in v1.27
 	EtcdLearnerMode = "EtcdLearnerMode"
 )
 

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -33,12 +33,15 @@ const (
 	PublicKeysECDSA = "PublicKeysECDSA"
 	// RootlessControlPlane is expected to be in alpha in v1.22
 	RootlessControlPlane = "RootlessControlPlane"
+	// EtcdLearnerMode is expected to be in alpha in v1.26
+	EtcdLearnerMode = "EtcdLearnerMode"
 )
 
 // InitFeatureGates are the default feature gates for the init command
 var InitFeatureGates = FeatureList{
 	PublicKeysECDSA:      {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 	RootlessControlPlane: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	EtcdLearnerMode:      {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 }
 
 // Feature represents a feature being gated

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -149,7 +149,11 @@ func CreateStackedEtcdStaticPodManifestFile(client clientset.Interface, manifest
 		fmt.Printf("[etcd] Would add etcd member: %s\n", etcdPeerAddress)
 	} else {
 		klog.V(1).Infof("[etcd] Adding etcd member: %s", etcdPeerAddress)
-		cluster, err = etcdClient.AddMember(nodeName, etcdPeerAddress)
+		if features.Enabled(cfg.FeatureGates, features.EtcdLearnerMode) {
+			cluster, err = etcdClient.AddMemberAsLeanerAndPromote(nodeName, etcdPeerAddress)
+		} else {
+			cluster, err = etcdClient.AddMember(nodeName, etcdPeerAddress)
+		}
 		if err != nil {
 			return err
 		}

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -251,6 +251,10 @@ func (c fakeTLSEtcdClient) ListMembers() ([]etcdutil.Member, error) {
 	return []etcdutil.Member{}, nil
 }
 
+func (c fakeTLSEtcdClient) AddMemberAsLeanerAndPromote(name string, peerAddrs string) ([]etcdutil.Member, error) {
+	return []etcdutil.Member{}, nil
+}
+
 func (c fakeTLSEtcdClient) AddMember(name string, peerAddrs string) ([]etcdutil.Member, error) {
 	return []etcdutil.Member{}, nil
 }
@@ -283,6 +287,10 @@ func (c fakePodManifestEtcdClient) CheckClusterHealth() error {
 func (c fakePodManifestEtcdClient) Sync() error { return nil }
 
 func (c fakePodManifestEtcdClient) ListMembers() ([]etcdutil.Member, error) {
+	return []etcdutil.Member{}, nil
+}
+
+func (c fakePodManifestEtcdClient) AddMemberAsLeanerAndPromote(name string, peerAddrs string) ([]etcdutil.Member, error) {
 	return []etcdutil.Member{}, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/kubeadm/issues/1793

#### Special notes for your reviewer:
similar implementation: https://github.com/siderolabs/talos/blob/fc48849d00c185442fb37c72e2c20462cc573a69/internal/app/machined/pkg/system/services/etcd.go#L589-L631

#### Does this PR introduce a user-facing change?
```release-note
kubeadm: add the experimental (alpha) feature gate EtcdLearnerMode that allows etcd members to be joined as learner and only then promoted as voting members
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

To be edited after KEP is merged.
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3614
```
