### PR TITLE
[PSA] default warn to enforce level

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/admission/admission_test.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/admission_test.go
@@ -278,7 +278,7 @@ func TestValidateNamespace(t *testing.T) {
 			expectAllowed:    true,
 			expectListPods:   false,
 			expectWarnings: []string{
-				`namespace "test" is exempt from Pod Security, and the policy (enforce=restricted:latest, warn=restricted:latest) will be ignored`,
+				`namespace "test" is exempt from Pod Security, and the policy (enforce=restricted:latest) will be ignored`,
 			},
 		},
 		{
@@ -1180,7 +1180,7 @@ func TestExemptNamespaceWarning(t *testing.T) {
 			api.EnforceLevelLabel: string(api.LevelBaseline),
 		},
 		expectWarning:         true,
-		expectWarningContains: "(enforce=baseline:latest, warn=baseline:latest)",
+		expectWarningContains: "(enforce=baseline:latest)",
 	}, {
 		name: "warn-on-warn",
 		labels: map[string]string{
@@ -1206,7 +1206,7 @@ func TestExemptNamespaceWarning(t *testing.T) {
 		},
 		defaultPolicy:         baselinePolicy,
 		expectWarning:         true,
-		expectWarningContains: "(enforce=baseline:v1.23, audit=baseline:v1.23, warn=baseline:latest)",
+		expectWarningContains: "(warn=baseline:latest)",
 	}}
 
 	const (
@@ -1228,7 +1228,7 @@ func TestExemptNamespaceWarning(t *testing.T) {
 			policy, err := api.PolicyToEvaluate(labels, defaultPolicy)
 			require.NoError(t, err.ToAggregate())
 
-			warning := a.exemptNamespaceWarning(test.name, policy)
+			warning := a.exemptNamespaceWarning(test.name, policy, labels)
 			if !test.expectWarning {
 				assert.Empty(t, warning)
 				return

--- a/staging/src/k8s.io/pod-security-admission/admission/admission_test.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/admission_test.go
@@ -278,7 +278,7 @@ func TestValidateNamespace(t *testing.T) {
 			expectAllowed:    true,
 			expectListPods:   false,
 			expectWarnings: []string{
-				`namespace "test" is exempt from Pod Security, and the policy (enforce=restricted:latest) will be ignored`,
+				`namespace "test" is exempt from Pod Security, and the policy (enforce=restricted:latest, warn=restricted:latest) will be ignored`,
 			},
 		},
 		{
@@ -1180,7 +1180,7 @@ func TestExemptNamespaceWarning(t *testing.T) {
 			api.EnforceLevelLabel: string(api.LevelBaseline),
 		},
 		expectWarning:         true,
-		expectWarningContains: "(enforce=baseline:latest)",
+		expectWarningContains: "(enforce=baseline:latest, warn=baseline:latest)",
 	}, {
 		name: "warn-on-warn",
 		labels: map[string]string{

--- a/staging/src/k8s.io/pod-security-admission/api/helpers.go
+++ b/staging/src/k8s.io/pod-security-admission/api/helpers.go
@@ -161,35 +161,6 @@ func (p *Policy) String() string {
 	return fmt.Sprintf("enforce=%#v, audit=%#v, warn=%#v", p.Enforce, p.Audit, p.Warn)
 }
 
-// CompactString prints a minimalist representation of the policy that excludes any privileged
-// levels.
-func (p *Policy) CompactString() string {
-	sb := strings.Builder{}
-	if p.Enforce.Level != LevelPrivileged {
-		sb.WriteString("enforce=")
-		sb.WriteString(p.Enforce.String())
-	}
-	if p.Audit.Level != LevelPrivileged {
-		if sb.Len() > 0 {
-			sb.WriteString(", ")
-		}
-		sb.WriteString("audit=")
-		sb.WriteString(p.Audit.String())
-	}
-	if p.Warn.Level != LevelPrivileged {
-		if sb.Len() > 0 {
-			sb.WriteString(", ")
-		}
-		sb.WriteString("warn=")
-		sb.WriteString(p.Warn.String())
-	}
-	if sb.Len() == 0 {
-		// All modes were privileged, just output "privileged".
-		return string(LevelPrivileged)
-	}
-	return sb.String()
-}
-
 // Equivalent determines whether two policies are functionally equivalent. Policies are considered
 // equivalent if all 3 modes are considered equivalent.
 func (p *Policy) Equivalent(other *Policy) bool {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Goal: in most cases, setting just the pod-security enforce level on a namespace should give warning on workload resource creation & update, rather than requiring both warn & enforce to be set.

When the pod-security enforce level is set, but the warn version is not set (and the default is less-restrictive), then default the warn level to the enforce level.

I wasn't sure exactly what the right behavior was for the version, so I went with this:
- when defaulting warn to enforce, also default the warn-version to the enforce-version

If only `enforce` and `warn-version` but not `warn` is set, should `warn` still be defaulted? I went with yes, but kept the `warn-version`.

#### Special notes for your reviewer:

I think we've discussed this change in the past. The issue is that if a defaulting admission controller causes a workload to pass, then this could lead to erroneous warnings. This is not the common case, and can easily be bypassed by setting the `warn` level to `privileged` across all namespaces. I'd prefer to optimize for the common case here.

#### Does this PR introduce a user-facing change?
```release-note
Pod Security admission: the pod-security `warn` level will now default to the `enforce` level.
```

/sig auth security
/milestone v1.26

/assign @liggitt 