### PR TITLE
WIP:Allow flags to be specified before kubectl plugins

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -76,6 +76,24 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 			expectPluginArgs: []string{"--bar"},
 		},
 		{
+			name:             "test that a longer plugin executable takes precedence over a shorter one when both exist",
+			args:             []string{"kubectl", "foo", "bar", "--baz"},
+			expectPlugin:     "plugin/testdata/kubectl-foo-bar",
+			expectPluginArgs: []string{"--baz"},
+		},
+		{
+			name:             "test that a plugin can have global flags before it",
+			args:             []string{"kubectl", "--namespace", "myns", "foo"},
+			expectPlugin:     "plugin/testdata/kubectl-foo",
+			expectPluginArgs: []string{"--namespace", "myns"},
+		},
+		{
+			name:             "test that a plugin can have various flags before and after it",
+			args:             []string{"kubectl", "--something", "--namespace", "myns", "--abc=123", "foo", "--bar"},
+			expectPlugin:     "plugin/testdata/kubectl-foo",
+			expectPluginArgs: []string{"--something", "--namespace", "myns", "--abc=123", "--bar"},
+		},
+		{
 			name: "test that a plugin does not execute over an existing command by the same name",
 			args: []string{"kubectl", "version"},
 		},
@@ -198,6 +216,7 @@ func (h *testPluginHandler) Execute(executablePath string, cmdArgs, env []string
 	h.executedPlugin = executablePath
 	h.withArgs = cmdArgs
 	h.withEnv = env
+	h.err = nil
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
@@ -184,6 +184,7 @@ func TestListPlugins(t *testing.T) {
 	pluginPath, _ := filepath.Abs("./testdata")
 	expectPlugins := []string{
 		filepath.Join(pluginPath, "kubectl-foo"),
+		filepath.Join(pluginPath, "kubectl-foo-bar"),
 		filepath.Join(pluginPath, "kubectl-version"),
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/testdata/kubectl-foo-bar
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/testdata/kubectl-foo-bar
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "I am plugin foo bar"


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Previously you could not specify flags before plugin names when executing a kubectl plugin. This PR fixes that bug.

Assuming a plugin named `kubectl-echo`:
```
#!/bin/bash
echo "I am a plugin named kubectl-echo and I was called with $@"
```

The old behavior:
```
$ kubectl --namespace myns echo
Error: flags cannot be placed before plugin name: --namespace
```

New behavior:
```
$ _output/bin/kubectl --namespace myns echo
I am a plugin named kubectl-echo and I was called with --namespace myns
```

Also notice you don't need to use `=`, so `--namespace myns` works as well as `--namespace=myns`.

It is not limited to global flags, so you can pass whatever flags you want and they will flow through to the plugin:
```
$ _output/bin/kubectl --bar --baz something --namespace myns echo --another
I am a plugin named kubectl-echo and I was called with --bar --baz something --namespace myns --another
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1324
Fixes https://github.com/kubernetes/kubectl/issues/884

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improved kubectl's ability to parse flags that occur before plugin and command names
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
