### PR TITLE
Fix API field references for coordination v1 and v1beta1

### DIFF
--- a/api/openapi-spec/v3/apis__coordination.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__coordination.k8s.io__v1_openapi.json
@@ -101,7 +101,7 @@
             "type": "string"
           },
           "leaseDurationSeconds": {
-            "description": "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed RenewTime.",
+            "description": "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed renewTime.",
             "format": "int32",
             "type": "integer"
           },

--- a/api/openapi-spec/v3/apis__coordination.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__coordination.k8s.io__v1_openapi.json
@@ -28,7 +28,7 @@
               }
             ],
             "default": {},
-            "description": "Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+            "description": "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
         "type": "object",
@@ -48,7 +48,7 @@
             "type": "string"
           },
           "items": {
-            "description": "Items is a list of schema objects.",
+            "description": "items is a list of schema objects.",
             "items": {
               "allOf": [
                 {

--- a/pkg/apis/coordination/types.go
+++ b/pkg/apis/coordination/types.go
@@ -40,7 +40,7 @@ type LeaseSpec struct {
 	HolderIdentity *string
 	// leaseDurationSeconds is a duration that candidates for a lease need
 	// to wait to force acquire it. This is measure against time of last
-	// observed RenewTime.
+	// observed renewTime.
 	// +optional
 	LeaseDurationSeconds *int32
 	// acquireTime is a time when the current lease was acquired.

--- a/pkg/apis/coordination/types.go
+++ b/pkg/apis/coordination/types.go
@@ -28,7 +28,7 @@ type Lease struct {
 	// +optional
 	metav1.ObjectMeta
 
-	// Specification of the Lease.
+	// spec contains the specification of the Lease.
 	// +optional
 	Spec LeaseSpec
 }
@@ -64,6 +64,6 @@ type LeaseList struct {
 	// +optional
 	metav1.ListMeta
 
-	// Items is a list of schema objects.
+	// items is a list of schema objects.
 	Items []Lease
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -15501,7 +15501,7 @@ func schema_k8sio_api_coordination_v1_LeaseSpec(ref common.ReferenceCallback) co
 					},
 					"leaseDurationSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed RenewTime.",
+							Description: "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed renewTime.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -15643,7 +15643,7 @@ func schema_k8sio_api_coordination_v1beta1_LeaseSpec(ref common.ReferenceCallbac
 					},
 					"leaseDurationSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed RenewTime.",
+							Description: "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed renewTime.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -15421,7 +15421,7 @@ func schema_k8sio_api_coordination_v1_Lease(ref common.ReferenceCallback) common
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Description: "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/coordination/v1.LeaseSpec"),
 						},
@@ -15464,7 +15464,7 @@ func schema_k8sio_api_coordination_v1_LeaseList(ref common.ReferenceCallback) co
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Items is a list of schema objects.",
+							Description: "items is a list of schema objects.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -15563,7 +15563,7 @@ func schema_k8sio_api_coordination_v1beta1_Lease(ref common.ReferenceCallback) c
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Description: "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/coordination/v1beta1.LeaseSpec"),
 						},
