### PR TITLE
Adds field to force non-aggregated discovery

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -277,6 +277,12 @@ func (d *CachedDiscoveryClient) Invalidate() {
 	}
 }
 
+// WithLegacy returns current cached discovery client;
+// current client does not support legacy-only discovery.
+func (d *CachedDiscoveryClient) WithLegacy() discovery.DiscoveryInterface {
+	return d
+}
+
 // NewCachedDiscoveryClientForConfig creates a new DiscoveryClient for the given config, and wraps
 // the created client in a CachedDiscoveryClient. The provided configuration is updated with a
 // custom transport that understands cache responses.

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -786,6 +786,10 @@ func (d *fakeDiscoveryClient) OpenAPIV3() openapi.Client {
 	panic("unimplemented")
 }
 
+func (d *fakeDiscoveryClient) WithLegacy() discovery.DiscoveryInterface {
+	panic("unimplemented")
+}
+
 func groupNamesFromList(groups *metav1.APIGroupList) []string {
 	result := []string{}
 	for _, group := range groups.Groups {

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
@@ -279,6 +279,12 @@ func (d *memCacheClient) serverResourcesForGroupVersion(groupVersion string) (*m
 	return r, nil
 }
 
+// WithLegacy returns current memory-cached discovery client;
+// current client does not support legacy-only discovery.
+func (d *memCacheClient) WithLegacy() discovery.DiscoveryInterface {
+	return d
+}
+
 // NewMemCacheClient creates a new CachedDiscoveryInterface which caches
 // discovery information in memory and will stay up-to-date if Invalidate is
 // called with regularity.

--- a/staging/src/k8s.io/client-go/discovery/fake/discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/fake/discovery.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/openapi"
 	kubeversion "k8s.io/client-go/pkg/version"
 	restclient "k8s.io/client-go/rest"
@@ -163,4 +164,8 @@ func (c *FakeDiscovery) OpenAPIV3() openapi.Client {
 // by this client implementation.
 func (c *FakeDiscovery) RESTClient() restclient.Interface {
 	return nil
+}
+
+func (c *FakeDiscovery) WithLegacy() discovery.DiscoveryInterface {
+	panic("unimplemented")
 }

--- a/staging/src/k8s.io/client-go/restmapper/discovery_test.go
+++ b/staging/src/k8s.io/client-go/restmapper/discovery_test.go
@@ -422,6 +422,10 @@ func (c *fakeFailingDiscovery) OpenAPIV3() openapi.Client {
 	panic("implement me")
 }
 
+func (c *fakeFailingDiscovery) WithLegacy() DiscoveryInterface {
+	panic("implement me")
+}
+
 type fakeCachedDiscoveryInterface struct {
 	invalidateCalls int
 	fresh           bool
@@ -496,6 +500,10 @@ func (c *fakeCachedDiscoveryInterface) OpenAPISchema() (*openapi_v2.Document, er
 }
 
 func (c *fakeCachedDiscoveryInterface) OpenAPIV3() openapi.Client {
+	panic("implement me")
+}
+
+func (c *fakeCachedDiscoveryInterface) WithLegacy() DiscoveryInterface {
 	panic("implement me")
 }
 

--- a/staging/src/k8s.io/client-go/restmapper/shortcut_test.go
+++ b/staging/src/k8s.io/client-go/restmapper/shortcut_test.go
@@ -362,6 +362,10 @@ func (c *fakeDiscoveryClient) OpenAPIV3() openapi.Client {
 	panic("implement me")
 }
 
+func (c *fakeDiscoveryClient) WithLegacy() discovery.DiscoveryInterface {
+	panic("implement me")
+}
+
 type fakeCachedDiscoveryClient struct {
 	discovery.DiscoveryInterface
 	freshHandler      func() bool


### PR DESCRIPTION
* Adds new function `WithLegacy()` to `DiscoveryInterface`.
* `DiscoveryClient` implements `WithLegacy()` function returning a copy of the current client with new field forcing un-aggregated discovery. 
* Provides an opt-out escape hatch for clients that can not use the new aggregated discovery.
* Adds unit test. Unit test coverage goes from 85.2% before this PR to 85.4%.

Example
```
// Returns discovery client that only requests the legacy discovery format
client := clientset.Discovery().WithLegacy()
```
/kind bug

```release-note
NONE
```

- [Aggregated Discovery KEP](https://github.com/kubernetes/enhancements/issues/3352)
