### PR TITLE
scheduler: integration test for ReadWriteOncePod alpha

### DIFF
--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -581,10 +581,7 @@ func (p *PodWrapper) Labels(labels map[string]string) *PodWrapper {
 
 // Annotation sets a {k,v} pair to the inner pod annotation.
 func (p *PodWrapper) Annotation(key, value string) *PodWrapper {
-	if p.ObjectMeta.Annotations == nil {
-		p.ObjectMeta.Annotations = make(map[string]string)
-	}
-	p.ObjectMeta.Annotations[key] = value
+	metav1.SetMetaDataAnnotation(&p.ObjectMeta, key, value)
 	return p
 }
 
@@ -694,4 +691,95 @@ func (n *NodeWrapper) Images(images map[string]int64) *NodeWrapper {
 func (n *NodeWrapper) Taints(taints []v1.Taint) *NodeWrapper {
 	n.Spec.Taints = taints
 	return n
+}
+
+// PersistentVolumeClaimWrapper wraps a PersistentVolumeClaim inside.
+type PersistentVolumeClaimWrapper struct{ v1.PersistentVolumeClaim }
+
+// MakePersistentVolumeClaim creates a PersistentVolumeClaim wrapper.
+func MakePersistentVolumeClaim() *PersistentVolumeClaimWrapper {
+	return &PersistentVolumeClaimWrapper{}
+}
+
+// Obj returns the inner PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) Obj() *v1.PersistentVolumeClaim {
+	return &p.PersistentVolumeClaim
+}
+
+// Name sets `s` as the name of the inner PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) Name(s string) *PersistentVolumeClaimWrapper {
+	p.SetName(s)
+	return p
+}
+
+// Namespace sets `s` as the namespace of the inner PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) Namespace(s string) *PersistentVolumeClaimWrapper {
+	p.SetNamespace(s)
+	return p
+}
+
+// Annotation sets a {k,v} pair to the inner PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) Annotation(key, value string) *PersistentVolumeClaimWrapper {
+	metav1.SetMetaDataAnnotation(&p.ObjectMeta, key, value)
+	return p
+}
+
+// VolumeName sets `name` as the volume name of the inner
+// PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) VolumeName(name string) *PersistentVolumeClaimWrapper {
+	p.PersistentVolumeClaim.Spec.VolumeName = name
+	return p
+}
+
+// AccessModes sets `accessModes` as the access modes of the inner
+// PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) AccessModes(accessModes []v1.PersistentVolumeAccessMode) *PersistentVolumeClaimWrapper {
+	p.PersistentVolumeClaim.Spec.AccessModes = accessModes
+	return p
+}
+
+// Resources sets `resources` as the resource requirements of the inner
+// PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) Resources(resources v1.ResourceRequirements) *PersistentVolumeClaimWrapper {
+	p.PersistentVolumeClaim.Spec.Resources = resources
+	return p
+}
+
+// PersistentVolumeWrapper wraps a PersistentVolume inside.
+type PersistentVolumeWrapper struct{ v1.PersistentVolume }
+
+// MakePersistentVolume creates a PersistentVolume wrapper.
+func MakePersistentVolume() *PersistentVolumeWrapper {
+	return &PersistentVolumeWrapper{}
+}
+
+// Obj returns the inner PersistentVolume.
+func (p *PersistentVolumeWrapper) Obj() *v1.PersistentVolume {
+	return &p.PersistentVolume
+}
+
+// Name sets `s` as the name of the inner PersistentVolume.
+func (p *PersistentVolumeWrapper) Name(s string) *PersistentVolumeWrapper {
+	p.SetName(s)
+	return p
+}
+
+// AccessModes sets `accessModes` as the access modes of the inner
+// PersistentVolume.
+func (p *PersistentVolumeWrapper) AccessModes(accessModes []v1.PersistentVolumeAccessMode) *PersistentVolumeWrapper {
+	p.PersistentVolume.Spec.AccessModes = accessModes
+	return p
+}
+
+// Capacity sets `capacity` as the resource list of the inner PersistentVolume.
+func (p *PersistentVolumeWrapper) Capacity(capacity v1.ResourceList) *PersistentVolumeWrapper {
+	p.PersistentVolume.Spec.Capacity = capacity
+	return p
+}
+
+// HostPathVolumeSource sets `src` as the host path volume source of the inner
+// PersistentVolume.
+func (p *PersistentVolumeWrapper) HostPathVolumeSource(src *v1.HostPathVolumeSource) *PersistentVolumeWrapper {
+	p.PersistentVolume.Spec.HostPath = src
+	return p
 }

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -610,6 +610,7 @@ type PausePodConfig struct {
 	Priority                          *int32
 	PreemptionPolicy                  *v1.PreemptionPolicy
 	PriorityClassName                 string
+	Volumes                           []v1.Volume
 }
 
 // InitPausePod initializes a pod API object from the given config. It is used
@@ -637,6 +638,7 @@ func InitPausePod(conf *PausePodConfig) *v1.Pod {
 			Priority:          conf.Priority,
 			PreemptionPolicy:  conf.PreemptionPolicy,
 			PriorityClassName: conf.PriorityClassName,
+			Volumes:           conf.Volumes,
 		},
 	}
 	if conf.Resources != nil {
@@ -672,6 +674,18 @@ func CreatePausePodWithResource(cs clientset.Interface, podName string,
 		}
 	}
 	return CreatePausePod(cs, InitPausePod(&conf))
+}
+
+// CreatePVC creates a PersistentVolumeClaim with the given config and returns
+// its pointer and error status.
+func CreatePVC(cs clientset.Interface, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
+	return cs.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+}
+
+// CreatePV creates a PersistentVolume with the given config and returns its
+// pointer and error status.
+func CreatePV(cs clientset.Interface, pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	return cs.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{})
 }
 
 // RunPausePod creates a pod with "Pause" image and the given config and waits


### PR DESCRIPTION
Scheduler integration test for enforcement of the `ReadWriteOncePod` PVC access mode.

1. Creates a pod using a PVC with `ReadWriteOncePod`
1. Creates a second pod using the same PVC
1. Observes the second pod fails to schedule because PVC is in-use
1. Deletes the first pod
1. Observes the second pod successfully schedules

To verify it works I ran the following:

```bash
go test -v -run TestUnschedulablePodBecomesSchedulable/scheduled_pod_uses_read-write-once-pod_pvc ./test/integration/scheduler/filters
```

#### What type of PR is this?
/kind feature

#### Which issue(s) this PR fixes:
Fixes #113418

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/2485-read-write-once-pod-pv-access-mode/README.md
```

/sig storage
/sig scheduling
/cc @msau42
/cc @jsafrane
/cc @alculquicondor