### PR TITLE
fix(corednsManifest): add recommended labels

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    k8s-app: kube-dns # deprecated
+    k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     app.kubernetes.io/name: "coredns"
@@ -62,7 +62,7 @@ metadata:
   name: {{ .DeploymentName }}
   namespace: kube-system
   labels:
-    k8s-app: kube-dns # deprecated
+    k8s-app: kube-dns
     app.kubernetes.io/name: "coredns"
 spec:
   replicas: {{ .Replicas }}
@@ -72,11 +72,11 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      k8s-app: kube-dns # deprecated
+      k8s-app: kube-dns
   template:
     metadata:
       labels:
-        k8s-app: kube-dns # deprecated
+        k8s-app: kube-dns
         app.kubernetes.io/name: "coredns"
     spec:
       priorityClassName: system-cluster-critical

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    k8s-app: kube-dns
+    k8s-app: kube-dns # deprecated
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     app.kubernetes.io/name: "coredns"
@@ -62,7 +62,7 @@ metadata:
   name: {{ .DeploymentName }}
   namespace: kube-system
   labels:
-    k8s-app: kube-dns
+    k8s-app: kube-dns # deprecated
     app.kubernetes.io/name: "coredns"
 spec:
   replicas: {{ .Replicas }}
@@ -72,11 +72,11 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      k8s-app: kube-dns
+      k8s-app: kube-dns # deprecated
   template:
     metadata:
       labels:
-        k8s-app: kube-dns
+        k8s-app: kube-dns # deprecated
         app.kubernetes.io/name: "coredns"
     spec:
       priorityClassName: system-cluster-critical
@@ -163,6 +163,8 @@ kind: ConfigMap
 metadata:
   name: coredns
   namespace: kube-system
+  labels:
+    app.kubernetes.io/name: "coredns"
 data:
   Corefile: |
     .:53 {
@@ -192,6 +194,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:coredns
+  labels:
+    app.kubernetes.io/name: "coredns"
 rules:
 - apiGroups:
   - ""
@@ -223,6 +227,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:coredns
+  labels:
+    app.kubernetes.io/name: "coredns"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -239,5 +245,7 @@ kind: ServiceAccount
 metadata:
   name: coredns
   namespace: kube-system
+  labels:
+    app.kubernetes.io/name: "coredns"
 `
 )

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -26,6 +26,7 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
+    app.kubernetes.io/name: "coredns"
   name: kube-dns
   namespace: kube-system
   annotations:
@@ -62,6 +63,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: kube-dns
+    app.kubernetes.io/name: "coredns"
 spec:
   replicas: {{ .Replicas }}
   strategy:
@@ -75,6 +77,7 @@ spec:
     metadata:
       labels:
         k8s-app: kube-dns
+        app.kubernetes.io/name: "coredns"
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -25,7 +25,7 @@ metadata:
   name: {{ .ProxyConfigMap }}
   namespace: kube-system
   labels:
-    app: kube-proxy
+    app: kube-proxy # deprecated
     app.kubernetes.io/name: kube-proxy
 data:
   kubeconfig.conf: |-
@@ -57,7 +57,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    k8s-app: kube-proxy
+    k8s-app: kube-proxy # deprecated
     app.kubernetes.io/name: kube-proxy
   name: kube-proxy
   namespace: kube-system
@@ -70,7 +70,7 @@ spec:
   template:
     metadata:
       labels:
-        k8s-app: kube-proxy
+        k8s-app: kube-proxy # deprecated
         app.kubernetes.io/name: kube-proxy
     spec:
       priorityClassName: system-node-critical

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -26,6 +26,7 @@ metadata:
   namespace: kube-system
   labels:
     app: kube-proxy
+    app.kubernetes.io/name: kube-proxy
 data:
   kubeconfig.conf: |-
     apiVersion: v1
@@ -57,6 +58,7 @@ kind: DaemonSet
 metadata:
   labels:
     k8s-app: kube-proxy
+    app.kubernetes.io/name: kube-proxy
   name: kube-proxy
   namespace: kube-system
 spec:
@@ -69,6 +71,7 @@ spec:
     metadata:
       labels:
         k8s-app: kube-proxy
+        app.kubernetes.io/name: kube-proxy
     spec:
       priorityClassName: system-node-critical
       containers:

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -25,7 +25,7 @@ metadata:
   name: {{ .ProxyConfigMap }}
   namespace: kube-system
   labels:
-    app: kube-proxy # deprecated
+    app: kube-proxy
     app.kubernetes.io/name: kube-proxy
 data:
   kubeconfig.conf: |-
@@ -57,7 +57,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    k8s-app: kube-proxy # deprecated
+    k8s-app: kube-proxy
     app.kubernetes.io/name: kube-proxy
   name: kube-proxy
   namespace: kube-system
@@ -70,7 +70,7 @@ spec:
   template:
     metadata:
       labels:
-        k8s-app: kube-proxy # deprecated
+        k8s-app: kube-proxy
         app.kubernetes.io/name: kube-proxy
     spec:
       priorityClassName: system-node-critical


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Kubernetes recommends [some labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/), but it does not apply them to coreDNS. It should have at least the app.kubernetes.io/name one

Following [coredns chart](https://github.com/coredns/helm/blob/0dbb02cedec3851e19031cde10f63901bbaf64bb/charts/coredns/templates/service.yaml#L16), but avoiding to add it to `deployment.spec.selector.matchLabels[]` since field is immutable, not sure if we should to consider upgrade path.

It would also make sense to add them to the kube-proxy DaemonSet, let me know what you think