### PR TITLE
Add etcd-auto-sync-interval option

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -166,6 +166,11 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&s.StorageConfig.Transport.ServerList, "etcd-servers", s.StorageConfig.Transport.ServerList,
 		"List of etcd servers to connect with (scheme://ip:port), comma separated.")
 
+	fs.DurationVar(&s.StorageConfig.Transport.AutoSyncInterval, "etcd-auto-sync-interval", s.StorageConfig.Transport.AutoSyncInterval, ""+
+		"The interval (in seconds) at which to update etcd endpoints to the latest members as reported by the cluster. "+
+		"Do not enable if the API server has a different network view of the etcd cluster members than the etcd cluster reports "+
+		"(for example, if accessing etcd via a load-balancer). Disabled when set to 0.")
+
 	fs.StringVar(&s.StorageConfig.Prefix, "etcd-prefix", s.StorageConfig.Prefix,
 		"The prefix to prepend to all resource paths in etcd.")
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
@@ -44,6 +44,9 @@ const (
 type TransportConfig struct {
 	// ServerList is the list of storage servers to connect with.
 	ServerList []string
+	// AutoSyncInterval is the interval to update endpoints with its latest members.
+	// 0 disables auto-sync.
+	AutoSyncInterval time.Duration
 	// TLS credentials
 	KeyFile       string
 	CertFile      string

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -285,6 +285,7 @@ var newETCD3Client = func(c storagebackend.TransportConfig) (*clientv3.Client, e
 	}
 
 	cfg := clientv3.Config{
+		AutoSyncInterval:     c.AutoSyncInterval,
 		DialTimeout:          dialTimeout,
 		DialKeepAliveTime:    keepaliveTime,
 		DialKeepAliveTimeout: keepaliveTimeout,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This largely coat tails on the work/discussion done in #107767. This PR allows for the use of a flag on the kube-apiserver `--etcd-auto-sync-interval` to map to [AutoSyncInterval](https://pkg.go.dev/go.etcd.io/etcd/client/v3#Config) in the etcd client config, which syncs the endpoint list from etcd. kube-apiserver would be able to account for changes to etcd cluster members without the need for a restart.

#### Special notes for your reviewer:
kube-apiserver static configuration changes would still need to occur out-of-band so that the apiserver can survive restarts. One reviewer previously noted that the healthz endpoint on kube-apiserver may falsely give the impression that the current configuration is correct. I believe healthz more accurately reflects the current state of the kube-apiserver and in this instance a dynamically determined configuration but not it's future state.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added new flag `--etcd-auto-sync-interval` which allows apiserver to periodically sync endpoint list from etcd.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
