### PR TITLE
debug: kube::version::get_version_vars

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -64,7 +64,6 @@ kube::version::get_version_vars() {
 
   if [[ -n ${KUBE_GIT_COMMIT-} ]] || KUBE_GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null); then
     if [[ -z ${KUBE_GIT_TREE_STATE-} ]]; then
-      echo "KUBE_GIT_TREE_STATE=${KUBE_GIT_TREE_STATE}"
       # Check if the tree is dirty.  default to dirty
       if git_status=$("${git[@]}" status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
         echo "git_status=${git_status}"

--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -61,6 +61,7 @@ kube::version::get_version_vars() {
   local git=(git --work-tree "${KUBE_ROOT}")
 
   "${git[@]}" log -n 1 >&2
+  "${git[@]}" diff HEAD^ HEAD >&2
 
   if [[ -n ${KUBE_GIT_COMMIT-} ]] || KUBE_GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null); then
     if [[ -z ${KUBE_GIT_TREE_STATE-} ]]; then

--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -60,6 +60,8 @@ kube::version::get_version_vars() {
 
   local git=(git --work-tree "${KUBE_ROOT}")
 
+  "${git[@]}" log -n 1 >&2
+
   if [[ -n ${KUBE_GIT_COMMIT-} ]] || KUBE_GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null); then
     if [[ -z ${KUBE_GIT_TREE_STATE-} ]]; then
       # Check if the tree is dirty.  default to dirty

--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -32,9 +32,9 @@
 # If KUBE_GIT_VERSION_FILE, this function will load from that file instead of
 # querying git.
 kube::version::get_version_vars() {
-  printf "kube::version::get_version_vars: KUBE_ROOT=${KUBE_ROOT}\n"
+  printf "kube::version::get_version_vars: KUBE_ROOT=${KUBE_ROOT}\n" >&2
   if [[ -n ${KUBE_GIT_VERSION_FILE-} ]]; then
-    printf "kube::version::get_version_vars: KUBE_GIT_VERSION_FILE is not empty\n"
+    printf "kube::version::get_version_vars: KUBE_GIT_VERSION_FILE is not empty\n" >&2
     kube::version::load_version_vars "${KUBE_GIT_VERSION_FILE}"
     return
   fi
@@ -45,16 +45,16 @@ kube::version::get_version_vars() {
   # Disabled as we're not expanding these at runtime, but rather expecting
   # that another tool may have expanded these and rewritten the source (!)
   if [[ '$Format:%%$' == "%" ]]; then
-    printf "kube::version::get_version_vars: exported through git archive\n"
+    printf "kube::version::get_version_vars: exported through git archive\n" >&2
     KUBE_GIT_COMMIT='$Format:%H$'
     KUBE_GIT_TREE_STATE="archive"
     # When a 'git archive' is exported, the '$Format:%D$' below will look
     # something like 'HEAD -> release-1.8, tag: v1.8.3' where then 'tag: '
     # can be extracted from it.
     if [[ '$Format:%D$' =~ tag:\ (v[^ ,]+) ]]; then
-     printf "kube::version::get_version_vars: we can extract tag\n"
+     printf "kube::version::get_version_vars: we can extract tag\n" >&2
      KUBE_GIT_VERSION="${BASH_REMATCH[1]}"
-     printf "KUBE_GIT_VERSION=${KUBE_GIT_VERSION}\n"
+     printf "KUBE_GIT_VERSION=${KUBE_GIT_VERSION}\n" >&2
     fi
   fi
 
@@ -69,11 +69,7 @@ kube::version::get_version_vars() {
         KUBE_GIT_TREE_STATE="dirty"
       fi
     fi
-    printf "kube::version::get_version_vars: KUBE_GIT_TREE_STATE=${KUBE_GIT_TREE_STATE}\n"
-
-    if [[ -n ${KUBE_GIT_VERSION-} ]]; then
-      printf "KUBE_GIT_VERSION is not empty\n"
-    fi
+    printf "kube::version::get_version_vars: KUBE_GIT_TREE_STATE=${KUBE_GIT_TREE_STATE}\n" >&2
 
     # Use git describe to find the version based on tags.
     if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --tags --match='v*' --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
@@ -88,7 +84,7 @@ kube::version::get_version_vars() {
       # We don't want to do them in pure shell, so disable SC2001
       # shellcheck disable=SC2001
       DASHES_IN_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/[^-]//g")
-      printf "kube::version::get_version_vars: DASHES_IN_VERSION=${DASHES_IN_VERSION}\n"
+      printf "kube::version::get_version_vars: DASHES_IN_VERSION=${DASHES_IN_VERSION}\n" >&2
       if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
         # shellcheck disable=SC2001
         # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
@@ -104,7 +100,7 @@ kube::version::get_version_vars() {
         # so use our idea of "dirty" from git status instead.
         KUBE_GIT_VERSION+="-dirty"
       fi
-      printf "kube::version::get_version_vars: KUBE_GIT_VERSION=${KUBE_GIT_VERSION}\n"
+      printf "kube::version::get_version_vars: KUBE_GIT_VERSION=${KUBE_GIT_VERSION}\n" >&2
 
 
       # Try to match the "git describe" output to a regex to try to extract

--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -119,11 +119,11 @@ kube::version::get_version_vars() {
         KUBE_GIT_MAJOR=${BASH_REMATCH[1]}
         echo "KUBE_GIT_MAJOR=${KUBE_GIT_MAJOR}"
         KUBE_GIT_MINOR=${BASH_REMATCH[2]}
-        echo "KUBE_GIT_MINOR=${KUBE_GIKUBE_GIT_MINORT_MAJOR}"
+        echo "KUBE_GIT_MINOR=${KUBE_GIT_MINOR}"
         if [[ -n "${BASH_REMATCH[4]}" ]]; then
           echo "we have a 4th pattern match"
           KUBE_GIT_MINOR+="+"
-          echo "KUBE_GIT_MINOR=${KUBE_GIKUBE_GIT_MINORT_MAJOR}"
+          echo "KUBE_GIT_MINOR=${KUBE_GIT_MINOR}"
         fi
       fi
 

--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -32,9 +32,9 @@
 # If KUBE_GIT_VERSION_FILE, this function will load from that file instead of
 # querying git.
 kube::version::get_version_vars() {
-  echo "inside get_version_vars"
+  printf "kube::version::get_version_vars: KUBE_ROOT=${KUBE_ROOT}\n"
   if [[ -n ${KUBE_GIT_VERSION_FILE-} ]]; then
-    echo "KUBE_GIT_VERSION_FILE is not empty"
+    printf "kube::version::get_version_vars: KUBE_GIT_VERSION_FILE is not empty\n"
     kube::version::load_version_vars "${KUBE_GIT_VERSION_FILE}"
     return
   fi
@@ -45,37 +45,38 @@ kube::version::get_version_vars() {
   # Disabled as we're not expanding these at runtime, but rather expecting
   # that another tool may have expanded these and rewritten the source (!)
   if [[ '$Format:%%$' == "%" ]]; then
-    echo "exported through git archive"
+    printf "kube::version::get_version_vars: exported through git archive\n"
     KUBE_GIT_COMMIT='$Format:%H$'
     KUBE_GIT_TREE_STATE="archive"
     # When a 'git archive' is exported, the '$Format:%D$' below will look
     # something like 'HEAD -> release-1.8, tag: v1.8.3' where then 'tag: '
     # can be extracted from it.
     if [[ '$Format:%D$' =~ tag:\ (v[^ ,]+) ]]; then
-     echo "we can extract tag"
+     printf "kube::version::get_version_vars: we can extract tag\n"
      KUBE_GIT_VERSION="${BASH_REMATCH[1]}"
-     echo "KUBE_GIT_VERSION=${KUBE_GIT_VERSION}"
+     printf "KUBE_GIT_VERSION=${KUBE_GIT_VERSION}\n"
     fi
   fi
 
-  echo "KUBE_ROOT=${KUBE_ROOT}"
   local git=(git --work-tree "${KUBE_ROOT}")
-  echo "git=${git}"
 
   if [[ -n ${KUBE_GIT_COMMIT-} ]] || KUBE_GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null); then
     if [[ -z ${KUBE_GIT_TREE_STATE-} ]]; then
       # Check if the tree is dirty.  default to dirty
       if git_status=$("${git[@]}" status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
-        echo "git_status=${git_status}"
         KUBE_GIT_TREE_STATE="clean"
       else
         KUBE_GIT_TREE_STATE="dirty"
       fi
     fi
+    printf "kube::version::get_version_vars: KUBE_GIT_TREE_STATE=${KUBE_GIT_TREE_STATE}\n"
+
+    if [[ -n ${KUBE_GIT_VERSION-} ]]; then
+      printf "KUBE_GIT_VERSION is not empty\n"
+    fi
 
     # Use git describe to find the version based on tags.
     if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --tags --match='v*' --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
-      echo "KUBE_GIT_VERSION=${KUBE_GIT_VERSION}"
       # This translates the "git describe" to an actual semver.org
       # compatible semantic version that looks something like this:
       #   v1.1.0-alpha.0.6+84c76d1142ea4d
@@ -87,43 +88,33 @@ kube::version::get_version_vars() {
       # We don't want to do them in pure shell, so disable SC2001
       # shellcheck disable=SC2001
       DASHES_IN_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/[^-]//g")
-      echo "DASHES_IN_VERSION=${DASHES_IN_VERSION}"
+      printf "kube::version::get_version_vars: DASHES_IN_VERSION=${DASHES_IN_VERSION}\n"
       if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
-        echo "there are three dashes"
         # shellcheck disable=SC2001
         # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
         KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
-        echo "KUBE_GIT_VERSION=${KUBE_GIT_VERSION}"
       elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
-        echo "there are two dashes"
         # shellcheck disable=SC2001
         # We have distance to base tag (v1.1.0-1-gCommitHash)
         KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
-        echo "KUBE_GIT_VERSION=${KUBE_GIT_VERSION}"
       fi
       if [[ "${KUBE_GIT_TREE_STATE}" == "dirty" ]]; then
-        echo "dirty git tree state"
         # git describe --dirty only considers changes to existing files, but
         # that is problematic since new untracked .go files affect the build,
         # so use our idea of "dirty" from git status instead.
         KUBE_GIT_VERSION+="-dirty"
-        echo "KUBE_GIT_VERSION=${KUBE_GIT_VERSION}"
       fi
+      printf "kube::version::get_version_vars: KUBE_GIT_VERSION=${KUBE_GIT_VERSION}\n"
 
 
       # Try to match the "git describe" output to a regex to try to extract
       # the "major" and "minor" versions and whether this is the exact tagged
       # version or whether the tree is between two tagged versions.
       if [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
-        echo "we have major and minor"
         KUBE_GIT_MAJOR=${BASH_REMATCH[1]}
-        echo "KUBE_GIT_MAJOR=${KUBE_GIT_MAJOR}"
         KUBE_GIT_MINOR=${BASH_REMATCH[2]}
-        echo "KUBE_GIT_MINOR=${KUBE_GIT_MINOR}"
         if [[ -n "${BASH_REMATCH[4]}" ]]; then
-          echo "we have a 4th pattern match"
           KUBE_GIT_MINOR+="+"
-          echo "KUBE_GIT_MINOR=${KUBE_GIT_MINOR}"
         fi
       fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

This PR will help debug why `kube::version::get_version_vars` is not returning the right commit in testgrid jobs for capz.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
