### PR TITLE
Add validation to avoid negative TerminationGracePeriodSeconds in pod.Spec

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -9764,6 +9764,8 @@ func TestValidatePod(t *testing.T) {
 		})
 	}
 
+	negativeTerminationGracePeriodSeconds := int64(-1)
+
 	errorCases := map[string]struct {
 		spec          core.Pod
 		expectedError string
@@ -9776,6 +9778,18 @@ func TestValidatePod(t *testing.T) {
 					RestartPolicy: core.RestartPolicyAlways,
 					DNSPolicy:     core.DNSClusterFirst,
 					Containers:    []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+				},
+			},
+		},
+		"bad terminationGracePeriodSeconds": {
+			expectedError: "spec.TerminationGracePeriodSeconds",
+			spec: core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "ns"},
+				Spec: core.PodSpec{
+					TerminationGracePeriodSeconds: &negativeTerminationGracePeriodSeconds,
+					RestartPolicy:                 core.RestartPolicyAlways,
+					DNSPolicy:                     core.DNSClusterFirst,
+					Containers:                    []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
goal:
Add validation to avoid negative TerminationGracePeriodSeconds in pod.Spec

for backwards compatibility :
1) we only add this non-negative validation for create pod process. 
2) we do not care about those already created pods with negative TerminationGracePeriodSeconds, since spec.TerminationGracePeriodSeconds is immutable (ps: allow it to be set to 1 if it was previously negative)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Yes, avoid negative TerminationGracePeriodSeconds in pod.Spec
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

/sig api-machinery