### PR TITLE
fix: Close the tmp log file before renaming it

### DIFF
--- a/pkg/kubelet/logs/container_log_manager.go
+++ b/pkg/kubelet/logs/container_log_manager.go
@@ -393,6 +393,7 @@ func (c *containerLogManager) compressLog(log string) error {
 	if _, err := io.Copy(w, r); err != nil {
 		return fmt.Errorf("failed to compress %q to %q: %v", log, tmpLog, err)
 	}
+	f.Close()
 	compressedLog := log + compressSuffix
 	if err := c.osInterface.Rename(tmpLog, compressedLog); err != nil {
 		return fmt.Errorf("failed to rename %q to %q: %v", tmpLog, compressedLog, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #110630

#### Special notes for your reviewer:
Reproduced the issue #110630 
```

PS C:\var\log\pods\default_sample2-57d4df799d-9tqv4_3044bf9f-b8ab-4270-8165-aec34e574aee\sample2> ls


    Directory: C:\var\log\pods\default_sample2-57d4df799d-9tqv4_3044bf9f-b8ab-4270-8165-aec34e574aee\sample2


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----       11/17/2022   5:54 AM      963078271 0.log
-a----       11/17/2022   5:47 AM       37850018 0.log.20221117-054731

kubelet.err.log
E1117 05:53:29.956847    5804 container_log_manager.go:259] "Failed to rotate log for container" err="failed to compress log \"\\\\var\\\\log\\\\pods\\\\default_sample2-57d4df799d-9tqv4_3044bf9f-b8ab-4270-8165
-aec34e574aee\\\\sample2\\\\0.log.20221117-054731\": failed to rename \"\\\\var\\\\log\\\\pods\\\\default_sample2-57d4df799d-9tqv4_3044bf9f-b8ab-4270-8165-aec34e574aee\\\\sample2\\\\0.log.20221117-054731.tmp\"
 to \"\\\\var\\\\log\\\\pods\\\\default_sample2-57d4df799d-9tqv4_3044bf9f-b8ab-4270-8165-aec34e574aee\\\\sample2\\\\0.log.20221117-054731.gz\": rename \\var\\log\\pods\\default_sample2-57d4df799d-9tqv4_3044bf9
f-b8ab-4270-8165-aec34e574aee\\sample2\\0.log.20221117-054731.tmp \\var\\log\\pods\\default_sample2-57d4df799d-9tqv4_3044bf9f-b8ab-4270-8165-aec34e574aee\\sample2\\0.log.20221117-054731.gz: The process cannot
access the file because it is being used by another process." path="\\var\\log\\pods\\default_sample2-57d4df799d-9tqv4_3044bf9f-b8ab-4270-8165-aec34e574aee\\sample2\\0.log" containerID="074e4476f2f85fd1644f8b5
bca21aa1e386abe6779de83a3b8997ed6e37e0fe3"

PS C:\var\log\pods\default_sample2-57d4df799d-9tqv4_3044bf9f-b8ab-4270-8165-aec34e574aee\sample2> C:\Handle\handle.exe .\0.log.20221117-054731  /accepteula

Nthandle v5.0 - Handle viewer
Copyright (C) 1997-2022 Mark Russinovich
Sysinternals - www.sysinternals.com

No matching handles found.
PS C:\var\log\pods\default_sample2-57d4df799d-9tqv4_3044bf9f-b8ab-4270-8165-aec34e574aee\sample2> C:\Handle\handle.exe  /accepteula 0.log

Nthandle v5.0 - Handle viewer
Copyright (C) 1997-2022 Mark Russinovich
Sysinternals - www.sysinternals.com

containerd.exe     pid: 988    type: File           E64: C:\var\log\pods\default_sample2-57d4df799d-9tqv4_3044bf9f-b8ab-4270-8165-aec34e574aee\sample2\0.log
```

Tested this PR with k8s 1.23.3 and it rotated the logs
```
PS C:\Users\azureuser> ls C:\var\log\pods\default_sample2-57d4df799d-pdtpt_8637bc3c-a6cc-4488-afe5-6695bd75f3f7\sample2


    Directory: C:\var\log\pods\default_sample2-57d4df799d-pdtpt_8637bc3c-a6cc-4488-afe5-6695bd75f3f7\sample2


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----       11/17/2022   7:34 AM              0 0.log
-a----       11/17/2022   7:33 AM         112570 0.log.20221117-073322.gz
-a----       11/17/2022   7:34 AM         174490 0.log.20221117-073353.gz
-a----       11/17/2022   7:34 AM       74649455 0.log.20221117-073416
-a----       11/17/2022   7:34 AM         124810 0.log.20221117-073416.gz
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
