### PR TITLE
Fix match onExitCodes when Pod is not terminated

### DIFF
--- a/pkg/controller/job/pod_failure_policy_test.go
+++ b/pkg/controller/job/pod_failure_policy_test.go
@@ -389,7 +389,10 @@ func TestMatchPodFailurePolicy(t *testing.T) {
 					Phase: v1.PodFailed,
 					ContainerStatuses: []v1.ContainerStatus{
 						{
-							Name: "main-container",
+							Name: "foo",
+						},
+						{
+							Name: "bar",
 							State: v1.ContainerState{
 								Terminated: &v1.ContainerStateTerminated{
 									ExitCode: 2,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix a panic in job controller when the Job has `podFailurePolicy` and a Pod is still terminating.

#### Which issue(s) this PR fixes:

Fixes #113852

#### Special notes for your reviewer:

Since there was no release yet, the release note focuses on the limitation described in #113855

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Known issue: Job field `.spec.podFailurePolicy.rules[*].onExitCode` might be ignored if the Pod is deleted before it terminates.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/e3f3faeb899e5739db4bbbd60a56715f6a4e8b45/keps/sig-apps/3329-retriable-and-non-retriable-failures
```
