### PR TITLE
docs: fix kubectl spelling in CHANGELOG/CHANGELOG-1.26.md

### DIFF
--- a/CHANGELOG/CHANGELOG-1.26.md
+++ b/CHANGELOG/CHANGELOG-1.26.md
@@ -905,7 +905,7 @@ name | architectures
 ### API Change
 
 - Add auth API to get self subject attributes (new selfsubjectreviews API is added). 
-  The corresponding command for kubctl is provided - `kubectl auth whoami`. ([#111333](https://github.com/kubernetes/kubernetes/pull/111333), [@nabokihms](https://github.com/nabokihms)) [SIG API Machinery, Auth, CLI and Testing]
+  The corresponding command for kubectl is provided - `kubectl auth whoami`. ([#111333](https://github.com/kubernetes/kubernetes/pull/111333), [@nabokihms](https://github.com/nabokihms)) [SIG API Machinery, Auth, CLI and Testing]
 - Clarified the CFS quota as 100ms in the code comments and set the minimum cpuCFSQuotaPeriod to 1ms to match Linux kernel expectations. ([#112123](https://github.com/kubernetes/kubernetes/pull/112123), [@paskal](https://github.com/paskal)) [SIG API Machinery and Node]
 - Component-base: make the validation logic about LeaderElectionConfiguration consistent between component-base and client-go ([#111758](https://github.com/kubernetes/kubernetes/pull/111758), [@SataQiu](https://github.com/SataQiu)) [SIG API Machinery and Scheduling]
 - Fixes spurious `field is immutable` errors validating updates to Event API objects via the `events.k8s.io/v1` API ([#112183](https://github.com/kubernetes/kubernetes/pull/112183), [@liggitt](https://github.com/liggitt)) [SIG Apps]


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:

Fixes `kubectl` misspelling in `CHANGELOG/CHANGELOG-1.26.md` 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
