### PR TITLE
hack/update-translations.sh: Improve backslash handling

### DIFF
--- a/hack/update-translations.sh
+++ b/hack/update-translations.sh
@@ -83,8 +83,7 @@ if [[ "${generate_pot}" == "true" ]]; then
   # shellcheck disable=SC2046
   go-xgettext -k=i18n.T $(grep -lr "i18n.T" "${KUBECTL_FILES[@]}" | grep -vE "${KUBECTL_IGNORE_FILES_REGEX}") > tmp.pot
   perl -pi -e 's/CHARSET/UTF-8/' tmp.pot
-  perl -pi -e 's/\\\(/\\\\\(/g' tmp.pot
-  perl -pi -e 's/\\\)/\\\\\)/g' tmp.pot
+  perl -pi -e 's/\\(?!n"\n|")/\\\\/g' tmp.pot
   kube::util::ensure-temp-dir
   if msgcat -s tmp.pot > "${KUBE_TEMP}/template.pot"; then
     mv "${KUBE_TEMP}/template.pot" "${TRANSLATIONS}/kubectl/template.pot"

--- a/staging/src/k8s.io/kubectl/pkg/util/i18n/translations/kubectl/template.pot
+++ b/staging/src/k8s.io/kubectl/pkg/util/i18n/translations/kubectl/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: EMAIL\n"
-"POT-Creation-Date: 2021-07-07 20:15+0200\n"
+"POT-Creation-Date: 2022-11-21 22:46-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:138
+#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:141
 msgid ""
 "\n"
 "\t\t\t# Approve CSR 'csr-sqgzp'\n"
@@ -25,7 +25,7 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:182
+#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:184
 msgid ""
 "\n"
 "\t\t\t# Deny CSR 'csr-sqgzp'\n"
@@ -74,7 +74,8 @@ msgid ""
 "\t\t  kubectl create configmap my-config --from-file=path/to/bar\n"
 "\n"
 "\t\t  # Create a new config map named my-config from an env file\n"
-"\t\t  kubectl create configmap my-config --from-env-file=path/to/bar.env"
+"\t\t  kubectl create configmap my-config --from-env-file=path/to/foo.env --"
+"from-env-file=path/to/bar.env"
 msgstr ""
 
 #: staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go:43
@@ -100,7 +101,7 @@ msgid ""
 "dockerconfigjson=path/to/.docker/config.json"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go:62
+#: staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go:63
 msgid ""
 "\n"
 "\t\t  # Show metrics for all nodes\n"
@@ -110,7 +111,7 @@ msgid ""
 "\t\t  kubectl top node NODE_NAME"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go:45
+#: staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go:42
 msgid ""
 "\n"
 "\t\t# !!!Important Note!!!\n"
@@ -145,7 +146,7 @@ msgid ""
 "\t\tkubectl cp <some-namespace>/<some-pod>:/tmp/foo /tmp/bar"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go:119
+#: staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go:149
 msgid ""
 "\n"
 "\t\t# Apply the configuration in pod.json to a pod\n"
@@ -158,6 +159,10 @@ msgid ""
 "\t\t# Apply the JSON passed into stdin to a pod\n"
 "\t\tcat pod.json | kubectl apply -f -\n"
 "\n"
+"\t\t# Apply the configuration from all files that end with '.json' - i.e. "
+"expand wildcard characters in file names\n"
+"\t\tkubectl apply -f '*.json'\n"
+"\n"
 "\t\t# Note: --prune is still in Alpha\n"
 "\t\t# Apply the configuration in manifest.yaml that matches label app=nginx "
 "and delete all other resources that are not in the file and match label "
@@ -166,11 +171,11 @@ msgid ""
 "\n"
 "\t\t# Apply the configuration in manifest.yaml and delete all the other "
 "config maps that are not in the file\n"
-"\t\tkubectl apply --prune -f manifest.yaml --all --prune-whitelist=core/v1/"
+"\t\tkubectl apply --prune -f manifest.yaml --all --prune-allowlist=core/v1/"
 "ConfigMap"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go:48
+#: staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go:49
 #, c-format
 msgid ""
 "\n"
@@ -214,8 +219,7 @@ msgid ""
 "resource-name=readablepod --resource-name=anotherpod\n"
 "\n"
 "\t\t# Create a cluster role named \"foo\" with API Group specified\n"
-"\t\tkubectl create clusterrole foo --verb=get,list,watch --resource=rs."
-"extensions\n"
+"\t\tkubectl create clusterrole foo --verb=get,list,watch --resource=rs.apps\n"
 "\n"
 "\t\t# Create a cluster role named \"foo\" with SubResource specified\n"
 "\t\tkubectl create clusterrole foo --verb=get,list,watch --resource=pods,"
@@ -273,7 +277,7 @@ msgid ""
 "\t\tkubectl create pdb my-pdb --selector=app=nginx --min-available=50%"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create.go:76
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create.go:79
 msgid ""
 "\n"
 "\t\t# Create a pod using the data in pod.json\n"
@@ -282,17 +286,17 @@ msgid ""
 "\t\t# Create a pod based on the JSON passed into stdin\n"
 "\t\tcat pod.json | kubectl create -f -\n"
 "\n"
-"\t\t# Edit the data in docker-registry.yaml in JSON then create the resource "
-"using the edited data\n"
-"\t\tkubectl create -f docker-registry.yaml --edit -o json"
+"\t\t# Edit the data in registry.yaml in JSON then create the resource using "
+"the edited data\n"
+"\t\tkubectl create -f registry.yaml --edit -o json"
 msgstr ""
 
 #: staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go:43
 msgid ""
 "\n"
 "\t\t# Create a priority class named high-priority\n"
-"\t\tkubectl create priorityclass high-priority --value=1000 --description="
-"\"high priority\"\n"
+"\t\tkubectl create priorityclass high-priority --value=1000 --"
+"description=\"high priority\"\n"
 "\n"
 "\t\t# Create a priority class named default-priority that is considered as "
 "the global default priority\n"
@@ -301,15 +305,15 @@ msgid ""
 "\n"
 "\t\t# Create a priority class named high-priority that cannot preempt pods "
 "with lower priority\n"
-"\t\tkubectl create priorityclass high-priority --value=1000 --description="
-"\"high priority\" --preemption-policy=\"Never\""
+"\t\tkubectl create priorityclass high-priority --value=1000 --"
+"description=\"high priority\" --preemption-policy=\"Never\""
 msgstr ""
 
 #: staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go:46
 msgid ""
 "\n"
-"\t\t# Create a role named \"pod-reader\" that allows user to perform \"get"
-"\", \"watch\" and \"list\" on pods\n"
+"\t\t# Create a role named \"pod-reader\" that allows user to perform "
+"\"get\", \"watch\" and \"list\" on pods\n"
 "\t\tkubectl create role pod-reader --verb=get --verb=list --verb=watch --"
 "resource=pods\n"
 "\n"
@@ -318,13 +322,13 @@ msgid ""
 "name=readablepod --resource-name=anotherpod\n"
 "\n"
 "\t\t# Create a role named \"foo\" with API Group specified\n"
