### PR TITLE
Add new OWNERS to client-go/discovery

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/OWNERS
+++ b/staging/src/k8s.io/client-go/discovery/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - apelisse
+  - seans3
+reviewers:
+  - alexzielenski
+  - apelisse
+  - seans3
+labels:
+  - sig/api-machinery


### PR DESCRIPTION
* Adds new OWNERS file to the `client-go/discovery` directory

/sig api-machinery
/priority backlog
/kind cleanup

```release-note
NONE
```