### PR TITLE
Enable VolumeBinding Score plugin only when VolumeCapacityPriority is enabled

### DIFF
--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -847,6 +847,11 @@ profiles:
 									{Name: names.VolumeBinding},
 								},
 							},
+							Score: kubeschedulerconfig.PluginSet{
+								Disabled: []kubeschedulerconfig.Plugin{
+									{Name: names.VolumeBinding},
+								},
+							},
 							MultiPoint: defaults.PluginsV1.MultiPoint,
 						},
 						PluginConfig: []kubeschedulerconfig.PluginConfig{
@@ -1189,6 +1194,11 @@ profiles:
 									{Name: names.VolumeBinding},
 								},
 							},
+							Score: kubeschedulerconfig.PluginSet{
+								Disabled: []kubeschedulerconfig.Plugin{
+									{Name: names.VolumeBinding},
+								},
+							},
 						},
 						PluginConfig: defaults.PluginConfigsV1,
 					},
@@ -1197,6 +1207,11 @@ profiles:
 						Plugins: &kubeschedulerconfig.Plugins{
 							MultiPoint: defaults.PluginsV1.MultiPoint,
 							PreBind: kubeschedulerconfig.PluginSet{
+								Disabled: []kubeschedulerconfig.Plugin{
+									{Name: names.VolumeBinding},
+								},
+							},
+							Score: kubeschedulerconfig.PluginSet{
 								Disabled: []kubeschedulerconfig.Plugin{
 									{Name: names.VolumeBinding},
 								},
@@ -1303,6 +1318,11 @@ profiles:
 									{Name: names.VolumeBinding},
 								},
 							},
+							Score: kubeschedulerconfig.PluginSet{
+								Disabled: []kubeschedulerconfig.Plugin{
+									{Name: names.VolumeBinding},
+								},
+							},
 						},
 						PluginConfig: defaults.PluginConfigsV1beta3,
 					},
@@ -1311,6 +1331,11 @@ profiles:
 						Plugins: &kubeschedulerconfig.Plugins{
 							MultiPoint: defaults.PluginsV1beta3.MultiPoint,
 							PreBind: kubeschedulerconfig.PluginSet{
+								Disabled: []kubeschedulerconfig.Plugin{
+									{Name: names.VolumeBinding},
+								},
+							},
+							Score: kubeschedulerconfig.PluginSet{
 								Disabled: []kubeschedulerconfig.Plugin{
 									{Name: names.VolumeBinding},
 								},

--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -177,6 +177,11 @@ var PluginsV1beta3 = &config.Plugins{
 			{Name: names.DefaultBinder},
 		},
 	},
+	Score: config.PluginSet{
+		Disabled: []config.Plugin{
+			{Name: names.VolumeBinding},
+		},
+	},
 }
 
 // ExpandedPluginsV1beta3 default set of v1beta3 plugins after MultiPoint expansion
@@ -240,11 +245,6 @@ var ExpandedPluginsV1beta3 = &config.Plugins{
 			// - This is a score coming from user preference.
 			{Name: names.NodeAffinity, Weight: 2},
 			{Name: names.NodeResourcesFit, Weight: 1},
-			// Weight is tripled because:
-			// - This is a score coming from user preference.
-			// - Usage of node tainting to group nodes in the cluster is increasing becoming a use-case
-			//	 for many user workloads
-			{Name: names.VolumeBinding, Weight: 1},
 			// Weight is doubled because:
 			// - This is a score coming from user preference.
 			// - It makes its signal comparable to NodeResourcesLeastAllocated.
@@ -347,6 +347,11 @@ var PluginsV1 = &config.Plugins{
 			{Name: names.DefaultBinder},
 		},
 	},
+	Score: config.PluginSet{
+		Disabled: []config.Plugin{
+			{Name: names.VolumeBinding},
+		},
+	},
 }
 
 // ExpandedPluginsV1 default set of v1 plugins after MultiPoint expansion
@@ -410,11 +415,6 @@ var ExpandedPluginsV1 = &config.Plugins{
 			// - This is a score coming from user preference.
 			{Name: names.NodeAffinity, Weight: 2},
 			{Name: names.NodeResourcesFit, Weight: 1},
-			// Weight is tripled because:
-			// - This is a score coming from user preference.
-			// - Usage of node tainting to group nodes in the cluster is increasing becoming a use-case
-			//	 for many user workloads
-			{Name: names.VolumeBinding, Weight: 1},
 			// Weight is doubled because:
 			// - This is a score coming from user preference.
 			// - It makes its signal comparable to NodeResourcesLeastAllocated.

--- a/pkg/scheduler/apis/config/v1/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins.go
@@ -18,8 +18,10 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	v1 "k8s.io/kube-scheduler/config/v1"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/utils/pointer"
 )
@@ -52,8 +54,15 @@ func getDefaultPlugins() *v1.Plugins {
 			},
 		},
 	}
