### PR TITLE
Switch deprecated API serving back to gating on beta

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds.go
@@ -55,8 +55,7 @@ type ResourceExpirationEvaluator interface {
 
 func NewResourceExpirationEvaluator(currentVersion apimachineryversion.Info) (ResourceExpirationEvaluator, error) {
 	ret := &resourceExpirationEvaluator{
-		// TODO https://github.com/kubernetes/kubernetes/issues/111972 set this back to false after beta is tagged.
-		strictRemovedHandlingInAlpha: true,
+		strictRemovedHandlingInAlpha: false,
 	}
 	if len(currentVersion.Major) > 0 {
 		currentMajor64, err := strconv.ParseInt(currentVersion.Major, 10, 32)


### PR DESCRIPTION
Fixes #111972 

Fixes https://testgrid.k8s.io/presubmits-kubernetes-blocking#pull-kubernetes-verify

```release-note
NONE
```

/kind failing-test
/milestone v1.26
/priority critical-urgent