### PR TITLE
Always dial using a context

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial.go
@@ -24,10 +24,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"k8s.io/klog/v2"
-
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/third_party/forked/golang/netutil"
+	"k8s.io/klog/v2"
 )
 
 // dialURL will dial the specified URL using the underlying dialer held by the passed
@@ -107,21 +106,6 @@ func dialURL(ctx context.Context, url *url.URL, transport http.RoundTripper) (ne
 			if err != nil {
 				return nil, err
 			}
-		}
-
-		// Return if we were configured to skip validation
-		if tlsConfig != nil && tlsConfig.InsecureSkipVerify {
-			return tlsConn, nil
-		}
-
-		// Verify
-		host, _, _ := net.SplitHostPort(dialAddr)
-		if tlsConfig != nil && len(tlsConfig.ServerName) > 0 {
-			host = tlsConfig.ServerName
-		}
-		if err := tlsConn.VerifyHostname(host); err != nil {
-			tlsConn.Close()
-			return nil, err
 		}
 
 		return tlsConn, nil

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -157,7 +157,11 @@ func (g *grpcProxier) proxy(ctx context.Context, addr string) (net.Conn, error) 
 type proxyServerConnector interface {
 	// connect establishes connection to the proxy server, and returns a
 	// proxier based on the connection.
-	connect() (proxier, error)
+	//
+	// The provided Context must be non-nil. The context is used for connecting to the proxy only.
+	// If the context expires before the connection is complete, an error is returned.
+	// Once successfully connected to the proxy, any expiration of the context will not affect the connection.
+	connect(context.Context) (proxier, error)
 }
 
 type tcpHTTPConnectConnector struct {
@@ -165,8 +169,11 @@ type tcpHTTPConnectConnector struct {
 	tlsConfig    *tls.Config
 }
 
-func (t *tcpHTTPConnectConnector) connect() (proxier, error) {
-	conn, err := tls.Dial("tcp", t.proxyAddress, t.tlsConfig)
+func (t *tcpHTTPConnectConnector) connect(ctx context.Context) (proxier, error) {
+	d := tls.Dialer{
+		Config: t.tlsConfig,
+	}
+	conn, err := d.DialContext(ctx, "tcp", t.proxyAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -177,8 +184,9 @@ type udsHTTPConnectConnector struct {
 	udsName string
 }
 
-func (u *udsHTTPConnectConnector) connect() (proxier, error) {
-	conn, err := net.Dial("unix", u.udsName)
+func (u *udsHTTPConnectConnector) connect(ctx context.Context) (proxier, error) {
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "unix", u.udsName)
 	if err != nil {
 		return nil, err
 	}
@@ -189,18 +197,24 @@ type udsGRPCConnector struct {
 	udsName string
 }
 
-func (u *udsGRPCConnector) connect() (proxier, error) {
+// connect establishes a connection to a proxy over gRPC.
+// TODO At the moment, it does not use the provided context.
+func (u *udsGRPCConnector) connect(_ context.Context) (proxier, error) {
 	udsName := u.udsName
-	dialOption := grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
-		c, err := net.Dial("unix", udsName)
+	dialOption := grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+		var d net.Dialer
+		c, err := d.DialContext(ctx, "unix", udsName)
 		if err != nil {
 			klog.Errorf("failed to create connection to uds name %s, error: %v", udsName, err)
 		}
 		return c, err
 	})
 
-	ctx := context.TODO()
-	tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, udsName, dialOption, grpc.WithInsecure())
+	// CreateSingleUseGrpcTunnel() unfortunately couples dial and connection contexts. Because of that,
+	// we cannot use ctx just for dialing and control the connection lifetime separately.
+	// See https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/357.
+	tunnelCtx := context.TODO()
+	tunnel, err := client.CreateSingleUseGrpcTunnel(tunnelCtx, udsName, dialOption, grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +240,7 @@ func (d *dialerCreator) createDialer() utilnet.DialFunc {
 		trace := utiltrace.New(fmt.Sprintf("Proxy via %s protocol over %s", d.options.protocol, d.options.transport), utiltrace.Field{Key: "address", Value: addr})
 		defer trace.LogIfLong(500 * time.Millisecond)
 		start := egressmetrics.Metrics.Clock().Now()
-		proxier, err := d.connector.connect()
+		proxier, err := d.connector.connect(ctx)
 		if err != nil {
 			egressmetrics.Metrics.ObserveDialFailure(d.options.protocol, d.options.transport, egressmetrics.StageConnect)
 			return nil, err

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
@@ -176,7 +176,7 @@ type fakeProxyServerConnector struct {
 	proxierErr   bool
 }
 
-func (f *fakeProxyServerConnector) connect() (proxier, error) {
+func (f *fakeProxyServerConnector) connect(context.Context) (proxier, error) {
 	if f.connectorErr {
 		return nil, fmt.Errorf("fake error")
 	}


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
/kind bug


#### What this PR does / why we need it:

This cherry-pick alone fixes context cancellation issues for egress requests (modes: TCP+HTTPConnect, UDS+HTTPConnect).

I'm also motivated because the fix at https://github.com/kubernetes/kubernetes/pull/113486 depends on this, which is only in release-1.25. I want to gain confidence that both can be backported.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Related to https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/357, but specifically mitigates the problem described at https://github.com/kubernetes/kubernetes/pull/113486 (leaked goroutines blocking on UDS dial).

#### Special notes for your reviewer:

This is a clean cherry pick of: https://github.com/kubernetes/kubernetes/pull/110029 and https://github.com/kubernetes/kubernetes/pull/110079

#### Does this PR introduce a user-facing change?

```release-note
kube-apiserver: resolves possible hung connections using konnectivity network proxy with TCP or UDS HTTP connect configurations
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
