### PR TITLE
endpoints: remove obsolete ServiceSelectorCache

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -145,7 +145,6 @@ func NewController(podInformer coreinformers.PodInformer,
 	c.eventRecorder = recorder
 
 	c.endpointUpdatesBatchPeriod = endpointUpdatesBatchPeriod
-	c.serviceSelectorCache = endpointutil.NewServiceSelectorCache()
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareHints) {
 		nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -233,10 +232,6 @@ type Controller struct {
 	// endpointUpdatesBatchPeriod is an artificial delay added to all service syncs triggered by pod changes.
 	// This can be used to reduce overall number of all endpoint slice updates.
 	endpointUpdatesBatchPeriod time.Duration
-
-	// serviceSelectorCache is a cache of service selectors to avoid high CPU consumption caused by frequent calls
-	// to AsSelectorPreValidated (see #73527)
-	serviceSelectorCache *endpointutil.ServiceSelectorCache
 
 	// topologyCache tracks the distribution of Nodes and endpoints across zones
 	// to enable TopologyAwareHints.
@@ -395,7 +390,6 @@ func (c *Controller) onServiceUpdate(obj interface{}) {
 		return
 	}
 
-	_ = c.serviceSelectorCache.Update(key, obj.(*v1.Service).Spec.Selector)
 	c.queue.Add(key)
 }
 
@@ -407,7 +401,6 @@ func (c *Controller) onServiceDelete(obj interface{}) {
 		return
 	}
 
-	c.serviceSelectorCache.Delete(key)
 	c.queue.Add(key)
 }
 
@@ -486,7 +479,7 @@ func (c *Controller) queueServiceForEndpointSlice(endpointSlice *discovery.Endpo
 
 func (c *Controller) addPod(obj interface{}) {
 	pod := obj.(*v1.Pod)
-	services, err := c.serviceSelectorCache.GetPodServiceMemberships(c.serviceLister, pod)
+	services, err := endpointutil.GetPodServiceMemberships(c.serviceLister, pod)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Unable to get pod %s/%s's service memberships: %v", pod.Namespace, pod.Name, err))
 		return
@@ -497,7 +490,7 @@ func (c *Controller) addPod(obj interface{}) {
 }
 
 func (c *Controller) updatePod(old, cur interface{}) {
-	services := endpointutil.GetServicesToUpdateOnPodChange(c.serviceLister, c.serviceSelectorCache, old, cur)
+	services := endpointutil.GetServicesToUpdateOnPodChange(c.serviceLister, old, cur)
 	for key := range services {
 		c.queue.AddAfter(key, c.endpointUpdatesBatchPeriod)
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Since https://github.com/kubernetes/kubernetes/pull/112648, we can
efficiently handle selectors from pre-existing `map[string]string`,
making the cache obsolete.

Benchmark:

```
name                         old time/op    new time/op    delta
GetPodServiceMemberships-48     189µs ± 1%     193µs ± 1%  +2.10%  (p=0.000 n=10+10)

name                         old alloc/op   new alloc/op   delta
GetPodServiceMemberships-48    59.0kB ± 0%    58.9kB ± 0%  -0.09%  (p=0.000 n=9+9)

name                         old allocs/op  new allocs/op  delta
GetPodServiceMemberships-48     1.02k ± 0%     1.02k ± 0%    ~     (all equal)
```

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
