### PR TITLE
DO NOT MERGE: Testing behavior when terminal pods are readded

### DIFF
--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -587,23 +587,15 @@ func (p *podWorkers) UpdatePod(options UpdatePodOptions) {
 			syncedAt: now,
 			fullname: kubecontainer.GetPodFullName(pod),
 		}
-		// if this pod is being synced for the first time, we need to make sure it is an active pod
-		if !isRuntimePod && (pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded) {
-			// check to see if the pod is not running and the pod is terminal.
-			// If this succeeds then record in the podWorker that it is terminated.
-			if statusCache, err := p.podCache.Get(pod.UID); err == nil {
-				if isPodStatusCacheTerminal(statusCache) {
-					status = &podSyncStatus{
-						terminatedAt:       now,
-						terminatingAt:      now,
-						syncedAt:           now,
-						startedTerminating: true,
-						finished:           true,
-						fullname:           kubecontainer.GetPodFullName(pod),
-					}
-				}
+
+		if !isRuntimePod {
+			if pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded {
+				// pod is terminal and we are seeing it for the first time - do nothing
+				klog.V(2).InfoS("DEBUG: Pod is already terminal and not known to the pod worker, no further updates necessary", "pod", klog.KObj(pod), "podUID", pod.UID)
+				// return
 			}
 		}
+
 		p.podSyncStatuses[uid] = status
 	}
 


### PR DESCRIPTION
We added this check in #105527, but it's not clear why we need it and I can't remember exactly why we had to do it this way. Remove it so the CI infra will verify the e2e test without it and I can see what fails.

The code check said:

1. if we hadn't seen the pod before
2. and it was not a runtime pod
3. and the pod config source says its terminal
4. and our own container runtime state says its terminal
5. mark it as a terminated and finished
6. which should then.... be a no-op and won't start a pod worker or call any of the sync methods, and then be cleared 2s later in HandlePodCleanups, which

Without the code block, we put the pod in syncTerminatingPod, which should happen fast (no containers) and then tear down the rest in syncTerminatedPod, then exit.  So we would be in the worker for longer, and other parts of the kubelet would see the pod as a) known, b) terminating (briefly).  But the pod isn't actually terminating, it's terminated in that case.

So the code is short circuiting syncTerminatingPod from getting run to reduce the race window, which also means we don't call syncTerminatedPod.  However, since a pod could be force deleted at any time, we don't rely on syncTerminatedPod to clean things up (it's just about gating transitions to the kubelet marking the pod successful), so it's ok to make that assumption.  However...