### PR TITLE
Swagger unmarshaljson

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/downloader.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/downloader.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"strings"
 
-	utiljson "k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -79,7 +78,7 @@ func (s *Downloader) Download(handler http.Handler, etag string) (returnSpec *sp
 		return nil, "", http.StatusNotFound, nil
 	case http.StatusOK:
 		openAPISpec := &spec.Swagger{}
-		if err := utiljson.Unmarshal(writer.data, openAPISpec); err != nil {
+		if err := openAPISpec.UnmarshalJSON(writer.data); err != nil {
 			return nil, "", 0, err
 		}
 		newEtag = writer.Header().Get("Etag")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Use `Swagger#UnmarhsalJson` rather than `json.Unmarshal` to deserialize OpenAPI spec since there is a 2x overhead with `json.Unmarshal` now that we're using the experimental json deserializer.

#### Which issue(s) this PR fixes:
Follow up from #112988

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

