### PR TITLE
Automated cherry pick of #113409: Disable expansion in SC, if driver does not support it

### DIFF
--- a/test/e2e/storage/testsuites/ephemeral.go
+++ b/test/e2e/storage/testsuites/ephemeral.go
@@ -137,6 +137,10 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 
 		l = local{}
 
+		if !driver.GetDriverInfo().Capabilities[storageframework.CapOnlineExpansion] {
+			pattern.AllowExpansion = false
+		}
+
 		// Now do the more expensive test initialization.
 		l.config, l.driverCleanup = driver.PrepareTest(f)
 		l.resource = storageframework.CreateVolumeResource(driver, l.config, pattern, e2evolume.SizeRange{})


### PR DESCRIPTION
Cherry pick of #113409 on release-1.25.

#113409: Disable expansion in SC, if driver does not support it

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```