### PR TITLE
Fix params to be null instead of an empty map if paramRef is null

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/validator.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/validator.go
@@ -146,7 +146,7 @@ func convertObjectToUnstructured(obj interface{}) (*unstructured.Unstructured, e
 }
 
 func objectToResolveVal(r runtime.Object) (interface{}, error) {
-	if r == nil {
+	if r == nil || reflect.ValueOf(r).IsNil() {
 		return nil, nil
 	}
 	v, err := convertObjectToUnstructured(r)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a bug in validation admission policies (alpha in 1.26) where if a ValidatingAdmissionPolicy has a paramKind but the ValidatingAdmissionPolicyBinding has no paramRef, then in CEL expressions, `param` is an empty map, but should be `null`.  This results in `param == null` evaluating to false.

#### Which issue(s) this PR fixes:

Found by @andrewsykim while expanding integration test coverage for validating admission policies.

#### Special notes for your reviewer:

Validated locally that the included unit test fails without the code fix.

#### Does this PR introduce a user-facing change?

```release-note
NOTE
```

/cc @cici37 @andrewsykim 
/sig api-machinery