### PR TITLE
Fix formatting of API server diagram

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -418,44 +418,40 @@ func (s *GenericAPIServer) PrepareRun() preparedGenericAPIServer {
 // or the secure port cannot be listened on initially.
 // This is the diagram of what channels/signals are dependent on each other:
 //
-//	                              stopCh
-//	                                |
-//	       ---------------------------------------------------------
-//	       |                                                       |
-//	ShutdownInitiated (shutdownInitiatedCh)                        |
-//	       |                                                       |
-//
-// (ShutdownDelayDuration)                                    (PreShutdownHooks)
-//
-//	         |                                                       |
-//	AfterShutdownDelayDuration (delayedStopCh)   PreShutdownHooksStopped (preShutdownHooksHasStoppedCh)
-//	         |                                                       |
-//	         |-------------------------------------------------------|
-//	                                  |
-//	                                  |
-//	             NotAcceptingNewRequest (notAcceptingNewRequestCh)
-//	                                  |
-//	                                  |
-//	         |---------------------------------------------------------|
-//	         |                        |              |                 |
-//	      [without                 [with             |                 |
-//
-// ShutdownSendRetryAfter]  ShutdownSendRetryAfter]  |                 |
-//
-//	     |                        |              |                 |
-//	     |                        ---------------|                 |
-//	     |                                       |                 |
-//	     |                         (HandlerChainWaitGroup::Wait)   |
-//	     |                                       |                 |
-//	     |                    InFlightRequestsDrained (drainedCh)  |
-//	     |                                       |                 |
-//	     ----------------------------------------|-----------------|
-//	                           |                 |
-//	                 stopHttpServerCh     (AuditBackend::Shutdown())
-//	                           |
-//	                 listenerStoppedCh
-//	                           |
-//	HTTPServerStoppedListening (httpServerStoppedListeningCh)
+// |                                  stopCh
+// |                                    |
+// |           ---------------------------------------------------------
+// |           |                                                       |
+// |    ShutdownInitiated (shutdownInitiatedCh)                        |
+// |           |                                                       |
+// | (ShutdownDelayDuration)                                    (PreShutdownHooks)
+// |           |                                                       |
+// |  AfterShutdownDelayDuration (delayedStopCh)   PreShutdownHooksStopped (preShutdownHooksHasStoppedCh)
+// |           |                                                       |
+// |           |-------------------------------------------------------|
+// |                                    |
+// |                                    |
+// |               NotAcceptingNewRequest (notAcceptingNewRequestCh)
+// |                                    |
+// |                                    |
+// |           |---------------------------------------------------------|
+// |           |                        |              |                 |
+// |        [without                 [with             |                 |
+// | ShutdownSendRetryAfter]  ShutdownSendRetryAfter]  |                 |
+// |           |                        |              |                 |
+// |           |                        ---------------|                 |
+// |           |                                       |                 |
+// |           |                         (HandlerChainWaitGroup::Wait)   |
+// |           |                                       |                 |
+// |           |                    InFlightRequestsDrained (drainedCh)  |
+// |           |                                       |                 |
+// |           ----------------------------------------|-----------------|
+// |                                 |                 |
+// |                       stopHttpServerCh     (AuditBackend::Shutdown())
+// |                                 |
+// |                       listenerStoppedCh
+// |                                 |
+// |      HTTPServerStoppedListening (httpServerStoppedListeningCh)
 func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) error {
 	delayedStopCh := s.lifecycleSignals.AfterShutdownDelayDuration
 	shutdownInitiatedCh := s.lifecycleSignals.ShutdownInitiated


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
Fixes formatting of apiserver stopCh diagram which was messed up in https://github.com/kubernetes/kubernetes/pull/111254.

Update: this was actually due to go fmt changes in go1.19, so in order to make the formatter happy I added a pipe `|` one space away from the comment markers `//`.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
