### PR TITLE
Allow DBG=1 to be used with make release-images and make quick-release-images

### DIFF
--- a/build/release-images.sh
+++ b/build/release-images.sh
@@ -37,7 +37,7 @@ fi
 
 kube::build::verify_prereqs
 kube::build::build_image
-kube::build::run_build_command make all WHAT="${CMD_TARGETS}" KUBE_BUILD_PLATFORMS="${KUBE_SERVER_PLATFORMS[*]}"
+kube::build::run_build_command make all WHAT="${CMD_TARGETS}" KUBE_BUILD_PLATFORMS="${KUBE_SERVER_PLATFORMS[*]}" DBG="${DBG:-}"
 
 kube::build::copy_output
 

--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -361,9 +361,14 @@ define RELEASE_IMAGES_HELP_INFO
 #
 # Args:
 #   KUBE_BUILD_CONFORMANCE: Whether to build conformance testing image as well. Set to 'n' to skip.
+#   DBG: If set to "1", build with optimizations disabled for easier debugging. Any other value is ignored.
 #
 # Example:
 #   make release-images
+#   make release-images DBG=1
+#     Note: Specify DBG=1 for building unstripped binaries, which allows you to use code debugging
+#           tools like delve. When DBG is unspecified, it defaults to "-s -w" which strips debug
+#           information.
 endef
 .PHONY: release-images
 ifeq ($(PRINT_HELP),y)
@@ -405,9 +410,14 @@ define QUICK_RELEASE_IMAGES_HELP_INFO
 # Args:
 #   KUBE_FASTBUILD: Whether to cross-compile for other architectures. Set to 'false' to do so.
 #   KUBE_BUILD_CONFORMANCE: Whether to build conformance testing image as well. Set to 'y' to do so.
+#   DBG: If set to "1", build with optimizations disabled for easier debugging. Any other value is ignored.
 #
 # Example:
 #   make quick-release-images
+#   make quick-release-images DBG=1
+#     Note: Specify DBG=1 for building unstripped binaries, which allows you to use code debugging
+#           tools like delve. When DBG is unspecified, it defaults to "-s -w" which strips debug
+#           information.
 endef
 .PHONY: quick-release-images
 ifeq ($(PRINT_HELP),y)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Currently, you can [build binaries containing debug symbols using `make all DBG=1`](https://github.com/kubernetes/kubernetes/blob/a2a2d5c13b8524102896299ec8aec0372debcdf7/build/root/Makefile#L81-L84).

I would like to be able to do the same when building images using `make quick-release-images DBG=1`

This PR allows DBG to be passed to the build command when running `make quick-release-images`. It is optional, so the default behavior remains unchanged.

(Because they use the same script, this also enables `DBG=1` to be used with `make release-images`)

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
