### PR TITLE
apiserver identity : use SHA256 hash in lease names

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -18,8 +18,9 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base32"
 	"fmt"
-	"hash/fnv"
 	"net"
 	"net/http"
 	"os"
@@ -335,9 +336,8 @@ func NewConfig(codecs serializer.CodecFactory) *Config {
 			klog.Fatalf("error getting hostname for apiserver identity: %v", err)
 		}
 
-		h := fnv.New32a()
-		h.Write([]byte(hostname))
-		id = "kube-apiserver-" + fmt.Sprint(h.Sum32())
+		hash := sha256.Sum256([]byte(hostname))
+		id = "kube-apiserver-" + strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hash[:16]))
 	}
 	lifecycleSignals := newLifecycleSignals()
 

--- a/test/integration/controlplane/apiserver_identity_test.go
+++ b/test/integration/controlplane/apiserver_identity_test.go
@@ -18,9 +18,11 @@ package controlplane
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base32"
 	"fmt"
-	"hash/fnv"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,9 +46,8 @@ const (
 )
 
 func expectedAPIServerIdentity(hostname string) string {
-	h := fnv.New32a()
-	h.Write([]byte(hostname))
-	return "kube-apiserver-" + fmt.Sprint(h.Sum32())
+	hash := sha256.Sum256([]byte(hostname))
+	return "kube-apiserver-" + strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hash[:16]))
 }
 
 func TestCreateLeaseOnStart(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Following up on https://github.com/kubernetes/kubernetes/pull/113307#discussion_r1014480914 and updating the apiserver identity lease to use a SHA256 hash in the lease name. 

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
