### PR TITLE
fix credential provider metric names

### DIFF
--- a/pkg/credentialprovider/plugin/metrics.go
+++ b/pkg/credentialprovider/plugin/metrics.go
@@ -24,9 +24,7 @@ import (
 )
 
 const (
-	kubeletCredentialProviderPluginErrorsKey   = "kubelet_credential_provider_plugin_errors"
-	kubeletCredentialProviderPluginDurationKey = "kubelet_credential_provider_plugin_duration"
-	KubeletSubsystem                           = "kubelet"
+	KubeletSubsystem = "kubelet"
 )
 
 var (
@@ -35,7 +33,7 @@ var (
 	kubeletCredentialProviderPluginErrors = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      KubeletSubsystem,
-			Name:           kubeletCredentialProviderPluginErrorsKey,
+			Name:           "credential_provider_plugin_errors",
 			Help:           "Number of errors from credential provider plugin",
 			StabilityLevel: metrics.ALPHA,
 		},
@@ -45,7 +43,7 @@ var (
 	kubeletCredentialProviderPluginDuration = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem:      KubeletSubsystem,
-			Name:           kubeletCredentialProviderPluginDurationKey,
+			Name:           "credential_provider_plugin_duration",
 			Help:           "Duration of execution in seconds for credential provider plugin",
 			Buckets:        metrics.DefBuckets,
 			StabilityLevel: metrics.ALPHA,
@@ -59,6 +57,5 @@ func registerMetrics() {
 	registerOnce.Do(func() {
 		legacyregistry.MustRegister(kubeletCredentialProviderPluginErrors)
 		legacyregistry.MustRegister(kubeletCredentialProviderPluginDuration)
-
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

We currently have two metrics which stutter, specifically `kubelet_kubelet_credential_provider_plugin_duration` and
`kubelet_kubelet_credential_provider_plugin_errors`. This PR fixes those metrics.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`kubelet_kubelet_credential_provider_plugin_duration` is renamed `kubelet_credential_provider_plugin_duration` and `kubelet_kubelet_credential_provider_plugin_errors` is renamed `kubelet_credential_provider_plugin_errors`.
```
