### PR TITLE
Automated cherry pick of #114096: changelog: CVE-2022-3294 and CVE-2022-3162 were fixed in

### DIFF
--- a/CHANGELOG/CHANGELOG-1.23.md
+++ b/CHANGELOG/CHANGELOG-1.23.md
@@ -240,7 +240,7 @@
   - [Urgent Upgrade Notes](#urgent-upgrade-notes)
     - [(No, really, you MUST read this before you upgrade)](#no-really-you-must-read-this-before-you-upgrade)
   - [Known Issues](#known-issues)
-    - [Etcd v3.5.[0-2] data corruption](#etcd-v350-2-data-corruption)
+    - [Etcd v3.5.\[0-2\] data corruption](#etcd-v350-2-data-corruption)
   - [Changes by Kind](#changes-by-kind-14)
     - [Deprecation](#deprecation)
     - [API Change](#api-change-5)
@@ -462,7 +462,7 @@ A security issue was discovered in Kubernetes where users authorized to list or 
 **Fixed Versions**:
   - kube-apiserver v1.25.4
   - kube-apiserver v1.24.8
-  - kube-apiserver v1.23.13
+  - kube-apiserver v1.23.14
   - kube-apiserver v1.22.16
 
 This vulnerability was reported by Richard Turnbull of NCC Group as part of the Kubernetes Audit
@@ -488,7 +488,7 @@ The merged fix enforces validation against the proxying address for a Node. In s
 **Fixed Versions**:
   - kube-apiserver v1.25.4
   - kube-apiserver v1.24.8
-  - kube-apiserver v1.23.13
+  - kube-apiserver v1.23.14
   - kube-apiserver v1.22.16
 
 This vulnerability was reported by Yuval Avrahami of Palo Alto Networks


### PR DESCRIPTION
Cherry pick of #114096 on release-1.23.

#114096: changelog: CVE-2022-3294 and CVE-2022-3162 were fixed in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```