### PR TITLE
Disallow prune for server-side applied objects

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -384,6 +384,11 @@ func (o *ApplyOptions) Validate() error {
 		return fmt.Errorf("--force cannot be used with --prune")
 	}
 
+	// Currently do not support pruning objects which are server-side applied.
+	if o.Prune && o.ServerSideApply {
+		return fmt.Errorf("--prune is in alpha and doesn't currently work on objects created by server-side apply")
+	}
+
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -147,6 +147,14 @@ func TestApplyFlagValidation(t *testing.T) {
 			},
 			expectedErr: "--force cannot be used with --prune",
 		},
+		{
+			args: [][]string{
+				{"server-side", "true"},
+				{"prune", "true"},
+				{"all", "true"},
+			},
+			expectedErr: "--prune is in alpha and doesn't currently work on objects created by server-side apply",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
* Disallows pruning for a server-side apply
 
/kind bug

```release-note
NONE
```
