### PR TITLE
pkg/volume/util/operationexecutor: Fix test order in operation_generator_test.go

### DIFF
--- a/pkg/volume/util/operationexecutor/operation_generator_test.go
+++ b/pkg/volume/util/operationexecutor/operation_generator_test.go
@@ -184,7 +184,7 @@ func TestOperationGenerator_GenerateExpandAndRecoverVolumeFunc(t *testing.T) {
 				t.Fatalf("GenerateExpandAndRecoverVolumeFunc failed: %v", expansionResponse.err)
 			}
 			updatedPVC := expansionResponse.pvc
-			assert.Equal(t, *updatedPVC.Status.ResizeStatus, test.expectedResizeStatus)
+			assert.Equal(t, test.expectedResizeStatus, *updatedPVC.Status.ResizeStatus)
 			actualAllocatedSize := updatedPVC.Status.AllocatedResources.Storage()
 			if test.expectedAllocatedSize.Cmp(*actualAllocatedSize) != 0 {
 				t.Fatalf("GenerateExpandAndRecoverVolumeFunc failed: expected allocated size %s, got %s", test.expectedAllocatedSize.String(), actualAllocatedSize.String())


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Per https://pkg.go.dev/github.com/stretchr/testify/assert#Equal expected goes before actual:
func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool

Fixes tests asserting that the expected values were the actual ones, when they were not. just like https://github.com/kubernetes/kubernetes/pull/102611

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:
none

Does this PR introduce a user-facing change?
none

```release-note

NONE

```