### PR TITLE
promote ProxyTerminatingEndpoints feature to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -655,6 +655,7 @@ const (
 	// owner: @andrewsykim
 	// kep: https://kep.k8s.io/1669
 	// alpha: v1.22
+	// beta: v1.26
 	//
 	// Enable kube-proxy to handle terminating ednpoints when externalTrafficPolicy=Local
 	ProxyTerminatingEndpoints featuregate.Feature = "ProxyTerminatingEndpoints"
@@ -983,7 +984,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	ProcMountType: {Default: false, PreRelease: featuregate.Alpha},
 
-	ProxyTerminatingEndpoints: {Default: false, PreRelease: featuregate.Alpha},
+	ProxyTerminatingEndpoints: {Default: true, PreRelease: featuregate.Beta},
 
 	QOSReserved: {Default: false, PreRelease: featuregate.Alpha},
 


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

#### What type of PR is this?

/kind feature

https://github.com/kubernetes/enhancements/issues/1672

#### What this PR does / why we need it:

Per KEP update in https://github.com/kubernetes/enhancements/pull/3505, this PR promote the ProxyTerminatingEndpoints feature to Beta. This feature has been alpha since v1.22 and meets following graduation criterias for Beta:
- [X] E2E tests are in place, exercising all permutations of internalTrafficPolicy and externalTrafficPolicy (see [Test Plan](#test-plan) section)
    - [should fail health check node port if there are only terminating endpoints](https://github.com/kubernetes/kubernetes/blob/126986016e363c5dd92a202e3f433f6696dbcae1/test/e2e/network/service.go#L2771)
    - [should fallback to terminating endpoints when there are no ready endpoints with internalTrafficPolicy=Cluster](https://github.com/kubernetes/kubernetes/blob/126986016e363c5dd92a202e3f433f6696dbcae1/test/e2e/network/service.go#L2870)
    - [should fallback to local terminating endpoints when there are no ready endpoints with internalTrafficPolicy=Local](https://github.com/kubernetes/kubernetes/blob/126986016e363c5dd92a202e3f433f6696dbcae1/test/e2e/network/service.go#L2953)
    - [should fallback to terminating endpoints when there are no ready endpoints with externallTrafficPolicy=Cluster](https://github.com/kubernetes/kubernetes/blob/126986016e363c5dd92a202e3f433f6696dbcae1/test/e2e/network/service.go#L3041)
    - [should fallback to local terminating endpoints when there are no ready endpoints with externalTrafficPolicy=Local](https://github.com/kubernetes/kubernetes/blob/126986016e363c5dd92a202e3f433f6696dbcae1/test/e2e/network/service.go#L3126)
- [X] Metrics to publish how many Services/Endpoints are routing traffic to terminating endpoints.
   - See metrics added in https://github.com/kubernetes/kubernetes/pull/108930  
- [x] Manual or automated rollback testing  

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The ProxyTerminatingEndpoints feature is now Beta and enabled by default. When enabled, kube-proxy will attempt to route traffic to terminating pods when the traffic policy is Local and there are only terminating pods remaining on a node.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
