### PR TITLE
Add Makefile target lint

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -338,6 +338,21 @@ vet:
 	hack/make-rules/vet.sh $(WHAT)
 endif
 
+define LINT_HELP_INFO
+# Run golangci-lint
+#
+# Example:
+#   make lint
+endef
+.PHONY: lint
+ifeq ($(PRINT_HELP),y)
+lint:
+	echo "$$LINT_HELP_INFO"
+else
+lint:
+	hack/verify-golangci-lint.sh
+endif
+
 define RELEASE_HELP_INFO
 # Build a release
 # Use the 'release-in-a-container' target to build the release when already in


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Adds Makefile target lint. It's a convenient and common target that many projects in the organization have. 

```
$ make lint
installing golangci-lint and logcheck plugin from hack/tools into /home/oscaru/go/src/kubernetes/kubernetes/_output/local/bin
running golangci-lint 
running golangci-lint for /home/oscaru/go/src/kube
(...)
```

```
$ make help
(...)
---------------------------------------------------------------------------------
lint
# Run golangci-lint
#
# Example:
#   make lint
---------------------------------------------------------------------------------
```


#### Does this PR introduce a user-facing change?
```release-note
NONE
```