### PR TITLE
Kubectl boolean condition clean up 

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
@@ -207,7 +207,7 @@ func (o *APIResourceOptions) RunAPIResources() error {
 		}
 	}
 
-	if o.NoHeaders == false && o.Output != "name" {
+	if !o.NoHeaders && o.Output != "name" {
 		if err = printContextHeaders(w, o.Output); err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
@@ -185,7 +185,7 @@ func TestDescribeObjectShowEvents(t *testing.T) {
 	cmd := NewCmdDescribe("kubectl", tf, genericclioptions.NewTestIOStreamsDiscard())
 	cmd.Flags().Set("show-events", "true")
 	cmd.Run(cmd, []string{"pods"})
-	if d.Settings.ShowEvents != true {
+	if !d.Settings.ShowEvents {
 		t.Errorf("ShowEvents = true expected, got ShowEvents = %v", d.Settings.ShowEvents)
 	}
 }
@@ -211,7 +211,7 @@ func TestDescribeObjectSkipEvents(t *testing.T) {
 	cmd := NewCmdDescribe("kubectl", tf, genericclioptions.NewTestIOStreamsDiscard())
 	cmd.Flags().Set("show-events", "false")
 	cmd.Run(cmd, []string{"pods"})
-	if d.Settings.ShowEvents != false {
+	if d.Settings.ShowEvents {
 		t.Errorf("ShowEvents = false expected, got ShowEvents = %v", d.Settings.ShowEvents)
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go
@@ -161,7 +161,7 @@ func (o *ProxyOptions) Complete(f cmdutil.Factory) error {
 		o.apiPrefix += "/"
 	}
 
-	if o.appendServerPath == false {
+	if !o.appendServerPath {
 		target, err := url.Parse(clientConfig.Host)
 		if err != nil {
 			return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject_test.go
@@ -412,7 +412,7 @@ func TestAddSubject(t *testing.T) {
 	for _, tt := range tests {
 		changed := false
 		var got []rbacv1.Subject
-		if changed, got = addSubjects(tt.existing, tt.subjects); (changed != false) != tt.wantChange {
+		if changed, got = addSubjects(tt.existing, tt.subjects); changed != tt.wantChange {
 			t.Errorf("%q. addSubjects() changed = %v, wantChange = %v", tt.Name, changed, tt.wantChange)
 		}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -448,7 +448,7 @@ func getObjAndCheckCondition(info *resource.Info, o *WaitOptions, condMet isCond
 		if err != nil {
 			return gottenObj, false, err
 		}
-		if conditionCheck == false {
+		if !conditionCheck {
 			return gottenObj, false, fmt.Errorf("condition not met for %s", info.ObjectName())
 		}
 		return gottenObj, true, nil

--- a/staging/src/k8s.io/kubectl/pkg/generate/generate_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/generate_test.go
@@ -254,10 +254,10 @@ func TestGetBool(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GetBool(tt.parameters, tt.key, tt.defaultValue)
-			if err != nil && tt.expectError == false {
+			if err != nil && !tt.expectError {
 				t.Errorf("%s: unexpected error: %v", tt.name, err)
 			}
-			if err == nil && tt.expectError == true {
+			if err == nil && tt.expectError {
 				t.Errorf("%s: expect error, got nil", tt.name)
 			}
 			if got != tt.expected {

--- a/staging/src/k8s.io/kubectl/pkg/scale/scale_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/scale/scale_test.go
@@ -180,7 +180,7 @@ func TestDeploymentScaleRetry(t *testing.T) {
 
 	scaleFunc := ScaleCondition(scaler, nil, namespace, name, count, nil, deploygvr, false)
 	pass, err := scaleFunc()
-	if pass != false {
+	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
 	if err != nil {
@@ -310,7 +310,7 @@ func TestStatefulSetScaleRetry(t *testing.T) {
 
 	scaleFunc := ScaleCondition(scaler, nil, namespace, name, count, nil, stsgvr, false)
 	pass, err := scaleFunc()
-	if pass != false {
+	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
 	if err != nil {
@@ -419,7 +419,7 @@ func TestReplicaSetScaleRetry(t *testing.T) {
 
 	scaleFunc := ScaleCondition(scaler, nil, namespace, name, count, nil, rsgvr, false)
 	pass, err := scaleFunc()
-	if pass != false {
+	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To clean up false/true condition in kubectl section
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
