### PR TITLE
Remove redundant prefix of kubelet credential provider metrics

### DIFF
--- a/pkg/credentialprovider/plugin/metrics.go
+++ b/pkg/credentialprovider/plugin/metrics.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	kubeletCredentialProviderPluginErrorsKey   = "kubelet_credential_provider_plugin_errors"
-	kubeletCredentialProviderPluginDurationKey = "kubelet_credential_provider_plugin_duration"
+	kubeletCredentialProviderPluginErrorsKey   = "credential_provider_plugin_errors"
+	kubeletCredentialProviderPluginDurationKey = "credential_provider_plugin_duration"
 	KubeletSubsystem                           = "kubelet"
 )
 
@@ -59,6 +59,5 @@ func registerMetrics() {
 	registerOnce.Do(func() {
 		legacyregistry.MustRegister(kubeletCredentialProviderPluginErrors)
 		legacyregistry.MustRegister(kubeletCredentialProviderPluginDuration)
-
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind api-change

#### What this PR does / why we need it:

This PR removes the redundant prefix of the kubelet `kubelet_kubelet_credential_provider_plugin_duration` and `kubelet_kubelet_credential_provider_plugin_errors` metrics.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove redundant prefix of kubelet_kubelet_credential_provider_plugin_duration and kubelet_kubelet_credential_provider_plugin_errors metrics.
```
