### PR TITLE
[WIP] add initial support for StorageVersion API for CRDs

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -35,6 +35,7 @@ import (
 	openapiv3controller "k8s.io/apiextensions-apiserver/pkg/controller/openapiv3"
 	"k8s.io/apiextensions-apiserver/pkg/controller/status"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition"
+	"k8s.io/apiextensions-apiserver/pkg/storageversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -49,6 +50,7 @@ import (
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/webhook"
+	"k8s.io/client-go/kubernetes"
 )
 
 var (
@@ -189,6 +191,18 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		delegate:  delegateHandler,
 	}
 	establishingController := establish.NewEstablishingController(s.Informers.Apiextensions().V1().CustomResourceDefinitions(), crdClient.ApiextensionsV1())
+
+	var storageVersionManager storageversion.Manager
+	if utilfeature.DefaultFeatureGate.Enabled(features.StorageVersionAPI) &&
+		utilfeature.DefaultFeatureGate.Enabled(features.APIServerIdentity) {
+		kubeclientset, err := kubernetes.NewForConfig(s.GenericAPIServer.LoopbackClientConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create clientset for storage versions: %v", err)
+		}
+		sc := kubeclientset.InternalV1alpha1().StorageVersions()
+		storageVersionManager = storageversion.NewManager(sc, c.GenericConfig.APIServerID)
+	}
+
 	crdHandler, err := NewCustomResourceDefinitionHandler(
 		versionDiscoveryHandler,
 		groupDiscoveryHandler,
@@ -205,6 +219,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		time.Duration(c.GenericConfig.MinRequestTimeout)*time.Second,
 		apiGroupInfo.StaticOpenAPISpec,
 		c.GenericConfig.MaxRequestBodyBytes,
+		storageVersionManager,
 	)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
