### PR TITLE
Automated cherry pick of #110343: kubeadm: mutate ClusterConfiguration.imageRepository to

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	patchnodephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/patchnode"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
+	"k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
@@ -72,7 +73,16 @@ func loadConfig(cfgPath string, client clientset.Interface, skipComponentConfigs
 	// The usual case here is to not have a config file, but rather load the config from the cluster.
 	// This is probably 90% of the time. So we handle it first.
 	if cfgPath == "" {
-		cfg, err := configutil.FetchInitConfigurationFromCluster(client, os.Stdout, logPrefix, false, skipComponentConfigs)
+		cfg, err := configutil.FetchInitConfigurationFromCluster(client, printer, logPrefix, false, skipComponentConfigs)
+		// In case we fetch a configuration from the cluster, mutate the ImageRepository field
+		// to be 'registry.k8s.io', if it was 'k8s.gcr.io'.
+		// TODO: Remove this in 1.26
+		// https://github.com/kubernetes/kubeadm/issues/2671
+		if err == nil {
+			if err := uploadconfig.MutateImageRepository(cfg, client); err != nil {
+				return nil, false, err
+			}
+		}
 		return cfg, false, err
 	}
 

--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -34,6 +34,7 @@ import (
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane"
+	"k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
@@ -118,7 +119,15 @@ func runDiff(flags *diffFlags, args []string) error {
 		if err != nil {
 			return errors.Wrapf(err, "couldn't create a Kubernetes client from file %q", flags.kubeConfigPath)
 		}
-		cfg, err = configutil.FetchInitConfigurationFromCluster(client, flags.out, "upgrade/diff", false, false)
+		cfg, err = configutil.FetchInitConfigurationFromCluster(client, nil, "upgrade/diff", false, false)
+		// In case we fetch a configuration from the cluster, mutate the ImageRepository field
+		// to be 'registry.k8s.io', if it was 'k8s.gcr.io'. Don't mutate the in-cluster value by passing
+		// nil as the client field; this is done only on "apply".
+		// TODO: Remove this in 1.26
+		// https://github.com/kubernetes/kubeadm/issues/2671
+		if err == nil {
+			_ = uploadconfig.MutateImageRepository(cfg, nil)
+		}
 	}
 	if err != nil {
 		return err

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -32,6 +32,7 @@ import (
 	phases "k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/upgrade/node"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 )
 
@@ -143,6 +144,12 @@ func newNodeData(cmd *cobra.Command, args []string, options *nodeOptions) (*node
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch the kubeadm-config ConfigMap")
 	}
+	// In case we fetch a configuration from the cluster, mutate the ImageRepository field
+	// to be 'registry.k8s.io', if it was 'k8s.gcr.io'. Don't mutate the in-cluster value by passing
+	// nil as the client field; this is done only on "apply".
+	// TODO: Remove this in 1.26
+	// https://github.com/kubernetes/kubeadm/issues/2671
+	_ = uploadconfig.MutateImageRepository(cfg, nil)
 
 	ignorePreflightErrorsSet, err := validation.ValidateIgnorePreflightErrors(options.ignorePreflightErrors, cfg.NodeRegistration.IgnorePreflightErrors)
 	if err != nil {

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
@@ -19,10 +19,12 @@ package uploadconfig
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -119,4 +121,26 @@ func UploadConfiguration(cfg *kubeadmapi.InitConfiguration, client clientset.Int
 			},
 		},
 	})
+}
+
+// MutateImageRepository mutates the imageRepository field in the ClusterConfiguration
+// to 'registry.k8s.io' in case it was the legacy default 'k8s.gcr.io'
+// TODO: Remove this in 1.26
+// https://github.com/kubernetes/kubeadm/issues/2671
+func MutateImageRepository(cfg *kubeadmapi.InitConfiguration, client clientset.Interface) error {
+	if cfg.ImageRepository != "k8s.gcr.io" {
+		return nil
+	}
+	cfg.ImageRepository = "registry.k8s.io"
+	// If the client is nil assume that we don't want to mutate the in-cluster config
+	if client == nil {
+		return nil
+	}
+	klog.V(1).Info("updating the ClusterConfiguration.ImageRepository field in the kube-system/kubeadm-config " +
+		"ConfigMap to be 'registry.k8s.io' instead of the legacy default of 'k8s.gcr.io'")
+	if err := UploadConfiguration(cfg, client); err != nil {
+		return errors.Wrap(err, "could not mutate the ClusterConfiguration.ImageRepository field in "+
+			"the kube-system/kubeadm-config ConfigMap")
+	}
+	return nil
 }


### PR DESCRIPTION
Cherry pick of #110343 on release-1.24.

#110343: kubeadm: mutate ClusterConfiguration.imageRepository to

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```