### PR TITLE
Bump GOLANG_VERSION to build etcd `migrate` utility

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -81,10 +81,10 @@ dependencies:
 
   # From https://github.com/etcd-io/etcd/blob/main/Makefile
   - name: "golang: etcd release version"
-    version: 1.16.15 # for etcd v3.5.5: https://github.com/etcd-io/etcd/blob/19002cfc689fba2b8f56605e5797bf79f8b61fdd/Makefile#L58
+    version: 1.17.13 # for etcd v3.5.6: https://github.com/etcd-io/etcd/blob/v3.5.6/Makefile#L58 golang version should be 1.16.15, BUT because of newer dependencies in our repository we use newer golang which has `unsafe.Slice`
     refPaths:
     - path: cluster/images/etcd/Makefile
-      match: 'GOLANG_VERSION\?=\d+.\d+(alpha|beta|rc)?\.?(\d+)?'
+      match: 'GOLANG_VERSION := \d+.\d+(alpha|beta|rc)?\.?(\d+)?'
 
   # Golang
   - name: "golang: upstream version"

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -34,7 +34,7 @@ LATEST_ETCD_VERSION?=3.5.6
 # REVISION provides a version number for this image and all it's bundled
 # artifacts. It should start at zero for each LATEST_ETCD_VERSION and increment
 # for each revision of this image at that etcd version.
-REVISION?=1
+REVISION?=0
 
 # IMAGE_TAG Uniquely identifies registry.k8s.io/etcd docker image with a tag of the form "<etcd-version>-<revision>".
 IMAGE_TAG=$(LATEST_ETCD_VERSION)-$(REVISION)
@@ -83,7 +83,7 @@ endif
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
 # golang version should match the golang version of the official build from https://github.com/etcd-io/etcd/releases.
-GOLANG_VERSION?=1.16.15
+GOLANG_VERSION := 1.17.13
 GOARM?=7
 TEMP_DIR:=$(shell mktemp -d)
 


### PR DESCRIPTION
`post-kubernetes-push-image-etcd` is failing to build etcd image version `v3.5.6-0`:
https://storage.googleapis.com/kubernetes-jenkins/logs/post-kubernetes-push-image-etcd/1595408405093158912/build-log.txt

Failure is as follows when building `migrate` utility:
```
# k8s.io/kubernetes/vendor/golang.org/x/sys/unix
src/k8s.io/kubernetes/vendor/golang.org/x/sys/unix/syscall.go:83:16: undefined: unsafe.Slice
src/k8s.io/kubernetes/vendor/golang.org/x/sys/unix/syscall_linux.go:2255:9: undefined: unsafe.Slice
src/k8s.io/kubernetes/vendor/golang.org/x/sys/unix/syscall_unix.go:118:7: undefined: unsafe.Slice
src/k8s.io/kubernetes/vendor/golang.org/x/sys/unix/sysvshm_unix.go:33:7: undefined: unsafe.Slice
install: can't stat '/workspace/tmp.HjFnIo/migrate': No such file or directory
```

This is because we moved our vendored directories for `x/sys/unix` which ends up using `unsafe.Slice` which was introduced in golang 1.17

So instead of using `1.16.15` from:
https://github.com/etcd-io/etcd/blob/v3.5.6/Makefile#L58

Let us use the latest in 1.17.x series of golang which is `go1.17.13`

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
