### PR TITLE
Add `ResourceExhausted` pod condition for oom killer and exceeding of local storage limits

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -668,3 +668,8 @@ const (
 	// log output that the termination message can contain.
 	MaxContainerTerminationMessageLogLines = 80
 )
+
+// Constant for the reason field set for containers terminated by OOM killer
+const (
+	OOMKilledReason = "OOMKilled"
+)

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -26,11 +26,14 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	v1helper "k8s.io/component-helpers/scheduling/corev1"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	apiv1resource "k8s.io/kubernetes/pkg/api/v1/resource"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
+	"k8s.io/kubernetes/pkg/features"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
@@ -384,7 +387,7 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 			gracePeriodOverride = m.config.MaxPodGracePeriodSeconds
 		}
 		message, annotations := evictionMessage(resourceToReclaim, pod, statsFunc)
-		if m.evictPod(pod, gracePeriodOverride, message, annotations) {
+		if m.evictPod(pod, gracePeriodOverride, message, annotations, nil) {
 			metrics.Evictions.WithLabelValues(string(thresholdToReclaim.Signal)).Inc()
 			return []*v1.Pod{pod}
 		}
@@ -490,7 +493,17 @@ func (m *managerImpl) emptyDirLimitEviction(podStats statsapi.PodStats, pod *v1.
 			used := podVolumeUsed[pod.Spec.Volumes[i].Name]
 			if used != nil && size != nil && size.Sign() == 1 && used.Cmp(*size) > 0 {
 				// the emptyDir usage exceeds the size limit, evict the pod
-				if m.evictPod(pod, 0, fmt.Sprintf(emptyDirMessageFmt, pod.Spec.Volumes[i].Name, size.String()), nil) {
+				message := fmt.Sprintf(emptyDirMessageFmt, pod.Spec.Volumes[i].Name, size.String())
+				var condition *v1.PodCondition
+				if utilfeature.DefaultFeatureGate.Enabled(features.PodDisruptionConditions) {
+					condition = &v1.PodCondition{
+						Type:    kubelettypes.ResourceExhausted,
+						Status:  v1.ConditionTrue,
+						Reason:  kubelettypes.EphemeralStorageLimitExceeded,
+						Message: message,
+					}
+				}
+				if m.evictPod(pod, 0, message, nil, condition) {
 					metrics.Evictions.WithLabelValues(signalEmptyDirFsLimit).Inc()
 					return true
 				}
@@ -517,7 +530,17 @@ func (m *managerImpl) podEphemeralStorageLimitEviction(podStats statsapi.PodStat
 	podEphemeralStorageLimit := podLimits[v1.ResourceEphemeralStorage]
 	if podEphemeralStorageTotalUsage.Cmp(podEphemeralStorageLimit) > 0 {
 		// the total usage of pod exceeds the total size limit of containers, evict the pod
-		if m.evictPod(pod, 0, fmt.Sprintf(podEphemeralStorageMessageFmt, podEphemeralStorageLimit.String()), nil) {
+		message := fmt.Sprintf(podEphemeralStorageMessageFmt, podEphemeralStorageLimit.String())
+		var condition *v1.PodCondition
+		if utilfeature.DefaultFeatureGate.Enabled(features.PodDisruptionConditions) {
+			condition = &v1.PodCondition{
+				Type:    kubelettypes.ResourceExhausted,
+				Status:  v1.ConditionTrue,
+				Reason:  kubelettypes.EphemeralStorageLimitExceeded,
+				Message: message,
+			}
+		}
+		if m.evictPod(pod, 0, message, nil, condition) {
 			metrics.Evictions.WithLabelValues(signalEphemeralPodFsLimit).Inc()
 			return true
 		}
@@ -543,7 +566,17 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(podStats statsapi.P
 
 		if ephemeralStorageThreshold, ok := thresholdsMap[containerStat.Name]; ok {
 			if ephemeralStorageThreshold.Cmp(*containerUsed) < 0 {
-				if m.evictPod(pod, 0, fmt.Sprintf(containerEphemeralStorageMessageFmt, containerStat.Name, ephemeralStorageThreshold.String()), nil) {
+				message := fmt.Sprintf(containerEphemeralStorageMessageFmt, containerStat.Name, ephemeralStorageThreshold.String())
+				var condition *v1.PodCondition
+				if utilfeature.DefaultFeatureGate.Enabled(features.PodDisruptionConditions) {
+					condition = &v1.PodCondition{
+						Type:    kubelettypes.ResourceExhausted,
+						Status:  v1.ConditionTrue,
+						Reason:  kubelettypes.EphemeralStorageLimitExceeded,
+						Message: message,
+					}
+				}
+				if m.evictPod(pod, 0, message, nil, condition) {
 					metrics.Evictions.WithLabelValues(signalEphemeralContainerFsLimit).Inc()
 					return true
 				}
@@ -554,7 +587,7 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(podStats statsapi.P
 	return false
 }
 
-func (m *managerImpl) evictPod(pod *v1.Pod, gracePeriodOverride int64, evictMsg string, annotations map[string]string) bool {
+func (m *managerImpl) evictPod(pod *v1.Pod, gracePeriodOverride int64, evictMsg string, annotations map[string]string, condition *v1.PodCondition) bool {
 	// If the pod is marked as critical and static, and support for critical pod annotations is enabled,
 	// do not evict such pods. Static pods are not re-admitted after evictions.
 	// https://github.com/kubernetes/kubernetes/issues/40573 has more details.
@@ -570,6 +603,9 @@ func (m *managerImpl) evictPod(pod *v1.Pod, gracePeriodOverride int64, evictMsg 
 		status.Phase = v1.PodFailed
 		status.Reason = Reason
 		status.Message = evictMsg
+		if condition != nil {
+			podutil.UpdatePodCondition(status, condition)
+		}
 	})
 	if err != nil {
 		klog.ErrorS(err, "Eviction manager: pod failed to evict", "pod", klog.KObj(pod))

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	gomock "github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -106,10 +108,11 @@ func makePodWithMemoryStats(name string, priority int32, requests v1.ResourceLis
 	return pod, podStats
 }
 
-func makePodWithDiskStats(name string, priority int32, requests v1.ResourceList, limits v1.ResourceList, rootFsUsed, logsUsed, perLocalVolumeUsed string) (*v1.Pod, statsapi.PodStats) {
+func makePodWithDiskStats(name string, priority int32, requests v1.ResourceList, limits, overhead v1.ResourceList, volumes []v1.Volume, rootFsUsed, logsUsed, perLocalVolumeUsed string) (*v1.Pod, statsapi.PodStats) {
 	pod := newPod(name, priority, []v1.Container{
 		newContainer(name, requests, limits),
-	}, nil)
+	}, volumes)
+	pod.Spec.Overhead = overhead
 	podStats := newPodDiskStats(pod, parseQuantity(rootFsUsed), parseQuantity(logsUsed), parseQuantity(perLocalVolumeUsed))
 	return pod, podStats
 }
@@ -175,6 +178,8 @@ type podToMake struct {
 	priority                 int32
 	requests                 v1.ResourceList
 	limits                   v1.ResourceList
+	overhead                 v1.ResourceList
+	volumes                  []v1.Volume
 	memoryWorkingSet         string
 	rootFsUsed               string
 	logsFsUsed               string
@@ -182,6 +187,146 @@ type podToMake struct {
 	rootFsInodesUsed         string
 	perLocalVolumeUsed       string
 	perLocalVolumeInodesUsed string
+}
+
+func TestEphemeralStorageEviction_VerifyPodStatus(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.LocalStorageCapacityIsolation, true)()
+
+	testCases := map[string]struct {
+		enablePodDisruptionConditions bool
+		wantPodStatus                 v1.PodStatus
+		podsToMake                    []podToMake
+	}{
+		"eviction due to exceeding emptyDir storage limit": {
+			podsToMake: []podToMake{
+				{name: "above-limits", requests: newResourceList("", "", "1Gi"), limits: newResourceList("", "", "1Gi"), rootFsUsed: "500Mi", perLocalVolumeUsed: "2Gi",
+					volumes: []v1.Volume{
+						{
+							Name: "emptyDir",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{
+									SizeLimit: quantityMustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPodStatus: v1.PodStatus{
+				Phase:   v1.PodFailed,
+				Reason:  "Evicted",
+				Message: `Usage of EmptyDir volume "emptyDir" exceeds the limit "1Gi". `,
+			},
+		},
+		"eviction due to exceeding pod-level storage limits": {
+			podsToMake: []podToMake{
+				{name: "above-limits", requests: newResourceList("", "", "1Gi"), limits: newResourceList("", "", "1Gi"), rootFsUsed: "700Mi", perLocalVolumeUsed: "700Mi",
+					volumes: []v1.Volume{
+						{
+							Name: "emptyDir",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{
+									SizeLimit: quantityMustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPodStatus: v1.PodStatus{
+				Phase:   v1.PodFailed,
+				Reason:  "Evicted",
+				Message: `Pod ephemeral local storage usage exceeds the total limit of containers 1Gi. `,
+			},
+		},
+		"eviction due to exceeding container-level storage limits": {
+			podsToMake: []podToMake{
+				{name: "above-limits", requests: newResourceList("", "", "1Gi"), limits: newResourceList("", "", "1Gi"), overhead: newResourceList("", "", "1Gi"), rootFsUsed: "1.5Gi"},
+			},
+			wantPodStatus: v1.PodStatus{
+				Phase:   v1.PodFailed,
+				Reason:  "Evicted",
+				Message: `Container above-limits exceeded its local ephemeral storage limit "1Gi". `,
+			},
+		},
+	}
+	for name, tc := range testCases {
+		for _, enablePodDisruptionConditions := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s;PodDisruptionConditions=%v", name, enablePodDisruptionConditions), func(t *testing.T) {
+				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodDisruptionConditions, enablePodDisruptionConditions)()
+
+				podMaker := makePodWithDiskStats
+				summaryStatsMaker := makeDiskStats
+
+				pods := []*v1.Pod{}
+				podStats := map[*v1.Pod]statsapi.PodStats{}
+				for _, podToMake := range tc.podsToMake {
+					pod, podStat := podMaker(podToMake.name, podToMake.priority, podToMake.requests, podToMake.limits, podToMake.overhead, podToMake.volumes, podToMake.rootFsUsed, podToMake.logsFsUsed, podToMake.perLocalVolumeUsed)
+					pods = append(pods, pod)
+					podStats[pod] = podStat
+				}
+				activePodsFunc := func() []*v1.Pod {
+					return pods
+				}
+
+				fakeClock := testingclock.NewFakeClock(time.Now())
+				podKiller := &mockPodKiller{}
+				diskInfoProvider := &mockDiskInfoProvider{dedicatedImageFs: false}
+				diskGC := &mockDiskGC{err: nil}
+				nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
+
+				config := Config{
+					PressureTransitionPeriod: time.Minute * 5,
+					Thresholds: []evictionapi.Threshold{
+						{
+							Signal:   evictionapi.SignalNodeFsAvailable,
+							Operator: evictionapi.OpLessThan,
+							Value: evictionapi.ThresholdValue{
+								Quantity: quantityMustParse("2Gi"),
+							},
+						},
+					},
+				}
+				summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("4Gi", "200Gi", podStats)}
+				manager := &managerImpl{
+					clock:                         fakeClock,
+					killPodFunc:                   podKiller.killPodNow,
+					imageGC:                       diskGC,
+					containerGC:                   diskGC,
+					config:                        config,
+					recorder:                      &record.FakeRecorder{},
+					summaryProvider:               summaryProvider,
+					nodeRef:                       nodeRef,
+					nodeConditionsLastObservedAt:  nodeConditionsObservedAt{},
+					thresholdsFirstObservedAt:     thresholdsObservedAt{},
+					localStorageCapacityIsolation: true,
+				}
+
+				// synchronize
+				manager.synchronize(diskInfoProvider, activePodsFunc)
+
+				// verify a pod is selected for eviction
+				if podKiller.pod == nil {
+					t.Fatalf("Manager should have selected a pod for eviction")
+				}
+				wantPodStatus := tc.wantPodStatus.DeepCopy()
+				if enablePodDisruptionConditions {
+					wantPodStatus.Conditions = append(wantPodStatus.Conditions, v1.PodCondition{
+						Type:    "ResourceExhausted",
+						Status:  "True",
+						Reason:  "EphemeralStorageLimitExceeded",
+						Message: wantPodStatus.Message,
+					})
+				}
+
+				// verify the pod status after applying the status update function
+				podKiller.statusFn(&podKiller.pod.Status)
+				if diff := cmp.Diff(*wantPodStatus, podKiller.pod.Status, cmpopts.IgnoreFields(v1.PodCondition{}, "LastProbeTime", "LastTransitionTime")); diff != "" {
+					t.Errorf("Unexpected pod status of the evicted pod (-want,+got):\n%s", diff)
+				}
+			})
+		}
+	}
 }
 
 // TestMemoryPressure
@@ -463,7 +608,7 @@ func TestDiskPressureNodeFs(t *testing.T) {
 	pods := []*v1.Pod{}
 	podStats := map[*v1.Pod]statsapi.PodStats{}
 	for _, podToMake := range podsToMake {
-		pod, podStat := podMaker(podToMake.name, podToMake.priority, podToMake.requests, podToMake.limits, podToMake.rootFsUsed, podToMake.logsFsUsed, podToMake.perLocalVolumeUsed)
+		pod, podStat := podMaker(podToMake.name, podToMake.priority, podToMake.requests, podToMake.limits, podToMake.overhead, podToMake.volumes, podToMake.rootFsUsed, podToMake.logsFsUsed, podToMake.perLocalVolumeUsed)
 		pods = append(pods, pod)
 		podStats[pod] = podStat
 	}
@@ -514,7 +659,7 @@ func TestDiskPressureNodeFs(t *testing.T) {
 	}
 
 	// create a best effort pod to test admission
-	podToAdmit, _ := podMaker("pod-to-admit", defaultPriority, newResourceList("", "", ""), newResourceList("", "", ""), "0Gi", "0Gi", "0Gi")
+	podToAdmit, _ := podMaker("pod-to-admit", defaultPriority, newResourceList("", "", ""), newResourceList("", "", ""), newResourceList("", "", ""), nil, "0Gi", "0Gi", "0Gi")
 
 	// synchronize
 	manager.synchronize(diskInfoProvider, activePodsFunc)
@@ -800,7 +945,7 @@ func TestNodeReclaimFuncs(t *testing.T) {
 	pods := []*v1.Pod{}
 	podStats := map[*v1.Pod]statsapi.PodStats{}
 	for _, podToMake := range podsToMake {
-		pod, podStat := podMaker(podToMake.name, podToMake.priority, podToMake.requests, podToMake.limits, podToMake.rootFsUsed, podToMake.logsFsUsed, podToMake.perLocalVolumeUsed)
+		pod, podStat := podMaker(podToMake.name, podToMake.priority, podToMake.requests, podToMake.limits, podToMake.overhead, podToMake.volumes, podToMake.rootFsUsed, podToMake.logsFsUsed, podToMake.perLocalVolumeUsed)
 		pods = append(pods, pod)
 		podStats[pod] = podStat
 	}

--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -146,7 +146,7 @@ func (m *kubeGenericRuntimeManager) getImageUser(image string) (*int64, string, 
 // 3. container gets OOMKilled.
 func isInitContainerFailed(status *kubecontainer.Status) bool {
 	// When oomkilled occurs, init container should be considered as a failure.
-	if status.Reason == "OOMKilled" {
+	if status.Reason == kubecontainer.OOMKilledReason {
 		return true
 	}
 

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -34,11 +34,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
 	kubeconfigmap "k8s.io/kubernetes/pkg/kubelet/configmap"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
@@ -1397,21 +1400,90 @@ func deleteAction() core.DeleteAction {
 
 func TestMergePodStatus(t *testing.T) {
 	useCases := []struct {
-		desc                 string
-		hasRunningContainers bool
-		oldPodStatus         func(input v1.PodStatus) v1.PodStatus
-		newPodStatus         func(input v1.PodStatus) v1.PodStatus
-		expectPodStatus      v1.PodStatus
+		desc                          string
+		enablePodDisruptionConditions bool
+		hasRunningContainers          bool
+		oldPodStatus                  func(input v1.PodStatus) v1.PodStatus
+		newPodStatus                  func(input v1.PodStatus) v1.PodStatus
+		expectPodStatus               v1.PodStatus
 	}{
 		{
 			"no change",
+			false,
 			false,
 			func(input v1.PodStatus) v1.PodStatus { return input },
 			func(input v1.PodStatus) v1.PodStatus { return input },
 			getPodStatus(),
 		},
 		{
+			"add ResourceExhausted condition",
+			true,
+			false,
+			func(input v1.PodStatus) v1.PodStatus { return input },
+			func(input v1.PodStatus) v1.PodStatus {
+				input.Conditions = append(input.Conditions, v1.PodCondition{
+					Type:   kubetypes.ResourceExhausted,
+					Status: v1.ConditionTrue,
+					Reason: "OOMKilled",
+				})
+				return input
+			},
+			v1.PodStatus{
+				Phase: v1.PodRunning,
+				Conditions: []v1.PodCondition{
+					{
+						Type:   v1.PodReady,
+						Status: v1.ConditionTrue,
+					},
+					{
+						Type:   v1.PodScheduled,
+						Status: v1.ConditionTrue,
+					},
+					{
+						Type:   kubetypes.ResourceExhausted,
+						Status: v1.ConditionTrue,
+						Reason: "OOMKilled",
+					},
+				},
+				Message: "Message",
+			},
+		},
+		{
+			"preserve ResourceExhausted condition",
+			true,
+			false,
+			func(input v1.PodStatus) v1.PodStatus {
+				input.Conditions = append(input.Conditions, v1.PodCondition{
+					Type:   kubetypes.ResourceExhausted,
+					Status: v1.ConditionTrue,
+					Reason: "OOMKilled",
+				})
+				return input
+			},
+			func(input v1.PodStatus) v1.PodStatus { return input },
+			v1.PodStatus{
+				Phase: v1.PodRunning,
+				Conditions: []v1.PodCondition{
+					{
+						Type:   v1.PodReady,
+						Status: v1.ConditionTrue,
+					},
+					{
+						Type:   v1.PodScheduled,
+						Status: v1.ConditionTrue,
+					},
+					{
+						Type:   kubetypes.ResourceExhausted,
+						Status: v1.ConditionTrue,
+						Reason: "OOMKilled",
+					},
+				},
+				Message: "Message",
+			},
+		},
+		{
 			"readiness changes",
+			false,
 			false,
 			func(input v1.PodStatus) v1.PodStatus { return input },
 			func(input v1.PodStatus) v1.PodStatus {
@@ -1435,6 +1507,7 @@ func TestMergePodStatus(t *testing.T) {
 		},
 		{
 			"additional pod condition",
+			false,
 			false,
 			func(input v1.PodStatus) v1.PodStatus {
 				input.Conditions = append(input.Conditions, v1.PodCondition{
@@ -1465,6 +1538,7 @@ func TestMergePodStatus(t *testing.T) {
 		},
 		{
 			"additional pod condition and readiness changes",
+			false,
 			false,
 			func(input v1.PodStatus) v1.PodStatus {
 				input.Conditions = append(input.Conditions, v1.PodCondition{
@@ -1498,6 +1572,7 @@ func TestMergePodStatus(t *testing.T) {
 		},
 		{
 			"additional pod condition changes",
+			false,
 			false,
 			func(input v1.PodStatus) v1.PodStatus {
 				input.Conditions = append(input.Conditions, v1.PodCondition{
@@ -1535,6 +1610,7 @@ func TestMergePodStatus(t *testing.T) {
 		{
 			"phase is transitioning to failed and no containers running",
 			false,
+			false,
 			func(input v1.PodStatus) v1.PodStatus {
 				input.Phase = v1.PodRunning
 				input.Reason = "Unknown"
@@ -1569,6 +1645,7 @@ func TestMergePodStatus(t *testing.T) {
 		},
 		{
 			"phase is transitioning to failed and containers running",
+			false,
 			true,
 			func(input v1.PodStatus) v1.PodStatus {
 				input.Phase = v1.PodRunning
@@ -1602,6 +1679,7 @@ func TestMergePodStatus(t *testing.T) {
 
 	for _, tc := range useCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodDisruptionConditions, tc.enablePodDisruptionConditions)()
 			output := mergePodStatus(tc.oldPodStatus(getPodStatus()), tc.newPodStatus(getPodStatus()), tc.hasRunningContainers)
 			if !conditionsEqual(output.Conditions, tc.expectPodStatus.Conditions) || !statusEqual(output, tc.expectPodStatus) {
 				t.Fatalf("unexpected output: %s", cmp.Diff(tc.expectPodStatus, output))

--- a/pkg/kubelet/types/constants.go
+++ b/pkg/kubelet/types/constants.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package types
 
+import v1 "k8s.io/api/core/v1"
+
 const (
 	// ResolvConfDefault is the system default DNS resolver configuration.
 	ResolvConfDefault = "/etc/resolv.conf"
@@ -52,4 +54,18 @@ const (
 	// pod and IP address(es) assigned. Images for containers specified in the pod
 	// spec can be pulled and containers launched after this condition is true.
 	PodHasNetwork = "PodHasNetwork"
+)
+
+const (
+	// ResourceExhausted indicates the pod is in the Failed phase or is about to
+	// transition into the Failed phase (and is about to be deleted) due to either:
+	// - exceeding its ephemeral storage limits; or
+	// - running an OOM killed container when the pod's .spec.restartPolicy=Never.
+	ResourceExhausted = v1.PodConditionType("ResourceExhausted")
+)
+
+// Reasons for pod failure conditions added by Kubelet
+const (
+	EphemeralStorageLimitExceeded = "EphemeralStorageLimitExceeded"
+	OOMKilled                     = "OOMKilled"
 )

--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -231,3 +231,33 @@ func mixinRestrictedContainerSecurityContext(container *v1.Container) {
 		}
 	}
 }
+
+// FindContainerStatusInPod finds a container status by its name in the provided pod
+func FindContainerStatusInPod(pod *v1.Pod, containerName string) *v1.ContainerStatus {
+	for _, container := range pod.Status.InitContainerStatuses {
+		if container.Name == containerName {
+			return &container
+		}
+	}
+	for _, container := range pod.Status.ContainerStatuses {
+		if container.Name == containerName {
+			return &container
+		}
+	}
+	for _, container := range pod.Status.EphemeralContainerStatuses {
+		if container.Name == containerName {
+			return &container
+		}
+	}
+	return nil
+}
+
+// findPodConditionByType loop ups the pod condition by type in the pod status
+func findPodConditionByType(podStatus *v1.PodStatus, conditionType v1.PodConditionType) *v1.PodCondition {
+	for _, cond := range podStatus.Conditions {
+		if cond.Type == conditionType {
+			return &cond
+		}
+	}
+	return nil
+}

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -651,13 +651,13 @@ func (v *podStartVerifier) Verify(event watch.Event) error {
 		return fmt.Errorf("pod %s on node %s had incorrect containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status.ContainerStatuses)
 	}
 
-	if status := findContainerStatusInPod(pod, "blocked"); status != nil {
+	if status := e2epod.FindContainerStatusInPod(pod, "blocked"); status != nil {
 		if (status.Started != nil && *status.Started == true) || status.LastTerminationState.Terminated != nil || status.State.Waiting == nil {
 			return fmt.Errorf("pod %s on node %s should not have started the blocked container: %#v", pod.Name, pod.Spec.NodeName, status)
 		}
 	}
 
-	status := findContainerStatusInPod(pod, "fail")
+	status := e2epod.FindContainerStatusInPod(pod, "fail")
 	if status == nil {
 		return fmt.Errorf("pod %s on node %s had incorrect containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status)
 	}
@@ -740,24 +740,4 @@ func (v *podStartVerifier) VerifyFinal(scenario string, total time.Duration) (*v
 
 	framework.Logf("Pod %s on node %s %s total=%s run=%s execute=%s", pod.Name, pod.Spec.NodeName, scenario, total, v.completeDuration, v.duration)
 	return pod, errs
-}
-
-// findContainerStatusInPod finds a container status by its name in the provided pod
-func findContainerStatusInPod(pod *v1.Pod, containerName string) *v1.ContainerStatus {
-	for _, container := range pod.Status.InitContainerStatuses {
-		if container.Name == containerName {
-			return &container
-		}
-	}
-	for _, container := range pod.Status.ContainerStatuses {
-		if container.Name == containerName {
-			return &container
-		}
-	}
-	for _, container := range pod.Status.EphemeralContainerStatuses {
-		if container.Name == containerName {
-			return &container
-		}
-	}
-	return nil
 }

--- a/test/e2e_node/oomkiller_test.go
+++ b/test/e2e_node/oomkiller_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/features"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/onsi/ginkgo/v2"
+)
+
+type testCase struct {
+	podSpec                    *v1.Pod
+	oomTargetContainerName     string
+	wantPodDisruptionCondition *v1.PodCondition
+}
+
+var _ = SIGDescribe("OOMKiller [LinuxOnly]", func() {
+	f := framework.NewDefaultFramework("oomkiller-test")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	ginkgo.Context("OOMKiller invoked when PodDisruptionConditions are enabled [Slow] [Serial] [Disruptive] [Feature:PodDisruptionConditions]", func() {
+		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {
+			initialConfig.FeatureGates = map[string]bool{
+				string(features.PodDisruptionConditions): true,
+			}
+		})
+
+		testCases := []testCase{
+			{
+				podSpec: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod-oomkill-target-pod",
+					},
+					Spec: v1.PodSpec{
+						RestartPolicy: v1.RestartPolicyNever,
+						Containers:    []v1.Container{getOOMTargetContainer("pod-oomkill-target-container")},
+					},
+				},
+				oomTargetContainerName: "pod-oomkill-target-container",
+				wantPodDisruptionCondition: &v1.PodCondition{
+					Type:    ResourceExhausted,
+					Status:  v1.ConditionTrue,
+					Reason:  "OOMKilled",
+					Message: "OOMKilled container: pod-oomkill-target-container",
+				},
+			},
+			{
+				podSpec: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod-oomkill-with-init-oomtarget-pod",
+					},
+					Spec: v1.PodSpec{
+						RestartPolicy:  v1.RestartPolicyNever,
+						InitContainers: []v1.Container{getOOMTargetContainer("pod-oomkill-with-init-oomtarget-container")},
+						Containers:     []v1.Container{getInnocentContainer("pod-oomkill-with-init-innocent-container")},
+					},
+				},
+				oomTargetContainerName: "pod-oomkill-with-init-oomtarget-container",
+				wantPodDisruptionCondition: &v1.PodCondition{
+					Type:    ResourceExhausted,
+					Status:  v1.ConditionTrue,
+					Reason:  "OOMKilled",
+					Message: "OOMKilled container: pod-oomkill-with-init-oomtarget-container",
+				},
+			},
+		}
+		runOomKillerTest(f, testCases)
+	})
+
+})
+
+func runOomKillerTest(f *framework.Framework, testCases []testCase) {
+	ginkgo.Context("", func() {
+
+		ginkgo.BeforeEach(func() {
+			for _, testCase := range testCases {
+				ginkgo.By("setting up the pod to be used in the test")
+				e2epod.NewPodClient(f).Create(testCase.podSpec)
+			}
+		})
+
+		ginkgo.It("The containers terminated by OOM killer should have the reason set to OOMKilled", func() {
+
+			for _, testCase := range testCases {
+				ginkgo.By("Waiting for the pod to be failed")
+				e2epod.WaitForPodTerminatedInNamespace(f.ClientSet, testCase.podSpec.Name, "", f.Namespace.Name)
+
+				ginkgo.By("Fetching the latest pod status")
+				pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), testCase.podSpec.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err, "Failed to get the recent pod object for name: %q", pod.Name)
+
+				ginkgo.By("Verifying the OOM target container has the expected reason")
+				verifyReasonForOOMKilledContainer(pod, testCase.oomTargetContainerName)
+
+				if testCase.wantPodDisruptionCondition != nil {
+					ginkgo.By("Verifying the pod has the expected pod condition")
+					e2epod.VerifyPodHasCondition(f, pod, *testCase.wantPodDisruptionCondition)
+				}
+			}
+		})
+
+		ginkgo.AfterEach(func() {
+			for _, testCase := range testCases {
+				ginkgo.By(fmt.Sprintf("deleting pod: %s", testCase.podSpec.Name))
+				e2epod.NewPodClient(f).DeleteSync(testCase.podSpec.Name, metav1.DeleteOptions{}, e2epod.PodDeleteTimeout)
+			}
+		})
+	})
+}
+
+func verifyReasonForOOMKilledContainer(pod *v1.Pod, oomTargetContainerName string) {
+	container := e2epod.FindContainerStatusInPod(pod, oomTargetContainerName)
+	if container == nil {
+		framework.Failf("OOM target pod %q, container %q does not have the expected state terminated", pod.Name, container.Name)
+	}
+	if container.State.Terminated == nil {
+		framework.Failf("OOM target pod %q, container %q is not in the terminated state", pod.Name, container.Name)
+	}
+	framework.ExpectEqual(container.State.Terminated.Reason, "OOMKilled",
+		fmt.Sprintf("pod: %q, container: %q has unexpected reason: %q", pod.Name, container.Name, container.State.Terminated.Reason))
+}
+
+func getOOMTargetContainer(name string) v1.Container {
+	return v1.Container{
+		Name:  name,
+		Image: busyboxImage,
+		Command: []string{
+			"sh",
+			"-c",
+			// the script iterates allocation of variables with random values
+			fmt.Sprintf("i=0; while [ $i -lt %d ]; do %s i=$(($i+1)); done", 10000000, "eval array$i=$RANDOM"),
+		},
+		Resources: v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+		},
+	}
+}
+
+func getInnocentContainer(name string) v1.Container {
+	return v1.Container{
+		Image: busyboxImage,
+		Name:  name,
+		Command: []string{
+			"sh",
+			"-c",
+			"echo hello",
+		},
+	}
+}

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -80,6 +80,10 @@ const (
 	memoryManagerStateFile = "/var/lib/kubelet/memory_manager_state"
 )
 
+const (
+	ResourceExhausted = "ResourceExhausted"
+)
+
 var kubeletHealthCheckURL = fmt.Sprintf("http://127.0.0.1:%d/healthz", ports.KubeletHealthzPort)
 
 func getNodeSummary() (*stats.Summary, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
- Tracking issue: https://github.com/kubernetes/enhancements/issues/3329

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubelet adds the following pod failure conditions:
- ResourceExhausted (OOM killed container when restartPolicy=Never or exceeding the pod's ephemeral storage limits)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
 ```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures 
```
