### PR TITLE
Disable expansion in SC, if driver does not support it

### DIFF
--- a/test/e2e/storage/testsuites/ephemeral.go
+++ b/test/e2e/storage/testsuites/ephemeral.go
@@ -135,6 +135,10 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 
 		l = local{}
 
+		if !driver.GetDriverInfo().Capabilities[storageframework.CapOnlineExpansion] {
+			pattern.AllowExpansion = false
+		}
+
 		// Now do the more expensive test initialization.
 		l.config = driver.PrepareTest(f)
 		l.resource = storageframework.CreateVolumeResource(driver, l.config, pattern, e2evolume.SizeRange{})


### PR DESCRIPTION
We enabled volume expansion tests for generic ephemeral volumes - https://github.com/kubernetes/kubernetes/pull/110180 but although code has logic to skip tests if driver does not support it, it appears to break intree vsphere tests, because vSphere CSI driver validation via webhook prevents creation of SCs with `allowVolumeExpansion` set to `true.

See - https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-sdn/1585505983071784960

Since vsphere intree tests are crucial for supporting migration, we need to carry this fix IMO.

Tested in real vsphere cluster:


```                                                                                                                                                                                             
started: (0/11/16) "[sig-storage] In-tree Volumes [Driver: vsphere] [Testpattern: Generic Ephemeral-volume (default fs) (immediate-binding)] ephemeral should create read-only inline ephemeral volume [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel] [Suite:k8s]"                                                                                               
```                                                                                                           


