### PR TITLE
Propagate HasSynced properly

### DIFF
--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -125,13 +125,13 @@ type conversionEventHandler struct {
 	handler cache.ResourceEventHandler
 }
 
-func (h conversionEventHandler) OnAdd(obj interface{}) {
+func (h conversionEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 	rs, err := convertRCtoRS(obj.(*v1.ReplicationController), nil)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("dropping RC OnAdd event: can't convert object %#v to RS: %v", obj, err))
 		return
 	}
-	h.handler.OnAdd(rs)
+	h.handler.OnAdd(rs, isInInitialList)
 }
 
 func (h conversionEventHandler) OnUpdate(oldObj, newObj interface{}) {

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -68,18 +68,18 @@ func NewServiceAccountsController(saInformer coreinformers.ServiceAccountInforme
 		queue:                   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "serviceaccount"),
 	}
 
-	saInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+	saHandler, _ := saInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: e.serviceAccountDeleted,
 	}, options.ServiceAccountResync)
 	e.saLister = saInformer.Lister()
-	e.saListerSynced = saInformer.Informer().HasSynced
+	e.saListerSynced = saHandler.HasSynced
 
-	nsInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+	nsHandler, _ := nsInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    e.namespaceAdded,
 		UpdateFunc: e.namespaceUpdated,
 	}, options.NamespaceResync)
 	e.nsLister = nsInformer.Lister()
-	e.nsListerSynced = nsInformer.Informer().HasSynced
+	e.nsListerSynced = nsHandler.HasSynced
 
 	e.syncHandler = e.syncNamespace
 

--- a/plugin/pkg/auth/authorizer/node/graph_populator.go
+++ b/plugin/pkg/auth/authorizer/node/graph_populator.go
@@ -44,30 +44,26 @@ func AddGraphEventHandlers(
 		graph: graph,
 	}
 
-	var hasSynced []cache.InformerSynced
-
-	pods.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	podHandler, _ := pods.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    g.addPod,
 		UpdateFunc: g.updatePod,
 		DeleteFunc: g.deletePod,
 	})
-	hasSynced = append(hasSynced, pods.Informer().HasSynced)
 
-	pvs.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	pvsHandler, _ := pvs.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    g.addPV,
 		UpdateFunc: g.updatePV,
 		DeleteFunc: g.deletePV,
 	})
-	hasSynced = append(hasSynced, pvs.Informer().HasSynced)
 
-	attachments.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	attachHandler, _ := attachments.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    g.addVolumeAttachment,
 		UpdateFunc: g.updateVolumeAttachment,
 		DeleteFunc: g.deleteVolumeAttachment,
 	})
-	hasSynced = append(hasSynced, attachments.Informer().HasSynced)
 
-	go cache.WaitForNamedCacheSync("node_authorizer", wait.NeverStop, hasSynced...)
+	go cache.WaitForNamedCacheSync("node_authorizer", wait.NeverStop,
+		podHandler.HasSynced, pvsHandler.HasSynced, attachHandler.HasSynced)
 }
 
 func (g *graphPopulator) addPod(obj interface{}) {

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
@@ -36,11 +36,6 @@ type mutatingWebhookConfigurationManager struct {
 	configuration *atomic.Value
 	lister        admissionregistrationlisters.MutatingWebhookConfigurationLister
 	hasSynced     func() bool
-	// initialConfigurationSynced tracks if
-	// the existing webhook configs have been synced (honored) by the
-	// manager at startup-- the informer has synced and either has no items
-	// or has finished executing updateConfiguration() once.
-	initialConfigurationSynced *atomic.Bool
 }
 
 var _ generic.Source = &mutatingWebhookConfigurationManager{}
@@ -48,22 +43,24 @@ var _ generic.Source = &mutatingWebhookConfigurationManager{}
 func NewMutatingWebhookConfigurationManager(f informers.SharedInformerFactory) generic.Source {
 	informer := f.Admissionregistration().V1().MutatingWebhookConfigurations()
 	manager := &mutatingWebhookConfigurationManager{
-		configuration:              &atomic.Value{},
-		lister:                     informer.Lister(),
-		hasSynced:                  informer.Informer().HasSynced,
-		initialConfigurationSynced: &atomic.Bool{},
+		configuration: &atomic.Value{},
+		lister:        informer.Lister(),
 	}
 
 	// Start with an empty list
 	manager.configuration.Store([]webhook.WebhookAccessor{})
-	manager.initialConfigurationSynced.Store(false)
 
 	// On any change, rebuild the config
-	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	// TODO: the initial sync for this is N ^ 2, ideally we should make it N.
+	handler, _ := informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(_ interface{}) { manager.updateConfiguration() },
 		UpdateFunc: func(_, _ interface{}) { manager.updateConfiguration() },
 		DeleteFunc: func(_ interface{}) { manager.updateConfiguration() },
 	})
