### PR TITLE
Stop creating three copies of admission plugins

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -77,18 +77,6 @@ func createAggregatorConfig(
 		genericConfig.BuildHandlerChainFunc = genericapiserver.BuildHandlerChainWithStorageVersionPrecondition
 	}
 
-	// override genericConfig.AdmissionControl with kube-aggregator's scheme,
-	// because aggregator apiserver should use its own scheme to convert its own resources.
-	err := commandOptions.Admission.ApplyTo(
-		&genericConfig,
-		externalInformers,
-		genericConfig.LoopbackClientConfig,
-		utilfeature.DefaultFeatureGate,
-		pluginInitializers...)
-	if err != nil {
-		return nil, err
-	}
-
 	// copy the etcd options so we don't mutate originals.
 	// we assume that the etcd options have been completed already.  avoid messing with anything outside
 	// of changes to StorageConfig as that may lead to unexpected behavior when the options are applied.

--- a/cmd/kube-apiserver/app/apiextensions.go
+++ b/cmd/kube-apiserver/app/apiextensions.go
@@ -50,18 +50,6 @@ func createAPIExtensionsConfig(
 	genericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
 	genericConfig.RESTOptionsGetter = nil
 
-	// override genericConfig.AdmissionControl with apiextensions' scheme,
-	// because apiextensions apiserver should use its own scheme to convert resources.
-	err := commandOptions.Admission.ApplyTo(
-		&genericConfig,
-		externalInformers,
-		genericConfig.LoopbackClientConfig,
-		utilfeature.DefaultFeatureGate,
-		pluginInitializers...)
-	if err != nil {
-		return nil, err
-	}
-
 	// copy the etcd options so we don't mutate originals.
 	// we assume that the etcd options have been completed already.  avoid messing with anything outside
 	// of changes to StorageConfig as that may lead to unexpected behavior when the options are applied.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Admission plugins were being initialized three times internally in the `kube-apiserver` process, once for kube-apiserver, once for kube-aggregator, once for apiextensions-apiserver.

This was added in https://github.com/kubernetes/kubernetes/pull/61404 in order to propagate a Scheme that knew about the types that server was serving correctly, since the scheme was used for conversions in admission webhooks.

The distinct Scheme was removed from admission initialization in https://github.com/kubernetes/kubernetes/pull/74154 when the per-request ObjectInterfaces type was propagated.

Dropping the duplicate admission constructions avoids creating multiple copies of plugins which do more work internally, like webhook admission or CEL admission (noted in https://github.com/kubernetes/kubernetes/pull/113314#discussion_r1013582954)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @alexzielenski 