### PR TITLE
Add missing PodStartupLatencyTracker to kubemark

### DIFF
--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -36,6 +36,7 @@ import (
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	probetest "k8s.io/kubernetes/pkg/kubelet/prober/testing"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	kubeletutil "k8s.io/kubernetes/pkg/kubelet/util"
 	"k8s.io/kubernetes/pkg/util/oom"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/cephfs"
@@ -94,21 +95,22 @@ func NewHollowKubelet(
 	runtimeService internalapi.RuntimeService,
 	containerManager cm.ContainerManager) *HollowKubelet {
 	d := &kubelet.Dependencies{
-		KubeClient:           client,
-		HeartbeatClient:      heartbeatClient,
-		ProbeManager:         probetest.FakeManager{},
-		RemoteRuntimeService: runtimeService,
-		RemoteImageService:   imageService,
-		CAdvisorInterface:    cadvisorInterface,
-		Cloud:                nil,
-		OSInterface:          &containertest.FakeOS{},
-		ContainerManager:     containerManager,
-		VolumePlugins:        volumePlugins(),
-		TLSOptions:           nil,
-		OOMAdjuster:          oom.NewFakeOOMAdjuster(),
-		Mounter:              &mount.FakeMounter{},
-		Subpather:            &subpath.FakeSubpath{},
-		HostUtil:             hostutil.NewFakeHostUtil(nil),
+		KubeClient:               client,
+		HeartbeatClient:          heartbeatClient,
+		ProbeManager:             probetest.FakeManager{},
+		RemoteRuntimeService:     runtimeService,
+		RemoteImageService:       imageService,
+		CAdvisorInterface:        cadvisorInterface,
+		Cloud:                    nil,
+		OSInterface:              &containertest.FakeOS{},
+		ContainerManager:         containerManager,
+		VolumePlugins:            volumePlugins(),
+		TLSOptions:               nil,
+		OOMAdjuster:              oom.NewFakeOOMAdjuster(),
+		Mounter:                  &mount.FakeMounter{},
+		Subpather:                &subpath.FakeSubpath{},
+		HostUtil:                 hostutil.NewFakeHostUtil(nil),
+		PodStartupLatencyTracker: kubeletutil.NewPodStartupLatencyTracker(),
 	}
 
 	return &HollowKubelet{


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:

Given that kubemark isn't using the standard kubelet code path, it needs to set PodStartupLatencyTracker (added in https://github.com/kubernetes/kubernetes/pull/111930) separately.

Regular code path:
* https://github.com/kubernetes/kubernetes/blob/8e48df135318026d5f8a972a96a2ff665889568a/cmd/kubelet/app/server.go#L768-L786
* kubemark is using https://github.com/kubernetes/kubernetes/blob/8e48df135318026d5f8a972a96a2ff665889568a/pkg/kubemark/hollow_kubelet.go#L123-L129 which calls RunKubelet directly.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #113886

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
