### PR TITLE
Fix data race in fakePodFailAdmission

### DIFF
--- a/test/integration/daemonset/util.go
+++ b/test/integration/daemonset/util.go
@@ -19,6 +19,7 @@ package daemonset
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"k8s.io/apiserver/pkg/admission"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -27,6 +28,7 @@ import (
 var _ admission.ValidationInterface = &fakePodFailAdmission{}
 
 type fakePodFailAdmission struct {
+	lock             sync.Mutex
 	limitedPodNumber int
 	succeedPodsCount int
 }
@@ -36,6 +38,8 @@ func (f *fakePodFailAdmission) Handles(operation admission.Operation) bool {
 }
 
 func (f *fakePodFailAdmission) Validate(ctx context.Context, attr admission.Attributes, o admission.ObjectInterfaces) (err error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
 	if attr.GetKind().GroupKind() != api.Kind("Pod") {
 		return nil
 	}

--- a/test/integration/statefulset/util.go
+++ b/test/integration/statefulset/util.go
@@ -19,6 +19,7 @@ package statefulset
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -344,6 +345,7 @@ func scaleSTS(t *testing.T, c clientset.Interface, sts *appsv1.StatefulSet, repl
 var _ admission.ValidationInterface = &fakePodFailAdmission{}
 
 type fakePodFailAdmission struct {
+	lock             sync.Mutex
 	limitedPodNumber int
 	succeedPodsCount int
 }
@@ -353,6 +355,8 @@ func (f *fakePodFailAdmission) Handles(operation admission.Operation) bool {
 }
 
 func (f *fakePodFailAdmission) Validate(ctx context.Context, attr admission.Attributes, o admission.ObjectInterfaces) (err error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
 	if attr.GetKind().GroupKind() != api.Kind("Pod") {
 		return nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #113036

This fixes a data race in fakePodFailAdmission.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