-"\t\tkubectl create role foo --verb=get,list,watch --resource=rs.extensions\n"
+"\t\tkubectl create role foo --verb=get,list,watch --resource=rs.apps\n"
 "\n"
 "\t\t# Create a role named \"foo\" with SubResource specified\n"
 "\t\tkubectl create role foo --verb=get,list,watch --resource=pods,pods/status"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:61
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:66
 msgid ""
 "\n"
 "\t\t# Create a service for a replicated nginx, which serves on port 80 and "
@@ -365,8 +369,8 @@ msgid ""
 "\t\t# Create a single ingress called 'simple' that directs requests to foo."
 "com/bar to svc\n"
 "\t\t# svc1:8080 with a tls secret \"my-cert\"\n"
-"\t\tkubectl create ingress simple --rule=\"foo.com/bar=svc1:8080,tls=my-cert"
-"\"\n"
+"\t\tkubectl create ingress simple --rule=\"foo.com/bar=svc1:8080,tls=my-"
+"cert\"\n"
 "\n"
 "\t\t# Create a catch all ingress of \"/path\" pointing to service svc:port "
 "and Ingress Class as \"otheringress\"\n"
@@ -376,35 +380,40 @@ msgid ""
 "\t\t# Create an ingress with two annotations: ingress.annotation1 and "
 "ingress.annotations2\n"
 "\t\tkubectl create ingress annotated --class=default --rule=\"foo.com/"
-"bar=svc:port\" \\n\t\t\t--annotation ingress.annotation1=foo \\n\t\t\t--"
-"annotation ingress.annotation2=bla\n"
+"bar=svc:port\" \\\n"
+"\t\t\t--annotation ingress.annotation1=foo \\\n"
+"\t\t\t--annotation ingress.annotation2=bla\n"
 "\n"
 "\t\t# Create an ingress with the same host and multiple paths\n"
-"\t\tkubectl create ingress multipath --class=default \\n\t\t\t--rule=\"foo."
-"com/=svc:port\" \\n\t\t\t--rule=\"foo.com/admin/=svcadmin:portadmin\"\n"
+"\t\tkubectl create ingress multipath --class=default \\\n"
+"\t\t\t--rule=\"foo.com/=svc:port\" \\\n"
+"\t\t\t--rule=\"foo.com/admin/=svcadmin:portadmin\"\n"
 "\n"
 "\t\t# Create an ingress with multiple hosts and the pathType as Prefix\n"
-"\t\tkubectl create ingress ingress1 --class=default \\n\t\t\t--rule=\"foo."
-"com/path*=svc:8080\" \\n\t\t\t--rule=\"bar.com/admin*=svc2:http\"\n"
+"\t\tkubectl create ingress ingress1 --class=default \\\n"
+"\t\t\t--rule=\"foo.com/path*=svc:8080\" \\\n"
+"\t\t\t--rule=\"bar.com/admin*=svc2:http\"\n"
 "\n"
 "\t\t# Create an ingress with TLS enabled using the default ingress "
 "certificate and different path types\n"
-"\t\tkubectl create ingress ingtls --class=default \\n\t\t   --rule=\"foo.com/"
-"=svc:https,tls\" \\n\t\t   --rule=\"foo.com/path/subpath*=othersvc:8080\"\n"
+"\t\tkubectl create ingress ingtls --class=default \\\n"
+"\t\t   --rule=\"foo.com/=svc:https,tls\" \\\n"
+"\t\t   --rule=\"foo.com/path/subpath*=othersvc:8080\"\n"
 "\n"
 "\t\t# Create an ingress with TLS enabled using a specific secret and "
 "pathType as Prefix\n"
-"\t\tkubectl create ingress ingsecret --class=default \\n\t\t   --rule=\"foo."
-"com/*=svc:8080,tls=secret1\"\n"
+"\t\tkubectl create ingress ingsecret --class=default \\\n"
+"\t\t   --rule=\"foo.com/*=svc:8080,tls=secret1\"\n"
 "\n"
 "\t\t# Create an ingress with a default backend\n"
-"\t\tkubectl create ingress ingdefault --class=default \\n\t\t   --default-"
-"backend=defaultsvc:http \\n\t\t   --rule=\"foo.com/*=svc:8080,tls=secret1\"\n"
+"\t\tkubectl create ingress ingdefault --class=default \\\n"
+"\t\t   --default-backend=defaultsvc:http \\\n"
+"\t\t   --rule=\"foo.com/*=svc:8080,tls=secret1\"\n"
 "\n"
 "\t\t"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:74
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:76
 msgid ""
 "\n"
 "\t\t# Create an interactive debugging session in pod mypod and immediately "
@@ -441,7 +450,7 @@ msgid ""
 "\t\tkubectl debug node/mynode -it --image=busybox\n"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go:74
+#: staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go:79
 msgid ""
 "\n"
 "\t\t# Delete a pod using the type and name specified in pod.json\n"
@@ -450,6 +459,10 @@ msgid ""
 "\t\t# Delete resources from a directory containing kustomization.yaml - e.g. "
 "dir/kustomization.yaml\n"
 "\t\tkubectl delete -k dir\n"
+"\n"
+"\t\t# Delete resources from all files that end with '.json' - i.e. expand "
+"wildcard characters in file names\n"
+"\t\tkubectl delete -f '*.json'\n"
 "\n"
 "\t\t# Delete a pod based on the type and name in the JSON passed into stdin\n"
 "\t\tcat pod.json | kubectl delete -f -\n"
@@ -488,9 +501,8 @@ msgid ""
 "\t\t# Describe pods by label name=myLabel\n"
 "\t\tkubectl describe po -l name=myLabel\n"
 "\n"
-"\t\t# Describe all pods managed by the 'frontend' replication controller (rc-"
-"created pods\n"
-"\t\t# get the name of the rc as a prefix in the pod the name)\n"
+"\t\t# Describe all pods managed by the 'frontend' replication controller \n"
+"\t\t# (rc-created pods get the name of the rc as a prefix in the pod name)\n"
 "\t\tkubectl describe pods frontend"
 msgstr ""
 
@@ -504,7 +516,7 @@ msgid ""
 "\t\tcat service.yaml | kubectl diff -f -"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:138
+#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:139
 msgid ""
 "\n"
 "\t\t# Drain node \"foo\", even if there are pods not managed by a "
@@ -520,21 +532,24 @@ msgstr ""
 #: staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go:55
 msgid ""
 "\n"
-"\t\t# Edit the service named 'docker-registry'\n"
-"\t\tkubectl edit svc/docker-registry\n"
+"\t\t# Edit the service named 'registry'\n"
+"\t\tkubectl edit svc/registry\n"
 "\n"
 "\t\t# Use an alternative editor\n"
-"\t\tKUBE_EDITOR=\"nano\" kubectl edit svc/docker-registry\n"
+"\t\tKUBE_EDITOR=\"nano\" kubectl edit svc/registry\n"
 "\n"
 "\t\t# Edit the job 'myjob' in JSON using the v1 API format\n"
 "\t\tkubectl edit job.v1.batch/myjob -o json\n"
 "\n"
 "\t\t# Edit the deployment 'mydeployment' in YAML and save the modified "
 "config in its annotation\n"
