### PR TITLE
fix aggregated discovery legacy fallback

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -232,7 +232,7 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 
 		dm.setCacheEntryForService(info.service, cached)
 		return &cached, nil
-	case http.StatusNotFound:
+	case http.StatusNotAcceptable:
 		// Discovery Document is not being served at all.
 		// Fall back to legacy discovery information
 		if len(gv.Version) == 0 {

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
@@ -206,6 +206,8 @@ func TestRemoveAPIService(t *testing.T) {
 func TestLegacyFallback(t *testing.T) {
 	aggregatedResourceManager := discoveryendpoint.NewResourceManager()
 
+	rootAPIsHandler := discovery.NewRootAPIsHandler(discovery.DefaultAddresses{DefaultAddress: "192.168.1.1"}, scheme.Codecs)
+
 	legacyGroupHandler := discovery.NewAPIGroupHandler(scheme.Codecs, metav1.APIGroup{
 		Name: "stable.example.com",
 		PreferredVersion: metav1.GroupVersionForDiscovery{
@@ -262,9 +264,11 @@ func TestLegacyFallback(t *testing.T) {
 		} else if r.URL.Path == "/apis/stable.example.com/v1" {
 			// defer to legacy discovery
 			legacyResourceHandler.ServeHTTP(w, r)
+		} else if r.URL.Path == "/apis" {
+			rootAPIsHandler.ServeHTTP(w, r)
 		} else {
 			// Unknown url
-			w.WriteHeader(http.StatusNotFound)
+			t.Fatalf("unexpected request sent to %v", r.URL.Path)
 		}
 	}))
 	testCtx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes bug and test for new gated aggregated discovery feature which is disabled by default

When feature is enabled, aggregated api servers which only implement legacy discovery won't be included in the response document. This is because the code expects the wrong response status: NotFound was correct in the initial design. This  was unfortunately not updated to become `NotAvailable` after the recent redesign during api review to use content-type negotiation on /apis.

Also updates the unit test which should have caught this issue - the mock test did not have correct handling for the /apis case. There already exists an e2e test for this case (which is how it was originally caught).

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig api-machinery
/cc @apelisse @Jefftree 
