### PR TITLE
check plugin nil for makeDeviceMountPath

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -656,6 +656,10 @@ func getAttachmentName(volName, csiDriverName, nodeName string) string {
 }
 
 func makeDeviceMountPath(plugin *csiPlugin, spec *volume.Spec) (string, error) {
+	if plugin == nil {
+		return "", errors.New("makeDeviceMountPath failed, plugin is nil")
+	}
+
 	if spec == nil {
 		return "", errors.New("makeDeviceMountPath failed, spec is nil")
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
If plugin is nil, program will panic:
```
	return filepath.Join(plugin.host.GetPluginDir(plugin.GetPluginName()), driver, volSha, globalMountInGlobalPath), nil
```

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