+	applyFeatureGates(plugins)
 
 	return plugins
+}
+
+func applyFeatureGates(config *v1.Plugins) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.VolumeCapacityPriority) {
+		config.Score.Disabled = append(config.Score.Disabled, v1.Plugin{Name: names.VolumeBinding})
+	}
 }
 
 // mergePlugins merges the custom set into the given default one, handling disabled sets.

--- a/pkg/scheduler/apis/config/v1/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	v1 "k8s.io/kube-scheduler/config/v1"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/utils/pointer"
 )
@@ -36,6 +37,43 @@ func TestApplyFeatureGates(t *testing.T) {
 	}{
 		{
 			name: "Feature gates disabled",
+			wantConfig: &v1.Plugins{
+				MultiPoint: v1.PluginSet{
+					Enabled: []v1.Plugin{
+						{Name: names.PrioritySort},
+						{Name: names.NodeUnschedulable},
+						{Name: names.NodeName},
+						{Name: names.TaintToleration, Weight: pointer.Int32(3)},
+						{Name: names.NodeAffinity, Weight: pointer.Int32(2)},
+						{Name: names.NodePorts},
+						{Name: names.NodeResourcesFit, Weight: pointer.Int32(1)},
+						{Name: names.VolumeRestrictions},
+						{Name: names.EBSLimits},
+						{Name: names.GCEPDLimits},
+						{Name: names.NodeVolumeLimits},
+						{Name: names.AzureDiskLimits},
+						{Name: names.VolumeBinding},
+						{Name: names.VolumeZone},
+						{Name: names.PodTopologySpread, Weight: pointer.Int32(2)},
+						{Name: names.InterPodAffinity, Weight: pointer.Int32(2)},
+						{Name: names.DefaultPreemption},
+						{Name: names.NodeResourcesBalancedAllocation, Weight: pointer.Int32(1)},
+						{Name: names.ImageLocality, Weight: pointer.Int32(1)},
+						{Name: names.DefaultBinder},
+					},
+				},
+				Score: v1.PluginSet{
+					Disabled: []v1.Plugin{
+						{Name: names.VolumeBinding},
+					},
+				},
+			},
+		},
+		{
+			name: "Feature gate VolumeCapacityPriority enabled",
+			features: map[featuregate.Feature]bool{
+				features.VolumeCapacityPriority: true,
+			},
 			wantConfig: &v1.Plugins{
 				MultiPoint: v1.PluginSet{
 					Enabled: []v1.Plugin{

--- a/pkg/scheduler/apis/config/v1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1/defaults_test.go
@@ -350,6 +350,11 @@ func TestSchedulerDefaults(t *testing.T) {
 									{Name: names.DefaultBinder},
 								},
 							},
+							Score: configv1.PluginSet{
+								Disabled: []configv1.Plugin{
+									{Name: names.VolumeBinding},
+								},
+							},
 							Bind: configv1.PluginSet{
 								Enabled: []configv1.Plugin{
 									{Name: "BarPlugin"},

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kube-scheduler/config/v1beta2"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/utils/pointer"
 )
@@ -94,6 +95,89 @@ func TestApplyFeatureGates(t *testing.T) {
 						{Name: names.NodeAffinity, Weight: pointer.Int32(1)},
 						{Name: names.PodTopologySpread, Weight: pointer.Int32(2)},
 						{Name: names.TaintToleration, Weight: pointer.Int32(1)},
+					},
+				},
+				Reserve: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: names.VolumeBinding},
+					},
+				},
+				PreBind: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: names.VolumeBinding},
+					},
+				},
+				Bind: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: names.DefaultBinder},
+					},
+				},
+			},
+		},
+		{
+			name: "Feature gates disabled",
+			features: map[featuregate.Feature]bool{
+				features.VolumeCapacityPriority: true,
+			},
+			wantConfig: &v1beta2.Plugins{
+				QueueSort: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: names.PrioritySort},
+					},
+				},
+				PreFilter: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: names.NodeResourcesFit},
+						{Name: names.NodePorts},
+						{Name: names.VolumeRestrictions},
+						{Name: names.PodTopologySpread},
+						{Name: names.InterPodAffinity},
+						{Name: names.VolumeBinding},
+						{Name: names.NodeAffinity},
+					},
+				},
+				Filter: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: names.NodeUnschedulable},
+						{Name: names.NodeName},
+						{Name: names.TaintToleration},
+						{Name: names.NodeAffinity},
+						{Name: names.NodePorts},
+						{Name: names.NodeResourcesFit},
+						{Name: names.VolumeRestrictions},
+						{Name: names.EBSLimits},
+						{Name: names.GCEPDLimits},
+						{Name: names.NodeVolumeLimits},
+						{Name: names.AzureDiskLimits},
+						{Name: names.VolumeBinding},
+						{Name: names.VolumeZone},
+						{Name: names.PodTopologySpread},
+						{Name: names.InterPodAffinity},
+					},
+				},
+				PostFilter: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: names.DefaultPreemption},
+					},
+				},
+				PreScore: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: names.InterPodAffinity},
+						{Name: names.PodTopologySpread},
+						{Name: names.TaintToleration},
+						{Name: names.NodeAffinity},
+					},
+				},
+				Score: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: names.NodeResourcesBalancedAllocation, Weight: pointer.Int32(1)},
+						{Name: names.ImageLocality, Weight: pointer.Int32(1)},
+						{Name: names.InterPodAffinity, Weight: pointer.Int32(1)},
+						{Name: names.NodeResourcesFit, Weight: pointer.Int32(1)},
+						{Name: names.NodeAffinity, Weight: pointer.Int32(1)},
+						{Name: names.PodTopologySpread, Weight: pointer.Int32(2)},
+						{Name: names.TaintToleration, Weight: pointer.Int32(1)},
+						{Name: names.VolumeBinding, Weight: pointer.Int32(1)},
 					},
 				},
 				Reserve: v1beta2.PluginSet{

--- a/pkg/scheduler/apis/config/v1beta3/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1beta3/default_plugins.go
@@ -18,8 +18,10 @@ package v1beta3
 
 import (
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	"k8s.io/kube-scheduler/config/v1beta3"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/utils/pointer"
 )
@@ -52,8 +54,15 @@ func getDefaultPlugins() *v1beta3.Plugins {
 			},
 		},
 	}
