### PR TITLE
Automated cherry pick of #112516: fix endpoint slice controller logging format error

### DIFF
--- a/pkg/controller/endpointslice/topologycache/topologycache.go
+++ b/pkg/controller/endpointslice/topologycache/topologycache.go
@@ -212,7 +212,7 @@ func (t *TopologyCache) SetNodes(nodes []*v1.Node) {
 	defer t.lock.Unlock()
 
 	if totalCPU.IsZero() || !sufficientNodeInfo || len(cpuByZone) < 2 {
-		klog.V(2).Infof("Insufficient node info for topology hints (%d zones, %s CPU, %t)", len(cpuByZone), totalCPU.MilliValue(), sufficientNodeInfo)
+		klog.V(2).Infof("Insufficient node info for topology hints (%d zones, %s CPU, %t)", len(cpuByZone), totalCPU.String(), sufficientNodeInfo)
 		t.sufficientNodeInfo = false
 		t.cpuByZone = nil
 		t.cpuRatiosByZone = nil


### PR DESCRIPTION
Cherry pick of #112516 on release-1.25.

#112516: fix endpoint slice controller logging format error

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```