### PR TITLE
egress_selector.go: Add a dial starts metric.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -243,6 +243,7 @@ func (d *dialerCreator) createDialer() utilnet.DialFunc {
 		ctx, span := tracing.Start(ctx, fmt.Sprintf("Proxy via %s protocol over %s", d.options.protocol, d.options.transport), attribute.String("address", addr))
 		defer span.End(500 * time.Millisecond)
 		start := egressmetrics.Metrics.Clock().Now()
+		egressmetrics.Metrics.ObserveDialStart(d.options.protocol, d.options.transport)
 		proxier, err := d.connector.connect(ctx)
 		if err != nil {
 			egressmetrics.Metrics.ObserveDialFailure(d.options.protocol, d.options.transport, egressmetrics.StageConnect)

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
@@ -201,6 +201,16 @@ func TestMetrics(t *testing.T) {
 		metrics      []string
 		want         string
 	}{
+		"connect to proxy server start": {
+			connectorErr: true,
+			proxierErr:   true,
+			metrics:      []string{"apiserver_egress_dialer_dial_start_total"},
+			want: `
+	# HELP apiserver_egress_dialer_dial_start_total [ALPHA] Dial starts, labeled by the protocol (http-connect or grpc) and transport (tcp or uds).
+	# TYPE apiserver_egress_dialer_dial_start_total counter
+	apiserver_egress_dialer_dial_start_total{protocol="fake_protocol",transport="fake_transport"} 1
+`,
+		},
 		"connect to proxy server error": {
 			connectorErr: true,
 			proxierErr:   false,


### PR DESCRIPTION
Emit this metric before any potentially blocking dial work.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We have seen clusters seem to fill up apiserver goroutines stuck on UDS dial.

https://github.com/kubernetes/kubernetes/pull/110079 improves the situation, but it is still possible to accumulate goroutines without any metric signal.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

This metric-only change is split off from https://github.com/kubernetes/kubernetes/pull/113486

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
