### PR TITLE
Remove misleading listType=map on CRD Validation rules

### DIFF
--- a/api/openapi-spec/v3/apis__apiextensions.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apiextensions.k8s.io__v1_openapi.json
@@ -709,13 +709,7 @@
               ],
               "default": {}
             },
-            "type": "array",
-            "x-kubernetes-list-map-keys": [
-              "rule"
-            ],
-            "x-kubernetes-list-type": "map",
-            "x-kubernetes-patch-merge-key": "rule",
-            "x-kubernetes-patch-strategy": "merge"
+            "type": "array"
           }
         },
         "type": "object"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -43983,16 +43983,6 @@ func schema_pkg_apis_apiextensions_v1_JSONSchemaProps(ref common.ReferenceCallba
 						},
 					},
 					"x-kubernetes-validations": {
-						VendorExtensible: spec.VendorExtensible{
-							Extensions: spec.Extensions{
-								"x-kubernetes-list-map-keys": []interface{}{
-									"rule",
-								},
-								"x-kubernetes-list-type":       "map",
-								"x-kubernetes-patch-merge-key": "rule",
-								"x-kubernetes-patch-strategy":  "merge",
-							},
-						},
 						SchemaProps: spec.SchemaProps{
 							Description: "x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.",
 							Type:        []string{"array"},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
@@ -552,10 +552,6 @@ message JSONSchemaProps {
 
   // x-kubernetes-validations describes a list of validation rules written in the CEL expression language.
   // This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.
-  // +patchMergeKey=rule
-  // +patchStrategy=merge
-  // +listType=map
-  // +listMapKey=rule
   repeated ValidationRule xKubernetesValidations = 44;
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go
@@ -164,10 +164,6 @@ type JSONSchemaProps struct {
 
 	// x-kubernetes-validations describes a list of validation rules written in the CEL expression language.
 	// This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.
-	// +patchMergeKey=rule
-	// +patchStrategy=merge
-	// +listType=map
-	// +listMapKey=rule
 	XValidations ValidationRules `json:"x-kubernetes-validations,omitempty" patchStrategy:"merge" patchMergeKey:"rule" protobuf:"bytes,44,rep,name=xKubernetesValidations"`
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go
@@ -164,7 +164,7 @@ type JSONSchemaProps struct {
 
 	// x-kubernetes-validations describes a list of validation rules written in the CEL expression language.
 	// This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.
-	XValidations ValidationRules `json:"x-kubernetes-validations,omitempty" patchStrategy:"merge" patchMergeKey:"rule" protobuf:"bytes,44,rep,name=xKubernetesValidations"`
+	XValidations ValidationRules `json:"x-kubernetes-validations,omitempty" protobuf:"bytes,44,rep,name=xKubernetesValidations"`
 }
 
 // ValidationRules describes a list of validation rules written in the CEL expression language.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Per https://github.com/kubernetes/kubernetes/pull/112883#discussion_r1007167949 the `listType=map` tags on CRD validation rules is not respected because it is nested under `spec.versions` which is marked as atomic. This change removes the tags, since they are not active and only serve to confuse API users.

#### Special notes for your reviewer:

From a system behavior point of view this is a no-op.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

