### PR TITLE
kubeadm: Add the option to cleaning up all container images for reset

### DIFF
--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -149,7 +149,7 @@ const (
 	// Print the addon manifests to STDOUT instead of installing them.
 	PrintManifest = "print-manifest"
 
-	// CleanupImages flag instruct kubeadm to cleaning up all container images
+	// CleanupImages flag indicates whether reset will cleanup all container images
 	CleanupImages = "cleanup-images"
 
 	// CleanupTmpDir flag indicates whether reset will cleanup the tmp dir

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -149,7 +149,7 @@ const (
 	// Print the addon manifests to STDOUT instead of installing them.
 	PrintManifest = "print-manifest"
 
-	// CleanupImages cleaning up all container images.
+	// CleanupImages flag instruct kubeadm to cleaning up all container images
 	CleanupImages = "cleanup-images"
 
 	// CleanupTmpDir flag indicates whether reset will cleanup the tmp dir

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -149,6 +149,9 @@ const (
 	// Print the addon manifests to STDOUT instead of installing them.
 	PrintManifest = "print-manifest"
 
+	// CleanupImages cleaning up all container images.
+	CleanupImages = "cleanup-images"
+
 	// CleanupTmpDir flag indicates whether reset will cleanup the tmp dir
 	CleanupTmpDir = "cleanup-tmp-dir"
 )

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -171,6 +171,7 @@ func cleanupImages(execer utilsexec.Interface, criSocketPath string) error {
 	if err != nil {
 		return err
 	}
+	// crictl rmi --all
 	images := []string{"--all"}
 	return containerRuntime.RemoveImages(images)
 }

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -104,12 +104,14 @@ func runCleanupNode(c workflow.RunData) error {
 	}
 
 	if r.CleanupImages() {
-		klog.V(1).Info("[reset] Cleaning up container images")
-		if err := cleanupImages(utilsexec.New(), r.CRISocketPath()); err != nil {
-			klog.Warningf("[reset] Failed to clean up container images: %v\n", err)
+		if !r.DryRun() {
+			klog.V(1).Info("[reset] Cleaning up container images")
+			if err := cleanupImages(utilsexec.New(), r.CRISocketPath()); err != nil {
+				klog.Warningf("[reset] Failed to clean up container images: %v\n", err)
+			}
+		} else {
+			fmt.Println("[reset] Would clean up container images")
 		}
-	} else {
-		fmt.Println("[reset] Would clean up container images")
 	}
 
 	// Remove contents from the config and pki directories

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
@@ -235,3 +235,27 @@ func TestRemoveContainers(t *testing.T) {
 
 	removeContainers(&fexec, "unix:///var/run/crio/crio.sock")
 }
+
+func TestRemoveImages(t *testing.T) {
+	fcmd := fakeexec.FakeCmd{
+		CombinedOutputScript: []fakeexec.FakeAction{
+			func() ([]byte, []byte, error) { return []byte("id1\nid2"), nil, nil },
+			func() ([]byte, []byte, error) { return []byte(""), nil, nil },
+			func() ([]byte, []byte, error) { return []byte(""), nil, nil },
+			func() ([]byte, []byte, error) { return []byte(""), nil, nil },
+			func() ([]byte, []byte, error) { return []byte(""), nil, nil },
+		},
+	}
+	fexec := fakeexec.FakeExec{
+		CommandScript: []fakeexec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+		LookPathFunc: func(cmd string) (string, error) { return "/usr/bin/crictl", nil },
+	}
+
+	cleanupImages(&fexec, "unix:///var/run/crio/crio.sock")
+}

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
@@ -236,7 +236,7 @@ func TestRemoveContainers(t *testing.T) {
 	removeContainers(&fexec, "unix:///var/run/crio/crio.sock")
 }
 
-func TestRemoveImages(t *testing.T) {
+func TestCleanupImages(t *testing.T) {
 	fcmd := fakeexec.FakeCmd{
 		CombinedOutputScript: []fakeexec.FakeAction{
 			func() ([]byte, []byte, error) { return []byte("id1\nid2"), nil, nil },

--- a/cmd/kubeadm/app/cmd/phases/reset/data.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/data.go
@@ -36,5 +36,6 @@ type resetData interface {
 	Client() clientset.Interface
 	CertificatesDir() string
 	CRISocketPath() string
+	CleanupImages() bool
 	CleanupTmpDir() bool
 }

--- a/cmd/kubeadm/app/cmd/phases/reset/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/data_test.go
@@ -39,4 +39,5 @@ func (t *testData) DryRun() bool                       { return false }
 func (t *testData) Client() clientset.Interface        { return nil }
 func (t *testData) CertificatesDir() string            { return "" }
 func (t *testData) CRISocketPath() string              { return "" }
+func (t *testData) CleanupImages() bool                { return false }
 func (t *testData) CleanupTmpDir() bool                { return false }

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -66,6 +66,7 @@ type resetOptions struct {
 	ignorePreflightErrors []string
 	kubeconfigPath        string
 	dryRun                bool
+	cleanupImages         bool
 	cleanupTmpDir         bool
 }
 
@@ -81,6 +82,7 @@ type resetData struct {
 	outputWriter          io.Writer
 	cfg                   *kubeadmapi.InitConfiguration
 	dryRun                bool
+	cleanupImages         bool
 	cleanupTmpDir         bool
 }
 
@@ -90,6 +92,7 @@ func newResetOptions() *resetOptions {
 		certificatesDir: kubeadmapiv1.DefaultCertificatesDir,
 		forceReset:      false,
 		kubeconfigPath:  kubeadmconstants.GetAdminKubeConfigPath(),
+		cleanupImages:   false,
 		cleanupTmpDir:   false,
 	}
 }
@@ -141,6 +144,7 @@ func newResetData(cmd *cobra.Command, options *resetOptions, in io.Reader, out i
 		outputWriter:          out,
 		cfg:                   cfg,
 		dryRun:                options.dryRun,
+		cleanupImages:         options.cleanupImages,
 		cleanupTmpDir:         options.cleanupTmpDir,
 	}, nil
 }
@@ -158,6 +162,10 @@ func AddResetFlags(flagSet *flag.FlagSet, resetOptions *resetOptions) {
 	flagSet.BoolVar(
 		&resetOptions.dryRun, options.DryRun, resetOptions.dryRun,
 		"Don't apply any changes; just output what would be done.",
+	)
+	flagSet.BoolVar(
+		&resetOptions.cleanupImages, options.CleanupImages, resetOptions.cleanupImages,
+		"Cleaning up all container images.",
 	)
 	flagSet.BoolVar(
 		&resetOptions.cleanupTmpDir, options.CleanupTmpDir, resetOptions.cleanupTmpDir,
@@ -221,6 +229,11 @@ func (r *resetData) Cfg() *kubeadmapi.InitConfiguration {
 // DryRun returns the dryRun flag.
 func (r *resetData) DryRun() bool {
 	return r.dryRun
+}
+
+// CleanupImages returns the cleanupImages flag.
+func (r *resetData) CleanupImages() bool {
+	return r.cleanupImages
 }
 
 // CleanupTmpDir returns the cleanupTmpDir flag.

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -220,6 +220,8 @@ const (
 	PullImageRetry = 5
 	// RemoveContainerRetry specifies how many times ContainerRuntime retries when removing container failed
 	RemoveContainerRetry = 5
+	// RemoveImageRetry specifies how many times ContainerRuntime retries when removing image failed
+	RemoveImageRetry = 5
 
 	// DefaultControlPlaneTimeout specifies the default control plane (actually API Server) timeout for use by kubeadm
 	DefaultControlPlaneTimeout = 4 * time.Minute

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -220,7 +220,7 @@ const (
 	PullImageRetry = 5
 	// RemoveContainerRetry specifies how many times ContainerRuntime retries when removing container failed
 	RemoveContainerRetry = 5
-	// RemoveImageRetry specifies how many times ContainerRuntime retries when removing image failed
+	// RemoveImageRetry specifies how many times ContainerRuntime retries when removing container image failed
 	RemoveImageRetry = 5
 
 	// DefaultControlPlaneTimeout specifies the default control plane (actually API Server) timeout for use by kubeadm

--- a/cmd/kubeadm/app/util/runtime/runtime_test.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_test.go
@@ -301,8 +301,9 @@ func TestRemoveImages(t *testing.T) {
 	fakeErr := func() ([]byte, []byte, error) { return []byte("error"), nil, &fakeexec.FakeExitError{Status: 1} }
 	fcmd := fakeexec.FakeCmd{
 		CombinedOutputScript: []fakeexec.FakeAction{
-			fakeErr, fakeErr, fakeErr, fakeErr, fakeOK, fakeErr, fakeErr, fakeErr, fakeErr, fakeOK,
-			fakeErr, fakeErr, fakeErr, fakeErr, fakeErr, fakeErr, fakeErr, fakeErr, fakeErr, fakeErr,
+			// If the remove fails, it will be retried 5 times (see RemoveImageRetry in constants/constants.go)
+			fakeErr, fakeErr, fakeErr, fakeErr, fakeOK, fakeErr, fakeErr, fakeErr, fakeErr, fakeOK, // Test case 1
+			fakeErr, fakeErr, fakeErr, fakeErr, fakeErr, fakeErr, fakeErr, fakeErr, fakeErr, fakeErr, // Test case 2
 		},
 	}
 	execer := fakeexec.FakeExec{
@@ -316,8 +317,8 @@ func TestRemoveImages(t *testing.T) {
 		images    []string
 		isError   bool
 	}{
-		{"valid: remove containers using CRI", "unix:///var/run/crio/crio.sock", []string{"image_1", "image_2"}, false},
-		{"invalid: CRI rmi failure", "unix:///var/run/crio/crio.sock", []string{"image_1", "image_2"}, true},
+		{"valid: remove containers using CRI", "unix:///var/run/crio/crio.sock", []string{"image_1", "image_2"}, false}, // Test case 1
+		{"invalid: CRI rmi failure", "unix:///var/run/crio/crio.sock", []string{"image_1", "image_2"}, true},            // Test case 2
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Currently, "kubeadm reset" does not provide an option to delete container images, so the user must manually delete the images.
This PR provides an option to cleaning up all container images.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: add the flag "--cleanup-images" for "kubeadm reset". It will cleaning up all container images. The flag is off by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

Signed-off-by: CaffeeLake <PascalCoffeeLake@gmail.com>
