### PR TITLE
fix(framework): fix the bug on PreFilter skip

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -203,9 +203,9 @@ func (s *Status) AppendReason(reason string) {
 	s.reasons = append(s.reasons, reason)
 }
 
-// IsSuccess returns true if and only if "Status" is nil or Code is "Success".
+// IsSuccess returns true if and only if "Status" is nil or Code is "Success" or "Skip".
 func (s *Status) IsSuccess() bool {
-	return s.Code() == Success
+	return s.Code() == Success || s.Code() == Skip
 }
 
 // IsWait returns true if and only if "Status" is non-nil and its Code is "Wait".

--- a/pkg/scheduler/framework/interface_test.go
+++ b/pkg/scheduler/framework/interface_test.go
@@ -73,7 +73,7 @@ func TestStatus(t *testing.T) {
 			status:            NewStatus(Skip, ""),
 			expectedCode:      Skip,
 			expectedMessage:   "",
-			expectedIsSuccess: false,
+			expectedIsSuccess: true,
 			expectedIsWait:    false,
 			expectedIsSkip:    true,
 			expectedAsError:   nil,

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -613,7 +613,7 @@ func (f *frameworkImpl) RunPreFilterPlugins(ctx context.Context, state *framewor
 	skipPlugins := sets.NewString()
 	for _, pl := range f.preFilterPlugins {
 		r, s := f.runPreFilterPlugin(ctx, pl, state, pod)
-		if !s.IsSuccess() && !s.IsSkip() {
+		if !s.IsSuccess() {
 			s.SetFailedPlugin(pl.Name())
 			if s.IsUnschedulable() {
 				return nil, s

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -109,7 +109,7 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 		defer metrics.Goroutines.WithLabelValues(metrics.Binding).Dec()
 
 		status := sched.bindingCycle(bindingCycleCtx, state, fwk, scheduleResult, assumedPodInfo, start, podsToActivate)
-		if !status.IsSuccess() {
+		if !status.IsSuccess() || status.IsSkip() {
 			sched.handleBindingCycleError(bindingCycleCtx, state, fwk, assumedPodInfo, start, scheduleResult, status)
 		}
 	}()
@@ -244,7 +244,7 @@ func (sched *Scheduler) bindingCycle(
 	}
 
 	// Run "bind" plugins.
-	if status := sched.bind(ctx, fwk, assumedPod, scheduleResult.SuggestedHost, state); !status.IsSuccess() {
+	if status := sched.bind(ctx, fwk, assumedPod, scheduleResult.SuggestedHost, state); !status.IsSuccess() || status.IsSkip() {
 		return status
 	}
 

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1979,6 +1979,42 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "test prefilter plugin returning skip",
+			registerPlugins: []st.RegisterPluginFunc{
+				st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				st.RegisterPreFilterPlugin(
+					"FakePreFilter1",
+					st.NewFakePreFilterPlugin("FakeFilter1", nil, nil),
+				),
+				st.RegisterFilterPlugin(
+					"FakeFilter1",
+					st.NewFakeFilterPlugin(map[string]framework.Code{
+						"node1": framework.Unschedulable,
+					}),
+				),
+				st.RegisterPluginAsExtensions("FakeFilter2", func(configuration runtime.Object, f framework.Handle) (framework.Plugin, error) {
+					return st.FakePreFilterAndFilterPlugin{
+						FakePreFilterPlugin: &st.FakePreFilterPlugin{
+							Result: nil,
+							Status: framework.NewStatus(framework.Skip),
+						},
+						FakeFilterPlugin: &st.FakeFilterPlugin{
+							// This Filter plugin shouldn't be executed in the Filter extension point due to skip.
+							// To confirm that, return the status code Error to all Nodes.
+							FailedNodeReturnCodeMap: map[string]framework.Code{
+								"node1": framework.Error, "node2": framework.Error, "node3": framework.Error,
+							},
+						},
+					}, nil
+				}, "PreFilter", "Filter"),
+				st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			},
+			nodes:              []string{"node1", "node2", "node3"},
+			pod:                st.MakePod().Name("test-prefilter").UID("test-prefilter").Obj(),
+			wantNodes:          sets.NewString("node2", "node3"),
+			wantEvaluatedNodes: pointer.Int32(3),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/scheduler/testing/fake_plugins.go
+++ b/pkg/scheduler/testing/fake_plugins.go
@@ -22,7 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
@@ -65,6 +65,16 @@ func (pl *TrueFilterPlugin) Filter(_ context.Context, _ *framework.CycleState, p
 // NewTrueFilterPlugin initializes a TrueFilterPlugin and returns it.
 func NewTrueFilterPlugin(_ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
 	return &TrueFilterPlugin{}, nil
+}
+
+type FakePreFilterAndFilterPlugin struct {
+	*FakePreFilterPlugin
+	*FakeFilterPlugin
+}
+
+// Name returns name of the plugin.
+func (pl FakePreFilterAndFilterPlugin) Name() string {
+	return "FakePreFilterAndFilterPlugin"
 }
 
 // FakeFilterPlugin is a test filter plugin to record how many times its Filter() function have

--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -395,6 +395,9 @@ func (bp *BindPlugin) Bind(ctx context.Context, state *framework.CycleState, p *
 	if bp.pluginInvokeEventChan != nil {
 		bp.pluginInvokeEventChan <- pluginInvokeEvent{pluginName: bp.Name(), val: bp.numBindCalled}
 	}
+	if bp.bindStatus.IsSkip() {
+		return bp.bindStatus
+	}
 	if bp.bindStatus.IsSuccess() {
 		if err := bp.client.CoreV1().Pods(p.Namespace).Bind(context.TODO(), &v1.Binding{
 			ObjectMeta: metav1.ObjectMeta{Namespace: p.Namespace, Name: p.Name, UID: p.UID, Annotations: map[string]string{bindPluginAnnotation: bp.Name()}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/priority critical-urgent
/kind bug
/sig scheduling

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/112637 got merged yesterday and it supports Skip status in the Filter plugin.
But, in the current implementation, when any PreFilter returns skip status, it results in unschedulable Pod.
We don't experience this issue because we don't return Skip in any in-tree plugins. But, it'll be an issue when users see the release note, realize the Skip in PreFIlter, and then try it on their custom plugins.

---

The skip status should be treated as success in all other places than calculating `SkipFilterPlugins` in the cycle state.
And, I added the test code on `schedulePod` func, which I should've implemented in #112637 along with other unit tests, and realized the bug 🙇 🙇

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Should I revert https://github.com/kubernetes/kubernetes/pull/112637 instead of aiming to merge it in v1.26?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
