### PR TITLE
kube-apiserver: avoid duplicate validations for the same authorization mode

### DIFF
--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -68,23 +68,21 @@ func (o *BuiltInAuthorizationOptions) Validate() []error {
 	}
 
 	modes := sets.NewString(o.Modes...)
-	for _, mode := range o.Modes {
+	for mode := range modes {
 		if !authzmodes.IsValidAuthorizationMode(mode) {
 			allErrors = append(allErrors, fmt.Errorf("authorization-mode %q is not a valid mode", mode))
 		}
-		if mode == authzmodes.ModeABAC && o.PolicyFile == "" {
-			allErrors = append(allErrors, fmt.Errorf("authorization-mode ABAC's authorization policy file not passed"))
-		}
-		if mode == authzmodes.ModeWebhook && o.WebhookConfigFile == "" {
-			allErrors = append(allErrors, fmt.Errorf("authorization-mode Webhook's authorization config file not passed"))
-		}
 	}
 
-	if o.PolicyFile != "" && !modes.Has(authzmodes.ModeABAC) {
+	if modes.Has(authzmodes.ModeABAC) && o.PolicyFile == "" {
+		allErrors = append(allErrors, fmt.Errorf("authorization-mode ABAC's authorization policy file not passed"))
+	} else if o.PolicyFile != "" && !modes.Has(authzmodes.ModeABAC) {
 		allErrors = append(allErrors, fmt.Errorf("cannot specify --authorization-policy-file without mode ABAC"))
 	}
 
-	if o.WebhookConfigFile != "" && !modes.Has(authzmodes.ModeWebhook) {
+	if modes.Has(authzmodes.ModeWebhook) && o.WebhookConfigFile == "" {
+		allErrors = append(allErrors, fmt.Errorf("authorization-mode Webhook's authorization config file not passed"))
+	} else if o.WebhookConfigFile != "" && !modes.Has(authzmodes.ModeWebhook) {
 		allErrors = append(allErrors, fmt.Errorf("cannot specify --authorization-webhook-config-file without mode Webhook"))
 	}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
1. `o.Modes` may contain some same elements, we should iterate over the `modes` set to avoid duplicate validations.
2.  some check logic can be moved out of the `for` loop,  and the same type of validations are put together more closely, enhancing readability.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
