### PR TITLE
Fix SELinux context mount with unknown context

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -377,7 +377,7 @@ func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMo
 		if err != nil {
 			return errors.New(log("failed to query for SELinuxMount support: %s", err))
 		}
-		if support {
+		if support && deviceMounterArgs.SELinuxLabel != "" {
 			mountOptions = util.AddSELinuxMountOption(mountOptions, deviceMounterArgs.SELinuxLabel)
 		}
 	}

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -249,7 +249,7 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 		if err != nil {
 			return errors.New(log("failed to query for SELinuxMount support: %s", err))
 		}
-		if support {
+		if support && mounterArgs.SELinuxLabel != "" {
 			mountOptions = util.AddSELinuxMountOption(mountOptions, mounterArgs.SELinuxLabel)
 			selinuxLabelMount = true
 		}

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -182,6 +182,15 @@ func TestMounterSetUp(t *testing.T) {
 			enableSELinuxFeatureGate: true,
 			expectedVolumeContext:    nil,
 		},
+		{
+			name:                     "should not include selinux mount options, if feature gate is enabled, driver supports it, but Pod does not have it",
+			driver:                   "supports_selinux",
+			seLinuxLabel:             "",
+			expectedSELinuxContext:   "", // especially make sure the volume plugin does not use -o context="", that is an invalid value
+			volumeContext:            nil,
+			enableSELinuxFeatureGate: true,
+			expectedVolumeContext:    nil,
+		},
 	}
 
 	noPodMountInfo := false


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
#### What this PR does / why we need it:
Don't mount with SELinux mount option if kubelet does not know the SELinux context, i.e.` MounterArgs.SELinuxLabel` is `""`. It will result in mount error when parsing `-o context=""`.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
https://github.com/kubernetes/enhancements/pull/3548
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/3548
```
