### PR TITLE
The second time the pod is deleted the grace period does not take effect

### DIFF
--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -79,6 +79,12 @@ type FakeRuntime struct {
 	imagePullErrBucket chan error
 	SwapBehavior       map[string]kubetypes.SwapBehavior
 	T                  TB
+	// Blocking hooks let cancellation tests verify that kubelet forwards the
+	// pod worker context into runtime operations that are already in flight.
+	BlockSyncPod   bool
+	BlockKillPod   bool
+	SyncPodStarted chan struct{}
+	KillPodStarted chan struct{}
 }
 
 const FakeHost = "localhost:12345"
@@ -259,7 +265,27 @@ func (f *FakeRuntime) GetPod(_ context.Context, podUID types.UID) (*kubecontaine
 	return nil, kubecontainer.ErrPodNotFound
 }
 
-func (f *FakeRuntime) SyncPod(_ context.Context, pod *v1.Pod, _ *kubecontainer.PodStatus, _ []v1.Secret, backOff *flowcontrol.Backoff, _ bool) (result kubecontainer.PodSyncResult) {
+func (f *FakeRuntime) SyncPod(ctx context.Context, pod *v1.Pod, _ *kubecontainer.PodStatus, _ []v1.Secret, backOff *flowcontrol.Backoff, _ bool) (result kubecontainer.PodSyncResult) {
+	f.Lock()
+	blockSyncPod := f.BlockSyncPod
+	syncPodStarted := f.SyncPodStarted
+	syncResults := f.SyncResults
+	f.Unlock()
+	if blockSyncPod {
+		if syncPodStarted != nil {
+			select {
+			case syncPodStarted <- struct{}{}:
+			default:
+			}
+		}
+		<-ctx.Done()
+		if syncResults != nil {
+			result = *syncResults
+		}
+		result.Fail(ctx.Err())
+		return result
+	}
+
 	f.Lock()
 	defer f.Unlock()
 
@@ -278,7 +304,22 @@ func (f *FakeRuntime) SyncPod(_ context.Context, pod *v1.Pod, _ *kubecontainer.P
 	return
 }
 
-func (f *FakeRuntime) KillPod(_ context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) error {
+func (f *FakeRuntime) KillPod(ctx context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) error {
+	f.Lock()
+	blockKillPod := f.BlockKillPod
+	killPodStarted := f.KillPodStarted
+	f.Unlock()
+	if blockKillPod {
+		if killPodStarted != nil {
+			select {
+			case killPodStarted <- struct{}{}:
+			default:
+			}
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
 	f.Lock()
 	defer f.Unlock()
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2249,13 +2249,6 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	// Ensure the pod is being probed
 	kl.probeManager.AddPod(ctx, pod)
 
-	// TODO(#113606): use cancellation from the incoming context parameter, which comes from the pod worker.
-	// Currently, using cancellation from that context causes test failures. To remove this WithoutCancel,
-	// any wait.Interrupted errors need to be filtered from result and bypass the reasonCache - cancelling
-	// the context for SyncPod is a known and deliberate error, not a generic error.
-	// Use WithoutCancel instead of a new context.TODO() to propagate trace context
-	// Call the container runtime's SyncPod callback
-	sctx := context.WithoutCancel(ctx)
 	restartingAllContainers := false
 	if utilfeature.DefaultFeatureGate.Enabled(features.RestartAllContainersOnContainerExits) {
 		for _, cond := range apiPodStatus.Conditions {
@@ -2264,7 +2257,15 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 			}
 		}
 	}
-	result := kl.containerRuntime.SyncPod(sctx, pod, podStatus, pullSecrets, kl.crashLoopBackOff, restartingAllContainers)
+	// Call the container runtime's SyncPod callback
+	result := kl.containerRuntime.SyncPod(ctx, pod, podStatus, pullSecrets, kl.crashLoopBackOff, restartingAllContainers)
+	// Cancelling the context for SyncPod is a known and deliberate action, for
+	// example when the pod starts terminating or its grace period is shortened.
+	// Such an interruption is not a generic error, so it must neither be cached
+	// in the reasonCache nor reported as a container failure.
+	if syncErr := result.Error(); wait.Interrupted(syncErr) {
+		return false, nil, syncErr
+	}
 	kl.reasonCache.Update(pod.UID, result)
 
 	// If we just performed a RestartAllContainers reset, we want to immediately
@@ -2338,10 +2339,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 // configuration and the kubelet is restarted - SyncTerminatingRuntimePod handles those orphaned
 // pods.
 func (kl *Kubelet) SyncTerminatingPod(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus, gracePeriod *int64, podStatusFn func(*v1.PodStatus)) (err error) {
-	// TODO(#113606): connect this with the incoming context parameter, which comes from the pod worker.
-	// Currently, using that context causes test failures.
 	logger := klog.FromContext(ctx)
-	ctx = klog.NewContext(context.TODO(), logger)
 	logger.V(4).Info("SyncTerminatingPod enter", "pod", klog.KObj(pod), "podUID", pod.UID)
 
 	ctx, otelSpan := kl.tracer.Start(ctx, "syncTerminatingPod", trace.WithAttributes(
@@ -2375,6 +2373,11 @@ func (kl *Kubelet) SyncTerminatingPod(ctx context.Context, pod *v1.Pod, podStatu
 
 	p := kubecontainer.ConvertPodStatusToRunningPod(kl.getRuntime().Type(), podStatus)
 	if err := kl.killPod(ctx, pod, p, gracePeriod); err != nil {
+		// A shortened grace period deliberately cancels this sync so the pod
+		// worker can process the queued update with the new deadline.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, events.FailedToKillPod, "error killing pod: %v", err)
 		// there was an error killing the pod, so we return that error directly
 		return fmt.Errorf("error killing terminating pod: %w", err)
@@ -2475,10 +2478,7 @@ func preserveDataFromBeforeStopping(stoppedPodStatus, podStatus *kubecontainer.P
 // not update the status of the pod because with the source of configuration removed, we have no
 // place to send that status.
 func (kl *Kubelet) SyncTerminatingRuntimePod(ctx context.Context, runningPod *kubecontainer.Pod) error {
-	// TODO(#113606): connect this with the incoming context parameter, which comes from the pod worker.
-	// Currently, using that context causes test failures.
 	logger := klog.FromContext(ctx)
-	ctx = klog.NewContext(context.TODO(), logger)
 	pod := runningPod.ToAPIPod()
 	logger.V(4).Info("SyncTerminatingRuntimePod enter", "pod", klog.KObj(pod), "podUID", pod.UID)
 	defer logger.V(4).Info("SyncTerminatingRuntimePod exit", "pod", klog.KObj(pod), "podUID", pod.UID)
@@ -2488,6 +2488,11 @@ func (kl *Kubelet) SyncTerminatingRuntimePod(ctx context.Context, runningPod *ku
 	// TODO: this should probably be zero, to bypass any waiting (needs fixes in container runtime)
 	gracePeriod := int64(1)
 	if err := kl.killPod(ctx, pod, *runningPod, &gracePeriod); err != nil {
+		// Cancellation means a newer pod worker update superseded this attempt;
+		// do not report it as a runtime failure.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, events.FailedToKillPod, "error killing pod: %v", err)
 		// there was an error killing the pod, so we return that error directly
 		utilruntime.HandleError(err)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3116,6 +3116,276 @@ func TestSyncTerminatingPodKillPod(t *testing.T) {
 	checkPodStatus(t, kl, pod, v1.PodFailed)
 }
 
+type contextBlockingVolumeManager struct {
+	kubeletvolume.VolumeManager
+	attachMountStarted chan<- struct{}
+	unmountStarted     chan<- struct{}
+}
+
+func (m *contextBlockingVolumeManager) WaitForAttachAndMount(ctx context.Context, _ *v1.Pod) error {
+	select {
+	case m.attachMountStarted <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (m *contextBlockingVolumeManager) WaitForUnmount(ctx context.Context, _ *v1.Pod) error {
+	select {
+	case m.unmountStarted <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestSyncPodCancellationDuringVolumeMount(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "mounting-pod", Name: "mounting-pod", Namespace: "test"},
+		Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "container", Image: "image"}}},
+	}
+	kl.podManager.SetPods([]*v1.Pod{pod})
+	podStatus := &kubecontainer.PodStatus{ID: pod.UID, Name: pod.Name, Namespace: pod.Namespace}
+
+	started := make(chan struct{}, 1)
+	kl.volumeManager = &contextBlockingVolumeManager{
+		VolumeManager:      kl.volumeManager,
+		attachMountStarted: started,
+	}
+
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+	var (
+		isTerminal bool
+		err        error
+	)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		isTerminal, _, err = kl.SyncPod(ctx, kubetypes.SyncPodCreate, pod, nil, podStatus)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncPod did not reach the blocking volume mount")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncPod did not return after its context was cancelled")
+	}
+	require.True(t, wait.Interrupted(err), "expected an interruption error, got %v", err)
+	assert.False(t, isTerminal, "a cancelled sync must not mark the pod terminal")
+}
+
+func TestSyncPodCancellationDuringContainerSync(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "sync-pod", Name: "sync-pod", Namespace: "test"},
+		Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "container", Image: "image"}}},
+	}
+	kl.podManager.SetPods([]*v1.Pod{pod})
+	podStatus := &kubecontainer.PodStatus{ID: pod.UID, Name: pod.Name, Namespace: pod.Namespace}
+
+	started := make(chan struct{}, 1)
+	cancelledStart := kubecontainer.NewSyncResult(kubecontainer.StartContainer, "container")
+	cancelledStart.Fail(context.Canceled, "container start was cancelled")
+	cancelledResult := kubecontainer.PodSyncResult{}
+	cancelledResult.AddSyncResult(cancelledStart)
+	testKubelet.fakeRuntime.Lock()
+	testKubelet.fakeRuntime.BlockSyncPod = true
+	testKubelet.fakeRuntime.SyncPodStarted = started
+	testKubelet.fakeRuntime.SyncResults = &cancelledResult
+	testKubelet.fakeRuntime.Unlock()
+
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+	var (
+		isTerminal bool
+		err        error
+	)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		isTerminal, _, err = kl.SyncPod(ctx, kubetypes.SyncPodCreate, pod, nil, podStatus)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncPod did not reach the blocking runtime call")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncPod did not return after its context was cancelled")
+	}
+	require.True(t, wait.Interrupted(err), "expected an interruption error, got %v", err)
+	assert.False(t, isTerminal, "a cancelled sync must not mark the pod terminal")
+	_, found := kl.reasonCache.Get(pod.UID, "container")
+	assert.False(t, found, "a deliberate cancellation must not be cached as a container start failure")
+}
+
+func TestSyncTerminatingPodCancellation(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	recorder := record.NewFakeRecorder(10)
+	kl.recorder = recorder
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "terminating-pod", Name: "terminating-pod", Namespace: "test"},
+		Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "container", Image: "image"}}},
+	}
+	kl.podManager.SetPods([]*v1.Pod{pod})
+	podStatus := &kubecontainer.PodStatus{
+		ID:        pod.UID,
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+		ContainerStatuses: []*kubecontainer.Status{{
+			ID:    kubecontainer.ContainerID{Type: "test", ID: "container"},
+			Name:  "container",
+			State: kubecontainer.ContainerStateRunning,
+		}},
+	}
+
+	started := make(chan struct{}, 1)
+	testKubelet.fakeRuntime.Lock()
+	testKubelet.fakeRuntime.BlockKillPod = true
+	testKubelet.fakeRuntime.KillPodStarted = started
+	testKubelet.fakeRuntime.Unlock()
+
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+	var err error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		gracePeriod := int64(30)
+		err = kl.SyncTerminatingPod(ctx, pod, podStatus, &gracePeriod, nil)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncTerminatingPod did not reach the blocking runtime call")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncTerminatingPod did not return after its context was cancelled")
+	}
+	require.True(t, wait.Interrupted(err), "expected an interruption error, got %v", err)
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("deliberate cancellation was reported as a warning event: %s", event)
+	default:
+	}
+}
+
+func TestSyncTerminatingRuntimePodCancellation(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	recorder := record.NewFakeRecorder(10)
+	kl.recorder = recorder
+	runningPod := &kubecontainer.Pod{
+		ID:        "runtime-pod",
+		Name:      "runtime-pod",
+		Namespace: "test",
+		Containers: []*kubecontainer.Container{{
+			ID:   kubecontainer.ContainerID{Type: "test", ID: "container"},
+			Name: "container",
+		}},
+	}
+
+	started := make(chan struct{}, 1)
+	testKubelet.fakeRuntime.Lock()
+	testKubelet.fakeRuntime.BlockKillPod = true
+	testKubelet.fakeRuntime.KillPodStarted = started
+	testKubelet.fakeRuntime.Unlock()
+
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+	var err error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		err = kl.SyncTerminatingRuntimePod(ctx, runningPod)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncTerminatingRuntimePod did not reach the blocking runtime call")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncTerminatingRuntimePod did not return after its context was cancelled")
+	}
+	require.True(t, wait.Interrupted(err), "expected an interruption error, got %v", err)
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("deliberate cancellation was reported as a warning event: %s", event)
+	default:
+	}
+}
+
+func TestSyncTerminatedPodCancellation(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "terminated-pod", Name: "terminated-pod", Namespace: "test"},
+	}
+	kl.podManager.SetPods([]*v1.Pod{pod})
+	podStatus := &kubecontainer.PodStatus{ID: pod.UID, Name: pod.Name, Namespace: pod.Namespace}
+
+	started := make(chan struct{}, 1)
+	kl.volumeManager = &contextBlockingVolumeManager{
+		VolumeManager:  kl.volumeManager,
+		unmountStarted: started,
+	}
+
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+	var err error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		err = kl.SyncTerminatedPod(ctx, pod, podStatus)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncTerminatedPod did not reach the blocking volume unmount")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncTerminatedPod did not return after its context was cancelled")
+	}
+	require.True(t, wait.Interrupted(err), "expected an interruption error, got %v", err)
+}
+
 func TestPullErrorReportsMissingSecrets(t *testing.T) {
 	tCtx := ktesting.Init(t)
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -754,9 +754,10 @@ func (m *kubeGenericRuntimeManager) toKubeContainerStatus(ctx context.Context, p
 	}
 
 	if status.State != runtimeapi.ContainerState_CONTAINER_CREATED {
-		// If container is not in the created state, we have tried and
-		// started the container. Set the StartedAt time.
 		cStatus.StartedAt = time.Unix(0, status.StartedAt)
+		if cStatus.StartedAt.Equal(time.Unix(0, 0)) {
+			cStatus.StartedAt = time.Time{}
+		}
 	}
 	if status.State == runtimeapi.ContainerState_CONTAINER_EXITED {
 		cStatus.Reason = status.Reason
@@ -801,6 +802,11 @@ func (m *kubeGenericRuntimeManager) executePreStopHook(ctx context.Context, pod 
 	select {
 	case <-time.After(time.Duration(gracePeriod) * time.Second):
 		logger.V(2).Info("PreStop hook not completed in grace period", "pod", klog.KObj(pod), "podUID", pod.UID,
+			"containerName", containerSpec.Name, "containerID", containerID.String(), "gracePeriod", gracePeriod)
+	case <-ctx.Done():
+		// A shorter deletion grace period supersedes this hook invocation. The
+		// queued pod worker update will retry termination with the new deadline.
+		logger.V(2).Info("PreStop hook interrupted", "pod", klog.KObj(pod), "podUID", pod.UID,
 			"containerName", containerSpec.Name, "containerID", containerID.String(), "gracePeriod", gracePeriod)
 	case <-done:
 		logger.V(3).Info("PreStop hook completed", "pod", klog.KObj(pod), "podUID", pod.UID,

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -48,6 +49,19 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/logs"
 )
+
+type blockingLifecycleRunner struct {
+	started chan struct{}
+	release chan struct{}
+	done    chan struct{}
+}
+
+func (r *blockingLifecycleRunner) Run(_ context.Context, _ kubecontainer.ContainerID, _ *v1.Pod, _ *v1.Container, _ *v1.LifecycleHandler) (string, error) {
+	close(r.started)
+	defer close(r.done)
+	<-r.release
+	return "", nil
+}
 
 // TestRemoveContainer tests removing the container and its corresponding container logs.
 func TestRemoveContainer(t *testing.T) {
@@ -282,6 +296,29 @@ func TestToKubeContainerStatus(t *testing.T) {
 				ExitCode:   121,
 				Reason:     "GotKilled",
 				Message:    "The container was killed",
+			},
+		},
+		"container whose start was cancelled": {
+			input: &runtimeapi.ContainerStatus{
+				Id:         cid.ID,
+				Metadata:   meta,
+				Image:      imageSpec,
+				State:      runtimeapi.ContainerState_CONTAINER_EXITED,
+				CreatedAt:  createdAt,
+				FinishedAt: finishedAt,
+				ExitCode:   int32(128),
+				Reason:     "StartError",
+				Message:    "context canceled",
+			},
+			expected: &kubecontainer.Status{
+				ID:         *cid,
+				Image:      imageSpec.Image,
+				State:      kubecontainer.ContainerStateExited,
+				CreatedAt:  time.Unix(0, createdAt),
+				FinishedAt: time.Unix(0, finishedAt),
+				ExitCode:   128,
+				Reason:     "StartError",
+				Message:    "context canceled",
 			},
 		},
 		"unknown container": {
@@ -587,6 +624,59 @@ func TestToKubeContainerStatusWithUser(t *testing.T) {
 			actual := m.toKubeContainerStatus(tCtx, podUID, cStatus, cid.Type)
 			assert.EqualValues(t, test.expected, actual.User, desc)
 		})
+	}
+}
+
+func TestExecutePreStopHookCancellation(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	require.NoError(t, err)
+	runner := &blockingLifecycleRunner{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+	m.runner = runner
+	defer func() {
+		select {
+		case <-runner.done:
+		default:
+			close(runner.release)
+			<-runner.done
+		}
+	}()
+
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod", Name: "pod", Namespace: "test"}}
+	container := &v1.Container{
+		Name:      "container",
+		Lifecycle: &v1.Lifecycle{PreStop: &v1.LifecycleHandler{Exec: &v1.ExecAction{Command: []string{"block"}}}},
+	}
+	containerID := kubecontainer.ContainerID{Type: "test", ID: "container"}
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+	hookDone := make(chan struct{})
+	go func() {
+		defer close(hookDone)
+		m.executePreStopHook(ctx, pod, containerID, container, 60)
+	}()
+
+	select {
+	case <-runner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("PreStop hook did not start")
+	}
+	cancel()
+	select {
+	case <-hookDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("executePreStopHook did not return after its context was cancelled")
+	}
+
+	close(runner.release)
+	select {
+	case <-runner.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("blocking lifecycle runner did not exit after release")
 	}
 }
 

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -144,6 +144,9 @@ func (hr *handlerRunner) runHTTPHandler(ctx context.Context, pod *v1.Pod, contai
 	if err != nil {
 		return err
 	}
+	// A shortened pod deletion grace period must interrupt an in-flight HTTP
+	// lifecycle hook instead of leaving the pod worker on the original timeout.
+	req = req.Clone(ctx)
 	resp, err := hr.httpDoer.Do(req)
 	discardHTTPRespBody(resp)
 

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -126,6 +126,16 @@ func (f *fakeHTTP) Do(req *http.Request) (*http.Response, error) {
 	return f.resp, f.err
 }
 
+type contextBlockingHTTP struct {
+	started chan context.Context
+}
+
+func (f *contextBlockingHTTP) Do(req *http.Request) (*http.Response, error) {
+	f.started <- req.Context()
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
 func TestRunHandlerHttp(t *testing.T) {
 	_, tCtx := ktesting.NewTestContext(t)
 	fakeHTTPGetter := fakeHTTP{}
@@ -160,6 +170,44 @@ func TestRunHandlerHttp(t *testing.T) {
 	if fakeHTTPGetter.url != "http://foo:8080/bar" {
 		t.Errorf("unexpected url: %s", fakeHTTPGetter.url)
 	}
+}
+
+func TestRunHandlerHTTPCancellation(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+	httpDoer := &contextBlockingHTTP{started: make(chan context.Context, 1)}
+	handlerRunner := NewHandlerRunner(httpDoer, &fakeContainerCommandRunner{}, nil, nil)
+	containerID := kubecontainer.ContainerID{Type: "test", ID: "container"}
+	container := v1.Container{
+		Name: "container",
+		Lifecycle: &v1.Lifecycle{PreStop: &v1.LifecycleHandler{HTTPGet: &v1.HTTPGetAction{
+			Host: "127.0.0.1",
+			Port: intstr.FromInt32(8080),
+		}}},
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "test"}}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := handlerRunner.Run(ctx, containerID, pod, &container, container.Lifecycle.PreStop)
+		done <- err
+	}()
+
+	var requestCtx context.Context
+	select {
+	case requestCtx = <-httpDoer.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("HTTP lifecycle hook did not start")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("HTTP lifecycle hook did not return after its context was cancelled")
+	}
+	require.ErrorIs(t, requestCtx.Err(), context.Canceled)
 }
 
 func TestRunHandlerHttpWithHeaders(t *testing.T) {

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -1011,6 +1011,7 @@ func (v *podStartVerifier) Verify(event watch.Event) error {
 		}
 
 		defer func() { v.hasTerminated = true }()
+		contextCanceled := t.ExitCode == 128 && t.Reason == "StartError" && strings.Contains(t.Message, context.Canceled.Error())
 		switch {
 		case t.ExitCode == 1:
 			// expected
@@ -1024,6 +1025,12 @@ func (v *podStartVerifier) Verify(event watch.Event) error {
 		case t.ExitCode == 128 && (t.Reason == "StartError" || t.Reason == "ContainerCannotRun") && reBug88766.MatchString(t.Message):
 			// pod volume teardown races with container start in CRI, which reports a failure
 			framework.Logf("pod %s on node %s failed with the symptoms of https://github.com/kubernetes/kubernetes/issues/88766", pod.Name, pod.Spec.NodeName)
+		case contextCanceled:
+			// Deleting the pod can cancel an in-flight CRI start. Such a
+			// container must never have been reported as started.
+			if status.Started != nil && *status.Started {
+				return fmt.Errorf("pod %s on node %s container was reported as started despite context cancellation: %#v", pod.Name, pod.Spec.NodeName, status)
+			}
 		default:
 			data, _ := json.MarshalIndent(pod.Status, "", "  ")
 			framework.Logf("pod %s on node %s had incorrect final status:\n%s", pod.Name, pod.Spec.NodeName, string(data))
@@ -1033,8 +1040,8 @@ func (v *podStartVerifier) Verify(event watch.Event) error {
 		case v.duration > time.Hour:
 			// problem with status reporting
 			return fmt.Errorf("pod %s container %s on node %s had very long duration %s: start=%s end=%s", pod.Name, status.Name, pod.Spec.NodeName, v.duration, t.StartedAt, t.FinishedAt)
-		case hasNoStartTime:
-			// should never happen
+		case hasNoStartTime && !contextCanceled:
+			// should never happen unless CRI start was cancelled
 			return fmt.Errorf("pod %s container %s on node %s had finish time but not start time: end=%s", pod.Name, status.Name, pod.Spec.NodeName, t.FinishedAt)
 		}
 	}

--- a/test/e2e_node/shortened_grace_period_test.go
+++ b/test/e2e_node/shortened_grace_period_test.go
@@ -1,0 +1,274 @@
+//go:build linux
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = SIGDescribe("Shortened Grace Period", framework.WithNodeConformance(), func() {
+	f := framework.NewDefaultFramework("shortened-grace-period")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
+
+	ginkgo.Context("when a pod is deleted again with a shorter grace period", func() {
+		var podClient *e2epod.PodClient
+		ginkgo.BeforeEach(func() {
+			podClient = e2epod.NewPodClient(f)
+		})
+
+		// The container ignores SIGTERM, so the first deletion keeps the kubelet
+		// waiting for the whole grace period. A second deletion carrying a much
+		// shorter grace period has to preempt that in-flight stop, otherwise the
+		// pod would only disappear once the original grace period expired.
+		ginkgo.It("should stop the pod before the original grace period elapses", func(ctx context.Context) {
+			const (
+				gracePeriod      = 100
+				gracePeriodShort = 1
+				firstStopTimeout = 30 * time.Second
+				// shortenedDeleteTimeout is well below gracePeriod so the test fails if the first deletion is not preempted.
+				shortenedDeleteTimeout = 30 * time.Second
+			)
+			podName := "shortened-grace-period-test"
+			podClient.CreateSync(ctx, getGracePeriodTestPod(podName, gracePeriod))
+
+			ginkgo.By("deleting the pod with the original grace period")
+			err := podClient.Delete(ctx, podName, *metav1.NewDeleteOptions(gracePeriod))
+			framework.ExpectNoError(err, "failed to delete pod with the original grace period")
+
+			// Waiting for the first SIGTERM makes the test exercise cancellation of
+			// an in-flight runtime stop instead of racing both deletes ahead of it.
+			ginkgo.By("waiting for the first container stop to be in flight")
+			gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
+				logs, err := podClient.GetLogs(podName, &v1.PodLogOptions{Container: podName}).DoRaw(ctx)
+				return string(logs), err
+			}, firstStopTimeout, time.Second).Should(gomega.ContainSubstring("ignoring SIGTERM"))
+
+			ginkgo.By("deleting the pod again with a shorter grace period")
+			start := time.Now()
+			podClient.DeleteSync(ctx, podName, *metav1.NewDeleteOptions(gracePeriodShort), shortenedDeleteTimeout)
+			framework.Logf("pod disappeared %v after the shortened delete", time.Since(start))
+		})
+
+		ginkgo.It("should cancel and rerun a blocking exec PreStop hook", func(ctx context.Context) {
+			const (
+				gracePeriod      = 100
+				gracePeriodShort = 20
+				testTimeout      = 30 * time.Second
+			)
+			podName := "shortened-grace-period-exec-prestop"
+			podClient.CreateSync(ctx, getPreStopCountingPod(podName, gracePeriod))
+			ginkgo.DeferCleanup(podClient.RemoveFinalizer, podName, shortenedGracePeriodFinalizer)
+
+			ginkgo.By("deleting the pod with the original grace period")
+			err := podClient.Delete(ctx, podName, *metav1.NewDeleteOptions(gracePeriod))
+			framework.ExpectNoError(err, "failed to delete pod with the original grace period")
+
+			ginkgo.By("waiting for the first PreStop invocation to block")
+			waitForPodLog(ctx, podClient, podName, "PRESTOP 1", testTimeout)
+
+			ginkgo.By("deleting the pod again with a shorter grace period")
+			start := time.Now()
+			err = podClient.Delete(ctx, podName, *metav1.NewDeleteOptions(gracePeriodShort))
+			framework.ExpectNoError(err, "failed to delete pod with the shortened grace period")
+			err = e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, podName, f.Namespace.Name, testTimeout)
+			framework.ExpectNoError(err, "pod did not terminate successfully after its PreStop hook was cancelled")
+			framework.Logf("pod terminated %v after the shortened delete", time.Since(start))
+
+			pod, err := podClient.Get(ctx, podName, metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get the terminated pod")
+			gomega.Expect(pod.Status.ContainerStatuses).To(gomega.HaveLen(1))
+			terminated := pod.Status.ContainerStatuses[0].State.Terminated
+			gomega.Expect(terminated).NotTo(gomega.BeNil())
+			// Exit code zero proves the replacement hook recorded its result;
+			// a missing result exits with two and an extra invocation exits with one.
+			gomega.Expect(terminated.ExitCode).To(gomega.Equal(int32(0)))
+		})
+
+		ginkgo.It("should cancel a blocking HTTP PreStop hook", func(ctx context.Context) {
+			const (
+				gracePeriod          = 100
+				gracePeriodShort     = 1
+				firstPreStopTimeout  = 30 * time.Second
+				shortenedDeleteLimit = 30 * time.Second
+			)
+			podName := "shortened-grace-period-http-prestop"
+			podClient.CreateSync(ctx, getBlockingHTTPPreStopPod(podName, gracePeriod))
+
+			ginkgo.By("deleting the pod with the original grace period")
+			err := podClient.Delete(ctx, podName, *metav1.NewDeleteOptions(gracePeriod))
+			framework.ExpectNoError(err, "failed to delete pod with the original grace period")
+
+			ginkgo.By("waiting for the HTTP PreStop request to block")
+			waitForPodLog(ctx, podClient, podName, "GET /shell?cmd=sleep 100000", firstPreStopTimeout)
+
+			ginkgo.By("deleting the pod again with a shorter grace period")
+			start := time.Now()
+			podClient.DeleteSync(ctx, podName, *metav1.NewDeleteOptions(gracePeriodShort), shortenedDeleteLimit)
+			framework.Logf("pod disappeared %v after the shortened delete cancelled its HTTP PreStop hook", time.Since(start))
+		})
+	})
+})
+
+const shortenedGracePeriodFinalizer = "e2e.k8s.io/shortened-grace-period"
+
+func waitForPodLog(ctx context.Context, podClient *e2epod.PodClient, podName, expected string, timeout time.Duration) {
+	gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
+		logs, err := podClient.GetLogs(podName, &v1.PodLogOptions{Container: podName}).DoRaw(ctx)
+		return string(logs), err
+	}, timeout, time.Second).Should(gomega.ContainSubstring(expected))
+}
+
+// getGracePeriodTestPod returns a pod whose container traps and ignores
+// SIGTERM, so that it is only removed once its grace period has expired and
+// the container runtime sends SIGKILL.
+func getGracePeriodTestPod(name string, gracePeriod int64) *v1.Pod {
+	pod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyNever,
+			Containers: []v1.Container{
+				{
+					Name:    name,
+					Image:   busyboxImage,
+					Command: []string{"sh", "-c"},
+					Args: []string{`
+trap 'echo ignoring SIGTERM' TERM
+touch /tmp/sigterm-handler-ready
+while true; do sleep 1; done
+`},
+					ReadinessProbe: &v1.Probe{
+						PeriodSeconds: 1,
+						ProbeHandler: v1.ProbeHandler{
+							Exec: &v1.ExecAction{Command: []string{"sh", "-c", "test -f /tmp/sigterm-handler-ready"}},
+						},
+					},
+				},
+			},
+			TerminationGracePeriodSeconds: &gracePeriod,
+		},
+	}
+	return pod
+}
+
+func getPreStopCountingPod(name string, gracePeriod int64) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Finalizers: []string{shortenedGracePeriodFinalizer},
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyNever,
+			Volumes: []v1.Volume{{
+				Name:         "shared",
+				VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+			}},
+			Containers: []v1.Container{{
+				Name:    name,
+				Image:   busyboxImage,
+				Command: []string{"sh", "-c"},
+				Args: []string{`
+term_handler() {
+  result=$(cat /shared/result 2>/dev/null || echo 2)
+  echo "PRESTOP RESULT $result"
+  exit "$result"
+}
+trap term_handler TERM
+touch /tmp/sigterm-handler-ready
+last=
+while true; do
+  current=$(cat /shared/count 2>/dev/null || true)
+  if [ -n "$current" ] && [ "$current" != "$last" ]; then
+    echo "PRESTOP $current"
+    last=$current
+  fi
+  sleep 1 &
+  wait $!
+done
+`},
+				Lifecycle: &v1.Lifecycle{
+					PreStop: &v1.LifecycleHandler{
+						Exec: &v1.ExecAction{Command: []string{"sh", "-c", `
+count=$(cat /shared/count 2>/dev/null || echo 0)
+count=$((count+1))
+echo "$count" > /shared/count
+case "$count" in
+  1) sleep 100000 ;;
+  2) echo 0 > /shared/result ;;
+  *) echo 1 > /shared/result ;;
+esac
+`}},
+					},
+				},
+				ReadinessProbe: &v1.Probe{
+					PeriodSeconds: 1,
+					ProbeHandler: v1.ProbeHandler{
+						Exec: &v1.ExecAction{Command: []string{"sh", "-c", "test -f /tmp/sigterm-handler-ready"}},
+					},
+				},
+				VolumeMounts: []v1.VolumeMount{{Name: "shared", MountPath: "/shared"}},
+			}},
+			TerminationGracePeriodSeconds: &gracePeriod,
+		},
+	}
+}
+
+func getBlockingHTTPPreStopPod(name string, gracePeriod int64) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyNever,
+			Containers: []v1.Container{{
+				Name:    name,
+				Image:   agnhostImage,
+				Command: []string{"/agnhost", "netexec", "--http-port=8080", "--udp-port=-1"},
+				Lifecycle: &v1.Lifecycle{
+					PreStop: &v1.LifecycleHandler{
+						HTTPGet: &v1.HTTPGetAction{
+							Path: "/shell?cmd=sleep%20100000",
+							Port: intstr.FromInt32(8080),
+						},
+					},
+				},
+				ReadinessProbe: &v1.Probe{
+					PeriodSeconds: 1,
+					ProbeHandler: v1.ProbeHandler{
+						TCPSocket: &v1.TCPSocketAction{Port: intstr.FromInt32(8080)},
+					},
+				},
+			}},
+			TerminationGracePeriodSeconds: &gracePeriod,
+		},
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
It doesn't work when deleting the same pod for the second time. And force stop doesn't work either, it only lets apiserver delete pods, but kubelet doesn't delete containers.
The prerequisite is that the container does not stop down! (e.g. if the container is in sleep 9999 state).
When I first kubectl delete pod --grace-perios=30, then when kubectl delete pod --grace-perios=0 -force. the second deletion (including forced deletion) does not have any effect on the kubelet.
According to the latest documentation, gracePeriod, when set to grace period for the second deletion, triggers the kubelet to start cleaning up immediately. But looking at the source code, the first delete needs to wait for the CRI to return the result, because it needs to interact with the CRI, so it needs to wait for the first gracePeriod to process successfully before processing this grace period. This is inconsistent with the documentation logic and the code logic.

Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/113712
Fixes https://github.com/kubernetes/kubernetes/issues/113717
Fixes https://github.com/kubernetes/kubernetes/issues/83916
Fixes https://github.com/kubernetes/kubernetes/issues/87039


Special notes for your reviewer:
1.Cannot shorten the grace period for the second deletion
2.This is an issue that has arisen since the kubelet was reworked after version 1.22. 

1.Kubelet delete pod name —garce-period=100
2.Kubelet delete pod name —garce-period=10
The second time when the deletion time is reduced to 10s, it should

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ACTION REQUIRED: shorter grace period of a second command overrides the longer grace period of a first command

```

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
none