### PR TITLE
daemonset: use contextual logging

### DIFF
--- a/cmd/kube-controller-manager/app/apps.go
+++ b/cmd/kube-controller-manager/app/apps.go
@@ -34,7 +34,9 @@ import (
 )
 
 func startDaemonSetController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+	ctx = klog.NewContext(ctx, klog.LoggerWithName(klog.FromContext(ctx), "daemonset-controller"))
 	dsc, err := daemon.NewDaemonSetsController(
+		ctx,
 		controllerContext.InformerFactory.Apps().V1().DaemonSets(),
 		controllerContext.InformerFactory.Apps().V1().ControllerRevisions(),
 		controllerContext.InformerFactory.Core().V1().Pods(),

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -130,6 +130,7 @@ type DaemonSetsController struct {
 
 // NewDaemonSetsController creates a new DaemonSetsController
 func NewDaemonSetsController(
+	ctx context.Context,
 	daemonSetInformer appsinformers.DaemonSetInformer,
 	historyInformer appsinformers.ControllerRevisionInformer,
 	podInformer coreinformers.PodInformer,
@@ -138,7 +139,7 @@ func NewDaemonSetsController(
 	failedPodsBackoff *flowcontrol.Backoff,
 ) (*DaemonSetsController, error) {
 	eventBroadcaster := record.NewBroadcaster()
-
+	logger := klog.FromContext(ctx)
 	dsc := &DaemonSetsController{
 		kubeClient:       kubeClient,
 		eventBroadcaster: eventBroadcaster,
@@ -156,17 +157,29 @@ func NewDaemonSetsController(
 	}
 
 	daemonSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    dsc.addDaemonset,
-		UpdateFunc: dsc.updateDaemonset,
-		DeleteFunc: dsc.deleteDaemonset,
+		AddFunc: func(obj interface{}) {
+			dsc.addDaemonset(logger, obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			dsc.updateDaemonset(logger, oldObj, newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			dsc.deleteDaemonset(logger, obj)
+		},
 	})
 	dsc.dsLister = daemonSetInformer.Lister()
 	dsc.dsStoreSynced = daemonSetInformer.Informer().HasSynced
 
 	historyInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    dsc.addHistory,
-		UpdateFunc: dsc.updateHistory,
-		DeleteFunc: dsc.deleteHistory,
+		AddFunc: func(obj interface{}) {
+			dsc.addHistory(logger, obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			dsc.updateHistory(logger, oldObj, newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			dsc.deleteHistory(logger, obj)
+		},
 	})
 	dsc.historyLister = historyInformer.Lister()
 	dsc.historyStoreSynced = historyInformer.Informer().HasSynced
@@ -174,16 +187,26 @@ func NewDaemonSetsController(
 	// Watch for creation/deletion of pods. The reason we watch is that we don't want a daemon set to create/delete
 	// more pods until all the effects (expectations) of a daemon set's create/delete have been observed.
 	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    dsc.addPod,
-		UpdateFunc: dsc.updatePod,
-		DeleteFunc: dsc.deletePod,
+		AddFunc: func(obj interface{}) {
+			dsc.addPod(logger, obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			dsc.updatePod(logger, oldObj, newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			dsc.deletePod(logger, obj)
+		},
 	})
 	dsc.podLister = podInformer.Lister()
 	dsc.podStoreSynced = podInformer.Informer().HasSynced
 
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    dsc.addNode,
-		UpdateFunc: dsc.updateNode,
+		AddFunc: func(obj interface{}) {
+			dsc.addNode(logger, obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			dsc.updateNode(logger, oldObj, newObj)
+		},
 	},
 	)
 	dsc.nodeStoreSynced = nodeInformer.Informer().HasSynced
@@ -197,13 +220,13 @@ func NewDaemonSetsController(
 	return dsc, nil
 }
 
-func (dsc *DaemonSetsController) addDaemonset(obj interface{}) {
+func (dsc *DaemonSetsController) addDaemonset(logger klog.Logger, obj interface{}) {
 	ds := obj.(*apps.DaemonSet)
-	klog.V(4).Infof("Adding daemon set %s", ds.Name)
+	logger.V(4).Info("Adding daemon set", "daemonset", klog.KObj(ds))
 	dsc.enqueueDaemonSet(ds)
 }
 
-func (dsc *DaemonSetsController) updateDaemonset(cur, old interface{}) {
+func (dsc *DaemonSetsController) updateDaemonset(logger klog.Logger, cur, old interface{}) {
 	oldDS := old.(*apps.DaemonSet)
 	curDS := cur.(*apps.DaemonSet)
 
@@ -214,17 +237,17 @@ func (dsc *DaemonSetsController) updateDaemonset(cur, old interface{}) {
 			utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", oldDS, err))
 			return
 		}
-		dsc.deleteDaemonset(cache.DeletedFinalStateUnknown{
+		dsc.deleteDaemonset(logger, cache.DeletedFinalStateUnknown{
 			Key: key,
 			Obj: oldDS,
 		})
 	}
 
-	klog.V(4).Infof("Updating daemon set %s", oldDS.Name)
+	logger.V(4).Info("Updating daemon set", "daemonset", klog.KObj(oldDS))
 	dsc.enqueueDaemonSet(curDS)
 }
 
-func (dsc *DaemonSetsController) deleteDaemonset(obj interface{}) {
+func (dsc *DaemonSetsController) deleteDaemonset(logger klog.Logger, obj interface{}) {
 	ds, ok := obj.(*apps.DaemonSet)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -238,7 +261,7 @@ func (dsc *DaemonSetsController) deleteDaemonset(obj interface{}) {
 			return
 		}
 	}
-	klog.V(4).Infof("Deleting daemon set %s", ds.Name)
+	logger.V(4).Info("Deleting daemon set", "daemonset", klog.KObj(ds))
 
 	key, err := controller.KeyFunc(ds)
 	if err != nil {
@@ -262,8 +285,9 @@ func (dsc *DaemonSetsController) Run(ctx context.Context, workers int) {
 
 	defer dsc.queue.ShutDown()
 
-	klog.Infof("Starting daemon sets controller")
-	defer klog.Infof("Shutting down daemon sets controller")
+	logger := klog.FromContext(ctx)
+	logger.Info("Starting daemon sets controller")
+	defer logger.Info("Shutting down daemon sets controller")
 
 	if !cache.WaitForNamedCacheSync("daemon sets", ctx.Done(), dsc.podStoreSynced, dsc.nodeStoreSynced, dsc.historyStoreSynced, dsc.dsStoreSynced) {
 		return
@@ -341,7 +365,7 @@ func (dsc *DaemonSetsController) getDaemonSetsForPod(pod *v1.Pod) []*apps.Daemon
 
 // getDaemonSetsForHistory returns a list of DaemonSets that potentially
 // match a ControllerRevision.
-func (dsc *DaemonSetsController) getDaemonSetsForHistory(history *apps.ControllerRevision) []*apps.DaemonSet {
+func (dsc *DaemonSetsController) getDaemonSetsForHistory(logger klog.Logger, history *apps.ControllerRevision) []*apps.DaemonSet {
 	daemonSets, err := dsc.dsLister.GetHistoryDaemonSets(history)
 	if err != nil || len(daemonSets) == 0 {
 		return nil
@@ -349,20 +373,20 @@ func (dsc *DaemonSetsController) getDaemonSetsForHistory(history *apps.Controlle
 	if len(daemonSets) > 1 {
 		// ControllerRef will ensure we don't do anything crazy, but more than one
 		// item in this list nevertheless constitutes user error.
-		klog.V(4).Infof("User error! more than one DaemonSets is selecting ControllerRevision %s/%s with labels: %#v",
-			history.Namespace, history.Name, history.Labels)
+		logger.V(4).Info("Found more than one DaemonSet selecting the ControllerRevision. This is potentially a user error",
+			"controllerRevision", klog.KObj(history), "labels", history.Labels)
 	}
 	return daemonSets
 }
 
 // addHistory enqueues the DaemonSet that manages a ControllerRevision when the ControllerRevision is created
 // or when the controller manager is restarted.
-func (dsc *DaemonSetsController) addHistory(obj interface{}) {
+func (dsc *DaemonSetsController) addHistory(logger klog.Logger, obj interface{}) {
 	history := obj.(*apps.ControllerRevision)
 	if history.DeletionTimestamp != nil {
 		// On a restart of the controller manager, it's possible for an object to
 		// show up in a state that is already pending deletion.
-		dsc.deleteHistory(history)
+		dsc.deleteHistory(logger, history)
 		return
 	}
 
@@ -372,17 +396,17 @@ func (dsc *DaemonSetsController) addHistory(obj interface{}) {
 		if ds == nil {
 			return
 		}
-		klog.V(4).Infof("ControllerRevision %s added.", history.Name)
+		logger.V(4).Info("Observed a ControllerRevision", "controllerRevision", klog.KObj(history))
 		return
 	}
 
 	// Otherwise, it's an orphan. Get a list of all matching DaemonSets and sync
 	// them to see if anyone wants to adopt it.
-	daemonSets := dsc.getDaemonSetsForHistory(history)
+	daemonSets := dsc.getDaemonSetsForHistory(logger, history)
 	if len(daemonSets) == 0 {
 		return
 	}
-	klog.V(4).Infof("Orphan ControllerRevision %s added.", history.Name)
+	logger.V(4).Info("Orphan ControllerRevision added", "controllerRevision", klog.KObj(history))
 	for _, ds := range daemonSets {
 		dsc.enqueueDaemonSet(ds)
 	}
@@ -391,7 +415,7 @@ func (dsc *DaemonSetsController) addHistory(obj interface{}) {
 // updateHistory figures out what DaemonSet(s) manage a ControllerRevision when the ControllerRevision
 // is updated and wake them up. If anything of the ControllerRevision has changed, we need to  awaken
 // both the old and new DaemonSets.
-func (dsc *DaemonSetsController) updateHistory(old, cur interface{}) {
+func (dsc *DaemonSetsController) updateHistory(logger klog.Logger, old, cur interface{}) {
 	curHistory := cur.(*apps.ControllerRevision)
 	oldHistory := old.(*apps.ControllerRevision)
 	if curHistory.ResourceVersion == oldHistory.ResourceVersion {
@@ -415,7 +439,7 @@ func (dsc *DaemonSetsController) updateHistory(old, cur interface{}) {
 		if ds == nil {
 			return
 		}
-		klog.V(4).Infof("ControllerRevision %s updated.", curHistory.Name)
+		logger.V(4).Info("Observed an update to a ControllerRevision", "controllerRevision", klog.KObj(curHistory))
 		dsc.enqueueDaemonSet(ds)
 		return
 	}
@@ -424,11 +448,11 @@ func (dsc *DaemonSetsController) updateHistory(old, cur interface{}) {
 	// to see if anyone wants to adopt it now.
 	labelChanged := !reflect.DeepEqual(curHistory.Labels, oldHistory.Labels)
 	if labelChanged || controllerRefChanged {
-		daemonSets := dsc.getDaemonSetsForHistory(curHistory)
+		daemonSets := dsc.getDaemonSetsForHistory(logger, curHistory)
 		if len(daemonSets) == 0 {
 			return
 		}
-		klog.V(4).Infof("Orphan ControllerRevision %s updated.", curHistory.Name)
+		logger.V(4).Info("Orphan ControllerRevision updated", "controllerRevision", klog.KObj(curHistory))
 		for _, ds := range daemonSets {
 			dsc.enqueueDaemonSet(ds)
 		}
@@ -438,7 +462,7 @@ func (dsc *DaemonSetsController) updateHistory(old, cur interface{}) {
 // deleteHistory enqueues the DaemonSet that manages a ControllerRevision when
 // the ControllerRevision is deleted. obj could be an *app.ControllerRevision, or
 // a DeletionFinalStateUnknown marker item.
-func (dsc *DaemonSetsController) deleteHistory(obj interface{}) {
+func (dsc *DaemonSetsController) deleteHistory(logger klog.Logger, obj interface{}) {
 	history, ok := obj.(*apps.ControllerRevision)
 
 	// When a delete is dropped, the relist will notice a ControllerRevision in the store not
@@ -467,17 +491,17 @@ func (dsc *DaemonSetsController) deleteHistory(obj interface{}) {
 	if ds == nil {
 		return
 	}
-	klog.V(4).Infof("ControllerRevision %s deleted.", history.Name)
+	logger.V(4).Info("ControllerRevision deleted", "controllerRevision", klog.KObj(history))
 	dsc.enqueueDaemonSet(ds)
 }
 
-func (dsc *DaemonSetsController) addPod(obj interface{}) {
+func (dsc *DaemonSetsController) addPod(logger klog.Logger, obj interface{}) {
 	pod := obj.(*v1.Pod)
 
 	if pod.DeletionTimestamp != nil {
 		// on a restart of the controller manager, it's possible a new pod shows up in a state that
 		// is already pending deletion. Prevent the pod from being a creation observation.
-		dsc.deletePod(pod)
+		dsc.deletePod(logger, pod)
 		return
 	}
 
@@ -491,7 +515,7 @@ func (dsc *DaemonSetsController) addPod(obj interface{}) {
 		if err != nil {
 			return
 		}
-		klog.V(4).Infof("Pod %s added.", pod.Name)
+		logger.V(4).Info("Pod added", "pod", klog.KObj(pod))
 		dsc.expectations.CreationObserved(dsKey)
 		dsc.enqueueDaemonSet(ds)
 		return
@@ -505,7 +529,7 @@ func (dsc *DaemonSetsController) addPod(obj interface{}) {
 	if len(dss) == 0 {
 		return
 	}
-	klog.V(4).Infof("Orphan Pod %s added.", pod.Name)
+	logger.V(4).Info("Orphan Pod added", "pod", klog.KObj(pod))
 	for _, ds := range dss {
 		dsc.enqueueDaemonSet(ds)
 	}
@@ -514,7 +538,7 @@ func (dsc *DaemonSetsController) addPod(obj interface{}) {
 // When a pod is updated, figure out what sets manage it and wake them
 // up. If the labels of the pod have changed we need to awaken both the old
 // and new set. old and cur must be *v1.Pod types.
-func (dsc *DaemonSetsController) updatePod(old, cur interface{}) {
+func (dsc *DaemonSetsController) updatePod(logger klog.Logger, old, cur interface{}) {
 	curPod := cur.(*v1.Pod)
 	oldPod := old.(*v1.Pod)
 	if curPod.ResourceVersion == oldPod.ResourceVersion {
@@ -528,7 +552,7 @@ func (dsc *DaemonSetsController) updatePod(old, cur interface{}) {
 		// and after such time has passed, the kubelet actually deletes it from the store. We receive an update
 		// for modification of the deletion timestamp and expect an ds to create more replicas asap, not wait
 		// until the kubelet actually deletes the pod.
-		dsc.deletePod(curPod)
+		dsc.deletePod(logger, curPod)
 		return
 	}
 
@@ -548,7 +572,7 @@ func (dsc *DaemonSetsController) updatePod(old, cur interface{}) {
 		if ds == nil {
 			return
 		}
-		klog.V(4).Infof("Pod %s updated.", curPod.Name)
+		logger.V(4).Info("Pod updated", "pod", klog.KObj(curPod))
 		dsc.enqueueDaemonSet(ds)
 		changedToReady := !podutil.IsPodReady(oldPod) && podutil.IsPodReady(curPod)
 		// See https://github.com/kubernetes/kubernetes/pull/38076 for more details
@@ -566,7 +590,7 @@ func (dsc *DaemonSetsController) updatePod(old, cur interface{}) {
 	if len(dss) == 0 {
 		return
 	}
-	klog.V(4).Infof("Orphan Pod %s updated.", curPod.Name)
+	logger.V(4).Info("Orphan Pod updated", "pod", klog.KObj(curPod))
 	labelChanged := !reflect.DeepEqual(curPod.Labels, oldPod.Labels)
 	if labelChanged || controllerRefChanged {
 		for _, ds := range dss {
@@ -575,7 +599,7 @@ func (dsc *DaemonSetsController) updatePod(old, cur interface{}) {
 	}
 }
 
-func (dsc *DaemonSetsController) deletePod(obj interface{}) {
+func (dsc *DaemonSetsController) deletePod(logger klog.Logger, obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 	// When a delete is dropped, the relist will notice a pod in the store not
 	// in the list, leading to the insertion of a tombstone object which contains
@@ -608,16 +632,16 @@ func (dsc *DaemonSetsController) deletePod(obj interface{}) {
 	if err != nil {
 		return
 	}
-	klog.V(4).Infof("Pod %s deleted.", pod.Name)
+	logger.V(4).Info("Pod deleted", "pod", klog.KObj(pod))
 	dsc.expectations.DeletionObserved(dsKey)
 	dsc.enqueueDaemonSet(ds)
 }
 
-func (dsc *DaemonSetsController) addNode(obj interface{}) {
+func (dsc *DaemonSetsController) addNode(logger klog.Logger, obj interface{}) {
 	// TODO: it'd be nice to pass a hint with these enqueues, so that each ds would only examine the added node (unless it has other work to do, too).
 	dsList, err := dsc.dsLister.List(labels.Everything())
 	if err != nil {
-		klog.V(4).Infof("Error enqueueing daemon sets: %v", err)
+		logger.V(4).Info("Error enqueueing daemon sets", "err", err)
 		return
 	}
 	node := obj.(*v1.Node)
@@ -666,7 +690,7 @@ func shouldIgnoreNodeUpdate(oldNode, curNode v1.Node) bool {
 	return apiequality.Semantic.DeepEqual(oldNode, curNode)
 }
 
-func (dsc *DaemonSetsController) updateNode(old, cur interface{}) {
+func (dsc *DaemonSetsController) updateNode(logger klog.Logger, old, cur interface{}) {
 	oldNode := old.(*v1.Node)
 	curNode := cur.(*v1.Node)
 	if shouldIgnoreNodeUpdate(*oldNode, *curNode) {
@@ -675,7 +699,7 @@ func (dsc *DaemonSetsController) updateNode(old, cur interface{}) {
 
 	dsList, err := dsc.dsLister.List(labels.Everything())
 	if err != nil {
-		klog.V(4).Infof("Error listing daemon sets: %v", err)
+		logger.V(4).Info("Error listing daemon sets", "err", err)
 		return
 	}
 	// TODO: it'd be nice to pass a hint with these enqueues, so that each ds would only examine the added node (unless it has other work to do, too).
@@ -733,11 +757,12 @@ func (dsc *DaemonSetsController) getNodesToDaemonPods(ctx context.Context, ds *a
 	}
 	// Group Pods by Node name.
 	nodeToDaemonPods := make(map[string][]*v1.Pod)
+	logger := klog.FromContext(ctx)
 	for _, pod := range claimedPods {
 		nodeName, err := util.GetTargetNodeName(pod)
 		if err != nil {
-			klog.Warningf("Failed to get target node name of Pod %v/%v in DaemonSet %v/%v",
-				pod.Namespace, pod.Name, ds.Namespace, ds.Name)
+			logger.Info("Failed to get target node name of Pod in DaemonSet",
+				"pod", klog.KObj(pod), "daemonset", klog.KObj(ds))
 			continue
 		}
 
@@ -773,6 +798,7 @@ func (dsc *DaemonSetsController) resolveControllerRef(namespace string, controll
 //   - podsToDelete: the Pods need to be deleted on the node
 //   - err: unexpected error
 func (dsc *DaemonSetsController) podsShouldBeOnNode(
+	logger klog.Logger,
 	node *v1.Node,
 	nodeToDaemonPods map[string][]*v1.Pod,
 	ds *apps.DaemonSet,
@@ -803,8 +829,8 @@ func (dsc *DaemonSetsController) podsShouldBeOnNode(
 				inBackoff := dsc.failedPodsBackoff.IsInBackOffSinceUpdate(backoffKey, now)
 				if inBackoff {
 					delay := dsc.failedPodsBackoff.Get(backoffKey)
-					klog.V(4).Infof("Deleting failed pod %s/%s on node %s has been limited by backoff - %v remaining",
-						pod.Namespace, pod.Name, node.Name, delay)
+					logger.V(4).Info("Deleting failed pod on node has been limited by backoff",
+						"pod", klog.KObj(pod), "node", klog.KObj(node), "currentDelay", delay)
 					dsc.enqueueDaemonSetAfter(ds, delay)
 					continue
 				}
@@ -812,7 +838,7 @@ func (dsc *DaemonSetsController) podsShouldBeOnNode(
 				dsc.failedPodsBackoff.Next(backoffKey, now)
 
 				msg := fmt.Sprintf("Found failed daemon pod %s/%s on node %s, will try to kill it", pod.Namespace, pod.Name, node.Name)
-				klog.V(2).Infof(msg)
+				logger.V(2).Info("Found failed daemon pod on node, will try to kill it", "pod", klog.KObj(pod), "node", klog.KObj(node))
 				// Emit an event so that it's discoverable to users.
 				dsc.eventRecorder.Eventf(ds, v1.EventTypeWarning, FailedDaemonPodReason, msg)
 				podsToDelete = append(podsToDelete, pod.Name)
@@ -866,10 +892,10 @@ func (dsc *DaemonSetsController) podsShouldBeOnNode(
 		if oldestNewPod != nil && oldestOldPod != nil {
 			switch {
 			case !podutil.IsPodReady(oldestOldPod):
-				klog.V(5).Infof("Pod %s/%s from daemonset %s is no longer ready and will be replaced with newer pod %s", oldestOldPod.Namespace, oldestOldPod.Name, ds.Name, oldestNewPod.Name)
+				logger.V(5).Info("Pod from daemonset is no longer ready and will be replaced with newer pod", "oldPod", klog.KObj(oldestOldPod), "daemonset", klog.KObj(ds), "newPod", klog.KObj(oldestNewPod))
 				podsToDelete = append(podsToDelete, oldestOldPod.Name)
 			case podutil.IsPodAvailable(oldestNewPod, ds.Spec.MinReadySeconds, metav1.Time{Time: dsc.failedPodsBackoff.Clock.Now()}):
-				klog.V(5).Infof("Pod %s/%s from daemonset %s is now ready and will replace older pod %s", oldestNewPod.Namespace, oldestNewPod.Name, ds.Name, oldestOldPod.Name)
+				logger.V(5).Info("Pod from daemonset is now ready and will replace older pod", "newPod", klog.KObj(oldestNewPod), "daemonset", klog.KObj(ds), "oldPod", klog.KObj(oldestOldPod))
 				podsToDelete = append(podsToDelete, oldestOldPod.Name)
 			}
 		}
@@ -926,10 +952,11 @@ func (dsc *DaemonSetsController) manage(ctx context.Context, ds *apps.DaemonSet,
 
 	// For each node, if the node is running the daemon pod but isn't supposed to, kill the daemon
 	// pod. If the node is supposed to run the daemon pod, but isn't, create the daemon pod on the node.
+	logger := klog.FromContext(ctx)
 	var nodesNeedingDaemonPods, podsToDelete []string
 	for _, node := range nodeList {
 		nodesNeedingDaemonPodsOnNode, podsToDeleteOnNode := dsc.podsShouldBeOnNode(
-			node, nodeToDaemonPods, ds, hash)
+			logger, node, nodeToDaemonPods, ds, hash)
 
 		nodesNeedingDaemonPods = append(nodesNeedingDaemonPods, nodesNeedingDaemonPodsOnNode...)
 		podsToDelete = append(podsToDelete, podsToDeleteOnNode...)
@@ -951,6 +978,7 @@ func (dsc *DaemonSetsController) manage(ctx context.Context, ds *apps.DaemonSet,
 // returns slice with errors if any
 func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonSet, podsToDelete, nodesNeedingDaemonPods []string, hash string) error {
 	// We need to set expectations before creating/deleting pods to avoid race conditions.
+	logger := klog.FromContext(ctx)
 	dsKey, err := controller.KeyFunc(ds)
 	if err != nil {
 		return fmt.Errorf("couldn't get key for object %#v: %v", ds, err)
@@ -971,7 +999,7 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 	// error channel to communicate back failures.  make the buffer big enough to avoid any blocking
 	errCh := make(chan error, createDiff+deleteDiff)
 
-	klog.V(4).Infof("Nodes needing daemon pods for daemon set %s: %+v, creating %d", ds.Name, nodesNeedingDaemonPods, createDiff)
+	logger.V(4).Info("Nodes needing daemon pods for daemon set, creating", "daemonset", klog.KObj(ds), "needCount", nodesNeedingDaemonPods, "createCount", createDiff)
 	createWait := sync.WaitGroup{}
 	// If the returned error is not nil we have a parse error.
 	// The controller handles this via the hash.
@@ -1014,7 +1042,7 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 					}
 				}
 				if err != nil {
-					klog.V(2).Infof("Failed creation, decrementing expectations for set %q/%q", ds.Namespace, ds.Name)
+					logger.V(2).Info("Failed creation, decrementing expectations for daemon set", "daemonset", klog.KObj(ds))
 					dsc.expectations.CreationObserved(dsKey)
 					errCh <- err
 					utilruntime.HandleError(err)
@@ -1025,7 +1053,7 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 		// any skipped pods that we never attempted to start shouldn't be expected.
 		skippedPods := createDiff - (batchSize + pos)
 		if errorCount < len(errCh) && skippedPods > 0 {
-			klog.V(2).Infof("Slow-start failure. Skipping creation of %d pods, decrementing expectations for set %q/%q", skippedPods, ds.Namespace, ds.Name)
+			logger.V(2).Info("Slow-start failure. Skipping creation pods, decrementing expectations for daemon set", "skippedPods", skippedPods, "daemonset", klog.KObj(ds))
 			dsc.expectations.LowerExpectations(dsKey, skippedPods, 0)
 			// The skipped pods will be retried later. The next controller resync will
 			// retry the slow start process.
@@ -1033,7 +1061,7 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 		}
 	}
 
-	klog.V(4).Infof("Pods to delete for daemon set %s: %+v, deleting %d", ds.Name, podsToDelete, deleteDiff)
+	logger.V(4).Info("Pods to delete for daemon set, deleting", "daemonset", klog.KObj(ds), "toDeleteCount", podsToDelete, "deleteCount", deleteDiff)
 	deleteWait := sync.WaitGroup{}
 	deleteWait.Add(deleteDiff)
 	for i := 0; i < deleteDiff; i++ {
@@ -1042,7 +1070,7 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 			if err := dsc.podControl.DeletePod(ctx, ds.Namespace, podsToDelete[ix], ds); err != nil {
 				dsc.expectations.DeletionObserved(dsKey)
 				if !apierrors.IsNotFound(err) {
-					klog.V(2).Infof("Failed deletion, decremented expectations for set %q/%q", ds.Namespace, ds.Name)
+					logger.V(2).Info("Failed deletion, decremented expectations for daemon set", "daemonset", klog.KObj(ds))
 					errCh <- err
 					utilruntime.HandleError(err)
 				}
@@ -1116,7 +1144,8 @@ func storeDaemonSetStatus(
 }
 
 func (dsc *DaemonSetsController) updateDaemonSetStatus(ctx context.Context, ds *apps.DaemonSet, nodeList []*v1.Node, hash string, updateObservedGen bool) error {
-	klog.V(4).Infof("Updating daemon set status")
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info("Updating daemon set status")
 	nodeToDaemonPods, err := dsc.getNodesToDaemonPods(ctx, ds)
 	if err != nil {
 		return fmt.Errorf("couldn't get node to daemon pod mapping for daemon set %q: %v", ds.Name, err)
@@ -1175,10 +1204,11 @@ func (dsc *DaemonSetsController) updateDaemonSetStatus(ctx context.Context, ds *
 }
 
 func (dsc *DaemonSetsController) syncDaemonSet(ctx context.Context, key string) error {
+	logger := klog.FromContext(ctx)
 	startTime := dsc.failedPodsBackoff.Clock.Now()
 
 	defer func() {
-		klog.V(4).Infof("Finished syncing daemon set %q (%v)", key, dsc.failedPodsBackoff.Clock.Now().Sub(startTime))
+		logger.V(4).Info("Finished syncing daemon set", "daemonset", key, "time", dsc.failedPodsBackoff.Clock.Now().Sub(startTime))
 	}()
 
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
@@ -1187,7 +1217,7 @@ func (dsc *DaemonSetsController) syncDaemonSet(ctx context.Context, key string) 
 	}
 	ds, err := dsc.dsLister.DaemonSets(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
-		klog.V(3).Infof("daemon set has been deleted %v", key)
+		logger.V(3).Info("Daemon set has been deleted", "daemonset", key)
 		dsc.expectations.DeleteExpectations(key)
 		return nil
 	}
@@ -1244,7 +1274,7 @@ func (dsc *DaemonSetsController) syncDaemonSet(ctx context.Context, key string) 
 	case err != nil && statusErr != nil:
 		// If there was an error, and we failed to update status,
 		// log it and return the original error.
-		klog.ErrorS(statusErr, "Failed to update status", "daemonSet", klog.KObj(ds))
+		klog.Error(statusErr, "Failed to update status", "daemonSet", klog.KObj(ds))
 		return err
 	case err != nil:
 		return err

--- a/pkg/controller/daemon/init_test.go
+++ b/pkg/controller/daemon/init_test.go
@@ -17,9 +17,5 @@ limitations under the License.
 package daemon
 
 import (
-	"k8s.io/klog/v2"
+	_ "k8s.io/klog/v2/ktesting/init"
 )
-
-func init() {
-	klog.InitFlags(nil)
-}

--- a/pkg/controller/daemon/update.go
+++ b/pkg/controller/daemon/update.go
@@ -42,11 +42,12 @@ import (
 // rollingUpdate identifies the set of old pods to delete, or additional pods to create on nodes,
 // remaining within the constraints imposed by the update strategy.
 func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.DaemonSet, nodeList []*v1.Node, hash string) error {
+	logger := klog.FromContext(ctx)
 	nodeToDaemonPods, err := dsc.getNodesToDaemonPods(ctx, ds)
 	if err != nil {
 		return fmt.Errorf("couldn't get node to daemon pod mapping for daemon set %q: %v", ds.Name, err)
 	}
-	maxSurge, maxUnavailable, err := dsc.updatedDesiredNodeCounts(ds, nodeList, nodeToDaemonPods)
+	maxSurge, maxUnavailable, err := dsc.updatedDesiredNodeCounts(ctx, ds, nodeList, nodeToDaemonPods)
 	if err != nil {
 		return fmt.Errorf("couldn't get unavailable numbers: %v", err)
 	}
@@ -73,7 +74,7 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 			newPod, oldPod, ok := findUpdatedPodsOnNode(ds, pods, hash)
 			if !ok {
 				// let the manage loop clean up this node, and treat it as an unavailable node
-				klog.V(3).Infof("DaemonSet %s/%s has excess pods on node %s, skipping to allow the core loop to process", ds.Namespace, ds.Name, nodeName)
+				logger.V(3).Info("DaemonSet has excess pods on node, skipping to allow the core loop to process", "daemonset", klog.KObj(ds), "node", klog.KRef("", nodeName))
 				numUnavailable++
 				continue
 			}
@@ -92,7 +93,7 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 				switch {
 				case !podutil.IsPodAvailable(oldPod, ds.Spec.MinReadySeconds, metav1.Time{Time: now}):
 					// the old pod isn't available, so it needs to be replaced
-					klog.V(5).Infof("DaemonSet %s/%s pod %s on node %s is out of date and not available, allowing replacement", ds.Namespace, ds.Name, oldPod.Name, nodeName)
+					logger.V(5).Info("DaemonSet pod on node is out of date and not available, allowing replacement", "daemonset", klog.KObj(ds), "pod", klog.KObj(oldPod), "node", klog.KRef("", nodeName))
 					// record the replacement
 					if allowedReplacementPods == nil {
 						allowedReplacementPods = make([]string, 0, len(nodeToDaemonPods))
@@ -102,7 +103,7 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 					// no point considering any other candidates
 					continue
 				default:
-					klog.V(5).Infof("DaemonSet %s/%s pod %s on node %s is out of date, this is a candidate to replace", ds.Namespace, ds.Name, oldPod.Name, nodeName)
+					logger.V(5).Info("DaemonSet pod on node is out of date, this is a candidate to replace", "daemonset", klog.KObj(ds), "pod", klog.KObj(oldPod), "node", klog.KRef("", nodeName))
 					// record the candidate
 					if candidatePodsToDelete == nil {
 						candidatePodsToDelete = make([]string, 0, maxUnavailable)
@@ -113,7 +114,7 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 		}
 
 		// use any of the candidates we can, including the allowedReplacemnntPods
-		klog.V(5).Infof("DaemonSet %s/%s allowing %d replacements, up to %d unavailable, %d new are unavailable, %d candidates", ds.Namespace, ds.Name, len(allowedReplacementPods), maxUnavailable, numUnavailable, len(candidatePodsToDelete))
+		logger.V(5).Info("DaemonSet allowing replacements", "daemonset", klog.KObj(ds), "replacements", len(allowedReplacementPods), "maxUnavailable", maxUnavailable, "numUnavailable", numUnavailable, "candidates", len(candidatePodsToDelete))
 		remainingUnavailable := maxUnavailable - numUnavailable
 		if remainingUnavailable < 0 {
 			remainingUnavailable = 0
@@ -148,7 +149,7 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 		newPod, oldPod, ok := findUpdatedPodsOnNode(ds, pods, hash)
 		if !ok {
 			// let the manage loop clean up this node, and treat it as a surge node
-			klog.V(3).Infof("DaemonSet %s/%s has excess pods on node %s, skipping to allow the core loop to process", ds.Namespace, ds.Name, nodeName)
+			logger.V(3).Info("DaemonSet has excess pods on node, skipping to allow the core loop to process", "daemonset", klog.KObj(ds), "node", klog.KRef("", nodeName))
 			numSurge++
 			continue
 		}
@@ -160,7 +161,7 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 			switch {
 			case !podutil.IsPodAvailable(oldPod, ds.Spec.MinReadySeconds, metav1.Time{Time: now}):
 				// the old pod isn't available, allow it to become a replacement
-				klog.V(5).Infof("Pod %s on node %s is out of date and not available, allowing replacement", ds.Namespace, ds.Name, oldPod.Name, nodeName)
+				logger.V(5).Info("Pod on node is out of date and not available, allowing replacement", "daemonset", klog.KObj(ds), "pod", klog.KObj(oldPod), "node", klog.KRef("", nodeName))
 				// record the replacement
 				if allowedNewNodes == nil {
 					allowedNewNodes = make([]string, 0, len(nodeToDaemonPods))
@@ -170,7 +171,7 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 				// no point considering any other candidates
 				continue
 			default:
-				klog.V(5).Infof("DaemonSet %s/%s pod %s on node %s is out of date, this is a surge candidate", ds.Namespace, ds.Name, oldPod.Name, nodeName)
+				logger.V(5).Info("DaemonSet pod on node is out of date, this is a surge candidate", "daemonset", klog.KObj(ds), "pod", klog.KObj(oldPod), "node", klog.KRef("", nodeName))
 				// record the candidate
 				if candidateNewNodes == nil {
 					candidateNewNodes = make([]string, 0, maxSurge)
@@ -185,13 +186,13 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 				continue
 			}
 			// we're available, delete the old pod
-			klog.V(5).Infof("DaemonSet %s/%s pod %s on node %s is available, remove %s", ds.Namespace, ds.Name, newPod.Name, nodeName, oldPod.Name)
+			logger.V(5).Info("DaemonSet pod on node is available, remove old pod", "daemonset", klog.KObj(ds), "newPod", klog.KObj(newPod), "node", nodeName, "oldPod", klog.KObj(oldPod))
 			oldPodsToDelete = append(oldPodsToDelete, oldPod.Name)
 		}
 	}
 
 	// use any of the candidates we can, including the allowedNewNodes
-	klog.V(5).Infof("DaemonSet %s/%s allowing %d replacements, surge up to %d, %d are in progress, %d candidates", ds.Namespace, ds.Name, len(allowedNewNodes), maxSurge, numSurge, len(candidateNewNodes))
+	logger.V(5).Info("DaemonSet allowing replacements", "daemonset", klog.KObj(ds), "replacements", len(allowedNewNodes), "maxSurge", maxSurge, "numSurge", numSurge, "candidates", len(candidateNewNodes))
 	remainingSurge := maxSurge - numSurge
 	if remainingSurge < 0 {
 		remainingSurge = 0
@@ -484,6 +485,7 @@ func (dsc *DaemonSetsController) snapshot(ctx context.Context, ds *apps.DaemonSe
 
 	history, err = dsc.kubeClient.AppsV1().ControllerRevisions(ds.Namespace).Create(ctx, history, metav1.CreateOptions{})
 	if outerErr := err; errors.IsAlreadyExists(outerErr) {
+		logger := klog.FromContext(ctx)
 		// TODO: Is it okay to get from historyLister?
 		existedHistory, getErr := dsc.kubeClient.AppsV1().ControllerRevisions(ds.Namespace).Get(ctx, name, metav1.GetOptions{})
 		if getErr != nil {
@@ -516,7 +518,7 @@ func (dsc *DaemonSetsController) snapshot(ctx context.Context, ds *apps.DaemonSe
 		if updateErr != nil {
 			return nil, updateErr
 		}
-		klog.V(2).Infof("Found a hash collision for DaemonSet %q - bumping collisionCount to %d to resolve it", ds.Name, *currDS.Status.CollisionCount)
+		logger.V(2).Info("Found a hash collision for DaemonSet - bumping collisionCount to resolve it", "daemonset", klog.KObj(ds), "collisionCount", *currDS.Status.CollisionCount)
 		return nil, outerErr
 	}
 	return history, err
@@ -524,8 +526,9 @@ func (dsc *DaemonSetsController) snapshot(ctx context.Context, ds *apps.DaemonSe
 
 // updatedDesiredNodeCounts calculates the true number of allowed unavailable or surge pods and
 // updates the nodeToDaemonPods array to include an empty array for every node that is not scheduled.
-func (dsc *DaemonSetsController) updatedDesiredNodeCounts(ds *apps.DaemonSet, nodeList []*v1.Node, nodeToDaemonPods map[string][]*v1.Pod) (int, int, error) {
+func (dsc *DaemonSetsController) updatedDesiredNodeCounts(ctx context.Context, ds *apps.DaemonSet, nodeList []*v1.Node, nodeToDaemonPods map[string][]*v1.Pod) (int, int, error) {
 	var desiredNumberScheduled int
+	logger := klog.FromContext(ctx)
 	for i := range nodeList {
 		node := nodeList[i]
 		wantToRun, _ := NodeShouldRunDaemonPod(node, ds)
@@ -552,10 +555,10 @@ func (dsc *DaemonSetsController) updatedDesiredNodeCounts(ds *apps.DaemonSet, no
 	// if the daemonset returned with an impossible configuration, obey the default of unavailable=1 (in the
 	// event the apiserver returns 0 for both surge and unavailability)
 	if desiredNumberScheduled > 0 && maxUnavailable == 0 && maxSurge == 0 {
-		klog.Warningf("DaemonSet %s/%s is not configured for surge or unavailability, defaulting to accepting unavailability", ds.Namespace, ds.Name)
+		logger.Info("DaemonSet is not configured for surge or unavailability, defaulting to accepting unavailability", "daemonset", klog.KObj(ds))
 		maxUnavailable = 1
 	}
-	klog.V(5).Infof("DaemonSet %s/%s, maxSurge: %d, maxUnavailable: %d", ds.Namespace, ds.Name, maxSurge, maxUnavailable)
+	logger.V(5).Info("DaemonSet with maxSurge and maxUnavailable", "daemonset", klog.KObj(ds), "maxSurge", maxSurge, "maxUnavailable", maxUnavailable)
 	return maxSurge, maxUnavailable, nil
 }
 

--- a/pkg/controller/daemon/update_test.go
+++ b/pkg/controller/daemon/update_test.go
@@ -27,15 +27,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller/daemon/util"
 	testingclock "k8s.io/utils/clock/testing"
 )
 
 func TestDaemonSetUpdatesPods(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	ds := newDaemonSet("foo")
-	manager, podControl, _, err := newTestController(ds)
+	manager, podControl, _, err := newTestController(ctx, ds)
 	if err != nil {
 		t.Fatalf("error creating DaemonSets controller: %v", err)
 	}
@@ -75,8 +76,9 @@ func TestDaemonSetUpdatesPods(t *testing.T) {
 }
 
 func TestDaemonSetUpdatesPodsWithMaxSurge(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	ds := newDaemonSet("foo")
-	manager, podControl, _, err := newTestController(ds)
+	manager, podControl, _, err := newTestController(ctx, ds)
 	if err != nil {
 		t.Fatalf("error creating DaemonSets controller: %v", err)
 	}
@@ -116,8 +118,9 @@ func TestDaemonSetUpdatesPodsWithMaxSurge(t *testing.T) {
 }
 
 func TestDaemonSetUpdatesWhenNewPosIsNotReady(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	ds := newDaemonSet("foo")
-	manager, podControl, _, err := newTestController(ds)
+	manager, podControl, _, err := newTestController(ctx, ds)
 	if err != nil {
 		t.Fatalf("error creating DaemonSets controller: %v", err)
 	}
@@ -152,8 +155,9 @@ func TestDaemonSetUpdatesWhenNewPosIsNotReady(t *testing.T) {
 }
 
 func TestDaemonSetUpdatesAllOldPodsNotReady(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	ds := newDaemonSet("foo")
-	manager, podControl, _, err := newTestController(ds)
+	manager, podControl, _, err := newTestController(ctx, ds)
 	if err != nil {
 		t.Fatalf("error creating DaemonSets controller: %v", err)
 	}
@@ -187,8 +191,9 @@ func TestDaemonSetUpdatesAllOldPodsNotReady(t *testing.T) {
 }
 
 func TestDaemonSetUpdatesAllOldPodsNotReadyMaxSurge(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	ds := newDaemonSet("foo")
-	manager, podControl, _, err := newTestController(ds)
+	manager, podControl, _, err := newTestController(ctx, ds)
 	if err != nil {
 		t.Fatalf("error creating DaemonSets controller: %v", err)
 	}
@@ -284,6 +289,7 @@ func podsByNodeMatchingHash(dsc *daemonSetsController, hash string) map[string][
 
 func setPodReadiness(t *testing.T, dsc *daemonSetsController, ready bool, count int, fn func(*v1.Pod) bool) {
 	t.Helper()
+	logger, _ := ktesting.NewTestContext(t)
 	for _, obj := range dsc.podStore.List() {
 		if count <= 0 {
 			break
@@ -310,7 +316,7 @@ func setPodReadiness(t *testing.T, dsc *daemonSetsController, ready bool, count 
 		// TODO: workaround UpdatePodCondition calling time.Now() directly
 		setCondition := podutil.GetPodReadyCondition(pod.Status)
 		setCondition.LastTransitionTime.Time = dsc.failedPodsBackoff.Clock.Now()
-		klog.Infof("marked pod %s ready=%t", pod.Name, ready)
+		logger.Info("marked pod ready", "pod", pod.Name, "ready", ready)
 		count--
 	}
 	if count > 0 {
@@ -329,8 +335,9 @@ func currentDSHash(dsc *daemonSetsController, ds *apps.DaemonSet) (string, error
 }
 
 func TestDaemonSetUpdatesNoTemplateChanged(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	ds := newDaemonSet("foo")
-	manager, podControl, _, err := newTestController(ds)
+	manager, podControl, _, err := newTestController(ctx, ds)
 	if err != nil {
 		t.Fatalf("error creating DaemonSets controller: %v", err)
 	}
@@ -373,7 +380,7 @@ func newUpdateUnavailable(value intstr.IntOrString) apps.DaemonSetUpdateStrategy
 func TestGetUnavailableNumbers(t *testing.T) {
 	cases := []struct {
 		name           string
-		Manager        *daemonSetsController
+		ManagerFunc    func(ctx context.Context) *daemonSetsController
 		ds             *apps.DaemonSet
 		nodeToPods     map[string][]*v1.Pod
 		maxSurge       int
@@ -383,13 +390,13 @@ func TestGetUnavailableNumbers(t *testing.T) {
 	}{
 		{
 			name: "No nodes",
-			Manager: func() *daemonSetsController {
-				manager, _, _, err := newTestController()
+			ManagerFunc: func(ctx context.Context) *daemonSetsController {
+				manager, _, _, err := newTestController(ctx)
 				if err != nil {
 					t.Fatalf("error creating DaemonSets controller: %v", err)
 				}
 				return manager
-			}(),
+			},
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
 				ds.Spec.UpdateStrategy = newUpdateUnavailable(intstr.FromInt(0))
@@ -401,14 +408,14 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		},
 		{
 			name: "Two nodes with ready pods",
-			Manager: func() *daemonSetsController {
-				manager, _, _, err := newTestController()
+			ManagerFunc: func(ctx context.Context) *daemonSetsController {
+				manager, _, _, err := newTestController(ctx)
 				if err != nil {
 					t.Fatalf("error creating DaemonSets controller: %v", err)
 				}
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
-			}(),
+			},
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
 				ds.Spec.UpdateStrategy = newUpdateUnavailable(intstr.FromInt(1))
@@ -429,14 +436,14 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		},
 		{
 			name: "Two nodes, one node without pods",
-			Manager: func() *daemonSetsController {
-				manager, _, _, err := newTestController()
+			ManagerFunc: func(ctx context.Context) *daemonSetsController {
+				manager, _, _, err := newTestController(ctx)
 				if err != nil {
 					t.Fatalf("error creating DaemonSets controller: %v", err)
 				}
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
-			}(),
+			},
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
 				ds.Spec.UpdateStrategy = newUpdateUnavailable(intstr.FromInt(0))
@@ -454,14 +461,14 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		},
 		{
 			name: "Two nodes, one node without pods, surge",
-			Manager: func() *daemonSetsController {
-				manager, _, _, err := newTestController()
+			ManagerFunc: func(ctx context.Context) *daemonSetsController {
+				manager, _, _, err := newTestController(ctx)
 				if err != nil {
 					t.Fatalf("error creating DaemonSets controller: %v", err)
 				}
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
-			}(),
+			},
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
 				ds.Spec.UpdateStrategy = newUpdateSurge(intstr.FromInt(0))
@@ -479,14 +486,14 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		},
 		{
 			name: "Two nodes with pods, MaxUnavailable in percents",
-			Manager: func() *daemonSetsController {
-				manager, _, _, err := newTestController()
+			ManagerFunc: func(ctx context.Context) *daemonSetsController {
+				manager, _, _, err := newTestController(ctx)
 				if err != nil {
 					t.Fatalf("error creating DaemonSets controller: %v", err)
 				}
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
-			}(),
+			},
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
 				ds.Spec.UpdateStrategy = newUpdateUnavailable(intstr.FromString("50%"))
@@ -507,14 +514,14 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		},
 		{
 			name: "Two nodes with pods, MaxUnavailable in percents, surge",
-			Manager: func() *daemonSetsController {
-				manager, _, _, err := newTestController()
+			ManagerFunc: func(ctx context.Context) *daemonSetsController {
+				manager, _, _, err := newTestController(ctx)
 				if err != nil {
 					t.Fatalf("error creating DaemonSets controller: %v", err)
 				}
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
-			}(),
+			},
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
 				ds.Spec.UpdateStrategy = newUpdateSurge(intstr.FromString("50%"))
@@ -536,14 +543,14 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		},
 		{
 			name: "Two nodes with pods, MaxUnavailable is 100%, surge",
-			Manager: func() *daemonSetsController {
-				manager, _, _, err := newTestController()
+			ManagerFunc: func(ctx context.Context) *daemonSetsController {
+				manager, _, _, err := newTestController(ctx)
 				if err != nil {
 					t.Fatalf("error creating DaemonSets controller: %v", err)
 				}
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
-			}(),
+			},
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
 				ds.Spec.UpdateStrategy = newUpdateSurge(intstr.FromString("100%"))
@@ -565,14 +572,14 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		},
 		{
 			name: "Two nodes with pods, MaxUnavailable in percents, pod terminating",
-			Manager: func() *daemonSetsController {
-				manager, _, _, err := newTestController()
+			ManagerFunc: func(ctx context.Context) *daemonSetsController {
+				manager, _, _, err := newTestController(ctx)
 				if err != nil {
 					t.Fatalf("error creating DaemonSets controller: %v", err)
 				}
 				addNodes(manager.nodeStore, 0, 3, nil)
 				return manager
-			}(),
+			},
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
 				ds.Spec.UpdateStrategy = newUpdateUnavailable(intstr.FromString("50%"))
@@ -597,12 +604,14 @@ func TestGetUnavailableNumbers(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			c.Manager.dsStore.Add(c.ds)
-			nodeList, err := c.Manager.nodeLister.List(labels.Everything())
+			_, ctx := ktesting.NewTestContext(t)
+			manager := c.ManagerFunc(ctx)
+			manager.dsStore.Add(c.ds)
+			nodeList, err := manager.nodeLister.List(labels.Everything())
 			if err != nil {
 				t.Fatalf("error listing nodes: %v", err)
 			}
-			maxSurge, maxUnavailable, err := c.Manager.updatedDesiredNodeCounts(c.ds, nodeList, c.nodeToPods)
+			maxSurge, maxUnavailable, err := manager.updatedDesiredNodeCounts(ctx, c.ds, nodeList, c.nodeToPods)
 			if err != nil && c.Err != nil {
 				if c.Err != err {
 					t.Fatalf("Expected error: %v but got: %v", c.Err, err)
@@ -635,42 +644,44 @@ func TestControlledHistories(t *testing.T) {
 	orphanCrNotInSameNsWithDs1 := newControllerRevision(ds1.GetName()+"-x3", ds1.GetNamespace()+"-other", ds1.Spec.Template.Labels, nil)
 	cases := []struct {
 		name                      string
-		manager                   *daemonSetsController
+		managerFunc               func(ctx context.Context) *daemonSetsController
 		historyCRAll              []*apps.ControllerRevision
 		expectControllerRevisions []*apps.ControllerRevision
 	}{
 		{
 			name: "controller revision in the same namespace",
-			manager: func() *daemonSetsController {
-				manager, _, _, err := newTestController(ds1, crOfDs1, orphanCrInSameNsWithDs1)
+			managerFunc: func(ctx context.Context) *daemonSetsController {
+				manager, _, _, err := newTestController(ctx, ds1, crOfDs1, orphanCrInSameNsWithDs1)
 				if err != nil {
 					t.Fatalf("error creating DaemonSets controller: %v", err)
 				}
 				manager.dsStore.Add(ds1)
 				return manager
-			}(),
+			},
 			historyCRAll:              []*apps.ControllerRevision{crOfDs1, orphanCrInSameNsWithDs1},
 			expectControllerRevisions: []*apps.ControllerRevision{crOfDs1, orphanCrInSameNsWithDs1},
 		},
 		{
 			name: "Skip adopting the controller revision in namespace other than the one in which DS lives",
-			manager: func() *daemonSetsController {
-				manager, _, _, err := newTestController(ds1, orphanCrNotInSameNsWithDs1)
+			managerFunc: func(ctx context.Context) *daemonSetsController {
+				manager, _, _, err := newTestController(ctx, ds1, orphanCrNotInSameNsWithDs1)
 				if err != nil {
 					t.Fatalf("error creating DaemonSets controller: %v", err)
 				}
 				manager.dsStore.Add(ds1)
 				return manager
-			}(),
+			},
 			historyCRAll:              []*apps.ControllerRevision{orphanCrNotInSameNsWithDs1},
 			expectControllerRevisions: []*apps.ControllerRevision{},
 		},
 	}
 	for _, c := range cases {
+		_, ctx := ktesting.NewTestContext(t)
+		manager := c.managerFunc(ctx)
 		for _, h := range c.historyCRAll {
-			c.manager.historyStore.Add(h)
+			manager.historyStore.Add(h)
 		}
-		crList, err := c.manager.controlledHistories(context.TODO(), ds1)
+		crList, err := manager.controlledHistories(context.TODO(), ds1)
 		if err != nil {
 			t.Fatalf("Test case: %s. Unexpected error: %v", c.name, err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Switch the daemonset controller code to use contextual and structured logging.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/enhancements/issues/3077

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Migrated the DaemonSet controller (within `kube-controller-manager) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging
```
