### PR TITLE
Automated cherry pick of #114138: Use t.Run() consistently in reconciler unit tests

### DIFF
--- a/pkg/controlplane/reconcilers/endpointsadapter.go
+++ b/pkg/controlplane/reconcilers/endpointsadapter.go
@@ -57,8 +57,7 @@ func (adapter *EndpointsAdapter) Get(namespace, name string, getOpts metav1.GetO
 }
 
 // Create accepts a namespace and Endpoints object and creates the Endpoints
-// object. If an endpointSliceClient exists, a matching EndpointSlice will also
-// be created or updated. The created Endpoints object or an error will be
+// object and matching EndpointSlice. The created Endpoints object or an error will be
 // returned.
 func (adapter *EndpointsAdapter) Create(namespace string, endpoints *corev1.Endpoints) (*corev1.Endpoints, error) {
 	endpoints, err := adapter.endpointClient.Endpoints(namespace).Create(context.TODO(), endpoints, metav1.CreateOptions{})
@@ -68,9 +67,8 @@ func (adapter *EndpointsAdapter) Create(namespace string, endpoints *corev1.Endp
 	return endpoints, err
 }
 
-// Update accepts a namespace and Endpoints object and updates it. If an
-// endpointSliceClient exists, a matching EndpointSlice will also be created or
-// updated. The updated Endpoints object or an error will be returned.
+// Update accepts a namespace and Endpoints object and updates it and its
+// matching EndpointSlice. The updated Endpoints object or an error will be returned.
 func (adapter *EndpointsAdapter) Update(namespace string, endpoints *corev1.Endpoints) (*corev1.Endpoints, error) {
 	endpoints, err := adapter.endpointClient.Endpoints(namespace).Update(context.TODO(), endpoints, metav1.UpdateOptions{})
 	if err == nil {
@@ -80,12 +78,9 @@ func (adapter *EndpointsAdapter) Update(namespace string, endpoints *corev1.Endp
 }
 
 // EnsureEndpointSliceFromEndpoints accepts a namespace and Endpoints resource
-// and creates or updates a corresponding EndpointSlice if an endpointSliceClient
-// exists. An error will be returned if it fails to sync the EndpointSlice.
+// and creates or updates a corresponding EndpointSlice. An error will be returned
+// if it fails to sync the EndpointSlice.
 func (adapter *EndpointsAdapter) EnsureEndpointSliceFromEndpoints(namespace string, endpoints *corev1.Endpoints) error {
-	if adapter.endpointSliceClient == nil {
-		return nil
-	}
 	endpointSlice := endpointSliceFromEndpoints(endpoints)
 	currentEndpointSlice, err := adapter.endpointSliceClient.EndpointSlices(namespace).Get(context.TODO(), endpointSlice.Name, metav1.GetOptions{})
 

--- a/pkg/controlplane/reconcilers/endpointsadapter.go
+++ b/pkg/controlplane/reconcilers/endpointsadapter.go
@@ -123,6 +123,7 @@ func (adapter *EndpointsAdapter) EnsureEndpointSliceFromEndpoints(namespace stri
 func endpointSliceFromEndpoints(endpoints *corev1.Endpoints) *discovery.EndpointSlice {
 	endpointSlice := &discovery.EndpointSlice{}
 	endpointSlice.Name = endpoints.Name
+	endpointSlice.Namespace = endpoints.Namespace
 	endpointSlice.Labels = map[string]string{discovery.LabelServiceName: endpoints.Name}
 
 	// TODO: Add support for dual stack here (and in the rest of

--- a/pkg/controlplane/reconcilers/endpointsadapter_test.go
+++ b/pkg/controlplane/reconcilers/endpointsadapter_test.go
@@ -35,36 +35,32 @@ func TestEndpointsAdapterGet(t *testing.T) {
 	endpoints1, _ := generateEndpointsAndSlice("foo", "testing", []int{80, 443}, []string{"10.1.2.3", "10.1.2.4"})
 
 	testCases := map[string]struct {
-		endpointSlicesEnabled bool
-		expectedError         error
-		expectedEndpoints     *corev1.Endpoints
-		initialState          []runtime.Object
-		namespaceParam        string
-		nameParam             string
+		expectedError     error
+		expectedEndpoints *corev1.Endpoints
+		initialState      []runtime.Object
+		namespaceParam    string
+		nameParam         string
 	}{
 		"single-existing-endpoints": {
-			endpointSlicesEnabled: true,
-			expectedError:         nil,
-			expectedEndpoints:     endpoints1,
-			initialState:          []runtime.Object{endpoints1},
-			namespaceParam:        "testing",
-			nameParam:             "foo",
+			expectedError:     nil,
+			expectedEndpoints: endpoints1,
+			initialState:      []runtime.Object{endpoints1},
+			namespaceParam:    "testing",
+			nameParam:         "foo",
 		},
 		"wrong-namespace": {
-			endpointSlicesEnabled: true,
-			expectedError:         errors.NewNotFound(schema.GroupResource{Group: "", Resource: "endpoints"}, "foo"),
-			expectedEndpoints:     nil,
-			initialState:          []runtime.Object{endpoints1},
-			namespaceParam:        "foo",
-			nameParam:             "foo",
+			expectedError:     errors.NewNotFound(schema.GroupResource{Group: "", Resource: "endpoints"}, "foo"),
+			expectedEndpoints: nil,
+			initialState:      []runtime.Object{endpoints1},
+			namespaceParam:    "foo",
+			nameParam:         "foo",
 		},
 		"wrong-name": {
-			endpointSlicesEnabled: true,
-			expectedError:         errors.NewNotFound(schema.GroupResource{Group: "", Resource: "endpoints"}, "bar"),
-			expectedEndpoints:     nil,
-			initialState:          []runtime.Object{endpoints1},
-			namespaceParam:        "testing",
-			nameParam:             "bar",
+			expectedError:     errors.NewNotFound(schema.GroupResource{Group: "", Resource: "endpoints"}, "bar"),
+			expectedEndpoints: nil,
+			initialState:      []runtime.Object{endpoints1},
+			namespaceParam:    "testing",
+			nameParam:         "bar",
 		},
 	}
 
@@ -100,49 +96,44 @@ func TestEndpointsAdapterCreate(t *testing.T) {
 	epSlice3.AddressType = discovery.AddressTypeIPv6
 
 	testCases := map[string]struct {
-		endpointSlicesEnabled bool
-		expectedError         error
-		expectedResult        *corev1.Endpoints
-		expectCreate          []runtime.Object
-		expectUpdate          []runtime.Object
-		initialState          []runtime.Object
-		namespaceParam        string
-		endpointsParam        *corev1.Endpoints
+		expectedError  error
+		expectedResult *corev1.Endpoints
+		expectCreate   []runtime.Object
+		expectUpdate   []runtime.Object
+		initialState   []runtime.Object
+		namespaceParam string
+		endpointsParam *corev1.Endpoints
 	}{
 		"single-endpoint": {
-			endpointSlicesEnabled: true,
-			expectedError:         nil,
-			expectedResult:        endpoints1,
-			expectCreate:          []runtime.Object{endpoints1, epSlice1},
-			initialState:          []runtime.Object{},
-			namespaceParam:        endpoints1.Namespace,
-			endpointsParam:        endpoints1,
+			expectedError:  nil,
+			expectedResult: endpoints1,
+			expectCreate:   []runtime.Object{endpoints1, epSlice1},
+			initialState:   []runtime.Object{},
+			namespaceParam: endpoints1.Namespace,
+			endpointsParam: endpoints1,
 		},
 		"single-endpoint-partial-ipv6": {
-			endpointSlicesEnabled: true,
-			expectedError:         nil,
-			expectedResult:        endpoints2,
-			expectCreate:          []runtime.Object{endpoints2, epSlice2},
-			initialState:          []runtime.Object{},
-			namespaceParam:        endpoints2.Namespace,
-			endpointsParam:        endpoints2,
+			expectedError:  nil,
+			expectedResult: endpoints2,
+			expectCreate:   []runtime.Object{endpoints2, epSlice2},
+			initialState:   []runtime.Object{},
+			namespaceParam: endpoints2.Namespace,
+			endpointsParam: endpoints2,
 		},
 		"single-endpoint-full-ipv6": {
-			endpointSlicesEnabled: true,
-			expectedError:         nil,
-			expectedResult:        endpoints3,
-			expectCreate:          []runtime.Object{endpoints3, epSlice3},
-			initialState:          []runtime.Object{},
-			namespaceParam:        endpoints3.Namespace,
-			endpointsParam:        endpoints3,
+			expectedError:  nil,
+			expectedResult: endpoints3,
+			expectCreate:   []runtime.Object{endpoints3, epSlice3},
+			initialState:   []runtime.Object{},
+			namespaceParam: endpoints3.Namespace,
+			endpointsParam: endpoints3,
 		},
 		"existing-endpoint": {
-			endpointSlicesEnabled: true,
-			expectedError:         errors.NewAlreadyExists(schema.GroupResource{Group: "", Resource: "endpoints"}, "foo"),
-			expectedResult:        nil,
-			initialState:          []runtime.Object{endpoints1, epSlice1},
-			namespaceParam:        endpoints1.Namespace,
-			endpointsParam:        endpoints1,
+			expectedError:  errors.NewAlreadyExists(schema.GroupResource{Group: "", Resource: "endpoints"}, "foo"),
+			expectedResult: nil,
+			initialState:   []runtime.Object{endpoints1, epSlice1},
+			namespaceParam: endpoints1.Namespace,
+			endpointsParam: endpoints1,
 
 			// We expect the create to be attempted, we just also expect it to fail
 			expectCreate: []runtime.Object{endpoints1},
@@ -186,34 +177,31 @@ func TestEndpointsAdapterUpdate(t *testing.T) {
 	_, epSlice4IPv4 := generateEndpointsAndSlice("foo", "testing", []int{80}, []string{"10.1.2.7", "10.1.2.8"})
 
 	testCases := map[string]struct {
-		endpointSlicesEnabled bool
-		expectedError         error
-		expectedResult        *corev1.Endpoints
-		expectCreate          []runtime.Object
-		expectUpdate          []runtime.Object
-		initialState          []runtime.Object
-		namespaceParam        string
-		endpointsParam        *corev1.Endpoints
+		expectedError  error
+		expectedResult *corev1.Endpoints
+		expectCreate   []runtime.Object
+		expectUpdate   []runtime.Object
+		initialState   []runtime.Object
+		namespaceParam string
+		endpointsParam *corev1.Endpoints
 	}{
 		"single-existing-endpoints-no-change": {
-			endpointSlicesEnabled: true,
-			expectedError:         nil,
-			expectedResult:        endpoints1,
-			initialState:          []runtime.Object{endpoints1, epSlice1},
-			namespaceParam:        "testing",
-			endpointsParam:        endpoints1,
+			expectedError:  nil,
+			expectedResult: endpoints1,
+			initialState:   []runtime.Object{endpoints1, epSlice1},
+			namespaceParam: "testing",
+			endpointsParam: endpoints1,
 
 			// Even though there's no change, we still expect Update() to be
 			// called, because this unit test ALWAYS calls Update().
 			expectUpdate: []runtime.Object{endpoints1},
 		},
 		"existing-endpointslice-replaced-with-updated-ipv4-address-type": {
-			endpointSlicesEnabled: true,
-			expectedError:         nil,
-			expectedResult:        endpoints4,
-			initialState:          []runtime.Object{endpoints4, epSlice4IP},
-			namespaceParam:        "testing",
-			endpointsParam:        endpoints4,
+			expectedError:  nil,
+			expectedResult: endpoints4,
+			initialState:   []runtime.Object{endpoints4, epSlice4IP},
+			namespaceParam: "testing",
+			endpointsParam: endpoints4,
 
 			// When AddressType changes, we Delete+Create the EndpointSlice,
 			// so that shows up in expectCreate, not expectUpdate.
@@ -221,21 +209,19 @@ func TestEndpointsAdapterUpdate(t *testing.T) {
 			expectCreate: []runtime.Object{epSlice4IPv4},
 		},
 		"add-ports-and-ips": {
-			endpointSlicesEnabled: true,
-			expectedError:         nil,
-			expectedResult:        endpoints2,
-			expectUpdate:          []runtime.Object{endpoints2, epSlice2},
-			initialState:          []runtime.Object{endpoints1, epSlice1},
-			namespaceParam:        "testing",
-			endpointsParam:        endpoints2,
+			expectedError:  nil,
+			expectedResult: endpoints2,
+			expectUpdate:   []runtime.Object{endpoints2, epSlice2},
+			initialState:   []runtime.Object{endpoints1, epSlice1},
+			namespaceParam: "testing",
+			endpointsParam: endpoints2,
 		},
 		"missing-endpoints": {
-			endpointSlicesEnabled: true,
-			expectedError:         errors.NewNotFound(schema.GroupResource{Group: "", Resource: "endpoints"}, "bar"),
-			expectedResult:        nil,
-			initialState:          []runtime.Object{endpoints1, epSlice1},
-			namespaceParam:        "testing",
-			endpointsParam:        endpoints3,
+			expectedError:  errors.NewNotFound(schema.GroupResource{Group: "", Resource: "endpoints"}, "bar"),
+			expectedResult: nil,
+			initialState:   []runtime.Object{endpoints1, epSlice1},
+			namespaceParam: "testing",
+			endpointsParam: endpoints3,
 
 			// We expect the update to be attempted, we just also expect it to fail
 			expectUpdate: []runtime.Object{endpoints3},
@@ -316,7 +302,6 @@ func TestEndpointsAdapterEnsureEndpointSliceFromEndpoints(t *testing.T) {
 	endpoints2, epSlice2 := generateEndpointsAndSlice("foo", "testing", []int{80, 443}, []string{"10.1.2.3", "10.1.2.4", "10.1.2.5"})
 
 	testCases := map[string]struct {
-		endpointSlicesEnabled bool
 		expectedError         error
 		expectedEndpointSlice *discovery.EndpointSlice
 		initialState          []runtime.Object
@@ -324,7 +309,6 @@ func TestEndpointsAdapterEnsureEndpointSliceFromEndpoints(t *testing.T) {
 		endpointsParam        *corev1.Endpoints
 	}{
 		"existing-endpointslice-no-change": {
-			endpointSlicesEnabled: true,
 			expectedError:         nil,
 			expectedEndpointSlice: epSlice1,
 			initialState:          []runtime.Object{epSlice1},
@@ -332,7 +316,6 @@ func TestEndpointsAdapterEnsureEndpointSliceFromEndpoints(t *testing.T) {
 			endpointsParam:        endpoints1,
 		},
 		"existing-endpointslice-change": {
-			endpointSlicesEnabled: true,
 			expectedError:         nil,
 			expectedEndpointSlice: epSlice2,
 			initialState:          []runtime.Object{epSlice1},
@@ -340,7 +323,6 @@ func TestEndpointsAdapterEnsureEndpointSliceFromEndpoints(t *testing.T) {
 			endpointsParam:        endpoints2,
 		},
 		"missing-endpointslice": {
-			endpointSlicesEnabled: true,
 			expectedError:         nil,
 			expectedEndpointSlice: epSlice1,
 			initialState:          []runtime.Object{},

--- a/pkg/controlplane/reconcilers/helpers_test.go
+++ b/pkg/controlplane/reconcilers/helpers_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func makeEndpointsArray(name string, ips []string, ports []corev1.EndpointPort) []runtime.Object {
+	return []runtime.Object{
+		makeEndpoints(name, ips, ports),
+	}
+}
+
+func makeEndpoints(name string, ips []string, ports []corev1.EndpointPort) *corev1.Endpoints {
+	endpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+			Name:      name,
+			Labels: map[string]string{
+				discoveryv1.LabelSkipMirror: "true",
+			},
+		},
+	}
+	if len(ips) > 0 || len(ports) > 0 {
+		endpoints.Subsets = []corev1.EndpointSubset{{
+			Addresses: make([]corev1.EndpointAddress, len(ips)),
+			Ports:     ports,
+		}}
+		for i := range ips {
+			endpoints.Subsets[0].Addresses[i].IP = ips[i]
+		}
+	}
+	return endpoints
+}

--- a/pkg/controlplane/reconcilers/instancecount_test.go
+++ b/pkg/controlplane/reconcilers/instancecount_test.go
@@ -21,8 +21,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
@@ -30,16 +28,6 @@ import (
 )
 
 func TestMasterCountEndpointReconciler(t *testing.T) {
-	ns := metav1.NamespaceDefault
-	om := func(name string, skipMirrorLabel bool) metav1.ObjectMeta {
-		o := metav1.ObjectMeta{Namespace: ns, Name: name}
-		if skipMirrorLabel {
-			o.Labels = map[string]string{
-				discoveryv1.LabelSkipMirror: "true",
-			}
-		}
-		return o
-	}
 	reconcileTests := []struct {
 		testName          string
 		serviceName       string
@@ -47,8 +35,8 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 		endpointPorts     []corev1.EndpointPort
 		additionalMasters int
 		initialState      []runtime.Object
-		expectUpdate      *corev1.Endpoints // nil means none expected
-		expectCreate      *corev1.Endpoints // nil means none expected
+		expectUpdate      []runtime.Object
+		expectCreate      []runtime.Object
 	}{
 		{
 			testName:      "no existing endpoints",
@@ -56,50 +44,22 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			initialState:  nil,
-			expectCreate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
+			expectCreate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:      "existing endpoints satisfy",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				},
-			},
+			initialState:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:      "existing endpoints satisfy but too many",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}, {IP: "4.3.2.1"}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				},
-			},
-			expectUpdate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
+			initialState:  makeEndpointsArray("foo", []string{"1.2.3.4", "4.3.2.1"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectUpdate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:          "existing endpoints satisfy but too many + extra masters",
@@ -107,33 +67,8 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			ip:                "1.2.3.4",
 			endpointPorts:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			additionalMasters: 3,
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{
-							{IP: "1.2.3.4"},
-							{IP: "4.3.2.1"},
-							{IP: "4.3.2.2"},
-							{IP: "4.3.2.3"},
-							{IP: "4.3.2.4"},
-						},
-						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				},
-			},
-			expectUpdate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{
-						{IP: "1.2.3.4"},
-						{IP: "4.3.2.2"},
-						{IP: "4.3.2.3"},
-						{IP: "4.3.2.4"},
-					},
-					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
+			initialState:      makeEndpointsArray("foo", []string{"1.2.3.4", "4.3.2.1", "4.3.2.2", "4.3.2.3", "4.3.2.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectUpdate:      makeEndpointsArray("foo", []string{"1.2.3.4", "4.3.2.2", "4.3.2.3", "4.3.2.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:          "existing endpoints satisfy but too many + extra masters + delete first",
@@ -141,33 +76,8 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			ip:                "4.3.2.4",
 			endpointPorts:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			additionalMasters: 3,
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{
-							{IP: "1.2.3.4"},
-							{IP: "4.3.2.1"},
-							{IP: "4.3.2.2"},
-							{IP: "4.3.2.3"},
-							{IP: "4.3.2.4"},
-						},
-						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				},
-			},
-			expectUpdate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{
-						{IP: "4.3.2.1"},
-						{IP: "4.3.2.2"},
-						{IP: "4.3.2.3"},
-						{IP: "4.3.2.4"},
-					},
-					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
+			initialState:      makeEndpointsArray("foo", []string{"1.2.3.4", "4.3.2.1", "4.3.2.2", "4.3.2.3", "4.3.2.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectUpdate:      makeEndpointsArray("foo", []string{"4.3.2.1", "4.3.2.2", "4.3.2.3", "4.3.2.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:          "existing endpoints satisfy and endpoint addresses length less than master count",
@@ -175,19 +85,8 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			ip:                "4.3.2.2",
 			endpointPorts:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			additionalMasters: 3,
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{
-							{IP: "4.3.2.1"},
-							{IP: "4.3.2.2"},
-						},
-						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				},
-			},
-			expectUpdate: nil,
+			initialState:      makeEndpointsArray("foo", []string{"4.3.2.1", "4.3.2.2"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectUpdate:      nil,
 		},
 		{
 			testName:          "existing endpoints current IP missing and address length less than master count",
@@ -195,137 +94,48 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			ip:                "4.3.2.2",
 			endpointPorts:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			additionalMasters: 3,
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{
-							{IP: "4.3.2.1"},
-						},
-						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				},
-			},
-			expectUpdate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{
-						{IP: "4.3.2.1"},
-						{IP: "4.3.2.2"},
-					},
-					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
+			initialState:      makeEndpointsArray("foo", []string{"4.3.2.1"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectUpdate:      makeEndpointsArray("foo", []string{"4.3.2.1", "4.3.2.2"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:      "existing endpoints wrong name",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("bar", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				},
-			},
-			expectCreate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
+			initialState:  makeEndpointsArray("bar", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectCreate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:      "existing endpoints wrong IP",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "4.3.2.1"}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				},
-			},
-			expectUpdate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
+			initialState:  makeEndpointsArray("foo", []string{"4.3.2.1"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectUpdate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:      "existing endpoints wrong port",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 9090, Protocol: "TCP"}},
-					}},
-				},
-			},
-			expectUpdate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
+			initialState:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 9090, Protocol: "TCP"}}),
+			expectUpdate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:      "existing endpoints wrong protocol",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "UDP"}},
-					}},
-				},
-			},
-			expectUpdate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
+			initialState:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "UDP"}}),
+			expectUpdate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:      "existing endpoints wrong port name",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				},
-			},
-			expectUpdate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []corev1.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
+			initialState:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectUpdate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:    "existing endpoints extra service ports satisfy",
@@ -336,19 +146,13 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 				{Name: "bar", Port: 1000, Protocol: "TCP"},
 				{Name: "baz", Port: 1010, Protocol: "TCP"},
 			},
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports: []corev1.EndpointPort{
-							{Name: "foo", Port: 8080, Protocol: "TCP"},
-							{Name: "bar", Port: 1000, Protocol: "TCP"},
-							{Name: "baz", Port: 1010, Protocol: "TCP"},
-						},
-					}},
+			initialState: makeEndpointsArray("foo", []string{"1.2.3.4"},
+				[]corev1.EndpointPort{
+					{Name: "foo", Port: 8080, Protocol: "TCP"},
+					{Name: "bar", Port: 1000, Protocol: "TCP"},
+					{Name: "baz", Port: 1010, Protocol: "TCP"},
 				},
-			},
+			),
 		},
 		{
 			testName:    "existing endpoints extra service ports missing port",
@@ -358,25 +162,13 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 				{Name: "foo", Port: 8080, Protocol: "TCP"},
 				{Name: "bar", Port: 1000, Protocol: "TCP"},
 			},
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
+			initialState: makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectUpdate: makeEndpointsArray("foo", []string{"1.2.3.4"},
+				[]corev1.EndpointPort{
+					{Name: "foo", Port: 8080, Protocol: "TCP"},
+					{Name: "bar", Port: 1000, Protocol: "TCP"},
 				},
-			},
-			expectUpdate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports: []corev1.EndpointPort{
-						{Name: "foo", Port: 8080, Protocol: "TCP"},
-						{Name: "bar", Port: 1000, Protocol: "TCP"},
-					},
-				}},
-			},
+			),
 		},
 		{
 			testName:      "no existing sctp endpoints",
@@ -384,13 +176,7 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "boo", Port: 7777, Protocol: "SCTP"}},
 			initialState:  nil,
