### PR TITLE
Revert "egress_selector: prevent goroutines leak on connect() step."

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -217,9 +217,6 @@ func (u *udsGRPCConnector) connect(_ context.Context) (proxier, error) {
 	// See https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/357.
 	tunnelCtx := context.TODO()
 	tunnel, err := client.CreateSingleUseGrpcTunnel(tunnelCtx, udsName, dialOption,
-		grpc.WithBlock(),
-		grpc.WithReturnConnectionError(),
-		grpc.WithTimeout(30*time.Second), // matches http.DefaultTransport dial timeout
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This reverts commit 906b97931abf3c53238eb0294de9c5f27fc08bde.

Due to https://github.com/kubernetes/kubernetes/pull/113486#issuecomment-1310322562

/cc @jkh52 
/kind bug

Opening this to get presubmit CI green while we figure out how to resolve the issue
/hold

```release-note
NONE
```