### PR TITLE
Fix SELinux check of mounted volumes

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -817,15 +817,11 @@ func (asw *actualStateOfWorld) PodExistsInVolume(podName volumetypes.UniquePodNa
 		return false, "", newVolumeNotAttachedError(volumeName)
 	}
 
+	// The volume exists, check its SELinux context mount option
 	if utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMountReadWriteOncePod) {
-		if volumeObj.seLinuxMountContext != nil {
-			// The volume is mounted, check its SELinux context mount option
-			if *volumeObj.seLinuxMountContext != seLinuxLabel {
-				fullErr := newSELinuxMountMismatchError(volumeName)
-				if util.VolumeSupportsSELinuxMount(volumeObj.spec) {
-					return false, volumeObj.devicePath, fullErr
-				}
-			}
+		if volumeObj.seLinuxMountContext != nil && *volumeObj.seLinuxMountContext != seLinuxLabel {
+			fullErr := newSELinuxMountMismatchError(volumeName)
+			return false, volumeObj.devicePath, fullErr
 		}
 	}
 

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
@@ -892,7 +892,8 @@ func Test_AddPodToVolume_Positive_SELinux(t *testing.T) {
 	verifyVolumeExistsAswWithSELinux(t, generatedVolumeName, "system_u:object_r:container_file_t:s0:c0,c1", asw)
 	verifyVolumeDoesntExistInUnmountedVolumes(t, generatedVolumeName, asw)
 	verifyVolumeDoesntExistInGloballyMountedVolumes(t, generatedVolumeName, asw)
-	verifyPodExistsInVolumeAsw(t, podName, generatedVolumeName, "fake/device/path" /* expectedDevicePath */, asw)
+	verifyPodExistsInVolumeAswWithSELinux(t, podName, generatedVolumeName, "fake/device/path" /* expectedDevicePath */, "system_u:object_r:container_file_t:s0:c0,c1", asw)
+	verifyPodExistsInVolumeSELinuxMismatch(t, podName, generatedVolumeName, "" /* wrong SELinux label */, asw)
 	verifyVolumeExistsWithSpecNameInVolumeAsw(t, podName, volumeSpec.Name(), asw)
 	verifyVolumeMountedElsewhere(t, podName, generatedVolumeName, false /*expectedMountedElsewhere */, asw)
 }
@@ -1154,8 +1155,18 @@ func verifyPodExistsInVolumeAsw(
 	expectedVolumeName v1.UniqueVolumeName,
 	expectedDevicePath string,
 	asw ActualStateOfWorld) {
+	verifyPodExistsInVolumeAswWithSELinux(t, expectedPodName, expectedVolumeName, expectedDevicePath, "", asw)
+}
+
+func verifyPodExistsInVolumeAswWithSELinux(
+	t *testing.T,
+	expectedPodName volumetypes.UniquePodName,
+	expectedVolumeName v1.UniqueVolumeName,
+	expectedDevicePath string,
+	expectedSELinuxLabel string,
+	asw ActualStateOfWorld) {
 	podExistsInVolume, devicePath, err :=
-		asw.PodExistsInVolume(expectedPodName, expectedVolumeName, resource.Quantity{}, "")
+		asw.PodExistsInVolume(expectedPodName, expectedVolumeName, resource.Quantity{}, expectedSELinuxLabel)
 	if err != nil {
 		t.Fatalf(
 			"ASW PodExistsInVolume failed. Expected: <no error> Actual: <%v>", err)
@@ -1218,6 +1229,26 @@ func verifyPodDoesntExistInVolumeAsw(
 		t.Fatalf(
 			"Invalid devicePath. Expected: <\"\"> Actual: <%q> ",
 			devicePath)
+	}
+}
+
+func verifyPodExistsInVolumeSELinuxMismatch(
+	t *testing.T,
+	podToCheck volumetypes.UniquePodName,
+	volumeToCheck v1.UniqueVolumeName,
+	unexpectedSELinuxLabel string,
+	asw ActualStateOfWorld) {
+
+	podExistsInVolume, _, err := asw.PodExistsInVolume(podToCheck, volumeToCheck, resource.Quantity{}, unexpectedSELinuxLabel)
+	if podExistsInVolume {
+		t.Errorf("expected Pod %s not to exists, but it does", podToCheck)
+	}
+	if err == nil {
+		t.Error("expected PodExistsInVolume to return error, but it returned nil")
+	}
+
+	if !IsSELinuxMountMismatchError(err) {
+		t.Errorf("expected PodExistsInVolume to return SELinuxMountMismatchError, got %s", err)
 	}
 }
 


### PR DESCRIPTION
/kind bug
#### What this PR does / why we need it:
Checking `VolumeSupportsSELinuxMount` for a volume in Actual State of Word is wrong, because the volume might have been reconstructed from pod directory and in that case the volume has filed `spec.Volume` and not `spec.PersistentVolume`.

In `PodExistsInVolume` with `volumeObj.seLinuxMountContext != nil` we know that the volume has been previously mounted with a given SELinuxMountContext. Either it has been mounted by this kubelet and we know it's correct _or_ it was mounted by a previous instance of kubelet and the context has been reconstructed from the filesystem. In both cases, the actual context is correct, regardless if the volume plugin or PV access mode supports SELinux mounts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
https://github.com/kubernetes/enhancements/pull/3548
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/3548
```
