### PR TITLE
i18n: Fix bug where package-level variables are not translated.

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -331,13 +331,6 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 
 	f := cmdutil.NewFactory(matchVersionKubeConfigFlags)
 
-	// Sending in 'nil' for the getLanguageFn() results in using
-	// the LANG environment variable.
-	//
-	// TODO: Consider adding a flag or file preference for setting
-	// the language, instead of just loading from the LANG env. variable.
-	i18n.LoadTranslations("kubectl", nil)
-
 	// Proxy command is incompatible with CommandHeaderRoundTripper, so
 	// clear the WrapConfigFn before running proxy command.
 	proxyCmd := proxy.NewCmdProxy(f, o.IOStreams)

--- a/staging/src/k8s.io/kubectl/pkg/util/i18n/i18n_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/i18n/i18n_test.go
@@ -18,7 +18,10 @@ package i18n
 
 import (
 	"os"
+	"sync"
 	"testing"
+
+	"github.com/chai2010/gettext-go"
 )
 
 var knownTestLocale = "en_US.UTF-8"
@@ -153,5 +156,133 @@ func TestTranslationUsingEnvVar(t *testing.T) {
 				t.Errorf("expected: %s, saw: %s", test.expectedStr, result)
 			}
 		})
+	}
+}
+
+// resetLazyLoading allows multiple tests to test translation lazy loading by resetting the state
+func resetLazyLoading() {
+	translationsLoaded = false
+	lazyLoadTranslationsOnce = sync.Once{}
+}
+
+func TestLazyLoadTranslationFuncIsCalled(t *testing.T) {
+	resetLazyLoading()
+
+	timesCalled := 0
+	err := SetLoadTranslationsFunc(func() error {
+		timesCalled++
+		return LoadTranslations("test", func() string { return "en_US" })
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if translationsLoaded {
+		t.Errorf("expected translationsLoaded to be false, but it was true")
+	}
+
+	// Translation should succeed and use the lazy loaded translations
+	result := T("test_string")
+	if result != "baz" {
+		t.Errorf("expected: %s, saw: %s", "baz", result)
+	}
+	if timesCalled != 1 {
+		t.Errorf("expected LoadTranslationsFunc to have been called 1 time, but it was called %d times", timesCalled)
+	}
+	if !translationsLoaded {
+		t.Errorf("expected translationsLoaded to be true, but it was false")
+	}
+
+	// Call T() again, and timesCalled should remain 1
+	T("test_string")
+	if timesCalled != 1 {
+		t.Errorf("expected LoadTranslationsFunc to have been called 1 time, but it was called %d times", timesCalled)
+	}
+}
+
+func TestLazyLoadTranslationFuncOnlyCalledIfTranslationsNotLoaded(t *testing.T) {
+	resetLazyLoading()
+
+	// Set a custom translations func
+	timesCalled := 0
+	err := SetLoadTranslationsFunc(func() error {
+		timesCalled++
+		return LoadTranslations("test", func() string { return "en_US" })
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if translationsLoaded {
+		t.Errorf("expected translationsLoaded to be false, but it was true")
+	}
+
+	// Explicitly load translations before lazy loading can occur
+	err = LoadTranslations("test", func() string { return "default" })
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !translationsLoaded {
+		t.Errorf("expected translationsLoaded to be true, but it was false")
+	}
+
+	// Translation should succeed, and use the explicitly loaded translations, not the lazy loaded ones
+	result := T("test_string")
+	if result != "foo" {
+		t.Errorf("expected: %s, saw: %s", "foo", result)
+	}
+	if timesCalled != 0 {
+		t.Errorf("expected LoadTranslationsFunc to have not been called, but it was called %d times", timesCalled)
+	}
+}
+
+func TestSetCustomLoadTranslationsFunc(t *testing.T) {
+	resetLazyLoading()
+
+	// Set a custom translations func that loads translations from a directory
+	err := SetLoadTranslationsFunc(func() error {
+		gettext.BindLocale(gettext.New("k8s", "./translations/test"))
+		gettext.SetDomain("k8s")
+		gettext.SetLanguage("en_US")
+		return nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if translationsLoaded {
+		t.Errorf("expected translationsLoaded to be false, but it was true")
+	}
+
+	// Translation should succeed
+	result := T("test_string")
+	if result != "baz" {
+		t.Errorf("expected: %s, saw: %s", "baz", result)
+	}
+	if !translationsLoaded {
+		t.Errorf("expected translationsLoaded to be true, but it was false")
+	}
+}
+
+func TestSetCustomLoadTranslationsFuncAfterTranslationsLoadedShouldFail(t *testing.T) {
+	resetLazyLoading()
+
+	// Explicitly load translations
+	err := LoadTranslations("test", func() string { return "en_US" })
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !translationsLoaded {
+		t.Errorf("expected translationsLoaded to be true, but it was false")
+	}
+
+	// This should fail because translations have already been loaded, and the custom function should not be called.
+	timesCalled := 0
+	err = SetLoadTranslationsFunc(func() error {
+		timesCalled++
+		return nil
+	})
+	if err == nil {
+		t.Errorf("expected error, but it did not occur")
+	}
+	if timesCalled != 0 {
+		t.Errorf("expected LoadTranslationsFunc to have not been called, but it was called %d times", timesCalled)
 	}
 }

--- a/test/cmd/help.sh
+++ b/test/cmd/help.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+run_kubectl_help_tests() {
+  set -o nounset
+  set -o errexit
+
+  # The purpose of this test is to exercise the translation functionality in a simple way.
+  # If the strings used by this test are changed, they will need to be updated here so that this test will pass.
+
+  kube::test::if_has_string "$(kubectl help)" "Modify kubeconfig files"
+  kube::test::if_has_string "$(LANG=de_DE.UTF8 kubectl help)" "Verändere kubeconfig Dateien"
+  kube::test::if_has_string "$(LANG=en_US.UTF8 kubectl help)" "Modify kubeconfig files"
+  kube::test::if_has_string "$(LANG=fr_FR.UTF8 kubectl help)" "Modifier des fichiers kubeconfig"
+  kube::test::if_has_string "$(LANG=it_IT.UTF8 kubectl help)" "Modifica i file kubeconfig"
+  kube::test::if_has_string "$(LANG=ja_JP.UTF8 kubectl help)" "kubeconfigを変更する"
+  kube::test::if_has_string "$(LANG=ko_KR.UTF8 kubectl help)" "kubeconfig 파일을 수정합니다"
+  kube::test::if_has_string "$(LANG=pt_BR.UTF8 kubectl help)" "Edita o arquivo kubeconfig"
+  kube::test::if_has_string "$(LANG=zh_CN.UTF8 kubectl help)" "修改 kubeconfig 文件"
+  kube::test::if_has_string "$(LANG=zh_TW.UTF8 kubectl help)" "修改 kubeconfig 檔案"
+
+  kube::test::if_has_string "$(kubectl uncordon --help)" "Mark node as schedulable."
+  kube::test::if_has_string "$(LANG=de_DE.UTF-8 kubectl uncordon --help)" "Markiere Knoten als schedulable."
+  kube::test::if_has_string "$(LANG=en_US.UTF-8 kubectl uncordon --help)" "Mark node as schedulable."
+  kube::test::if_has_string "$(LANG=fr_FR.UTF-8 kubectl uncordon --help)" "Mark node as schedulable."
+  kube::test::if_has_string "$(LANG=it_IT.UTF-8 kubectl uncordon --help)" "Contrassegna il nodo come programmabile."
+  kube::test::if_has_string "$(LANG=ja_JP.UTF-8 kubectl uncordon --help)" "Mark node as schedulable."
+  kube::test::if_has_string "$(LANG=ko_KR.UTF-8 kubectl uncordon --help)" "Mark node as schedulable."
+  kube::test::if_has_string "$(LANG=pt_BR.UTF-8 kubectl uncordon --help)" "Remove a restrição de execução de workloads no node."
+  kube::test::if_has_string "$(LANG=zh_CN.UTF-8 kubectl uncordon --help)" "标记节点为可调度。"
+  kube::test::if_has_string "$(LANG=zh_TW.UTF-8 kubectl uncordon --help)" "Mark node as schedulable."
+
+  set +o nounset
+  set +o errexit
+}

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -45,6 +45,7 @@ source "${KUBE_ROOT}/test/cmd/events.sh"
 source "${KUBE_ROOT}/test/cmd/exec.sh"
 source "${KUBE_ROOT}/test/cmd/generic-resources.sh"
 source "${KUBE_ROOT}/test/cmd/get.sh"
+source "${KUBE_ROOT}/test/cmd/help.sh"
 source "${KUBE_ROOT}/test/cmd/kubeconfig.sh"
 source "${KUBE_ROOT}/test/cmd/node-management.sh"
 source "${KUBE_ROOT}/test/cmd/plugins.sh"
@@ -554,6 +555,12 @@ runTests() {
   if kube::test::if_supports_resource "${pods}" ; then
     record_command run_kubectl_get_tests
   fi
+
+  ################
+  # Kubectl help #
+  ################
+
+  record_command run_kubectl_help_tests
 
   ##################
   # Kubectl events #


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

The call to `i18n.LoadTranslations()` needs to occur on init so that package-level variables that call `i18n.T()` to initialize their values will be able to receive the translated string.

Added new integration tests to test help output translation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1327

#### Special notes for your reviewer:

I *think* it should be OK to move `LoadTranslations` to `init`, but let me know if you can think of any problems this would cause.  The alternative to this would be we say you cannot use `i18n.T()` to initialize package-level variables.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
