### PR TITLE
Move events command to top level

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/alpha.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/alpha.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/cmd/auth"
-	"k8s.io/kubectl/pkg/cmd/events"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -37,7 +36,6 @@ func NewCmdAlpha(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 
 	// Alpha commands should be added here. As features graduate from alpha they should move
 	// from here to the CommandGroups defined by NewKubeletCommand() in cmd.go.
-	cmd.AddCommand(events.NewCmdEvents(f, streams))
 
 	authCmds := &cobra.Command{
 		Use:   "auth",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/diff"
 	"k8s.io/kubectl/pkg/cmd/drain"
 	"k8s.io/kubectl/pkg/cmd/edit"
+	"k8s.io/kubectl/pkg/cmd/events"
 	cmdexec "k8s.io/kubectl/pkg/cmd/exec"
 	"k8s.io/kubectl/pkg/cmd/explain"
 	"k8s.io/kubectl/pkg/cmd/expose"
@@ -399,6 +400,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 				cp.NewCmdCp(f, o.IOStreams),
 				auth.NewCmdAuth(f, o.IOStreams),
 				debug.NewCmdDebug(f, o.IOStreams),
+				events.NewCmdEvents(f, o.IOStreams),
 			},
 		},
 		{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/events/events.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/events/events.go
@@ -48,7 +48,7 @@ import (
 
 var (
 	eventsLong = templates.LongDesc(i18n.T(`
-		Experimental: Display events
+		Display events
 
 		Prints a table of the most important information about events.
 		You can request events for a namespace, for all namespace, or
@@ -56,19 +56,19 @@ var (
 
 	eventsExample = templates.Examples(i18n.T(`
 	# List recent events in the default namespace.
-	kubectl alpha events
+	kubectl events
 
 	# List recent events in all namespaces.
-	kubectl alpha events --all-namespaces
+	kubectl events --all-namespaces
 
 	# List recent events for the specified pod, then wait for more events and list them as they arrive.
-	kubectl alpha events --for pod/web-pod-13je7 --watch
+	kubectl events --for pod/web-pod-13je7 --watch
 
 	# List recent events in given format. Supported ones, apart from default, are json and yaml.
-	kubectl alpha events -oyaml
+	kubectl events -oyaml
 
 	# List recent only events in given event types
-	kubectl alpha events --types=Warning,Normal`))
+	kubectl events --types=Warning,Normal`))
 )
 
 // EventsFlags directly reflect the information that CLI is gathering via flags.  They will be converted to Options, which
@@ -122,7 +122,7 @@ func NewCmdEvents(restClientGetter genericclioptions.RESTClientGetter, streams g
 	cmd := &cobra.Command{
 		Use:                   fmt.Sprintf("events [(-o|--output=)%s] [--for TYPE/NAME] [--watch] [--event=Normal,Warning]", strings.Join(flags.PrintFlags.AllowedFormats(), "|")),
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Experimental: List events"),
+		Short:                 i18n.T("List events"),
 		Long:                  eventsLong,
 		Example:               eventsExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/test/cmd/events.sh
+++ b/test/cmd/events.sh
@@ -35,7 +35,7 @@ run_kubectl_events_tests() {
     kube::test::get_object_assert 'namespaces/test-events' "{{$id_field}}" 'test-events'
 
     # Pre-condition: event does not exist for Cronjob/pi in any namespace
-    output_message=$(kubectl alpha events -A "${kube_flags[@]:?}" 2>&1)
+    output_message=$(kubectl events -A "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_not_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
     # Pre-condition: cronjob does not exist in test-events namespace
@@ -46,40 +46,40 @@ run_kubectl_events_tests() {
     kube::test::get_object_assert 'cronjob/pi --namespace=test-events' "{{$id_field}}" 'pi'
 
     # Post-Condition: events --all-namespaces returns event for Cronjob/pi
-    output_message=$(kubectl alpha events -A "${kube_flags[@]:?}" 2>&1)
+    output_message=$(kubectl events -A "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
     # Post-Condition: events for test-events namespace returns event for Cronjob/pi
-    output_message=$(kubectl alpha events -n test-events "${kube_flags[@]:?}" 2>&1)
+    output_message=$(kubectl events -n test-events "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
     # Post-Condition: events returns event for Cronjob/pi when --for flag is used
-    output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi "${kube_flags[@]:?}" 2>&1)
+    output_message=$(kubectl events -n test-events --for=Cronjob/pi "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
     # Post-Condition: events returns event for Cronjob/pi when watch is enabled
-    output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi --watch --request-timeout=1 "${kube_flags[@]:?}" 2>&1)
+    output_message=$(kubectl events -n test-events --for=Cronjob/pi --watch --request-timeout=1 "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
     # Post-Condition: events returns event for Cronjob/pi when filtered by Warning
-    output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi --types=Warning "${kube_flags[@]:?}" 2>&1)
+    output_message=$(kubectl events -n test-events --for=Cronjob/pi --types=Warning "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
     # Post-Condition: events not returns event for Cronjob/pi when filtered only by Normal
-    output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi --types=Normal "${kube_flags[@]:?}" 2>&1)
+    output_message=$(kubectl events -n test-events --for=Cronjob/pi --types=Normal "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_not_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
     # Post-Condition: events returns event for Cronjob/pi without headers
-    output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi --no-headers "${kube_flags[@]:?}" 2>&1)
+    output_message=$(kubectl events -n test-events --for=Cronjob/pi --no-headers "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_not_string "${output_message}" "LAST SEEN" "TYPE" "REASON"
     kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
     # Post-Condition: events returns event for Cronjob/pi in json format
-    output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi --output=json "${kube_flags[@]:?}" 2>&1)
+    output_message=$(kubectl events -n test-events --for=Cronjob/pi --output=json "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
     # Post-Condition: events returns event for Cronjob/pi in yaml format
-    output_message=$(kubectl alpha events -n test-events --for=Cronjob/pi --output=yaml "${kube_flags[@]:?}" 2>&1)
+    output_message=$(kubectl events -n test-events --for=Cronjob/pi --output=yaml "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
     #Clean up

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1955,7 +1955,7 @@ metadata:
 			}
 
 			ginkgo.By("show started event for this pod")
-			events := e2ekubectl.RunKubectlOrDie(ns, "alpha", "events", "--for=pod/"+podName)
+			events := e2ekubectl.RunKubectlOrDie(ns, "events", "--for=pod/"+podName)
 
 			// replace multi spaces into single white space
 			eventsStr := strings.Join(strings.Fields(strings.TrimSpace(events)), " ")
@@ -1964,7 +1964,7 @@ metadata:
 			}
 
 			ginkgo.By("expect not showing any WARNING message except timeouts")
-			events = e2ekubectl.RunKubectlOrDie(ns, "alpha", "events", "--types=WARNING", "--for=pod/"+podName)
+			events = e2ekubectl.RunKubectlOrDie(ns, "events", "--types=WARNING", "--for=pod/"+podName)
 			if events != "" && !strings.Contains(events, "timed out") {
 				framework.Failf("unexpected WARNING event fired")
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig cli

#### What this PR does / why we need it:
This moves `kubectl alpha events` to `kubectl events` as part of beta promotion. 

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
Promote kubectl alpha events to kubectl events
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/1440
```
