### PR TITLE
Fix API field references for scheduling v1, v1alpha1 and v1beta1

### DIFF
--- a/api/openapi-spec/v3/apis__scheduling.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__scheduling.k8s.io__v1_openapi.json
@@ -30,12 +30,12 @@
             "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
           },
           "preemptionPolicy": {
-            "description": "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+            "description": "preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
             "type": "string"
           },
           "value": {
             "default": 0,
-            "description": "The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
+            "description": "value represents the integer value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
             "format": "int32",
             "type": "integer"
           }

--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -51,7 +51,7 @@ type PriorityClass struct {
 	// +optional
 	metav1.ObjectMeta
 
-	// The value of this priority class. This is the actual priority that pods
+	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
 	Value int32
 
@@ -63,12 +63,12 @@ type PriorityClass struct {
 	// +optional
 	GlobalDefault bool
 
-	// Description is an arbitrary string that usually provides guidelines on
+	// description is an arbitrary string that usually provides guidelines on
 	// when this priority class should be used.
 	// +optional
 	Description string
 
-	// PreemptionPolicy it the Policy for preempting pods with lower priority.
+	// preemptionPolicy it the Policy for preempting pods with lower priority.
 	// This field is beta-level.
 	// +optional
 	PreemptionPolicy *core.PreemptionPolicy
@@ -84,6 +84,6 @@ type PriorityClassList struct {
 	// +optional
 	metav1.ListMeta
 
-	// Items is the list of PriorityClasses.
+	// items is the list of PriorityClasses.
 	Items []PriorityClass
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -42259,7 +42259,7 @@ func schema_k8sio_api_scheduling_v1_PriorityClass(ref common.ReferenceCallback) 
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
+							Description: "value represents the integer value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -42281,7 +42281,7 @@ func schema_k8sio_api_scheduling_v1_PriorityClass(ref common.ReferenceCallback) 
 					},
 					"preemptionPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+							Description: "preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -42376,7 +42376,7 @@ func schema_k8sio_api_scheduling_v1alpha1_PriorityClass(ref common.ReferenceCall
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
+							Description: "value represents the integer value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -42398,7 +42398,7 @@ func schema_k8sio_api_scheduling_v1alpha1_PriorityClass(ref common.ReferenceCall
 					},
 					"preemptionPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+							Description: "preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -42493,7 +42493,7 @@ func schema_k8sio_api_scheduling_v1beta1_PriorityClass(ref common.ReferenceCallb
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
+							Description: "value represents the integer value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -42515,7 +42515,7 @@ func schema_k8sio_api_scheduling_v1beta1_PriorityClass(ref common.ReferenceCallb
 					},
 					"preemptionPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+							Description: "preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/api/scheduling/v1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1/generated.proto
@@ -37,7 +37,7 @@ message PriorityClass {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // The value of this priority class. This is the actual priority that pods
+  // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
   optional int32 value = 2;
 
@@ -54,7 +54,7 @@ message PriorityClass {
   // +optional
   optional string description = 4;
 
-  // PreemptionPolicy is the Policy for preempting pods with lower priority.
+  // preemptionPolicy is the Policy for preempting pods with lower priority.
   // One of Never, PreemptLowerPriority.
   // Defaults to PreemptLowerPriority if unset.
   // +optional

--- a/staging/src/k8s.io/api/scheduling/v1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1/types.go
@@ -34,7 +34,7 @@ type PriorityClass struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// The value of this priority class. This is the actual priority that pods
+	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
@@ -51,7 +51,7 @@ type PriorityClass struct {
 	// +optional
 	Description string `json:"description,omitempty" protobuf:"bytes,4,opt,name=description"`
 
-	// PreemptionPolicy is the Policy for preempting pods with lower priority.
+	// preemptionPolicy is the Policy for preempting pods with lower priority.
 	// One of Never, PreemptLowerPriority.
 	// Defaults to PreemptLowerPriority if unset.
 	// +optional

--- a/staging/src/k8s.io/api/scheduling/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/scheduling/v1/types_swagger_doc_generated.go
@@ -30,10 +30,10 @@ package v1
 var map_PriorityClass = map[string]string{
 	"":                 "PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.",
 	"metadata":         "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"value":            "The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
+	"value":            "value represents the integer value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
 	"globalDefault":    "globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.",
 	"description":      "description is an arbitrary string that usually provides guidelines on when this priority class should be used.",
-	"preemptionPolicy": "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+	"preemptionPolicy": "preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
 }
 
 func (PriorityClass) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
@@ -38,7 +38,7 @@ message PriorityClass {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // The value of this priority class. This is the actual priority that pods
+  // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
   optional int32 value = 2;
 
@@ -55,7 +55,7 @@ message PriorityClass {
   // +optional
   optional string description = 4;
 
-  // PreemptionPolicy is the Policy for preempting pods with lower priority.
+  // preemptionPolicy is the Policy for preempting pods with lower priority.
   // One of Never, PreemptLowerPriority.
   // Defaults to PreemptLowerPriority if unset.
   // +optional

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
@@ -35,7 +35,7 @@ type PriorityClass struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// The value of this priority class. This is the actual priority that pods
+	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
@@ -52,7 +52,7 @@ type PriorityClass struct {
 	// +optional
 	Description string `json:"description,omitempty" protobuf:"bytes,4,opt,name=description"`
 
-	// PreemptionPolicy is the Policy for preempting pods with lower priority.
+	// preemptionPolicy is the Policy for preempting pods with lower priority.
 	// One of Never, PreemptLowerPriority.
 	// Defaults to PreemptLowerPriority if unset.
 	// +optional

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types_swagger_doc_generated.go
@@ -30,10 +30,10 @@ package v1alpha1
 var map_PriorityClass = map[string]string{
 	"":                 "DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.",
 	"metadata":         "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"value":            "The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
+	"value":            "value represents the integer value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
 	"globalDefault":    "globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.",
 	"description":      "description is an arbitrary string that usually provides guidelines on when this priority class should be used.",
-	"preemptionPolicy": "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+	"preemptionPolicy": "preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
 }
 
 func (PriorityClass) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
@@ -38,7 +38,7 @@ message PriorityClass {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // The value of this priority class. This is the actual priority that pods
+  // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
   optional int32 value = 2;
 
@@ -55,7 +55,7 @@ message PriorityClass {
   // +optional
   optional string description = 4;
 
-  // PreemptionPolicy is the Policy for preempting pods with lower priority.
+  // preemptionPolicy is the Policy for preempting pods with lower priority.
   // One of Never, PreemptLowerPriority.
   // Defaults to PreemptLowerPriority if unset.
   // +optional

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types.go
@@ -39,7 +39,7 @@ type PriorityClass struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// The value of this priority class. This is the actual priority that pods
+	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
@@ -56,7 +56,7 @@ type PriorityClass struct {
 	// +optional
 	Description string `json:"description,omitempty" protobuf:"bytes,4,opt,name=description"`
 
-	// PreemptionPolicy is the Policy for preempting pods with lower priority.
+	// preemptionPolicy is the Policy for preempting pods with lower priority.
 	// One of Never, PreemptLowerPriority.
 	// Defaults to PreemptLowerPriority if unset.
 	// +optional

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types_swagger_doc_generated.go
@@ -30,10 +30,10 @@ package v1beta1
 var map_PriorityClass = map[string]string{
 	"":                 "DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.",
 	"metadata":         "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"value":            "The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
+	"value":            "value represents the integer value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
 	"globalDefault":    "globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.",
 	"description":      "description is an arbitrary string that usually provides guidelines on when this priority class should be used.",
-	"preemptionPolicy": "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+	"preemptionPolicy": "preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
 }
 
 func (PriorityClass) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Signed-off-by: Chirayu Kapoor <dev.csociety@gmail.com>

#### What type of PR is this?
/kind documentation

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/113438

#### Does this PR introduce a user-facing change?
This PR changes API field references on API docs. It uses exact field names instead of Golang type names.
