### PR TITLE
Initialize the AuditEvent with the AuditContext

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/audit_test.go
@@ -142,10 +142,10 @@ func TestWithAudit(t *testing.T) {
 	}
 	for tcName, tc := range testCases {
 		var handler Interface = fakeHandler{tc.admit, tc.admitAnnotations, tc.validate, tc.validateAnnotations, tc.handles}
-		ae := &auditinternal.Event{Level: auditinternal.LevelMetadata}
 		ctx := audit.WithAuditContext(context.Background())
 		ac := audit.AuditContextFrom(ctx)
-		ac.Event = ae
+		ae := &ac.Event
+		ae.Level = auditinternal.LevelMetadata
 		auditHandler := WithAudit(handler)
 		a := attributes()
 
@@ -188,7 +188,7 @@ func TestWithAuditConcurrency(t *testing.T) {
 	var handler Interface = fakeHandler{admitAnnotations: admitAnnotations, handles: true}
 	ctx := audit.WithAuditContext(context.Background())
 	ac := audit.AuditContextFrom(ctx)
-	ac.Event = &auditinternal.Event{Level: auditinternal.LevelMetadata}
+	ac.Event.Level = auditinternal.LevelMetadata
 	auditHandler := WithAudit(handler)
 	a := attributes()
 

--- a/staging/src/k8s.io/apiserver/pkg/audit/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/context.go
@@ -39,21 +39,16 @@ type AuditContext struct {
 	RequestAuditConfig RequestAuditConfig
 
 	// Event is the audit Event object that is being captured to be written in
-	// the API audit log. It is set to nil when the request is not being audited.
-	Event *auditinternal.Event
+	// the API audit log.
+	Event auditinternal.Event
 
-	// annotations holds audit annotations that are recorded before the event has been initialized.
-	// This is represented as a slice rather than a map to preserve order.
-	annotations []annotation
-	// annotationMutex guards annotations AND event.Annotations
+	// annotationMutex guards event.Annotations
 	annotationMutex sync.Mutex
-
-	// auditID is the Audit ID associated with this request.
-	auditID types.UID
 }
 
-type annotation struct {
-	key, value string
+// Enabled checks whether auditing is enabled for this audit context.
+func (ac *AuditContext) Enabled() bool {
+	return ac != nil && ac.RequestAuditConfig.Level != auditinternal.LevelNone
 }
 
 // AddAuditAnnotation sets the audit annotation for the given key, value pair.
@@ -65,8 +60,7 @@ type annotation struct {
 // prefer AddAuditAnnotation over LogAnnotation to avoid dropping annotations.
 func AddAuditAnnotation(ctx context.Context, key, value string) {
 	ac := AuditContextFrom(ctx)
-	if ac == nil {
-		// auditing is not enabled
+	if !ac.Enabled() {
 		return
 	}
 
@@ -81,8 +75,7 @@ func AddAuditAnnotation(ctx context.Context, key, value string) {
 // keysAndValues are the key-value pairs to add, and must have an even number of items.
 func AddAuditAnnotations(ctx context.Context, keysAndValues ...string) {
 	ac := AuditContextFrom(ctx)
-	if ac == nil {
-		// auditing is not enabled
+	if !ac.Enabled() {
 		return
 	}
 
@@ -101,8 +94,7 @@ func AddAuditAnnotations(ctx context.Context, keysAndValues ...string) {
 // restrictions on when this can be called.
 func AddAuditAnnotationsMap(ctx context.Context, annotations map[string]string) {
 	ac := AuditContextFrom(ctx)
-	if ac == nil {
-		// auditing is not enabled
+	if !ac.Enabled() {
 		return
 	}
 
@@ -114,38 +106,10 @@ func AddAuditAnnotationsMap(ctx context.Context, annotations map[string]string) 
 	}
 }
 
-// addAuditAnnotationLocked is the shared code for recording an audit annotation. This method should
-// only be called while the auditAnnotationsMutex is locked.
+// addAuditAnnotationLocked records the audit annotation on the event.
 func addAuditAnnotationLocked(ac *AuditContext, key, value string) {
-	if ac.Event != nil {
-		logAnnotation(ac.Event, key, value)
-	} else {
-		ac.annotations = append(ac.annotations, annotation{key: key, value: value})
-	}
-}
+	ae := &ac.Event
 
-// This is private to prevent reads/write to the slice from outside of this package.
-// The audit event should be directly read to get access to the annotations.
-func addAuditAnnotationsFrom(ctx context.Context, ev *auditinternal.Event) {
-	ac := AuditContextFrom(ctx)
-	if ac == nil {
-		// auditing is not enabled
-		return
-	}
-
-	ac.annotationMutex.Lock()
-	defer ac.annotationMutex.Unlock()
-
-	for _, kv := range ac.annotations {
-		logAnnotation(ev, kv.key, kv.value)
-	}
-}
-
-// LogAnnotation fills in the Annotations according to the key value pair.
-func logAnnotation(ae *auditinternal.Event, key, value string) {
-	if ae == nil || ae.Level.Less(auditinternal.LevelMetadata) {
-		return
-	}
 	if ae.Annotations == nil {
 		ae.Annotations = make(map[string]string)
 	}
@@ -167,8 +131,8 @@ func WithAuditContext(parent context.Context) context.Context {
 
 // AuditEventFrom returns the audit event struct on the ctx
 func AuditEventFrom(ctx context.Context) *auditinternal.Event {
-	if o := AuditContextFrom(ctx); o != nil {
-		return o.Event
+	if ac := AuditContextFrom(ctx); ac.Enabled() {
+		return &ac.Event
 	}
 	return nil
 }
@@ -188,19 +152,17 @@ func WithAuditID(ctx context.Context, auditID types.UID) {
 		return
 	}
 	ac := AuditContextFrom(ctx)
-	if ac == nil {
+	if !ac.Enabled() {
 		return
 	}
-	ac.auditID = auditID
-	if ac.Event != nil {
-		ac.Event.AuditID = auditID
-	}
+	ac.Event.AuditID = auditID
 }
 
-// AuditIDFrom returns the value of the audit ID from the request context.
+// AuditIDFrom returns the value of the audit ID from the request context, along with whether
+// auditing is enabled.
 func AuditIDFrom(ctx context.Context) (types.UID, bool) {
-	if ac := AuditContextFrom(ctx); ac != nil {
-		return ac.auditID, ac.auditID != ""
+	if ac := AuditContextFrom(ctx); ac.Enabled() {
+		return ac.Event.AuditID, true
 	}
 	return "", false
 }

--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -28,14 +28,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/klog/v2"
-
-	"github.com/google/uuid"
 )
 
 const (
@@ -55,12 +52,6 @@ func LogRequestMetadata(ctx context.Context, req *http.Request, requestReceivedT
 	ev.RequestURI = req.URL.RequestURI()
 	ev.UserAgent = maybeTruncateUserAgent(req)
 	ev.Level = level
-
-	auditID, found := AuditIDFrom(req.Context())
-	if !found {
-		auditID = types.UID(uuid.New().String())
-	}
-	ev.AuditID = auditID
 
 	ips := utilnet.SourceIPs(req)
 	ev.SourceIPs = make([]string, len(ips))

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go
@@ -197,15 +197,14 @@ func (a *cachedTokenAuthenticator) doAuthenticateToken(ctx context.Context, toke
 		recorder := &recorder{}
 		ctx = warning.WithWarningRecorder(ctx, recorder)
 
-		// since this is shared work between multiple requests, we have no way of knowing if any
-		// particular request supports audit annotations.  thus we always attempt to record them.
-		ev := &auditinternal.Event{Level: auditinternal.LevelMetadata}
 		ctx = audit.WithAuditContext(ctx)
 		ac := audit.AuditContextFrom(ctx)
-		ac.Event = ev
+		// since this is shared work between multiple requests, we have no way of knowing if any
+		// particular request supports audit annotations.  thus we always attempt to record them.
+		ac.Event.Level = auditinternal.LevelMetadata
 
 		record.resp, record.ok, record.err = a.authenticator.AuthenticateToken(ctx, token)
-		record.annotations = ev.Annotations
+		record.annotations = ac.Event.Annotations
 		record.warnings = recorder.extractWarnings()
 
 		if !a.cacheErrs && record.err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator_test.go
@@ -544,6 +544,6 @@ func (s *singleBenchmark) bench(b *testing.B) {
 func withAudit(ctx context.Context) context.Context {
 	ctx = audit.WithAuditContext(ctx)
 	ac := audit.AuditContextFrom(ctx)
-	ac.Event = &auditinternal.Event{Level: auditinternal.LevelMetadata}
+	ac.Event.Level = auditinternal.LevelMetadata
 	return ctx
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -123,7 +123,8 @@ func WithAudit(handler http.Handler, sink audit.Sink, policy audit.PolicyRuleEva
 func evaluatePolicyAndCreateAuditEvent(req *http.Request, policy audit.PolicyRuleEvaluator) (*audit.AuditContext, error) {
 	ctx := req.Context()
 	ac := audit.AuditContextFrom(ctx)
-	if !ac.Enabled() {
+	if ac == nil {
+		// Auditing not configured.
 		return nil, nil
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -849,7 +849,7 @@ func withTestContext(req *http.Request, user user.Info, ae *auditinternal.Event)
 	}
 	if ae != nil {
 		ac := audit.AuditContextFrom(ctx)
-		ac.Event = ae
+		ac.Event = *ae
 	}
 	if info, err := newTestRequestInfoResolver().NewRequestInfo(req); err == nil {
 		ctx = request.WithRequestInfo(ctx, info)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit.go
@@ -43,11 +43,11 @@ func WithFailedAuthenticationAudit(failedHandler http.Handler, sink audit.Sink, 
 			return
 		}
 
-		if ac == nil || ac.Event == nil {
+		if !ac.Enabled() {
 			failedHandler.ServeHTTP(w, req)
 			return
 		}
-		ev := ac.Event
+		ev := &ac.Event
 
 		ev.ResponseStatus = &metav1.Status{}
 		ev.ResponseStatus.Message = getAuthMethods(req)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/request_deadline.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/request_deadline.go
@@ -115,11 +115,11 @@ func withFailedRequestAudit(failedHandler http.Handler, statusErr *apierrors.Sta
 			return
 		}
 
-		if ac == nil || ac.Event == nil {
+		if !ac.Enabled() {
 			failedHandler.ServeHTTP(w, req)
 			return
 		}
-		ev := ac.Event
+		ev := &ac.Event
 
 		ev.ResponseStatus = &metav1.Status{}
 		ev.Stage = auditinternal.StageResponseStarted

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
@@ -66,9 +66,7 @@ func TestDeleteResourceAuditLogRequestObject(t *testing.T) {
 
 	ctx := audit.WithAuditContext(context.TODO())
 	ac := audit.AuditContextFrom(ctx)
-	ac.Event = &auditapis.Event{
-		Level: auditapis.LevelRequestResponse,
-	}
+	ac.Event.Level = auditapis.LevelRequestResponse
 
 	policy := metav1.DeletePropagationBackground
 	deleteOption := &metav1.DeleteOptions{

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -285,11 +285,6 @@ func TestAuthenticationAuditAnnotationsDefaultChain(t *testing.T) {
 		// confirm that we can set an audit annotation in a handler before WithAudit
 		audit.AddAuditAnnotation(req.Context(), "pandas", "are awesome")
 
-		// confirm that trying to use the audit event directly would never work
-		if ae := audit.AuditEventFrom(req.Context()); ae != nil {
-			t.Errorf("expected nil audit event, got %v", ae)
-		}
-
 		return &authenticator.Response{User: &user.DefaultInfo{}}, true, nil
 	})
 	backend := &testBackend{}

--- a/staging/src/k8s.io/apiserver/pkg/util/x509metrics/server_cert_deprecations_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/x509metrics/server_cert_deprecations_test.go
@@ -247,7 +247,7 @@ func TestCheckForHostnameError(t *testing.T) {
 			}
 			req = req.WithContext(audit.WithAuditContext(req.Context()))
 			auditCtx := audit.AuditContextFrom(req.Context())
-			auditCtx.Event = &auditapi.Event{Level: auditapi.LevelMetadata}
+			auditCtx.Event.Level = auditapi.LevelMetadata
 
 			_, err = client.Transport.RoundTrip(req)
 
@@ -390,7 +390,7 @@ func TestCheckForInsecureAlgorithmError(t *testing.T) {
 			}
 			req = req.WithContext(audit.WithAuditContext(req.Context()))
 			auditCtx := audit.AuditContextFrom(req.Context())
-			auditCtx.Event = &auditapi.Event{Level: auditapi.LevelMetadata}
+			auditCtx.Event.Level = auditapi.LevelMetadata
 
 			// can't use tlsServer.Client() as it contains the server certificate
 			// in tls.Config.Certificates. The signatures are, however, only checked


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Always initialize the audit event at the beginning of the request chain, and store audit data directly on the event.

#### Which issue(s) this PR fixes:
For https://github.com/kubernetes/kubernetes/issues/109087

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig auth api-machinery
/milestone v1.26