### PR TITLE
cluster: remove KUBE_TEST_IGNORE_CLOUDPROVIDER_TAINT which is no longer needed

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -160,9 +160,6 @@ fi
 # shellcheck disable=SC2034 # Variables sourced in other scripts.
 FEATURE_GATES=${KUBE_FEATURE_GATES:-}
 
-#Optional: disable the cloud provider no schedule taint for testing.
-TEST_IGNORE_CLOUDPROVIDER_TAINT=${KUBE_TEST_IGNORE_CLOUDPROVIDER_TAINT:-}
-
 TERMINATED_POD_GC_THRESHOLD=${TERMINATED_POD_GC_THRESHOLD:-100}
 
 # Extra docker options for nodes.
@@ -297,8 +294,6 @@ export LOGGING_DESTINATION=${KUBE_LOGGING_DESTINATION:-gcp} # options: gcp
 # Optional: When set to true, Elasticsearch and Kibana will be setup as part of the cluster bring up.
 export ENABLE_CLUSTER_LOGGING=${KUBE_ENABLE_CLUSTER_LOGGING:-true}
 export ELASTICSEARCH_LOGGING_REPLICAS=1
-
-export TEST_IGNORE_CLOUDPROVIDER_TAINT=${KUBE_TEST_IGNORE_CLOUDPROVIDER_TAINT:-false}
 
 # Optional: Don't require https for registries in our local RFC1918 network
 if [[ ${KUBE_ENABLE_INSECURE_REGISTRY:-false} = 'true' ]]; then

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -130,11 +130,6 @@ if [[ "${KUBERNETES_PROVIDER}" == "azure" ]]; then
     fi
 fi
 
-if [[ "${TEST_IGNORE_CLOUDPROVIDER_TAINT:-}" == true ]]; then
-  echo "Found test ignore cloude provider taint, removing NoSchedule taint from all nodes"
-  "${KUBE_ROOT}/cluster/kubectl.sh" taint nodes --all node.cloudprovider.kubernetes.io/uninitialized:NoSchedule-
-fi
-
 # These arguments are understood by both Ginkgo test suite and CLI.
 # Some arguments (like --nodes) are only supported when using the CLI.
 # Those get set below when choosing the program.


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

The only prow job using this env var was recently updated to not set this env var anymore (https://github.com/kubernetes/test-infra/pull/27875), so we can delete it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
