### PR TITLE
Fix a potential goroutine leak

### DIFF
--- a/cluster/images/etcd/migrate/migrate_server.go
+++ b/cluster/images/etcd/migrate/migrate_server.go
@@ -66,10 +66,10 @@ func (r *EtcdMigrateServer) Start(version *EtcdVersion) error {
 	}
 	interval := time.NewTicker(time.Millisecond * 500)
 	defer interval.Stop()
-	done := make(chan bool, 1)
+	done := make(chan bool)
 	go func() {
 		time.Sleep(time.Minute * 2)
-		done <- true
+		close(done)
 	}()
 	for {
 		select {
@@ -108,7 +108,7 @@ func (r *EtcdMigrateServer) Stop() error {
 	timedout := make(chan bool)
 	go func() {
 		time.Sleep(gracefulWait)
-		timedout <- true
+		close(timedout)
 	}()
 	go func() {
 		select {
@@ -121,7 +121,7 @@ func (r *EtcdMigrateServer) Stop() error {
 		}
 	}()
 	err = r.cmd.Wait()
-	stopped <- true
+	close(stopped)
 	if exiterr, ok := err.(*exec.ExitError); ok {
 		klog.Infof("etcd server stopped (signal: %s)", exiterr.Error())
 		// stopped


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When the server stopped before timeout, the `stopped <-true` will be executed and in the select block, the first case will be chosen. This will lead to a hanging goroutine at line 111 because no receiver of `timeout` is left. Changing the `timeout` chan to a buffered one can fix it.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #114070

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
