### PR TITLE
Migrate StorageVersionGC to contextual logging

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -681,7 +681,9 @@ func setNodeCIDRMaskSizes(cfg nodeipamconfig.NodeIPAMControllerConfiguration, cl
 }
 
 func startStorageVersionGCController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+	ctx = klog.NewContext(ctx, klog.LoggerWithName(klog.FromContext(ctx), "storageVersionGC"))
 	go storageversiongc.NewStorageVersionGC(
+		ctx,
 		controllerContext.ClientBuilder.ClientOrDie("storage-version-garbage-collector"),
 		controllerContext.InformerFactory.Coordination().V1().Leases(),
 		controllerContext.InformerFactory.Internal().V1alpha1().StorageVersions(),

--- a/test/integration/storageversion/gc_test.go
+++ b/test/integration/storageversion/gc_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2/ktesting"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/pkg/controller/storageversiongc"
 	"k8s.io/kubernetes/pkg/controlplane"
@@ -62,7 +63,8 @@ func TestStorageVersionGarbageCollection(t *testing.T) {
 	leaseInformer := informers.Coordination().V1().Leases()
 	storageVersionInformer := informers.Internal().V1alpha1().StorageVersions()
 
-	controller := storageversiongc.NewStorageVersionGC(kubeclient, leaseInformer, storageVersionInformer)
+	_, ctx := ktesting.NewTestContext(t)
+	controller := storageversiongc.NewStorageVersionGC(ctx, kubeclient, leaseInformer, storageVersionInformer)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
Update the ttl controller to use contextual logging.

Which issue(s) this PR fixes:
Part of kubernetes/enhancements#3077

Special notes for your reviewer:
Does this PR introduce a user-facing change?

```release-note

StorageVersionGC (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).


```