@@ -15606,7 +15606,7 @@ func schema_k8sio_api_coordination_v1beta1_LeaseList(ref common.ReferenceCallbac
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Items is a list of schema objects.",
+							Description: "items is a list of schema objects.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/staging/src/k8s.io/api/coordination/v1/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1/generated.proto
@@ -34,7 +34,7 @@ message Lease {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Specification of the Lease.
+  // spec contains the specification of the Lease.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
   // +optional
   optional LeaseSpec spec = 2;
@@ -47,7 +47,7 @@ message LeaseList {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
-  // Items is a list of schema objects.
+  // items is a list of schema objects.
   repeated Lease items = 2;
 }
 

--- a/staging/src/k8s.io/api/coordination/v1/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1/generated.proto
@@ -59,7 +59,7 @@ message LeaseSpec {
 
   // leaseDurationSeconds is a duration that candidates for a lease need
   // to wait to force acquire it. This is measure against time of last
-  // observed RenewTime.
+  // observed renewTime.
   // +optional
   optional int32 leaseDurationSeconds = 2;
 

--- a/staging/src/k8s.io/api/coordination/v1/types.go
+++ b/staging/src/k8s.io/api/coordination/v1/types.go
@@ -30,7 +30,7 @@ type Lease struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Specification of the Lease.
+	// spec contains the specification of the Lease.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	// +optional
 	Spec LeaseSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
@@ -69,6 +69,6 @@ type LeaseList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Items is a list of schema objects.
+	// items is a list of schema objects.
 	Items []Lease `json:"items" protobuf:"bytes,2,rep,name=items"`
 }

--- a/staging/src/k8s.io/api/coordination/v1/types.go
+++ b/staging/src/k8s.io/api/coordination/v1/types.go
@@ -43,7 +43,7 @@ type LeaseSpec struct {
 	HolderIdentity *string `json:"holderIdentity,omitempty" protobuf:"bytes,1,opt,name=holderIdentity"`
 	// leaseDurationSeconds is a duration that candidates for a lease need
 	// to wait to force acquire it. This is measure against time of last
-	// observed RenewTime.
+	// observed renewTime.
 	// +optional
 	LeaseDurationSeconds *int32 `json:"leaseDurationSeconds,omitempty" protobuf:"varint,2,opt,name=leaseDurationSeconds"`
 	// acquireTime is a time when the current lease was acquired.

--- a/staging/src/k8s.io/api/coordination/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/coordination/v1/types_swagger_doc_generated.go
@@ -50,7 +50,7 @@ func (LeaseList) SwaggerDoc() map[string]string {
 var map_LeaseSpec = map[string]string{
 	"":                     "LeaseSpec is a specification of a Lease.",
 	"holderIdentity":       "holderIdentity contains the identity of the holder of a current lease.",
-	"leaseDurationSeconds": "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed RenewTime.",
+	"leaseDurationSeconds": "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed renewTime.",
 	"acquireTime":          "acquireTime is a time when the current lease was acquired.",
 	"renewTime":            "renewTime is a time when the current holder of a lease has last updated the lease.",
 	"leaseTransitions":     "leaseTransitions is the number of transitions of a lease between holders.",

--- a/staging/src/k8s.io/api/coordination/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/coordination/v1/types_swagger_doc_generated.go
@@ -30,7 +30,7 @@ package v1
 var map_Lease = map[string]string{
 	"":         "Lease defines a lease concept.",
 	"metadata": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"spec":     "Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+	"spec":     "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
 }
 
 func (Lease) SwaggerDoc() map[string]string {
@@ -40,7 +40,7 @@ func (Lease) SwaggerDoc() map[string]string {
 var map_LeaseList = map[string]string{
 	"":         "LeaseList is a list of Lease objects.",
 	"metadata": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"items":    "Items is a list of schema objects.",
+	"items":    "items is a list of schema objects.",
 }
 
 func (LeaseList) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
@@ -34,7 +34,7 @@ message Lease {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Specification of the Lease.
+  // spec contains the specification of the Lease.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
   // +optional
   optional LeaseSpec spec = 2;
@@ -47,7 +47,7 @@ message LeaseList {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
-  // Items is a list of schema objects.
+  // items is a list of schema objects.
   repeated Lease items = 2;
 }
 

--- a/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
@@ -59,7 +59,7 @@ message LeaseSpec {
 
   // leaseDurationSeconds is a duration that candidates for a lease need
   // to wait to force acquire it. This is measure against time of last
-  // observed RenewTime.
+  // observed renewTime.
   // +optional
   optional int32 leaseDurationSeconds = 2;
 

--- a/staging/src/k8s.io/api/coordination/v1beta1/types.go
+++ b/staging/src/k8s.io/api/coordination/v1beta1/types.go
@@ -46,7 +46,7 @@ type LeaseSpec struct {
 	HolderIdentity *string `json:"holderIdentity,omitempty" protobuf:"bytes,1,opt,name=holderIdentity"`
 	// leaseDurationSeconds is a duration that candidates for a lease need
 	// to wait to force acquire it. This is measure against time of last
-	// observed RenewTime.
+	// observed renewTime.
 	// +optional
 	LeaseDurationSeconds *int32 `json:"leaseDurationSeconds,omitempty" protobuf:"varint,2,opt,name=leaseDurationSeconds"`
 	// acquireTime is a time when the current lease was acquired.

--- a/staging/src/k8s.io/api/coordination/v1beta1/types.go
+++ b/staging/src/k8s.io/api/coordination/v1beta1/types.go
@@ -33,7 +33,7 @@ type Lease struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Specification of the Lease.
+	// spec contains the specification of the Lease.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	// +optional
 	Spec LeaseSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
@@ -75,6 +75,6 @@ type LeaseList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Items is a list of schema objects.
+	// items is a list of schema objects.
 	Items []Lease `json:"items" protobuf:"bytes,2,rep,name=items"`
 }

--- a/staging/src/k8s.io/api/coordination/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/coordination/v1beta1/types_swagger_doc_generated.go
@@ -50,7 +50,7 @@ func (LeaseList) SwaggerDoc() map[string]string {
 var map_LeaseSpec = map[string]string{
 	"":                     "LeaseSpec is a specification of a Lease.",
 	"holderIdentity":       "holderIdentity contains the identity of the holder of a current lease.",
-	"leaseDurationSeconds": "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed RenewTime.",
+	"leaseDurationSeconds": "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed renewTime.",
 	"acquireTime":          "acquireTime is a time when the current lease was acquired.",
 	"renewTime":            "renewTime is a time when the current holder of a lease has last updated the lease.",
 	"leaseTransitions":     "leaseTransitions is the number of transitions of a lease between holders.",

--- a/staging/src/k8s.io/api/coordination/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/coordination/v1beta1/types_swagger_doc_generated.go
@@ -30,7 +30,7 @@ package v1beta1
 var map_Lease = map[string]string{
 	"":         "Lease defines a lease concept.",
 	"metadata": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"spec":     "Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+	"spec":     "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
 }
 
 func (Lease) SwaggerDoc() map[string]string {
@@ -40,7 +40,7 @@ func (Lease) SwaggerDoc() map[string]string {
 var map_LeaseList = map[string]string{
 	"":         "LeaseList is a list of Lease objects.",
 	"metadata": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"items":    "Items is a list of schema objects.",
+	"items":    "items is a list of schema objects.",
 }
 
 func (LeaseList) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Signed-off-by: Chirayu Kapoor <dev.csociety@gmail.com>

#### What type of PR is this?
/kind documentation

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/113438

#### Does this PR introduce a user-facing change?
This PR changes API field references on API docs. It uses exact field names instead of Golang type names.