### PR TITLE
Reconstruct SELinux  mount label

### DIFF
--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -290,7 +290,7 @@ func (dsw *desiredStateOfWorld) AddPodToVolume(
 	if err != nil {
 		return "", err
 	}
-	klog.V(4).InfoS("volume final SELinux label decided", "volume", volumeSpec.Name(), "label", seLinuxFileLabel)
+	klog.V(4).InfoS("expected volume SELinux label context", "volume", volumeSpec.Name(), "label", seLinuxFileLabel)
 
 	if vol, volumeExists := dsw.volumesToMount[volumeName]; !volumeExists {
 		var sizeLimit *resource.Quantity
@@ -309,6 +309,7 @@ func (dsw *desiredStateOfWorld) AddPodToVolume(
 		}
 		if !util.VolumeSupportsSELinuxMount(volumeSpec) {
 			// Clear SELinux label for the volume with unsupported access modes.
+			klog.V(4).InfoS("volume does not support SELinux context mount, clearing the expected label", "volume", volumeSpec.Name())
 			seLinuxFileLabel = ""
 		}
 		if seLinuxFileLabel != "" {

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct.go
@@ -160,7 +160,6 @@ func (rc *reconciler) updateStates(volumesNeedUpdate map[v1.UniqueVolumeName]*gl
 				klog.ErrorS(err, "Could not find device mount path for volume", "volumeName", gvl.volumeName)
 				continue
 			}
-			// TODO(jsafrane): add reconstructed SELinux context
 			err = rc.actualStateOfWorld.MarkDeviceAsMounted(gvl.volumeName, gvl.devicePath, deviceMountPath, "")
 			if err != nil {
 				klog.ErrorS(err, "Could not mark device is mounted to actual state of world", "volume", gvl.volumeName)

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -275,6 +275,10 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 		volDataKey.attachmentID:        getAttachmentName(volumeHandle, string(c.driverName), nodeName),
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMountReadWriteOncePod) && selinuxLabelMount {
+		volData[volDataKey.seLinuxMountContext] = mounterArgs.SELinuxLabel
+	}
+
 	err = saveVolumeData(parentDir, volDataFileName, volData)
 	defer func() {
 		// Only if there was an error and volume operation was considered

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -60,7 +60,7 @@ var (
 	testAccount = "test-service-account"
 )
 
-func prepareVolumeInfoFile(mountPath string, plug *csiPlugin, specVolumeName, volumeID, driverName, lifecycleMode string) error {
+func prepareVolumeInfoFile(mountPath string, plug *csiPlugin, specVolumeName, volumeID, driverName, lifecycleMode, seLinuxMountContext string) error {
 	nodeName := string(plug.host.GetNodeName())
 	volData := map[string]string{
 		volDataKey.specVolID:           specVolumeName,
@@ -69,6 +69,7 @@ func prepareVolumeInfoFile(mountPath string, plug *csiPlugin, specVolumeName, vo
 		volDataKey.nodeName:            nodeName,
 		volDataKey.attachmentID:        getAttachmentName(volumeID, driverName, nodeName),
 		volDataKey.volumeLifecycleMode: lifecycleMode,
+		volDataKey.seLinuxMountContext: seLinuxMountContext,
 	}
 	if err := os.MkdirAll(mountPath, 0755); err != nil {
 		return fmt.Errorf("failed to create dir for volume info file: %s", err)

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -573,7 +573,11 @@ type VolumeConfig struct {
 // ReconstructedVolume contains information about a volume reconstructed by
 // ConstructVolumeSpec().
 type ReconstructedVolume struct {
+	// Spec is the volume spec of a mounted volume
 	Spec *Spec
+	// SELinuxMountContext is value of -o context=XYZ mount option.
+	// If empty, no such mount option is used.
+	SELinuxMountContext string
 }
 
 // NewSpecFromVolume creates an Spec from an v1.Volume

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -430,8 +430,18 @@ func (plugin *rbdPlugin) ConstructVolumeSpec(volumeName, mountPath string) (volu
 			},
 		},
 	}
+
+	var mountContext string
+	if utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMountReadWriteOncePod) {
+		mountContext, err = hu.GetSELinuxMountContext(mountPath)
+		if err != nil {
+			return volume.ReconstructedVolume{}, err
+		}
+	}
+
 	return volume.ReconstructedVolume{
-		Spec: volume.NewSpecFromVolume(rbdVolume),
+		Spec:                volume.NewSpecFromVolume(rbdVolume),
+		SELinuxMountContext: mountContext,
 	}, nil
 }
 

--- a/pkg/volume/util/hostutil/fake_hostutil.go
+++ b/pkg/volume/util/hostutil/fake_hostutil.go
@@ -116,3 +116,9 @@ func (hu *FakeHostUtil) GetSELinuxSupport(pathname string) (bool, error) {
 func (hu *FakeHostUtil) GetMode(pathname string) (os.FileMode, error) {
 	return 0, errors.New("not implemented")
 }
+
+// GetSELinuxMountContext returns value of -o context=XYZ mount option on
+// given mount point.
+func (hu *FakeHostUtil) GetSELinuxMountContext(pathname string) (string, error) {
+	return "", errors.New("not implemented")
+}

--- a/pkg/volume/util/hostutil/hostutil.go
+++ b/pkg/volume/util/hostutil/hostutil.go
@@ -68,6 +68,9 @@ type HostUtils interface {
 	GetSELinuxSupport(pathname string) (bool, error)
 	// GetMode returns permissions of the path.
 	GetMode(pathname string) (os.FileMode, error)
+	// GetSELinuxMountContext returns value of -o context=XYZ mount option on
+	// given mount point.
+	GetSELinuxMountContext(pathname string) (string, error)
 }
 
 // Compile-time check to ensure all HostUtil implementations satisfy

--- a/pkg/volume/util/hostutil/hostutil_linux.go
+++ b/pkg/volume/util/hostutil/hostutil_linux.go
@@ -299,3 +299,35 @@ func GetModeLinux(pathname string) (os.FileMode, error) {
 	}
 	return info.Mode(), nil
 }
+
+// GetSELinuxMountContext returns value of -o context=XYZ mount option on
+// given mount point.
+func (hu *HostUtil) GetSELinuxMountContext(pathname string) (string, error) {
+	return getSELinuxMountContext(pathname, procMountInfoPath, selinux.GetEnabled)
+}
+
+// getSELinux is common implementation of GetSELinuxSupport on Linux.
+// Using an extra function for unit tests.
+func getSELinuxMountContext(path string, mountInfoFilename string, selinuxEnabled seLinuxEnabledFunc) (string, error) {
+	// Skip /proc/mounts parsing if SELinux is disabled.
+	if !selinuxEnabled() {
+		return "", nil
+	}
+
+	info, err := findMountInfo(path, mountInfoFilename)
+	if err != nil {
+		return "", err
+	}
+
+	for _, opt := range info.SuperOptions {
+		if !strings.HasPrefix(opt, "context=") {
+			continue
+		}
+		// Remove context=
+		context := strings.TrimPrefix(opt, "context=")
+		// Remove double quotes
+		context = strings.Trim(context, "\"")
+		return context, nil
+	}
+	return "", nil
+}

--- a/pkg/volume/util/hostutil/hostutil_unsupported.go
+++ b/pkg/volume/util/hostutil/hostutil_unsupported.go
@@ -101,3 +101,9 @@ func (hu *HostUtil) GetMode(pathname string) (os.FileMode, error) {
 func getDeviceNameFromMount(mounter mount.Interface, mountPath, pluginMountDir string) (string, error) {
 	return "", errUnsupported
 }
+
+// GetSELinuxMountContext returns value of -o context=XYZ mount option on
+// given mount point.
+func (hu *HostUtil) GetSELinuxMountContext(pathname string) (string, error) {
+	return "", errUnsupported
+}

--- a/pkg/volume/util/hostutil/hostutil_windows.go
+++ b/pkg/volume/util/hostutil/hostutil_windows.go
@@ -123,3 +123,9 @@ func (hu *HostUtil) GetMode(pathname string) (os.FileMode, error) {
 	}
 	return info.Mode(), nil
 }
+
+// GetSELinuxMountContext returns value of -o context=XYZ mount option on
+// given mount point.
+func (hu *HostUtil) GetSELinuxMountContext(pathname string) (string, error) {
+	return "", nil
+}

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -309,6 +309,7 @@ type mockCSIDriver struct {
 	embedded               bool
 	calls                  MockCSICalls
 	embeddedCSIDriver      *mockdriver.CSIDriver
+	enableSELinuxMount     *bool
 
 	// Additional values set during PrepareTest
 	clientSet       clientset.Interface
@@ -355,6 +356,7 @@ type CSIMockDriverOpts struct {
 	TokenRequests          []storagev1.TokenRequest
 	RequiresRepublish      *bool
 	FSGroupPolicy          *storagev1.FSGroupPolicy
+	EnableSELinuxMount     *bool
 
 	// Embedded defines whether the CSI mock driver runs
 	// inside the cluster (false, the default) or just a proxy
@@ -507,6 +509,7 @@ func InitMockCSIDriver(driverOpts CSIMockDriverOpts) MockCSITestDriver {
 		requiresRepublish:      driverOpts.RequiresRepublish,
 		fsGroupPolicy:          driverOpts.FSGroupPolicy,
 		enableVolumeMountGroup: driverOpts.EnableVolumeMountGroup,
+		enableSELinuxMount:     driverOpts.EnableSELinuxMount,
 		embedded:               driverOpts.Embedded,
 		hooks:                  driverOpts.Hooks,
 	}
@@ -657,6 +660,7 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) *storageframework.Pe
 		TokenRequests:     m.tokenRequests,
 		RequiresRepublish: m.requiresRepublish,
 		FSGroupPolicy:     m.fsGroupPolicy,
+		SELinuxMount:      m.enableSELinuxMount,
 	}
 	cleanup, err := utils.CreateFromManifests(f, m.driverNamespace, func(item interface{}) error {
 		if err := utils.PatchCSIDeployment(config.Framework, o, item); err != nil {

--- a/test/e2e/storage/testsuites/disruptive.go
+++ b/test/e2e/storage/testsuites/disruptive.go
@@ -18,7 +18,6 @@ package testsuites
 
 import (
 	"github.com/onsi/ginkgo/v2"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
@@ -90,7 +89,7 @@ func (s *disruptiveTestSuite) DefineTests(driver storageframework.TestDriver, pa
 	f := framework.NewFrameworkWithCustomTimeouts("disruptive", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	init := func() {
+	init := func(accessModes []v1.PersistentVolumeAccessMode) {
 		l = local{}
 		l.ns = f.Namespace
 		l.cs = f.ClientSet
@@ -99,7 +98,20 @@ func (s *disruptiveTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		l.config = driver.PrepareTest(f)
 
 		testVolumeSizeRange := s.GetTestSuiteInfo().SupportedSizeRange
-		l.resource = storageframework.CreateVolumeResource(driver, l.config, pattern, testVolumeSizeRange)
+		if accessModes == nil {
+			l.resource = storageframework.CreateVolumeResource(
+				driver,
+				l.config,
+				pattern,
+				testVolumeSizeRange)
+		} else {
+			l.resource = storageframework.CreateVolumeResourceWithAccessModes(
+				driver,
+				l.config,
+				pattern,
+				testVolumeSizeRange,
+				accessModes)
+		}
 	}
 
 	cleanup := func() {
@@ -120,13 +132,13 @@ func (s *disruptiveTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		framework.ExpectNoError(errors.NewAggregate(errs), "while cleaning up resource")
 	}
 
-	type testBody func(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod)
-	type disruptiveTest struct {
+	type singlePodTestBody func(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod)
+	type singlePodTest struct {
 		testItStmt   string
-		runTestFile  testBody
-		runTestBlock testBody
+		runTestFile  singlePodTestBody
+		runTestBlock singlePodTestBody
 	}
-	disruptiveTestTable := []disruptiveTest{
+	singlePodTests := []singlePodTest{
 		{
 			testItStmt:   "Should test that pv written before kubelet restart is readable after restart.",
 			runTestFile:  storageutils.TestKubeletRestartsAndRestoresMount,
@@ -144,12 +156,12 @@ func (s *disruptiveTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		},
 	}
 
-	for _, test := range disruptiveTestTable {
-		func(t disruptiveTest) {
+	for _, test := range singlePodTests {
+		func(t singlePodTest) {
 			if (pattern.VolMode == v1.PersistentVolumeBlock && t.runTestBlock != nil) ||
 				(pattern.VolMode == v1.PersistentVolumeFilesystem && t.runTestFile != nil) {
 				ginkgo.It(t.testItStmt, func() {
-					init()
+					init(nil)
 					defer cleanup()
 
 					var err error
@@ -177,6 +189,82 @@ func (s *disruptiveTestSuite) DefineTests(driver storageframework.TestDriver, pa
 					}
 					if pattern.VolMode == v1.PersistentVolumeFilesystem && t.runTestFile != nil {
 						t.runTestFile(l.cs, l.config.Framework, l.pod)
+					}
+				})
+			}
+		}(test)
+	}
+	type multiplePodTestBody func(c clientset.Interface, f *framework.Framework, pod1, pod2 *v1.Pod)
+	type multiplePodTest struct {
+		testItStmt            string
+		changeSELinuxContexts bool
+		runTestFile           multiplePodTestBody
+	}
+	multiplePodTests := []multiplePodTest{
+		{
+			testItStmt: "Should test that pv used in a pod that is deleted while the kubelet is down is usable by a new pod when kubelet returns.",
+			runTestFile: func(c clientset.Interface, f *framework.Framework, pod1, pod2 *v1.Pod) {
+				storageutils.TestVolumeUnmountsFromDeletedPodWithForceOption(c, f, pod1, false, false, pod2)
+			},
+		},
+		{
+			testItStmt: "Should test that pv used in a pod that is force deleted while the kubelet is down is usable by a new pod when kubelet returns.",
+			runTestFile: func(c clientset.Interface, f *framework.Framework, pod1, pod2 *v1.Pod) {
+				storageutils.TestVolumeUnmountsFromDeletedPodWithForceOption(c, f, pod1, true, false, pod2)
+			},
+		},
+		{
+			testItStmt:            "Should test that pv used in a pod that is deleted while the kubelet is down is usable by a new pod with a different SELinux context when kubelet returns [Feature:SELinuxMountReadWriteOncePod].",
+			changeSELinuxContexts: true,
+			runTestFile: func(c clientset.Interface, f *framework.Framework, pod1, pod2 *v1.Pod) {
+				storageutils.TestVolumeUnmountsFromDeletedPodWithForceOption(c, f, pod1, false, false, pod2)
+			},
+		},
+		{
+			testItStmt:            "Should test that pv used in a pod that is force deleted while the kubelet is down is usable by a new pod with a different SELinux context when kubelet returns [Feature:SELinuxMountReadWriteOncePod].",
+			changeSELinuxContexts: true,
+			runTestFile: func(c clientset.Interface, f *framework.Framework, pod1, pod2 *v1.Pod) {
+				storageutils.TestVolumeUnmountsFromDeletedPodWithForceOption(c, f, pod1, true, false, pod2)
+			},
+		},
+	}
+
+	for _, test := range multiplePodTests {
+		func(t multiplePodTest) {
+			if pattern.VolMode == v1.PersistentVolumeFilesystem && t.runTestFile != nil {
+				ginkgo.It(t.testItStmt, func() {
+					init([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod})
+					defer cleanup()
+
+					var err error
+					var pvcs []*v1.PersistentVolumeClaim
+					var inlineSources []*v1.VolumeSource
+					if pattern.VolType == storageframework.InlineVolume {
+						inlineSources = append(inlineSources, l.resource.VolSource)
+					} else {
+						pvcs = append(pvcs, l.resource.Pvc)
+					}
+					ginkgo.By("Creating a pod with pvc")
+					podConfig := e2epod.Config{
+						NS:                  l.ns.Name,
+						PVCs:                pvcs,
+						InlineVolumeSources: inlineSources,
+						SeLinuxLabel:        e2epv.SELinuxLabel,
+						NodeSelection:       l.config.ClientNodeSelection,
+						ImageID:             e2epod.GetDefaultTestImageID(),
+					}
+					l.pod, err = e2epod.CreateSecPodWithNodeSelection(l.cs, &podConfig, f.Timeouts.PodStart)
+					framework.ExpectNoError(err, "While creating pods for kubelet restart test")
+					if t.changeSELinuxContexts {
+						// Different than e2epv.SELinuxLabel
+						podConfig.SeLinuxLabel = &v1.SELinuxOptions{Level: "s0:c98,c99"}
+					}
+					pod2, err := e2epod.MakeSecPod(&podConfig)
+					// Instantly schedule the second pod on the same node as the first one.
+					pod2.Spec.NodeName = l.pod.Spec.NodeName
+					framework.ExpectNoError(err, "While creating second pod for kubelet restart test")
+					if pattern.VolMode == v1.PersistentVolumeFilesystem && t.runTestFile != nil {
+						t.runTestFile(l.cs, l.config.Framework, l.pod, pod2)
 					}
 				})
 			}

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -66,6 +66,7 @@ type StorageClassTest struct {
 	VolumeMode           v1.PersistentVolumeMode
 	AllowVolumeExpansion bool
 	NodeSelection        e2epod.NodeSelection
+	MountOptions         []string
 }
 
 type provisioningTestSuite struct {

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -1002,7 +1002,7 @@ func testSubpathReconstruction(f *framework.Framework, hostExec storageutils.Hos
 	}
 	framework.ExpectNotEqual(podNode, nil, "pod node should exist in schedulable nodes")
 
-	storageutils.TestVolumeUnmountsFromDeletedPodWithForceOption(f.ClientSet, f, pod, forceDelete, true)
+	storageutils.TestVolumeUnmountsFromDeletedPodWithForceOption(f.ClientSet, f, pod, forceDelete, true, nil)
 
 	if podNode != nil {
 		mountPoints := globalMountPointsByNode[podNode.Name]

--- a/test/e2e/storage/utils/deployment.go
+++ b/test/e2e/storage/utils/deployment.go
@@ -152,6 +152,9 @@ func PatchCSIDeployment(f *e2eframework.Framework, o PatchCSIOptions, object int
 		if o.FSGroupPolicy != nil {
 			object.Spec.FSGroupPolicy = o.FSGroupPolicy
 		}
+		if o.SELinuxMount != nil {
+			object.Spec.SELinuxMount = o.SELinuxMount
+		}
 	}
 
 	return nil
@@ -211,4 +214,8 @@ type PatchCSIOptions struct {
 	// field *if* the driver deploys a CSIDriver object. Ignored
 	// otherwise.
 	FSGroupPolicy *storagev1.FSGroupPolicy
+	// If not nil, the value to use for the CSIDriver.Spec.SELinuxMount
+	// field *if* the driver deploys a CSIDriver object. Ignored
+	// otherwise.
+	SELinuxMount *bool
 }

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -808,7 +808,7 @@ func newStorageClass(t testsuites.StorageClassTest, ns string, prefix string) *s
 		}
 	}
 
-	sc := getStorageClass(pluginName, t.Parameters, &bindingMode, ns, prefix)
+	sc := getStorageClass(pluginName, t.Parameters, &bindingMode, t.MountOptions, ns, prefix)
 	if t.AllowVolumeExpansion {
 		sc.AllowVolumeExpansion = &t.AllowVolumeExpansion
 	}
@@ -819,6 +819,7 @@ func getStorageClass(
 	provisioner string,
 	parameters map[string]string,
 	bindingMode *storagev1.VolumeBindingMode,
+	mountOptions []string,
 	ns string,
 	prefix string,
 ) *storagev1.StorageClass {
@@ -837,6 +838,7 @@ func getStorageClass(
 		Provisioner:       provisioner,
 		Parameters:        parameters,
 		VolumeBindingMode: bindingMode,
+		MountOptions:      mountOptions,
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Reconstruct SELinux mount option `-o context=XYZ` and add it to volume manager's Actual State of World (ASW) when kubelet starts. Kubelet then can see if a mounted volume in ASW has the right context that new Pods need and can unmount it and mount back to get the right SELinux context.

SELinux context for CSI volumes is determined from json file, for in-tree volumes it's taken directly from the mount table.

~In addition, there is a new e2e test that checks the reconstruction gets the right SELinux context and volume from an old pod is un-mounted when needed.~ E2e tests will be a separate PR.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added reconstruction of SELinux mount context after kubelet restart. Feature SELinuxMountReadWriteOncePod is now fully implemented and kubelet does not lose its cache of SELinux contexts after kubelet process restart.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
https://github.com/kubernetes/enhancements/pull/3548
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling
```
