### PR TITLE
AddOrUpdateTaintOnNode: if node does not exists, return an error

### DIFF
--- a/pkg/controller/testutil/test_utils.go
+++ b/pkg/controller/testutil/test_utils.go
@@ -152,7 +152,7 @@ func (m *FakeNodeHandler) Get(ctx context.Context, name string, opts metav1.GetO
 			return &nodeCopy, nil
 		}
 	}
-	return nil, nil
+	return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, name)
 }
 
 func (m *FakeNodeHandler) runAsyncCalls() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
- @secsys-go  uses [go-fuzz](https://github.com/dvyukov/go-fuzz) to find this problem.
- However, this nil pointer is never reported by end users which means that before we call AddOrUpdateTaintOnNode, the node existence is checked. 

So I think this should be a low priority.
/priority backlog

To make the code more stable, fixing it is valid. This would avoid future bugs if somewhere calls `AddOrUpdateTaintOnNode` without checking whether the node exists.


#### Which issue(s) this PR fixes:

Fixes #113239

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```