### PR TITLE
ReplicaSet: fix availableReplicas update with unstable pods

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -2758,6 +2758,9 @@ func (t *trackingWorkqueue) Done(item interface{}) {
 func (t *trackingWorkqueue) Forget(item interface{}) {
 	t.limiter.Forget(item)
 }
+func (t *trackingWorkqueue) ForgetDelayed(item interface{}) {
+	t.limiter.ForgetDelayed(item)
+}
 func (t *trackingWorkqueue) NumRequeues(item interface{}) int {
 	return 0
 }

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -3813,6 +3813,11 @@ func (f *fakeRateLimitingQueue) AddAfter(item interface{}, duration time.Duratio
 	f.duration = duration
 }
 
+func (f *fakeRateLimitingQueue) ForgetDelayed(item interface{}) {
+	f.item = nil
+	f.duration = 0
+}
+
 func TestJobBackoff(t *testing.T) {
 	job := newJob(1, 1, 1, batch.NonIndexedCompletion)
 	oldPod := newPod(fmt.Sprintf("pod-%v", rand.String(10)), job)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind bug
/sig apps

#### What this PR does / why we need it:

Replica set might skip availability checks in certain situations and not update `availableReplicas`. This also stops deployment from progressing.

This applies to pods that are struggling to become `Ready` or become Ready with a certain delay.

For more details, please see: https://github.com/kubernetes/kubernetes/issues/108266#issuecomment-1302639795

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108266

#### Special notes for your reviewer:

I would like to suggest similar changes for stateful set and daemon set as well

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

TODO
- [x] https://github.com/kubernetes/kubernetes/pull/113607
- [ ] https://github.com/kubernetes/kubernetes/pull/112328
