### PR TITLE
node: cpumgr: stricter pre-check for  the policy option full-pcpus-only

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -43,11 +43,15 @@ const (
 
 // SMTAlignmentError represents an error due to SMT alignment
 type SMTAlignmentError struct {
-	RequestedCPUs int
-	CpusPerCore   int
+	RequestedCPUs         int
+	CpusPerCore           int
+	AvailablePhysicalCPUs int
 }
 
 func (e SMTAlignmentError) Error() string {
+	if e.AvailablePhysicalCPUs > 0 {
+		return fmt.Sprintf("SMT Alignment Error: not enough free physical CPUs: available physical CPUs = %d, requested CPUs = %d, CPUs per core = %d", e.AvailablePhysicalCPUs, e.RequestedCPUs, e.CpusPerCore)
+	}
 	return fmt.Sprintf("SMT Alignment Error: requested %d cpus not multiple cpus per core = %d", e.RequestedCPUs, e.CpusPerCore)
 }
 
@@ -98,7 +102,13 @@ type staticPolicy struct {
 	// cpu socket topology
 	topology *topology.CPUTopology
 	// set of CPUs that is not available for exclusive assignment
-	reserved cpuset.CPUSet
+	reservedCPUs cpuset.CPUSet
+	// Superset of reservedCPUs. It includes not just the reservedCPUs themselves,
+	// but also any siblings of those reservedCPUs on the same physical die.
+	// NOTE: If the reserved set includes full physical CPUs from the beginning
+	// (e.g. only reserved pairs of core siblings) this set is expected to be
+	// identical to the reserved set.
+	reservedPhysicalCPUs cpuset.CPUSet
 	// topology manager reference to get container Topology affinity
 	affinity topologymanager.Store
 	// set of CPUs to reuse across allocations in a pod
@@ -150,8 +160,18 @@ func NewStaticPolicy(topology *topology.CPUTopology, numReservedCPUs int, reserv
 		return nil, err
 	}
 
-	klog.InfoS("Reserved CPUs not available for exclusive assignment", "reservedSize", reserved.Size(), "reserved", reserved)
-	policy.reserved = reserved
+	var reservedPhysicalCPUs cpuset.CPUSet
+	for _, cpu := range reserved.UnsortedList() {
+		core, err := topology.CPUCoreID(cpu)
+		if err != nil {
+			return nil, fmt.Errorf("[cpumanager] unable to build the reserved physical CPUs from the reserved set: %w", err)
+		}
+		reservedPhysicalCPUs = reservedPhysicalCPUs.Union(topology.CPUDetails.CPUsInCores(core))
+	}
+
+	klog.InfoS("Reserved CPUs not available for exclusive assignment", "reservedSize", reserved.Size(), "reserved", reserved, "reservedPhysicalCPUs", reservedPhysicalCPUs)
+	policy.reservedCPUs = reserved
+	policy.reservedPhysicalCPUs = reservedPhysicalCPUs
 
 	return policy, nil
 }
@@ -187,9 +207,9 @@ func (p *staticPolicy) validateState(s state.State) error {
 	// 1. Check if the reserved cpuset is not part of default cpuset because:
 	// - kube/system reserved have changed (increased) - may lead to some containers not being able to start
 	// - user tampered with file
-	if !p.reserved.Intersection(tmpDefaultCPUset).Equals(p.reserved) {
+	if !p.reservedCPUs.Intersection(tmpDefaultCPUset).Equals(p.reservedCPUs) {
 		return fmt.Errorf("not all reserved cpus: \"%s\" are present in defaultCpuSet: \"%s\"",
-			p.reserved.String(), tmpDefaultCPUset.String())
+			p.reservedCPUs.String(), tmpDefaultCPUset.String())
 	}
 
 	// 2. Check if state for static policy is consistent
@@ -228,12 +248,16 @@ func (p *staticPolicy) validateState(s state.State) error {
 
 // GetAllocatableCPUs returns the total set of CPUs available for allocation.
 func (p *staticPolicy) GetAllocatableCPUs(s state.State) cpuset.CPUSet {
-	return p.topology.CPUDetails.CPUs().Difference(p.reserved)
+	return p.topology.CPUDetails.CPUs().Difference(p.reservedCPUs)
 }
 
 // GetAvailableCPUs returns the set of unassigned CPUs minus the reserved set.
 func (p *staticPolicy) GetAvailableCPUs(s state.State) cpuset.CPUSet {
-	return s.GetDefaultCPUSet().Difference(p.reserved)
+	return s.GetDefaultCPUSet().Difference(p.reservedCPUs)
+}
+
+func (p *staticPolicy) GetAvailablePhysicalCPUs(s state.State) cpuset.CPUSet {
+	return s.GetDefaultCPUSet().Difference(p.reservedPhysicalCPUs)
 }
 
 func (p *staticPolicy) updateCPUsToReuse(pod *v1.Pod, container *v1.Container, cset cpuset.CPUSet) {
@@ -276,19 +300,36 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 		}
 	}()
 
-	if p.options.FullPhysicalCPUsOnly && ((numCPUs % p.topology.CPUsPerCore()) != 0) {
-		// Since CPU Manager has been enabled requesting strict SMT alignment, it means a guaranteed pod can only be admitted
-		// if the CPU requested is a multiple of the number of virtual cpus per physical cores.
-		// In case CPU request is not a multiple of the number of virtual cpus per physical cores the Pod will be put
-		// in Failed state, with SMTAlignmentError as reason. Since the allocation happens in terms of physical cores
-		// and the scheduler is responsible for ensuring that the workload goes to a node that has enough CPUs,
-		// the pod would be placed on a node where there are enough physical cores available to be allocated.
-		// Just like the behaviour in case of static policy, takeByTopology will try to first allocate CPUs from the same socket
-		// and only in case the request cannot be sattisfied on a single socket, CPU allocation is done for a workload to occupy all
-		// CPUs on a physical core. Allocation of individual threads would never have to occur.
-		return SMTAlignmentError{
-			RequestedCPUs: numCPUs,
-			CpusPerCore:   p.topology.CPUsPerCore(),
+	if p.options.FullPhysicalCPUsOnly {
+		CPUsPerCore := p.topology.CPUsPerCore()
+		if (numCPUs % CPUsPerCore) != 0 {
+			// Since CPU Manager has been enabled requesting strict SMT alignment, it means a guaranteed pod can only be admitted
+			// if the CPU requested is a multiple of the number of virtual cpus per physical cores.
+			// In case CPU request is not a multiple of the number of virtual cpus per physical cores the Pod will be put
+			// in Failed state, with SMTAlignmentError as reason. Since the allocation happens in terms of physical cores
+			// and the scheduler is responsible for ensuring that the workload goes to a node that has enough CPUs,
+			// the pod would be placed on a node where there are enough physical cores available to be allocated.
+			// Just like the behaviour in case of static policy, takeByTopology will try to first allocate CPUs from the same socket
+			// and only in case the request cannot be sattisfied on a single socket, CPU allocation is done for a workload to occupy all
+			// CPUs on a physical core. Allocation of individual threads would never have to occur.
+			return SMTAlignmentError{
+				RequestedCPUs: numCPUs,
+				CpusPerCore:   CPUsPerCore,
+			}
+		}
+
+		availablePhysicalCPUs := p.GetAvailablePhysicalCPUs(s).Size()
+
+		// It's legal to reserve CPUs which are not core siblings. In this case the CPU allocator can descend to single cores
+		// when picking CPUs. This will void the guarantee of FullPhysicalCPUsOnly. To prevent this, we need to additionally consider
+		// all the core siblings of the reserved CPUs as unavailable when computing the free CPUs, before to start the actual allocation.
+		// This way, by construction all possible CPUs allocation whose number is multiple of the SMT level are now correct again.
+		if numCPUs > availablePhysicalCPUs {
+			return SMTAlignmentError{
+				RequestedCPUs:         numCPUs,
+				CpusPerCore:           CPUsPerCore,
+				AvailablePhysicalCPUs: availablePhysicalCPUs,
+			}
 		}
 	}
 	if cpuset, ok := s.GetCPUSet(string(pod.UID), container.Name); ok {

--- a/pkg/kubelet/cm/cpumanager/topology/topology.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology.go
@@ -62,6 +62,34 @@ func (topo *CPUTopology) CPUsPerSocket() int {
 	return topo.NumCPUs / topo.NumSockets
 }
 
+// CPUCoreID returns the physical core ID which the given logical CPU
+// belongs to.
+func (topo *CPUTopology) CPUCoreID(cpu int) (int, error) {
+	info, ok := topo.CPUDetails[cpu]
+	if !ok {
+		return -1, fmt.Errorf("unknown CPU ID: %d", cpu)
+	}
+	return info.CoreID, nil
+}
+
+// CPUCoreID returns the socket ID which the given logical CPU belongs to.
+func (topo *CPUTopology) CPUSocketID(cpu int) (int, error) {
+	info, ok := topo.CPUDetails[cpu]
+	if !ok {
+		return -1, fmt.Errorf("unknown CPU ID: %d", cpu)
+	}
+	return info.SocketID, nil
+}
+
+// CPUCoreID returns the NUMA node ID which the given logical CPU belongs to.
+func (topo *CPUTopology) CPUNUMANodeID(cpu int) (int, error) {
+	info, ok := topo.CPUDetails[cpu]
+	if !ok {
+		return -1, fmt.Errorf("unknown CPU ID: %d", cpu)
+	}
+	return info.NUMANodeID, nil
+}
+
 // CPUInfo contains the NUMA, socket, and core IDs associated with a CPU.
 type CPUInfo struct {
 	NUMANodeID int

--- a/pkg/kubelet/cm/cpumanager/topology/topology_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology_test.go
@@ -923,3 +923,180 @@ func TestCPUDetailsCPUsInCores(t *testing.T) {
 		})
 	}
 }
+
+func TestCPUCoreID(t *testing.T) {
+	topoDualSocketHT := &CPUTopology{
+		NumCPUs:    12,
+		NumSockets: 2,
+		NumCores:   6,
+		CPUDetails: map[int]CPUInfo{
+			0:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+			1:  {CoreID: 1, SocketID: 1, NUMANodeID: 1},
+			2:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+			3:  {CoreID: 3, SocketID: 1, NUMANodeID: 1},
+			4:  {CoreID: 4, SocketID: 0, NUMANodeID: 0},
+			5:  {CoreID: 5, SocketID: 1, NUMANodeID: 1},
+			6:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+			7:  {CoreID: 1, SocketID: 1, NUMANodeID: 1},
+			8:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+			9:  {CoreID: 3, SocketID: 1, NUMANodeID: 1},
+			10: {CoreID: 4, SocketID: 0, NUMANodeID: 0},
+			11: {CoreID: 5, SocketID: 1, NUMANodeID: 1},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		topo    *CPUTopology
+		id      int
+		want    int
+		wantErr bool
+	}{{
+		name: "Known Core ID",
+		topo: topoDualSocketHT,
+		id:   2,
+		want: 2,
+	}, {
+		name: "Known Core ID (core sibling).",
+		topo: topoDualSocketHT,
+		id:   8,
+		want: 2,
+	}, {
+		name:    "Unknown Core ID.",
+		topo:    topoDualSocketHT,
+		id:      -2,
+		want:    -1,
+		wantErr: true,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.topo.CPUCoreID(tt.id)
+			gotErr := (err != nil)
+			if gotErr != tt.wantErr {
+				t.Errorf("CPUCoreID() returned err %v, want %v", gotErr, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("CPUCoreID() returned %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUSocketID(t *testing.T) {
+	topoDualSocketHT := &CPUTopology{
+		NumCPUs:    12,
+		NumSockets: 2,
+		NumCores:   6,
+		CPUDetails: map[int]CPUInfo{
+			0:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+			1:  {CoreID: 1, SocketID: 1, NUMANodeID: 1},
+			2:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+			3:  {CoreID: 3, SocketID: 1, NUMANodeID: 1},
+			4:  {CoreID: 4, SocketID: 0, NUMANodeID: 0},
+			5:  {CoreID: 5, SocketID: 1, NUMANodeID: 1},
+			6:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+			7:  {CoreID: 1, SocketID: 1, NUMANodeID: 1},
+			8:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+			9:  {CoreID: 3, SocketID: 1, NUMANodeID: 1},
+			10: {CoreID: 4, SocketID: 0, NUMANodeID: 0},
+			11: {CoreID: 5, SocketID: 1, NUMANodeID: 1},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		topo    *CPUTopology
+		id      int
+		want    int
+		wantErr bool
+	}{{
+		name: "Known Core ID",
+		topo: topoDualSocketHT,
+		id:   3,
+		want: 1,
+	}, {
+		name: "Known Core ID (core sibling).",
+		topo: topoDualSocketHT,
+		id:   9,
+		want: 1,
+	}, {
+		name:    "Unknown Core ID.",
+		topo:    topoDualSocketHT,
+		id:      1000,
+		want:    -1,
+		wantErr: true,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.topo.CPUSocketID(tt.id)
+			gotErr := (err != nil)
+			if gotErr != tt.wantErr {
+				t.Errorf("CPUSocketID() returned err %v, want %v", gotErr, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("CPUSocketID() returned %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUNUMANodeID(t *testing.T) {
+	topoDualSocketHT := &CPUTopology{
+		NumCPUs:    12,
+		NumSockets: 2,
+		NumCores:   6,
+		CPUDetails: map[int]CPUInfo{
+			0:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+			1:  {CoreID: 1, SocketID: 1, NUMANodeID: 1},
+			2:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+			3:  {CoreID: 3, SocketID: 1, NUMANodeID: 1},
+			4:  {CoreID: 4, SocketID: 0, NUMANodeID: 0},
+			5:  {CoreID: 5, SocketID: 1, NUMANodeID: 1},
+			6:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+			7:  {CoreID: 1, SocketID: 1, NUMANodeID: 1},
+			8:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+			9:  {CoreID: 3, SocketID: 1, NUMANodeID: 1},
+			10: {CoreID: 4, SocketID: 0, NUMANodeID: 0},
+			11: {CoreID: 5, SocketID: 1, NUMANodeID: 1},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		topo    *CPUTopology
+		id      int
+		want    int
+		wantErr bool
+	}{{
+		name: "Known Core ID",
+		topo: topoDualSocketHT,
+		id:   0,
+		want: 0,
+	}, {
+		name: "Known Core ID (core sibling).",
+		topo: topoDualSocketHT,
+		id:   6,
+		want: 0,
+	}, {
+		name:    "Unknown Core ID.",
+		topo:    topoDualSocketHT,
+		id:      1000,
+		want:    -1,
+		wantErr: true,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.topo.CPUNUMANodeID(tt.id)
+			gotErr := (err != nil)
+			if gotErr != tt.wantErr {
+				t.Errorf("CPUSocketID() returned err %v, want %v", gotErr, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("CPUSocketID() returned %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Make sure we allocate full cores when the full-pcpus-only option is enabled, the existing pre-check is not sufficient.
We need to make sure we never get as far as allocating single CPUs, so the smallest unit we allocate is a virtual thread group.

#### Which issue(s) this PR fixes:
Fixes #113537

#### Special notes for your reviewer:
Alternative take to https://github.com/kubernetes/kubernetes/pull/113924
Instead of validating the allocation if was aligned or not, keep leveraging the existing cpus allocation, and add stricter precheck instead.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```