### PR TITLE
clarify valueFrom text

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2024,6 +2024,7 @@ type EnvVar struct {
 	// Escaped references will never be expanded, regardless of whether the variable
 	// exists or not.
 	// Defaults to "".
+	// You cannot set both value and valueFrom.
 	// +optional
 	Value string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
 	// Source for this environment variable's value. You cannot set both value and valueFrom.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2026,7 +2026,7 @@ type EnvVar struct {
 	// Defaults to "".
 	// +optional
 	Value string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
-	// Source for the environment variable's value. Only used if value is empty.
+	// Source for this environment variable's value. You cannot set both value and valueFrom.
 	// +optional
 	ValueFrom *EnvVarSource `json:"valueFrom,omitempty" protobuf:"bytes,3,opt,name=valueFrom"`
 }

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2026,7 +2026,7 @@ type EnvVar struct {
 	// Defaults to "".
 	// +optional
 	Value string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
-	// Source for the environment variable's value. Cannot be used if value is not empty.
+	// Source for the environment variable's value. Only used if value is empty.
 	// +optional
 	ValueFrom *EnvVarSource `json:"valueFrom,omitempty" protobuf:"bytes,3,opt,name=valueFrom"`
 }


### PR DESCRIPTION
The following text is unclear:
"Source for the environment variable's value. Cannot be used if value is not empty."

* double negative
* the word `value` is ambiguous in this context

addresses https://github.com/kubernetes/kubernetes/issues/114042