### PR TITLE
releng: Update images, dependencies and version to Go 1.19.3

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.25.0-go1.19.2-bullseye.0
+v1.25.0-go1.19.3-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -96,7 +96,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
 readonly __default_distroless_iptables_version=v0.1.2
-readonly __default_go_runner_version=v2.3.1-go1.19.2-bullseye.0
+readonly __default_go_runner_version=v2.3.1-go1.19.3-bullseye.0
 readonly __default_setcap_version=bullseye-v1.3.0
 
 # These are the base images for the Docker-wrapped binaries.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -88,7 +88,7 @@ dependencies:
 
   # Golang
   - name: "golang: upstream version"
-    version: 1.19.2
+    version: 1.19.3
     refPaths:
     - path: build/build-image/cross/VERSION
     - path: staging/publishing/rules.yaml
@@ -109,7 +109,7 @@ dependencies:
       match: minimum_go_version=go([0-9]+\.[0-9]+)
 
   - name: "registry.k8s.io/kube-cross: dependents"
-    version: v1.25.0-go1.19.2-bullseye.0
+    version: v1.25.0-go1.19.3-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -139,7 +139,7 @@ dependencies:
       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
 
   - name: "registry.k8s.io/go-runner: dependents"
-    version: v2.3.1-go1.19.2-bullseye.0
+    version: v2.3.1-go1.19.3-bullseye.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -21,7 +21,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/code-generator
@@ -47,7 +47,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/apimachinery
@@ -86,7 +86,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/api
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -152,7 +152,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -216,7 +216,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-base
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -278,7 +278,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -357,7 +357,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/apiserver
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -447,7 +447,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -560,7 +560,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -660,7 +660,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -762,7 +762,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -839,7 +839,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/metrics
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -903,7 +903,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.25
@@ -973,7 +973,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1044,7 +1044,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1116,7 +1116,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubelet
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1188,7 +1188,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1270,7 +1270,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1370,7 +1370,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1482,7 +1482,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1546,7 +1546,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1598,7 +1598,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1630,7 +1630,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/mount-utils
@@ -1741,7 +1741,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1789,7 +1789,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/cri-api
@@ -1884,7 +1884,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubectl
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1974,7 +1974,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.25
-    go: 1.19.2
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1992,4 +1992,4 @@ rules:
   library: true
 recursive-delete-patterns:
 - '*/.gitattributes'
-default-go-version: 1.19.2
+default-go-version: 1.19.3

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -16,7 +16,7 @@ REGISTRY ?= registry.k8s.io/e2e-test-images
 GOARM ?= 7
 DOCKER_CERT_BASE_PATH ?=
 QEMUVERSION=v5.1.0-2
-GOLANG_VERSION=1.19.2
+GOLANG_VERSION=1.19.3
 export
 
 ifndef WHAT


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- Bump kube-cross and go-runner images to Go 1.19.3 based ones
- Bump test Makefile to Go 1.19.3
- Bump default Go version for publishing bot to 1.19.3

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2726

#### Does this PR introduce a user-facing change?
```release-note
Kubernetes is now built with Go 1.19.3
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

cc @kubernetes/release-engineering 