### PR TITLE
endpointslicemirroring handle endpoints with multiple subsets

### DIFF
--- a/pkg/controller/endpointslicemirroring/reconciler.go
+++ b/pkg/controller/endpointslicemirroring/reconciler.go
@@ -29,6 +29,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
+	endpointsv1 "k8s.io/kubernetes/pkg/api/v1/endpoints"
 	"k8s.io/kubernetes/pkg/controller/endpointslicemirroring/metrics"
 	endpointutil "k8s.io/kubernetes/pkg/controller/util/endpoint"
 	endpointsliceutil "k8s.io/kubernetes/pkg/controller/util/endpointslice"
@@ -68,7 +69,9 @@ func (r *reconciler) reconcile(endpoints *corev1.Endpoints, existingSlices []*di
 	numInvalidAddresses := 0
 	addressesSkipped := 0
 
-	for _, subset := range endpoints.Subsets {
+	// canonicalize the Endpoints subsets before processing them
+	subsets := endpointsv1.RepackSubsets(endpoints.Subsets)
+	for _, subset := range subsets {
 		multiKey := d.initPorts(subset.Ports)
 
 		totalAddresses := len(subset.Addresses) + len(subset.NotReadyAddresses)

--- a/pkg/controller/endpointslicemirroring/reconciler_test.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/metrics/testutil"
+	endpointsv1 "k8s.io/kubernetes/pkg/api/v1/endpoints"
 	"k8s.io/kubernetes/pkg/controller/endpointslicemirroring/metrics"
 	endpointsliceutil "k8s.io/kubernetes/pkg/controller/util/endpointslice"
 	"k8s.io/utils/pointer"
@@ -90,6 +91,102 @@ func TestReconcile(t *testing.T) {
 		expectedNumSlices:      1,
 		expectedClientActions:  1,
 		expectedMetrics:        &expectedMetrics{desiredSlices: 1, actualSlices: 1, desiredEndpoints: 1, addedPerSync: 1, numCreated: 1},
+	}, {
+		testName: "Endpoints with 2 subset, different port and address",
+		subsets: []corev1.EndpointSubset{
+			{
+				Ports: []corev1.EndpointPort{{
+					Name:     "http",
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+				}},
+				Addresses: []corev1.EndpointAddress{{
+					IP:       "10.0.0.1",
+					Hostname: "pod-1",
+					NodeName: pointer.String("node-1"),
+				}},
+			},
+			{
+				Ports: []corev1.EndpointPort{{
+					Name:     "https",
+					Port:     443,
+					Protocol: corev1.ProtocolTCP,
+				}},
+				Addresses: []corev1.EndpointAddress{{
+					IP:       "10.0.0.2",
+					Hostname: "pod-2",
+					NodeName: pointer.String("node-1"),
+				}},
+			},
+		},
+		existingEndpointSlices: []*discovery.EndpointSlice{},
+		expectedNumSlices:      2,
+		expectedClientActions:  2,
+		expectedMetrics:        &expectedMetrics{desiredSlices: 2, actualSlices: 2, desiredEndpoints: 2, addedPerSync: 2, numCreated: 2},
+	}, {
+		testName: "Endpoints with 2 subset, different port and same address",
+		subsets: []corev1.EndpointSubset{
+			{
+				Ports: []corev1.EndpointPort{{
+					Name:     "http",
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+				}},
+				Addresses: []corev1.EndpointAddress{{
+					IP:       "10.0.0.1",
+					Hostname: "pod-1",
+					NodeName: pointer.String("node-1"),
+				}},
+			},
+			{
+				Ports: []corev1.EndpointPort{{
+					Name:     "https",
+					Port:     443,
+					Protocol: corev1.ProtocolTCP,
+				}},
+				Addresses: []corev1.EndpointAddress{{
+					IP:       "10.0.0.1",
+					Hostname: "pod-1",
+					NodeName: pointer.String("node-1"),
+				}},
+			},
+		},
+		existingEndpointSlices: []*discovery.EndpointSlice{},
+		expectedNumSlices:      1,
+		expectedClientActions:  1,
+		expectedMetrics:        &expectedMetrics{desiredSlices: 1, actualSlices: 1, desiredEndpoints: 1, addedPerSync: 1, numCreated: 1},
+	}, {
+		testName: "Endpoints with 2 subset, different address and same port",
+		subsets: []corev1.EndpointSubset{
+			{
+				Ports: []corev1.EndpointPort{{
+					Name:     "http",
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+				}},
+				Addresses: []corev1.EndpointAddress{{
+					IP:       "10.0.0.1",
+					Hostname: "pod-1",
+					NodeName: pointer.String("node-1"),
+				}},
+			},
+			{
+				Ports: []corev1.EndpointPort{{
+					Name:     "http",
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+				}},
+				Addresses: []corev1.EndpointAddress{{
+					IP:       "10.0.0.2",
+					Hostname: "pod-2",
+					NodeName: pointer.String("node-1"),
+				}},
+			},
+		},
+		existingEndpointSlices: []*discovery.EndpointSlice{},
+		expectedNumSlices:      1,
+		expectedClientActions:  1,
+		expectedMetrics:        &expectedMetrics{desiredSlices: 1, actualSlices: 1, desiredEndpoints: 2, addedPerSync: 2, numCreated: 1},
 	}, {
 		testName: "Endpoints with 1 subset, port, and address, pending deletion",
 		subsets: []corev1.EndpointSubset{{
@@ -1015,7 +1112,10 @@ func expectEndpointSlices(t *testing.T, num, maxEndpointsPerSubset int, endpoint
 		}
 	}
 
-	for _, epSubset := range endpoints.Subsets {
+	// canonicalize endpoints to match the expected endpoints, otherwise the test
+	// that creates more endpoints than allowed fail becaused the list of final
+	// endpoints doesn't match.
+	for _, epSubset := range endpointsv1.RepackSubsets(endpoints.Subsets) {
 		if len(epSubset.Addresses) == 0 && len(epSubset.NotReadyAddresses) == 0 {
 			continue
 		}


### PR DESCRIPTION
Endpoints generated by the endpoints controller are in the canonical form, however, custom endpoints may not be in canonical format, there was a time they were canonicalized in the apiserver, but this caused performance issues because the endpoint controller kept updating them since the created endpoint were different than the stored one due to the canonicalization, see https://github.com/kubernetes/kubernetes/pull/94112.

There are cases where a custom endpoint may generate multiple slices due to the controller, per example, when the same address is present in different subsets. Per example:

```
apiVersion: v1
kind: Endpoints
metadata:
  name: test
  namespace: test
subsets:
- addresses:
  - ip: 10.40.0.2
  ports:
  - name: nginx-8989
    port: 8080
    protocol: TCP
- addresses:
  - ip: 10.40.0.2
  ports:
  - name: nginx-4444
    port: 8082
    protocol: TCP
```

yields 2 slices in the format:
```
addressType: IPv4
apiVersion: discovery.k8s.io/v1
endpoints:
- addresses:
  - 10.40.0.2
  conditions:
    ready: true
kind: EndpointSlice
metadata:
  generateName: test-
  generation: 1
  labels:
    endpointslice.kubernetes.io/managed-by: endpointslicemirroring-controller.k8s.io
    kubernetes.io/service-name: test
  name: test-spjnn
  namespace: test
ports:
- name: nginx-4444
  port: 8082
  protocol: TCP
```

```
addressType: IPv4
apiVersion: discovery.k8s.io/v1
endpoints:
- addresses:
  - 10.40.0.2
  conditions:
    ready: true
kind: EndpointSlice
metadata:
  generateName: test-
  labels:
    endpointslice.kubernetes.io/managed-by: endpointslicemirroring-controller.k8s.io
    kubernetes.io/service-name: test
  name: test-ss6sx
  namespace: test
ports:
- name: nginx-8989
  port: 8080
  protocol: TCP
```

The endpointslice mirroring controller should canonicalize the endpoints subsets before start processing them to be consistent on the slices generated, there is no risk of hotlooping because the endpoint is only used as input.

/kind bug

Fixes #

```release-note
fix a bug on the endpointslice mirroring controller that generated multiple slices in some cases for custom endpoints in non canonical format
```
