### PR TITLE
Fix kubelet start failed on windows 10

### DIFF
--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/listener_unix.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/listener_unix.go
@@ -1,0 +1,28 @@
+//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"net"
+)
+
+func GetListener(socketPath string) (net.Listener, error) {
+	return net.Listen("unix", socketPath)
+}

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/listener_windows.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/listener_windows.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"net"
+
+	"github.com/Microsoft/go-winio"
+	api "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+func GetListener(socketPath string) (net.Listener, error) {
+	return winio.ListenPipe("//./pipe"+api.KubeletSocket, nil)
+}

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"sync"
@@ -95,7 +94,7 @@ func (s *server) Start() error {
 		return err
 	}
 
-	ln, err := net.Listen("unix", s.SocketPath())
+	ln, err := GetListener(s.SocketPath())
 	if err != nil {
 		klog.ErrorS(err, "Failed to listen to socket while starting device plugin registry")
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubelet start failed on Windows 10

<img width="1898" alt="image" src="https://user-images.githubusercontent.com/6076617/198256641-3a1208f9-50d5-4168-b43c-e84c4767618c.png">


#### Special notes for your reviewer:
kubelet-1.22

#### Does this PR introduce a user-facing change?
The sock that kubelet listen on windows is: `npipe:////./pipe/var/lib/kubelet/device-plugins/kubelet.sock`, and the sock that kubelet monitors on unix is: `/var/lib/kubelet/device-plugins/kubelet.sock`


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