-"\t\tkubectl edit deployment/mydeployment -o yaml --save-config"
+"\t\tkubectl edit deployment/mydeployment -o yaml --save-config\n"
+"\n"
+"\t\t# Edit the deployment/mydeployment's status subresource\n"
+"\t\tkubectl edit deployment mydeployment --subresource='status'"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go:44
+#: staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go:46
 msgid ""
 "\n"
 "\t\t# Get output from running pod mypod; use the 'kubectl.kubernetes.io/"
@@ -594,7 +609,7 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go:46
+#: staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go:49
 msgid ""
 "\n"
 "\t\t# Get the documentation of the resource and its fields\n"
@@ -604,7 +619,7 @@ msgid ""
 "\t\tkubectl explain pods.spec.containers"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go:65
+#: staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go:66
 msgid ""
 "\n"
 "\t\t# Installing bash completion on macOS using homebrew\n"
@@ -638,10 +653,38 @@ msgid ""
 "\t\t# Load the kubectl completion code for zsh[1] into the current shell\n"
 "\t\t    source <(kubectl completion zsh)\n"
 "\t\t# Set the kubectl completion code for zsh[1] to autoload on startup\n"
-"\t\t    kubectl completion zsh > \"${fpath[1]}/_kubectl\""
+"\t\t    kubectl completion zsh > \"${fpath[1]}/_kubectl\"\n"
+"\n"
+"\n"
+"\t\t# Load the kubectl completion code for fish[2] into the current shell\n"
+"\t\t    kubectl completion fish | source\n"
+"\t\t# To load completions for each session, execute once: \n"
+"\t\t    kubectl completion fish > ~/.config/fish/completions/kubectl.fish\n"
+"\n"
+"\t\t# Load the kubectl completion code for powershell into the current "
+"shell\n"
+"\t\t    kubectl completion powershell | Out-String | Invoke-Expression\n"
+"\t\t# Set kubectl completion code for powershell to run on startup\n"
+"\t\t## Save completion code to a script and execute in the profile\n"
+"\t\t    kubectl completion powershell > $HOME\\.kube\\completion.ps1\n"
+"\t\t    Add-Content $PROFILE \"$HOME\\.kube\\completion.ps1\"\n"
+"\t\t## Execute completion code in the profile\n"
+"\t\t    Add-Content $PROFILE \"if (Get-Command kubectl -ErrorAction "
+"SilentlyContinue) {\n"
+"\t\t        kubectl completion powershell | Out-String | Invoke-Expression\n"
+"\t\t    }\"\n"
+"\t\t## Add completion code directly to the $PROFILE script\n"
+"\t\t    kubectl completion powershell >> $PROFILE"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/get/get.go:105
+#: staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go:46
+msgid ""
+"\n"
+"\t\t# List all available plugins\n"
+"\t\tkubectl plugin list"
+msgstr ""
+
+#: staging/src/k8s.io/kubectl/pkg/cmd/get/get.go:101
 msgid ""
 "\n"
 "\t\t# List all pods in ps output format\n"
@@ -682,10 +725,13 @@ msgid ""
 "\t\tkubectl get rc,services\n"
 "\n"
 "\t\t# List one or more resources by their type and names\n"
-"\t\tkubectl get rc/web service/frontend pods/web-pod-13je7"
+"\t\tkubectl get rc/web service/frontend pods/web-pod-13je7\n"
+"\n"
+"\t\t# List status subresource for a single pod.\n"
+"\t\tkubectl get pod web-pod-13je7 --subresource status"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go:72
+#: staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go:73
 msgid ""
 "\n"
 "\t\t# Listen on ports 5000 and 6000 locally, forwarding data to/from ports "
@@ -715,21 +761,21 @@ msgid ""
 "\t\tkubectl port-forward pod/mypod :5000"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:87
+#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:88
 msgid ""
 "\n"
 "\t\t# Mark node \"foo\" as schedulable\n"
 "\t\tkubectl uncordon foo"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:58
+#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:59
 msgid ""
 "\n"
 "\t\t# Mark node \"foo\" as unschedulable\n"
 "\t\tkubectl cordon foo"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go:83
+#: staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go:89
 msgid ""
 "\n"
 "\t\t# Partially update a node using a strategic merge patch, specifying the "
@@ -752,7 +798,12 @@ msgid ""
 "\n"
 "\t\t# Update a container's image using a JSON patch with positional arrays\n"
 "\t\tkubectl patch pod valid-pod --type='json' -p='[{\"op\": \"replace\", "
-"\"path\": \"/spec/containers/0/image\", \"value\":\"new image\"}]'"
+"\"path\": \"/spec/containers/0/image\", \"value\":\"new image\"}]'\n"
+"\t\t\n"
+"\t\t# Update a deployment's replicas through the scale subresource using a "
+"merge patch.\n"
+"\t\tkubectl patch deployment nginx-deployment --subresource='scale' --"
+"type='merge' -p '{\"spec\":{\"replicas\":2}}'"
 msgstr ""
 
 #: staging/src/k8s.io/kubectl/pkg/cmd/options/options.go:29
@@ -769,7 +820,7 @@ msgid ""
 "\t\tkubectl cluster-info"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/version/version.go:44
+#: staging/src/k8s.io/kubectl/pkg/cmd/version/version.go:49
 msgid ""
 "\n"
 "\t\t# Print the client and server versions for the current context\n"
@@ -783,7 +834,7 @@ msgid ""
 "\t\tkubectl api-versions"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go:56
+#: staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go:57
 msgid ""
 "\n"
 "\t\t# Replace a pod using the data in pod.json\n"
@@ -793,14 +844,14 @@ msgid ""
 "\t\tcat pod.json | kubectl replace -f -\n"
 "\n"
 "\t\t# Update a single-container pod's image version (tag) to v4\n"
-"\t\tkubectl get pod mypod -o yaml | sed 's/\\(image: myimage\\):.*$/:v4/' | "
-"kubectl replace -f -\n"
+"\t\tkubectl get pod mypod -o yaml | sed 's/\\(image: myimage\\):.*$/\\1:v4/' "
+"| kubectl replace -f -\n"
 "\n"
 "\t\t# Force replace, delete and then re-create the resource\n"
 "\t\tkubectl replace --force -f ./pod.json"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go:53
+#: staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go:54
 msgid ""
 "\n"
 "\t\t# Return snapshot logs from pod nginx with only one container\n"
@@ -878,7 +929,7 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go:75
+#: staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go:76
 msgid ""
 "\n"
 "\t\t# Show metrics for all pods in the default namespace\n"
@@ -905,13 +956,13 @@ msgid ""
 "\n"
 "\t\t# Start a hazelcast pod and set environment variables "
 "\"DNS_DOMAIN=cluster\" and \"POD_NAMESPACE=default\" in the container\n"
-"\t\tkubectl run hazelcast --image=hazelcast/hazelcast --env="
-"\"DNS_DOMAIN=cluster\" --env=\"POD_NAMESPACE=default\"\n"
+"\t\tkubectl run hazelcast --image=hazelcast/hazelcast --"
+"env=\"DNS_DOMAIN=cluster\" --env=\"POD_NAMESPACE=default\"\n"
 "\n"
