### PR TITLE
add github.com/mindprince/gonvml to unwanted dependencies

### DIFF
--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -18,13 +18,13 @@
       "github.com/influxdata/influxdb1-client": "",
       "github.com/json-iterator/go": "refer to #105030",
       "github.com/miekg/dns": "no dns client/server should be required",
+      "github.com/mndrix/tap-go": "unmaintained",
       "github.com/onsi/ginkgo": "Ginkgo has been migrated to V2, refer to #109111",
       "github.com/spf13/viper": "refer to #102598",
+      "github.com/xeipuuv/gojsonschema": "unmaintained",
       "go.mongodb.org/mongo-driver": "",
       "gopkg.in/fsnotify.v1": "obsolete, use github.com/fsnotify/fsnotify",
       "k8s.io/klog": "we have switched to klog v2, so avoid klog v1",
-      "github.com/mndrix/tap-go": "unmaintained",
-      "github.com/xeipuuv/gojsonschema": "unmaintained",
       "rsc.io/quote": "refer to #102833",
       "rsc.io/sampler": "refer to #102833"
     }

--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -18,6 +18,7 @@
       "github.com/influxdata/influxdb1-client": "",
       "github.com/json-iterator/go": "refer to #105030",
       "github.com/miekg/dns": "no dns client/server should be required",
+      "github.com/mindprince/gonvml": "depends on nvml.h that does not appear to permit modification, redistribution",
       "github.com/mndrix/tap-go": "unmaintained",
       "github.com/onsi/ginkgo": "Ginkgo has been migrated to V2, refer to #109111",
       "github.com/spf13/viper": "refer to #102598",
@@ -56,6 +57,9 @@
         "go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful",
         "k8s.io/kube-openapi",
         "sigs.k8s.io/structured-merge-diff/v4"
+      ],
+      "github.com/mindprince/gonvml": [
+        "github.com/google/cadvisor"
       ]
     }
   }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
See https://groups.google.com/d/msgid/kubernetes-sig-architecture/CAJ18wa9iwCsfugDOR%2B%2Bo86udHjx6qGjYWfp6qCwBVL7gBu5C2A%40mail.gmail.com?utm_medium=email&utm_source=footer for discussions.

github.com/mindprince/gonvml
- https://github.com/mindprince/gonvml/blob/ac0b66419a4131fe2348bceb59358888edd9c4e4/bindings.go#L25

#### Which issue(s) this PR fixes:
Fixes None
- BTW, sort unwanted dependencies in order
- [ ] https://github.com/google/cadvisor/releases waiting for new release of cadvisor

#### Special notes for your reviewer:
cncf/kubernetes, code pulled 2022-10-13
  - report: https://lfscanning.org/reports/cncf/kubernetes-2022-10-13-19a6e7e7-4f53-4c58-9dcb-6ab28ebf194d.html

#### Does this PR introduce a user-facing change?
```release-note
None
```