### PR TITLE
Use "ip string" rather than "ip net.IP" in reconciler interface

### DIFF
--- a/pkg/controlplane/controller.go
+++ b/pkg/controlplane/controller.go
@@ -153,7 +153,7 @@ func (c *Controller) Start() {
 
 	// Reconcile during first run removing itself until server is ready.
 	endpointPorts := createEndpointPortSpec(c.PublicServicePort, "https")
-	if err := c.EndpointReconciler.RemoveEndpoints(kubernetesServiceName, c.PublicIP, endpointPorts); err == nil {
+	if err := c.EndpointReconciler.RemoveEndpoints(kubernetesServiceName, c.PublicIP.String(), endpointPorts); err == nil {
 		klog.Error("Found stale data, removed previous endpoints on kubernetes service, apiserver didn't exit successfully previously")
 	} else if !storage.IsNotFound(err) {
 		klog.Errorf("Error removing old endpoints from kubernetes service: %v", err)
@@ -210,7 +210,7 @@ func (c *Controller) Stop() {
 		defer close(finishedReconciling)
 		klog.Infof("Shutting down kubernetes service endpoint reconciler")
 		c.EndpointReconciler.StopReconciling()
-		if err := c.EndpointReconciler.RemoveEndpoints(kubernetesServiceName, c.PublicIP, endpointPorts); err != nil {
+		if err := c.EndpointReconciler.RemoveEndpoints(kubernetesServiceName, c.PublicIP.String(), endpointPorts); err != nil {
 			klog.Errorf("Unable to remove endpoints from kubernetes service: %v", err)
 		}
 		c.EndpointReconciler.Destroy()
@@ -271,7 +271,7 @@ func (c *Controller) UpdateKubernetesService(reconcile bool) error {
 		return err
 	}
 	endpointPorts := createEndpointPortSpec(c.PublicServicePort, "https")
-	if err := c.EndpointReconciler.ReconcileEndpoints(kubernetesServiceName, c.PublicIP, endpointPorts, reconcile); err != nil {
+	if err := c.EndpointReconciler.ReconcileEndpoints(kubernetesServiceName, c.PublicIP.String(), endpointPorts, reconcile); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/controlplane/reconcilers/instancecount_test.go
+++ b/pkg/controlplane/reconcilers/instancecount_test.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	netutils "k8s.io/utils/net"
 )
 
 func TestMasterCountEndpointReconciler(t *testing.T) {
@@ -232,7 +231,7 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(test.initialState...)
 			epAdapter := NewEndpointsAdapter(fakeClient.CoreV1(), fakeClient.DiscoveryV1())
 			reconciler := NewMasterCountEndpointReconciler(test.additionalMasters+1, epAdapter)
-			err := reconciler.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, true)
+			err := reconciler.ReconcileEndpoints(test.serviceName, test.ip, test.endpointPorts, true)
 			if err != nil {
 				t.Errorf("unexpected error reconciling: %v", err)
 			}
@@ -290,7 +289,7 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(test.initialState...)
 			epAdapter := NewEndpointsAdapter(fakeClient.CoreV1(), fakeClient.DiscoveryV1())
 			reconciler := NewMasterCountEndpointReconciler(test.additionalMasters+1, epAdapter)
-			err := reconciler.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, false)
+			err := reconciler.ReconcileEndpoints(test.serviceName, test.ip, test.endpointPorts, false)
 			if err != nil {
 				t.Errorf("unexpected error reconciling: %v", err)
 			}
@@ -311,7 +310,7 @@ func TestEmptySubsets(t *testing.T) {
 	endpointPorts := []corev1.EndpointPort{
 		{Name: "foo", Port: 8080, Protocol: "TCP"},
 	}
-	err := reconciler.RemoveEndpoints("foo", netutils.ParseIPSloppy("1.2.3.4"), endpointPorts)
+	err := reconciler.RemoveEndpoints("foo", "1.2.3.4", endpointPorts)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/controlplane/reconcilers/lease.go
+++ b/pkg/controlplane/reconcilers/lease.go
@@ -23,7 +23,6 @@ https://github.com/openshift/origin/blob/bb340c5dd5ff72718be86fb194dedc0faed7f4c
 
 import (
 	"fmt"
-	"net"
 	"path"
 	"sync"
 	"time"
@@ -166,7 +165,7 @@ func NewLeaseEndpointReconciler(epAdapter EndpointsAdapter, masterLeases Leases)
 // expire. ReconcileEndpoints will notice that the endpoints object is
 // different from the directory listing, and update the endpoints object
 // accordingly.
-func (r *leaseEndpointReconciler) ReconcileEndpoints(serviceName string, ip net.IP, endpointPorts []corev1.EndpointPort, reconcilePorts bool) error {
+func (r *leaseEndpointReconciler) ReconcileEndpoints(serviceName, ip string, endpointPorts []corev1.EndpointPort, reconcilePorts bool) error {
 	r.reconcilingLock.Lock()
 	defer r.reconcilingLock.Unlock()
 
@@ -177,7 +176,7 @@ func (r *leaseEndpointReconciler) ReconcileEndpoints(serviceName string, ip net.
 	// Refresh the TTL on our key, independently of whether any error or
 	// update conflict happens below. This makes sure that at least some of
 	// the masters will add our endpoint.
-	if err := r.masterLeases.UpdateLease(ip.String()); err != nil {
+	if err := r.masterLeases.UpdateLease(ip); err != nil {
 		return err
 	}
 
@@ -312,8 +311,8 @@ func checkEndpointSubsetFormatWithLease(e *corev1.Endpoints, expectedIPs []strin
 	return true, ipsCorrect, portsCorrect
 }
 
-func (r *leaseEndpointReconciler) RemoveEndpoints(serviceName string, ip net.IP, endpointPorts []corev1.EndpointPort) error {
-	if err := r.masterLeases.RemoveLease(ip.String()); err != nil {
+func (r *leaseEndpointReconciler) RemoveEndpoints(serviceName, ip string, endpointPorts []corev1.EndpointPort) error {
+	if err := r.masterLeases.RemoveLease(ip); err != nil {
 		return err
 	}
 

--- a/pkg/controlplane/reconcilers/lease_test.go
+++ b/pkg/controlplane/reconcilers/lease_test.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/apiserver/pkg/storage/storagebackend/factory"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/apis/core"
-	netutils "k8s.io/utils/net"
 )
 
 func init() {
@@ -349,7 +348,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 
 			epAdapter := NewEndpointsAdapter(clientset.CoreV1(), clientset.DiscoveryV1())
 			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
-			err = r.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, true)
+			err = r.ReconcileEndpoints(test.serviceName, test.ip, test.endpointPorts, true)
 			if err != nil {
 				t.Errorf("unexpected error reconciling: %v", err)
 			}
@@ -427,7 +426,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			clientset := fake.NewSimpleClientset(test.initialState...)
 			epAdapter := NewEndpointsAdapter(clientset.CoreV1(), clientset.DiscoveryV1())
 			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
-			err = r.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, false)
+			err = r.ReconcileEndpoints(test.serviceName, test.ip, test.endpointPorts, false)
 			if err != nil {
 				t.Errorf("unexpected error reconciling: %v", err)
 			}
@@ -514,7 +513,7 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 			clientset := fake.NewSimpleClientset(test.initialState...)
 			epAdapter := NewEndpointsAdapter(clientset.CoreV1(), clientset.DiscoveryV1())
 			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
-			err = r.RemoveEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts)
+			err = r.RemoveEndpoints(test.serviceName, test.ip, test.endpointPorts)
 			// if the ip is not on the endpoints, it must return an storage error and stop reconciling
 			if !contains(test.endpointKeys, test.ip) {
 				if !storage.IsNotFound(err) {

--- a/pkg/controlplane/reconcilers/none.go
+++ b/pkg/controlplane/reconcilers/none.go
@@ -18,8 +18,6 @@ limitations under the License.
 package reconcilers
 
 import (
-	"net"
-
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -33,12 +31,12 @@ func NewNoneEndpointReconciler() EndpointReconciler {
 }
 
 // ReconcileEndpoints noop reconcile
-func (r *noneEndpointReconciler) ReconcileEndpoints(serviceName string, ip net.IP, endpointPorts []corev1.EndpointPort, reconcilePorts bool) error {
+func (r *noneEndpointReconciler) ReconcileEndpoints(serviceName, ip string, endpointPorts []corev1.EndpointPort, reconcilePorts bool) error {
 	return nil
 }
 
 // RemoveEndpoints noop reconcile
-func (r *noneEndpointReconciler) RemoveEndpoints(serviceName string, ip net.IP, endpointPorts []corev1.EndpointPort) error {
+func (r *noneEndpointReconciler) RemoveEndpoints(serviceName, ip string, endpointPorts []corev1.EndpointPort) error {
 	return nil
 }
 

--- a/pkg/controlplane/reconcilers/reconcilers.go
+++ b/pkg/controlplane/reconcilers/reconcilers.go
@@ -18,8 +18,6 @@ limitations under the License.
 package reconcilers
 
 import (
-	"net"
-
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -35,9 +33,9 @@ type EndpointReconciler interface {
 	//  * All apiservers MUST use ReconcileEndpoints and only ReconcileEndpoints to manage the
 	//      endpoints for their {rw, ro} services.
 	//  * ReconcileEndpoints is called periodically from all apiservers.
-	ReconcileEndpoints(serviceName string, ip net.IP, endpointPorts []corev1.EndpointPort, reconcilePorts bool) error
+	ReconcileEndpoints(serviceName, ip string, endpointPorts []corev1.EndpointPort, reconcilePorts bool) error
 	// RemoveEndpoints removes this apiserver's lease.
-	RemoveEndpoints(serviceName string, ip net.IP, endpointPorts []corev1.EndpointPort) error
+	RemoveEndpoints(serviceName, ip string, endpointPorts []corev1.EndpointPort) error
 	// StopReconciling turns any later ReconcileEndpoints call into a noop.
 	StopReconciling()
 	// Destroy shuts down all internal structures.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Both endpoint reconciler implementations (instancecount and lease) work in terms of strings, so it simplifies their code if the controller passes the apiserver IP as a string rather than as a `net.IP`.

(Further cleanup/simplification of the endpoint slice reconciler code in preparation for flipping it from "Endpoints reconciler that also writes out EndpointSlices" to "EndpointSlice reconciler that also writes out Endpoints", in preparation for supporting dual-stack apiservers.)

#### Which issue(s) this PR fixes:
none

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2438
```