-"\t\t# Start a hazelcast pod and set labels \"app=hazelcast\" and \"env=prod"
-"\" in the container\n"
-"\t\tkubectl run hazelcast --image=hazelcast/hazelcast --labels="
-"\"app=hazelcast,env=prod\"\n"
+"\t\t# Start a hazelcast pod and set labels \"app=hazelcast\" and "
+"\"env=prod\" in the container\n"
+"\t\tkubectl run hazelcast --image=hazelcast/hazelcast --"
+"labels=\"app=hazelcast,env=prod\"\n"
 "\n"
 "\t\t# Dry run; print the corresponding API objects without creating them\n"
 "\t\tkubectl run nginx --image=nginx --dry-run=client\n"
@@ -933,7 +984,7 @@ msgid ""
 "\t\tkubectl run nginx --image=nginx --command -- <cmd> <arg1> ... <argN>"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go:73
+#: staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go:76
 msgid ""
 "\n"
 "\t\t# To proxy all of the Kubernetes API and nothing else\n"
@@ -962,7 +1013,7 @@ msgid ""
 "\t\tkubectl proxy --api-prefix=/k8s-api"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go:80
+#: staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go:81
 msgid ""
 "\n"
 "\t\t# Update node 'foo' with a taint with key 'dedicated' and value 'special-"
@@ -985,7 +1036,7 @@ msgid ""
 "\t\tkubectl taint nodes foo bar:NoSchedule"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/label/label.go:95
+#: staging/src/k8s.io/kubectl/pkg/cmd/label/label.go:101
 msgid ""
 "\n"
 "\t\t# Update pod 'foo' with the label 'unhealthy' and the value 'true'\n"
@@ -1009,7 +1060,7 @@ msgid ""
 "\t\tkubectl label pods foo bar-"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go:53
+#: staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go:54
 msgid ""
 "\n"
 "\t\t# View the last-applied-configuration annotations by type/name in YAML\n"
@@ -1019,16 +1070,21 @@ msgid ""
 "\t\tkubectl apply view-last-applied -f deploy.yaml -o json"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go:61
+#: staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go:66
 msgid ""
 "\n"
 "\t\t# Wait for the pod \"busybox1\" to contain the status condition of type "
 "\"Ready\"\n"
 "\t\tkubectl wait --for=condition=Ready pod/busybox1\n"
 "\n"
-"\t\t# The default value of status condition is true; you can set it to "
-"false\n"
+"\t\t# The default value of status condition is true; you can wait for other "
+"targets after an equal delimiter (compared after Unicode simple case "
+"folding, which is a more general form of case-insensitivity):\n"
 "\t\tkubectl wait --for=condition=Ready=false pod/busybox1\n"
+"\n"
+"\t\t# Wait for the pod \"busybox1\" to contain the status phase to be "
+"\"Running\".\n"
+"\t\tkubectl wait --for=jsonpath='{.status.phase}'=Running pod/busybox1\n"
 "\n"
 "\t\t# Wait for the pod \"busybox1\" to be deleted, with a timeout of 60s, "
 "after having issued the \"delete\" command\n"
@@ -1036,7 +1092,7 @@ msgid ""
 "\t\tkubectl wait --for=delete pod/busybox1 --timeout=60s"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go:110
+#: staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go:140
 msgid ""
 "\n"
 "\t\tApply a configuration to a resource by file name or stdin.\n"
@@ -1052,7 +1108,7 @@ msgid ""
 "k8s.io/34274."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:126
+#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:129
 msgid ""
 "\n"
 "\t\tApprove a certificate signing request.\n"
@@ -1153,7 +1209,7 @@ msgid ""
 "\t\tCreate a job with the specified name."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go:39
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go:40
 msgid ""
 "\n"
 "\t\tCreate a namespace with the specified name."
@@ -1196,7 +1252,7 @@ msgid ""
 "and description."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create.go:71
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create.go:74
 msgid ""
 "\n"
 "\t\tCreate a resource from a file or from stdin.\n"
@@ -1249,7 +1305,7 @@ msgid ""
 "\t\tCreate a service account with the specified name."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go:67
+#: staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go:70
 msgid ""
 "\n"
 "\t\tCreates a proxy server or application-level gateway between localhost "
@@ -1262,7 +1318,7 @@ msgid ""
 "static content path."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go:42
+#: staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go:43
 msgid ""
 "\n"
 "\t\tCreates an autoscaler that automatically chooses and sets the number of "
@@ -1275,7 +1331,7 @@ msgid ""
 "deployed within the system as needed."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:57
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:59
 msgid ""
 "\n"
 "\t\tDebug cluster resources using interactive debugging containers.\n"
@@ -1300,7 +1356,7 @@ msgid ""
 "\t\t        the node's filesystem.\n"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go:45
+#: staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go:46
 msgid ""
 "\n"
 "\t\tDelete resources by file names, stdin, resources and names, or by "
@@ -1349,10 +1405,16 @@ msgid ""
 "someone submits an\n"
 "\t\tupdate to a resource right when you submit a delete, their update will "
 "be lost along with the\n"
-"\t\trest of the resource."
+"\t\trest of the resource.\n"
+"\n"
+"\t\tAfter a CustomResourceDefinition is deleted, invalidation of discovery "
+"cache may take up\n"
+"\t\tto 6 hours. If you don't want to wait, you might want to run \"kubectl "
+"api-resources\" to refresh\n"
+"\t\tthe discovery cache."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:175
+#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:177
 msgid ""
 "\n"
 "\t\tDeny a certificate signing request.\n"
@@ -1406,7 +1468,17 @@ msgid ""
 "working on the server. "
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/config/view.go:54
+#: staging/src/k8s.io/kubectl/pkg/cmd/events/events.go:50
+msgid ""
+"\n"
+"\t\tDisplay events\n"
+"\n"
+"\t\tPrints a table of the most important information about events.\n"
+"\t\tYou can request events for a namespace, for all namespace, or\n"
+"\t\tfiltered to only those pertaining to a specified resource."
+msgstr ""
+
+#: staging/src/k8s.io/kubectl/pkg/cmd/config/view.go:52
 msgid ""
 "\n"
 "\t\tDisplay merged kubeconfig settings or a specified kubeconfig file.\n"
@@ -1415,7 +1487,7 @@ msgid ""
 "jsonpath expression."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/get/get.go:92
+#: staging/src/k8s.io/kubectl/pkg/cmd/get/get.go:90
 msgid ""
 "\n"
 "\t\tDisplay one or many resources.\n"
@@ -1428,16 +1500,13 @@ msgid ""
 "current\n"
 "\t\tnamespace unless you pass --all-namespaces.\n"
 "\n"
-"\t\tUninitialized objects are not shown unless --include-uninitialized is "
-"passed.\n"
-"\n"
 "\t\tBy specifying the output as 'template' and providing a Go template as "
 "the value\n"
 "\t\tof the --template flag, you can filter the attributes of the fetched "
 "resources."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go:57
+#: staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go:58
 msgid ""
 "\n"
 "\t\tDisplay resource (CPU/memory) usage of nodes.\n"
@@ -1445,7 +1514,7 @@ msgid ""
 "\t\tThe top-node command allows you to see the resource consumption of nodes."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go:67
+#: staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go:68
 msgid ""
 "\n"
 "\t\tDisplay resource (CPU/memory) usage of pods.\n"
@@ -1464,7 +1533,7 @@ msgid ""
 "\t\tDisplay the current-context."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:113
