### PR TITLE
Update shellcheck version (0.7.1 -> 0.7.2) and fix findings

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -140,6 +140,7 @@ eval "testargs=(${KUBE_TEST_ARGS:-})"
 # Used to filter verbose test output.
 go_test_grep_pattern=".*"
 
+goflags=()
 # The junit report tool needs full test case information to produce a
 # meaningful report.
 if [[ -n "${KUBE_JUNIT_REPORT_DIR}" ]] ; then

--- a/hack/make-rules/vet.sh
+++ b/hack/make-rules/vet.sh
@@ -25,6 +25,7 @@ cd "${KUBE_ROOT}"
 
 # Filter out arguments that start with "-" and move them to goflags.
 targets=()
+goflags=()
 for arg; do
   if [[ "${arg}" == -* ]]; then
     goflags+=("${arg}")

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -30,9 +30,8 @@ DOCKER="${DOCKER:-docker}"
 
 # required version for this script, if not installed on the host we will
 # use the official docker image instead. keep this in sync with SHELLCHECK_IMAGE
-SHELLCHECK_VERSION="0.7.1"
-# upstream shellcheck latest stable image as of October 23rd, 2019
-SHELLCHECK_IMAGE="docker.io/koalaman/shellcheck-alpine:v0.7.1@sha256:d6147f30864ddb7c9cf983fc277d345bc315e798e309ddf70062b194843ee252"
+SHELLCHECK_VERSION="0.7.2"
+SHELLCHECK_IMAGE="docker.io/koalaman/shellcheck-alpine:v0.7.2@sha256:ce6fd9cc808a47d1d121ba92c203ecc02e8ed78e0e4c412f7fca54c2e954526d"
 
 # disabled lints
 disabled=(


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Updates shellcheck version 0.7.1 -> 0.7.2 which introduces the following new checks: https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v072---2021-04-19

Fixes the following findings
```
Using shellcheck 0.7.2 docker image.

In ./hack/make-rules/test.sh line 146:
  goflags+=(-v)
  ^-----^ SC2031: goflags was modified in a subshell. That change might be lost.


In ./hack/make-rules/vet.sh line 30:
    goflags+=("${arg}")
    ^-----^ SC2031: goflags was modified in a subshell. That change might be lost.

For more information:
  https://www.shellcheck.net/wiki/SC2031 -- goflags was modified in a subshel...
```

Note this isn't the newest version of shellcheck. There is a version 0.8.0. However in order to avoid having to fix everything at once I made this update first. This will limit the risk and keep this pr smaller.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```