### PR TITLE
Extend metrics with the new labels

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1031,6 +1031,7 @@ func (jm *Controller) trackJobStatusAndRemoveFinalizers(ctx context.Context, job
 	if cleanUncountedPodsWithoutFinalizers(&job.Status, uidsWithFinalizer) {
 		needsFlush = true
 	}
+	podFailureCountByPolicyAction := map[string]int{}
 	for _, pod := range pods {
 		if !hasJobTrackingFinalizer(pod) || expectedRmFinalizers.Has(string(pod.UID)) {
 			continue
@@ -1061,7 +1062,10 @@ func (jm *Controller) trackJobStatusAndRemoveFinalizers(ctx context.Context, job
 			ix := getCompletionIndex(pod.Annotations)
 			if !uncounted.failed.Has(string(pod.UID)) && (!isIndexed || (ix != unknownCompletionIndex && ix < int(*job.Spec.Completions))) {
 				if feature.DefaultFeatureGate.Enabled(features.JobPodFailurePolicy) && job.Spec.PodFailurePolicy != nil {
-					_, countFailed := matchPodFailurePolicy(job.Spec.PodFailurePolicy, pod)
+					_, countFailed, action := matchPodFailurePolicy(job.Spec.PodFailurePolicy, pod)
+					if action != nil {
+						podFailureCountByPolicyAction[string(*action)] += 1
+					}
 					if countFailed {
 						needsFlush = true
 						uncountedStatus.Failed = append(uncountedStatus.Failed, pod.UID)
@@ -1102,7 +1106,7 @@ func (jm *Controller) trackJobStatusAndRemoveFinalizers(ctx context.Context, job
 		}
 	}
 	var err error
-	if job, needsFlush, err = jm.flushUncountedAndRemoveFinalizers(ctx, job, podsToRemoveFinalizer, uidsWithFinalizer, &oldCounters, needsFlush); err != nil {
+	if job, needsFlush, err = jm.flushUncountedAndRemoveFinalizers(ctx, job, podsToRemoveFinalizer, uidsWithFinalizer, &oldCounters, podFailureCountByPolicyAction, needsFlush); err != nil {
 		return err
 	}
 	jobFinished := jm.enactJobFinished(job, finishedCond)
@@ -1132,7 +1136,7 @@ func (jm *Controller) trackJobStatusAndRemoveFinalizers(ctx context.Context, job
 //
 // Returns whether there are pending changes in the Job status that need to be
 // flushed in subsequent calls.
-func (jm *Controller) flushUncountedAndRemoveFinalizers(ctx context.Context, job *batch.Job, podsToRemoveFinalizer []*v1.Pod, uidsWithFinalizer sets.String, oldCounters *batch.JobStatus, needsFlush bool) (*batch.Job, bool, error) {
+func (jm *Controller) flushUncountedAndRemoveFinalizers(ctx context.Context, job *batch.Job, podsToRemoveFinalizer []*v1.Pod, uidsWithFinalizer sets.String, oldCounters *batch.JobStatus, podFailureCountByPolicyAction map[string]int, needsFlush bool) (*batch.Job, bool, error) {
 	var err error
 	if needsFlush {
 		if job, err = jm.updateStatusHandler(ctx, job); err != nil {
@@ -1143,6 +1147,8 @@ func (jm *Controller) flushUncountedAndRemoveFinalizers(ctx context.Context, job
 		*oldCounters = job.Status
 		needsFlush = false
 	}
+	recordJobPodFailurePolicyActions(job, podFailureCountByPolicyAction)
+
 	jobKey, err := controller.KeyFunc(job)
 	if err != nil {
 		return job, needsFlush, fmt.Errorf("getting job key: %w", err)
@@ -1263,10 +1269,10 @@ func (jm *Controller) recordJobFinished(job *batch.Job, finishedCond *batch.JobC
 			jm.recorder.Event(job, v1.EventTypeWarning, "TooManySucceededPods", "Too many succeeded pods running after completion count reached")
 		}
 		jm.recorder.Event(job, v1.EventTypeNormal, "Completed", "Job completed")
-		metrics.JobFinishedNum.WithLabelValues(completionMode, "succeeded").Inc()
+		metrics.JobFinishedNum.WithLabelValues(completionMode, "succeeded", "").Inc()
 	} else {
 		jm.recorder.Event(job, v1.EventTypeWarning, finishedCond.Reason, finishedCond.Message)
-		metrics.JobFinishedNum.WithLabelValues(completionMode, "failed").Inc()
+		metrics.JobFinishedNum.WithLabelValues(completionMode, "failed", finishedCond.Reason).Inc()
 	}
 	return true
 }
@@ -1345,7 +1351,7 @@ func getFailJobMessage(job *batch.Job, pods []*v1.Pod, uncounted sets.String) *s
 	}
 	for _, p := range pods {
 		if isPodFailed(p, uncounted != nil) {
-			jobFailureMessage, _ := matchPodFailurePolicy(job.Spec.PodFailurePolicy, p)
+			jobFailureMessage, _, _ := matchPodFailurePolicy(job.Spec.PodFailurePolicy, p)
 			if jobFailureMessage != nil {
 				return jobFailureMessage
 			}
@@ -1369,7 +1375,7 @@ func getStatus(job *batch.Job, pods []*v1.Pod, uncounted *uncountedTerminatedPod
 			if !isPodFailed(p, uncounted != nil) {
 				return false
 			}
-			_, countFailed := matchPodFailurePolicy(job.Spec.PodFailurePolicy, p)
+			_, countFailed, _ := matchPodFailurePolicy(job.Spec.PodFailurePolicy, p)
 			return countFailed
 		} else {
 			return isPodFailed(p, uncounted != nil)
@@ -1766,6 +1772,12 @@ func recordJobPodFinished(job *batch.Job, oldCounters batch.JobStatus) {
 	metrics.JobPodsFinished.WithLabelValues(completionMode, metrics.Succeeded).Add(float64(diff))
 	diff = job.Status.Failed - oldCounters.Failed
 	metrics.JobPodsFinished.WithLabelValues(completionMode, metrics.Failed).Add(float64(diff))
+}
+
+func recordJobPodFailurePolicyActions(job *batch.Job, podFailureCountByPolicyAction map[string]int) {
+	for action, count := range podFailureCountByPolicyAction {
+		metrics.PodFailuresHandledByFailurePolicy.WithLabelValues(action).Add(float64(count))
+	}
 }
 
 func countReadyPods(pods []*v1.Pod) int32 {

--- a/pkg/controller/job/metrics/metrics.go
+++ b/pkg/controller/job/metrics/metrics.go
@@ -55,10 +55,12 @@ var (
 		},
 		[]string{"completion_mode", "result", "action"},
 	)
-	// JobFinishedNum tracks the number of Jobs that finish. Possible label
-	// values:
+	// JobFinishedNum tracks the number of Jobs that finish. Empty reason label
+	// is used to count successful jobs.
+	// Possible label values:
 	//   completion_mode: Indexed, NonIndexed
 	//   result:          failed, succeeded
+	//   reason:          "BackoffLimitExceeded", "DeadlineExceeded", "PodFailurePolicy", ""
 	JobFinishedNum = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      JobControllerSubsystem,
@@ -66,7 +68,7 @@ var (
 			Help:           "The number of finished job",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"completion_mode", "result"},
+		[]string{"completion_mode", "result", "reason"},
 	)
 
 	// JobPodsFinished records the number of finished Pods that the job controller
@@ -83,6 +85,22 @@ var (
 			Help:      "The number of finished Pods that are fully tracked",
 		},
 		[]string{"completion_mode", "result"})
+
+	// PodFailuresHandledByFailurePolicy records the number of finished Pods
+	// handled by pod failure policy.
+	// Possible label values:
+	//   action: FailJob, Ignore, Count
+	PodFailuresHandledByFailurePolicy = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem: JobControllerSubsystem,
+			Name:      "pod_failures_handled_by_failure_policy_total",
+			Help: `The number of failed Pods handled by failure policy with
+			respect to the failure policy action applied based on the matched
+			rule. Possible values of the action label correspond to the
+			possible values for the failure policy rule action, which are:
+			"FailJob", "Ignore" and "Count".`,
+		},
+		[]string{"action"})
 
 	// TerminatedPodsWithTrackingFinalizer records the addition and removal of
 	// terminated pods that have the finalizer batch.kubernetes.io/job-tracking,
@@ -137,6 +155,7 @@ func Register() {
 		legacyregistry.MustRegister(JobSyncNum)
 		legacyregistry.MustRegister(JobFinishedNum)
 		legacyregistry.MustRegister(JobPodsFinished)
+		legacyregistry.MustRegister(PodFailuresHandledByFailurePolicy)
 		legacyregistry.MustRegister(TerminatedPodsTrackingFinalizerTotal)
 	})
 }

--- a/pkg/controller/job/pod_failure_policy_test.go
+++ b/pkg/controller/job/pod_failure_policy_test.go
@@ -19,6 +19,7 @@ package job
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -706,30 +707,14 @@ func TestMatchPodFailurePolicy(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			jobFailMessage, countFailed, action := matchPodFailurePolicy(tc.podFailurePolicy, tc.failedPod)
-			if tc.wantJobFailureMessage == nil {
-				if jobFailMessage != nil {
-					t.Errorf("Unexpected job fail message. Got: %q", *jobFailMessage)
-				}
-			} else {
-				if jobFailMessage == nil {
-					t.Errorf("Missing job fail message. want: %q", *tc.wantJobFailureMessage)
-				} else if *tc.wantJobFailureMessage != *jobFailMessage {
-					t.Errorf("Unexpected job fail message. want: %q. got: %q", *tc.wantJobFailureMessage, *jobFailMessage)
-				}
+			if diff := cmp.Diff(tc.wantJobFailureMessage, jobFailMessage); diff != "" {
+				t.Errorf("Unexpected job failure message: %s", diff)
 			}
 			if tc.wantCountFailed != countFailed {
 				t.Errorf("Unexpected count failed. want: %v. got: %v", tc.wantCountFailed, countFailed)
 			}
-			if tc.wantAction == nil {
-				if action != nil {
-					t.Errorf("Unexpected job failure polic action. Got: %q", *action)
-				}
-			} else {
-				if action == nil {
-					t.Errorf("Missing job failure policy action. want: %q", *tc.wantAction)
-				} else if *tc.wantAction != *action {
-					t.Errorf("Unexpected job failure policy action. want: %v. got: %v", tc.wantAction, action)
-				}
+			if diff := cmp.Diff(tc.wantAction, action); diff != "" {
+				t.Errorf("Unexpected failure policy action: %s", diff)
 			}
 		})
 	}

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -68,7 +68,7 @@ type metricLabelsWithValue struct {
 	Value  int
 }
 
-func TestMetrics(t *testing.T) {
+func TestMetricsOnSuccesses(t *testing.T) {
 	nonIndexedCompletion := batchv1.NonIndexedCompletion
 	indexedCompletion := batchv1.IndexedCompletion
 	wFinalizers := true
@@ -81,365 +81,10 @@ func TestMetrics(t *testing.T) {
 	defer cancel()
 
 	testCases := map[string]struct {
-		job                                      *batchv1.Job
-		failedPodUpdate                          func(pod *v1.Pod) bool
-		enableJobPodFailurePolicy                bool
-		wantJobFailedPods                        int
-		wantJobFailure                           bool
-		wantJobFinishedNumMetric                 metricLabelsWithValue
-		wantJobPodsFinishedMetric                metricLabelsWithValue
-		wantPodFailuresHandledByPolicyRuleMetric *metricLabelsWithValue
+		job                       *batchv1.Job
+		wantJobFinishedNumMetric  metricLabelsWithValue
+		wantJobPodsFinishedMetric metricLabelsWithValue
 	}{
-		"non-indexed job; failed pod handled by FailJob action; JobPodFailurePolicy enabled": {
-			enableJobPodFailurePolicy: true,
-			job: &batchv1.Job{
-				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					CompletionMode: &nonIndexedCompletion,
-					BackoffLimit:   pointer.Int32(1),
-					PodFailurePolicy: &batchv1.PodFailurePolicy{
-						Rules: []batchv1.PodFailurePolicyRule{
-							{
-								Action: batchv1.PodFailurePolicyActionFailJob,
-								OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
-									Operator: batchv1.PodFailurePolicyOnExitCodesOpIn,
-									Values:   []int32{5},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantJobFailedPods: 1,
-			wantJobFailure:    true,
-			failedPodUpdate: func(pod *v1.Pod) bool {
-				pod.Status = v1.PodStatus{
-					Phase: v1.PodFailed,
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							State: v1.ContainerState{
-								Terminated: &v1.ContainerStateTerminated{
-									ExitCode: 5,
-								},
-							},
-						},
-					},
-				}
-				return true
-			},
-			wantJobFinishedNumMetric: metricLabelsWithValue{
-				Labels: []string{"NonIndexed", "failed", "PodFailurePolicy"},
-				Value:  1,
-			},
-			wantJobPodsFinishedMetric: metricLabelsWithValue{
-				Labels: []string{"NonIndexed", "failed"},
-				Value:  1,
-			},
-			wantPodFailuresHandledByPolicyRuleMetric: &metricLabelsWithValue{
-				Labels: []string{"FailJob"},
-				Value:  1,
-			},
-		},
-		"non-indexed job; failed pod not matching any defined action; JobPodFailurePolicy enabled": {
-			enableJobPodFailurePolicy: true,
-			job: &batchv1.Job{
-				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					CompletionMode: &nonIndexedCompletion,
-					BackoffLimit:   pointer.Int32(0),
-					PodFailurePolicy: &batchv1.PodFailurePolicy{
-						Rules: []batchv1.PodFailurePolicyRule{
-							{
-								Action: batchv1.PodFailurePolicyActionFailJob,
-								OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
-									Operator: batchv1.PodFailurePolicyOnExitCodesOpIn,
-									Values:   []int32{5},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantJobFailedPods: 1,
-			wantJobFailure:    true,
-			failedPodUpdate: func(pod *v1.Pod) bool {
-				pod.Status = v1.PodStatus{
-					Phase: v1.PodFailed,
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							State: v1.ContainerState{
-								Terminated: &v1.ContainerStateTerminated{
-									ExitCode: 10,
-								},
-							},
-						},
-					},
-				}
-				return true
-			},
-			wantJobFinishedNumMetric: metricLabelsWithValue{
-				Labels: []string{"NonIndexed", "failed", "BackoffLimitExceeded"},
-				Value:  1,
-			},
-			wantJobPodsFinishedMetric: metricLabelsWithValue{
-				Labels: []string{"NonIndexed", "failed"},
-				Value:  1,
-			},
-		},
-		"non-indexed job; failed pod handled by Count action; JobPodFailurePolicy enabled": {
-			enableJobPodFailurePolicy: true,
-			job: &batchv1.Job{
-				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					CompletionMode: &nonIndexedCompletion,
-					BackoffLimit:   pointer.Int32(0),
-					PodFailurePolicy: &batchv1.PodFailurePolicy{
-						Rules: []batchv1.PodFailurePolicyRule{
-							{
-								Action: batchv1.PodFailurePolicyActionCount,
-								OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
-									Operator: batchv1.PodFailurePolicyOnExitCodesOpIn,
-									Values:   []int32{5},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantJobFailedPods: 1,
-			wantJobFailure:    true,
-			failedPodUpdate: func(pod *v1.Pod) bool {
-				pod.Status = v1.PodStatus{
-					Phase: v1.PodFailed,
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							State: v1.ContainerState{
-								Terminated: &v1.ContainerStateTerminated{
-									ExitCode: 5,
-								},
-							},
-						},
-					},
-				}
-				return true
-			},
-			wantJobFinishedNumMetric: metricLabelsWithValue{
-				Labels: []string{"NonIndexed", "failed", "BackoffLimitExceeded"},
-				Value:  1,
-			},
-			wantJobPodsFinishedMetric: metricLabelsWithValue{
-				Labels: []string{"NonIndexed", "failed"},
-				Value:  1,
-			},
-			wantPodFailuresHandledByPolicyRuleMetric: &metricLabelsWithValue{
-				Labels: []string{"Count"},
-				Value:  1,
-			},
-		},
-		"non-indexed job; failed pod handled by Ignore action; JobPodFailurePolicy enabled": {
-			enableJobPodFailurePolicy: true,
-			job: &batchv1.Job{
-				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					CompletionMode: &nonIndexedCompletion,
-					BackoffLimit:   pointer.Int32(0),
-					PodFailurePolicy: &batchv1.PodFailurePolicy{
-						Rules: []batchv1.PodFailurePolicyRule{
-							{
-								Action: batchv1.PodFailurePolicyActionIgnore,
-								OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
-									Operator: batchv1.PodFailurePolicyOnExitCodesOpIn,
-									Values:   []int32{5},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantJobFailedPods: 0,
-			wantJobFailure:    false,
-			failedPodUpdate: func(pod *v1.Pod) bool {
-				pod.Status = v1.PodStatus{
-					Phase: v1.PodFailed,
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							State: v1.ContainerState{
-								Terminated: &v1.ContainerStateTerminated{
-									ExitCode: 5,
-								},
-							},
-						},
-					},
-				}
-				return true
-			},
-			wantJobFinishedNumMetric: metricLabelsWithValue{
-				Labels: []string{"NonIndexed", "succeeded", ""},
-				Value:  1,
-			},
-			wantJobPodsFinishedMetric: metricLabelsWithValue{
-				Labels: []string{"NonIndexed", "failed"},
-				Value:  0,
-			},
-			wantPodFailuresHandledByPolicyRuleMetric: &metricLabelsWithValue{
-				Labels: []string{"Ignore"},
-				Value:  1,
-			},
-		},
-		"indexed job; failed pod handled by FailJob action on pod conditions; JobPodFailurePolicy enabled": {
-			enableJobPodFailurePolicy: true,
-			job: &batchv1.Job{
-				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					CompletionMode: &indexedCompletion,
-					BackoffLimit:   pointer.Int32(0),
-					PodFailurePolicy: &batchv1.PodFailurePolicy{
-						Rules: []batchv1.PodFailurePolicyRule{
-							{
-								Action: batchv1.PodFailurePolicyActionFailJob,
-								OnPodConditions: []batchv1.PodFailurePolicyOnPodConditionsPattern{
-									{
-										Type:   v1.PodConditionType("ResourceExhausted"),
-										Status: v1.ConditionTrue,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantJobFailedPods: 1,
-			wantJobFailure:    true,
-			failedPodUpdate: func(pod *v1.Pod) bool {
-				pod.Status = v1.PodStatus{
-					Phase: v1.PodFailed,
-					Conditions: []v1.PodCondition{
-						{
-							Type:   v1.PodConditionType("ResourceExhausted"),
-							Status: v1.ConditionTrue,
-						},
-					},
-				}
-				return true
-			},
-			wantJobFinishedNumMetric: metricLabelsWithValue{
-				Labels: []string{"Indexed", "failed", "PodFailurePolicy"},
-				Value:  1,
-			},
-			wantJobPodsFinishedMetric: metricLabelsWithValue{
-				Labels: []string{"Indexed", "failed"},
-				Value:  1,
-			},
-			wantPodFailuresHandledByPolicyRuleMetric: &metricLabelsWithValue{
-				Labels: []string{"FailJob"},
-				Value:  1,
-			},
-		},
-		"indexed job; failed pod handled by Count action on pod conditions; JobPodFailurePolicy enabled": {
-			enableJobPodFailurePolicy: true,
-			job: &batchv1.Job{
-				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					CompletionMode: &indexedCompletion,
-					BackoffLimit:   pointer.Int32(0),
-					PodFailurePolicy: &batchv1.PodFailurePolicy{
-						Rules: []batchv1.PodFailurePolicyRule{
-							{
-								Action: batchv1.PodFailurePolicyActionCount,
-								OnPodConditions: []batchv1.PodFailurePolicyOnPodConditionsPattern{
-									{
-										Type:   v1.PodConditionType("ResourceExhausted"),
-										Status: v1.ConditionTrue,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantJobFailedPods: 1,
-			wantJobFailure:    true,
-			failedPodUpdate: func(pod *v1.Pod) bool {
-				pod.Status = v1.PodStatus{
-					Phase: v1.PodFailed,
-					Conditions: []v1.PodCondition{
-						{
-							Type:   v1.PodConditionType("ResourceExhausted"),
-							Status: v1.ConditionTrue,
-						},
-					},
-				}
-				return true
-			},
-			wantJobFinishedNumMetric: metricLabelsWithValue{
-				Labels: []string{"Indexed", "failed", "BackoffLimitExceeded"},
-				Value:  1,
-			},
-			wantJobPodsFinishedMetric: metricLabelsWithValue{
-				Labels: []string{"Indexed", "failed"},
-				Value:  1,
-			},
-			wantPodFailuresHandledByPolicyRuleMetric: &metricLabelsWithValue{
-				Labels: []string{"Count"},
-				Value:  1,
-			},
-		},
-		"indexed job; failed pod handled by Ignore action on pod conditions; JobPodFailurePolicy enabled": {
-			enableJobPodFailurePolicy: true,
-			job: &batchv1.Job{
-				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					CompletionMode: &indexedCompletion,
-					BackoffLimit:   pointer.Int32(0),
-					PodFailurePolicy: &batchv1.PodFailurePolicy{
-						Rules: []batchv1.PodFailurePolicyRule{
-							{
-								Action: batchv1.PodFailurePolicyActionIgnore,
-								OnPodConditions: []batchv1.PodFailurePolicyOnPodConditionsPattern{
-									{
-										Type:   v1.AlphaNoCompatGuaranteeDisruptionTarget,
-										Status: v1.ConditionTrue,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantJobFailedPods: 0,
-			wantJobFailure:    false,
-			failedPodUpdate: func(pod *v1.Pod) bool {
-				pod.Status = v1.PodStatus{
-					Phase: v1.PodFailed,
-					Conditions: []v1.PodCondition{
-						{
-							Type:   v1.AlphaNoCompatGuaranteeDisruptionTarget,
-							Status: v1.ConditionTrue,
-						},
-					},
-				}
-				return true
-			},
-			wantJobFinishedNumMetric: metricLabelsWithValue{
-				Labels: []string{"Indexed", "succeeded", ""},
-				Value:  1,
-			},
-			wantJobPodsFinishedMetric: metricLabelsWithValue{
-				Labels: []string{"Indexed", "failed"},
-				Value:  0,
-			},
-			wantPodFailuresHandledByPolicyRuleMetric: &metricLabelsWithValue{
-				Labels: []string{"Ignore"},
-				Value:  1,
-			},
-		},
 		"non-indexed job": {
 			job: &batchv1.Job{
 				Spec: batchv1.JobSpec{
@@ -455,29 +100,6 @@ func TestMetrics(t *testing.T) {
 			wantJobPodsFinishedMetric: metricLabelsWithValue{
 				Labels: []string{"NonIndexed", "succeeded"},
 				Value:  2,
-			},
-		},
-		"non-indexed job; failed": {
-			job: &batchv1.Job{
-				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					CompletionMode: &nonIndexedCompletion,
-					BackoffLimit:   pointer.Int32(0),
-				},
-			},
-			wantJobFailure: true,
-			failedPodUpdate: func(pod *v1.Pod) bool {
-				pod.Status.Phase = v1.PodFailed
-				return true
-			},
-			wantJobFinishedNumMetric: metricLabelsWithValue{
-				Labels: []string{"NonIndexed", "failed", "BackoffLimitExceeded"},
-				Value:  1,
-			},
-			wantJobPodsFinishedMetric: metricLabelsWithValue{
-				Labels: []string{"NonIndexed", "failed"},
-				Value:  1,
 			},
 		},
 		"indexed job": {
@@ -501,6 +123,141 @@ func TestMetrics(t *testing.T) {
 	job_index := 0 // job index to avoid collisions between job names created by different test cases
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			resetMetrics()
+			// create a single job and wait for its completion
+			job := tc.job.DeepCopy()
+			job.Name = fmt.Sprintf("job-%v", job_index)
+			job_index++
+			jobObj, err := createJobWithDefaults(ctx, clientSet, ns.Name, job)
+			if err != nil {
+				t.Fatalf("Failed to create Job: %v", err)
+			}
+			validateJobPodsStatus(ctx, t, clientSet, jobObj, podsByStatus{
+				Active: int(*jobObj.Spec.Parallelism),
+				Ready:  pointer.Int32(0),
+			}, wFinalizers)
+			if err, _ := setJobPodsPhase(ctx, clientSet, jobObj, v1.PodSucceeded, int(*jobObj.Spec.Parallelism)); err != nil {
+				t.Fatalf("Failed setting phase %s on Job Pod: %v", v1.PodSucceeded, err)
+			}
+			validateJobSucceeded(ctx, t, clientSet, jobObj)
+
+			// verify metric values after the job is finished
+			validateCounterMetric(t, metrics.JobFinishedNum, tc.wantJobFinishedNumMetric)
+			validateCounterMetric(t, metrics.JobPodsFinished, tc.wantJobPodsFinishedMetric)
+			validateTerminatedPodsTrackingFinalizerMetric(t, int(*jobObj.Spec.Parallelism))
+		})
+	}
+}
+
+func TestJobFinishedNumReasonMetric(t *testing.T) {
+	wFinalizers := true
+	// setup the job controller
+	closeFn, restConfig, clientSet, ns := setup(t, "simple")
+	defer closeFn()
+	ctx, cancel := startJobControllerAndWaitForCaches(restConfig)
+	defer cancel()
+
+	testCases := map[string]struct {
+		job                       batchv1.Job
+		podStatus                 v1.PodStatus
+		enableJobPodFailurePolicy bool
+		wantJobFinishedNumMetric  metricLabelsWithValue
+	}{
+		"non-indexed job; failed pod handled by FailJob action; JobPodFailurePolicy enabled": {
+			enableJobPodFailurePolicy: true,
+			job: batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Completions:  pointer.Int32(1),
+					Parallelism:  pointer.Int32(1),
+					BackoffLimit: pointer.Int32(1),
+					PodFailurePolicy: &batchv1.PodFailurePolicy{
+						Rules: []batchv1.PodFailurePolicyRule{
+							{
+								Action: batchv1.PodFailurePolicyActionFailJob,
+								OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
+									Operator: batchv1.PodFailurePolicyOnExitCodesOpIn,
+									Values:   []int32{5},
+								},
+							},
+						},
+					},
+				},
+			},
+			podStatus: v1.PodStatus{
+				Phase: v1.PodFailed,
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						State: v1.ContainerState{
+							Terminated: &v1.ContainerStateTerminated{
+								ExitCode: 5,
+							},
+						},
+					},
+				},
+			},
+			wantJobFinishedNumMetric: metricLabelsWithValue{
+				Labels: []string{"NonIndexed", "failed", "PodFailurePolicy"},
+				Value:  1,
+			},
+		},
+		"non-indexed job; failed pod handled by Count action; JobPodFailurePolicy enabled": {
+			enableJobPodFailurePolicy: true,
+			job: batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Completions:  pointer.Int32(1),
+					Parallelism:  pointer.Int32(1),
+					BackoffLimit: pointer.Int32(0),
+					PodFailurePolicy: &batchv1.PodFailurePolicy{
+						Rules: []batchv1.PodFailurePolicyRule{
+							{
+								Action: batchv1.PodFailurePolicyActionCount,
+								OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
+									Operator: batchv1.PodFailurePolicyOnExitCodesOpIn,
+									Values:   []int32{5},
+								},
+							},
+						},
+					},
+				},
+			},
+			podStatus: v1.PodStatus{
+				Phase: v1.PodFailed,
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						State: v1.ContainerState{
+							Terminated: &v1.ContainerStateTerminated{
+								ExitCode: 5,
+							},
+						},
+					},
+				},
+			},
+			wantJobFinishedNumMetric: metricLabelsWithValue{
+				Labels: []string{"NonIndexed", "failed", "BackoffLimitExceeded"},
+				Value:  1,
+			},
+		},
+		"non-indexed job; failed": {
+			job: batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Completions:  pointer.Int32(1),
+					Parallelism:  pointer.Int32(1),
+					BackoffLimit: pointer.Int32(0),
+				},
+			},
+			podStatus: v1.PodStatus{
+				Phase: v1.PodFailed,
+			},
+			wantJobFinishedNumMetric: metricLabelsWithValue{
+				Labels: []string{"NonIndexed", "failed", "BackoffLimitExceeded"},
+				Value:  1,
+			},
+		},
+	}
+	job_index := 0 // job index to avoid collisions between job names created by different test cases
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobTrackingWithFinalizers, wFinalizers)()
 			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobPodFailurePolicy, tc.enableJobPodFailurePolicy)()
 			resetMetrics()
 			// create a single job and wait for its completion
@@ -516,44 +273,18 @@ func TestMetrics(t *testing.T) {
 				Ready:  pointer.Int32(0),
 			}, wFinalizers)
 
-			// we can optionally fail a pod
-			if tc.failedPodUpdate != nil {
-				if err, _ := updateJobPodsStatus(ctx, clientSet, jobObj, tc.failedPodUpdate, 1); err != nil {
-					t.Fatalf("Failed setting phase %s on Job Pod: %v", v1.PodFailed, err)
-				}
+			op := func(p *v1.Pod) bool {
+				p.Status = tc.podStatus
+				return true
+			}
+			if err, _ := updateJobPodsStatus(ctx, clientSet, jobObj, op, 1); err != nil {
+				t.Fatalf("Error %q while updating pod status for Job: %q", err, jobObj.Name)
 			}
 
-			if tc.wantJobFailure {
-				validateJobFailed(ctx, t, clientSet, jobObj)
-			} else {
-				validateJobPodsStatus(ctx, t, clientSet, jobObj, podsByStatus{
-					Active:    int(*jobObj.Spec.Parallelism),
-					Succeeded: 0,
-					Failed:    tc.wantJobFailedPods,
-					Ready:     pointer.Int32(0),
-				}, wFinalizers)
-				if err, _ := setJobPodsPhase(ctx, clientSet, jobObj, v1.PodSucceeded, int(*jobObj.Spec.Parallelism)); err != nil {
-					t.Fatalf("Failed setting phase %s on Job Pod: %v", v1.PodSucceeded, err)
-				}
-				validateJobSucceeded(ctx, t, clientSet, jobObj)
-			}
+			validateJobFailed(ctx, t, clientSet, jobObj)
 
 			// verify metric values after the job is finished
 			validateCounterMetric(t, metrics.JobFinishedNum, tc.wantJobFinishedNumMetric)
-			validateCounterMetric(t, metrics.JobPodsFinished, tc.wantJobPodsFinishedMetric)
-			if tc.wantPodFailuresHandledByPolicyRuleMetric != nil {
-				validateCounterMetric(t, metrics.PodFailuresHandledByFailurePolicy, *tc.wantPodFailuresHandledByPolicyRuleMetric)
-			}
-			wantPodCount := 0
-			if tc.wantJobFailure {
-				wantPodCount += int(*jobObj.Spec.Parallelism)
-			} else {
-				wantPodCount += int(*jobObj.Spec.Completions)
-				if tc.failedPodUpdate != nil {
-					wantPodCount += 1
-				}
-			}
-			validateTerminatedPodsTrackingFinalizerMetric(t, wantPodCount)
 		})
 	}
 }
@@ -761,6 +492,13 @@ func TestJobPodFailurePolicy(t *testing.T) {
 						},
 					},
 					{
+						Action: batchv1.PodFailurePolicyActionCount,
+						OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
+							Operator: batchv1.PodFailurePolicyOnExitCodesOpIn,
+							Values:   []int32{10},
+						},
+					},
+					{
 						Action: batchv1.PodFailurePolicyActionFailJob,
 						OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
 							Operator: batchv1.PodFailurePolicyOnExitCodesOpIn,
@@ -784,6 +522,19 @@ func TestJobPodFailurePolicy(t *testing.T) {
 			},
 		},
 	}
+	podStatusMatchingOnExitCodesCountRule := v1.PodStatus{
+		Phase: v1.PodFailed,
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				Name: "main-container",
+				State: v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						ExitCode: 10,
+					},
+				},
+			},
+		},
+	}
 	podStatusMatchingOnPodConditionsIgnoreRule := v1.PodStatus{
 		Phase: v1.PodFailed,
 		Conditions: []v1.PodCondition{
@@ -793,14 +544,18 @@ func TestJobPodFailurePolicy(t *testing.T) {
 			},
 		},
 	}
+	podStatusNotMatchingAnyRule := v1.PodStatus{
+		Phase: v1.PodFailed,
+	}
 	testCases := map[string]struct {
-		enableJobPodFailurePolicy bool
-		restartController         bool
-		job                       batchv1.Job
-		podStatus                 v1.PodStatus
-		wantActive                int
-		wantFailed                int
-		wantJobConditionType      batchv1.JobConditionType
+		enableJobPodFailurePolicy                bool
+		restartController                        bool
+		job                                      batchv1.Job
+		podStatus                                v1.PodStatus
+		wantActive                               int
+		wantFailed                               int
+		wantJobConditionType                     batchv1.JobConditionType
+		wantPodFailuresHandledByPolicyRuleMetric *metricLabelsWithValue
 	}{
 		"pod status matching the configured FailJob rule on exit codes; job terminated when JobPodFailurePolicy enabled": {
 			enableJobPodFailurePolicy: true,
@@ -809,6 +564,10 @@ func TestJobPodFailurePolicy(t *testing.T) {
 			wantActive:                0,
 			wantFailed:                1,
 			wantJobConditionType:      batchv1.JobFailed,
+			wantPodFailuresHandledByPolicyRuleMetric: &metricLabelsWithValue{
+				Labels: []string{"FailJob"},
+				Value:  1,
+			},
 		},
 		"pod status matching the configured FailJob rule on exit codes; with controller restart; job terminated when JobPodFailurePolicy enabled": {
 			enableJobPodFailurePolicy: true,
@@ -834,11 +593,40 @@ func TestJobPodFailurePolicy(t *testing.T) {
 			wantActive:                1,
 			wantFailed:                0,
 			wantJobConditionType:      batchv1.JobComplete,
+			wantPodFailuresHandledByPolicyRuleMetric: &metricLabelsWithValue{
+				Labels: []string{"Ignore"},
+				Value:  1,
+			},
+		},
+		"pod status matching the configured Count rule on exit codes; pod failure counted when JobPodFailurePolicy enabled": {
+			enableJobPodFailurePolicy: true,
+			job:                       job,
+			podStatus:                 podStatusMatchingOnExitCodesCountRule,
+			wantActive:                1,
+			wantFailed:                1,
+			wantJobConditionType:      batchv1.JobComplete,
+			wantPodFailuresHandledByPolicyRuleMetric: &metricLabelsWithValue{
+				Labels: []string{"Count"},
+				Value:  1,
+			},
+		},
+		"pod status non-matching any configured rule; pod failure counted when JobPodFailurePolicy enabled": {
+			enableJobPodFailurePolicy: true,
+			job:                       job,
+			podStatus:                 podStatusNotMatchingAnyRule,
+			wantActive:                1,
+			wantFailed:                1,
+			wantJobConditionType:      batchv1.JobComplete,
+			wantPodFailuresHandledByPolicyRuleMetric: &metricLabelsWithValue{
+				Labels: []string{"Count"},
+				Value:  0,
+			},
 		},
 	}
 	for name, test := range testCases {
 		for _, wFinalizers := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s; finalizers=%t", name, wFinalizers), func(t *testing.T) {
+				resetMetrics()
 				defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobTrackingWithFinalizers, wFinalizers)()
 				defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobPodFailurePolicy, test.enableJobPodFailurePolicy)()
 
@@ -884,6 +672,9 @@ func TestJobPodFailurePolicy(t *testing.T) {
 					}
 				}
 				validateJobCondition(ctx, t, clientSet, jobObj, test.wantJobConditionType)
+				if wFinalizers && test.wantPodFailuresHandledByPolicyRuleMetric != nil {
+					validateCounterMetric(t, metrics.PodFailuresHandledByFailurePolicy, *test.wantPodFailuresHandledByPolicyRuleMetric)
+				}
 				validateFinishedPodsNoFinalizer(ctx, t, clientSet, jobObj)
 			})
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

It extends the job metrics:
- `job_finished_total` - by a new label `reason` which can take values: "BackoffLimitExceeded", "DeadlineExceeded", "PodFailurePolicy", "". The metric corresponding to the new label counts the number of jobs failed with a given result. The `reason` field is left empty for successful jobs.
- `pod_failures_handled_by_pod_failure_policy_total` - new counter metric with the `action` which can take values: "FailJob", "Ignore", "Count". The metric counts the number of pods handled by a given pod failure policy action. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
- Tracking issue: https://github.com/kubernetes/enhancements/issues/3329

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Extend the job `job_finished_total metric by new `reason` label and introduce a new job metric to count pod failures
handled by pod failure policy with respect to the action applied.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
 ```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures 
```