+#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:114
 msgid ""
 "\n"
 "\t\tDrain node in preparation for maintenance.\n"
@@ -1576,7 +1645,7 @@ msgid ""
 "\t\tsaved copy to include the latest resource version."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go:49
+#: staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go:54
 msgid ""
 "\n"
 "\t\tExperimental: Wait for a specific condition on one or many resources.\n"
@@ -1595,7 +1664,7 @@ msgid ""
 "destination."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:47
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:52
 msgid ""
 "\n"
 "\t\tExpose a resource as a new Kubernetes service.\n"
@@ -1618,7 +1687,7 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go:46
+#: staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go:50
 msgid ""
 "\n"
 "\t\tList all available plugin files on a user's PATH.\n"
@@ -1629,7 +1698,7 @@ msgid ""
 "\t\t- begin with \"kubectl-\"\n"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go:35
+#: staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go:38
 msgid ""
 "\n"
 "\t\tList the fields for supported resources.\n"
@@ -1649,22 +1718,22 @@ msgstr ""
 #: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout.go:30
 msgid ""
 "\n"
-"\t\tManage the rollout of a resource."
+"\t\tManage the rollout of one or many resources."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:84
+#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:85
 msgid ""
 "\n"
 "\t\tMark node as schedulable."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:55
+#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:56
 msgid ""
 "\n"
 "\t\tMark node as unschedulable."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause.go:57
+#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause.go:58
 msgid ""
 "\n"
 "\t\tMark the provided resource as paused.\n"
@@ -1674,10 +1743,11 @@ msgid ""
 "\t\tCurrently only deployments support being paused."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go:46
+#: staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go:47
 msgid ""
 "\n"
-"\t\tOutput shell completion code for the specified shell (bash or zsh).\n"
+"\t\tOutput shell completion code for the specified shell (bash, zsh, fish, "
+"or powershell).\n"
 "\t\tThe shell code must be evaluated to provide interactive\n"
 "\t\tcompletion of kubectl commands.  This can be done by sourcing it from\n"
 "\t\tthe .bash_profile.\n"
@@ -1700,7 +1770,7 @@ msgid ""
 "of zsh >= 5.2."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go:49
+#: staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go:50
 msgid ""
 "\n"
 "\t\tPrint the logs for a container in a pod or specified resource. \n"
@@ -1736,7 +1806,7 @@ msgid ""
 "will also be updated."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go:48
+#: staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go:49
 msgid ""
 "\n"
 "\t\tReplace a resource by file name or stdin.\n"
@@ -1748,7 +1818,7 @@ msgid ""
 "\t\t    $ kubectl get TYPE NAME -o yaml"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go:57
+#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go:58
 msgid ""
 "\n"
 "\t\tRestart a resource.\n"
@@ -1756,7 +1826,7 @@ msgid ""
 "\t        Resource rollout will be restarted."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_resume.go:58
+#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_resume.go:59
 msgid ""
 "\n"
 "\t\tResume a paused resource.\n"
@@ -1766,13 +1836,13 @@ msgid ""
 "\t\tCurrently only deployments support being resumed."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_undo.go:55
+#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_undo.go:56
 msgid ""
 "\n"
 "\t\tRoll back to a previous rollout."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster.go:47
+#: staging/src/k8s.io/kubectl/pkg/cmd/config/set_cluster.go:48
 msgid ""
 "\n"
 "\t\tSet a cluster entry in kubeconfig.\n"
@@ -1781,7 +1851,7 @@ msgid ""
 "existing values for those fields."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/config/create_context.go:44
+#: staging/src/k8s.io/kubectl/pkg/cmd/config/set_context.go:45
 msgid ""
 "\n"
 "\t\tSet a context entry in kubeconfig.\n"
@@ -1806,7 +1876,7 @@ msgid ""
 "\t\tscale is sent to the server."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/config/create_authinfo.go:70
+#: staging/src/k8s.io/kubectl/pkg/cmd/config/set_credentials.go:70
 #, c-format
 msgid ""
 "\n"
@@ -1903,7 +1973,7 @@ msgid ""
 "\t\tPossible resources include (case insensitive): %s."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go:50
+#: staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go:51
 msgid ""
 "\n"
 "\t\tUpdate environment variables on a pod template.\n"
@@ -1926,7 +1996,7 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go:71
+#: staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go:79
 msgid ""
 "\n"
 "\t\tUpdate existing container image(s) of resources.\n"
@@ -1935,13 +2005,15 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go:78
+#: staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go:82
 msgid ""
 "\n"
 "\t\tUpdate fields of a resource using strategic merge patch, a JSON merge "
 "patch, or a JSON patch.\n"
 "\n"
-"\t\tJSON and YAML formats are accepted."
+"\t\tJSON and YAML formats are accepted.\n"
+"\n"
+"\t\tNote: Strategic merge patch is not supported for custom resources."
 msgstr ""
 
 #: staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go:83
@@ -1964,7 +2036,7 @@ msgid ""
 "\t\tthe server the command will fail."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/label/label.go:87
+#: staging/src/k8s.io/kubectl/pkg/cmd/label/label.go:93
 #, c-format
 msgid ""
 "\n"
@@ -1981,7 +2053,7 @@ msgid ""
 "resource version, otherwise the existing resource-version will be used."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go:70
+#: staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go:71
 #, c-format
 msgid ""
 "\n"
@@ -2000,13 +2072,13 @@ msgid ""
 "\t\t* Currently taint can only apply to node."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go:36
+#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go:37
 msgid ""
 "\n"
 "\t\tView previous rollout revisions and configurations."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go:47
+#: staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go:48
 msgid ""
 "\n"
 "\t\tView the latest last-applied-configuration annotations by type/name or "
@@ -2025,7 +2097,7 @@ msgid ""
 "to/tls.key"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go:42
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go:43
 msgid ""
 "\n"
 "\t  # Create a new namespace named my-namespace\n"
@@ -2054,8 +2126,9 @@ msgid ""
 "\t  kubectl create secret generic my-secret --from-file=ssh-privatekey=path/"
 "to/id_rsa --from-literal=passphrase=topsecret\n"
 "\n"
-"\t  # Create a new secret named my-secret from an env file\n"
-"\t  kubectl create secret generic my-secret --from-env-file=path/to/bar.env"
+"\t  # Create a new secret named my-secret from env files\n"
+"\t  kubectl create secret generic my-secret --from-env-file=path/to/foo.env "
+"--from-env-file=path/to/bar.env"
 msgstr ""
 
 #: staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go:43
@@ -2083,11 +2156,32 @@ msgid ""
 "\tkubectl create deployment my-dep --image=busybox --port=5701"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:351
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:358
 msgid ""
 "\n"
 "\t# Create a new ExternalName service named my-ns\n"
 "\tkubectl create service externalname my-ns --external-name bar.com"
+msgstr ""
+
+#: staging/src/k8s.io/kubectl/pkg/cmd/events/events.go:57
+msgid ""
+"\n"
+"\t# List recent events in the default namespace.\n"
+"\tkubectl events\n"
+"\n"
+"\t# List recent events in all namespaces.\n"
+"\tkubectl events --all-namespaces\n"
+"\n"
+"\t# List recent events for the specified pod, then wait for more events and "
+"list them as they arrive.\n"
+"\tkubectl events --for pod/web-pod-13je7 --watch\n"
+"\n"
+"\t# List recent events in given format. Supported ones, apart from default, "
+"are json and yaml.\n"
+"\tkubectl events -oyaml\n"
+"\n"
+"\t# List recent only events in given event types\n"
+"\tkubectl events --types=Warning,Normal"
 msgstr ""
 
 #: staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount.go:50
