### PR TITLE
Migrate another usage of utiltrace to component base tracing

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -30,7 +32,7 @@ import (
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/util/webhook"
 	"k8s.io/client-go/rest"
-	utiltrace "k8s.io/utils/trace"
+	"k8s.io/component-base/tracing"
 )
 
 const (
@@ -126,15 +128,16 @@ func (b *backend) processEvents(ev ...*auditinternal.Event) error {
 		list.Items = append(list.Items, *e)
 	}
 	return b.w.WithExponentialBackoff(context.Background(), func() rest.Result {
-		trace := utiltrace.New("Call Audit Events webhook",
-			utiltrace.Field{"name", b.name},
-			utiltrace.Field{"event-count", len(list.Items)})
+		ctx, span := tracing.Start(context.Background(), "Call Audit Events webhook",
+			attribute.String("name", b.name),
+			attribute.Int("event-count", len(list.Items)),
+		)
 		// Only log audit webhook traces that exceed a 25ms per object limit plus a 50ms
 		// request overhead allowance. The high per object limit used here is primarily to
 		// allow enough time for the serialization/deserialization of audit events, which
 		// contain nested request and response objects plus additional event fields.
-		defer trace.LogIfLong(time.Duration(50+25*len(list.Items)) * time.Millisecond)
-		return b.w.RestClient.Post().Body(&list).Do(context.Background())
+		defer span.End(time.Duration(50+25*len(list.Items)) * time.Millisecond)
+		return b.w.RestClient.Post().Body(&list).Do(ctx)
 	}).Error()
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/sig instrumentation
/kind feature

#### What this PR does / why we need it:

Follow-up to https://github.com/kubernetes/kubernetes/pull/113172.  I had missed one usage of utiltracing.  This change  keeps existing log-based "tracing" in-place without changes.  It also results in OpenTelemetry spans being created for the tracing.Start calls if APIServerTracing is enabled.

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/kubernetes/issues/113170

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @logicalhan 