### PR TITLE
Deletion protection for CustomResourceDefinition

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types.go
@@ -69,6 +69,12 @@ type CustomResourceDefinitionSpec struct {
 	// See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning for details.
 	// +optional
 	PreserveUnknownFields bool `json:"preserveUnknownFields,omitempty" protobuf:"varint,10,opt,name=preserveUnknownFields"`
+
+	// deletionProtection blocks deletion if true and there are still instances of a CRD
+	// if this field is true, all instances of this CRD must be deleted before this CRD can be deleted
+	// if this field is false, all instances of this CRD will automatically be deleted when this CRD is deleted
+	// +optional
+	DeletionProtection bool `json:"deletionProtection,omitempty" protobuf:"varint,10,opt,name=deletionProtection"`
 }
 
 // CustomResourceConversion describes how to convert different versions of a CR.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -201,6 +201,15 @@ func (c *CRDFinalizer) deleteInstances(crd *apiextensionsv1.CustomResourceDefini
 		}, err
 	}
 
+	if crd.Spec.DeletionProtection && len(allResources.(*unstructured.UnstructuredList).Items) > 0 {
+		return apiextensionsv1.CustomResourceDefinitionCondition{
+			Type:    apiextensionsv1.Terminating,
+			Status:  apiextensionsv1.ConditionTrue,
+			Reason:  "InstancesStillExist",
+			Message: "could not delete, since instances still exist and deletionProtection is true",
+		}, nil
+	}
+
 	deletedNamespaces := sets.String{}
 	deleteErrors := []error{}
 	for _, item := range allResources.(*unstructured.UnstructuredList).Items {


### PR DESCRIPTION

#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This adds a `deletionProtection` field to the CRD spec. When deleting a CRD, the controller gets the list of CR instances and deletes them. But if this field is true and there are 1 or more CR instances, the deletion will be skipped. If this field is false, original behaviour is preserved and CR instances will still be deleted

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/114003

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add deletionProtection field to CustomResourceDefinition spec to optionally block deletion if 1 or more CustomResource instances still exist
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
