### PR TITLE
Add verb resource to api server tracing

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers.go
@@ -21,6 +21,7 @@ import (
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/audit"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
 const (
@@ -84,6 +85,42 @@ type lazyAuditID struct {
 func (lazy *lazyAuditID) String() string {
 	if lazy.req != nil {
 		return audit.GetAuditIDTruncated(lazy.req.Context())
+	}
+
+	return "unknown"
+}
+
+// lazyVerb implements String() string and it will
+// lazily get Verb from request info based on request context
+type lazyVerb struct {
+	req *http.Request
+}
+
+func (lazy *lazyVerb) String() string {
+	if lazy.req != nil {
+		ctx := lazy.req.Context()
+		requestInfo, ok := apirequest.RequestInfoFrom(ctx)
+		if ok {
+			return requestInfo.Verb
+		}
+	}
+
+	return "unknown"
+}
+
+// lazyVerb implements String() string and it will
+// lazily get Resource from request info based on request context
+type lazyResource struct {
+	req *http.Request
+}
+
+func (lazy *lazyResource) String() string {
+	if lazy.req != nil {
+		ctx := lazy.req.Context()
+		requestInfo, ok := apirequest.RequestInfoFrom(ctx)
+		if ok {
+			return requestInfo.Resource
+		}
 	}
 
 	return "unknown"

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers.go
@@ -21,6 +21,7 @@ import (
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/endpoints/metrics"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
@@ -91,25 +92,20 @@ func (lazy *lazyAuditID) String() string {
 }
 
 // lazyVerb implements String() string and it will
-// lazily get Verb from request info based on request context
+// lazily get normalized Verb
 type lazyVerb struct {
 	req *http.Request
 }
 
 func (lazy *lazyVerb) String() string {
-	if lazy.req != nil {
-		ctx := lazy.req.Context()
-		requestInfo, ok := apirequest.RequestInfoFrom(ctx)
-		if ok {
-			return requestInfo.Verb
-		}
+	if lazy.req == nil {
+		return "unknown"
 	}
-
-	return "unknown"
+	return metrics.NormalizedVerb(lazy.req)
 }
 
-// lazyVerb implements String() string and it will
-// lazily get Resource from request info based on request context
+// lazyResource implements String() string and it will
+// lazily get Resource from request info
 type lazyResource struct {
 	req *http.Request
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers_test.go
@@ -18,9 +18,10 @@ package handlers
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLazyTruncatedUserAgent(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
 func TestLazyTruncatedUserAgent(t *testing.T) {
@@ -71,4 +74,25 @@ func TestLazyAccept(t *testing.T) {
 
 	acceptWithoutReq := &lazyAccept{}
 	assert.Equal(t, "unknown", fmt.Sprintf("%v", acceptWithoutReq))
+}
+
+func TestLazyVerb(t *testing.T) {
+	assert.Equal(t, "unknown", fmt.Sprintf("%v", &lazyVerb{}))
+
+	u, _ := url.Parse("?watch=true")
+	req := &http.Request{Method: "GET", URL: u}
+	verbWithReq := &lazyVerb{req: req}
+	assert.Equal(t, "WATCH", fmt.Sprintf("%v", verbWithReq))
+}
+
+func TestLazyResource(t *testing.T) {
+	assert.Equal(t, "unknown", fmt.Sprintf("%v", &lazyResource{}))
+
+	resourceWithEmptyReq := &lazyResource{&http.Request{}}
+	assert.Equal(t, "unknown", fmt.Sprintf("%v", resourceWithEmptyReq))
+
+	req := &http.Request{}
+	ctx := request.WithRequestInfo(context.TODO(), &request.RequestInfo{Resource: "resource"})
+	resourceWithReq := &lazyResource{req: req.WithContext(ctx)}
+	assert.Equal(t, "resource", fmt.Sprintf("%v", resourceWithReq))
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/trace_util.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/trace_util.go
@@ -24,11 +24,13 @@ import (
 
 func traceFields(req *http.Request) []attribute.KeyValue {
 	return []attribute.KeyValue{
-		attribute.String("url", req.URL.Path),
-		attribute.Stringer("user-agent", &lazyTruncatedUserAgent{req: req}),
+		attribute.Stringer("accept", &lazyAccept{req: req}),
 		attribute.Stringer("audit-id", &lazyAuditID{req: req}),
 		attribute.Stringer("client", &lazyClientIP{req: req}),
-		attribute.Stringer("accept", &lazyAccept{req: req}),
 		attribute.String("protocol", req.Proto),
+		attribute.Stringer("resource", &lazyResource{req: req}),
+		attribute.String("url", req.URL.Path),
+		attribute.Stringer("user-agent", &lazyTruncatedUserAgent{req: req}),
+		attribute.Stringer("verb", &lazyVerb{req: req}),
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -565,6 +565,20 @@ func InstrumentHandlerFunc(verb, group, version, resource, subresource, scope, c
 	}
 }
 
+// NormalizedVerb returns normalized verb
+func NormalizedVerb(req *http.Request) string {
+	verb := req.Method
+	if requestInfo, ok := request.RequestInfoFrom(req.Context()); ok {
+		// If we can find a requestInfo, we can get a scope, and then
+		// we can convert GETs to LISTs when needed.
+		scope := CleanScope(requestInfo)
+		verb = CanonicalVerb(strings.ToUpper(verb), scope)
+	}
+
+	// mark APPLY requests and WATCH requests correctly.
+	return CleanVerb(verb, req)
+}
+
 // CleanScope returns the scope of the request.
 func CleanScope(requestInfo *request.RequestInfo) string {
 	if requestInfo.Name != "" || requestInfo.Verb == "create" {

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -243,16 +243,7 @@ func SetStacktracePredicate(ctx context.Context, pred StacktracePred) {
 func (rl *respLogger) Log() {
 	latency := time.Since(rl.startTime)
 	auditID := audit.GetAuditIDTruncated(rl.req.Context())
-
-	verb := rl.req.Method
-	if requestInfo, ok := request.RequestInfoFrom(rl.req.Context()); ok {
-		// If we can find a requestInfo, we can get a scope, and then
-		// we can convert GETs to LISTs when needed.
-		scope := metrics.CleanScope(requestInfo)
-		verb = metrics.CanonicalVerb(strings.ToUpper(verb), scope)
-	}
-	// mark APPLY requests and WATCH requests correctly.
-	verb = metrics.CleanVerb(verb, rl.req)
+	verb := metrics.NormalizedVerb(rl.req)
 
 	keysAndValues := []interface{}{
 		"verb", verb,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds verb and resource as trace attributes which makes it easier to filter traced requests.

#### Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/113628

```release-note
NONE
```