@@ -2109,7 +2203,7 @@ msgid ""
 "\tCreate a deployment with the specified name."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:344
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:351
 msgid ""
 "\n"
 "\tCreate an ExternalName service with the specified name.\n"
@@ -2174,14 +2268,14 @@ msgid ""
 "role binding."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go:68
+#: staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go:76
 msgid ""
 "\n"
 "  \tpod (po), replicationcontroller (rc), deployment (deploy), daemonset "
-"(ds), replicaset (rs)"
+"(ds), statefulset (sts), cronjob (cj), replicaset (rs)"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go:63
+#: staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go:64
 msgid ""
 "\n"
 "                Forward one or more local ports to a pod.\n"
@@ -2196,7 +2290,7 @@ msgid ""
 "                to resume forwarding."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:233
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:240
 msgid ""
 "\n"
 "    # Create a new ClusterIP service named my-cs\n"
@@ -2206,14 +2300,14 @@ msgid ""
 "    kubectl create service clusterip my-cs --clusterip=\"None\""
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:311
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:318
 msgid ""
 "\n"
 "    # Create a new LoadBalancer service named my-lbs\n"
 "    kubectl create service loadbalancer my-lbs --tcp=5678:8080"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:274
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:281
 msgid ""
 "\n"
 "    # Create a new NodePort service named my-ns\n"
@@ -2267,19 +2361,19 @@ msgid ""
 "    kubectl annotate pods foo description-"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:230
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:237
 msgid ""
 "\n"
 "    Create a ClusterIP service with the specified name."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:308
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:315
 msgid ""
 "\n"
 "    Create a LoadBalancer service with the specified name."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:271
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:278
 msgid ""
 "\n"
 "    Create a NodePort service with the specified name."
@@ -2332,104 +2426,103 @@ msgstr ""
 msgid " is used and no merging takes place."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go:107
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go:108
 msgid ""
 "A comma-delimited set of quota scopes that must all match each object "
 "tracked by the quota."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go:106
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go:107
 msgid ""
 "A comma-delimited set of resource=quantity pairs that define a hard limit."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go:113
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go:114
 msgid ""
 "A label selector to use for this budget. Only equality-based selector "
 "requirements are supported."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:152
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:180
 msgid ""
 "A label selector to use for this service. Only equality-based selector "
 "requirements are supported. If empty (the default) infer the selector from "
 "the replication controller or replica set.)"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:157
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:183
 msgid ""
 "Additional external IP address (not managed by Kubernetes) to accept for the "
 "service. If this IP is routed to a node, the service can be accessed by this "
 "IP in addition to its generated service IP."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:178
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:184
 msgid "Allocate a TTY for the debugging container."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:158
-#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:178
+#: staging/src/k8s.io/kubectl/pkg/cmd/util/override_options.go:50
 msgid ""
 "An inline JSON override for the generated object. If this is non-empty, it "
 "is used to override the generated object. Requires that the object supply a "
 "valid apiVersion field."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:173
+#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:191
 msgid "Annotations to apply to the pod."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go:173
+#: staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go:198
 msgid "Apply a configuration to a resource by file name or stdin"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:125
+#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:128
 msgid "Approve a certificate signing request"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:263
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:270
 msgid ""
 "Assign your own ClusterIP or set to 'None' for a 'headless' service (no "
 "loadbalancing)."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go:106
+#: staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go:108
 msgid ""
 "Attach to a process that is already running inside an existing container."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go:105
+#: staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go:107
 msgid "Attach to a running container"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go:107
+#: staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go:108
 msgid ""
 "Auto-scale a deployment, replica set, stateful set, or replication controller"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:161
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:186
 msgid ""
 "ClusterIP to be assigned to the service. Leave empty to auto-allocate, or "
 "set to 'None' to create a headless service."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go:101
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go:102
 msgid "ClusterRole this ClusterRoleBinding should reference"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go:104
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go:105
 msgid "ClusterRole this RoleBinding should reference"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/alpha.go:32
+#: staging/src/k8s.io/kubectl/pkg/cmd/alpha.go:33
 msgid "Commands for features in alpha"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:170
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:176
 msgid "Container image to use for debug container."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:166
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:172
 msgid "Container name to use for debug container."
 msgstr ""
 
@@ -2437,27 +2530,27 @@ msgstr ""
 msgid "Convert config files between different API versions"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go:105
+#: staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go:99
 msgid "Copy files and directories to and from containers"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go:106
+#: staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go:100
 msgid "Copy files and directories to and from containers."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:248
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:255
 msgid "Create a ClusterIP service"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:323
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:330
 msgid "Create a LoadBalancer service"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:286
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:293
 msgid "Create a NodePort service"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go:94
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go:95
 msgid "Create a TLS secret"
 msgstr ""
 
@@ -2465,63 +2558,63 @@ msgstr ""
 msgid "Create a cluster role"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go:87
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go:88
 msgid "Create a cluster role binding for a particular cluster role"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go:124
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go:123
 msgid "Create a config map from a local file, directory or literal value"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:167
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:173
 msgid "Create a copy of the target Pod with this name."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go:90
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go:91
 msgid "Create a cron job with the specified name"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go:100
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go:101
 msgid "Create a deployment with the specified name"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go:91
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go:92
 msgid "Create a job with the specified name"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go:83
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go:85
 msgid "Create a namespace with the specified name"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go:95
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go:96
 msgid "Create a pod disruption budget with the specified name"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go:92
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go:93
 msgid "Create a priority class with the specified name"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go:91
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go:92
 msgid "Create a quota with the specified name"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create.go:106
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create.go:109
 msgid "Create a resource from a file or from stdin"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go:89
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go:90
 msgid "Create a role binding for a particular role or cluster role"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go:161
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go:172
 msgid "Create a role with single rule"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go:134
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go:135
 msgid "Create a secret for use with a Docker registry"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go:137
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go:138
 msgid "Create a secret from a local file, directory, or literal value"
 msgstr ""
 
@@ -2533,7 +2626,7 @@ msgstr ""
 msgid "Create a secret using specified subcommand."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go:85
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go:86
 msgid "Create a service account with the specified name"
 msgstr ""
 
@@ -2545,11 +2638,11 @@ msgstr ""
 msgid "Create a service using a specified subcommand."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:363
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:370
 msgid "Create an ExternalName service"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go:145
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go:146
 msgid "Create an ingress with the specified name"
 msgstr ""
 
@@ -2557,11 +2650,15 @@ msgstr ""
 msgid "Create and run a particular image in a pod."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:149
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:155
 msgid "Create debugging sessions for troubleshooting workloads and nodes"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go:137
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:185
+msgid "Debugging profile."
+msgstr ""
+
+#: staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go:146
 msgid ""
 "Delete resources by file names, stdin, resources and names, or by resources "
 "and label selector"