-			expectCreate: &corev1.Endpoints{
-				ObjectMeta: om("boo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []corev1.EndpointPort{{Name: "boo", Port: 7777, Protocol: "SCTP"}},
-				}},
-			},
+			expectCreate:  makeEndpointsArray("boo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "boo", Port: 7777, Protocol: "SCTP"}}),
 		},
 	}
 	for _, test := range reconcileTests {
@@ -413,7 +199,7 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			if test.expectUpdate != nil {
 				if len(updates) != 1 {
 					t.Errorf("unexpected updates: %v", updates)
-				} else if e, a := test.expectUpdate, updates[0].GetObject(); !reflect.DeepEqual(e, a) {
+				} else if e, a := test.expectUpdate[0], updates[0].GetObject(); !reflect.DeepEqual(e, a) {
 					t.Errorf("expected update:\n%#v\ngot:\n%#v\n", e, a)
 				}
 			}
@@ -431,7 +217,7 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			if test.expectCreate != nil {
 				if len(creates) != 1 {
 					t.Errorf("unexpected creates: %v", creates)
-				} else if e, a := test.expectCreate, creates[0].GetObject(); !reflect.DeepEqual(e, a) {
+				} else if e, a := test.expectCreate[0], creates[0].GetObject(); !reflect.DeepEqual(e, a) {
 					t.Errorf("expected create:\n%#v\ngot:\n%#v\n", e, a)
 				}
 			}
@@ -448,8 +234,8 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 		endpointPorts     []corev1.EndpointPort
 		additionalMasters int
 		initialState      []runtime.Object
-		expectUpdate      *corev1.Endpoints // nil means none expected
-		expectCreate      *corev1.Endpoints // nil means none expected
+		expectUpdate      []runtime.Object
+		expectCreate      []runtime.Object
 	}{
 		{
 			testName:    "existing endpoints extra service ports missing port no update",
@@ -459,15 +245,7 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 				{Name: "foo", Port: 8080, Protocol: "TCP"},
 				{Name: "bar", Port: 1000, Protocol: "TCP"},
 			},
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				},
-			},
+			initialState: makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 			expectUpdate: nil,
 		},
 		{
@@ -478,22 +256,8 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 				{Name: "foo", Port: 8080, Protocol: "TCP"},
 				{Name: "bar", Port: 1000, Protocol: "TCP"},
 			},
