### PR TITLE
Remove clear of all UDP contrack entries in sync

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1420,13 +1420,6 @@ func (proxier *Proxier) syncProxyRules() {
 				lps = append(lps, lp)
 			}
 
-			// For ports on node IPs, open the actual port and hold it.
-			for _, lp := range lps {
-				if svcInfo.Protocol() != v1.ProtocolSCTP && lp.Protocol == netutils.UDP {
-					conntrack.ClearEntriesForPort(proxier.exec, lp.Port, isIPv6, v1.ProtocolUDP)
-				}
-			}
-
 			// Nodeports need SNAT, unless they're local.
 			// ipset call
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area kube-proxy
/area ipvs

#### What this PR does / why we need it:

Removes a blind clear of all UDP conntrack entries on sync of kube-proxy=ipvs

#### Which issue(s) this PR fixes:

Fixes #113802

#### Special notes for your reviewer:

I have assumed that the clear was an ancient mistake and just deleted it. Some more investigation may be appropriate, so hold for now.

/hold

I have tested manually and it fixes the problem in the [test setup](https://github.com/issues/assigned#issuecomment-1311592222). Also tested, when the service is deleted the conntrack entries are cleared.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
