### PR TITLE
e2e framework: fix incorrect backtrace in Failf

### DIFF
--- a/test/e2e/framework/log.go
+++ b/test/e2e/framework/log.go
@@ -41,11 +41,11 @@ func Logf(format string, args ...interface{}) {
 	log("INFO", format, args...)
 }
 
-// Failf logs the fail info, including a stack trace starts at 2 levels above its caller
-// (for example, for call chain f -> g -> Failf("foo", ...) error would be logged for "f").
+// Failf logs the fail info, including a stack trace starts with its direct caller
+// (for example, for call chain f -> g -> Failf("foo", ...) error would be logged for "g").
 func Failf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	skip := 2
+	skip := 1
 	log("FAIL", "%s\n\nFull Stack Trace\n%s", msg, PrunedStack(skip))
 	fail(nowStamp()+": "+msg, skip)
 	panic("unreachable")

--- a/test/e2e/framework/log_test.go
+++ b/test/e2e/framework/log_test.go
@@ -154,10 +154,14 @@ k8s.io/kubernetes/test/e2e/framework_test.glob..func1.5()
 FAIL: I'm failing.
 
 Full Stack Trace
+k8s.io/kubernetes/test/e2e/framework_test.glob..func1.3.1(...)
+	log_test.go:56
 k8s.io/kubernetes/test/e2e/framework_test.glob..func1.3()
 	log_test.go:57` + commonOutput,
 			Failure: "I'm failing.",
-			Stack: `k8s.io/kubernetes/test/e2e/framework_test.glob..func1.3()
+			Stack: `k8s.io/kubernetes/test/e2e/framework_test.glob..func1.3.1(...)
+	log_test.go:56
+k8s.io/kubernetes/test/e2e/framework_test.glob..func1.3()
 	log_test.go:57`,
 		},
 		output.TestResult{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Commit 99e909603467a36050e046b7274627debc47959e was only supposed to remove the FailfWithOffset function, but it also changed the behavior by skipping one additional stack frame. That makes no sense and is inconsistent with Fail, which also logs the direct caller.

#### Special notes for your reviewer:

I had discussed the off-by-one with @oomichi already and we agreed that it is a bug, I just don't remember where we discussed it and why it then didn't get fixed.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
