### PR TITLE
use filepath.WalkDir to improve performance

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -518,7 +518,7 @@ func (m *cgroupManagerImpl) Pids(name CgroupName) []int {
 		// Walk through the pod cgroup directory to check if
 		// container cgroups haven't been GCed yet. Get attached processes to
 		// all such unwanted containers under the pod cgroup
-		if err = filepath.Walk(dir, visitor); err != nil {
+		if err = filepath.WalkDir(dir, visitor); err != nil {
 			klog.V(4).InfoS("Cgroup manager encountered error scanning pids for directory", "path", dir, "err", err)
 		}
 	}

--- a/pkg/util/filesystem/defaultfs.go
+++ b/pkg/util/filesystem/defaultfs.go
@@ -116,7 +116,7 @@ func (fs *DefaultFs) ReadDir(dirname string) ([]os.DirEntry, error) {
 
 // Walk via filepath.Walk
 func (fs *DefaultFs) Walk(root string, walkFn filepath.WalkFunc) error {
-	return filepath.Walk(fs.prefix(root), walkFn)
+	return filepath.WalkDir(fs.prefix(root), walkFn)
 }
 
 // defaultFile implements File using same-named functions from "os"

--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -331,7 +331,7 @@ func (w *AtomicWriter) pathsToRemove(payload map[string]FileProjection, oldTsDir
 		return nil
 	}
 
-	err := filepath.Walk(oldTsDir, visitor)
+	err := filepath.WalkDir(oldTsDir, visitor)
 	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {

--- a/pkg/volume/util/atomic_writer_test.go
+++ b/pkg/volume/util/atomic_writer_test.go
@@ -796,7 +796,7 @@ func checkVolumeContents(targetDir, tcName string, payload map[string]FileProjec
 				t.Errorf("Unable to read symlink %v: %v", p, err)
 				continue
 			}
-			if err := filepath.Walk(filepath.Join(targetDir, actual), visitor); err != nil {
+			if err := filepath.WalkDir(filepath.Join(targetDir, actual), visitor); err != nil {
 				t.Errorf("%v: unexpected error walking directory: %v", tcName, err)
 			}
 		}

--- a/pkg/volume/util/fs/fs.go
+++ b/pkg/volume/util/fs/fs.go
@@ -100,7 +100,7 @@ func DiskUsage(path string) (UsageInfo, error) {
 	// dedupedInode stores inodes that could be duplicates (nlink > 1)
 	dedupedInodes := make(map[uint64]struct{})
 
-	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(path, func(path string, info os.FileInfo, err error) error {
 		// ignore files that have been deleted after directory was read
 		if os.IsNotExist(err) {
 			return nil

--- a/pkg/volume/util/subpath/subpath_linux_test.go
+++ b/pkg/volume/util/subpath/subpath_linux_test.go
@@ -588,7 +588,7 @@ func TestCleanSubPaths(t *testing.T) {
 				return mounts, nil
 			},
 			unmount: func(mountpath string) error {
-				err := filepath.Walk(mountpath, func(path string, info os.FileInfo, _ error) error {
+				err := filepath.WalkDir(mountpath, func(path string, info os.FileInfo, _ error) error {
 					if path == mountpath {
 						// Skip top level directory
 						return nil

--- a/pkg/volume/util/volumepathhandler/volume_path_handler_linux.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler_linux.go
@@ -157,7 +157,7 @@ func getLoopDeviceFromSysfs(path string) (string, error) {
 func (v VolumePathHandler) FindGlobalMapPathUUIDFromPod(pluginDir, mapPath string, podUID types.UID) (string, error) {
 	var globalMapPathUUID string
 	// Find symbolic link named pod uuid under plugin dir
-	err := filepath.Walk(pluginDir, func(path string, fi os.FileInfo, err error) error {
+	err := filepath.WalkDir(pluginDir, func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Just as #107669, After go 1.16, filepath.WalkDir is introduced, which is more efficient than Walk, as the comment said in golang https://github.com/golang/go/blob/master/src/io/fs/walk.go#L54

// The differences between WalkDirFunc compared to filepath.WalkFunc are:
//
//   - The second argument has type fs.DirEntry instead of fs.FileInfo.
//   - The function is called before reading a directory, to allow SkipDir
//     to bypass the directory read entirely.
//   - If a directory read fails, the function is called a second time
//     for that directory to report the error.
//

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
