### PR TITLE
remove unused afterEach hook on e2e services

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -762,22 +762,9 @@ var _ = common.SIGDescribe("Services", func() {
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	var cs clientset.Interface
-	serviceLBNames := []string{}
 
 	ginkgo.BeforeEach(func() {
 		cs = f.ClientSet
-	})
-
-	ginkgo.AfterEach(func() {
-		if ginkgo.CurrentSpecReport().Failed() {
-			DescribeSvc(f.Namespace.Name)
-		}
-		for _, lb := range serviceLBNames {
-			framework.Logf("cleaning load balancer resource for %s", lb)
-			e2eservice.CleanupServiceResources(cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
-		}
-		//reset serviceLBNames
-		serviceLBNames = []string{}
 	})
 
 	// TODO: We get coverage of TCP/UDP and multi-port services through the DNS test. We should have a simpler test for multi-port TCP here.


### PR DESCRIPTION

/kind cleanup
/kind failing-test
```release-note
NONE
```


Remove an unused hook that makes the framework to panic if the initialization of the framework didn't work correctly

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/113795/pull-kubernetes-e2e-kind-ipv6/1590812398711738368

```
Kubernetes e2e suite: [It] [sig-network] Services should be able to change the type from NodePort to ExternalName [Conformance] expand_less	30s
{Nov 10 21:29:44.825: timed out waiting for the condition failed test/e2e/framework/framework.go:241
k8s.io/kubernetes/test/e2e/framework.(*Framework).BeforeEach(0xc000cf05a0)
	test/e2e/framework/framework.go:241 +0x96f
There were additional failures detected after the initial failure:
[PANICKED]
Test Panicked
In [AfterEach] at: /usr/local/go/src/runtime/panic.go:260

runtime error: invalid memory address or nil pointer dereference

Full Stack Trace
  k8s.io/kubernetes/test/e2e/network.glob..func26.2()
  	test/e2e/network/service.go:773 +0x133
````

The same hook was also removed from the loadbalancer tests last week solving flake issues caused by it

https://github.com/kubernetes/kubernetes/pull/113562