### PR TITLE
Fix autogeneration mark for instrumentation doc

### DIFF
--- a/test/instrumentation/documentation/documentation.md
+++ b/test/instrumentation/documentation/documentation.md
@@ -1,14 +1,14 @@
 ---
 title: Kubernetes Metrics Reference
 content_type: reference
-auto-generated: true
+auto_generated: true
 description: >-
   Details of the metric data that Kubernetes components export.
 ---
 
 ## Metrics (v1.26)
 
-<!-- (auto-generated 2022 Nov 10) -->
+<!-- (auto-generated 2022 Nov 11) -->
 <!-- (auto-generated v1.26) -->
 This page details the metrics that different Kubernetes components export. You can query the metrics endpoint for these 
 components using an HTTP scrape, and fetch the current metrics data in Prometheus format.

--- a/test/instrumentation/documentation/main.go
+++ b/test/instrumentation/documentation/main.go
@@ -44,7 +44,7 @@ const (
 	templ = `---
 title: Kubernetes Metrics Reference
 content_type: reference
-auto-generated: true
+auto_generated: true
 description: >-
   Details of the metric data that Kubernetes components export.
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind documentation

#### What this PR does / why we need it:

Update the generator code that produces https://kubernetes.io/docs/reference/instrumentation/metrics/ so that the page gets correctly marked as automatically generated.

#### Special notes for your reviewer:
Eventually this change will reach the live website. No hurry on that.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig instrumentation