### PR TITLE
Add ShortNames for RoleBinding, ClusterRoleBinding and ClusterRole

### DIFF
--- a/pkg/registry/rbac/clusterrole/storage/storage.go
+++ b/pkg/registry/rbac/clusterrole/storage/storage.go
@@ -30,6 +30,14 @@ type REST struct {
 	*genericregistry.Store
 }
 
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+        return []string{"cr"}
+}
+
 // NewREST returns a RESTStorage object that will work against ClusterRole objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 	store := &genericregistry.Store{

--- a/pkg/registry/rbac/clusterrolebinding/storage/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/storage/storage.go
@@ -32,6 +32,14 @@ type REST struct {
 	*genericregistry.Store
 }
 
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+        return []string{"crb"}
+}
+
 // NewREST returns a RESTStorage object that will work against ClusterRoleBinding objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 	store := &genericregistry.Store{

--- a/pkg/registry/rbac/rolebinding/storage/storage.go
+++ b/pkg/registry/rbac/rolebinding/storage/storage.go
@@ -32,6 +32,14 @@ type REST struct {
 	*genericregistry.Store
 }
 
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+        return []string{"rb"}
+}
+
 // NewREST returns a RESTStorage object that will work against RoleBinding objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 	store := &genericregistry.Store{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

This PR implements ShortNames for the RoleBinding, ClusterRoleBinding and ClusterRole object so we can do e.g. `kubectl get rb` and therefore save valuable time (and make kubectl even more awesome).

With kind regards to our course teacher who mentioned kubectl couldn't do this whilst teaching us Kubernetes.

**Which issue(s) this PR fixes:**

None

**Special notes for your reviewer:**

None

**Does this PR introduce a user-facing change?**
 ```release-note
Added short names for RoleBinding (rb), ClusterRoleBinding (crb) and ClusterRole (cr)
```
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**

``````