### PR TITLE
kubelet: fix nil pointer in startReflector for standalone mode

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -128,8 +128,8 @@ const (
 	// nodeStatusUpdateRetry specifies how many times kubelet retries when posting node status failed.
 	nodeStatusUpdateRetry = 5
 
-	// ContainerLogsDir is the location of container logs.
-	ContainerLogsDir = "/var/log/containers"
+	// DefaultContainerLogsDir is the location of container logs.
+	DefaultContainerLogsDir = "/var/log/containers"
 
 	// MaxContainerBackOff is the max backoff period, exported for the e2e test
 	MaxContainerBackOff = 300 * time.Second
@@ -181,7 +181,11 @@ const (
 	nodeLeaseRenewIntervalFraction = 0.25
 )
 
-var etcHostsPath = getContainerEtcHostsPath()
+var (
+	// ContainerLogsDir can be overwrited for testing usage
+	ContainerLogsDir = DefaultContainerLogsDir
+	etcHostsPath     = getContainerEtcHostsPath()
+)
 
 func getContainerEtcHostsPath() string {
 	if sysruntime.GOOS == "windows" {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -550,24 +550,26 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 
 	var secretManager secret.Manager
 	var configMapManager configmap.Manager
-	switch kubeCfg.ConfigMapAndSecretChangeDetectionStrategy {
-	case kubeletconfiginternal.WatchChangeDetectionStrategy:
-		secretManager = secret.NewWatchingSecretManager(kubeDeps.KubeClient, klet.resyncInterval)
-		configMapManager = configmap.NewWatchingConfigMapManager(kubeDeps.KubeClient, klet.resyncInterval)
-	case kubeletconfiginternal.TTLCacheChangeDetectionStrategy:
-		secretManager = secret.NewCachingSecretManager(
-			kubeDeps.KubeClient, manager.GetObjectTTLFromNodeFunc(klet.GetNode))
-		configMapManager = configmap.NewCachingConfigMapManager(
-			kubeDeps.KubeClient, manager.GetObjectTTLFromNodeFunc(klet.GetNode))
-	case kubeletconfiginternal.GetChangeDetectionStrategy:
-		secretManager = secret.NewSimpleSecretManager(kubeDeps.KubeClient)
-		configMapManager = configmap.NewSimpleConfigMapManager(kubeDeps.KubeClient)
-	default:
-		return nil, fmt.Errorf("unknown configmap and secret manager mode: %v", kubeCfg.ConfigMapAndSecretChangeDetectionStrategy)
-	}
+	if klet.kubeClient != nil {
+		switch kubeCfg.ConfigMapAndSecretChangeDetectionStrategy {
+		case kubeletconfiginternal.WatchChangeDetectionStrategy:
+			secretManager = secret.NewWatchingSecretManager(klet.kubeClient, klet.resyncInterval)
+			configMapManager = configmap.NewWatchingConfigMapManager(klet.kubeClient, klet.resyncInterval)
+		case kubeletconfiginternal.TTLCacheChangeDetectionStrategy:
+			secretManager = secret.NewCachingSecretManager(
+				klet.kubeClient, manager.GetObjectTTLFromNodeFunc(klet.GetNode))
+			configMapManager = configmap.NewCachingConfigMapManager(
+				klet.kubeClient, manager.GetObjectTTLFromNodeFunc(klet.GetNode))
+		case kubeletconfiginternal.GetChangeDetectionStrategy:
+			secretManager = secret.NewSimpleSecretManager(klet.kubeClient)
+			configMapManager = configmap.NewSimpleConfigMapManager(klet.kubeClient)
+		default:
+			return nil, fmt.Errorf("unknown configmap and secret manager mode: %v", kubeCfg.ConfigMapAndSecretChangeDetectionStrategy)
+		}
 
-	klet.secretManager = secretManager
-	klet.configMapManager = configMapManager
+		klet.secretManager = secretManager
+		klet.configMapManager = configMapManager
+	}
 
 	if klet.experimentalHostUserNamespaceDefaulting {
 		klog.InfoS("Experimental host user namespace defaulting is enabled")

--- a/pkg/kubelet/oom/oom_watcher_linux.go
+++ b/pkg/kubelet/oom/oom_watcher_linux.go
@@ -46,6 +46,12 @@ var _ Watcher = &realWatcher{}
 // NewWatcher creates and initializes a OOMWatcher backed by Cadvisor as
 // the oom streamer.
 func NewWatcher(recorder record.EventRecorder) (Watcher, error) {
+	// for test purpose
+	_, ok := recorder.(*record.FakeRecorder)
+	if ok {
+		return nil, nil
+	}
+
 	oomStreamer, err := oomparser.New()
 	if err != nil {
 		return nil, err

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -261,7 +261,7 @@ func (kvh *kubeletVolumeHost) GetSecretFunc() func(namespace, name string) (*v1.
 		return kvh.secretManager.GetSecret
 	}
 	return func(namespace, name string) (*v1.Secret, error) {
-		return nil, fmt.Errorf("not supported")
+		return nil, fmt.Errorf("not supported due to running kubelet in standalone mode")
 	}
 }
 
@@ -270,7 +270,7 @@ func (kvh *kubeletVolumeHost) GetConfigMapFunc() func(namespace, name string) (*
 		return kvh.configMapManager.GetConfigMap
 	}
 	return func(namespace, name string) (*v1.ConfigMap, error) {
-		return nil, fmt.Errorf("not supported")
+		return nil, fmt.Errorf("not supported due to running kubelet in standalone mode")
 	}
 }
 

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -257,11 +257,21 @@ func (kvh *kubeletVolumeHost) GetNodeAllocatable() (v1.ResourceList, error) {
 }
 
 func (kvh *kubeletVolumeHost) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return kvh.secretManager.GetSecret
+	if kvh.secretManager != nil {
+		return kvh.secretManager.GetSecret
+	}
+	return func(namespace, name string) (*v1.Secret, error) {
+		return nil, fmt.Errorf("not supported")
+	}
 }
 
 func (kvh *kubeletVolumeHost) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
-	return kvh.configMapManager.GetConfigMap
+	if kvh.configMapManager != nil {
+		return kvh.configMapManager.GetConfigMap
+	}
+	return func(namespace, name string) (*v1.ConfigMap, error) {
+		return nil, fmt.Errorf("not supported")
+	}
 }
 
 func (kvh *kubeletVolumeHost) GetServiceAccountTokenFunc() func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
1. The `startReflector` was introduced in https://github.com/kubernetes/kubernetes/pull/99393 @chenyw1990 since v1.21
2. https://github.com/kubernetes/kubernetes/pull/110138 fixed a goroutine leak in it @wojtek-t 
3. This PR focus on NPE fix.

#### Which issue(s) this PR fixes:

Fixes #113492

#### Special notes for your reviewer:
```
2022-10-31T20:00:48+0000 gke-b27bb59e05314f15b662-a7f3-3599-vm kubelet[3019]: k8s.io/kubernetes/pkg/kubelet/util/manager.(*objectCacheItem).startReflector(0xc000e03ce0)\r\n
2022-10-31T20:00:48+0000 gke-b27bb59e05314f15b662-a7f3-3599-vm kubelet[3019]: pkg/kubelet/util/manager/watch_based_manager.go:123 +0x91\r\n
```

https://github.com/kubernetes/kubernetes/blob/1f60f12e0ca7d26f9464e036b78f0f3974735ed4/pkg/kubelet/status/status_manager.go#L665-L672

if running in standalone mode, we should not update the pod status.

#### Does this PR introduce a user-facing change?
```release-note
kubelet: fix nil pointer in reflector start for standalone mode
```