-			initialState: []runtime.Object{
-				&corev1.Endpoints{
-					ObjectMeta: om("foo", true),
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "4.3.2.1"}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
-				},
-			},
-			expectUpdate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
+			initialState: makeEndpointsArray("foo", []string{"4.3.2.1"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectUpdate: makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:      "no existing endpoints",
@@ -501,13 +265,7 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			initialState:  nil,
-			expectCreate: &corev1.Endpoints{
-				ObjectMeta: om("foo", true),
-				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-				}},
-			},
+			expectCreate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 	}
 	for _, test := range nonReconcileTests {
@@ -530,7 +288,7 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			if test.expectUpdate != nil {
 				if len(updates) != 1 {
 					t.Errorf("unexpected updates: %v", updates)
-				} else if e, a := test.expectUpdate, updates[0].GetObject(); !reflect.DeepEqual(e, a) {
+				} else if e, a := test.expectUpdate[0], updates[0].GetObject(); !reflect.DeepEqual(e, a) {
 					t.Errorf("expected update:\n%#v\ngot:\n%#v\n", e, a)
 				}
 			}
@@ -548,7 +306,7 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			if test.expectCreate != nil {
 				if len(creates) != 1 {
 					t.Errorf("unexpected creates: %v", creates)
-				} else if e, a := test.expectCreate, creates[0].GetObject(); !reflect.DeepEqual(e, a) {
+				} else if e, a := test.expectCreate[0], creates[0].GetObject(); !reflect.DeepEqual(e, a) {
 					t.Errorf("expected create:\n%#v\ngot:\n%#v\n", e, a)
 				}
 			}
@@ -561,16 +319,7 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 }
 
 func TestEmptySubsets(t *testing.T) {
-	ns := metav1.NamespaceDefault
-	om := func(name string) metav1.ObjectMeta {
-		return metav1.ObjectMeta{Namespace: ns, Name: name}
-	}
-	endpoints := &corev1.EndpointsList{
-		Items: []corev1.Endpoints{{
-			ObjectMeta: om("foo"),
-			Subsets:    nil,
-		}},
-	}
+	endpoints := makeEndpoints("foo", nil, nil)
 	fakeClient := fake.NewSimpleClientset(endpoints)
 	epAdapter := NewEndpointsAdapter(fakeClient.CoreV1(), nil)
 	reconciler := NewMasterCountEndpointReconciler(1, epAdapter)

--- a/pkg/controlplane/reconcilers/instancecount_test.go
+++ b/pkg/controlplane/reconcilers/instancecount_test.go
@@ -52,6 +52,56 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 			initialState:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
+			testName:      "existing endpoints satisfy, no endpointslice",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			initialState: []runtime.Object{
+				makeEndpoints("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+			expectCreate: []runtime.Object{
+				makeEndpointSlice("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+		},
+		{
+			testName:      "existing endpointslice satisfies, no endpoints",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			initialState: []runtime.Object{
+				makeEndpointSlice("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+			expectCreate: []runtime.Object{
+				makeEndpoints("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+		},
+		{
+			testName:      "existing endpoints satisfy, endpointslice is wrong",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			initialState: []runtime.Object{
+				makeEndpoints("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+				makeEndpointSlice("foo", []string{"4.3.2.1"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+			expectUpdate: []runtime.Object{
+				makeEndpointSlice("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+		},
+		{
+			testName:      "existing endpointslice satisfies, endpoints is wrong",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			initialState: []runtime.Object{
+				makeEndpoints("foo", []string{"4.3.2.1"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+				makeEndpointSlice("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+			expectUpdate: []runtime.Object{
+				makeEndpoints("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+		},
+		{
 			testName:      "existing endpoints satisfy but too many",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",

--- a/pkg/controlplane/reconcilers/instancecount_test.go
+++ b/pkg/controlplane/reconcilers/instancecount_test.go
@@ -180,7 +180,7 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 	for _, test := range reconcileTests {
 		t.Run(test.testName, func(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(test.initialState...)
-			epAdapter := NewEndpointsAdapter(fakeClient.CoreV1(), nil)
+			epAdapter := NewEndpointsAdapter(fakeClient.CoreV1(), fakeClient.DiscoveryV1())
 			reconciler := NewMasterCountEndpointReconciler(test.additionalMasters+1, epAdapter)
 			err := reconciler.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, true)
 			if err != nil {
@@ -238,7 +238,7 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 	for _, test := range nonReconcileTests {
 		t.Run(test.testName, func(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(test.initialState...)
-			epAdapter := NewEndpointsAdapter(fakeClient.CoreV1(), nil)
+			epAdapter := NewEndpointsAdapter(fakeClient.CoreV1(), fakeClient.DiscoveryV1())
 			reconciler := NewMasterCountEndpointReconciler(test.additionalMasters+1, epAdapter)
 			err := reconciler.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, false)
 			if err != nil {
@@ -254,9 +254,9 @@ func TestMasterCountEndpointReconciler(t *testing.T) {
 }
 
 func TestEmptySubsets(t *testing.T) {
-	endpoints := makeEndpoints("foo", nil, nil)
-	fakeClient := fake.NewSimpleClientset(endpoints)
-	epAdapter := NewEndpointsAdapter(fakeClient.CoreV1(), nil)
+	endpoints := makeEndpointsArray("foo", nil, nil)
+	fakeClient := fake.NewSimpleClientset(endpoints...)
+	epAdapter := NewEndpointsAdapter(fakeClient.CoreV1(), fakeClient.DiscoveryV1())
 	reconciler := NewMasterCountEndpointReconciler(1, epAdapter)
 	endpointPorts := []corev1.EndpointPort{
 		{Name: "foo", Port: 8080, Protocol: "TCP"},

--- a/pkg/controlplane/reconcilers/lease.go
+++ b/pkg/controlplane/reconcilers/lease.go
@@ -113,7 +113,8 @@ func (s *storageLeases) UpdateLease(ip string) error {
 
 // RemoveLease removes the lease on a master IP in storage
 func (s *storageLeases) RemoveLease(ip string) error {
-	return s.storage.Delete(apirequest.NewDefaultContext(), s.baseKey+"/"+ip, &corev1.Endpoints{}, nil, rest.ValidateAllObjectFunc, nil)
+	key := path.Join(s.baseKey, ip)
+	return s.storage.Delete(apirequest.NewDefaultContext(), key, &corev1.Endpoints{}, nil, rest.ValidateAllObjectFunc, nil)
 }
 
 // NewLeases creates a new etcd-based Leases implementation.

--- a/pkg/controlplane/reconcilers/lease_test.go
+++ b/pkg/controlplane/reconcilers/lease_test.go
@@ -22,8 +22,6 @@ https://github.com/openshift/origin/blob/bb340c5dd5ff72718be86fb194dedc0faed7f4c
 */
 
 import (
-	"context"
-	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -86,6 +84,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 		endpointKeys  []string
 		initialState  []runtime.Object
 		expectUpdate  []runtime.Object
+		expectCreate  []runtime.Object
 	}{
 		{
 			testName:      "no existing endpoints",
@@ -93,7 +92,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			initialState:  nil,
-			expectUpdate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectCreate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:      "existing endpoints satisfy",
@@ -151,7 +150,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			initialState:  makeEndpointsArray("bar", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
-			expectUpdate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectCreate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
 			testName:      "existing endpoints wrong IP",
@@ -250,17 +249,14 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
 			err := r.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, true)
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf("unexpected error reconciling: %v", err)
 			}
-			actualEndpoints, err := clientset.CoreV1().Endpoints(corev1.NamespaceDefault).Get(context.TODO(), test.serviceName, metav1.GetOptions{})
+
+			err = verifyCreatesAndUpdates(clientset, test.expectCreate, test.expectUpdate)
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf("unexpected error in side effects: %v", err)
 			}
-			if test.expectUpdate != nil {
-				if e, a := test.expectUpdate[0], actualEndpoints; !reflect.DeepEqual(e, a) {
-					t.Errorf("expected update:\n%#v\ngot:\n%#v\n", e, a)
-				}
-			}
+
 			if updatedKeys := fakeLeases.GetUpdatedKeys(); len(updatedKeys) != 1 || updatedKeys[0] != test.ip {
 				t.Errorf("expected the master's IP to be refreshed, but the following IPs were refreshed instead: %v", updatedKeys)
 			}
@@ -275,6 +271,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 		endpointKeys  []string
 		initialState  []runtime.Object
 		expectUpdate  []runtime.Object
+		expectCreate  []runtime.Object
 	}{
 		{
 			testName:    "existing endpoints extra service ports missing port no update",
@@ -304,7 +301,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			initialState:  nil,
-			expectUpdate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectCreate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 	}
 	for _, test := range nonReconcileTests {
@@ -316,17 +313,14 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
 			err := r.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, false)
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf("unexpected error reconciling: %v", err)
 			}
-			actualEndpoints, err := clientset.CoreV1().Endpoints(corev1.NamespaceDefault).Get(context.TODO(), test.serviceName, metav1.GetOptions{})
+
+			err = verifyCreatesAndUpdates(clientset, test.expectCreate, test.expectUpdate)
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf("unexpected error in side effects: %v", err)
 			}
-			if test.expectUpdate != nil {
-				if e, a := test.expectUpdate[0], actualEndpoints; !reflect.DeepEqual(e, a) {
-					t.Errorf("expected update:\n%#v\ngot:\n%#v\n", e, a)
-				}
-			}
+
 			if updatedKeys := fakeLeases.GetUpdatedKeys(); len(updatedKeys) != 1 || updatedKeys[0] != test.ip {
 				t.Errorf("expected the master's IP to be refreshed, but the following IPs were refreshed instead: %v", updatedKeys)
 			}
@@ -368,6 +362,7 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			endpointKeys:  []string{"1.2.3.4", "4.3.2.2", "4.3.2.3", "4.3.2.4"},
 			initialState:  makeEndpointsArray("foo", nil, nil),
+			expectUpdate:  makeEndpointsArray("foo", []string{"1.2.3.4", "4.3.2.2", "4.3.2.3", "4.3.2.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 	}
 	for _, test := range stopTests {
@@ -379,17 +374,14 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
 			err := r.RemoveEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts)
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf("unexpected error reconciling: %v", err)
 			}
-			actualEndpoints, err := clientset.CoreV1().Endpoints(corev1.NamespaceDefault).Get(context.TODO(), test.serviceName, metav1.GetOptions{})
+
+			err = verifyCreatesAndUpdates(clientset, nil, test.expectUpdate)
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf("unexpected error in side effects: %v", err)
 			}
-			if test.expectUpdate != nil {
-				if e, a := test.expectUpdate[0], actualEndpoints; !reflect.DeepEqual(e, a) {
-					t.Errorf("expected update:\n%#v\ngot:\n%#v\n", e, a)
-				}
-			}
+
 			for _, key := range fakeLeases.GetUpdatedKeys() {
 				if key == test.ip {
 					t.Errorf("Found ip %s in leases but shouldn't be there", key)

--- a/pkg/controlplane/reconcilers/lease_test.go
+++ b/pkg/controlplane/reconcilers/lease_test.go
@@ -102,6 +102,56 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			initialState:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 		},
 		{
+			testName:      "existing endpoints satisfy, no endpointslice",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			initialState: []runtime.Object{
+				makeEndpoints("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+			expectCreate: []runtime.Object{
+				makeEndpointSlice("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+		},
+		{
+			testName:      "existing endpointslice satisfies, no endpoints",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			initialState: []runtime.Object{
+				makeEndpointSlice("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+			expectCreate: []runtime.Object{
+				makeEndpoints("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+		},
+		{
+			testName:      "existing endpoints satisfy, endpointslice is wrong",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			initialState: []runtime.Object{
+				makeEndpoints("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+				makeEndpointSlice("foo", []string{"4.3.2.1"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+			expectUpdate: []runtime.Object{
+				makeEndpointSlice("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+		},
+		{
+			testName:      "existing endpointslice satisfies, endpoints is wrong",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			initialState: []runtime.Object{
+				makeEndpoints("foo", []string{"4.3.2.1"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+				makeEndpointSlice("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+			expectUpdate: []runtime.Object{
+				makeEndpoints("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			},
+		},
+		{
 			testName:      "existing endpoints satisfy + refresh existing key",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",

--- a/pkg/controlplane/reconcilers/lease_test.go
+++ b/pkg/controlplane/reconcilers/lease_test.go
@@ -202,8 +202,12 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				},
+				makeEndpointSlice("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 			},
-			expectUpdate: makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectUpdate: []runtime.Object{
+				makeEndpoints("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+				// EndpointSlice does not get updated because it was already correct
+			},
 		},
 		{
 			testName:    "existing endpoints extra service ports satisfy",
@@ -245,7 +249,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			fakeLeases.SetKeys(test.endpointKeys)
 			clientset := fake.NewSimpleClientset(test.initialState...)
 
-			epAdapter := EndpointsAdapter{endpointClient: clientset.CoreV1()}
+			epAdapter := NewEndpointsAdapter(clientset.CoreV1(), clientset.DiscoveryV1())
 			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
 			err := r.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, true)
 			if err != nil {
@@ -309,7 +313,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			fakeLeases := newFakeLeases()
 			fakeLeases.SetKeys(test.endpointKeys)
 			clientset := fake.NewSimpleClientset(test.initialState...)
-			epAdapter := EndpointsAdapter{endpointClient: clientset.CoreV1()}
+			epAdapter := NewEndpointsAdapter(clientset.CoreV1(), clientset.DiscoveryV1())
 			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
 			err := r.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, false)
 			if err != nil {
@@ -370,7 +374,7 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 			fakeLeases := newFakeLeases()
 			fakeLeases.SetKeys(test.endpointKeys)
 			clientset := fake.NewSimpleClientset(test.initialState...)
-			epAdapter := EndpointsAdapter{endpointClient: clientset.CoreV1()}
+			epAdapter := NewEndpointsAdapter(clientset.CoreV1(), clientset.DiscoveryV1())
 			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
 			err := r.RemoveEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts)
 			if err != nil {


### PR DESCRIPTION
Cherry pick of #114138 on release-1.23.

#114138: Use t.Run() consistently in reconciler unit tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix endpoint reconciler not being able to delete the apiserver lease on shutdown
```