### PR TITLE
egress_selector: prevent goroutines leak on connect() step.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -214,7 +214,11 @@ func (u *udsGRPCConnector) connect(_ context.Context) (proxier, error) {
 	// we cannot use ctx just for dialing and control the connection lifetime separately.
 	// See https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/357.
 	tunnelCtx := context.TODO()
-	tunnel, err := client.CreateSingleUseGrpcTunnel(tunnelCtx, udsName, dialOption, grpc.WithInsecure())
+	tunnel, err := client.CreateSingleUseGrpcTunnel(tunnelCtx, udsName, dialOption,
+		grpc.WithBlock(),
+		grpc.WithReturnConnectionError(),
+		grpc.WithTimeout(30*time.Second), // matches http.DefaultTransport dial timeout
+		grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

Cherry pick https://github.com/kubernetes/kubernetes/pull/113486 to release-1.24

I want this because:
* egress_selector.go: defense in depth against goroutine leaks stuck dialing UDS
* WithBlock fixes the accuracy of `dial_failure_count` (for `StageConnect`)

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

This includes a manually resolve a merge conflict.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
