### PR TITLE
Add metric deleting_pods_total

### DIFF
--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -70,7 +70,7 @@ type PodGCController struct {
 
 func init() {
 	// Register prometheus metrics
-	Register()
+	RegisterMetrics()
 }
 
 func NewPodGC(ctx context.Context, kubeClient clientset.Interface, podInformer coreinformers.PodInformer,

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -68,6 +68,11 @@ type PodGCController struct {
 	quarantineTime         time.Duration
 }
 
+func init() {
+	// Register prometheus metrics
+	Register()
+}
+
 func NewPodGC(ctx context.Context, kubeClient clientset.Interface, podInformer coreinformers.PodInformer,
 	nodeInformer coreinformers.NodeInformer, terminatedPodThreshold int) *PodGCController {
 	return NewPodGCInternal(ctx, kubeClient, podInformer, nodeInformer, terminatedPodThreshold, gcCheckPeriod, quarantineTime)
@@ -76,9 +81,6 @@ func NewPodGC(ctx context.Context, kubeClient clientset.Interface, podInformer c
 // This function is only intended for integration tests
 func NewPodGCInternal(ctx context.Context, kubeClient clientset.Interface, podInformer coreinformers.PodInformer,
 	nodeInformer coreinformers.NodeInformer, terminatedPodThreshold int, gcCheckPeriod, quarantineTime time.Duration) *PodGCController {
-	// Register prometheus metrics
-	Register()
-
 	gcc := &PodGCController{
 		kubeClient:             kubeClient,
 		terminatedPodThreshold: terminatedPodThreshold,

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -76,6 +76,9 @@ func NewPodGC(ctx context.Context, kubeClient clientset.Interface, podInformer c
 // This function is only intended for integration tests
 func NewPodGCInternal(ctx context.Context, kubeClient clientset.Interface, podInformer coreinformers.PodInformer,
 	nodeInformer coreinformers.NodeInformer, terminatedPodThreshold int, gcCheckPeriod, quarantineTime time.Duration) *PodGCController {
+	// Register prometheus metrics
+	Register()
+
 	gcc := &PodGCController{
 		kubeClient:             kubeClient,
 		terminatedPodThreshold: terminatedPodThreshold,
@@ -173,9 +176,11 @@ func (gcc *PodGCController) gcTerminating(ctx context.Context, pods []*v1.Pod) {
 		wait.Add(1)
 		go func(pod *v1.Pod) {
 			defer wait.Done()
+			deletingPodsTotal.WithLabelValues().Inc()
 			if err := gcc.markFailedAndDeletePod(ctx, pod); err != nil {
 				// ignore not founds
 				utilruntime.HandleError(err)
+				deletingPodsErrorTotal.WithLabelValues().Inc()
 			}
 		}(terminatingPods[i])
 	}

--- a/pkg/controller/podgc/metrics.go
+++ b/pkg/controller/podgc/metrics.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podgc
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	podGCController   = "pod_gc_collector"
+	deletingPods      = "deleting_pods_total"
+	deletingPodsError = "deleting_pods_error_total"
+)
+
+var (
+	deletingPodsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      podGCController,
+			Name:           deletingPods,
+			Help:           "Number of pods that are being forcefully deleted since the Pod GC Controller started.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{},
+	)
+	deletingPodsErrorTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      podGCController,
+			Name:           deletingPodsError,
+			Help:           "Number of errors encountered when forcefully deleting the pods since the Pod GC Controller started.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{},
+	)
+)
+
+var registerMetrics sync.Once
+
+// Register the metrics that are to be monitored.
+func Register() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(deletingPodsTotal)
+		legacyregistry.MustRegister(deletingPodsErrorTotal)
+	})
+}

--- a/pkg/controller/podgc/metrics.go
+++ b/pkg/controller/podgc/metrics.go
@@ -25,8 +25,8 @@ import (
 
 const (
 	podGCController   = "pod_gc_collector"
-	deletingPods      = "deleting_pods_total"
-	deletingPodsError = "deleting_pods_error_total"
+	deletingPods      = "force_delete_pods_total"
+	deletingPodsError = "force_delete_pod_errors_total"
 )
 
 var (

--- a/pkg/controller/podgc/metrics.go
+++ b/pkg/controller/podgc/metrics.go
@@ -24,16 +24,14 @@ import (
 )
 
 const (
-	podGCController   = "pod_gc_collector"
-	deletingPods      = "force_delete_pods_total"
-	deletingPodsError = "force_delete_pod_errors_total"
+	podGCController = "pod_gc_collector"
 )
 
 var (
 	deletingPodsTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      podGCController,
-			Name:           deletingPods,
+			Name:           "force_delete_pods_total",
 			Help:           "Number of pods that are being forcefully deleted since the Pod GC Controller started.",
 			StabilityLevel: metrics.ALPHA,
 		},
@@ -42,7 +40,7 @@ var (
 	deletingPodsErrorTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      podGCController,
-			Name:           deletingPodsError,
+			Name:           "force_delete_pod_errors_total",
 			Help:           "Number of errors encountered when forcefully deleting the pods since the Pod GC Controller started.",
 			StabilityLevel: metrics.ALPHA,
 		},
@@ -53,7 +51,7 @@ var (
 var registerMetrics sync.Once
 
 // Register the metrics that are to be monitored.
-func Register() {
+func RegisterMetrics() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(deletingPodsTotal)
 		legacyregistry.MustRegister(deletingPodsErrorTotal)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds metrics `force_delete_pods_total` and `force_delete_pod_errors_total` in the Pod GC Controller.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Adds metrics `force_delete_pods_total` and `force_delete_pod_errors_total` in the Pod GC Controller.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2268-non-graceful-shutdown
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
