### PR TITLE
publishing-bot: Fix apimachinery rule for release-1.26 pointing to the wrong staging dir and use correct Go version

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -26,7 +26,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     source: 
       branch: release-1.26
       dir: staging/src/k8s.io/code-generator
@@ -57,7 +57,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     source: 
       branch: release-1.26
       dir: staging/src/k8s.io/apimachinery
@@ -104,7 +104,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -184,7 +184,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -260,7 +260,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -334,7 +334,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -354,7 +354,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/kms
@@ -432,7 +432,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -540,7 +540,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -676,7 +676,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -795,7 +795,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -917,7 +917,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1008,7 +1008,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1084,7 +1084,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1168,7 +1168,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1253,7 +1253,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1339,7 +1339,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1425,7 +1425,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1523,7 +1523,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1643,7 +1643,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1777,7 +1777,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1851,7 +1851,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1913,7 +1913,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1950,7 +1950,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/mount-utils
@@ -2087,7 +2087,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2140,7 +2140,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/cri-api
@@ -2257,7 +2257,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2363,7 +2363,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2397,7 +2397,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.19
+    go: 1.19.3
     dependencies:
       - repository: apimachinery
         branch: release-1.26

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -60,7 +60,7 @@ rules:
     go: 1.19
     source: 
       branch: release-1.26
-      dir: staging/src/k8s.io/code-generator
+      dir: staging/src/k8s.io/apimachinery
   library: true
 - destination: api
   branches:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR fixes two issues in the publishing-bot rules:

- Fix publishing-bot rule for `apimachinery` on the `release-1.26` branch pointing to `staging/src/k8s.io/code-generator` instead of `staging/src/k8s.io/apimachinery`
- Ensure the Go version for the `release-1.26` branch is Go 1.19.3 (as it is for other branches using Go 1.19)

#### Which issue(s) this PR fixes:

Fixes #114192

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/assign @dims @liggitt 
/priority critical-urgent
/milestone v1.26