### PR TITLE
Promote APIServerIdentity to Beta

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -82,9 +82,6 @@ type ServerRunOptions struct {
 	MasterCount            int
 	EndpointReconcilerType string
 
-	IdentityLeaseDurationSeconds      int
-	IdentityLeaseRenewIntervalSeconds int
-
 	ServiceAccountSigningKeyFile     string
 	ServiceAccountIssuer             serviceaccount.TokenGenerator
 	ServiceAccountTokenMaxExpiration time.Duration
@@ -110,12 +107,10 @@ func NewServerRunOptions() *ServerRunOptions {
 		Logs:                    logs.NewOptions(),
 		Traces:                  genericoptions.NewTracingOptions(),
 
-		EnableLogsHandler:                 true,
-		EventTTL:                          1 * time.Hour,
-		MasterCount:                       1,
-		EndpointReconcilerType:            string(reconcilers.LeaseEndpointReconcilerType),
-		IdentityLeaseDurationSeconds:      3600,
-		IdentityLeaseRenewIntervalSeconds: 10,
+		EnableLogsHandler:      true,
+		EventTTL:               1 * time.Hour,
+		MasterCount:            1,
+		EndpointReconcilerType: string(reconcilers.LeaseEndpointReconcilerType),
 		KubeletConfig: kubeletclient.KubeletClientConfig{
 			Port:         ports.KubeletPort,
 			ReadOnlyPort: ports.KubeletReadOnlyPort,
@@ -184,12 +179,6 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 
 	fs.StringVar(&s.EndpointReconcilerType, "endpoint-reconciler-type", s.EndpointReconcilerType,
 		"Use an endpoint reconciler ("+strings.Join(reconcilers.AllTypes.Names(), ", ")+") master-count is deprecated, and will be removed in a future version.")
-
-	fs.IntVar(&s.IdentityLeaseDurationSeconds, "identity-lease-duration-seconds", s.IdentityLeaseDurationSeconds,
-		"The duration of kube-apiserver lease in seconds, must be a positive number. (In use when the APIServerIdentity feature gate is enabled.)")
-
-	fs.IntVar(&s.IdentityLeaseRenewIntervalSeconds, "identity-lease-renew-interval-seconds", s.IdentityLeaseRenewIntervalSeconds,
-		"The interval of kube-apiserver renewing its lease in seconds, must be a positive number. (In use when the APIServerIdentity feature gate is enabled.)")
 
 	// See #14282 for details on how to test/try this option out.
 	// TODO: remove this comment once this option is tested in CI.

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -318,8 +318,6 @@ func TestAddFlags(t *testing.T) {
 		Traces: &apiserveroptions.TracingOptions{
 			ConfigFile: "/var/run/kubernetes/tracing_config.yaml",
 		},
-		IdentityLeaseDurationSeconds:        3600,
-		IdentityLeaseRenewIntervalSeconds:   10,
 		AggregatorRejectForwardingRedirects: true,
 	}
 

--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -142,17 +142,6 @@ func validateAPIPriorityAndFairness(options *ServerRunOptions) []error {
 	return nil
 }
 
-func validateAPIServerIdentity(options *ServerRunOptions) []error {
-	var errs []error
-	if options.IdentityLeaseDurationSeconds <= 0 {
-		errs = append(errs, fmt.Errorf("--identity-lease-duration-seconds should be a positive number, but value '%d' provided", options.IdentityLeaseDurationSeconds))
-	}
-	if options.IdentityLeaseRenewIntervalSeconds <= 0 {
-		errs = append(errs, fmt.Errorf("--identity-lease-renew-interval-seconds should be a positive number, but value '%d' provided", options.IdentityLeaseRenewIntervalSeconds))
-	}
-	return errs
-}
-
 // Validate checks ServerRunOptions and return a slice of found errs.
 func (s *ServerRunOptions) Validate() []error {
 	var errs []error
@@ -171,7 +160,6 @@ func (s *ServerRunOptions) Validate() []error {
 	errs = append(errs, s.APIEnablement.Validate(legacyscheme.Scheme, apiextensionsapiserver.Scheme, aggregatorscheme.Scheme)...)
 	errs = append(errs, validateTokenRequest(s)...)
 	errs = append(errs, s.Metrics.Validate()...)
-	errs = append(errs, validateAPIServerIdentity(s)...)
 
 	return errs
 }

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -283,9 +283,6 @@ func CreateKubeAPIServerConfig(s completedServerRunOptions) (
 			ExtendExpiration:            s.Authentication.ServiceAccounts.ExtendExpiration,
 
 			VersionedInformers: versionedInformers,
-
-			IdentityLeaseDurationSeconds:      s.IdentityLeaseDurationSeconds,
-			IdentityLeaseRenewIntervalSeconds: s.IdentityLeaseRenewIntervalSeconds,
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -216,7 +216,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	APIResponseCompression: {Default: true, PreRelease: featuregate.Beta},
 
-	APIServerIdentity: {Default: false, PreRelease: featuregate.Alpha},
+	APIServerIdentity: {Default: true, PreRelease: featuregate.Beta},
 
 	APIServerTracing: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/test/e2e/apimachinery/apiserver_identity.go
+++ b/test/e2e/apimachinery/apiserver_identity.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apimachinery
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+func getControlPlaneHostname(node *v1.Node) (string, error) {
+	nodeAddresses := e2enode.GetAddresses(node, v1.NodeExternalIP)
+	if len(nodeAddresses) == 0 {
+		return "", errors.New("no valid addresses to use for SSH")
+	}
+
+	controlPlaneAddress := nodeAddresses[0]
+
+	host := controlPlaneAddress + ":" + e2essh.SSHPort
+	result, err := e2essh.SSH("hostname", host, framework.TestContext.Provider)
+	if err != nil {
+		return "", err
+	}
+
+	if result.Code != 0 {
+		return "", fmt.Errorf("encountered non-zero exit code when running hostname command: %d", result.Code)
+	}
+
+	return strings.TrimSpace(result.Stdout), nil
+}
+
+// restartAPIServer attempts to restart the kube-apiserver on a node
+func restartAPIServer(node *v1.Node) error {
+	nodeAddresses := e2enode.GetAddresses(node, v1.NodeExternalIP)
+	if len(nodeAddresses) == 0 {
+		return errors.New("no valid addresses to use for SSH")
+	}
+
+	controlPlaneAddress := nodeAddresses[0]
+	cmd := "pidof kube-apiserver | xargs sudo kill"
+	framework.Logf("Restarting kube-apiserver via ssh, running: %v", cmd)
+	result, err := e2essh.SSH(cmd, net.JoinHostPort(controlPlaneAddress, e2essh.SSHPort), framework.TestContext.Provider)
+	if err != nil || result.Code != 0 {
+		e2essh.LogResult(result)
+		return fmt.Errorf("couldn't restart kube-apiserver: %v", err)
+	}
+	return nil
+}
+
+// This test requires that --feature-gates=APIServerIdentity=true be set on the apiserver
+var _ = SIGDescribe("kube-apiserver identity [Feature:APIServerIdentity]", func() {
+	f := framework.NewDefaultFramework("kube-apiserver-identity")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	ginkgo.It("kube-apiserver identity should persist after restart [Disruptive]", func() {
+		e2eskipper.SkipUnlessProviderIs("gce")
+
+		client := f.ClientSet
+
+		var controlPlaneNodes []v1.Node
+		nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		framework.ExpectNoError(err)
+
+		for _, node := range nodes.Items {
+			if _, ok := node.Labels["node-role.kubernetes.io/control-plane"]; ok {
+				controlPlaneNodes = append(controlPlaneNodes, node)
+				continue
+			}
+
+			if _, ok := node.Labels["node-role.kubernetes.io/master"]; ok {
+				controlPlaneNodes = append(controlPlaneNodes, node)
+				continue
+			}
+
+			for _, taint := range node.Spec.Taints {
+				if taint.Key == "node-role.kubernetes.io/master" {
+					controlPlaneNodes = append(controlPlaneNodes, node)
+					break
+				}
+
+				if taint.Key == "node-role.kubernetes.io/control-plane" {
+					controlPlaneNodes = append(controlPlaneNodes, node)
+					break
+				}
+			}
+		}
+
+		leases, err := client.CoordinationV1().Leases(metav1.NamespaceSystem).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "k8s.io/component=kube-apiserver",
+		})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(len(leases.Items), len(controlPlaneNodes), "unexpected number of leases")
+
+		for _, node := range controlPlaneNodes {
+			hostname, err := getControlPlaneHostname(&node)
+			framework.ExpectNoError(err)
+
+			hash := sha256.Sum256([]byte(hostname))
+			leaseName := "kube-apiserver-" + strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hash[:16]))
+
+			lease, err := client.CoordinationV1().Leases(metav1.NamespaceSystem).Get(context.TODO(), leaseName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			oldHolderIdentity := lease.Spec.HolderIdentity
+			lastRenewedTime := lease.Spec.RenewTime
+
+			err = restartAPIServer(&node)
+			framework.ExpectNoError(err)
+
+			err = wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+				lease, err = client.CoordinationV1().Leases(metav1.NamespaceSystem).Get(context.TODO(), leaseName, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+
+				// expect only the holder identity to change after a restart
+				newHolderIdentity := lease.Spec.HolderIdentity
+				if newHolderIdentity == oldHolderIdentity {
+					return false, nil
+				}
+
+				// wait for at least one lease heart beat after the holder identity changes
+				if !lease.Spec.RenewTime.After(lastRenewedTime.Time) {
+					return false, nil
+				}
+
+				return true, nil
+
+			})
+			framework.ExpectNoError(err, "holder identity did not change after a restart")
+		}
+
+		// As long as the hostname of kube-apiserver is unchanged, a restart should not result in new Lease objects.
+		// Check that the number of lease objects remains the same after restarting kube-apiserver.
+		leases, err = client.CoordinationV1().Leases(metav1.NamespaceSystem).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "k8s.io/component=kube-apiserver",
+		})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(len(leases.Items), len(controlPlaneNodes), "unexpected number of leases")
+	})
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR promotes the APIServerIdentity feature, per KEP-1965 updates for v1.26:
* https://github.com/kubernetes/enhancements/pull/3589
* https://github.com/kubernetes/enhancements/pull/3621
* https://github.com/kubernetes/enhancements/pull/3635 

In addition, it adds e2e tests which were part of the Beta graduation criterias and also removes kube-apiserver flags used to configure the lease duration and renewal interval.

The following Beta criterias have been met:
- [X] Appropriate metrics are agreed on and implemented
    - See poststarthook SLI metrics added in https://github.com/kubernetes/kubernetes/pull/112741, which can be used to check the health of the lease controller and lease gc controller running in kube-apiserver
- [X] Sufficient integration tests covering basic functionality of this enhancement.
    - Integration tests can be found in [test/integration/controlplane/apiserver_identity_test.go](https://github.com/kubernetes/kubernetes/blob/master/test/integration/controlplane/apiserver_identity_test.go)
    -  Additional unit tests for the apiserverleasegc controller was also added in https://github.com/kubernetes/kubernetes/pull/113074/files
- [X] e2e tests outlined in the test plan are implemented  
    - This PR adds an e2e test validating behavior for kube-apiserver leases on restart.
- [X] SIG consensus on lease identity format, see https://github.com/kubernetes/kubernetes/pull/113307 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promote the `APIServerIdentity` feature to Beta. By default, each kube-apiserver will now create a Lease in the `kube-system` namespace. These lease objects can be used to identify the number of active API servers in the cluster, and may also be used for future features such as the Storage Version API. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
