### PR TITLE
e2e: Update GetExternalIP and GetInternalIP method name to make them more explicit.

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -1070,7 +1070,7 @@ func httpGetNoConnectionPoolTimeout(url string, timeout time.Duration) (*http.Re
 // This function executes commands on a node so it will work only for some
 // environments.
 func TestUnderTemporaryNetworkFailure(c clientset.Interface, ns string, node *v1.Node, testFunc func()) {
-	host, err := e2enode.GetExternalIP(node)
+	host, err := e2enode.GetSSHExternalIP(node)
 	if err != nil {
 		framework.Failf("Error getting node external ip : %v", err)
 	}

--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -217,36 +217,28 @@ func TotalReady(c clientset.Interface) (int, error) {
 	return len(nodes.Items), nil
 }
 
-// GetExternalIP returns node external IP concatenated with port 22 for ssh
+// GetSSHExternalIP returns node external IP concatenated with port 22 for ssh
 // e.g. 1.2.3.4:22
-func GetExternalIP(node *v1.Node) (string, error) {
+func GetSSHExternalIP(node *v1.Node) (string, error) {
 	framework.Logf("Getting external IP address for %s", node.Name)
-	host := ""
+
 	for _, a := range node.Status.Addresses {
 		if a.Type == v1.NodeExternalIP && a.Address != "" {
-			host = net.JoinHostPort(a.Address, sshPort)
-			break
+			return net.JoinHostPort(a.Address, sshPort), nil
 		}
 	}
-	if host == "" {
-		return "", fmt.Errorf("Couldn't get the external IP of host %s with addresses %v", node.Name, node.Status.Addresses)
-	}
-	return host, nil
+	return "", fmt.Errorf("Couldn't get the external IP of host %s with addresses %v", node.Name, node.Status.Addresses)
 }
 
-// GetInternalIP returns node internal IP
-func GetInternalIP(node *v1.Node) (string, error) {
-	host := ""
+// GetSSHInternalIP returns node internal IP concatenated with port 22 for ssh
+func GetSSHInternalIP(node *v1.Node) (string, error) {
 	for _, address := range node.Status.Addresses {
 		if address.Type == v1.NodeInternalIP && address.Address != "" {
-			host = net.JoinHostPort(address.Address, sshPort)
-			break
+			return net.JoinHostPort(address.Address, sshPort), nil
 		}
 	}
-	if host == "" {
-		return "", fmt.Errorf("Couldn't get the internal IP of host %s with addresses %v", node.Name, node.Status.Addresses)
-	}
-	return host, nil
+
+	return "", fmt.Errorf("Couldn't get the internal IP of host %s with addresses %v", node.Name, node.Status.Addresses)
 }
 
 // FirstAddressByTypeAndFamily returns the first address that matches the given type and family of the list of nodes

--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -78,9 +78,9 @@ func installFlex(c clientset.Interface, node *v1.Node, vendor, driver, filePath 
 	host := ""
 	var err error
 	if node != nil {
-		host, err = e2enode.GetExternalIP(node)
+		host, err = e2enode.GetSSHExternalIP(node)
 		if err != nil {
-			host, err = e2enode.GetInternalIP(node)
+			host, err = e2enode.GetSSHInternalIP(node)
 		}
 	} else {
 		instanceWithPort := framework.APIAddress()
@@ -110,9 +110,9 @@ func uninstallFlex(c clientset.Interface, node *v1.Node, vendor, driver string) 
 	host := ""
 	var err error
 	if node != nil {
-		host, err = e2enode.GetExternalIP(node)
+		host, err = e2enode.GetSSHExternalIP(node)
 		if err != nil {
-			host, err = e2enode.GetInternalIP(node)
+			host, err = e2enode.GetSSHInternalIP(node)
 		}
 	} else {
 		instanceWithPort := framework.APIAddress()

--- a/test/e2e/storage/nfs_persistent_volume-disruptive.go
+++ b/test/e2e/storage/nfs_persistent_volume-disruptive.go
@@ -126,7 +126,7 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 			for _, node := range nodes.Items {
 				if node.Name != nfsServerPod.Spec.NodeName {
 					clientNode = &node
-					clientNodeIP, err = e2enode.GetExternalIP(clientNode)
+					clientNodeIP, err = e2enode.GetSSHExternalIP(clientNode)
 					framework.ExpectNoError(err)
 					break
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Update GetExternalIP and GetInternalIP method name within test/e2e/framework/node/resource.go to make them more explicit. As these methods do not return the IP only but IP concatenated with port 22 for ssh.
Change the method name to make it clear, also did some code cleanup.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
