### PR TITLE
chore: reduce mockCSIDriver test permissions

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -52,7 +52,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -309,6 +308,7 @@ type mockCSIDriver struct {
 	embedded               bool
 	calls                  MockCSICalls
 	embeddedCSIDriver      *mockdriver.CSIDriver
+	requiresSecretReader   bool
 
 	// Additional values set during PrepareTest
 	clientSet       clientset.Interface
@@ -509,6 +509,7 @@ func InitMockCSIDriver(driverOpts CSIMockDriverOpts) MockCSITestDriver {
 		enableVolumeMountGroup: driverOpts.EnableVolumeMountGroup,
 		embedded:               driverOpts.Embedded,
 		hooks:                  driverOpts.Hooks,
+		requiresSecretReader:   driverOpts.EnableSnapshot,
 	}
 }
 
@@ -658,26 +659,14 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) *storageframework.Pe
 		RequiresRepublish: m.requiresRepublish,
 		FSGroupPolicy:     m.fsGroupPolicy,
 	}
+
+	// if m.requiresSecretReader {
+	grantSecretReader(f.ClientSet, testns, "csi-snapshotter", driverns)
+	grantSecretReader(f.ClientSet, testns, "csi-mock", driverns)
+	// }
+
 	cleanup, err := utils.CreateFromManifests(f, m.driverNamespace, func(item interface{}) error {
-		if err := utils.PatchCSIDeployment(config.Framework, o, item); err != nil {
-			return err
-		}
-
-		switch item := item.(type) {
-		case *rbacv1.ClusterRole:
-			if strings.HasPrefix(item.Name, "external-snapshotter-runner") {
-				// Re-enable access to secrets for the snapshotter sidecar for
-				// https://github.com/kubernetes/kubernetes/blob/6ede5ca95f78478fa627ecfea8136e0dff34436b/test/e2e/storage/csi_mock_volume.go#L1539-L1548
-				// It was disabled in https://github.com/kubernetes-csi/external-snapshotter/blob/501cc505846c03ee665355132f2da0ce7d5d747d/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml#L26-L32
-				item.Rules = append(item.Rules, rbacv1.PolicyRule{
-					APIGroups: []string{""},
-					Resources: []string{"secrets"},
-					Verbs:     []string{"get", "list"},
-				})
-			}
-		}
-
-		return nil
+		return utils.PatchCSIDeployment(f, o, item)
 	}, m.manifests...)
 
 	if err != nil {


### PR DESCRIPTION
The CSI e2e storage test previously granted get and list permissions for all secrets to the external-snapshot-runner service account.

Now those permissions are scoped to the test namespace.



#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Scopes the secret permissions in some of the storage e2e tests to what's needed.
#### Which issue(s) this PR fixes:
Fixes #101334

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE