### PR TITLE
release-1.24: debug: kube::version::get_version_vars

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -32,7 +32,9 @@
 # If KUBE_GIT_VERSION_FILE, this function will load from that file instead of
 # querying git.
 kube::version::get_version_vars() {
+  printf "kube::version::get_version_vars: KUBE_ROOT=${KUBE_ROOT}\n" >&2
   if [[ -n ${KUBE_GIT_VERSION_FILE-} ]]; then
+    printf "kube::version::get_version_vars: KUBE_GIT_VERSION_FILE is not empty\n" >&2
     kube::version::load_version_vars "${KUBE_GIT_VERSION_FILE}"
     return
   fi
@@ -43,17 +45,22 @@ kube::version::get_version_vars() {
   # Disabled as we're not expanding these at runtime, but rather expecting
   # that another tool may have expanded these and rewritten the source (!)
   if [[ '$Format:%%$' == "%" ]]; then
+    printf "kube::version::get_version_vars: exported through git archive\n" >&2
     KUBE_GIT_COMMIT='$Format:%H$'
     KUBE_GIT_TREE_STATE="archive"
     # When a 'git archive' is exported, the '$Format:%D$' below will look
     # something like 'HEAD -> release-1.8, tag: v1.8.3' where then 'tag: '
     # can be extracted from it.
     if [[ '$Format:%D$' =~ tag:\ (v[^ ,]+) ]]; then
+     printf "kube::version::get_version_vars: we can extract tag\n" >&2
      KUBE_GIT_VERSION="${BASH_REMATCH[1]}"
     fi
   fi
 
   local git=(git --work-tree "${KUBE_ROOT}")
+
+  "${git[@]}" log -n 1 >&2
+  "${git[@]}" diff HEAD^ HEAD >&2
 
   if [[ -n ${KUBE_GIT_COMMIT-} ]] || KUBE_GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null); then
     if [[ -z ${KUBE_GIT_TREE_STATE-} ]]; then
@@ -64,6 +71,7 @@ kube::version::get_version_vars() {
         KUBE_GIT_TREE_STATE="dirty"
       fi
     fi
+    printf "kube::version::get_version_vars: KUBE_GIT_TREE_STATE=${KUBE_GIT_TREE_STATE}\n" >&2
 
     # Use git describe to find the version based on tags.
     if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --tags --match='v*' --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
@@ -78,6 +86,7 @@ kube::version::get_version_vars() {
       # We don't want to do them in pure shell, so disable SC2001
       # shellcheck disable=SC2001
       DASHES_IN_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/[^-]//g")
+      printf "kube::version::get_version_vars: DASHES_IN_VERSION=${DASHES_IN_VERSION}\n" >&2
       if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
         # shellcheck disable=SC2001
         # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
@@ -93,6 +102,7 @@ kube::version::get_version_vars() {
         # so use our idea of "dirty" from git status instead.
         KUBE_GIT_VERSION+="-dirty"
       fi
+      printf "kube::version::get_version_vars: KUBE_GIT_VERSION=${KUBE_GIT_VERSION}\n" >&2
 
 
       # Try to match the "git describe" output to a regex to try to extract


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test 

#### What this PR does / why we need it:

This PR will help debug why kube::version::get_version_vars is not returning the right commit in testgrid jobs for capz.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
