### PR TITLE
kubectl/get: remove Run function args

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
@@ -198,8 +198,10 @@ func CompGetFromTemplate(template *string, f cmdutil.Factory, namespace string, 
 		}
 		return printer.PrintObj, nil
 	}
+	o.Factory = f
+	o.Args = args
 
-	o.Run(f, cmd, args)
+	o.Run()
 
 	var comps []string
 	resources := strings.Split(buf.String(), " ")


### PR DESCRIPTION
Signed-off-by: iyear <ljyngup@gmail.com>

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
A TODO in comments: `remove the need to pass these arguments, like other commands.`

#### Special notes for your reviewer:
I closed the #113356 yesterday and tried to fix it today. I am not sure if it's ok...

This PR makes the `cmd` parameter of `CompGetFromTemplate` no longer needed, should I remove related code?

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
