### PR TITLE
Automated cherry pick of #114096: changelog: CVE-2022-3294 and CVE-2022-3162 were fixed in v1.23.14

### DIFF
--- a/CHANGELOG/CHANGELOG-1.25.md
+++ b/CHANGELOG/CHANGELOG-1.25.md
@@ -303,7 +303,7 @@ A security issue was discovered in Kubernetes where users authorized to list or 
 **Fixed Versions**:
   - kube-apiserver v1.25.4
   - kube-apiserver v1.24.8
-  - kube-apiserver v1.23.13
+  - kube-apiserver v1.23.14
   - kube-apiserver v1.22.16
 
 This vulnerability was reported by Richard Turnbull of NCC Group as part of the Kubernetes Audit
@@ -329,7 +329,7 @@ The merged fix enforces validation against the proxying address for a Node. In s
 **Fixed Versions**:
   - kube-apiserver v1.25.4
   - kube-apiserver v1.24.8
-  - kube-apiserver v1.23.13
+  - kube-apiserver v1.23.14
   - kube-apiserver v1.22.16
 
 This vulnerability was reported by Yuval Avrahami of Palo Alto Networks


### PR DESCRIPTION
Cherry pick of #114096 on release-1.25.

#114096: changelog: CVE-2022-3294 and CVE-2022-3162 were fixed in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
/kind documentation
/cc @xmudrii
```release-note
None
```