### PR TITLE
egress_selector.go: hard cap UDS dial.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -217,6 +217,9 @@ func (u *udsGRPCConnector) connect(_ context.Context) (proxier, error) {
 	// See https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/357.
 	tunnelCtx := context.TODO()
 	tunnel, err := client.CreateSingleUseGrpcTunnel(tunnelCtx, udsName, dialOption,
+		grpc.WithBlock(),
+		grpc.WithReturnConnectionError(),
+		grpc.WithTimeout(30*time.Second), // matches http.DefaultTransport dial timeout
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
egress_selector: Enforce a static connect() timeout.

We have seen clusters seem to fill up apiserver goroutines stuck on UDS dial. Admittedly this was with binaries older than https://github.com/kubernetes/kubernetes/pull/110079, which was using plain `net.Dial('unix', ...)`. Still, the `ctx` passed to connect is not as tight as we should have.


#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Incrementally improves https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/357


#### Special notes for your reviewer:

I have a more ambitious context cleanup: https://github.com/kubernetes/kubernetes/pull/110781, which may help clarify the different "levels" of dial going on (UDS, grpc, egress request, etc).

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
