### PR TITLE
Promoting WindowsHostProcessContainers to stable

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -411,7 +411,6 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 		AllowInvalidPodDeletionCost: !utilfeature.DefaultFeatureGate.Enabled(features.PodDeletionCost),
 		// Do not allow pod spec to use non-integer multiple of huge page unit size default
 		AllowIndivisibleHugePagesValues: false,
-		AllowWindowsHostProcessField:    utilfeature.DefaultFeatureGate.Enabled(features.WindowsHostProcessContainers),
 		// Allow pod spec with expanded DNS configuration
 		AllowExpandedDNSConfig: utilfeature.DefaultFeatureGate.Enabled(features.ExpandedDNSConfig) || haveSameExpandedDNSConfig(podSpec, oldPodSpec),
 	}
@@ -426,8 +425,6 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 				return !opts.AllowDownwardAPIHugePages
 			})
 		}
-		// if old spec has Windows Host Process fields set, we must allow it
-		opts.AllowWindowsHostProcessField = opts.AllowWindowsHostProcessField || setsWindowsHostProcess(oldPodSpec)
 
 		// if old spec used non-integer multiple of huge page unit size, we must allow it
 		opts.AllowIndivisibleHugePagesValues = usesIndivisibleHugePagesValues(oldPodSpec)
@@ -745,29 +742,4 @@ func SeccompAnnotationForField(field *api.SeccompProfile) string {
 	// provided field type is SeccompProfileTypeLocalhost or if an unrecognized
 	// type is specified
 	return ""
-}
-
-// setsWindowsHostProcess returns true if WindowsOptions.HostProcess is set (true or false)
-// anywhere in the pod spec.
-func setsWindowsHostProcess(podSpec *api.PodSpec) bool {
-	if podSpec == nil {
-		return false
-	}
-
-	// Check Pod's WindowsOptions.HostProcess
-	if podSpec.SecurityContext != nil && podSpec.SecurityContext.WindowsOptions != nil && podSpec.SecurityContext.WindowsOptions.HostProcess != nil {
-		return true
-	}
-
-	// Check WindowsOptions.HostProcess for each container
-	inUse := false
-	VisitContainers(podSpec, AllContainers, func(c *api.Container, containerType ContainerType) bool {
-		if c.SecurityContext != nil && c.SecurityContext.WindowsOptions != nil && c.SecurityContext.WindowsOptions.HostProcess != nil {
-			inUse = true
-			return false
-		}
-		return true
-	})
-
-	return inUse
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -783,6 +783,7 @@ const (
 	// owner: @marosset
 	// alpha: v1.22
 	// beta: v1.23
+	// GA: v1.26
 	//
 	// Enables support for 'HostProcess' containers on Windows nodes.
 	WindowsHostProcessContainers featuregate.Feature = "WindowsHostProcessContainers"
@@ -1021,7 +1022,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	WinOverlay: {Default: true, PreRelease: featuregate.Beta},
 
-	WindowsHostProcessContainers: {Default: true, PreRelease: featuregate.Beta},
+	WindowsHostProcessContainers: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.28
 
 	NodeInclusionPolicyInPodTopologySpread: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -148,7 +148,7 @@ func (kl *Kubelet) makeBlockVolumes(pod *v1.Pod, container *v1.Container, podVol
 // - Windows pod contains a hostProcess container
 func shouldMountHostsFile(pod *v1.Pod, podIPs []string) bool {
 	shouldMount := len(podIPs) > 0
-	if runtime.GOOS == "windows" && utilfeature.DefaultFeatureGate.Enabled(features.WindowsHostProcessContainers) {
+	if runtime.GOOS == "windows" {
 		return shouldMount && !kubecontainer.HasWindowsHostProcessContainer(pod)
 	}
 	return shouldMount

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go
@@ -20,14 +20,11 @@ limitations under the License.
 package kuberuntime
 
 import (
-	"fmt"
 	"runtime"
 
 	v1 "k8s.io/api/core/v1"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/securitycontext"
 )
@@ -126,9 +123,6 @@ func (m *kubeGenericRuntimeManager) generateWindowsContainerConfig(container *v1
 	}
 
 	if securitycontext.HasWindowsHostProcessRequest(pod, container) {
-		if !utilfeature.DefaultFeatureGate.Enabled(features.WindowsHostProcessContainers) {
-			return nil, fmt.Errorf("pod contains HostProcess containers but feature 'WindowsHostProcessContainers' is not enabled")
-		}
 		wc.SecurityContext.HostProcess = true
 	}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_windows_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_windows_test.go
@@ -100,12 +100,4 @@ func TestApplyPlatformSpecificContainerConfig(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expectedWindowsConfig, containerConfig.Windows)
-
-	// Check if it fails if we require HostProcess but the feature is not enabled.
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsHostProcessContainers, false)()
-	err = fakeRuntimeSvc.applyPlatformSpecificContainerConfig(containerConfig, &pod.Spec.Containers[0], pod, new(int64), "foo", nil)
-	expectedErrMsg := "pod contains HostProcess containers but feature 'WindowsHostProcessContainers' is not enabled"
-	if err == nil || err.Error() != expectedErrMsg {
-		t.Errorf("expected error message `%s` but got `%v`", expectedErrMsg, err)
-	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -24,10 +24,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	runtimeutil "k8s.io/kubernetes/pkg/kubelet/kuberuntime/util"
 	"k8s.io/kubernetes/pkg/kubelet/types"
@@ -236,13 +234,6 @@ func (m *kubeGenericRuntimeManager) generatePodSandboxWindowsConfig(pod *v1.Pod)
 	// If all of the containers in a pod are HostProcess containers, set the pod's HostProcess field
 	// explicitly because the container runtime requires this information at sandbox creation time.
 	if kubecontainer.HasWindowsHostProcessContainer(pod) {
-		// Pods containing HostProcess containers should fail to schedule if feature is not
-		// enabled instead of trying to schedule containers as regular containers as stated in
-		// PRR review.
-		if !utilfeature.DefaultFeatureGate.Enabled(features.WindowsHostProcessContainers) {
-			return nil, fmt.Errorf("pod contains HostProcess containers but feature 'WindowsHostProcessContainers' is not enabled")
-		}
-
 		// At present Windows all containers in a Windows pod must be HostProcess containers
 		// and HostNetwork is required to be set.
 		if !kubecontainer.AllContainersAreWindowsHostProcess(pod) {

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -26,10 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
-	"k8s.io/kubernetes/pkg/features"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/runtimeclass"
 	rctest "k8s.io/kubernetes/pkg/kubelet/runtimeclass/testing"
@@ -182,15 +179,13 @@ func TestGeneratePodSandboxWindowsConfig(t *testing.T) {
 	falseVar := false
 
 	testCases := []struct {
-		name                      string
-		hostProcessFeatureEnabled bool
-		podSpec                   *v1.PodSpec
-		expectedWindowsConfig     *runtimeapi.WindowsPodSandboxConfig
-		expectedError             error
+		name                  string
+		podSpec               *v1.PodSpec
+		expectedWindowsConfig *runtimeapi.WindowsPodSandboxConfig
+		expectedError         error
 	}{
 		{
-			name:                      "Empty PodSecurityContext",
-			hostProcessFeatureEnabled: false,
+			name: "Empty PodSecurityContext",
 			podSpec: &v1.PodSpec{
 				Containers: []v1.Container{{
 					Name: containerName,
@@ -202,8 +197,7 @@ func TestGeneratePodSandboxWindowsConfig(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name:                      "GMSACredentialSpec in PodSecurityContext",
-			hostProcessFeatureEnabled: false,
+			name: "GMSACredentialSpec in PodSecurityContext",
 			podSpec: &v1.PodSpec{
 				SecurityContext: &v1.PodSecurityContext{
 					WindowsOptions: &v1.WindowsSecurityContextOptions{
@@ -222,8 +216,7 @@ func TestGeneratePodSandboxWindowsConfig(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name:                      "RunAsUserName in PodSecurityContext",
-			hostProcessFeatureEnabled: false,
+			name: "RunAsUserName in PodSecurityContext",
 			podSpec: &v1.PodSpec{
 				SecurityContext: &v1.PodSecurityContext{
 					WindowsOptions: &v1.WindowsSecurityContextOptions{
@@ -242,24 +235,7 @@ func TestGeneratePodSandboxWindowsConfig(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name:                      "Pod with HostProcess containers and feature gate disabled",
-			hostProcessFeatureEnabled: false,
-			podSpec: &v1.PodSpec{
-				SecurityContext: &v1.PodSecurityContext{
-					WindowsOptions: &v1.WindowsSecurityContextOptions{
-						HostProcess: &trueVar,
-					},
-				},
-				Containers: []v1.Container{{
-					Name: containerName,
-				}},
-			},
-			expectedWindowsConfig: nil,
-			expectedError:         fmt.Errorf("pod contains HostProcess containers but feature 'WindowsHostProcessContainers' is not enabled"),
-		},
-		{
-			name:                      "Pod with HostProcess containers and non-HostProcess containers",
-			hostProcessFeatureEnabled: true,
+			name: "Pod with HostProcess containers and non-HostProcess containers",
 			podSpec: &v1.PodSpec{
 				SecurityContext: &v1.PodSecurityContext{
 					WindowsOptions: &v1.WindowsSecurityContextOptions{
@@ -281,8 +257,7 @@ func TestGeneratePodSandboxWindowsConfig(t *testing.T) {
 			expectedError:         fmt.Errorf("pod must not contain both HostProcess and non-HostProcess containers"),
 		},
 		{
-			name:                      "Pod with HostProcess containers and HostNetwork not set",
-			hostProcessFeatureEnabled: true,
+			name: "Pod with HostProcess containers and HostNetwork not set",
 			podSpec: &v1.PodSpec{
 				SecurityContext: &v1.PodSecurityContext{
 					WindowsOptions: &v1.WindowsSecurityContextOptions{
@@ -297,8 +272,7 @@ func TestGeneratePodSandboxWindowsConfig(t *testing.T) {
 			expectedError:         fmt.Errorf("hostNetwork is required if Pod contains HostProcess containers"),
 		},
 		{
-			name:                      "Pod with HostProcess containers and HostNetwork set",
-			hostProcessFeatureEnabled: true,
+			name: "Pod with HostProcess containers and HostNetwork set",
 			podSpec: &v1.PodSpec{
 				HostNetwork: true,
 				SecurityContext: &v1.PodSecurityContext{
@@ -318,8 +292,7 @@ func TestGeneratePodSandboxWindowsConfig(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name:                      "Pod's WindowsOptions.HostProcess set to false and pod has HostProcess containers",
-			hostProcessFeatureEnabled: true,
+			name: "Pod's WindowsOptions.HostProcess set to false and pod has HostProcess containers",
 			podSpec: &v1.PodSpec{
 				HostNetwork: true,
 				SecurityContext: &v1.PodSecurityContext{
@@ -340,8 +313,7 @@ func TestGeneratePodSandboxWindowsConfig(t *testing.T) {
 			expectedError:         fmt.Errorf("pod must not contain any HostProcess containers if Pod's WindowsOptions.HostProcess is set to false"),
 		},
 		{
-			name:                      "Pod's security context doesn't specify HostProcess containers but Container's security context does",
-			hostProcessFeatureEnabled: true,
+			name: "Pod's security context doesn't specify HostProcess containers but Container's security context does",
 			podSpec: &v1.PodSpec{
 				HostNetwork: true,
 				Containers: []v1.Container{{
@@ -364,7 +336,6 @@ func TestGeneratePodSandboxWindowsConfig(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsHostProcessContainers, testCase.hostProcessFeatureEnabled)()
 			pod := &v1.Pod{}
 			pod.Spec = *testCase.podSpec
 

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -574,10 +574,8 @@ func Register(collectors ...metrics.StableCollector) {
 		legacyregistry.MustRegister(StartedPodsErrorsTotal)
 		legacyregistry.MustRegister(StartedContainersTotal)
 		legacyregistry.MustRegister(StartedContainersErrorsTotal)
-		if utilfeature.DefaultFeatureGate.Enabled(features.WindowsHostProcessContainers) {
-			legacyregistry.MustRegister(StartedHostProcessContainersTotal)
-			legacyregistry.MustRegister(StartedHostProcessContainersErrorsTotal)
-		}
+		legacyregistry.MustRegister(StartedHostProcessContainersTotal)
+		legacyregistry.MustRegister(StartedHostProcessContainersErrorsTotal)
 		legacyregistry.MustRegister(RunPodSandboxDuration)
 		legacyregistry.MustRegister(RunPodSandboxErrors)
 

--- a/test/integration/auth/podsecurity_test.go
+++ b/test/integration/auth/podsecurity_test.go
@@ -53,7 +53,6 @@ import (
 func TestPodSecurity(t *testing.T) {
 	// Enable all feature gates needed to allow all fields to be exercised
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ProcMountType, true)()
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsHostProcessContainers, true)()
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AppArmor, true)()
 	// Start server
 	server := startPodSecurityServer(t)
@@ -96,7 +95,6 @@ func TestPodSecurityGAOnly(t *testing.T) {
 func TestPodSecurityWebhook(t *testing.T) {
 	// Enable all feature gates needed to allow all fields to be exercised
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ProcMountType, true)()
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsHostProcessContainers, true)()
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AppArmor, true)()
 
 	// Start test API server.


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR sets the `WindowsHostProcessContainers` feature to stable

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/enhancements/issues/1981

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promoting WindowsHostProcessContainers to stable
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support
```

/sig windows