@@ -510,7 +510,7 @@ func testHandlerConversion(t *testing.T, enableWatchCache bool) {
 		func(r webhook.AuthenticationInfoResolver) webhook.AuthenticationInfoResolver { return r },
 		1,
 		dummyAuthorizerImpl{},
-		time.Minute, time.Minute, nil, 3*1024*1024)
+		time.Minute, time.Minute, nil, 3*1024*1024, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager.go
@@ -1,0 +1,275 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	genericstorageversion "k8s.io/apiserver/pkg/storageversion"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// updateQueueBufferSize is the channel buffer size for each
+	// StorageVersion updateQueue. Since the storage version manager keeps
+	// one updateQueue for each CRD UID, this means each CRD may have at
+	// most 10 pending storage version updates in the queue. When a queue
+	// is full, new storage version updates will be dropped.
+	updateQueueBufferSize = 10
+)
+
+// Manager provides methods for updating StorageVersion for CRDs. It does
+// goroutine management to allow CRD storage version updates running in the
+// background and not blocking the caller.
+type Manager interface {
+	// EnqueueStorageVersionUpdate queues a StorageVesrion update for the given
+	// CRD and returns immediately. Optionally, the caller may specify a
+	// non-nil waitCh and/or a non-nil processedCh.
+	// A non-nil waitCh will block the StorageVersion update until waitCh is
+	// closed.
+	// The manager will close the non-nil processedCh if it finished
+	// processing the StorageVersion update (note that the update can either
+	// succeeded or failed).
+	EnqueueStorageVersionUpdate(crd *apiextensionsv1.CustomResourceDefinition,
+		waitCh <-chan struct{}, processedCh chan<- struct{})
+	// TeardownFor aborts all pending updates for the given CRD UID, and
+	// stops the corresponding goroutine.
+	TeardownFor(uid types.UID)
+}
+
+// update represents one CRD StorageVersion update request that needs to be processed.
+type update struct {
+	crd *apiextensionsv1.CustomResourceDefinition
+	// If non-nil, wait for the channel to be closed before processing the update.
+	waitCh <-chan struct{}
+	// If non-nil, close the channel after the update process is finished.
+	processedCh chan<- struct{}
+}
+
+// updateQueue is a queue of StorageVersion updates. Upon creation, a goroutine
+// is also created which keeps processing pending updates in the queue, until
+// the queue is closed.
+type updateQueue struct {
+	// q is the actual queue. A user can send StorageVersion updates to the
+	// queue. A goroutine runs in the background keeps processing the
+	// pending updates and doing the actual work, until the queue is closed.
+	q chan<- *update
+	// All the updates in the queue share the same context. Calling cancel
+	// aborts all the pending updates in the queue. This function is used
+	// when a CRD is deleted and we want to release all the associated
+	// resources (channel and goroutine). The caller should also close q to
+	// stop the background goroutine.
+	cancel context.CancelFunc
+}
+
+// manager implements the Manager interface.
+type manager struct {
+	// lock protects updateQueues from concurrent writes, and protects
+	// individual queues from concurrent write and close().
+	lock sync.Mutex
+	// updateQueues holds a CRD UID to updateQueue map. Each CRD has its
+	// own queue of StorageVersion updates, and a goroutine which processes
+	// the pending updates in the queue. The manager sends update requests
+	// to the queue.
+	updateQueues map[types.UID]*updateQueue
+	// client is the client interface that manager uses to update
+	// StorageVersion objects.
+	client genericstorageversion.Client
+	// apiserverID is the ID of the apiserver that invokes this manager.
+	apiserverID string
+}
+
+// NewManager creates a CRD StorageVersion Manager.
+func NewManager(client genericstorageversion.Client, apiserverID string) Manager {
+	return &manager{
+		updateQueues: make(map[types.UID]*updateQueue),
+		client:       client,
+		apiserverID:  apiserverID,
+	}
+}
+
+// EnqueueStorageVersionUpdate queues a StorageVesrion update for the given
+// CRD and returns immediately. Optionally, the caller may specify a
+// non-nil waitCh and/or a non-nil processedCh.
+// A non-nil waitCh will block the StorageVersion update until waitCh is
+// closed.
+// The manager will close the non-nil processedCh if it finished
+// processing the StorageVersion update (note that the update can either
+// succeeded or failed).
+func (m *manager) EnqueueStorageVersionUpdate(crd *apiextensionsv1.CustomResourceDefinition,
+	waitCh <-chan struct{}, processedCh chan<- struct{}) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	q := m.getOrCreateUpdateQueueLocked(crd.UID)
+	// When the channel buffer is full, writing to the channel becomes
+	// blocking. Here we give up updating storage version for this CRD and
+	// print a log, so that we can return immediately and not block the
+	// caller.
+	if len(q) == updateQueueBufferSize {
+		// TODO(roycaihw): use warning instead of info when StorageVersionAPI
+		// graduates to beta/GA
+		klog.V(2).Infof("Skipping the storage version update for CRD with UID %v due to the queue being full (queue size: %v).",
+			crd.UID, updateQueueBufferSize)
+		if processedCh != nil {
+			close(processedCh)
+		}
+		return
+	}
+	// m.lock ensures we won't write to a closed queue.
+	q <- &update{
+		crd:         crd,
+		waitCh:      waitCh,
+		processedCh: processedCh,
+	}
+}
+
+// getOrCreateUpdateQueueLocked returns the channel for the given UID, or create a new
+// one and a new goroutine if necessary. The goroutine keeps processing updates
+// until the channel is closed. The caller should hold the manager's lock.
+func (m *manager) getOrCreateUpdateQueueLocked(uid types.UID) chan<- *update {
+	if queue, ok := m.updateQueues[uid]; ok {
+		return queue.q
+	}
+
+	queue := make(chan *update, updateQueueBufferSize)
+	ctx, cancel := context.WithCancel(context.TODO())
+	m.updateQueues[uid] = &updateQueue{
+		q:      queue,
+		cancel: cancel,
+	}
+	go func() {
+		defer func() {
+			err := recover()
+			if err != nil {
+				// Log the panic and teardown the queue, so
+				// that the manager can restart a new queue.
+				utilruntime.HandleError(fmt.Errorf("panic observed in CRD storage version update queue %v: %v", uid, err))
+				m.TeardownFor(uid)
+			}
+		}()
+		for update := range queue {
+			select {
+			case <-ctx.Done():
+				// The queue was cancelled. Abort the update.
+				if update.processedCh != nil {
+					close(update.processedCh)
+				}
+				continue
+			default:
+			}
+
+			// TODO(roycaihw): there are two types of updates:
+			//   1) the ones with nil processedCh, requested by
+			//      watch events handler
+			//   2) the ones with non-nil processedCh, requested
+			//      by newly-created CRD storage
+			// An update of type 1) can be merged with a consecutive update,
+			// where the latter update's storage version is honored, and both
+			// updates' waitChs get evaluated.
+			if update.waitCh != nil {
+				<-update.waitCh
+			}
+			if err := m.updateCRDStorageVersion(ctx, update.crd); err != nil {
+				utilruntime.HandleError(err)
+			}
+			if update.processedCh != nil {
+				close(update.processedCh)
+			}
+		}
+	}()
+	return queue
+}
+
+// TeardownFor closes the channel for the given UID. It ensures that we don't
+// leak goroutines.
+func (m *manager) TeardownFor(uid types.UID) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if queue, ok := m.updateQueues[uid]; ok {
+		// Cancel all the pending updates, so that if the CRD is
+		// re-created, the old updates won't race with the new updates.
+		// We can safely discard the old storage version updates
+		// because:
+		//   1. if the CRD is deleted forever, all CRs will be GC'ed and
+		//      the storage version doesn't matter.
+		//   2. if the CRD gets deleted and re-created in a short period
+		//      and the old CRs remain, the new CRD will update new
+		//      storage version.
+		klog.V(4).Infof("Cancelling the storage version update queue for CRD with UID %v.",
+			uid)
+		queue.cancel()
+		// Since writers to the queue acquire the same lock as we do, we
+		// make sure no one can write to a closed queue.
+		close(queue.q)
+		delete(m.updateQueues, uid)
+	}
+}
+
+func (m *manager) updateCRDStorageVersion(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) error {
+	gr := schema.GroupResource{
+		Group:    crd.Spec.Group,
+		Resource: crd.Spec.Names.Plural,
+	}
+	storageVersion, err := apiextensionshelpers.GetCRDStorageVersion(crd)
+	if err != nil {
+		// This should never happened if crd is valid, which is true since we
+		// only update storage version for CRDs that have been written to the
+		// storage.
+		return err
+	}
+
+	encodingVersion := crd.Spec.Group + "/" + storageVersion
+	var decodableVersions []string
+	for _, v := range crd.Spec.Versions {
+		decodableVersions = append(decodableVersions, crd.Spec.Group+"/"+v.Name)
+	}
+
+	appendOwnerRefFunc := func(sv *apiserverinternalv1alpha1.StorageVersion) error {
+		ref := metav1.OwnerReference{
+			APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+			Kind:       "CustomResourceDefinition",
+			Name:       crd.Name,
+			UID:        crd.UID,
+		}
+		for _, r := range sv.OwnerReferences {
+			if r == ref {
+				return nil
+			}
+		}
+		sv.OwnerReferences = append(sv.OwnerReferences, ref)
+		return nil
+	}
+	return genericstorageversion.UpdateStorageVersionFor(
+		ctx,
+		m.client,
+		m.apiserverID,
+		gr,
+		encodingVersion,
+		decodableVersions,
+		appendOwnerRefFunc,
+		true)
+}

