### PR TITLE
Standardize naming in generic storage watcher tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
@@ -37,9 +37,6 @@ import (
 	"k8s.io/apiserver/pkg/storage/value"
 )
 
-// basePath for storage keys used across tests
-const basePath = "/keybase"
-
 // CreateObjList will create a list from the array of objects.
 func CreateObjList(prefix string, helper storage.Interface, items []runtime.Object) error {
 	for i := range items {


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/109831

```release-note
NONE
```

/kind cleanup
/priority important-longterm
/sig api-machinery

/assign @stevekuznetsov 
/cc @tallclair 