### PR TITLE
kubectl debug: ensure profile application occurs after pod spec mutation in the CopyTo case

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -654,9 +654,6 @@ func (o *DebugOptions) generatePodCopyWithDebugContainer(pod *corev1.Pod) (*core
 			Name:                     name,
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 		}
-		defer func() {
-			copied.Spec.Containers = append(copied.Spec.Containers, *c)
-		}()
 	}
 
 	if len(o.Args) > 0 {
@@ -678,6 +675,9 @@ func (o *DebugOptions) generatePodCopyWithDebugContainer(pod *corev1.Pod) (*core
 	}
 	c.Stdin = o.Interactive
 	c.TTY = o.TTY
+	if !ok {
+		copied.Spec.Containers = append(copied.Spec.Containers, *c)
+	}
 
 	err := o.applier.Apply(copied, c.Name, pod)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a bug in `generatePodCopyWithDebugContainer` where the debug container's creation could be deferred, causing the container list mutation to occur after the debug profile applier had already ran. The presence of the bug today does not lead to any user observable problems, this is because the only supported debug profile `legacy` does not modify containers. However, as `kubectl debug` add support for more debug profiles, this bug will manifest. Rather than deferring the bug's manifestation, it's better to go ahead and fix it now.

#### Does this PR introduce a user-facing change?

NONE
