### PR TITLE
Optimize volumebinding by moving PV list calls to PreFilter

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -845,14 +845,14 @@ func checkReasons(t *testing.T, actual, expected ConflictReasons) {
 
 // findPodVolumes gets and finds volumes for given pod and node
 func findPodVolumes(binder SchedulerVolumeBinder, pod *v1.Pod, node *v1.Node) (*PodVolumes, ConflictReasons, error) {
-	boundClaims, claimsToBind, unboundClaimsImmediate, err := binder.GetPodVolumes(pod)
+	podVolumeClaims, err := binder.GetPodVolumeClaims(pod)
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(unboundClaimsImmediate) > 0 {
+	if len(podVolumeClaims.unboundClaimsImmediate) > 0 {
 		return nil, nil, fmt.Errorf("pod has unbound immediate PersistentVolumeClaims")
 	}
-	return binder.FindPodVolumes(pod, boundClaims, claimsToBind, node)
+	return binder.FindPodVolumes(pod, podVolumeClaims, node)
 }
 
 func TestFindPodVolumesWithoutProvisioning(t *testing.T) {

--- a/pkg/scheduler/framework/plugins/volumebinding/fake_binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/fake_binder.go
@@ -49,9 +49,9 @@ type FakeVolumeBinder struct {
 
 var _ SchedulerVolumeBinder = &FakeVolumeBinder{}
 
-// GetPodVolumes implements SchedulerVolumeBinder.GetPodVolumes.
-func (b *FakeVolumeBinder) GetPodVolumes(pod *v1.Pod) (boundClaims, unboundClaimsDelayBinding, unboundClaimsImmediate []*v1.PersistentVolumeClaim, err error) {
-	return nil, nil, nil, nil
+// GetPodVolumeClaims implements SchedulerVolumeBinder.GetPodVolumes.
+func (b *FakeVolumeBinder) GetPodVolumeClaims(pod *v1.Pod) (podVolumeClaims *PodVolumeClaims, err error) {
+	return &PodVolumeClaims{}, nil
 }
 
 // GetEligibleNodes implements SchedulerVolumeBinder.GetEligibleNodes.
@@ -60,7 +60,7 @@ func (b *FakeVolumeBinder) GetEligibleNodes(boundClaims []*v1.PersistentVolumeCl
 }
 
 // FindPodVolumes implements SchedulerVolumeBinder.FindPodVolumes.
-func (b *FakeVolumeBinder) FindPodVolumes(pod *v1.Pod, _, _ []*v1.PersistentVolumeClaim, node *v1.Node) (podVolumes *PodVolumes, reasons ConflictReasons, err error) {
+func (b *FakeVolumeBinder) FindPodVolumes(pod *v1.Pod, _ *PodVolumeClaims, node *v1.Node) (podVolumes *PodVolumes, reasons ConflictReasons, err error) {
 	return nil, b.config.FindReasons, b.config.FindErr
 }
 

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -47,14 +47,13 @@ const (
 // framework.CycleState, in the later phases we don't need to call Write method
 // to update the value
 type stateData struct {
-	skip         bool // set true if pod does not have PVCs
-	boundClaims  []*v1.PersistentVolumeClaim
-	claimsToBind []*v1.PersistentVolumeClaim
-	allBound     bool
+	skip     bool // set true if pod does not have PVCs
+	allBound bool
 	// podVolumesByNode holds the pod's volume information found in the Filter
 	// phase for each node
 	// it's initialized in the PreFilter phase
 	podVolumesByNode map[string]*PodVolumes
+	podVolumeClaims  *PodVolumeClaims
 	sync.Mutex
 }
 
@@ -170,11 +169,11 @@ func (pl *VolumeBinding) PreFilter(ctx context.Context, state *framework.CycleSt
 		state.Write(stateKey, &stateData{skip: true})
 		return nil, nil
 	}
-	boundClaims, claimsToBind, unboundClaimsImmediate, err := pl.Binder.GetPodVolumes(pod)
+	podVolumeClaims, err := pl.Binder.GetPodVolumeClaims(pod)
 	if err != nil {
 		return nil, framework.AsStatus(err)
 	}
-	if len(unboundClaimsImmediate) > 0 {
+	if len(podVolumeClaims.unboundClaimsImmediate) > 0 {
 		// Return UnschedulableAndUnresolvable error if immediate claims are
 		// not bound. Pod will be moved to active/backoff queues once these
 		// claims are bound by PV controller.
@@ -184,13 +183,20 @@ func (pl *VolumeBinding) PreFilter(ctx context.Context, state *framework.CycleSt
 	}
 	// Attempt to reduce down the number of nodes to consider in subsequent scheduling stages if pod has bound claims.
 	var result *framework.PreFilterResult
-	if eligibleNodes := pl.Binder.GetEligibleNodes(boundClaims); eligibleNodes != nil {
+	if eligibleNodes := pl.Binder.GetEligibleNodes(podVolumeClaims.boundClaims); eligibleNodes != nil {
 		result = &framework.PreFilterResult{
 			NodeNames: eligibleNodes,
 		}
 	}
 
-	state.Write(stateKey, &stateData{boundClaims: boundClaims, claimsToBind: claimsToBind, podVolumesByNode: make(map[string]*PodVolumes)})
+	state.Write(stateKey, &stateData{
+		podVolumesByNode: make(map[string]*PodVolumes),
+		podVolumeClaims: &PodVolumeClaims{
+			boundClaims:                podVolumeClaims.boundClaims,
+			unboundClaimsDelayBinding:  podVolumeClaims.unboundClaimsDelayBinding,
+			unboundVolumesDelayBinding: podVolumeClaims.unboundVolumesDelayBinding,
+		},
+	})
 	return result, nil
 }
 
@@ -241,7 +247,7 @@ func (pl *VolumeBinding) Filter(ctx context.Context, cs *framework.CycleState, p
 		return nil
 	}
 
-	podVolumes, reasons, err := pl.Binder.FindPodVolumes(pod, state.boundClaims, state.claimsToBind, node)
+	podVolumes, reasons, err := pl.Binder.FindPodVolumes(pod, state.podVolumeClaims, node)
 
 	if err != nil {
 		return framework.AsStatus(err)

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -115,10 +115,13 @@ func TestVolumeBinding(t *testing.T) {
 				makePV("pv-a", waitSC.Name).withPhase(v1.VolumeAvailable).PersistentVolume,
 			},
 			wantStateAfterPreFilter: &stateData{
-				boundClaims: []*v1.PersistentVolumeClaim{
-					makePVC("pvc-a", waitSC.Name).withBoundPV("pv-a").PersistentVolumeClaim,
+				podVolumeClaims: &PodVolumeClaims{
+					boundClaims: []*v1.PersistentVolumeClaim{
+						makePVC("pvc-a", waitSC.Name).withBoundPV("pv-a").PersistentVolumeClaim,
+					},
+					unboundClaimsDelayBinding:  []*v1.PersistentVolumeClaim{},
+					unboundVolumesDelayBinding: map[string][]*v1.PersistentVolume{},
 				},
-				claimsToBind:     []*v1.PersistentVolumeClaim{},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
 			wantFilterStatus: []*framework.Status{
@@ -150,11 +153,14 @@ func TestVolumeBinding(t *testing.T) {
 				NodeNames: sets.NewString("node-a"),
 			},
 			wantStateAfterPreFilter: &stateData{
-				boundClaims: []*v1.PersistentVolumeClaim{
-					makePVC("pvc-a", waitSC.Name).withBoundPV("pv-a").PersistentVolumeClaim,
-					makePVC("pvc-b", waitSC.Name).withBoundPV("pv-b").PersistentVolumeClaim,
+				podVolumeClaims: &PodVolumeClaims{
+					boundClaims: []*v1.PersistentVolumeClaim{
+						makePVC("pvc-a", waitSC.Name).withBoundPV("pv-a").PersistentVolumeClaim,
+						makePVC("pvc-b", waitSC.Name).withBoundPV("pv-b").PersistentVolumeClaim,
+					},
+					unboundClaimsDelayBinding:  []*v1.PersistentVolumeClaim{},
+					unboundVolumesDelayBinding: map[string][]*v1.PersistentVolume{},
 				},
-				claimsToBind:     []*v1.PersistentVolumeClaim{},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
 			wantFilterStatus: []*framework.Status{
@@ -223,9 +229,12 @@ func TestVolumeBinding(t *testing.T) {
 				makePVC("pvc-a", waitSC.Name).PersistentVolumeClaim,
 			},
 			wantStateAfterPreFilter: &stateData{
-				boundClaims: []*v1.PersistentVolumeClaim{},
-				claimsToBind: []*v1.PersistentVolumeClaim{
-					makePVC("pvc-a", waitSC.Name).PersistentVolumeClaim,
+				podVolumeClaims: &PodVolumeClaims{
+					boundClaims: []*v1.PersistentVolumeClaim{},
+					unboundClaimsDelayBinding: []*v1.PersistentVolumeClaim{
+						makePVC("pvc-a", waitSC.Name).PersistentVolumeClaim,
+					},
+					unboundVolumesDelayBinding: map[string][]*v1.PersistentVolume{waitSC.Name: {}},
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
@@ -252,11 +261,20 @@ func TestVolumeBinding(t *testing.T) {
 					withNodeAffinity(map[string][]string{"foo": {"bar"}}).PersistentVolume,
 			},
 			wantStateAfterPreFilter: &stateData{
-				boundClaims: []*v1.PersistentVolumeClaim{
-					makePVC("pvc-a", waitSC.Name).withBoundPV("pv-a").PersistentVolumeClaim,
-				},
-				claimsToBind: []*v1.PersistentVolumeClaim{
-					makePVC("pvc-b", waitSC.Name).PersistentVolumeClaim,
+				podVolumeClaims: &PodVolumeClaims{
+					boundClaims: []*v1.PersistentVolumeClaim{
+						makePVC("pvc-a", waitSC.Name).withBoundPV("pv-a").PersistentVolumeClaim,
+					},
+					unboundClaimsDelayBinding: []*v1.PersistentVolumeClaim{
+						makePVC("pvc-b", waitSC.Name).PersistentVolumeClaim,
+					},
+					unboundVolumesDelayBinding: map[string][]*v1.PersistentVolume{
+						waitSC.Name: {
+							makePV("pv-a", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withNodeAffinity(map[string][]string{"foo": {"bar"}}).PersistentVolume,
+						},
+					},
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
@@ -292,10 +310,13 @@ func TestVolumeBinding(t *testing.T) {
 			},
 			wantPreFilterStatus: nil,
 			wantStateAfterPreFilter: &stateData{
-				boundClaims: []*v1.PersistentVolumeClaim{
-					makePVC("pvc-a", waitSC.Name).withBoundPV("pv-a").PersistentVolumeClaim,
+				podVolumeClaims: &PodVolumeClaims{
+					boundClaims: []*v1.PersistentVolumeClaim{
+						makePVC("pvc-a", waitSC.Name).withBoundPV("pv-a").PersistentVolumeClaim,
+					},
+					unboundClaimsDelayBinding:  []*v1.PersistentVolumeClaim{},
+					unboundVolumesDelayBinding: map[string][]*v1.PersistentVolume{},
 				},
-				claimsToBind:     []*v1.PersistentVolumeClaim{},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
 			wantFilterStatus: []*framework.Status{
@@ -356,9 +377,31 @@ func TestVolumeBinding(t *testing.T) {
 			},
 			wantPreFilterStatus: nil,
 			wantStateAfterPreFilter: &stateData{
-				boundClaims: []*v1.PersistentVolumeClaim{},
-				claimsToBind: []*v1.PersistentVolumeClaim{
-					makePVC("pvc-a", waitSC.Name).withRequestStorage(resource.MustParse("50Gi")).PersistentVolumeClaim,
+				podVolumeClaims: &PodVolumeClaims{
+					boundClaims: []*v1.PersistentVolumeClaim{},
+					unboundClaimsDelayBinding: []*v1.PersistentVolumeClaim{
+						makePVC("pvc-a", waitSC.Name).withRequestStorage(resource.MustParse("50Gi")).PersistentVolumeClaim,
+					},
+					unboundVolumesDelayBinding: map[string][]*v1.PersistentVolume{
+						waitSC.Name: {
+							makePV("pv-a-0", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("200Gi")).
+								withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-a"}}).PersistentVolume,
+							makePV("pv-a-1", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("200Gi")).
+								withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-a"}}).PersistentVolume,
+							makePV("pv-b-0", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("100Gi")).
+								withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-b"}}).PersistentVolume,
+							makePV("pv-b-1", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("100Gi")).
+								withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-b"}}).PersistentVolume,
+						},
+					},
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
@@ -424,10 +467,50 @@ func TestVolumeBinding(t *testing.T) {
 			},
 			wantPreFilterStatus: nil,
 			wantStateAfterPreFilter: &stateData{
-				boundClaims: []*v1.PersistentVolumeClaim{},
-				claimsToBind: []*v1.PersistentVolumeClaim{
-					makePVC("pvc-0", waitSC.Name).withRequestStorage(resource.MustParse("50Gi")).PersistentVolumeClaim,
-					makePVC("pvc-1", waitHDDSC.Name).withRequestStorage(resource.MustParse("100Gi")).PersistentVolumeClaim,
+				podVolumeClaims: &PodVolumeClaims{
+					boundClaims: []*v1.PersistentVolumeClaim{},
+					unboundClaimsDelayBinding: []*v1.PersistentVolumeClaim{
+						makePVC("pvc-0", waitSC.Name).withRequestStorage(resource.MustParse("50Gi")).PersistentVolumeClaim,
+						makePVC("pvc-1", waitHDDSC.Name).withRequestStorage(resource.MustParse("100Gi")).PersistentVolumeClaim,
+					},
+					unboundVolumesDelayBinding: map[string][]*v1.PersistentVolume{
+						waitHDDSC.Name: {
+							makePV("pv-a-2", waitHDDSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("200Gi")).
+								withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-a"}}).PersistentVolume,
+							makePV("pv-a-3", waitHDDSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("200Gi")).
+								withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-a"}}).PersistentVolume,
+							makePV("pv-b-2", waitHDDSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("100Gi")).
+								withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-b"}}).PersistentVolume,
+							makePV("pv-b-3", waitHDDSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("100Gi")).
+								withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-b"}}).PersistentVolume,
+						},
+						waitSC.Name: {
+							makePV("pv-a-0", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("200Gi")).
+								withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-a"}}).PersistentVolume,
+							makePV("pv-a-1", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("200Gi")).
+								withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-a"}}).PersistentVolume,
+							makePV("pv-b-0", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("100Gi")).
+								withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-b"}}).PersistentVolume,
+							makePV("pv-b-1", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("100Gi")).
+								withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-b"}}).PersistentVolume,
+						},
+					},
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
@@ -503,9 +586,43 @@ func TestVolumeBinding(t *testing.T) {
 			},
 			wantPreFilterStatus: nil,
 			wantStateAfterPreFilter: &stateData{
-				boundClaims: []*v1.PersistentVolumeClaim{},
-				claimsToBind: []*v1.PersistentVolumeClaim{
-					makePVC("pvc-a", waitSC.Name).withRequestStorage(resource.MustParse("50Gi")).PersistentVolumeClaim,
+				podVolumeClaims: &PodVolumeClaims{
+					boundClaims: []*v1.PersistentVolumeClaim{},
+					unboundClaimsDelayBinding: []*v1.PersistentVolumeClaim{
+						makePVC("pvc-a", waitSC.Name).withRequestStorage(resource.MustParse("50Gi")).PersistentVolumeClaim,
+					},
+					unboundVolumesDelayBinding: map[string][]*v1.PersistentVolume{
+						waitSC.Name: {
+							makePV("pv-a-0", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("200Gi")).
+								withNodeAffinity(map[string][]string{
+									"topology.kubernetes.io/region": {"region-a"},
+									"topology.kubernetes.io/zone":   {"zone-a"},
+								}).PersistentVolume,
+							makePV("pv-a-1", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("200Gi")).
+								withNodeAffinity(map[string][]string{
+									"topology.kubernetes.io/region": {"region-a"},
+									"topology.kubernetes.io/zone":   {"zone-a"},
+								}).PersistentVolume,
+							makePV("pv-b-0", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("100Gi")).
+								withNodeAffinity(map[string][]string{
+									"topology.kubernetes.io/region": {"region-b"},
+									"topology.kubernetes.io/zone":   {"zone-b"},
+								}).PersistentVolume,
+							makePV("pv-b-1", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("100Gi")).
+								withNodeAffinity(map[string][]string{
+									"topology.kubernetes.io/region": {"region-b"},
+									"topology.kubernetes.io/zone":   {"zone-b"},
+								}).PersistentVolume,
+						},
+					},
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
@@ -604,9 +721,44 @@ func TestVolumeBinding(t *testing.T) {
 			},
 			wantPreFilterStatus: nil,
 			wantStateAfterPreFilter: &stateData{
-				boundClaims: []*v1.PersistentVolumeClaim{},
-				claimsToBind: []*v1.PersistentVolumeClaim{
-					makePVC("pvc-a", waitSC.Name).withRequestStorage(resource.MustParse("50Gi")).PersistentVolumeClaim,
+				podVolumeClaims: &PodVolumeClaims{
+					boundClaims: []*v1.PersistentVolumeClaim{},
+					unboundClaimsDelayBinding: []*v1.PersistentVolumeClaim{
+						makePVC("pvc-a", waitSC.Name).withRequestStorage(resource.MustParse("50Gi")).PersistentVolumeClaim,
+					},
+					unboundClaimsImmediate: nil,
+					unboundVolumesDelayBinding: map[string][]*v1.PersistentVolume{
+						waitSC.Name: {
+							makePV("pv-a-0", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("200Gi")).
+								withNodeAffinity(map[string][]string{
+									"topology.kubernetes.io/region": {"region-a"},
+									"topology.kubernetes.io/zone":   {"zone-a"},
+								}).PersistentVolume,
+							makePV("pv-a-1", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("200Gi")).
+								withNodeAffinity(map[string][]string{
+									"topology.kubernetes.io/region": {"region-a"},
+									"topology.kubernetes.io/zone":   {"zone-a"},
+								}).PersistentVolume,
+							makePV("pv-b-0", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("100Gi")).
+								withNodeAffinity(map[string][]string{
+									"topology.kubernetes.io/region": {"region-b"},
+									"topology.kubernetes.io/zone":   {"zone-b"},
+								}).PersistentVolume,
+							makePV("pv-b-1", waitSC.Name).
+								withPhase(v1.VolumeAvailable).
+								withCapacity(resource.MustParse("100Gi")).
+								withNodeAffinity(map[string][]string{
+									"topology.kubernetes.io/region": {"region-b"},
+									"topology.kubernetes.io/zone":   {"zone-b"},
+								}).PersistentVolume,
+						},
+					},
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
@@ -708,7 +860,14 @@ func TestVolumeBinding(t *testing.T) {
 			}
 			stateCmpOpts := []cmp.Option{
 				cmp.AllowUnexported(stateData{}),
+				cmp.AllowUnexported(PodVolumeClaims{}),
 				cmpopts.IgnoreFields(stateData{}, "Mutex"),
+				cmpopts.SortSlices(func(a *v1.PersistentVolume, b *v1.PersistentVolume) bool {
+					return a.Name < b.Name
+				}),
+				cmpopts.SortSlices(func(a v1.NodeSelectorRequirement, b v1.NodeSelectorRequirement) bool {
+					return a.Key < b.Key
+				}),
 			}
 			if diff := cmp.Diff(item.wantStateAfterPreFilter, got, stateCmpOpts...); diff != "" {
 				t.Errorf("state got after prefilter does not match (-want,+got):\n%s", diff)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The call to list all PVs that belong to a storage class is expensive to do per node at scale. 
Moved to PreFilter and so done once for all nodes.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #114075 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
