### PR TITLE
initial implementation of kuberc

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -327,7 +327,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 	if kubeConfigFlags == nil {
 		kubeConfigFlags = defaultConfigFlags
 	}
-	if os.Getenv("ENABLE_KUBERC") != "" {
+	if cmdutil.KubeRc.IsEnabled() {
 		klog.Infoln("kuberc is enabled!")
 		if o.KubercHandler != nil {
 			o.KubercHandler.InjectOverridesRoot(kubeConfigFlags, o.Arguments)
@@ -456,7 +456,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 	// If the alpha feature of kuberc is enabled then render new command
 	// args using the defined values in the kuberc config file, and
 	// overwrite the args stored in the KubectlOptions object.
-	if os.Getenv("ENABLE_KUBERC") != "" {
+	if cmdutil.KubeRc.IsEnabled() {
 		if o.KubercHandler != nil {
 			// TODO: Determine how to protect against flags that can be supplied multiple times
 			// inheritence for flags is as follows, in ascending order of hierachy:

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/kuberc.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberc
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/yaml"
+
+	"github.com/ohler55/ojg/jp"
+	"github.com/ohler55/ojg/oj"
+)
+
+// Example kuberc.yaml file
+// ---
+//apiVersion: v1alpha1
+//kind: Preferences
+//command:
+//	aliases:
+//		getdbprod:
+//			command: get pods -l what=database --namespace us-2-production
+//	overrides:
+//		apply:
+//			flags:
+//				- name: server-side
+//				  default: "true"
+//		config:
+//			flags:
+//				- name: kubeconfig
+//				  default: "~/.kube/config"
+//			set:
+//				flags:
+//					- name: set-raw-bytes
+//					  default: ""
+//			view:
+//				flags:
+//					- name: raw
+//					  default: ""
+//		delete:
+//			flags:
+//				- name: confirm
+//				  default: "true"
+//		default:
+//			flags:
+//				- name: exec-auth-allowlist
+//				  default: /var/kubectl/exec/...
+
+type Preferences struct {
+	Kind       string  `json:"kind,omitempty"`
+	APIVersion string  `json:"apiVersion,omitempty"`
+	Command    Command `json:"command,omitempty"`
+}
+
+type Command struct {
+	Aliases   map[string]Alias    `json:"aliases,omitempty"`
+	Overrides map[string]Override `json:"omitempty"`
+}
+
+type Alias struct {
+	Command string           `json:"command,omitempty"`
+	Aliases map[string]Alias `json:"omitempty"`
+}
+
+type Override struct {
+	Flags     []Flag              `json:"flags,omitempty"`
+	Overrides map[string]Override `json:"omitempty"`
+}
+
+type Flag struct {
+	Name    string `json:"name"`
+	Default string `json:"default"`
+}
+
+// ComposeCmdArgs will rewrite the user provided command in place if there is
+// a definition in the kuberc file for either an alias or an override, then
+// supply the rewritten args back to the top level kubectl command to be
+// run as defined
+func ComposeCmdArgs(ioStreams genericclioptions.IOStreams, arguments []string) ([]string, error) {
+	var renderedCmd []string
+	// Figure out how many subcommands deep we're going before the flags start
+	var flagsStart int
+	for i, arg := range arguments {
+		if string(arg[0]) == "-" {
+			flagsStart = i
+			break
+		}
+	}
+	if flagsStart == 0 {
+		flagsStart = len(arguments)
+	}
+
+	subcommands := arguments[:flagsStart]
+	userFlags := arguments[flagsStart:]
+
+	// Search for a --kuberc flag that will provide a non-default path to the
+	// kuberc file
+	kubercPath := filepath.Join(clientcmd.RecommendedConfigDir, "kuberc")
+	for i, flag := range userFlags {
+		if flag == "--kuberc" {
+			kubercPath = userFlags[i+1]
+
+			// remove the kuberc flag and value so it doesn't mess up argument parsing
+			userFlags = append(userFlags[:i], userFlags[i+2:]...)
+			break
+		}
+	}
+
+	kuberc, err := LoadKubeRC(kubercPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use jsonpath to look up nested fields in the kuberc yaml without a
+	// bunch of recursive functions
+	kubercYAML, err := oj.Parse(kuberc)
+	if err != nil {
+		return nil, err
+	}
+	aliasJsonPath := fmt.Sprintf("command.aliases.%s.command", strings.Join(subcommands, "."))
+	x, err := jp.ParseString(aliasJsonPath)
+	resultsAlias := x.Get(kubercYAML)
+
+	if resultsAlias != nil {
+		renderedCmd = strings.Split(resultsAlias[0].(string), " ")
+	} else {
+		renderedCmd = append(subcommands, userFlags...)
+	}
+
+	for i, arg := range renderedCmd {
+		if string(arg[0]) == "-" {
+			flagsStart = i
+			break
+		}
+	}
+
+	subcommands = renderedCmd[:flagsStart]
+	userFlags = renderedCmd[flagsStart:]
+
+	// Use jsonpath to look up nested fields in the kuberc yaml without a
+	// bunch of recursive functions
+	overridesJsonPath := fmt.Sprintf("command.overrides.%s.flags", strings.Join(subcommands, "."))
+	x, err = jp.ParseString(overridesJsonPath)
+	resultsOverride := x.Get(kubercYAML)
+
+	// Get all the flags used in the default command override and populate
+	// a new slice with them
+	var overrideFlags []string
+	for i := range resultsOverride {
+		// Get the name of the flag
+		overridesJsonPathFlagName := fmt.Sprintf("%s[%d].name", overridesJsonPath, i)
+		x, err = jp.ParseString(overridesJsonPathFlagName)
+		resultsOverride = x.Get(kubercYAML)
+
+		// Check if this is a short or long flag for proper use of dashes
+		if resultsOverride != nil && len(resultsOverride[0].(string)) == 1 {
+			overrideFlags = append(overrideFlags, "-"+resultsOverride[0].(string))
+		} else if resultsOverride != nil && len(resultsOverride[0].(string)) > 1 {
+			overrideFlags = append(overrideFlags, "--"+resultsOverride[0].(string))
+		}
+
+		// Add the default value for the flag override
+		overridesJsonPathDefault := fmt.Sprintf("%s[%d].default", overridesJsonPath, i)
+		x, err = jp.ParseString(overridesJsonPathDefault)
+		resultsOverride = x.Get(kubercYAML)
+		if resultsOverride != nil && resultsOverride[0].(string) != "" {
+			overrideFlags = append(overrideFlags, resultsOverride[0].(string))
+		}
+	}
+
+	fmt.Fprintf(ioStreams.Out, "override flags are %s\n", strings.Join(overrideFlags, " "))
+
+	// To follow the proper precidencing we must concatenate the slices
+	// in the order of subcommands -> kuberc specified override flags
+	// -> user supplied flags to ensure that any user supplied flags will
+	// be what is used in the event of collision.
+	finalFlags := append(overrideFlags, userFlags...)
+	renderedCmdStr := append(subcommands, finalFlags...)
+
+	return renderedCmdStr, nil
+}
+
+// LoadKubeRC reads kuberc file and stores the values in a Preferences struct
+// that is then returned
+func LoadKubeRC(path string) ([]byte, error) {
+	kubercBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	kuberc, err := yaml.YAMLToJSON(kubercBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return kuberc, nil
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/kuberc.go
@@ -192,7 +192,8 @@ func LoadKubeRC(path string) (Preferences, error) {
 	var preferences Preferences
 	// TODO: (mpuckett159) This probably should be UnmarshalStrict but I'm not sure
 	if err := yaml.Unmarshal(kubercBytes, &preferences); err != nil {
-		klog.Warningf("error unmarshalling the yaml for kuberc")
+		klog.Errorf("error unmarshalling the yaml for kuberc")
+		return Preferences{}, err
 	}
 
 	return preferences, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/kuberc.go
@@ -17,17 +17,15 @@ limitations under the License.
 package kuberc
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
+	"reflect"
 	"strings"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/yaml"
+	"github.com/spf13/cobra"
 
-	"github.com/ohler55/ojg/jp"
-	"github.com/ohler55/ojg/oj"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
 // Example kuberc.yaml file
@@ -35,34 +33,48 @@ import (
 //apiVersion: v1alpha1
 //kind: Preferences
 //command:
-//	aliases:
-//		getdbprod:
-//			command: get pods -l what=database --namespace us-2-production
-//	overrides:
-//		apply:
-//			flags:
-//				- name: server-side
-//				  default: "true"
-//		config:
-//			flags:
-//				- name: kubeconfig
-//				  default: "~/.kube/config"
-//			set:
-//				flags:
-//					- name: set-raw-bytes
-//					  default: ""
-//			view:
-//				flags:
-//					- name: raw
-//					  default: ""
-//		delete:
-//			flags:
-//				- name: confirm
-//				  default: "true"
-//		default:
-//			flags:
-//				- name: exec-auth-allowlist
-//				  default: /var/kubectl/exec/...
+//  aliases:
+//    dbprod:
+//      command: get pods
+//      flags:
+//        - -l what=database
+//        - --namespace us-2-production
+//    dbdev:
+//      command: get pods
+//      flags:
+//        - -l what=database
+//        - --namespace us-2-development
+//    raw:
+//      command: config view
+//      flags:
+//        - --raw
+//    nginx:
+//      command: run
+//      arguments:
+//        - nginx
+//      flags:
+//        - --image=nginx
+//        - --port=5701
+//  overrides:
+//    apply:
+//      flags:
+//        - --server-side=true
+//    config set:
+//      flags:
+//        - --set-raw-bytes
+//    config view:
+//      flags:
+//        - --output=json
+//    delete:
+//      flags:
+//        - --confirm=true
+//    default:
+//      flags:
+//        - --kubeconfig='/Users/marcuspuckett/.kube/config-test'
+//        - --namespace='test-ns'
+//        - --v=7
+
+const DefaultKubercPath = ".kube/kuberc"
 
 type Preferences struct {
 	Kind       string  `json:"kind,omitempty"`
@@ -72,144 +84,116 @@ type Preferences struct {
 
 type Command struct {
 	Aliases   map[string]Alias    `json:"aliases,omitempty"`
-	Overrides map[string]Override `json:"omitempty"`
+	Overrides map[string]Override `json:"overrides,omitempty"`
 }
 
 type Alias struct {
-	Command string           `json:"command,omitempty"`
-	Aliases map[string]Alias `json:"omitempty"`
+	Command string   `json:"command,omitempty"`
+	Flags   []string `json:"flags,omitempty"`
 }
 
 type Override struct {
-	Flags     []Flag              `json:"flags,omitempty"`
-	Overrides map[string]Override `json:"omitempty"`
+	Flags []string `json:"flags,omitempty"`
 }
 
-type Flag struct {
-	Name    string `json:"name"`
-	Default string `json:"default"`
+// Handler is responsible for injecting aliases for commands and
+// setting default flags arguments based on user's kuberc configuration.
+type Handler interface {
+	InjectAliases(rootCmd *cobra.Command, args []string)
+	InjectOverrides(rootCmd *cobra.Command, args []string)
+	InjectOverridesRoot(flags *genericclioptions.ConfigFlags, args []string)
 }
 
-// ComposeCmdArgs will rewrite the user provided command in place if there is
-// a definition in the kuberc file for either an alias or an override, then
-// supply the rewritten args back to the top level kubectl command to be
-// run as defined
-func ComposeCmdArgs(ioStreams genericclioptions.IOStreams, arguments []string) ([]string, error) {
-	var renderedCmd []string
-	// Figure out how many subcommands deep we're going before the flags start
-	var flagsStart int
-	for i, arg := range arguments {
-		if string(arg[0]) == "-" {
-			flagsStart = i
-			break
-		}
-	}
-	if flagsStart == 0 {
-		flagsStart = len(arguments)
-	}
+// DefaultKubercHandler implements AliasHandler
+type DefaultKubercHandler struct {
+	Command Command
+}
 
-	subcommands := arguments[:flagsStart]
-	userFlags := arguments[flagsStart:]
-
-	// Search for a --kuberc flag that will provide a non-default path to the
-	// kuberc file
-	kubercPath := filepath.Join(clientcmd.RecommendedConfigDir, "kuberc")
-	for i, flag := range userFlags {
-		if flag == "--kuberc" {
-			kubercPath = userFlags[i+1]
-
-			// remove the kuberc flag and value so it doesn't mess up argument parsing
-			userFlags = append(userFlags[:i], userFlags[i+2:]...)
-			break
-		}
-	}
-
+// NewDefaultKubercHandler instantiates the DefaultKubercHandler by reading the
+// kuberc file.
+func NewDefaultKubercHandler(kubercPath string) *DefaultKubercHandler {
 	kuberc, err := LoadKubeRC(kubercPath)
 	if err != nil {
-		return nil, err
+		return &DefaultKubercHandler{}
 	}
+	return &DefaultKubercHandler{
+		kuberc.Command,
+	}
+}
 
-	// Use jsonpath to look up nested fields in the kuberc yaml without a
-	// bunch of recursive functions
-	kubercYAML, err := oj.Parse(kuberc)
+func (h *DefaultKubercHandler) InjectAliases(rootCmd *cobra.Command, args []string) {
+	// Register all aliases
+	for alias, command := range h.Command.Aliases {
+		commands := strings.Split(command.Command, " ")
+		cmd, _, err := rootCmd.Find(commands)
+		if err != nil {
+			klog.Warningf("Command %q not found to set alias %q", commands, alias)
+			continue
+		}
+
+		// do not allow shadowing built-ins
+		if _, _, err := rootCmd.Find([]string{alias}); err == nil {
+			klog.Warningf("Setting alias %q to a built-in command is not supported", alias)
+			continue
+		}
+
+		// register alias
+		cmd.Aliases = append(cmd.Aliases, alias)
+
+		// inject alias flags if this is the command that is being targetted
+		// fullAliasCmdPath is the command path defined in kuberc minus the
+		// last command (which is being aliased) and the last arg of the cmdArgs
+		// (which is what the alias would be). The cmdArgs will also include
+		// kubectl so we will ignore the first entry in that array
+		//
+		// Example: kuberc defines alias "raw" for "config view" subcommand,
+		// the user thus will supply "kubectl config raw" on the command line
+		// so we take the command defined in the kuberc file and drop the last
+		// subcommand, which is view, and replace it with the alias defined in
+		// the kuberc file, giving us "kubectl config raw", then we check to
+		// see if that is equal to commands supplied by the user.
+		fullAliasCmdPath := append(commands[:len(commands)-1], alias)
+		if reflect.DeepEqual(fullAliasCmdPath, args[1:]) {
+			klog.V(2).Infof("using alias %q, adding flags...", alias)
+			cmd.Flags().Parse(command.Flags)
+		}
+	}
+}
+
+func (h *DefaultKubercHandler) InjectOverrides(rootCmd *cobra.Command, args []string) {
+	cmd, _, err := rootCmd.Find(args)
 	if err != nil {
-		return nil, err
+		klog.Warningf("could not find command %q", args)
+		return
 	}
-	aliasJsonPath := fmt.Sprintf("command.aliases.%s.command", strings.Join(subcommands, "."))
-	x, err := jp.ParseString(aliasJsonPath)
-	resultsAlias := x.Get(kubercYAML)
-
-	if resultsAlias != nil {
-		renderedCmd = strings.Split(resultsAlias[0].(string), " ")
-	} else {
-		renderedCmd = append(subcommands, userFlags...)
-	}
-
-	for i, arg := range renderedCmd {
-		if string(arg[0]) == "-" {
-			flagsStart = i
-			break
+	if flags, found := h.Command.Overrides[strings.Join(args, " ")]; found {
+		klog.V(2).Infof("adding default flags %q for command %q", flags.Flags, strings.Join(args, " "))
+		if err := cmd.Flags().Parse(flags.Flags); err != nil {
+			klog.Warningf("error parsing flags - %q", err)
 		}
 	}
+}
 
-	subcommands = renderedCmd[:flagsStart]
-	userFlags = renderedCmd[flagsStart:]
-
-	// Use jsonpath to look up nested fields in the kuberc yaml without a
-	// bunch of recursive functions
-	overridesJsonPath := fmt.Sprintf("command.overrides.%s.flags", strings.Join(subcommands, "."))
-	x, err = jp.ParseString(overridesJsonPath)
-	resultsOverride := x.Get(kubercYAML)
-
-	// Get all the flags used in the default command override and populate
-	// a new slice with them
-	var overrideFlags []string
-	for i := range resultsOverride {
-		// Get the name of the flag
-		overridesJsonPathFlagName := fmt.Sprintf("%s[%d].name", overridesJsonPath, i)
-		x, err = jp.ParseString(overridesJsonPathFlagName)
-		resultsOverride = x.Get(kubercYAML)
-
-		// Check if this is a short or long flag for proper use of dashes
-		if resultsOverride != nil && len(resultsOverride[0].(string)) == 1 {
-			overrideFlags = append(overrideFlags, "-"+resultsOverride[0].(string))
-		} else if resultsOverride != nil && len(resultsOverride[0].(string)) > 1 {
-			overrideFlags = append(overrideFlags, "--"+resultsOverride[0].(string))
-		}
-
-		// Add the default value for the flag override
-		overridesJsonPathDefault := fmt.Sprintf("%s[%d].default", overridesJsonPath, i)
-		x, err = jp.ParseString(overridesJsonPathDefault)
-		resultsOverride = x.Get(kubercYAML)
-		if resultsOverride != nil && resultsOverride[0].(string) != "" {
-			overrideFlags = append(overrideFlags, resultsOverride[0].(string))
-		}
+func (h *DefaultKubercHandler) InjectOverridesRoot(flags *genericclioptions.ConfigFlags, args []string) {
+	if kubercFlags, found := h.Command.Overrides["default"]; found {
+		klog.V(2).Infof("adding default flags %q", kubercFlags.Flags)
+		flags.OverwriteDefaultConfigFlags(kubercFlags.Flags, args)
 	}
-
-	fmt.Fprintf(ioStreams.Out, "override flags are %s\n", strings.Join(overrideFlags, " "))
-
-	// To follow the proper precidencing we must concatenate the slices
-	// in the order of subcommands -> kuberc specified override flags
-	// -> user supplied flags to ensure that any user supplied flags will
-	// be what is used in the event of collision.
-	finalFlags := append(overrideFlags, userFlags...)
-	renderedCmdStr := append(subcommands, finalFlags...)
-
-	return renderedCmdStr, nil
 }
 
 // LoadKubeRC reads kuberc file and stores the values in a Preferences struct
 // that is then returned
-func LoadKubeRC(path string) ([]byte, error) {
+func LoadKubeRC(path string) (Preferences, error) {
 	kubercBytes, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return Preferences{}, err
 	}
 
-	kuberc, err := yaml.YAMLToJSON(kubercBytes)
-	if err != nil {
-		return nil, err
+	var preferences Preferences
+	// TODO: (mpuckett159) This probably should be UnmarshalStrict but I'm not sure
+	if err := yaml.Unmarshal(kubercBytes, &preferences); err != nil {
+		klog.Warningf("error unmarshalling the yaml for kuberc")
 	}
 
-	return kuberc, nil
+	return preferences, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -427,6 +427,7 @@ type FeatureGate string
 const (
 	ApplySet         FeatureGate = "KUBECTL_APPLYSET"
 	ExplainOpenapiV3 FeatureGate = "KUBECTL_EXPLAIN_OPENAPIV3"
+	KubeRc           FeatureGate = "KUBECTL_KUBERC"
 )
 
 func (f FeatureGate) IsEnabled() bool {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR seeks to implement the initial alpha version of the kuberc feature that was proposed in [KEP 3104](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3104-introduce-kuberc). This is a very early stage attempt at this and definitely has a lot of work to be done on it and leaves a lot to be desired, particularly the fact that we're manually parsing out flags instead of using cobra's built in flag functionality. This is intended to be fixed up.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
This is a very early attempt and will definitely need to be iterated on and improved. Just trying to get something out the door that is at least mostly workable/usable. One hugely notable draw back is that the `--kuberc` flag can not be called in the form of `--kuberc="path/to/kuberc"` and must be called using the form `--kuberc path/to/kuberc`.

Another thing is that I have done nothing to implement the default flags for every command, but that shouldn't be too hard after we get consensus on how the changes I've made.

I haven't done much testing on this yet and am opening this PR as a draft to gather some feedback from the sig-cli chairs on the methodology I'm using and make sure my changes to the YAML config file are acceptable.

This PR also makes use of the github.com/ohler55/ojg library which is what I intend to use to replace the in tree jsonpath library that we have in k/k. This seemed simpler and more straightforward to read/understand in code than doing a bunch of weird recursive look ups.

#### Does this PR introduce a user-facing change?
```release-note
Introduces an alpha version of the kuberc functionality
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP 3104]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3104-introduce-kuberc
```