@@ -2583,23 +2680,23 @@ msgstr ""
 msgid "Delete the specified context from the kubeconfig."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user.go:64
+#: staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user.go:65
 msgid "Delete the specified user from the kubeconfig"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user.go:65
+#: staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user.go:66
 msgid "Delete the specified user from the kubeconfig."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:174
+#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:176
 msgid "Deny a certificate signing request"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go:72
+#: staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go:75
 msgid "Describe one or many contexts"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go:142
+#: staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go:136
 msgid "Diff the live version against a would-be applied version"
 msgstr ""
 
@@ -2615,15 +2712,15 @@ msgstr ""
 msgid "Display clusters defined in the kubeconfig."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/config/view.go:81
+#: staging/src/k8s.io/kubectl/pkg/cmd/config/view.go:79
 msgid "Display merged kubeconfig settings or a specified kubeconfig file"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go:50
+#: staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go:53
 msgid "Display one or many contexts from the kubeconfig file."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/get/get.go:165
+#: staging/src/k8s.io/kubectl/pkg/cmd/get/get.go:166
 msgid "Display one or many resources"
 msgstr ""
 
@@ -2631,11 +2728,11 @@ msgstr ""
 msgid "Display resource (CPU/memory) usage"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go:81
+#: staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go:82
 msgid "Display resource (CPU/memory) usage of nodes"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go:100
+#: staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go:101
 msgid "Display resource (CPU/memory) usage of pods"
 msgstr ""
 
@@ -2651,7 +2748,7 @@ msgstr ""
 msgid "Display users defined in the kubeconfig."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:184
+#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:185
 msgid "Drain node in preparation for maintenance"
 msgstr ""
 
@@ -2659,7 +2756,7 @@ msgstr ""
 msgid "Dump relevant information for debugging and diagnosis"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go:77
+#: staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go:78
 msgid "Edit a resource on the server"
 msgstr ""
 
@@ -2667,11 +2764,11 @@ msgstr ""
 msgid "Edit latest last-applied-configuration annotations of a resource/object"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go:152
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go:153
 msgid "Email for Docker registry"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:169
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:175
 msgid "Environment variables to set in the container."
 msgstr ""
 
@@ -2683,19 +2780,19 @@ msgstr ""
 msgid "Execute a command in a container."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go:115
+#: staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go:123
 msgid "Experimental: Wait for a specific condition on one or many resources"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:378
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go:385
 msgid "External name of service"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go:109
+#: staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go:110
 msgid "Forward one or more local ports to a pod"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go:79
+#: staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go:97
 msgid "Get documentation for a resource"
 msgstr ""
 
@@ -2703,80 +2800,84 @@ msgstr ""
 msgid "Help about any command"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:151
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:179
 msgid ""
 "IP to assign to the LoadBalancer. If empty, an ephemeral IP will be created "
 "and used (cloud-provider specific)."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:160
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:185
 msgid ""
 "If non-empty, set the session affinity for the service to this; legal "
 "values: 'None', 'ClientIP'"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go:157
+#: staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go:156
 msgid ""
 "If non-empty, the annotation update will only succeed if this is the current "
 "resource-version for the object. Only valid when specifying a single "
 "resource."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/label/label.go:154
+#: staging/src/k8s.io/kubectl/pkg/cmd/label/label.go:159
 msgid ""
 "If non-empty, the labels update will only succeed if this is the current "
 "resource-version for the object. Only valid when specifying a single "
 "resource."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:164
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:170
 msgid ""
 "If specified, everything after -- will be passed to the new container as "
 "Args instead of Command."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:198
+#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:207
 msgid "If true, run the container in privileged mode."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:174
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:180
 msgid "If true, suppress informational messages."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:165
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:171
 msgid ""
 "If true, wait for the container to start running, and then attach as if "
 "'kubectl attach ...' were called.  Default false, unless '-i/--stdin' is "
 "set, in which case the default is true."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:173
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:179
 msgid ""
 "Keep stdin open on the container(s) in the pod, even if nothing is attached."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go:90
+#: staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go:94
 msgid "List all visible plugin executables on a user's PATH"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout.go:54
+#: staging/src/k8s.io/kubectl/pkg/cmd/events/events.go:125
+msgid "List events"
+msgstr ""
+
+#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout.go:60
 msgid "Manage the rollout of a resource"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:98
+#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:99
 msgid "Mark node as schedulable"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:69
+#: staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go:70
 msgid "Mark node as unschedulable"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause.go:83
+#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause.go:84
 msgid "Mark the provided resource as paused"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:49
-#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:50
+#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:47
+#: staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:48
 msgid "Modify certificate resources."
 msgstr ""
 
@@ -2784,24 +2885,26 @@ msgstr ""
 msgid "Modify kubeconfig files"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:156
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:182
 msgid ""
 "Name or number for the port on the container that the service should direct "
 "traffic to. Optional."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/alpha.go:43
+#: staging/src/k8s.io/kubectl/pkg/cmd/alpha.go:53
 msgid "No alpha commands are available in this version of kubectl"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go:174
+#: staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go:175
 msgid ""
 "Only return logs after a specific date (RFC3339). Defaults to all logs. Only "
 "one of since-time / since may be used."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go:112
-msgid "Output shell completion code for the specified shell (bash or zsh)"
+#: staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go:134
+msgid ""
+"Output shell completion code for the specified shell (bash, zsh, fish, or "
+"powershell)"
 msgstr ""
 
 #: pkg/kubectl/cmd/convert/convert.go:105
@@ -2810,29 +2913,29 @@ msgid ""
 "'extensions/v1beta1')."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go:151
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go:152
 msgid "Password for Docker registry authentication"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go:110
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go:111
 msgid "Path to PEM encoded public key certificate."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go:111
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go:112
 msgid "Path to private key associated with given certificate."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go:130
+#: staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go:129
 msgid ""
 "Precondition for resource version. Requires that the current resource "
 "version match this value in order to scale."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/version/version.go:73
+#: staging/src/k8s.io/kubectl/pkg/cmd/version/version.go:80
 msgid "Print the client and server version information"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/version/version.go:74
+#: staging/src/k8s.io/kubectl/pkg/cmd/version/version.go:81
 msgid ""
 "Print the client and server version information for the current context."
 msgstr ""
@@ -2842,15 +2945,15 @@ msgstr ""
 msgid "Print the list of flags inherited by all commands"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go:152
+#: staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go:153
 msgid "Print the logs for a container in a pod"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go:97
+#: staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go:101
 msgid "Print the supported API resources on the server"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go:98
+#: staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go:102
 msgid "Print the supported API resources on the server."
 msgstr ""
 
@@ -2866,7 +2969,7 @@ msgid ""
 "version\"."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go:62
+#: staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go:66
 msgid "Provides utilities for interacting with plugins"
 msgstr ""
 
@@ -2874,39 +2977,39 @@ msgstr ""
 msgid "Rename a context from the kubeconfig file"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go:115
+#: staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go:121
 msgid "Replace a resource by file name or stdin"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go:87
+#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go:91
 msgid "Restart a resource"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_resume.go:87
+#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_resume.go:88
 msgid "Resume a paused resource"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go:105
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go:106
 msgid "Role this RoleBinding should reference"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:152