+	applyFeatureGates(plugins)
 
 	return plugins
+}
+
+func applyFeatureGates(config *v1beta3.Plugins) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.VolumeCapacityPriority) {
+		config.Score.Disabled = append(config.Score.Enabled, v1beta3.Plugin{Name: names.VolumeBinding})
+	}
 }
 
 // mergePlugins merges the custom set into the given default one, handling disabled sets.

--- a/pkg/scheduler/apis/config/v1beta3/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1beta3/default_plugins_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kube-scheduler/config/v1beta3"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/utils/pointer"
 )
@@ -36,6 +37,43 @@ func TestApplyFeatureGates(t *testing.T) {
 	}{
 		{
 			name: "Feature gates disabled",
+			wantConfig: &v1beta3.Plugins{
+				MultiPoint: v1beta3.PluginSet{
+					Enabled: []v1beta3.Plugin{
+						{Name: names.PrioritySort},
+						{Name: names.NodeUnschedulable},
+						{Name: names.NodeName},
+						{Name: names.TaintToleration, Weight: pointer.Int32(3)},
+						{Name: names.NodeAffinity, Weight: pointer.Int32(2)},
+						{Name: names.NodePorts},
+						{Name: names.NodeResourcesFit, Weight: pointer.Int32(1)},
+						{Name: names.VolumeRestrictions},
+						{Name: names.EBSLimits},
+						{Name: names.GCEPDLimits},
+						{Name: names.NodeVolumeLimits},
+						{Name: names.AzureDiskLimits},
+						{Name: names.VolumeBinding},
+						{Name: names.VolumeZone},
+						{Name: names.PodTopologySpread, Weight: pointer.Int32(2)},
+						{Name: names.InterPodAffinity, Weight: pointer.Int32(2)},
+						{Name: names.DefaultPreemption},
+						{Name: names.NodeResourcesBalancedAllocation, Weight: pointer.Int32(1)},
+						{Name: names.ImageLocality, Weight: pointer.Int32(1)},
+						{Name: names.DefaultBinder},
+					},
+				},
+				Score: v1beta3.PluginSet{
+					Disabled: []v1beta3.Plugin{
+						{Name: names.VolumeBinding},
+					},
+				},
+			},
+		},
+		{
+			name: "Feature gates disabled",
+			features: map[featuregate.Feature]bool{
+				features.VolumeCapacityPriority: true,
+			},
 			wantConfig: &v1beta3.Plugins{
 				MultiPoint: v1beta3.PluginSet{
 					Enabled: []v1beta3.Plugin{

--- a/pkg/scheduler/apis/config/v1beta3/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1beta3/defaults_test.go
@@ -350,6 +350,11 @@ func TestSchedulerDefaults(t *testing.T) {
 									{Name: names.DefaultBinder},
 								},
 							},
+							Score: v1beta3.PluginSet{
+								Disabled: []v1beta3.Plugin{
+									{Name: names.VolumeBinding},
+								},
+							},
 							Bind: v1beta3.PluginSet{
 								Enabled: []v1beta3.Plugin{
 									{Name: "BarPlugin"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/sig scheduling

#### What this PR does / why we need it:

This PR adds `VolumeBinding` to `score.disabled` list if VolumeCapacityPriority is disabled.

#### Which issue(s) this PR fixes:

Fixes #113705

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
VolumeBinding Score plugin is enabled only if the feature gate VolumeCapacityPriority is enabled.
```
