### PR TITLE
Enable shell completion descriptions for bash

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
@@ -167,7 +167,7 @@ func runCompletionBash(out io.Writer, boilerPlate string, kubectl *cobra.Command
 		return err
 	}
 
-	return kubectl.GenBashCompletionV2(out, false) // TODO: Upgrade to Cobra 1.3.0 or later before including descriptions (See https://github.com/spf13/cobra/pull/1509)
+	return kubectl.GenBashCompletionV2(out, true)
 }
 
 func runCompletionZsh(out io.Writer, boilerPlate string, kubectl *cobra.Command) error {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR enables descriptions for `kubectl` shell completion for the bash shell, just like is already supported for `zsh`, `fish` and `powershell`.

This support is transparently provided by Cobra. It was turned off for `kubetl` because of a [bug with certain bash menu options](https://github.com/spf13/cobra/pull/1509) which has been fixed by Cobra 1.3.0 which has been used by `kubectl` for a while now.  

Before the PR:
```
bash-5.1$ kubectl a[tab][tab]
alpha          api-resources  apply          attach         autoscale
annotate       api-versions   argo           auth

bash-5.1$ kubectl --c[tab][tab]
--cache-dir              --client-certificate     --cluster
--certificate-authority  --client-key             --context
```

With the PR:
```
bash-5.1$ kubectl a[tab][tab]
alpha          (Commands for features in alpha)
annotate       (Update the annotations on a resource)
api-resources  (Print the supported API resources on the server)
api-versions   (Print the supported API versions on the server, in the form of "group/version")
apply          (Apply a configuration to a resource by file name or stdin)
argo           (The command argo is a plugin installed by the user)
attach         (Attach to a running container)
auth           (Inspect authorization)
autoscale      (Auto-scale a deployment, replica set, stateful set, or replication controller)

bash-5.1$ kubectl --c[tab][tab]
--cache-dir              (Default cache directory)
--certificate-authority  (Path to a cert file for the certificate authority)
--client-certificate     (Path to a client certificate file for TLS)
--client-key             (Path to a client key file for TLS)
--cluster                (The name of the kubeconfig cluster to use)
--context                (The name of the kubeconfig context to use)
```

#### Special notes for your reviewer:

Helm has been using this feature without issue since Helm 3.7.0 which has been released September 15, 2021.

However, in a possibly overly cautious approach, helm allows users to choose to disable completion descriptions for bash and all other shells as well.  As for `kubectl`, it currently enables shell descriptions all the time for `zsh`, `powershell` and `fish`, so this PR does the same for `bash`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubectl shell completions for the bash shell now include descriptions.
```

cc @brianpursley 