### PR TITLE
scheduler/framework: remove useless SetFailedPlugin

### DIFF
--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -1226,7 +1226,6 @@ func (f *frameworkImpl) WaitOnPermit(ctx context.Context, pod *v1.Pod) *framewor
 	if !s.IsSuccess() {
 		if s.IsUnschedulable() {
 			klog.V(4).InfoS("Pod rejected while waiting on permit", "pod", klog.KObj(pod), "status", s.Message())
-			s.SetFailedPlugin(s.FailedPlugin())
 			return s
 		}
 		err := s.AsError()


### PR DESCRIPTION
Signed-off-by: iyear <ljyngup@gmail.com>

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This line of code is equal to `s.failedPlugin = s.failedPlugin`. `FailedPlugin` is already set in https://github.com/kubernetes/kubernetes/blob/f8a6bdb044c61a6bcd2abb7775f6c0b947ddfe7e/pkg/scheduler/framework/runtime/waiting_pods_map.go#L159-L164

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