--- a/staging/src/k8s.io/apiserver/pkg/storageversion/manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/storageversion/manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package storageversion
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -143,7 +144,7 @@ func (s *defaultManager) UpdateStorageVersions(kubeAPIServerClientConfig *rest.C
 		if len(gr.Group) == 0 {
 			gr.Group = "core"
 		}
-		if err := updateStorageVersionFor(sc, serverID, gr, r.EncodingVersion, decodableVersions); err != nil {
+		if err := UpdateStorageVersionFor(context.TODO(), sc, serverID, gr, r.EncodingVersion, decodableVersions, nil, false); err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to update storage version for %v: %v", r.GroupResource, err))
 			s.recordStatusFailure(&r, err)
 			hasFailure = true

--- a/staging/src/k8s.io/apiserver/pkg/storageversion/updater.go
+++ b/staging/src/k8s.io/apiserver/pkg/storageversion/updater.go
@@ -22,11 +22,14 @@ import (
 	"time"
 
 	"k8s.io/api/apiserverinternal/v1alpha1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 )
+
+type processStorageVersionFunc func(*v1alpha1.StorageVersion) error
 
 // Client has the methods required to update the storage version.
 type Client interface {
@@ -122,13 +125,23 @@ func setStatusCondition(conditions *[]v1alpha1.StorageVersionCondition, newCondi
 	existingCondition.ObservedGeneration = newCondition.ObservedGeneration
 }
 
-// updateStorageVersionFor updates the storage version object for the resource.
-func updateStorageVersionFor(c Client, apiserverID string, gr schema.GroupResource, encodingVersion string, decodableVersions []string) error {
+// UpdateStorageVersionFor updates the storage version object for the resource.
+// postProcessFunc is invoked on the storage version object after the local
+// calulation is finished, and before the client sends the create/update request.
+// It allows the caller to customizes the storage version object, e.g. setting
+// an owner reference.
+func UpdateStorageVersionFor(ctx context.Context, c Client, apiserverID string, gr schema.GroupResource, encodingVersion string, decodableVersions []string, postProcessFunc processStorageVersionFunc, alwaysRetry bool) error {
 	retries := 3
 	var retry int
 	var err error
-	for retry < retries {
-		err = singleUpdate(c, apiserverID, gr, encodingVersion, decodableVersions)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		err = singleUpdate(ctx, c, apiserverID, gr, encodingVersion, decodableVersions, postProcessFunc)
 		if err == nil {
 			return nil
 		}
@@ -141,14 +154,17 @@ func updateStorageVersionFor(c Client, apiserverID string, gr schema.GroupResour
 			retry++
 			time.Sleep(1 * time.Second)
 		}
+		if !alwaysRetry && retry >= retries {
+			break
+		}
 	}
 	return err
 }
 
-func singleUpdate(c Client, apiserverID string, gr schema.GroupResource, encodingVersion string, decodableVersions []string) error {
+func singleUpdate(ctx context.Context, c Client, apiserverID string, gr schema.GroupResource, encodingVersion string, decodableVersions []string, postProcessFunc processStorageVersionFunc) error {
 	shouldCreate := false
 	name := fmt.Sprintf("%s.%s", gr.Group, gr.Resource)
-	sv, err := c.Get(context.TODO(), name, metav1.GetOptions{})
+	sv, err := c.Get(ctx, name, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
@@ -157,18 +173,28 @@ func singleUpdate(c Client, apiserverID string, gr schema.GroupResource, encodin
 		sv = &v1alpha1.StorageVersion{}
 		sv.ObjectMeta.Name = name
 	}
+	svCopy := sv.DeepCopy()
 	updatedSV := localUpdateStorageVersion(sv, apiserverID, encodingVersion, decodableVersions)
+	if postProcessFunc != nil {
+		if err := postProcessFunc(updatedSV); err != nil {
+			return err
+		}
+	}
 	if shouldCreate {
-		createdSV, err := c.Create(context.TODO(), updatedSV, metav1.CreateOptions{})
+		createdSV, err := c.Create(ctx, updatedSV, metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
 		// assign the calculated status to the object just created, then update status
 		createdSV.Status = updatedSV.Status
-		_, err = c.UpdateStatus(context.TODO(), createdSV, metav1.UpdateOptions{})
+		_, err = c.UpdateStatus(ctx, createdSV, metav1.UpdateOptions{})
 		return err
 	}
-	_, err = c.UpdateStatus(context.TODO(), updatedSV, metav1.UpdateOptions{})
+	if apiequality.Semantic.DeepEqual(svCopy, updatedSV) {
+		klog.V(6).Infof("Ignoring storageversion %s update because nothing changed", name)
+		return nil
+	}
+	_, err = c.UpdateStatus(ctx, updatedSV, metav1.UpdateOptions{})
 	return err
 }
 

--- a/test/integration/storageversion/storage_version_crd_test.go
+++ b/test/integration/storageversion/storage_version_crd_test.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/etcd"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestStorageVersionCustomResource(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()
+	etcdConfig := framework.SharedEtcd()
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil,
+		[]string{
+			"--runtime-config=internal.apiserver.k8s.io/v1alpha1=true",
+		},
+		etcdConfig)
+	crdClient := apiextensionsclientset.NewForConfigOrDie(server.ClientConfig)
+	crd := etcd.GetCustomResourceDefinitionData()[0]
+	etcd.CreateTestCRDs(t, crdClient, false, crd)
+	defer server.TearDownFn()
+
+	kubeclient := kubernetes.NewForConfigOrDie(server.ClientConfig)
+	gr := crd.Spec.Group + "." + crd.Spec.Names.Plural
+	createdCRD, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get crd: %v", err)
+	}
+
+	var lastErr error
+	var storageVersion apiserverinternalv1alpha1.ServerStorageVersion
+	if err := wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+		sv, err := kubeclient.InternalV1alpha1().StorageVersions().Get(context.TODO(), gr, metav1.GetOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get storage version: %v", err)
+			return false, nil
+		}
+		ref := metav1.OwnerReference{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+			Name:       createdCRD.Name,
+			UID:        createdCRD.UID,
+		}
+		if len(sv.OwnerReferences) == 0 || sv.OwnerReferences[0] != ref {
+			return false, fmt.Errorf("apiserver failed to set crd owner references, expect: %v, got: %v", ref, sv.OwnerReferences)
+		}
+		if len(sv.Status.StorageVersions) != 1 {
+			lastErr = fmt.Errorf("apiserver failed to set one storage version record in the status, got: %v", sv.Status.StorageVersions)
+			return false, nil
+		}
+		storageVersion = sv.Status.StorageVersions[0]
+		return true, nil
+	}); err != nil {
+		t.Fatalf("failed to wait for storage version creation: %v, last error: %v", err, lastErr)
+	}
+
+	if !strings.HasPrefix(storageVersion.APIServerID, "kube-apiserver-") {
+		t.Errorf("apiserver ID doesn't contain kube-apiserver- prefix, has: %v", storageVersion.APIServerID)
+	}
+	expectecdVersion := crd.Spec.Group + "/" + crd.Spec.Versions[0].Name
+	if storageVersion.EncodingVersion != expectecdVersion {
+		t.Errorf("unexpected encoding version, expected: %v, got: %v", expectecdVersion, storageVersion.EncodingVersion)
+	}
+	if len(storageVersion.DecodableVersions) != 1 {
+		t.Errorf("unexpected number of decodable versions, expected 1 version, got: %v", storageVersion.DecodableVersions)
+	}
+	if storageVersion.DecodableVersions[0] != expectecdVersion {
+		t.Errorf("unexpected decodable version, expected %v, got: %v", expectecdVersion, storageVersion.DecodableVersions[0])
+	}
+
+	// add a new version v2 to the CRD and make it the storage version
+	newVersion := createdCRD.Spec.Versions[0]
+	newVersion.Name = "v2"
+	createdCRD.Spec.Versions[0].Storage = false
+	createdCRD.Spec.Versions = append(createdCRD.Spec.Versions, newVersion)
+	if _, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), createdCRD, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("failed to update crd: %v", err)
+	}
+
+	expectedNewVersion := crd.Spec.Group + "/" + newVersion.Name
+	expectedDecodableVersions := []string{expectecdVersion, expectedNewVersion}
+	lastErr = nil
+	if err := wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+		sv, err := kubeclient.InternalV1alpha1().StorageVersions().Get(context.TODO(), gr, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		storageVersion := sv.Status.StorageVersions[0]
+		if len(storageVersion.DecodableVersions) != 2 {
+			lastErr = fmt.Errorf("unexpected number of decodable versions, expected 2 versions, got: %v", sv.Status.StorageVersions)
+			return false, nil
+		}
+		if !reflect.DeepEqual(storageVersion.DecodableVersions, expectedDecodableVersions) {
+			lastErr = fmt.Errorf("unexpected decodable versions, expected %v, got: %v", expectedDecodableVersions, storageVersion.DecodableVersions)
+			return false, nil
+		}
+		if storageVersion.EncodingVersion != expectedNewVersion {
+			lastErr = fmt.Errorf("unexpected encoding version, expected: %v, got: %v", expectedNewVersion, storageVersion.EncodingVersion)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("failed to wait for storage version update: %v, last error: %v", err, lastErr)
+	}
+
+	// cleanup
+	if err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete crd: %v", err)
+	}
+	if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(context.TODO(), gr, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete storage version: %v", err)
+	}
+}
+
+func TestStorageVersionMultipleCRDs(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()
+	etcdConfig := framework.SharedEtcd()
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil,
+		[]string{
+			"--runtime-config=internal.apiserver.k8s.io/v1alpha1=true",
+		},
+		etcdConfig)
+	crdClient := apiextensionsclientset.NewForConfigOrDie(server.ClientConfig)
+	crd := etcd.GetCustomResourceDefinitionData()[0]
+	etcd.CreateTestCRDs(t, crdClient, false, crd)
+	defer server.TearDownFn()
+	dynamicClient, err := dynamic.NewForConfig(server.ClientConfig)
+	if err != nil {
+		t.Fatalf("unexpected error creating dynamic client: %v", err)
+	}
+	gvr := schema.GroupVersionResource{Group: crd.Spec.Group, Version: crd.Spec.Versions[0].Name, Resource: crd.Spec.Names.Plural}
+
+	errCh := make(chan error)
+	// keep flipping the storage version of the CRD and create new CRs
+	go func() {
+		for i := 0; i < 10; i++ {
+			createdCRD, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+			if err != nil {
+				errCh <- fmt.Errorf("failed to get crd: %v", err)
+				return
+			}
+
+			// add a new version to the CRD and set it as the storage version
+			newVersion := createdCRD.Spec.Versions[i]
+			newVersion.Name = fmt.Sprintf("v%d", i+2)
+			createdCRD.Spec.Versions[i].Storage = false
+			createdCRD.Spec.Versions = append(createdCRD.Spec.Versions, newVersion)
+			if _, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), createdCRD, metav1.UpdateOptions{}); err != nil {
+				errCh <- fmt.Errorf("failed to update crd: %v", err)
+				return
+			}
+			cr := &unstructured.Unstructured{}
+			cr.SetName(newVersion.Name)
+			cr.SetAPIVersion(fmt.Sprintf("%s/v1", crd.Spec.Group))
+			cr.SetKind(crd.Spec.Names.Kind)
+			if _, err = dynamicClient.Resource(gvr).Namespace("default").Create(context.TODO(), cr, metav1.CreateOptions{}); err != nil {
+				errCh <- fmt.Errorf("unexpected error creating cr for version %v: %v", newVersion.Name, err)
+				return
+			}
+		}
+	}()
+
+	// verify new CRD creation is not blocked by storage version update of the first CRD
+	newCRD := etcd.GetCustomResourceDefinitionData()[1]
+	etcd.CreateTestCRDs(t, crdClient, false, newCRD)
+
+	// verify that the storage version of the first CRD eventually stablize to the expected version
+	kubeclient := kubernetes.NewForConfigOrDie(server.ClientConfig)
+	gr := crd.Spec.Group + "." + crd.Spec.Names.Plural
+	var lastErr error
+	if err := wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+		select {
+		case err := <-errCh:
+			return false, err
+		default:
+		}
+
+		sv, err := kubeclient.InternalV1alpha1().StorageVersions().Get(context.TODO(), gr, metav1.GetOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get storage version: %v", err)
+			return false, nil
+		}
+		if len(sv.Status.StorageVersions) != 1 {
+			lastErr = fmt.Errorf("apiserver failed to set one storage version record in the status, got: %v", sv.Status.StorageVersions)
+			return false, nil
+		}
+		storageVersion := sv.Status.StorageVersions[0]
+		if len(storageVersion.DecodableVersions) != 11 {
+			lastErr = fmt.Errorf("unexpected number of decodable versions, expected 11 versions, got: %v", sv.Status.StorageVersions)
+			return false, nil
+		}
+		expectedNewVersion := fmt.Sprintf("%s/v11", crd.Spec.Group)
+		if storageVersion.EncodingVersion != expectedNewVersion {
+			lastErr = fmt.Errorf("unexpected encoding version, expected: %v, got: %v", expectedNewVersion, storageVersion.EncodingVersion)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Errorf("failed to wait for storage version update: %v, last error: %v", err, lastErr)
+	}
+
+	// cleanup
+	if err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete crd: %v", err)
+	}
+	if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(context.TODO(), gr, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete storage version: %v", err)
+	}
+	if err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), newCRD.Name, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete crd: %v", err)
+	}
+	gr = newCRD.Spec.Group + "." + newCRD.Spec.Names.Plural
+	if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(context.TODO(), gr, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete storage version: %v", err)
+	}
+
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1355,6 +1355,7 @@ k8s.io/apiextensions-apiserver/pkg/generated/openapi
 k8s.io/apiextensions-apiserver/pkg/registry/customresource
 k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor
 k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition
+k8s.io/apiextensions-apiserver/pkg/storageversion
 k8s.io/apiextensions-apiserver/test/integration
 k8s.io/apiextensions-apiserver/test/integration/fixtures
 # k8s.io/apimachinery v0.0.0 => ./staging/src/k8s.io/apimachinery


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>
Co-authored-by: Haowei Cai (Roy) <haoweic@google.com>

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR is based off of https://github.com/kubernetes/kubernetes/pull/96403, but rebased off of master. Implementation still needs a lot of work, opening the PR now to get more feedback and run CI against the changes.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
add initial support for StorageVersion API for CRDs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
