### PR TITLE
remove SetUpAt() in hostpath volume

### DIFF
--- a/pkg/volume/hostpath/host_path.go
+++ b/pkg/volume/hostpath/host_path.go
@@ -252,11 +252,6 @@ func (b *hostPathMounter) SetUp(mounterArgs volume.MounterArgs) error {
 	}
 }
 
-// SetUpAt does not make sense for host paths - probably programmer error.
-func (b *hostPathMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
-	return fmt.Errorf("SetUpAt() does not make sense for host paths")
-}
-
 func (b *hostPathMounter) GetPath() string {
 	return b.path
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
SetUpAt() in hostpath volume is not used, existence causes confusion, so it is better to remove it.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

