### PR TITLE
Key encipherment v1.27 (without adding dynamic getUsages)

### DIFF
--- a/pkg/apis/certificates/helpers.go
+++ b/pkg/apis/certificates/helpers.go
@@ -62,10 +62,10 @@ var (
 	)
 )
 
-func IsKubeletServingCSR(req *x509.CertificateRequest, usages sets.String, allowOmittingUsageKeyEncipherment bool) bool {
-	return ValidateKubeletServingCSR(req, usages, allowOmittingUsageKeyEncipherment) == nil
+func IsKubeletServingCSR(req *x509.CertificateRequest, usages sets.String) bool {
+	return ValidateKubeletServingCSR(req, usages) == nil
 }
-func ValidateKubeletServingCSR(req *x509.CertificateRequest, usages sets.String, allowOmittingUsageKeyEncipherment bool) error {
+func ValidateKubeletServingCSR(req *x509.CertificateRequest, usages sets.String) error {
 	if !reflect.DeepEqual([]string{"system:nodes"}, req.Subject.Organization) {
 		return organizationNotSystemNodesErr
 	}
@@ -82,14 +82,8 @@ func ValidateKubeletServingCSR(req *x509.CertificateRequest, usages sets.String,
 		return uriSANNotAllowedErr
 	}
 
-	if allowOmittingUsageKeyEncipherment {
-		if !kubeletServingRequiredUsages.Equal(usages) && !kubeletServingRequiredUsagesNoRSA.Equal(usages) {
-			return fmt.Errorf("usages did not match %v", kubeletServingRequiredUsages.List())
-		}
-	} else {
-		if !kubeletServingRequiredUsages.Equal(usages) {
-			return fmt.Errorf("usages did not match %v", kubeletServingRequiredUsages.List())
-		}
+	if !kubeletServingRequiredUsages.Equal(usages) && !kubeletServingRequiredUsagesNoRSA.Equal(usages) {
+		return fmt.Errorf("usages did not match %v", kubeletServingRequiredUsages.List())
 	}
 
 	if !strings.HasPrefix(req.Subject.CommonName, "system:node:") {
@@ -111,10 +105,10 @@ var (
 	)
 )
 
-func IsKubeletClientCSR(req *x509.CertificateRequest, usages sets.String, allowOmittingUsageKeyEncipherment bool) bool {
-	return ValidateKubeletClientCSR(req, usages, allowOmittingUsageKeyEncipherment) == nil
+func IsKubeletClientCSR(req *x509.CertificateRequest, usages sets.String) bool {
+	return ValidateKubeletClientCSR(req, usages) == nil
 }
-func ValidateKubeletClientCSR(req *x509.CertificateRequest, usages sets.String, allowOmittingUsageKeyEncipherment bool) error {
+func ValidateKubeletClientCSR(req *x509.CertificateRequest, usages sets.String) error {
 	if !reflect.DeepEqual([]string{"system:nodes"}, req.Subject.Organization) {
 		return organizationNotSystemNodesErr
 	}
@@ -136,14 +130,8 @@ func ValidateKubeletClientCSR(req *x509.CertificateRequest, usages sets.String, 
 		return commonNameNotSystemNode
 	}
 
-	if allowOmittingUsageKeyEncipherment {
-		if !kubeletClientRequiredUsages.Equal(usages) && !kubeletClientRequiredUsagesNoRSA.Equal(usages) {
-			return fmt.Errorf("usages did not match %v", kubeletClientRequiredUsages.List())
-		}
-	} else {
-		if !kubeletClientRequiredUsages.Equal(usages) {
-			return fmt.Errorf("usages did not match %v", kubeletClientRequiredUsages.List())
-		}
+	if !kubeletClientRequiredUsages.Equal(usages) && !kubeletClientRequiredUsagesNoRSA.Equal(usages) {
+		return fmt.Errorf("usages did not match %v", kubeletClientRequiredUsages.List())
 	}
 
 	return nil

--- a/pkg/apis/certificates/v1beta1/defaults.go
+++ b/pkg/apis/certificates/v1beta1/defaults.go
@@ -56,9 +56,9 @@ func DefaultSignerNameFromSpec(obj *certificatesv1beta1.CertificateSigningReques
 		// Set the signerName to 'legacy-unknown' as the CSR could not be
 		// recognised.
 		return certificatesv1beta1.LegacyUnknownSignerName
-	case IsKubeletClientCSR(csr, obj.Usages, false):
+	case IsKubeletClientCSR(csr, obj.Usages, true):
 		return certificatesv1beta1.KubeAPIServerClientKubeletSignerName
-	case IsKubeletServingCSR(csr, obj.Usages, false):
+	case IsKubeletServingCSR(csr, obj.Usages, true):
 		return certificatesv1beta1.KubeletServingSignerName
 	default:
 		return certificatesv1beta1.LegacyUnknownSignerName

--- a/pkg/apis/certificates/v1beta1/defaults.go
+++ b/pkg/apis/certificates/v1beta1/defaults.go
@@ -56,27 +56,27 @@ func DefaultSignerNameFromSpec(obj *certificatesv1beta1.CertificateSigningReques
 		// Set the signerName to 'legacy-unknown' as the CSR could not be
 		// recognised.
 		return certificatesv1beta1.LegacyUnknownSignerName
-	case IsKubeletClientCSR(csr, obj.Usages, true):
+	case IsKubeletClientCSR(csr, obj.Usages):
 		return certificatesv1beta1.KubeAPIServerClientKubeletSignerName
-	case IsKubeletServingCSR(csr, obj.Usages, true):
+	case IsKubeletServingCSR(csr, obj.Usages):
 		return certificatesv1beta1.KubeletServingSignerName
 	default:
 		return certificatesv1beta1.LegacyUnknownSignerName
 	}
 }
 
-func IsKubeletServingCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage, allowOmittingUsageKeyEncipherment bool) bool {
-	return certificates.IsKubeletServingCSR(req, usagesToSet(usages), allowOmittingUsageKeyEncipherment)
+func IsKubeletServingCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage) bool {
+	return certificates.IsKubeletServingCSR(req, usagesToSet(usages))
 }
-func ValidateKubeletServingCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage, allowOmittingUsageKeyEncipherment bool) error {
-	return certificates.ValidateKubeletServingCSR(req, usagesToSet(usages), allowOmittingUsageKeyEncipherment)
+func ValidateKubeletServingCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage) error {
+	return certificates.ValidateKubeletServingCSR(req, usagesToSet(usages))
 }
 
-func IsKubeletClientCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage, allowOmittingUsageKeyEncipherment bool) bool {
-	return certificates.IsKubeletClientCSR(req, usagesToSet(usages), allowOmittingUsageKeyEncipherment)
+func IsKubeletClientCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage) bool {
+	return certificates.IsKubeletClientCSR(req, usagesToSet(usages))
 }
-func ValidateKubeletClientCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage, allowOmittingUsageKeyEncipherment bool) error {
-	return certificates.ValidateKubeletClientCSR(req, usagesToSet(usages), allowOmittingUsageKeyEncipherment)
+func ValidateKubeletClientCSR(req *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage) error {
+	return certificates.ValidateKubeletClientCSR(req, usagesToSet(usages))
 }
 
 func usagesToSet(usages []certificatesv1beta1.KeyUsage) sets.String {

--- a/pkg/apis/certificates/v1beta1/defaults_test.go
+++ b/pkg/apis/certificates/v1beta1/defaults_test.go
@@ -40,27 +40,19 @@ func TestIsKubeletServingCSR(t *testing.T) {
 		return csr
 	}
 	tests := map[string]struct {
-		req                               *x509.CertificateRequest
-		usages                            []capi.KeyUsage
-		allowOmittingUsageKeyEncipherment bool
-		exp                               bool
+		req    *x509.CertificateRequest
+		usages []capi.KeyUsage
+		exp    bool
 	}{
 		"defaults for kubelet-serving": {
 			req:    newCSR(kubeletServerPEMOptions),
 			usages: kubeletServerUsages,
 			exp:    true,
 		},
-		"defaults without key encipherment for kubelet-serving if allow omitting key encipherment": {
-			req:                               newCSR(kubeletServerPEMOptions),
-			usages:                            kubeletServerUsagesNoRSA,
-			allowOmittingUsageKeyEncipherment: true,
-			exp:                               true,
-		},
-		"defaults for kubelet-serving if allow omitting key encipherment": {
-			req:                               newCSR(kubeletServerPEMOptions),
-			usages:                            kubeletServerUsages,
-			allowOmittingUsageKeyEncipherment: true,
-			exp:                               true,
+		"defaults without key encipherment for kubelet-serving": {
+			req:    newCSR(kubeletServerPEMOptions),
+			usages: kubeletServerUsagesNoRSA,
+			exp:    true,
 		},
 		"does not default to kube-apiserver-client-kubelet if org is not 'system:nodes'": {
 			req:    newCSR(kubeletServerPEMOptions, pemOptions{org: "not-system:nodes"}),
@@ -82,17 +74,6 @@ func TestIsKubeletServingCSR(t *testing.T) {
 			usages: kubeletServerUsages[1:],
 			exp:    false,
 		},
-		"does not default to kubelet-serving if it is missing an expected usage if allow omitting key encipherment": {
-			req:                               newCSR(kubeletServerPEMOptions),
-			usages:                            kubeletServerUsagesNoRSA[1:],
-			allowOmittingUsageKeyEncipherment: true,
-			exp:                               false,
-		},
-		"does not default to kubelet-serving if it is missing an expected usage withou key encipherment": {
-			req:    newCSR(kubeletServerPEMOptions),
-			usages: kubeletServerUsagesNoRSA,
-			exp:    false,
-		},
 		"does not default to kubelet-serving if it does not specify any dnsNames or ipAddresses": {
 			req:    newCSR(kubeletServerPEMOptions, pemOptions{ipAddresses: []net.IP{}, dnsNames: []string{}}),
 			usages: kubeletServerUsages[1:],
@@ -111,7 +92,7 @@ func TestIsKubeletServingCSR(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := IsKubeletServingCSR(test.req, test.usages, test.allowOmittingUsageKeyEncipherment)
+			got := IsKubeletServingCSR(test.req, test.usages)
 			if test.exp != got {
 				t.Errorf("unexpected IsKubeletClientCSR output: exp=%v, got=%v", test.exp, got)
 			}
@@ -129,10 +110,9 @@ func TestIsKubeletClientCSR(t *testing.T) {
 		return csr
 	}
 	tests := map[string]struct {
-		req                               *x509.CertificateRequest
-		usages                            []capi.KeyUsage
-		allowOmittingUsageKeyEncipherment bool
-		exp                               bool
+		req    *x509.CertificateRequest
+		usages []capi.KeyUsage
+		exp    bool
 	}{
 		"defaults for kube-apiserver-client-kubelet": {
 			req:    newCSR(kubeletClientPEMOptions),
@@ -180,27 +160,19 @@ func TestIsKubeletClientCSR(t *testing.T) {
 			exp:    false,
 		},
 		"does not default to kube-apiserver-client-kubelet if it is missing an expected usage without key encipherment": {
-			req:                               newCSR(kubeletClientPEMOptions),
-			usages:                            kubeletClientUsagesNoRSA[1:],
-			allowOmittingUsageKeyEncipherment: true,
-			exp:                               false,
-		},
-		"default to kube-apiserver-client-kubelet with key encipherment": {
-			req:                               newCSR(kubeletClientPEMOptions),
-			usages:                            kubeletClientUsages,
-			allowOmittingUsageKeyEncipherment: true,
-			exp:                               true,
+			req:    newCSR(kubeletClientPEMOptions),
+			usages: kubeletClientUsagesNoRSA[1:],
+			exp:    false,
 		},
 		"default to kube-apiserver-client-kubelet without key encipherment": {
-			req:                               newCSR(kubeletClientPEMOptions),
-			usages:                            kubeletClientUsagesNoRSA,
-			allowOmittingUsageKeyEncipherment: true,
-			exp:                               true,
+			req:    newCSR(kubeletClientPEMOptions),
+			usages: kubeletClientUsagesNoRSA,
+			exp:    true,
 		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := IsKubeletClientCSR(test.req, test.usages, test.allowOmittingUsageKeyEncipherment)
+			got := IsKubeletClientCSR(test.req, test.usages)
 			if test.exp != got {
 				t.Errorf("unexpected IsKubeletClientCSR output: exp=%v, got=%v", test.exp, got)
 			}

--- a/pkg/controller/certificates/approver/sarapprove.go
+++ b/pkg/controller/certificates/approver/sarapprove.go
@@ -152,7 +152,7 @@ func isNodeClientCert(csr *capi.CertificateSigningRequest, x509cr *x509.Certific
 	if csr.Spec.SignerName != capi.KubeAPIServerClientKubeletSignerName {
 		return false
 	}
-	return capihelper.IsKubeletClientCSR(x509cr, usagesToSet(csr.Spec.Usages), true)
+	return capihelper.IsKubeletClientCSR(x509cr, usagesToSet(csr.Spec.Usages))
 }
 
 func isSelfNodeClientCert(csr *capi.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {

--- a/pkg/controller/certificates/signer/signer.go
+++ b/pkg/controller/certificates/signer/signer.go
@@ -248,14 +248,14 @@ func isKubeletServing(req *x509.CertificateRequest, usages []capi.KeyUsage, sign
 	if signerName != capi.KubeletServingSignerName {
 		return false, nil
 	}
-	return true, capihelper.ValidateKubeletServingCSR(req, usagesToSet(usages), true)
+	return true, capihelper.ValidateKubeletServingCSR(req, usagesToSet(usages))
 }
 
 func isKubeletClient(req *x509.CertificateRequest, usages []capi.KeyUsage, signerName string) (bool, error) {
 	if signerName != capi.KubeAPIServerClientKubeletSignerName {
 		return false, nil
 	}
-	return true, capihelper.ValidateKubeletClientCSR(req, usagesToSet(usages), true)
+	return true, capihelper.ValidateKubeletClientCSR(req, usagesToSet(usages))
 }
 
 func isKubeAPIServerClient(req *x509.CertificateRequest, usages []capi.KeyUsage, signerName string) (bool, error) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug



#### What this PR does / why we need it:
/cc @liggitt 

I still cannot fix all test failures in https://github.com/kubernetes/kubernetes/pull/111660 (some tests failed due to pending CSR approval.) 😞 

This PR only changed the validation part to relax the API validation.(I think this can be in v1.26 and I can move on later for the left part in https://github.com/kubernetes/kubernetes/pull/111660) 

#### Which issue(s) this PR fixes:
xref https://github.com/kubernetes/kubernetes/issues/109077

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?

```release-note
Relax API validation for usage key encipherment
```
