### PR TITLE
Fix setting resource version on etcd3 deletion

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -330,7 +330,15 @@ func (s *store) conditionalDelete(
 			origStateIsCurrent = true
 			continue
 		}
-		return decode(s.codec, s.versioner, origState.data, out, origState.rev)
+
+		if len(txnResp.Responses) == 0 || txnResp.Responses[0].GetResponseDeleteRange() == nil {
+			return errors.New(fmt.Sprintf("invalid DeleteRange response: %v", txnResp.Responses))
+		}
+		deleteResp := txnResp.Responses[0].GetResponseDeleteRange()
+		if deleteResp.Header == nil {
+			return errors.New("invalid DeleteRange response - nil header")
+		}
+		return decode(s.codec, s.versioner, origState.data, out, deleteResp.Header.Revision)
 	}
 }
 


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/113368

```release-note
The resourceVersion returned in objects from delete responses is now consistent with the resourceVersion contained in the delete watch event
```

/kind bug
/sig api-machinery
/priority important-soon

/assign @liggitt @lavalamp @deads2k 
/cc @stevekuznetsov 