### PR TITLE
Don't nest utiltracing spans in component-base/tracing

### DIFF
--- a/staging/src/k8s.io/component-base/tracing/tracing.go
+++ b/staging/src/k8s.io/component-base/tracing/tracing.go
@@ -34,8 +34,7 @@ func Start(ctx context.Context, name string, attributes ...attribute.KeyValue) (
 	// If the incoming context already includes an OpenTelemetry span, create a child span with the provided name and attributes.
 	// If the caller is not using OpenTelemetry, or has tracing disabled (e.g. with a component-specific feature flag), this is a noop.
 	ctx, otelSpan := trace.SpanFromContext(ctx).TracerProvider().Tracer(instrumentationScope).Start(ctx, name, trace.WithAttributes(attributes...))
-	// If there is already a utiltrace span in the context, use that as our parent span.
-	utilSpan := utiltrace.FromContext(ctx).Nest(name, attributesToFields(attributes)...)
+	utilSpan := utiltrace.New(name, attributesToFields(attributes)...)
 	// Set the trace as active in the context so that subsequent Start calls create nested spans.
 	return utiltrace.ContextWithTrace(ctx, utilSpan), &Span{
 		otelSpan: otelSpan,


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/sig instrumentation

#### What this PR does / why we need it:

This is a partial revert of functionality added in https://github.com/kubernetes/kubernetes/pull/113172 and https://github.com/kubernetes/kubernetes/pull/113183.  The new library uses `utiltrace.Nest` instead of using `utiltrace.New` to nest spans with the utiltrace library.

This means we lose nesting of utiltrace spans, for now, but that was the state before https://github.com/kubernetes/kubernetes/pull/113172 and https://github.com/kubernetes/kubernetes/pull/113183.

#### Which issue(s) this PR fixes:

This may be the cause of integration test flakes: https://github.com/kubernetes/kubernetes/issues/113651

#### Special notes for your reviewer:

This switches back to using utiltrace.New, which is the function that was originally being called in API Server code before https://github.com/kubernetes/kubernetes/pull/113172.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

cc @liggitt 