### PR TITLE
Add benchmark for large indexed job

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1230,7 +1230,7 @@ func (jm *Controller) removeTrackingFinalizerFromPods(ctx context.Context, jobKe
 					}
 					if !apierrors.IsNotFound(err) {
 						errCh <- err
-						utilruntime.HandleError(err)
+						utilruntime.HandleError(fmt.Errorf("removing tracking finalizer: %w", err))
 						return
 					}
 				}

--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -45,7 +45,7 @@ const (
 )
 
 // CreateNamespaceOrDie creates a namespace.
-func CreateNamespaceOrDie(c clientset.Interface, baseName string, t *testing.T) *v1.Namespace {
+func CreateNamespaceOrDie(c clientset.Interface, baseName string, t testing.TB) *v1.Namespace {
 	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: baseName}}
 	result, err := c.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
 	if err != nil {
@@ -55,7 +55,7 @@ func CreateNamespaceOrDie(c clientset.Interface, baseName string, t *testing.T) 
 }
 
 // DeleteNamespaceOrDie deletes a namespace.
-func DeleteNamespaceOrDie(c clientset.Interface, ns *v1.Namespace, t *testing.T) {
+func DeleteNamespaceOrDie(c clientset.Interface, ns *v1.Namespace, t testing.TB) {
 	err := c.CoreV1().Namespaces().Delete(context.TODO(), ns.Name, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Failed to delete namespace: %v", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add a benchmark at integration level to measure the performance of JobTrackingWithFinalizers

#### Which issue(s) this PR fixes:

Ref kubernetes/enhancements#2307

#### Special notes for your reviewer:

Test results, using 100 QPS for the job controller, and 200 qps for the test client.

```
cpu: Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GH

BenchmarkLargeIndexedJob/nPods=1000-56         	       1	19301690238 ns/op	1947668976 B/op	11732517 allocs/op
BenchmarkLargeIndexedJob/nPods=10000-56                     1	224971781074 ns/op	19479116856 B/op	117253793 allocs/op
```

The times translate to ~19sec and ~224s. This means that the job status updates add very little overhead and most of the API calls are pod creations and removal of finalizers.

I decided not to test 10^5 pods, as we can see that the runtime is linear and limited by the controller's QPS. We can safely deduce that it would take around 30min.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
