### PR TITLE
kubeadm: Improve testcases for `init` and `join` command

### DIFF
--- a/cmd/kubeadm/app/cmd/init_test.go
+++ b/cmd/kubeadm/app/cmd/init_test.go
@@ -100,7 +100,7 @@ func TestNewInitData(t *testing.T) {
 			},
 		},
 		{
-			name: "--cri-socket and --node-name flags override config from file",
+			name: "--node-name flags override config from file",
 			flags: map[string]string{
 				options.CfgPath:  configFilePath,
 				options.NodeName: "anotherName",

--- a/cmd/kubeadm/app/cmd/init_test.go
+++ b/cmd/kubeadm/app/cmd/init_test.go
@@ -36,7 +36,7 @@ localAPIEndpoint:
 bootstrapTokens:
 - token: "abcdef.0123456789abcdef"
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///var/run/containerd/containerd.sock
   name: someName
   ignorePreflightErrors:
     - c

--- a/cmd/kubeadm/app/cmd/init_test.go
+++ b/cmd/kubeadm/app/cmd/init_test.go
@@ -108,7 +108,7 @@ func TestNewInitData(t *testing.T) {
 			validate: func(t *testing.T, data *initData) {
 				// validate that node-name is overwritten
 				if data.cfg.NodeRegistration.Name != "anotherName" {
-					t.Errorf("Invalid NodeRegistration.Name")
+					t.Error("Invalid NodeRegistration.Name")
 				}
 			},
 		},
@@ -162,7 +162,7 @@ func TestNewInitData(t *testing.T) {
 				t.Fatalf("newInitData returned unexpected error: %v", err)
 			}
 			if err == nil && tc.expectError {
-				t.Fatalf("newInitData didn't return error when expected")
+				t.Fatal("newInitData didn't return error when expected")
 			}
 
 			// exec additional validation on the returned value

--- a/cmd/kubeadm/app/cmd/join_test.go
+++ b/cmd/kubeadm/app/cmd/join_test.go
@@ -104,7 +104,7 @@ func TestNewJoinData(t *testing.T) {
 			validate: func(t *testing.T, data *joinData) {
 				// validate that file discovery settings are set into join data
 				if data.cfg.Discovery.File == nil || data.cfg.Discovery.File.KubeConfigPath != "https://foo" {
-					t.Errorf("Invalid data.cfg.Discovery.File")
+					t.Error("Invalid data.cfg.Discovery.File")
 				}
 			},
 		},
@@ -121,7 +121,7 @@ func TestNewJoinData(t *testing.T) {
 					data.cfg.Discovery.BootstrapToken.APIServerEndpoint != "1.2.3.4:6443" || //only first arg should be kept as APIServerEndpoint
 					data.cfg.Discovery.BootstrapToken.Token != "abcdef.0123456789abcdef" ||
 					data.cfg.Discovery.BootstrapToken.UnsafeSkipCAVerification != true {
-					t.Errorf("Invalid data.cfg.Discovery.BootstrapToken")
+					t.Error("Invalid data.cfg.Discovery.BootstrapToken")
 				}
 			},
 		},
@@ -137,7 +137,7 @@ func TestNewJoinData(t *testing.T) {
 				if data.cfg.Discovery.TLSBootstrapToken != "abcdef.0123456789abcdef" ||
 					data.cfg.Discovery.BootstrapToken == nil ||
 					data.cfg.Discovery.BootstrapToken.Token != "abcdef.0123456789abcdef" {
-					t.Errorf("Invalid TLSBootstrapToken or BootstrapToken.Token")
+					t.Error("Invalid TLSBootstrapToken or BootstrapToken.Token")
 				}
 			},
 		},
@@ -155,7 +155,7 @@ func TestNewJoinData(t *testing.T) {
 				if data.cfg.Discovery.TLSBootstrapToken != "abcdef.0123456789abcdef" ||
 					data.cfg.Discovery.BootstrapToken == nil ||
 					data.cfg.Discovery.BootstrapToken.Token != "defghi.0123456789defghi" {
-					t.Errorf("Invalid TLSBootstrapToken or BootstrapToken.Token")
+					t.Error("Invalid TLSBootstrapToken or BootstrapToken.Token")
 				}
 			},
 		},
@@ -172,7 +172,7 @@ func TestNewJoinData(t *testing.T) {
 				if data.cfg.ControlPlane == nil ||
 					data.cfg.ControlPlane.LocalAPIEndpoint.AdvertiseAddress != "1.2.3.4" ||
 					data.cfg.ControlPlane.LocalAPIEndpoint.BindPort != 1234 {
-					t.Errorf("Invalid ControlPlane")
+					t.Error("Invalid ControlPlane")
 				}
 			},
 		},
@@ -187,7 +187,7 @@ func TestNewJoinData(t *testing.T) {
 			validate: func(t *testing.T, data *joinData) {
 				// validate that control plane attributes are unset in join data
 				if data.cfg.ControlPlane != nil {
-					t.Errorf("Invalid ControlPlane")
+					t.Error("Invalid ControlPlane")
 				}
 			},
 			expectWarn: true,
@@ -216,7 +216,7 @@ func TestNewJoinData(t *testing.T) {
 			validate: func(t *testing.T, data *joinData) {
 				// validate that node-name is overwritten
 				if data.cfg.NodeRegistration.Name != "anotherName" {
-					t.Errorf("Invalid NodeRegistration.Name")
+					t.Error("Invalid NodeRegistration.Name")
 				}
 			},
 		},
@@ -304,7 +304,7 @@ func TestNewJoinData(t *testing.T) {
 				t.Fatalf("newJoinData returned unexpected error: %v", err)
 			}
 			if err == nil && tc.expectError {
-				t.Fatalf("newJoinData didn't return error when expected")
+				t.Fatal("newJoinData didn't return error when expected")
 			}
 
 			// exec additional validation on the returned value

--- a/cmd/kubeadm/app/cmd/join_test.go
+++ b/cmd/kubeadm/app/cmd/join_test.go
@@ -42,7 +42,7 @@ discovery:
 controlPlane:
   certificateKey: c39a18bae4a72e71b178661f437363da218a3efb83ddb03f1cd91d9ae1da41bd
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///var/run/containerd/containerd.sock
   name: someName
   ignorePreflightErrors:
     - c

--- a/cmd/kubeadm/app/cmd/join_test.go
+++ b/cmd/kubeadm/app/cmd/join_test.go
@@ -208,7 +208,7 @@ func TestNewJoinData(t *testing.T) {
 			},
 		},
 		{
-			name: "--cri-socket and --node-name flags override config from file",
+			name: "--node-name flags override config from file",
 			flags: map[string]string{
 				options.CfgPath:  configFilePath,
 				options.NodeName: "anotherName",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

- `cri-socket` is not allowed for mixed configuration
Set the `cri-socket` both in flags and config file will hit errors, this should not be a valid case to validate in current testcases.
- use the right methods for logging if no args are passing
- stop using of CRI endpoints without URL scheme
run the testcase with `-v` flag will reveal the warning, e.g. `W1103 ... Usage of CRI endpoints without URL scheme is deprecated...`
- improve test coverage by validating the data structure
data structure is what returned if everything okay, but this structure is not validated at all both in `init` and `join` cmd.

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
