### PR TITLE
Added scope to api server tracing

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers.go
@@ -121,3 +121,21 @@ func (lazy *lazyResource) String() string {
 
 	return "unknown"
 }
+
+// lazyScope implements String() string and it will
+// lazily get Scope from request info
+type lazyScope struct {
+	req *http.Request
+}
+
+func (lazy *lazyScope) String() string {
+	if lazy.req != nil {
+		ctx := lazy.req.Context()
+		requestInfo, ok := apirequest.RequestInfoFrom(ctx)
+		if ok {
+			return metrics.CleanScope(requestInfo)
+		}
+	}
+
+	return "unknown"
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers_test.go
@@ -96,3 +96,15 @@ func TestLazyResource(t *testing.T) {
 	resourceWithReq := &lazyResource{req: req.WithContext(ctx)}
 	assert.Equal(t, "resource", fmt.Sprintf("%v", resourceWithReq))
 }
+
+func TestLazyScope(t *testing.T) {
+	assert.Equal(t, "unknown", fmt.Sprintf("%v", &lazyScope{}))
+
+	scopeWithEmptyReq := &lazyScope{&http.Request{}}
+	assert.Equal(t, "unknown", fmt.Sprintf("%v", scopeWithEmptyReq))
+
+	req := &http.Request{}
+	ctx := request.WithRequestInfo(context.TODO(), &request.RequestInfo{Namespace: "ns"})
+	scopeWithReq := &lazyScope{req: req.WithContext(ctx)}
+	assert.Equal(t, "namespace", fmt.Sprintf("%v", scopeWithReq))
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/trace_util.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/trace_util.go
@@ -29,6 +29,7 @@ func traceFields(req *http.Request) []attribute.KeyValue {
 		attribute.Stringer("client", &lazyClientIP{req: req}),
 		attribute.String("protocol", req.Proto),
 		attribute.Stringer("resource", &lazyResource{req: req}),
+		attribute.Stringer("scope", &lazyScope{req: req}),
 		attribute.String("url", req.URL.Path),
 		attribute.Stringer("user-agent", &lazyTruncatedUserAgent{req: req}),
 		attribute.Stringer("verb", &lazyVerb{req: req}),


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds scope as trace attribute which makes it easier to filter traced requests.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/113628

#### Does this PR introduce a user-facing change?
```release-note
NONE
```