### PR TITLE
Fix time.Since() in defer. Wrap in anonymous function

### DIFF
--- a/pkg/credentialprovider/plugin/plugin.go
+++ b/pkg/credentialprovider/plugin/plugin.go
@@ -435,7 +435,9 @@ func (e *execPlugin) ExecPlugin(ctx context.Context, image string) (*credentialp
 
 func (e *execPlugin) runPlugin(ctx context.Context, cmd *exec.Cmd, image string) error {
 	startTime := time.Now()
-	defer kubeletCredentialProviderPluginDuration.WithLabelValues(e.name).Observe(time.Since(startTime).Seconds())
+	defer func() {
+		kubeletCredentialProviderPluginDuration.WithLabelValues(e.name).Observe(time.Since(startTime).Seconds())
+	}()
 
 	err := cmd.Run()
 	if ctx.Err() != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
@@ -101,7 +101,10 @@ func getBaseEnv() (*cel.Env, error) {
 // perCallLimit was added for testing purpose only. Callers should always use const PerCallLimit as input.
 func Compile(s *schema.Structural, declType *apiservercel.DeclType, perCallLimit uint64) ([]CompilationResult, error) {
 	t := time.Now()
-	defer metrics.Metrics.ObserveCompilation(time.Since(t))
+	defer func() {
+		metrics.Metrics.ObserveCompilation(time.Since(t))
+	}()
+
 	if len(s.Extensions.XValidations) == 0 {
 		return nil, nil
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
@@ -139,7 +139,9 @@ func validator(s *schema.Structural, isResourceRoot bool, declType *cel.DeclType
 // context is passed for supporting context cancellation during cel validation
 func (s *Validator) Validate(ctx context.Context, fldPath *field.Path, sts *schema.Structural, obj, oldObj interface{}, costBudget int64) (errs field.ErrorList, remainingBudget int64) {
 	t := time.Now()
-	defer metrics.Metrics.ObserveEvaluation(time.Since(t))
+	defer func() {
+		metrics.Metrics.ObserveEvaluation(time.Since(t))
+	}()
 	remainingBudget = costBudget
 	if s == nil || obj == nil {
 		return nil, remainingBudget


### PR DESCRIPTION
Function arguments in defer evaluated during definition of defer, not during execution

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
using time.Since in defer needs to we wrapped in anonymous function, otherwise, time.Since gives not the time that happened before calling defer, but time, before just defining defer. Compare this (proper) https://go.dev/play/p/9WfdoCzkVzh and this (buggy) https://go.dev/play/p/D47_U-LZpUI

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
