### PR TITLE
docs: Correct the log message for pv controller to make it more accurately descriptive

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -728,7 +728,7 @@ func (ctrl *PersistentVolumeController) syncVolume(ctx context.Context, volume *
 				// the user know. Don't overwrite existing Failed status!
 				if volume.Status.Phase != v1.VolumeReleased && volume.Status.Phase != v1.VolumeFailed {
 					// Also, log this only once:
-					klog.V(2).Infof("dynamically volume %q is released and it will be deleted", volume.Name)
+					klog.V(2).Infof("dynamically provisioned volume %q is released and it will be deleted", volume.Name)
 					if volume, err = ctrl.updateVolumePhase(volume, v1.VolumeReleased, ""); err != nil {
 						// Nothing was saved; we will fall back into the same condition
 						// in the next call to this method


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
It reduces the ambiguity of the log message when a dynamically provisioned volume is released and makes it more clear


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
