### PR TITLE
Promote replaceCoreV1NamespaceFinalize +1 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -384,6 +384,14 @@
     MUST cause pods created by that RC to be orphaned.
   release: v1.9
   file: test/e2e/apimachinery/garbage_collector.go
+- testname: Namespace, apply finalizer to a namespace
+  codename: '[sig-api-machinery] Namespaces [Serial] should apply a finalizer to a
+    Namespace [Conformance]'
+  description: Attempt to create a Namespace which MUST be succeed. Updating the namespace
+    with a fake finalizer MUST succeed. The fake finalizer MUST be found. Removing
+    the fake finalizer from the namespace MUST succeed and MUST NOT be found.
+  release: v1.26
+  file: test/e2e/apimachinery/namespace.go
 - testname: Namespace, apply update to a namespace
   codename: '[sig-api-machinery] Namespaces [Serial] should apply an update to a Namespace
     [Conformance]'

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -383,7 +383,15 @@ var _ = SIGDescribe("Namespaces [Serial]", func() {
 		framework.Logf("Namespace %q now has labels, %#v", ns, updatedNamespace.Labels)
 	})
 
-	ginkgo.It("should apply a finalizer to a Namespace", func() {
+	/*
+		Release: v1.26
+		Testname: Namespace, apply finalizer to a namespace
+		Description: Attempt to create a Namespace which MUST be succeed.
+		Updating the namespace with a fake finalizer MUST succeed. The
+		fake finalizer MUST be found. Removing the fake finalizer from
+		the namespace MUST succeed and MUST NOT be found.
+	*/
+	framework.ConformanceIt("should apply a finalizer to a Namespace", func() {
 
 		fakeFinalizer := v1.FinalizerName("e2e.example.com/fakeFinalizer")
 		var updatedNamespace *v1.Namespace


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a conformance test to test the following untested endpoints:
- replaceCoreV1NamespaceFinalize

**Which issue(s) this PR fixes:**
Fixes #112890

**Testgrid Link:** 
[testgrid-link](https://testgrid.k8s.io/sig-api-machinery-gce-gke#gce-serial&graph-metrics=test-duration-minutes&width=20&include-filter-by-regex=should.apply.a.finalizer.to.a.Namespace)

**Special notes for your reviewer:**
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance