### PR TITLE
Automated cherry pick of #113136: NodeLifecycleController: Remove race condition

### DIFF
--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -988,6 +988,43 @@ func TestAddOrUpdateTaintOnNode(t *testing.T) {
 			},
 			requestCount: 1,
 		},
+		{
+			name: "add taint to changed node",
+			nodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "node1",
+							ResourceVersion: "1",
+						},
+						Spec: v1.NodeSpec{
+							Taints: []v1.Taint{
+								{Key: "key1", Value: "value1", Effect: "NoSchedule"},
+							},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+				AsyncCalls: []func(*testutil.FakeNodeHandler){func(m *testutil.FakeNodeHandler) {
+					if len(m.UpdatedNodes) == 0 {
+						m.UpdatedNodes = append(m.UpdatedNodes, &v1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:            "node1",
+								ResourceVersion: "2",
+							},
+							Spec: v1.NodeSpec{
+								Taints: []v1.Taint{},
+							}})
+					}
+				}},
+			},
+			nodeName:    "node1",
+			taintsToAdd: []*v1.Taint{{Key: "key2", Value: "value2", Effect: "NoExecute"}},
+			expectedTaints: []v1.Taint{
+				{Key: "key2", Value: "value2", Effect: "NoExecute"},
+			},
+			requestCount: 5,
+		},
 	}
 	for _, test := range tests {
 		err := AddOrUpdateTaintOnNode(context.TODO(), test.nodeHandler, test.nodeName, test.taintsToAdd...)

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -54,7 +54,7 @@ const (
 	testNodeMonitorGracePeriod = 40 * time.Second
 	testNodeStartupGracePeriod = 60 * time.Second
 	testNodeMonitorPeriod      = 5 * time.Second
-	testRateLimiterQPS         = float32(10000)
+	testRateLimiterQPS         = float32(100000)
 	testLargeClusterThreshold  = 20
 	testUnhealthyThreshold     = float32(0.55)
 )

--- a/staging/src/k8s.io/cloud-provider/node/helpers/taints.go
+++ b/staging/src/k8s.io/cloud-provider/node/helpers/taints.go
@@ -89,9 +89,14 @@ func AddOrUpdateTaintOnNode(c clientset.Interface, nodeName string, taints ...*v
 
 // PatchNodeTaints patches node's taints.
 func PatchNodeTaints(c clientset.Interface, nodeName string, oldNode *v1.Node, newNode *v1.Node) error {
-	oldData, err := json.Marshal(oldNode)
+	// Strip base diff node from RV to ensure that our Patch request will set RV to check for conflicts over .spec.taints.
+	// This is needed because .spec.taints does not specify patchMergeKey and patchStrategy and adding them is no longer an option for compatibility reasons.
+	// Using other Patch strategy works for adding new taints, however will not resolve problem with taint removal.
+	oldNodeNoRV := oldNode.DeepCopy()
+	oldNodeNoRV.ResourceVersion = ""
+	oldDataNoRV, err := json.Marshal(&oldNodeNoRV)
 	if err != nil {
-		return fmt.Errorf("failed to marshal old node %#v for node %q: %v", oldNode, nodeName, err)
+		return fmt.Errorf("failed to marshal old node %#v for node %q: %v", oldNodeNoRV, nodeName, err)
 	}
 
 	newTaints := newNode.Spec.Taints
@@ -102,7 +107,7 @@ func PatchNodeTaints(c clientset.Interface, nodeName string, oldNode *v1.Node, n
 		return fmt.Errorf("failed to marshal new node %#v for node %q: %v", newNodeClone, nodeName, err)
 	}
 
-	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldDataNoRV, newData, v1.Node{})
 	if err != nil {
 		return fmt.Errorf("failed to create patch for node %q: %v", nodeName, err)
 	}


### PR DESCRIPTION
Cherry pick of #113136 on release-1.25.

#113136: NodeLifecycleController: Remove race condition

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```