### PR TITLE
util/wait: Add ManagedExponentialBackoff()

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -276,7 +276,7 @@ func (b *Backoff) Step() time.Duration {
 	duration := b.Duration
 
 	// calculate the next step
-	if b.Factor != 0 {
+	if b.Factor != 0 && b.Steps != 0 {
 		b.Duration = time.Duration(float64(b.Duration) * b.Factor)
 		if b.Cap > 0 && b.Duration > b.Cap {
 			b.Duration = b.Cap

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -646,10 +646,10 @@ func TestBackoff_Step(t *testing.T) {
 		{initial: &Backoff{Duration: time.Second, Steps: 0}, want: []time.Duration{time.Second, time.Second, time.Second}},
 		{initial: &Backoff{Duration: time.Second, Steps: 1}, want: []time.Duration{time.Second, time.Second, time.Second}},
 		{initial: &Backoff{Duration: time.Second, Factor: 1.0, Steps: 1}, want: []time.Duration{time.Second, time.Second, time.Second}},
-		{initial: &Backoff{Duration: time.Second, Factor: 2, Steps: 3}, want: []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}},
-		{initial: &Backoff{Duration: time.Second, Factor: 2, Steps: 3, Cap: 3 * time.Second}, want: []time.Duration{1 * time.Second, 2 * time.Second, 3 * time.Second}},
+		{initial: &Backoff{Duration: time.Second, Factor: 2, Steps: 3}, want: []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second, 4 * time.Second}},
+		{initial: &Backoff{Duration: time.Second, Factor: 2, Steps: 5, Cap: 3 * time.Second}, want: []time.Duration{1 * time.Second, 2 * time.Second, 3 * time.Second, 3 * time.Second}},
 		{initial: &Backoff{Duration: time.Second, Factor: 2, Steps: 2, Cap: 3 * time.Second, Jitter: 0.5}, want: []time.Duration{2 * time.Second, 3 * time.Second, 3 * time.Second}},
-		{initial: &Backoff{Duration: time.Second, Factor: 2, Steps: 6, Jitter: 4}, want: []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second, 32 * time.Second}},
+		{initial: &Backoff{Duration: time.Second, Factor: 2, Steps: 7, Jitter: 4}, want: []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second, 32 * time.Second, 32 * time.Second}},
 	}
 	for seed := int64(0); seed < 5; seed++ {
 		for _, tt := range tests {


### PR DESCRIPTION
#### What type of PR is this?:
/kind feature

/kind regression

#### What this PR does / why we need it:
`ManagedExponentialBackoff()` is like `ExponentialBackoff()`, but does not return `ErrTimeout`, and continues indefinitely with maximum duration until success is reached.

I use this in collectors, in steps that may error, but shall be retried until success. Using `Backoff.Steps = 99999` or similar isn't reasonable, as the duration gets too large. Looping `ExponentialBackoff()` is inefficient.

Also bugfix in behaviour of `Backoff.Step()`, where it stepped one extra step before reaching the limit.

#### Does this PR introduce a user-facing change?
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
apimachinery: Add wait.ManagedExponentialBackoff()
```
