### PR TITLE
qos: Return an error when the host has no memory

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -76,8 +76,11 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerConfig(container *v1.C
 	}
 	lc.Resources = m.calculateLinuxResources(cpuRequest, container.Resources.Limits.Cpu(), container.Resources.Limits.Memory())
 
-	lc.Resources.OomScoreAdj = int64(qos.GetContainerOOMScoreAdjust(pod, container,
-		int64(m.machineInfo.MemoryCapacity)))
+	oomScoreAdj, err := qos.GetContainerOOMScoreAdjust(pod, container, int64(m.machineInfo.MemoryCapacity))
+	if err != nil {
+		return nil, err
+	}
+	lc.Resources.OomScoreAdj = int64(oomScoreAdj)
 
 	lc.Resources.HugepageLimits = GetHugepageLimitsFromResources(container.Resources)
 

--- a/pkg/kubelet/qos/policy.go
+++ b/pkg/kubelet/qos/policy.go
@@ -17,6 +17,8 @@ limitations under the License.
 package qos
 
 import (
+	"errors"
+
 	v1 "k8s.io/api/core/v1"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"k8s.io/kubernetes/pkg/kubelet/types"
@@ -37,18 +39,22 @@ const (
 // multiplied by 10 (barring exceptional cases) + a configurable quantity which is between -1000
 // and 1000. Containers with higher OOM scores are killed if the system runs out of memory.
 // See https://lwn.net/Articles/391222/ for more information.
-func GetContainerOOMScoreAdjust(pod *v1.Pod, container *v1.Container, memoryCapacity int64) int {
+func GetContainerOOMScoreAdjust(pod *v1.Pod, container *v1.Container, memoryCapacity int64) (int, error) {
+	if memoryCapacity <= 0 {
+		return 0, errors.New("expected a non-zero memory capacity for the host")
+	}
+
 	if types.IsNodeCriticalPod(pod) {
 		// Only node critical pod should be the last to get killed.
-		return guaranteedOOMScoreAdj
+		return guaranteedOOMScoreAdj, nil
 	}
 
 	switch v1qos.GetPodQOS(pod) {
 	case v1.PodQOSGuaranteed:
 		// Guaranteed containers should be the last to get killed.
-		return guaranteedOOMScoreAdj
+		return guaranteedOOMScoreAdj, nil
 	case v1.PodQOSBestEffort:
-		return besteffortOOMScoreAdj
+		return besteffortOOMScoreAdj, nil
 	}
 
 	// Burstable containers are a middle tier, between Guaranteed and Best-Effort. Ideally,
@@ -64,11 +70,11 @@ func GetContainerOOMScoreAdjust(pod *v1.Pod, container *v1.Container, memoryCapa
 	// A guaranteed pod using 100% of memory can have an OOM score of 10. Ensure
 	// that burstable pods have a higher OOM score adjustment.
 	if int(oomScoreAdjust) < (1000 + guaranteedOOMScoreAdj) {
-		return (1000 + guaranteedOOMScoreAdj)
+		return (1000 + guaranteedOOMScoreAdj), nil
 	}
 	// Give burstable pods a higher chance of survival over besteffort pods.
 	if int(oomScoreAdjust) == besteffortOOMScoreAdj {
-		return int(oomScoreAdjust - 1)
+		return int(oomScoreAdjust - 1), nil
 	}
-	return int(oomScoreAdjust)
+	return int(oomScoreAdjust), nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node
/priority backlog

#### What this PR does / why we need it:

Although it's unlikely that a host will ever return 0 for available memory, we don't validate it ahead of this point in Kubernetes itself.

We should return an error rather than unhelpfully dividing by zero, if only partially for correctness, and partially to give a more helpful error if this _did_ ever happen.

#### Which issue(s) this PR fixes:

Fixes #113243

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A