+#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:153
 msgid "Run a particular image on the cluster"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go:119
+#: staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go:122
 msgid "Run a proxy to the Kubernetes API server"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go:153
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go:154
 msgid "Server location for Docker registry"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster.go:73
+#: staging/src/k8s.io/kubectl/pkg/cmd/config/set_cluster.go:77
 msgid "Set a cluster entry in kubeconfig"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/config/create_context.go:61
+#: staging/src/k8s.io/kubectl/pkg/cmd/config/set_context.go:62
 msgid "Set a context entry in kubeconfig"
 msgstr ""
 
@@ -2914,7 +3017,7 @@ msgstr ""
 msgid "Set a new size for a deployment, replica set, or replication controller"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/config/create_authinfo.go:152
+#: staging/src/k8s.io/kubectl/pkg/cmd/config/set_credentials.go:158
 msgid "Set a user entry in kubeconfig"
 msgstr ""
 
@@ -2940,118 +3043,92 @@ msgstr ""
 msgid "Set the selector on a resource"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go:107
+#: staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go:150
 msgid "Show details of a specific resource or group of resources"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go:102
+#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go:103
 msgid "Show the status of the rollout"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:154
-msgid "Synonym for --target-port"
-msgstr ""
-
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:134
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:163
 msgid ""
 "Take a replication controller, service, deployment or pod and expose it as a "
 "new Kubernetes service"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:174
+#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:192
 msgid "The image for the container to run."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:176
+#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:194
 msgid ""
-"The image pull policy for the container. If left empty, this value will not "
-"be specified by the client and defaulted by the server"
+"The image pull policy for the container.  If left empty, this value will not "
+"be specified by the client and defaulted by the server."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:172
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:178
 msgid ""
 "The image pull policy for the container. If left empty, this value will not "
 "be specified by the client and defaulted by the server."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go:112
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go:113
 msgid ""
 "The maximum number or percentage of unavailable pods this budget requires."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go:111
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go:112
 msgid ""
 "The minimum number or percentage of available pods this budget requires."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:159
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:184
 msgid "The name for the newly created object."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go:125
+#: staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go:126
 msgid ""
 "The name for the newly created object. If not specified, the name of the "
 "input resource will be used."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:147
-msgid ""
-"The name of the API generator to use. There are 2 generators: 'service/v1' "
-"and 'service/v2'. The only difference between them is that service port in "
-"v1 is named 'default', while it is left unnamed in v2. Default is 'service/"
-"v2'."
-msgstr ""
-
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:148
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:176
 msgid "The network protocol for the service to be created. Default is 'TCP'."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:149
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:177
 msgid ""
 "The port that the service should serve on. Copied from the resource being "
 "exposed, if unspecified"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:182
+#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:197
 msgid "The port that this container exposes."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:194
-msgid ""
-"The resource requirement limits for this container.  For example, 'cpu=200m,"
-"memory=512Mi'.  Note that server side components may assign limits depending "
-"on the server configuration, such as limit ranges."
-msgstr ""
-
-#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:192
-msgid ""
-"The resource requirement requests for this container.  For example, "
-"'cpu=100m,memory=256Mi'.  Note that server side components may assign "
-"requests depending on the server configuration, such as limit ranges."
-msgstr ""
-
-#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:190
+#: staging/src/k8s.io/kubectl/pkg/cmd/run/run.go:203
 msgid ""
 "The restart policy for this Pod.  Legal values [Always, OnFailure, Never]."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go:155
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go:156
 msgid "The type of secret to create"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/alpha.go:33
+#: staging/src/k8s.io/kubectl/pkg/cmd/alpha.go:34
 msgid ""
 "These commands correspond to alpha features that are not enabled in "
 "Kubernetes clusters by default."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:150
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:178
 msgid ""
 "Type for this service: ClusterIP, NodePort, LoadBalancer, or ExternalName. "
 "Default is 'ClusterIP'."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_undo.go:87
+#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_undo.go:88
 msgid "Undo a previous rollout"
 msgstr ""
 
@@ -3059,11 +3136,11 @@ msgstr ""
 msgid "Unset an individual value in a kubeconfig file"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go:154
+#: staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go:156
 msgid "Update environment variables on a pod template"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go:115
+#: staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go:126
 msgid "Update fields of a resource"
 msgstr ""
 
@@ -3075,11 +3152,11 @@ msgstr ""
 msgid "Update the annotations on a resource"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go:110
+#: staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go:118
 msgid "Update the image of a pod template"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/label/label.go:133
+#: staging/src/k8s.io/kubectl/pkg/cmd/label/label.go:139
 msgid "Update the labels on a resource"
 msgstr ""
 
@@ -3087,7 +3164,7 @@ msgstr ""
 msgid "Update the service account of a resource"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go:109
+#: staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go:110
 msgid "Update the taints on one or more nodes"
 msgstr ""
 
@@ -3097,40 +3174,40 @@ msgid ""
 "binding"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go:150
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go:151
 msgid "Username for Docker registry authentication"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go:83
+#: staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go:85
 msgid "View rollout history"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go:77
+#: staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go:78
 msgid ""
 "View the latest last-applied-configuration annotations of a resource/object"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:171
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:177
 msgid ""
 "When used with '--copy-to', a list of name=image pairs for changing "
 "container images, similar to how 'kubectl set image' works."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:168
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:174
 msgid "When used with '--copy-to', delete the original Pod."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:176
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:182
 msgid ""
 "When used with '--copy-to', enable process namespace sharing in the copy."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:175
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:181
 msgid ""
 "When used with '--copy-to', schedule the copy of target Pod on the same node."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:177
+#: staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go:183
 msgid ""
 "When using an ephemeral container, target processes in this container name."
 msgstr ""
@@ -3141,7 +3218,7 @@ msgid ""
 "directory hierarchy in that directory"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go:108
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go:109
 msgid ""
 "description is an arbitrary string that usually provides guidelines on when "
 "this priority class should be used."
@@ -3151,23 +3228,23 @@ msgstr ""
 msgid "dummy restart flag)"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go:107
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go:108
 msgid ""
 "global-default specifies whether this PriorityClass should be considered as "
 "the default priority."
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/cmd.go:227
+#: staging/src/k8s.io/kubectl/pkg/cmd/cmd.go:274
 msgid "kubectl controls the Kubernetes cluster manager"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:45
+#: staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go:50
 msgid ""
 "pod (po), service (svc), replicationcontroller (rc), deployment (deploy), "
 "replicaset (rs)"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go:109
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go:110
 msgid ""
 "preemption-policy is the policy for preempting pods with lower priority."
 msgstr ""
@@ -3178,6 +3255,6 @@ msgid ""
 "replicaset (rs), statefulset"
 msgstr ""
 
-#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go:106
+#: staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go:107
 msgid "the value of this priority class."
 msgstr ""


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Replace specific backslash escape handling with generalized backslash handling.

Fixes bug where `\` would not be escaped when it should, resulting in `hack/update-translations.sh` failing or producing the wrong output.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1326

#### Special notes for your reviewer:
I regenerated `template.pot` now that the script works again.  This picked up a bunch of changes since it hasn't been updated in 17 months.

This doesn't update translations, but the updated `template.pot` enables translations to be updated again as it contains the updated msgid keys.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
