### PR TITLE
Fix kubernetes/gce-ingress jobs

### DIFF
--- a/cluster/addons/rbac/cluster-loadbalancing/glbc/roles.yaml
+++ b/cluster/addons/rbac/cluster-loadbalancing/glbc/roles.yaml
@@ -67,3 +67,7 @@ rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get","create","update"]
+ # GLBC uses endpoint slices
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get","list", "watch"]

--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -15,7 +15,7 @@ spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: gcr.io/k8s-ingress-image-push/ingress-gce-glbc-amd64:v1.12.0
+  - image: gcr.io/k8s-ingress-image-push/ingress-gce-glbc-amd64:v1.20.1
     livenessProbe:
       httpGet:
         path: /healthz
@@ -56,6 +56,7 @@ spec:
     - --running-in-cluster=false
     - --config-file-path=/etc/gce.conf
     - --healthz-port=8086
+    - --enable-endpoint-slices
     - --gce-ratelimit=ga.Operations.Get,qps,10,100
     - --gce-ratelimit=alpha.Operations.Get,qps,10,100
     - --gce-ratelimit=beta.Operations.Get,qps,10,100


### PR DESCRIPTION
/kind cleanup
/kind failing-test

```release-note
NONE
```

We have jobs running with a very old version, nightly is updated with the latest changes and provider a better signal

Per example, this job is permanent failing with the controller restarting

https://testgrid.k8s.io/sig-network-gce#e2e-cos-ingress

And this job fails because it doesn't have permissions for endpointslices

https://testgrid.k8s.io/sig-network-ingress-gce-e2e#ingress-gce-e2e-scale

