### PR TITLE
egress_selector: prevent goroutines leak on connect() step.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -216,6 +216,9 @@ func (u *udsGRPCConnector) connect(_ context.Context) (proxier, error) {
 	// See https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/357.
 	tunnelCtx := context.TODO()
 	tunnel, err := client.CreateSingleUseGrpcTunnel(tunnelCtx, udsName, dialOption,
+		grpc.WithBlock(),
+		grpc.WithReturnConnectionError(),
+		grpc.WithTimeout(30*time.Second), // matches http.DefaultTransport dial timeout
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

Cherry pick https://github.com/kubernetes/kubernetes/pull/113486 to release-1.25

I want this because:
* egress_selector.go: defense in depth against goroutine leaks stuck dialing UDS
* WithBlock fixes the accuracy of `dial_failure_count` (for `StageConnect`)

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
