### PR TITLE
Combine RequestAuditConfig with RequestAuditConfigWithLevel

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/evaluator.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/evaluator.go
@@ -25,6 +25,9 @@ import (
 // a given request. PolicyRuleEvaluator evaluates the audit policy against the
 // authorizer attributes and returns a RequestAuditConfig that applies to the request.
 type RequestAuditConfig struct {
+	// Level at which the request is being audited at
+	Level audit.Level
+
 	// OmitStages is the stages that need to be omitted from being audited.
 	OmitStages []audit.Stage
 
@@ -33,21 +36,10 @@ type RequestAuditConfig struct {
 	OmitManagedFields bool
 }
 
-// RequestAuditConfigWithLevel includes Level at which the request is being audited.
-// PolicyRuleEvaluator evaluates the audit configuration for a request
-// against the authorizer attributes and returns an RequestAuditConfigWithLevel
-// that applies to the request.
-type RequestAuditConfigWithLevel struct {
-	RequestAuditConfig
-
-	// Level at which the request is being audited at
-	Level audit.Level
-}
-
 // PolicyRuleEvaluator exposes methods for evaluating the policy rules.
 type PolicyRuleEvaluator interface {
 	// EvaluatePolicyRule evaluates the audit policy of the apiserver against
 	// the given authorizer attributes and returns the audit configuration that
 	// is applicable to the given equest.
-	EvaluatePolicyRule(authorizer.Attributes) RequestAuditConfigWithLevel
+	EvaluatePolicyRule(authorizer.Attributes) RequestAuditConfig
 }

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/checker.go
@@ -61,25 +61,21 @@ type policyRuleEvaluator struct {
 	audit.Policy
 }
 
-func (p *policyRuleEvaluator) EvaluatePolicyRule(attrs authorizer.Attributes) auditinternal.RequestAuditConfigWithLevel {
+func (p *policyRuleEvaluator) EvaluatePolicyRule(attrs authorizer.Attributes) auditinternal.RequestAuditConfig {
 	for _, rule := range p.Rules {
 		if ruleMatches(&rule, attrs) {
-			return auditinternal.RequestAuditConfigWithLevel{
-				Level: rule.Level,
-				RequestAuditConfig: auditinternal.RequestAuditConfig{
-					OmitStages:        rule.OmitStages,
-					OmitManagedFields: isOmitManagedFields(&rule, p.OmitManagedFields),
-				},
+			return auditinternal.RequestAuditConfig{
+				Level:             rule.Level,
+				OmitStages:        rule.OmitStages,
+				OmitManagedFields: isOmitManagedFields(&rule, p.OmitManagedFields),
 			}
 		}
 	}
 
-	return auditinternal.RequestAuditConfigWithLevel{
-		Level: DefaultAuditLevel,
-		RequestAuditConfig: auditinternal.RequestAuditConfig{
-			OmitStages:        p.OmitStages,
-			OmitManagedFields: p.OmitManagedFields,
-		},
+	return auditinternal.RequestAuditConfig{
+		Level:             DefaultAuditLevel,
+		OmitStages:        p.OmitStages,
+		OmitManagedFields: p.OmitManagedFields,
 	}
 }
 
@@ -235,11 +231,9 @@ type fakePolicyRuleEvaluator struct {
 	stage []audit.Stage
 }
 
-func (f *fakePolicyRuleEvaluator) EvaluatePolicyRule(_ authorizer.Attributes) auditinternal.RequestAuditConfigWithLevel {
-	return auditinternal.RequestAuditConfigWithLevel{
-		Level: f.level,
-		RequestAuditConfig: auditinternal.RequestAuditConfig{
-			OmitStages: f.stage,
-		},
+func (f *fakePolicyRuleEvaluator) EvaluatePolicyRule(_ authorizer.Attributes) auditinternal.RequestAuditConfig {
+	return auditinternal.RequestAuditConfig{
+		Level:      f.level,
+		OmitStages: f.stage,
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -133,10 +133,10 @@ func evaluatePolicyAndCreateAuditEvent(req *http.Request, policy audit.PolicyRul
 		return ac, fmt.Errorf("failed to GetAuthorizerAttributes: %v", err)
 	}
 
-	ls := policy.EvaluatePolicyRule(attribs)
-	audit.ObservePolicyLevel(ctx, ls.Level)
-	ac.RequestAuditConfig = ls.RequestAuditConfig
-	if ls.Level == auditinternal.LevelNone {
+	rac := policy.EvaluatePolicyRule(attribs)
+	audit.ObservePolicyLevel(ctx, rac.Level)
+	ac.RequestAuditConfig = rac
+	if rac.Level == auditinternal.LevelNone {
 		// Don't audit.
 		return ac, nil
 	}
@@ -145,7 +145,7 @@ func evaluatePolicyAndCreateAuditEvent(req *http.Request, policy audit.PolicyRul
 	if !ok {
 		requestReceivedTimestamp = time.Now()
 	}
-	ev, err := audit.NewEventFromRequest(req, requestReceivedTimestamp, ls.Level, attribs)
+	ev, err := audit.NewEventFromRequest(req, requestReceivedTimestamp, rac.Level, attribs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to complete audit event from request: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_graceful_termination_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_graceful_termination_test.go
@@ -780,10 +780,9 @@ func (a *fakeAudit) requestAudited(auditID string) bool {
 	return exists
 }
 
-func (a *fakeAudit) EvaluatePolicyRule(attrs authorizer.Attributes) audit.RequestAuditConfigWithLevel {
-	return audit.RequestAuditConfigWithLevel{
-		Level:              auditinternal.LevelMetadata,
-		RequestAuditConfig: audit.RequestAuditConfig{},
+func (a *fakeAudit) EvaluatePolicyRule(attrs authorizer.Attributes) audit.RequestAuditConfig {
+	return audit.RequestAuditConfig{
+		Level: auditinternal.LevelMetadata,
 	}
 }
 

--- a/test/integration/examples/webhook_test.go
+++ b/test/integration/examples/webhook_test.go
@@ -50,14 +50,14 @@ func TestWebhookLoopback(t *testing.T) {
 
 			// Hook into audit to watch requests
 			config.GenericConfig.AuditBackend = auditSinkFunc(func(events ...*auditinternal.Event) {})
-			config.GenericConfig.AuditPolicyRuleEvaluator = auditPolicyRuleEvaluator(func(attrs authorizer.Attributes) audit.RequestAuditConfigWithLevel {
+			config.GenericConfig.AuditPolicyRuleEvaluator = auditPolicyRuleEvaluator(func(attrs authorizer.Attributes) audit.RequestAuditConfig {
 				if attrs.GetPath() == webhookPath {
 					if attrs.GetUser().GetName() != "system:apiserver" {
 						t.Errorf("expected user %q, got %q", "system:apiserver", attrs.GetUser().GetName())
 					}
 					atomic.AddInt32(&called, 1)
 				}
-				return audit.RequestAuditConfigWithLevel{
+				return audit.RequestAuditConfig{
 					Level: auditinternal.LevelNone,
 				}
 			})
@@ -107,9 +107,9 @@ func TestWebhookLoopback(t *testing.T) {
 	}
 }
 
-type auditPolicyRuleEvaluator func(authorizer.Attributes) audit.RequestAuditConfigWithLevel
+type auditPolicyRuleEvaluator func(authorizer.Attributes) audit.RequestAuditConfig
 
-func (f auditPolicyRuleEvaluator) EvaluatePolicyRule(attrs authorizer.Attributes) audit.RequestAuditConfigWithLevel {
+func (f auditPolicyRuleEvaluator) EvaluatePolicyRule(attrs authorizer.Attributes) audit.RequestAuditConfig {
 	return f(attrs)
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

I don't know why `RequestAuditConfig` and `RequestAuditConifgWithLevel` were kept separate (probably to avoid having 2 places where level is represented in the `AuditContext`?).

This simplifies things by adding the `Level` to `RequestAuditConfig`. This was extracted from a larger audit cleanup.

For https://github.com/kubernetes/kubernetes/issues/109087

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig auth