### PR TITLE
client-go: Use `Patch` to release a lock to avoid confliction

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor_test.go
@@ -47,6 +47,11 @@ func (fl *fakeLock) Update(ctx context.Context, ler rl.LeaderElectionRecord) err
 	return nil
 }
 
+// Patch will patch an existing LeaderElectionRecord
+func (fl *fakeLock) Patch(ctx context.Context, newLer, oldLer rl.LeaderElectionRecord) error {
+	return nil
+}
+
 // RecordEvent is a dummy to allow us to have a fakeLock for testing.
 func (fl *fakeLock) RecordEvent(string) {}
 

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -292,19 +292,20 @@ func (le *LeaderElector) release() bool {
 	if !le.IsLeader() {
 		return true
 	}
+	oldLer := le.getObservedRecord()
 	now := metav1.NewTime(le.clock.Now())
-	leaderElectionRecord := rl.LeaderElectionRecord{
+	newLer := rl.LeaderElectionRecord{
 		LeaderTransitions:    le.observedRecord.LeaderTransitions,
 		LeaseDurationSeconds: 1,
 		RenewTime:            now,
 		AcquireTime:          now,
 	}
-	if err := le.config.Lock.Update(context.TODO(), leaderElectionRecord); err != nil {
+	if err := le.config.Lock.Patch(context.TODO(), newLer, oldLer); err != nil {
 		klog.Errorf("Failed to release lock: %v", err)
 		return false
 	}
 
-	le.setObservedRecord(&leaderElectionRecord)
+	le.setObservedRecord(&newLer)
 	return true
 }
 

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
@@ -19,9 +19,10 @@ package resourcelock
 import (
 	"context"
 	"fmt"
+	"time"
+
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -148,8 +149,11 @@ type Interface interface {
 	// Create attempts to create a LeaderElectionRecord
 	Create(ctx context.Context, ler LeaderElectionRecord) error
 
-	// Update will update and existing LeaderElectionRecord
+	// Update will update an existing LeaderElectionRecord
 	Update(ctx context.Context, ler LeaderElectionRecord) error
+
+	// Patch will patch an existing LeaderElectionRecord
+	Patch(ctx context.Context, newLer, oldLer LeaderElectionRecord) error
 
 	// RecordEvent is used to record events
 	RecordEvent(string)

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
@@ -69,7 +69,7 @@ func (ml *MultiLock) Create(ctx context.Context, ler LeaderElectionRecord) error
 	return ml.Secondary.Create(ctx, ler)
 }
 
-// Update will update and existing annotation on both two resources.
+// Update will update an existing annotation on both two resources.
 func (ml *MultiLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
 	err := ml.Primary.Update(ctx, ler)
 	if err != nil {
@@ -80,6 +80,19 @@ func (ml *MultiLock) Update(ctx context.Context, ler LeaderElectionRecord) error
 		return ml.Secondary.Create(ctx, ler)
 	}
 	return ml.Secondary.Update(ctx, ler)
+}
+
+// Patch will patch an existing annotation on both two resources.
+func (ml *MultiLock) Patch(ctx context.Context, newLer, oldLer LeaderElectionRecord) error {
+	err := ml.Primary.Patch(ctx, newLer, oldLer)
+	if err != nil {
+		return err
+	}
+	_, _, err = ml.Secondary.Get(ctx)
+	if err != nil && apierrors.IsNotFound(err) {
+		return ml.Secondary.Create(ctx, newLer)
+	}
+	return ml.Secondary.Patch(ctx, newLer, oldLer)
 }
 
 // RecordEvent in leader election while adding meta-data


### PR DESCRIPTION
I have run into the same error as said in https://github.com/kubernetes/client-go/issues/1155.  I believe I've found the cause.


Signed-off-by: linlin <linlin152@foxmail.com>
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Fix the issue, as the lease can't be cleaned automatically. That will cause some service fail to work, i.e. one can't gain the leadership after the old leader crashed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes https://github.com/kubernetes/client-go/issues/1155

#### Special notes for your reviewer:
As currently I don't know how to add a unittest, I can use some help. Thanks for your time.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
NONE

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
