### PR TITLE
add sig/storage label for pkg/controller/volume package PR

### DIFF
--- a/pkg/controller/volume/OWNERS
+++ b/pkg/controller/volume/OWNERS
@@ -4,3 +4,5 @@ approvers:
   - sig-storage-approvers
 reviewers:
   - sig-storage-reviewers
+labels:
+  - sig/storage


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

- `pkg/controller/` is managed by sig apps
- `pkg/controller/volume` is managed by sig storage

#### Does this PR introduce a user-facing change?
```release-note
None
```
