### PR TITLE
Automated cherry pick of #113208: Set default test timeouts first, only then modify the

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -2155,3 +2155,11 @@ func (v *azureFileVolume) DeleteVolume() {
 	err := e2epv.DeleteShare(v.accountName, v.shareName)
 	framework.ExpectNoError(err)
 }
+
+func (a *azureDiskDriver) GetTimeouts() *framework.TimeoutContext {
+	timeouts := framework.NewTimeoutContextWithDefaults()
+	timeouts.PodStart = time.Minute * 15
+	timeouts.PodDelete = time.Minute * 15
+	timeouts.PVDelete = time.Minute * 20
+	return timeouts
+}


### PR DESCRIPTION
Cherry pick of #113208 on release-1.24.

#113208: Set default test timeouts first, only then modify the

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```