### PR TITLE
update ineligible_endpoints.yaml to include getResourceAPIGroup

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -109,6 +109,9 @@
 - endpoint: getInternalApiserverAPIGroup
   reason: Not eligible for conformance yet
   link: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190802-dynamic-coordinated-storage-version.md
+- endpoint: getResourceAPIGroup
+  reason: still an alpha feature plan for GA 1.31
+  link: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3063-dynamic-resource-allocation/kep.yaml#L29-L33
 - endpoint: getStorageAPIGroup
   reason: vendor specific feature
   link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
The endpoint `getResourceAPIGroup` is a new Alpa endpoint. 
It does not have `alpha` in it's file path therefore it is showing as a new `GA` endpoints in APISnoop making it look like new technical debt.
The endpoint will be [promoted to `GA` in 1.31](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3063-dynamic-resource-allocation/kep.yaml#L29-L33), which is noted in the `ineligible_endpoints.yaml`

**Special notes for your reviewer:**


**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig architecture
/area conformance
/sig node