### PR TITLE
Fix endpoint reconciler failing to delete masterlease

### DIFF
--- a/pkg/controlplane/reconcilers/lease.go
+++ b/pkg/controlplane/reconcilers/lease.go
@@ -120,7 +120,8 @@ func (s *storageLeases) UpdateLease(ip string) error {
 
 // RemoveLease removes the lease on a master IP in storage
 func (s *storageLeases) RemoveLease(ip string) error {
-	return s.storage.Delete(apirequest.NewDefaultContext(), s.baseKey+"/"+ip, &corev1.Endpoints{}, nil, rest.ValidateAllObjectFunc, nil)
+	key := path.Join(s.baseKey, ip)
+	return s.storage.Delete(apirequest.NewDefaultContext(), key, &corev1.Endpoints{}, nil, rest.ValidateAllObjectFunc, nil)
 }
 
 func (s *storageLeases) Destroy() {


### PR DESCRIPTION
Ref #114049

```release-note
Fix endpoint reconciler not being able to delete the apiserver lease on shutdown
```

This was introduced in #113686 so will need to be cherrypicked back to all releases that PR was cherrypicked.

/king bug
/kind regression
/sig api-machinery
/priority critical-urgent

/assign @aojea @liggitt @lavalamp @tallclair 