+
+	// Since our processing is synchronous, this is all we need to do to
+	// see if we have processed everything or not.
+	manager.hasSynced = handler.HasSynced
 
 	return manager
 }
@@ -73,28 +70,9 @@ func (m *mutatingWebhookConfigurationManager) Webhooks() []webhook.WebhookAccess
 	return m.configuration.Load().([]webhook.WebhookAccessor)
 }
 
-// HasSynced returns true when the manager is synced with existing webhookconfig
-// objects at startup-- which means the informer is synced and either has no items
-// or updateConfiguration() has completed.
-func (m *mutatingWebhookConfigurationManager) HasSynced() bool {
-	if !m.hasSynced() {
-		return false
-	}
-	if m.initialConfigurationSynced.Load() {
-		// the informer has synced and configuration has been updated
-		return true
-	}
-	if configurations, err := m.lister.List(labels.Everything()); err == nil && len(configurations) == 0 {
-		// the empty list we initially stored is valid to use.
-		// Setting initialConfigurationSynced to true, so subsequent checks
-		// would be able to take the fast path on the atomic boolean in a
-		// cluster without any admission webhooks configured.
-		m.initialConfigurationSynced.Store(true)
-		// the informer has synced and we don't have any items
-		return true
-	}
-	return false
-}
+// HasSynced returns true if the initial set of mutating webhook configurations
+// has been loaded.
+func (m *mutatingWebhookConfigurationManager) HasSynced() bool { return m.hasSynced() }
 
 func (m *mutatingWebhookConfigurationManager) updateConfiguration() {
 	configurations, err := m.lister.List(labels.Everything())
@@ -103,7 +81,6 @@ func (m *mutatingWebhookConfigurationManager) updateConfiguration() {
 		return
 	}
 	m.configuration.Store(mergeMutatingWebhookConfigurations(configurations))
-	m.initialConfigurationSynced.Store(true)
 }
 
 func mergeMutatingWebhookConfigurations(configurations []*v1.MutatingWebhookConfiguration) []webhook.WebhookAccessor {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller_reconcile.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller_reconcile.go
@@ -128,7 +128,7 @@ func (c *celAdmissionController) reconcilePolicyDefinition(namespace, name strin
 			c.dynamicClient,
 			paramsGVR.Resource,
 			corev1.NamespaceAll,
-			30*time.Second,
+			30*time.Second, // TODO: do we really need to ever resync these?
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 			nil,
 		)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/internal/generic/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/internal/generic/controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +31,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/cache/synctrack"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 )
@@ -45,6 +47,11 @@ type controller[T runtime.Object] struct {
 	reconciler func(namespace, name string, newObj T) error
 
 	options ControllerOptions
+
+	// must hold a func() bool or nil
+	notificationsDelivered atomic.Value
+
+	hasProcessed synctrack.AsyncTracker[string]
 }
 
 type ControllerOptions struct {
@@ -69,12 +76,20 @@ func NewController[T runtime.Object](
 		options.Name = fmt.Sprintf("%T-controller", *new(T))
 	}
 
-	return &controller[T]{
+	c := &controller[T]{
 		options:    options,
 		informer:   informer,
 		reconciler: reconciler,
 		queue:      nil,
 	}
+	c.hasProcessed.UpstreamHasSynced = func() bool {
+		f := c.notificationsDelivered.Load()
+		if f == nil {
+			return false
+		}
+		return f.(func() bool)()
+	}
+	return c
 }
 
 // Runs the controller and returns an error explaining why running was stopped.
@@ -92,20 +107,22 @@ func (c *controller[T]) Run(ctx context.Context) error {
 	// would never shut down the workqueue
 	defer c.queue.ShutDown()
 
-	enqueue := func(obj interface{}) {
+	enqueue := func(obj interface{}, isInInitialList bool) {
 		var key string
 		var err error
 		if key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj); err != nil {
 			utilruntime.HandleError(err)
 			return
 		}
+		if isInInitialList {
+			c.hasProcessed.Start(key)
+		}
+
 		c.queue.Add(key)
 	}
 
-	registration, err := c.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			enqueue(obj)
-		},
+	registration, err := c.informer.AddEventHandler(cache.ResourceEventHandlerDetailedFuncs{
+		AddFunc: enqueue,
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			oldMeta, err1 := meta.Accessor(oldObj)
 			newMeta, err2 := meta.Accessor(newObj)
@@ -126,13 +143,14 @@ func (c *controller[T]) Run(ctx context.Context) error {
 				return
 			}
 
-			enqueue(newObj)
+			enqueue(newObj, false)
 		},
 		DeleteFunc: func(obj interface{}) {
 			// Enqueue
-			enqueue(obj)
+			enqueue(obj, false)
 		},
 	})
+	c.notificationsDelivered.Store(registration.HasSynced)
 
 	// Error might be raised if informer was started and stopped already
 	if err != nil {
@@ -142,6 +160,7 @@ func (c *controller[T]) Run(ctx context.Context) error {
 	// Make sure event handler is removed from informer in case return early from
 	// an error
 	defer func() {
+		c.notificationsDelivered.Store(func() bool { return false })
 		// Remove event handler and Handle Error here. Error should only be raised
 		// for improper usage of event handler API.
 		if err := c.informer.RemoveEventHandler(registration); err != nil {
@@ -188,7 +207,7 @@ func (c *controller[T]) Run(ctx context.Context) error {
 }
 
 func (c *controller[T]) HasSynced() bool {
-	return c.informer.HasSynced()
+	return c.hasProcessed.HasSynced()
 }
 
 func (c *controller[T]) runWorker() {
@@ -220,6 +239,7 @@ func (c *controller[T]) runWorker() {
 				// but the key is invalid so there is no point in doing that)
 				return fmt.Errorf("expected string in workqueue but got %#v", obj)
 			}
+			defer c.hasProcessed.Finished(key)
 
 			if err := c.reconcile(key); err != nil {
 				// Put the item back on the workqueue to handle any transient errors.

--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -62,7 +62,7 @@ func Example() {
 
 		// Let's implement a simple controller that just deletes
 		// everything that comes in.
-		Process: func(obj interface{}) error {
+		Process: func(obj interface{}, isInInitialList bool) error {
 			// Obj is from the Pop method of the Queue we make above.
 			newest := obj.(Deltas).Newest()
 
@@ -137,8 +137,8 @@ func ExampleNewInformer() {
 		source,
 		&v1.Pod{},
 		time.Millisecond*100,
-		ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+		ResourceEventHandlerDetailedFuncs{
+			AddFunc: func(obj interface{}, isInInitialList bool) {
 				source.Delete(obj.(runtime.Object))
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -213,8 +213,8 @@ func TestHammerController(t *testing.T) {
 		source,
 		&v1.Pod{},
 		time.Millisecond*100,
-		ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { recordFunc("add", obj) },
+		ResourceEventHandlerDetailedFuncs{
+			AddFunc:    func(obj interface{}, isInInitialList bool) { recordFunc("add", obj) },
 			UpdateFunc: func(oldObj, newObj interface{}) { recordFunc("update", newObj) },
 			DeleteFunc: func(obj interface{}) { recordFunc("delete", obj) },
 		},
@@ -416,8 +416,8 @@ func TestPanicPropagated(t *testing.T) {
 		source,
 		&v1.Pod{},
 		time.Millisecond*100,
-		ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+		ResourceEventHandlerDetailedFuncs{
+			AddFunc: func(obj interface{}, isInInitialList bool) {
 				// Create a panic.
 				panic("Just panic.")
 			},
@@ -526,8 +526,8 @@ func TestTransformingInformer(t *testing.T) {
 		source,
 		&v1.Pod{},
 		0,
-		ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { recordEvent(watch.Added, nil, obj) },
+		ResourceEventHandlerDetailedFuncs{
+			AddFunc:    func(obj interface{}, isInInitialList bool) { recordEvent(watch.Added, nil, obj) },
 			UpdateFunc: func(oldObj, newObj interface{}) { recordEvent(watch.Modified, oldObj, newObj) },
 			DeleteFunc: func(obj interface{}) { recordEvent(watch.Deleted, obj, nil) },
 		},

--- a/staging/src/k8s.io/client-go/tools/cache/fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/fifo_test.go
@@ -76,7 +76,7 @@ func TestFIFO_requeueOnPop(t *testing.T) {
 	f := NewFIFO(testFifoObjectKeyFunc)
 
 	f.Add(mkFifoObj("foo", 10))
-	_, err := f.Pop(func(obj interface{}) error {
+	_, err := f.Pop(func(obj interface{}, isInInitialList bool) error {
 		if obj.(testFifoObject).name != "foo" {
 			t.Fatalf("unexpected object: %#v", obj)
 		}
@@ -89,7 +89,7 @@ func TestFIFO_requeueOnPop(t *testing.T) {
 		t.Fatalf("object should have been requeued: %t %v", ok, err)
 	}
 
-	_, err = f.Pop(func(obj interface{}) error {
+	_, err = f.Pop(func(obj interface{}, isInInitialList bool) error {
 		if obj.(testFifoObject).name != "foo" {
 			t.Fatalf("unexpected object: %#v", obj)
 		}
@@ -102,7 +102,7 @@ func TestFIFO_requeueOnPop(t *testing.T) {
 		t.Fatalf("object should have been requeued: %t %v", ok, err)
 	}
 
-	_, err = f.Pop(func(obj interface{}) error {
+	_, err = f.Pop(func(obj interface{}, isInInitialList bool) error {
 		if obj.(testFifoObject).name != "foo" {
 			t.Fatalf("unexpected object: %#v", obj)
 		}
@@ -289,7 +289,7 @@ func TestFIFO_PopShouldUnblockWhenClosed(t *testing.T) {
 	const jobs = 10
 	for i := 0; i < jobs; i++ {
 		go func() {
-			f.Pop(func(obj interface{}) error {
+			f.Pop(func(obj interface{}, isInInitialList bool) error {
 				return nil
 			})
 			c <- struct{}{}

--- a/staging/src/k8s.io/client-go/tools/cache/processor_listener_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/processor_listener_test.go
@@ -39,7 +39,7 @@ func BenchmarkListener(b *testing.B) {
 		AddFunc: func(obj interface{}) {
 			swg.Done()
 		},
-	}, 0, 0, time.Now(), 1024*1024)
+	}, 0, 0, time.Now(), 1024*1024, func() bool { return true })
 	var wg wait.Group
 	defer wg.Wait()       // Wait for .run and .pop to stop
 	defer close(pl.addCh) // Tell .run and .pop to stop

--- a/staging/src/k8s.io/client-go/tools/cache/synctrack/synctrack.go
+++ b/staging/src/k8s.io/client-go/tools/cache/synctrack/synctrack.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package synctrack contains utilities for helping controllers track whether
+// they are "synced" or not, that is, whether they have processed all items
+// from the informer's initial list.
+package synctrack
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// AsyncTracker helps propagate HasSynced in the face of multiple worker threads.
+type AsyncTracker[T comparable] struct {
+	UpstreamHasSynced func() bool
+
+	lock    sync.Mutex
+	waiting sets.Set[T]
+}
+
+// Start should be called prior to processing each key which is part of the
+// initial list.
+func (t *AsyncTracker[T]) Start(key T) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.waiting == nil {
+		t.waiting = sets.New[T](key)
+	} else {
+		t.waiting.Insert(key)
+	}
+}
+
+// Finished should be called when finished processing a key which was part of
+// the initial list. Since keys are tracked individually, nothing bad happens
+// if you call Finished without a corresponding call to Start. This makes it
+// easier to use this in combination with e.g. queues which don't make it easy
+// to plumb through the isInInitialList boolean.
+func (t *AsyncTracker[T]) Finished(key T) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.waiting != nil {
+		t.waiting.Delete(key)
+	}
+}
+
+// HasSynced returns true if the source is synced and every key present in the
+// initial list has been processed. This relies on the source not considering
+// itself synced until *after* it has delivered the notification for the last
+// key, and that notification handler must have called Start.
+func (t *AsyncTracker[T]) HasSynced() bool {
+	// Call UpstreamHasSynced first: it might take a lock, which might take
+	// a significant amount of time, and we can't hold our lock while
+	// waiting on that or a user is likely to get a deadlock.
+	if !t.UpstreamHasSynced() {
+		return false
+	}
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.waiting.Len() == 0
+}
+
+// SingleFileTracker helps propagate HasSynced when events are processed in
+// order (i.e. via a queue).
+type SingleFileTracker struct {
+	UpstreamHasSynced func() bool
+
+	count int64
+}
+
+// Start should be called prior to processing each key which is part of the
+// initial list.
+func (t *SingleFileTracker) Start() {
+	atomic.AddInt64(&t.count, 1)
+}
+
+// Finished should be called when finished processing a key which was part of
+// the initial list. You must never call Finished() before (or without) its
+// corresponding Start(), that is a logic error that could cause HasSynced to
+// return a wrong value. To help you notice this should it happen, Finished()
+// will panic if the internal counter goes negative.
+func (t *SingleFileTracker) Finished() {
+	result := atomic.AddInt64(&t.count, -1)
+	if result < 0 {
+		panic("synctrack: negative counter; this logic error means HasSynced may return incorrect value")
+	}
+}
+
+// HasSynced returns true if the source is synced and every key present in the
+// initial list has been processed. This relies on the source not considering
+// itself synced until *after* it has delivered the notification for the last
+// key, and that notification handler must have called Start.
+func (t *SingleFileTracker) HasSynced() bool {
+	// Call UpstreamHasSynced first: it might take a lock, which might take
+	// a significant amount of time, and we don't want to then act on a
+	// stale count value.
+	if !t.UpstreamHasSynced() {
+		return false
+	}
+	return atomic.LoadInt64(&t.count) <= 0
+}

--- a/staging/src/k8s.io/client-go/tools/cache/synctrack/synctrack_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/synctrack/synctrack_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package synctrack
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"testing"
+)
+
+func testSingleFileFuncs(upstreamHasSynced func() bool) (start func(), finished func(), hasSynced func() bool) {
+	tracker := SingleFileTracker{
+		UpstreamHasSynced: upstreamHasSynced,
+	}
+	return tracker.Start, tracker.Finished, tracker.HasSynced
+}
+
+func testAsyncFuncs(upstreamHasSynced func() bool) (start func(), finished func(), hasSynced func() bool) {
+	tracker := AsyncTracker[string]{
+		UpstreamHasSynced: upstreamHasSynced,
+	}
+	return func() { tracker.Start("key") }, func() { tracker.Finished("key") }, tracker.HasSynced
+}
+
+func TestBasicLogic(t *testing.T) {
+	table := []struct {
+		name      string
+		construct func(func() bool) (func(), func(), func() bool)
+	}{
+		{"SingleFile", testSingleFileFuncs},
+		{"Async", testAsyncFuncs},
+	}
+
+	for _, entry := range table {
+		t.Run(entry.name, func(t *testing.T) {
+			table := []struct {
+				synced       bool
+				start        bool
+				finish       bool
+				expectSynced bool
+			}{
+				{false, true, true, false},
+				{true, true, false, false},
+				{false, true, false, false},
+				{true, true, true, true},
+			}
+			for _, tt := range table {
+				Start, Finished, HasSynced := entry.construct(func() bool { return tt.synced })
+				if tt.start {
+					Start()
+				}
+				if tt.finish {
+					Finished()
+				}
+				got := HasSynced()
+				if e, a := tt.expectSynced, got; e != a {
+					t.Errorf("for %#v got %v (wanted %v)", tt, a, e)
+				}
+			}
+		})
+	}
+}
+
+func TestAsyncLocking(t *testing.T) {
+	aft := AsyncTracker[int]{UpstreamHasSynced: func() bool { return true }}
+
+	var wg sync.WaitGroup
+	for _, i := range []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10} {
+		wg.Add(1)
+		go func(i int) {
+			aft.Start(i)
+			go func() {
+				aft.Finished(i)
+				wg.Done()
+			}()
+		}(i)
+	}
+	wg.Wait()
+	if !aft.HasSynced() {
+		t.Errorf("async tracker must have made a threading error?")
+	}
+
+}
+
+func TestSingleFileCounting(t *testing.T) {
+	sft := SingleFileTracker{UpstreamHasSynced: func() bool { return true }}
+
+	for i := 0; i < 100; i++ {
+		sft.Start()
+	}
+	if sft.HasSynced() {
+		t.Fatal("Unexpectedly synced?")
+	}
+	for i := 0; i < 99; i++ {
+		sft.Finished()
+	}
+	if sft.HasSynced() {
+		t.Fatal("Unexpectedly synced?")
+	}
+
+	sft.Finished()
+	if !sft.HasSynced() {
+		t.Fatal("Unexpectedly not synced?")
+	}
+
+	// Calling an extra time will panic.
+	func() {
+		defer func() {
+			x := recover()
+			if x == nil {
+				t.Error("no panic?")
+				return
+			}
+			msg, ok := x.(string)
+			if !ok {
+				t.Errorf("unexpected panic value: %v", x)
+				return
+			}
+			if !strings.Contains(msg, "negative counter") {
+				t.Errorf("unexpected panic message: %v", msg)
+				return
+			}
+		}()
+		sft.Finished()
+	}()
+
+	// Negative counter still means it is synced
+	if !sft.HasSynced() {
+		t.Fatal("Unexpectedly not synced?")
+	}
+}
+
+func TestSingleFile(t *testing.T) {
+	table := []struct {
+		synced       bool
+		starts       int
+		stops        int
+		expectSynced bool
+	}{
+		{false, 1, 1, false},
+		{true, 1, 0, false},
+		{false, 1, 0, false},
+		{true, 1, 1, true},
+	}
+	for _, tt := range table {
+		sft := SingleFileTracker{UpstreamHasSynced: func() bool { return tt.synced }}
+		for i := 0; i < tt.starts; i++ {
+			sft.Start()
+		}
+		for i := 0; i < tt.stops; i++ {
+			sft.Finished()
+		}
+		got := sft.HasSynced()
+		if e, a := tt.expectSynced, got; e != a {
+			t.Errorf("for %#v got %v (wanted %v)", tt, a, e)
+		}
+	}
+
+}
+
+func TestNoStaleValue(t *testing.T) {
+	table := []struct {
+		name      string
+		construct func(func() bool) (func(), func(), func() bool)
+	}{
+		{"SingleFile", testSingleFileFuncs},
+		{"Async", testAsyncFuncs},
+	}
+
+	for _, entry := range table {
+		t.Run(entry.name, func(t *testing.T) {
+			var lock sync.Mutex
+			upstreamHasSynced := func() bool {
+				lock.Lock()
+				defer lock.Unlock()
+				return true
+			}
+
+			Start, Finished, HasSynced := entry.construct(upstreamHasSynced)
+
+			// Ordinarily the corresponding lock would be held and you wouldn't be
+			// able to call this function at this point.
+			if !HasSynced() {
+				t.Fatal("Unexpectedly not synced??")
+			}
+
+			Start()
+			if HasSynced() {
+				t.Fatal("Unexpectedly synced??")
+			}
+			Finished()
+			if !HasSynced() {
+				t.Fatal("Unexpectedly not synced??")
+			}
+
+			// Now we will prove that if the lock is held, you can't get a false
+			// HasSynced return.
+			lock.Lock()
+
+			// This goroutine calls HasSynced
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if HasSynced() {
+					t.Error("Unexpectedly synced??")
+				}
+			}()
+
+			// This goroutine increments + unlocks. The sleep is to bias the
+			// runtime such that the other goroutine usually wins (it needs to work
+			// in both orderings, this one is more likely to be buggy).
+			go func() {
+				time.Sleep(time.Millisecond)
+				Start()
+				lock.Unlock()
+			}()
+
+			wg.Wait()
+		})
+	}
+
+}

--- a/test/integration/client/exec_test.go
+++ b/test/integration/client/exec_test.go
@@ -562,7 +562,7 @@ type informerSpy struct {
 	deletes []interface{}
 }
 
-func (is *informerSpy) OnAdd(obj interface{}) {
+func (is *informerSpy) OnAdd(obj interface{}, isInInitialList bool) {
 	is.mu.Lock()
 	defer is.mu.Unlock()
 	is.adds = append(is.adds, obj)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1906,6 +1906,7 @@ k8s.io/client-go/testing
 k8s.io/client-go/third_party/forked/golang/template
 k8s.io/client-go/tools/auth
 k8s.io/client-go/tools/cache
+k8s.io/client-go/tools/cache/synctrack
 k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/tools/clientcmd/api
 k8s.io/client-go/tools/clientcmd/api/latest


### PR DESCRIPTION
Fix #113763 by:
* Fix informers to track HasSynced properly
* propagate HasSynced to each Handle individually
* Add AsyncTracker to help multi-worker controllers track whether they've synced or not


/kind bug

#### What this PR does / why we need it:

Plumbs the fact of whether an item was in the initial list or not to controllers, where they can choose to track whether they have processed it or not.

```release-note
Shared informers now correctly propagate whether they are synced or not. Individual informer handlers may now check if they are synced or not (new HasSynced method). Library support is added to assist controllers in tracking whether their own work is completed for items in the initial list (AsyncTracker).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
