### PR TITLE
apiserver: use the correct error when logging errors updating managedFields

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -202,8 +202,7 @@ func (f *FieldManager) UpdateNoErrors(liveObj, newObj runtime.Object, manager st
 	if err != nil {
 		atMostEverySecond.Do(func() {
 			ns, name := "unknown", "unknown"
-			accessor, err := meta.Accessor(newObj)
-			if err == nil {
+			if accessor, err := meta.Accessor(newObj); err == nil {
 				ns = accessor.GetNamespace()
 				name = accessor.GetName()
 			}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

I noticed that `[SHOULD NOT HAPPEN] failed to update managedFields` was being logged but there was no error logged with it. After looking at the code, it's because the err passed into `klog.ErrorS` is the nil error from `meta.Accessor(newObj)` when it should be the err from trying to update `managedFields`



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
apiserver: use the correct error when logging errors updating managedFields
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
