### PR TITLE
Promote test for ResourceQuota status to Conformance +3 Endpoints 

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -428,6 +428,20 @@
     MUST now include the new Label.
   release: v1.18
   file: test/e2e/apimachinery/namespace.go
+- testname: ResourceQuota, apply changes to a ResourceQuota status
+  codename: '[sig-api-machinery] ResourceQuota should apply changes to a resourcequota
+    status [Conformance]'
+  description: Attempt to create a ResourceQuota for CPU and Memory quota limits.
+    Creation MUST be successful. Updating the hard status values MUST succeed and
+    the new values MUST be found. The reported hard status values MUST equal the spec
+    hard values. Patching the spec hard values MUST succeed and the new values MUST
+    be found. Patching the hard status values MUST succeed. The reported hard status
+    values MUST equal the new spec hard values. Getting the /status MUST succeed and
+    the reported hard status values MUST equal the spec hard values. Repatching the
+    hard status values MUST succeed. The spec spec MUST NOT be changed when patching
+    /status.
+  release: v1.26
+  file: test/e2e/apimachinery/resource_quota.go
 - testname: ResourceQuota, update and delete
   codename: '[sig-api-machinery] ResourceQuota should be able to update and delete
     ResourceQuota. [Conformance]'

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -992,7 +992,22 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		}
 	})
 
-	ginkgo.It("should apply changes to a resourcequota status", func() {
+	/*
+		Release: v1.26
+		Testname: ResourceQuota, apply changes to a ResourceQuota status
+		Description: Attempt to create a ResourceQuota for CPU and Memory
+		quota limits. Creation MUST be successful. Updating the hard
+		status values MUST succeed and the new values MUST be found. The
+		reported hard status values MUST equal the spec hard values.
+		Patching the spec hard values MUST succeed and the new values MUST
+		be found. Patching the hard status values MUST succeed. The
+		reported hard status values MUST equal the new spec hard values.
+		Getting the /status MUST succeed and the reported hard status
+		values MUST equal the spec hard values. Repatching the hard status
+		values MUST succeed. The spec spec MUST NOT be changed when
+		patching /status.
+	*/
+	framework.ConformanceIt("should apply changes to a resourcequota status", func() {
 		ns := f.Namespace.Name
 		rqClient := f.ClientSet.CoreV1().ResourceQuotas(ns)
 		rqName := "e2e-rq-status-" + utilrand.String(5)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- patchCoreV1NamespacedResourceQuotaStatus
- replaceCoreV1NamespacedResourceQuotaStatus
- readCoreV1NamespacedResourceQuotaStatus

**Which issue(s) this PR fixes:**
Fixes #111956

**Testgrid Link:** 
[testgrid-link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.apply.changes.to.a.resourcequota.status)

**Special notes for your reviewer:**
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance
/priority important-soon