### PR TITLE
Allow profiling information to be served on Unix-Domain Socket

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/feature.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/feature.go
@@ -25,6 +25,7 @@ import (
 
 type FeatureOptions struct {
 	EnableProfiling           bool
+	DebugSocketPath           string
 	EnableContentionProfiling bool
 }
 
@@ -33,6 +34,7 @@ func NewFeatureOptions() *FeatureOptions {
 
 	return &FeatureOptions{
 		EnableProfiling:           defaults.EnableProfiling,
+		DebugSocketPath:           defaults.DebugSocketPath,
 		EnableContentionProfiling: defaults.EnableContentionProfiling,
 	}
 }
@@ -46,6 +48,8 @@ func (o *FeatureOptions) AddFlags(fs *pflag.FlagSet) {
 		"Enable profiling via web interface host:port/debug/pprof/")
 	fs.BoolVar(&o.EnableContentionProfiling, "contention-profiling", o.EnableContentionProfiling,
 		"Enable lock contention profiling, if profiling is enabled")
+	fs.StringVar(&o.DebugSocketPath, "debug-socket-path", o.DebugSocketPath,
+		"Use an unprotected (no authn/authz) unix-domain socket for profiling with the given path")
 }
 
 func (o *FeatureOptions) ApplyTo(c *server.Config) error {
@@ -54,6 +58,7 @@ func (o *FeatureOptions) ApplyTo(c *server.Config) error {
 	}
 
 	c.EnableProfiling = o.EnableProfiling
+	c.DebugSocketPath = o.DebugSocketPath
 	c.EnableContentionProfiling = o.EnableContentionProfiling
 
 	return nil

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/debugsocket.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/debugsocket.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routes
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"path"
+)
+
+// DebugSocket installs profiling and debugflag as a Unix-Domain socket.
+type DebugSocket struct {
+	path string
+	mux  *http.ServeMux
+}
+
+// NewDebugSocket creates a new DebugSocket for the given path.
+func NewDebugSocket(path string) *DebugSocket {
+	return &DebugSocket{
+		path: path,
+		mux:  http.NewServeMux(),
+	}
+}
+
+// InstallProfiling installs profiling endpoints in the socket.
+func (s *DebugSocket) InstallProfiling() {
+	s.mux.HandleFunc("/debug/pprof", redirectTo("/debug/pprof/"))
+	s.mux.HandleFunc("/debug/pprof/", pprof.Index)
+	s.mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	s.mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	s.mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	s.mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+}
+
+// InstallDebugFlag installs debug flag endpoints in the socket.
+func (s *DebugSocket) InstallDebugFlag(flag string, handler func(http.ResponseWriter, *http.Request)) {
+	f := DebugFlags{}
+	s.mux.HandleFunc("/debug/flags", f.Index)
+	s.mux.HandleFunc("/debug/flags/", f.Index)
+
+	url := path.Join("/debug/flags", flag)
+	s.mux.HandleFunc(url, handler)
+
+	f.addFlag(flag)
+}
+
+// Run starts the server and waits for stopCh to be closed to close the server.
+func (s *DebugSocket) Run(stopCh <-chan struct{}) error {
+	if err := os.Remove(s.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove (%v): %v", s.path, err)
+	}
+
+	l, err := net.Listen("unix", s.path)
+	if err != nil {
+		return fmt.Errorf("listen error (%v): %v", s.path, err)
+	}
+	defer l.Close()
+
+	srv := http.Server{Handler: s.mux}
+	go func() {
+		<-stopCh
+		srv.Close()
+	}()
+	return srv.Serve(l)
+}


### PR DESCRIPTION
Serving profiling information can leak information or expose the apiserver to possible DoS attacks. Serving on a UDS is more secure though slightly less convenient. One can't use `go tool pprof` directly against the socket since it's not supported, but can either run a proxy to copy from the socket over to http, or use `curl --unix-socket` to download the profile and then use `go tool pprof`.

I'm really not happy with the wiring (and lack of clean shutdown) but still decided to push it for review for suggestions. Also I don't have tests yet, suggestions on how to do that is welcome.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Profiling can now be served on a unix-domain socket by using the `--profiling-path` option (when profiling is enabled) for security purposes.
```
