### PR TITLE
Bump gcb-docker-gcloud to `v20221007-69e0da97ef`

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -220,3 +220,14 @@ dependencies:
       match: gcr.io\/cadvisor\/cadvisor:v\d+\.\d+\.\d+
     - path: test/e2e_node/image_list.go
       mathc: gcr.io\/cadvisor\/cadvisor:v\d+\.\d+\.\d+
+
+  # GCB docker gcloud image
+  - name: "gcb-docker-gcloud: dependents"
+    version: v20221007-69e0da97ef
+    refPaths:
+    - path: build/pause/cloudbuild.yaml
+      match: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
+    - path: cluster/images/etcd/cloudbuild.yaml
+      match: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
+    - path: test/images/cloudbuild.yaml
+      match: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud

--- a/build/pause/cloudbuild.yaml
+++ b/build/pause/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-69e0da97ef'
     entrypoint: 'bash'
     dir: ./build/pause
     env:

--- a/cluster/images/etcd/cloudbuild.yaml
+++ b/cluster/images/etcd/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-69e0da97ef'
     entrypoint: 'bash'
     dir: ./cluster/images/etcd
     env:

--- a/test/images/cloudbuild.yaml
+++ b/test/images/cloudbuild.yaml
@@ -9,7 +9,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-69e0da97ef'
     entrypoint: 'bash'
     dir: ./test/images/
     env:


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update the container images used in cloudbuild to their latest version.

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:
Found during the debugging in https://github.com/kubernetes/kubernetes/pull/114084

**Can be merged after 1.26 and has no need to be part of the 1.26 milestone.**

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
