### PR TITLE
Re-factor FieldManager tests for better re-use

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package fieldmanager
+package fieldmanager_test
 
 import (
 	"bytes"
@@ -29,18 +29,19 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 type fakeManager struct{}
 
-var _ Manager = &fakeManager{}
+var _ fieldmanager.Manager = &fakeManager{}
 
-func (*fakeManager) Update(_, newObj runtime.Object, managed Managed, _ string) (runtime.Object, Managed, error) {
+func (*fakeManager) Update(_, newObj runtime.Object, managed fieldmanager.Managed, _ string) (runtime.Object, fieldmanager.Managed, error) {
 	return newObj, managed, nil
 }
 
-func (*fakeManager) Apply(_, _ runtime.Object, _ Managed, _ string, _ bool) (runtime.Object, Managed, error) {
+func (*fakeManager) Apply(_, _ runtime.Object, _ fieldmanager.Managed, _ string, _ bool) (runtime.Object, fieldmanager.Managed, error) {
 	panic("not implemented")
 	return nil, nil, nil
 }
@@ -48,8 +49,8 @@ func (*fakeManager) Apply(_, _ runtime.Object, _ Managed, _ string, _ bool) (run
 func TestCapManagersManagerMergesEntries(t *testing.T) {
 	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"),
 		"",
-		func(m Manager) Manager {
-			return NewCapManagersManager(m, 3)
+		func(m fieldmanager.Manager) fieldmanager.Manager {
+			return fieldmanager.NewCapManagersManager(m, 3)
 		})
 
 	podWithLabels := func(labels ...string) runtime.Object {
@@ -114,8 +115,8 @@ func TestCapManagersManagerMergesEntries(t *testing.T) {
 func TestCapUpdateManagers(t *testing.T) {
 	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"),
 		"",
-		func(m Manager) Manager {
-			return NewCapManagersManager(m, 3)
+		func(m fieldmanager.Manager) fieldmanager.Manager {
+			return fieldmanager.NewCapManagersManager(m, 3)
 		})
 
 	set := func(fields ...string) *metav1.FieldsV1 {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanagertest"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
@@ -47,7 +48,7 @@ func (*fakeManager) Apply(_, _ runtime.Object, _ fieldmanager.Managed, _ string,
 }
 
 func TestCapManagersManagerMergesEntries(t *testing.T) {
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"),
+	f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"),
 		"",
 		func(m fieldmanager.Manager) fieldmanager.Manager {
 			return fieldmanager.NewCapManagersManager(m, 3)
@@ -113,7 +114,7 @@ func TestCapManagersManagerMergesEntries(t *testing.T) {
 }
 
 func TestCapUpdateManagers(t *testing.T) {
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"),
+	f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"),
 		"",
 		func(m fieldmanager.Manager) fieldmanager.Manager {
 			return fieldmanager.NewCapManagersManager(m, 3)
@@ -233,12 +234,13 @@ func TestCapUpdateManagers(t *testing.T) {
 
 	for _, tc := range testCases {
 		f.Reset()
-		accessor, err := meta.Accessor(f.liveObj)
+		live := f.Live()
+		accessor, err := meta.Accessor(live)
 		if err != nil {
 			t.Fatalf("%v: couldn't get accessor: %v", tc.name, err)
 		}
 		accessor.SetManagedFields(tc.input)
-		if err := f.Update(f.liveObj, "no-op-update"); err != nil {
+		if err := f.Update(live, "no-op-update"); err != nil {
 			t.Fatalf("%v: failed to do no-op update to object: %v", tc.name, err)
 		}
 
@@ -250,13 +252,13 @@ func TestCapUpdateManagers(t *testing.T) {
 }
 
 // expectIdempotence does a no-op update and ensures that managedFields doesn't change by calling capUpdateManagers.
-func expectIdempotence(t *testing.T, f TestFieldManager) {
+func expectIdempotence(t *testing.T, f fieldmanagertest.TestFieldManager) {
 	before := []metav1.ManagedFieldsEntry{}
 	for _, m := range f.ManagedFields() {
 		before = append(before, *m.DeepCopy())
 	}
 
-	if err := f.Update(f.liveObj, "no-op-update"); err != nil {
+	if err := f.Update(f.Live(), "no-op-update"); err != nil {
 		t.Fatalf("failed to do no-op update to object: %v", err)
 	}
 
@@ -266,7 +268,7 @@ func expectIdempotence(t *testing.T, f TestFieldManager) {
 }
 
 // expectManagesField ensures that manager m currently manages field path p.
-func expectManagesField(t *testing.T, f TestFieldManager, m string, p fieldpath.Path) {
+func expectManagesField(t *testing.T, f fieldmanagertest.TestFieldManager, m string, p fieldpath.Path) {
 	for _, e := range f.ManagedFields() {
 		if e.Manager == m {
 			var s fieldpath.Set

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal"
 	"k8s.io/kube-openapi/pkg/util/proto"
 	prototesting "k8s.io/kube-openapi/pkg/util/proto/testing"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
@@ -920,7 +921,7 @@ spec:
 	}
 
 	invalidLastApplied := "invalid-object"
-	if err := setLastApplied(newObj, invalidLastApplied); err != nil {
+	if err := internal.SetLastApplied(newObj, invalidLastApplied); err != nil {
 		t.Errorf("failed to set last applied: %v", err)
 	}
 
@@ -1223,7 +1224,7 @@ func setLastAppliedFromEncoded(obj runtime.Object, lastApplied []byte) error {
 	if err != nil {
 		return err
 	}
-	return setLastApplied(obj, lastAppliedJSON)
+	return internal.SetLastApplied(obj, lastAppliedJSON)
 }
 
 func getLastApplied(obj runtime.Object) (string, error) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -77,6 +77,16 @@ type fakeObjectDefaulter struct{}
 
 func (d *fakeObjectDefaulter) Default(in runtime.Object) {}
 
+type sameVersionConverter struct{}
+
+func (sameVersionConverter) Convert(object *typed.TypedValue, version fieldpath.APIVersion) (*typed.TypedValue, error) {
+	return object, nil
+}
+
+func (sameVersionConverter) IsMissingVersionError(error) bool {
+	return false
+}
+
 type TestFieldManager struct {
 	fieldManager *FieldManager
 	apiVersion   string
@@ -91,9 +101,8 @@ func NewDefaultTestFieldManager(gvk schema.GroupVersionKind) TestFieldManager {
 func NewTestFieldManager(gvk schema.GroupVersionKind, subresource string, chainFieldManager func(Manager) Manager) TestFieldManager {
 	m := NewFakeOpenAPIModels()
 	typeConverter := NewFakeTypeConverter(m)
-	converter := newVersionConverter(typeConverter, &fakeObjectConvertor{}, gvk.GroupVersion())
 	apiVersion := fieldpath.APIVersion(gvk.GroupVersion().String())
-	objectConverter := &fakeObjectConvertor{converter, apiVersion}
+	objectConverter := &fakeObjectConvertor{sameVersionConverter{}, apiVersion}
 	f, err := NewStructuredMergeManager(
 		typeConverter,
 		objectConverter,

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -88,10 +88,6 @@ func NewDefaultTestFieldManager(gvk schema.GroupVersionKind) TestFieldManager {
 	return NewTestFieldManager(gvk, "", nil)
 }
 
-func NewSubresourceTestFieldManager(gvk schema.GroupVersionKind) TestFieldManager {
-	return NewTestFieldManager(gvk, "scale", nil)
-}
-
 func NewTestFieldManager(gvk schema.GroupVersionKind, subresource string, chainFieldManager func(Manager) Manager) TestFieldManager {
 	m := NewFakeOpenAPIModels()
 	typeConverter := NewFakeTypeConverter(m)
@@ -1239,7 +1235,7 @@ func getLastApplied(obj runtime.Object) (string, error) {
 }
 
 func TestUpdateViaSubresources(t *testing.T) {
-	f := NewSubresourceTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"))
+	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "scale", nil)
 
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
 	if err := yaml.Unmarshal([]byte(`{

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanagertest/testfieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanagertest/testfieldmanager.go
@@ -102,18 +102,16 @@ func (sameVersionConverter) IsMissingVersionError(error) bool {
 
 // NewFakeObjectCreater implements ObjectCreater, it can create empty
 // objects (unstructured) of the given GVK.
-func NewFakeObjectCreater(gvk schema.GroupVersionKind) runtime.ObjectCreater {
-	return &fakeObjectCreater{gvk: gvk}
+func NewFakeObjectCreater() runtime.ObjectCreater {
+	return &fakeObjectCreater{}
 }
 
-type fakeObjectCreater struct {
-	gvk schema.GroupVersionKind
-}
+type fakeObjectCreater struct{}
 
-func (f *fakeObjectCreater) New(_ schema.GroupVersionKind) (runtime.Object, error) {
+func (f *fakeObjectCreater) New(gvk schema.GroupVersionKind) (runtime.Object, error) {
 	u := unstructured.Unstructured{Object: map[string]interface{}{}}
-	u.SetAPIVersion(f.gvk.GroupVersion().String())
-	u.SetKind(f.gvk.Kind)
+	u.SetAPIVersion(gvk.GroupVersion().String())
+	u.SetKind(gvk.Kind)
 	return &u, nil
 }
 
@@ -167,7 +165,7 @@ func NewTestFieldManager(gvk schema.GroupVersionKind, subresource string, chainF
 					fieldmanager.NewManagedFieldsUpdater(
 						fieldmanager.NewStripMetaManager(f),
 					), gvk.GroupVersion(), subresource,
-				), NewFakeObjectCreater(gvk), gvk, fieldmanager.DefaultTrackOnCreateProbability,
+				), NewFakeObjectCreater(), gvk, fieldmanager.DefaultTrackOnCreateProbability,
 			), typeConverter, objectConverter, gvk.GroupVersion(),
 		),
 	)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanagertest/testfieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanagertest/testfieldmanager.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldmanagertest
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
+	"k8s.io/kube-openapi/pkg/util/proto"
+	prototesting "k8s.io/kube-openapi/pkg/util/proto/testing"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+)
+
+var kubernetesSwaggerSchema = prototesting.Fake{
+	Path: filepath.Join(
+		strings.Repeat(".."+string(filepath.Separator), 8),
+		"api", "openapi-spec", "swagger.json"),
+}
+
+// NewBuiltinTypeConverter creates a TypeConverter with all the built-in
+// types defined, given the committed kubernetes swagger.json.
+func NewBuiltinTypeConverter() fieldmanager.TypeConverter {
+	tc, err := fieldmanager.NewTypeConverter(newFakeOpenAPIModels(), false)
+	if err != nil {
+		panic(fmt.Errorf("Failed to build TypeConverter: %v", err))
+	}
+	return tc
+}
+
+func newFakeOpenAPIModels() proto.Models {
+	d, err := kubernetesSwaggerSchema.OpenAPISchema()
+	if err != nil {
+		panic(err)
+	}
+	m, err := proto.NewOpenAPIData(d)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+type fakeObjectConvertor struct {
+	converter  merge.Converter
+	apiVersion fieldpath.APIVersion
+}
+
+//nolint:staticcheck,ineffassign // SA4009 backwards compatibility
+func (c *fakeObjectConvertor) Convert(in, out, context interface{}) error {
+	if typedValue, ok := in.(*typed.TypedValue); ok {
+		var err error
+		out, err = c.converter.Convert(typedValue, c.apiVersion)
+		return err
+	}
+	return nil
+}
+
+func (c *fakeObjectConvertor) ConvertToVersion(in runtime.Object, _ runtime.GroupVersioner) (runtime.Object, error) {
+	return in, nil
+}
+
+func (c *fakeObjectConvertor) ConvertFieldLabel(_ schema.GroupVersionKind, _, _ string) (string, string, error) {
+	return "", "", errors.New("not implemented")
+}
+
+type fakeObjectDefaulter struct{}
+
+func (d *fakeObjectDefaulter) Default(in runtime.Object) {}
+
+type sameVersionConverter struct{}
+
+func (sameVersionConverter) Convert(object *typed.TypedValue, version fieldpath.APIVersion) (*typed.TypedValue, error) {
+	return object, nil
+}
+
+func (sameVersionConverter) IsMissingVersionError(error) bool {
+	return false
+}
+
+// NewFakeObjectCreater implements ObjectCreater, it can create empty
+// objects (unstructured) of the given GVK.
+func NewFakeObjectCreater(gvk schema.GroupVersionKind) runtime.ObjectCreater {
+	return &fakeObjectCreater{gvk: gvk}
+}
+
+type fakeObjectCreater struct {
+	gvk schema.GroupVersionKind
+}
+
+func (f *fakeObjectCreater) New(_ schema.GroupVersionKind) (runtime.Object, error) {
+	u := unstructured.Unstructured{Object: map[string]interface{}{}}
+	u.SetAPIVersion(f.gvk.GroupVersion().String())
+	u.SetKind(f.gvk.Kind)
+	return &u, nil
+}
+
+// TestFieldManager is a FieldManager that can be used in test to
+// simulate the behavior of Server-Side Apply and field tracking. This
+// also has a few methods to get a sense of the state of the object.
+//
+// This TestFieldManager uses a series of "fake" objects to simulate
+// some behavior which come with the limitation that you can only use
+// one version since there is no version conversion logic.
+//
+// You can use this rather than NewDefaultTestFieldManager if you want
+// to specify either a sub-resource, or a set of modified Manager to
+// test them specifically.
+type TestFieldManager struct {
+	fieldManager *fieldmanager.FieldManager
+	apiVersion   string
+	emptyObj     runtime.Object
+	liveObj      runtime.Object
+}
+
+// NewDefaultTestFieldManager returns a new TestFieldManager built for
+// the given gvk, on the main resource.
+func NewDefaultTestFieldManager(gvk schema.GroupVersionKind) TestFieldManager {
+	return NewTestFieldManager(gvk, "", nil)
+}
+
+// NewTestFieldManager creates a new manager for the given GVK.
+func NewTestFieldManager(gvk schema.GroupVersionKind, subresource string, chainFieldManager func(fieldmanager.Manager) fieldmanager.Manager) TestFieldManager {
+	typeConverter := NewBuiltinTypeConverter()
+	apiVersion := fieldpath.APIVersion(gvk.GroupVersion().String())
+	objectConverter := &fakeObjectConvertor{sameVersionConverter{}, apiVersion}
+	f, err := fieldmanager.NewStructuredMergeManager(
+		typeConverter,
+		objectConverter,
+		&fakeObjectDefaulter{},
+		gvk.GroupVersion(),
+		gvk.GroupVersion(),
+		nil,
+	)
+	if err != nil {
+		panic(err)
+	}
+	live := &unstructured.Unstructured{}
+	live.SetKind(gvk.Kind)
+	live.SetAPIVersion(gvk.GroupVersion().String())
+	f = fieldmanager.NewLastAppliedUpdater(
+		fieldmanager.NewLastAppliedManager(
+			fieldmanager.NewProbabilisticSkipNonAppliedManager(
+				fieldmanager.NewBuildManagerInfoManager(
+					fieldmanager.NewManagedFieldsUpdater(
+						fieldmanager.NewStripMetaManager(f),
+					), gvk.GroupVersion(), subresource,
+				), NewFakeObjectCreater(gvk), gvk, fieldmanager.DefaultTrackOnCreateProbability,
+			), typeConverter, objectConverter, gvk.GroupVersion(),
+		),
+	)
+	if chainFieldManager != nil {
+		f = chainFieldManager(f)
+	}
+	return TestFieldManager{
+		fieldManager: fieldmanager.NewFieldManager(f, subresource),
+		apiVersion:   gvk.GroupVersion().String(),
+		emptyObj:     live,
+		liveObj:      live.DeepCopyObject(),
+	}
+}
+
+// APIVersion of the object that we're tracking.
+func (f *TestFieldManager) APIVersion() string {
+	return f.apiVersion
+}
+
+// Reset resets the state of the liveObject by resetting it to an empty object.
+func (f *TestFieldManager) Reset() {
+	f.liveObj = f.emptyObj.DeepCopyObject()
+}
+
+// Live returns a copy of the current liveObject.
+func (f *TestFieldManager) Live() runtime.Object {
+	return f.liveObj.DeepCopyObject()
+}
+
+// Apply applies the given object on top of the current liveObj, for the
+// given manager and force flag.
+func (f *TestFieldManager) Apply(obj runtime.Object, manager string, force bool) error {
+	out, err := f.fieldManager.Apply(f.liveObj, obj, manager, force)
+	if err == nil {
+		f.liveObj = out
+	}
+	return err
+}
+
+// Update will updates the managed fields in the liveObj based on the
+// changes performed by the update.
+func (f *TestFieldManager) Update(obj runtime.Object, manager string) error {
+	out, err := f.fieldManager.Update(f.liveObj, obj, manager)
+	if err == nil {
+		f.liveObj = out
+	}
+	return err
+}
+
+// ManagedFields returns the list of existing managed fields for the
+// liveObj.
+func (f *TestFieldManager) ManagedFields() []metav1.ManagedFieldsEntry {
+	accessor, err := meta.Accessor(f.liveObj)
+	if err != nil {
+		panic(fmt.Errorf("couldn't get accessor: %v", err))
+	}
+
+	return accessor.GetManagedFields()
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/lastapplied.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/lastapplied.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// SetLastApplied sets the last-applied annotation the given value in
+// the object.
+func SetLastApplied(obj runtime.Object, value string) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		panic(fmt.Sprintf("couldn't get accessor: %v", err))
+	}
+	var annotations = accessor.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[corev1.LastAppliedConfigAnnotation] = value
+	if err := apimachineryvalidation.ValidateAnnotationsSize(annotations); err != nil {
+		delete(annotations, corev1.LastAppliedConfigAnnotation)
+	}
+	accessor.SetAnnotations(annotations)
+	return nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedmanager_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package fieldmanager
+package fieldmanager_test
 
 import (
 	"fmt"

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedmanager_test.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanagertest"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 	"sigs.k8s.io/structured-merge-diff/v4/merge"
@@ -43,7 +44,7 @@ type testArgs struct {
 // created with the client-side apply last-applied annotation
 // will not give conflicts
 func TestApplyUsingLastAppliedAnnotation(t *testing.T) {
-	f := NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("apps/v1", "Deployment"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("apps/v1", "Deployment"))
 
 	tests := []testArgs{
 		{
@@ -563,7 +564,7 @@ spec:
 }
 
 func TestServiceApply(t *testing.T) {
-	f := NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "Service"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "Service"))
 
 	tests := []testArgs{
 		{
@@ -674,7 +675,7 @@ spec:
 }
 
 func TestReplicationControllerApply(t *testing.T) {
-	f := NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ReplicationController"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ReplicationController"))
 
 	tests := []testArgs{
 		{
@@ -737,7 +738,7 @@ spec:
 }
 
 func TestPodApply(t *testing.T) {
-	f := NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"))
 
 	tests := []testArgs{
 		{
@@ -914,7 +915,7 @@ spec:
 	testConflicts(t, f, tests)
 }
 
-func testConflicts(t *testing.T, f TestFieldManager, tests []testArgs) {
+func testConflicts(t *testing.T, f fieldmanagertest.TestFieldManager, tests []testArgs) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
 			f.Reset()
@@ -972,8 +973,8 @@ func testConflicts(t *testing.T, f TestFieldManager, tests []testArgs) {
 			}
 
 			// Eventually resource should contain applied changes
-			if !apiequality.Semantic.DeepDerivative(appliedObj, f.Get()) {
-				t.Errorf("expected equal resource: \n%#v, got: \n%#v", appliedObj, f.Get())
+			if !apiequality.Semantic.DeepDerivative(appliedObj, f.Live()) {
+				t.Errorf("expected equal resource: \n%#v, got: \n%#v", appliedObj, f.Live())
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedupdater_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedupdater_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package fieldmanager
+package fieldmanager_test
 
 import (
 	"fmt"
@@ -26,14 +26,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
 	"sigs.k8s.io/yaml"
 )
 
 func TestLastAppliedUpdater(t *testing.T) {
 	f := NewTestFieldManager(schema.FromAPIVersionAndKind("apps/v1", "Deployment"),
 		"",
-		func(m Manager) Manager {
-			return NewLastAppliedUpdater(m)
+		func(m fieldmanager.Manager) fieldmanager.Manager {
+			return fieldmanager.NewLastAppliedUpdater(m)
 		})
 
 	originalLastApplied := `nonempty`
@@ -189,8 +190,8 @@ func TestLargeLastApplied(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"),
 				"",
-				func(m Manager) Manager {
-					return NewLastAppliedUpdater(m)
+				func(m fieldmanager.Manager) fieldmanager.Manager {
+					return fieldmanager.NewLastAppliedUpdater(m)
 				})
 
 			if err := f.Apply(test.oldObject, "kubectl", false); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedupdater_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedupdater_test.go
@@ -27,11 +27,12 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanagertest"
 	"sigs.k8s.io/yaml"
 )
 
 func TestLastAppliedUpdater(t *testing.T) {
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("apps/v1", "Deployment"),
+	f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("apps/v1", "Deployment"),
 		"",
 		func(m fieldmanager.Manager) fieldmanager.Manager {
 			return fieldmanager.NewLastAppliedUpdater(m)
@@ -70,7 +71,7 @@ spec:
 		t.Errorf("error applying object: %v", err)
 	}
 
-	lastApplied, err := getLastApplied(f.liveObj)
+	lastApplied, err := getLastApplied(f.Live())
 	if err != nil {
 		t.Errorf("failed to get last applied: %v", err)
 	}
@@ -83,7 +84,7 @@ spec:
 		t.Errorf("error applying object: %v", err)
 	}
 
-	lastApplied, err = getLastApplied(f.liveObj)
+	lastApplied, err = getLastApplied(f.Live())
 	if err != nil {
 		t.Errorf("failed to get last applied: %v", err)
 	}
@@ -188,7 +189,7 @@ func TestLargeLastApplied(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"),
+			f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"),
 				"",
 				func(m fieldmanager.Manager) fieldmanager.Manager {
 					return fieldmanager.NewLastAppliedUpdater(m)
@@ -198,7 +199,7 @@ func TestLargeLastApplied(t *testing.T) {
 				t.Errorf("Error applying object: %v", err)
 			}
 
-			lastApplied, err := getLastApplied(f.liveObj)
+			lastApplied, err := getLastApplied(f.Live())
 			if err != nil {
 				t.Errorf("Failed to access last applied annotation: %v", err)
 			}
@@ -211,12 +212,12 @@ func TestLargeLastApplied(t *testing.T) {
 			}
 
 			accessor := meta.NewAccessor()
-			annotations, err := accessor.Annotations(f.liveObj)
+			annotations, err := accessor.Annotations(f.Live())
 			if err != nil {
 				t.Errorf("Failed to access annotations: %v", err)
 			}
 			if annotations == nil {
-				t.Errorf("No annotations on obj: %v", f.liveObj)
+				t.Errorf("No annotations on obj: %v", f.Live())
 			}
 			lastApplied, ok := annotations[corev1.LastAppliedConfigAnnotation]
 			if ok || len(lastApplied) > 0 {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/managedfieldsupdater_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/managedfieldsupdater_test.go
@@ -14,19 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package fieldmanager
+package fieldmanager_test
 
 import (
 	"fmt"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
 	"time"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal"
 	"sigs.k8s.io/yaml"
 )
@@ -425,11 +427,11 @@ func TestTakingOverManagedFieldsDuringApplyDoesNotModifyPreviousManagerTime(t *t
 
 type NoopManager struct{}
 
-func (NoopManager) Apply(liveObj, appliedObj runtime.Object, managed Managed, fieldManager string, force bool) (runtime.Object, Managed, error) {
+func (NoopManager) Apply(liveObj, appliedObj runtime.Object, managed fieldmanager.Managed, fieldManager string, force bool) (runtime.Object, fieldmanager.Managed, error) {
 	return nil, managed, nil
 }
 
-func (NoopManager) Update(liveObj, newObj runtime.Object, managed Managed, manager string) (runtime.Object, Managed, error) {
+func (NoopManager) Update(liveObj, newObj runtime.Object, managed fieldmanager.Managed, manager string) (runtime.Object, fieldmanager.Managed, error) {
 	return nil, nil, nil
 }
 
@@ -495,12 +497,12 @@ func TestNilNewObjectReplacedWithDeepCopyExcludingManagedFields(t *testing.T) {
 	}
 
 	// Decode the managed fields in the live object, since it isn't allowed in the patch.
-	managed, err := DecodeManagedFields(accessor.GetManagedFields())
+	managed, err := fieldmanager.DecodeManagedFields(accessor.GetManagedFields())
 	if err != nil {
 		t.Fatalf("failed to decode managed fields: %v", err)
 	}
 
-	updater := NewManagedFieldsUpdater(NoopManager{})
+	updater := fieldmanager.NewManagedFieldsUpdater(NoopManager{})
 
 	newObject, _, err := updater.Apply(obj, obj.DeepCopyObject(), managed, "some_manager", false)
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/managedfieldsupdater_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/managedfieldsupdater_test.go
@@ -29,13 +29,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanagertest"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal"
 	"sigs.k8s.io/yaml"
 )
 
 func TestManagedFieldsUpdateDoesModifyTime(t *testing.T) {
 	var err error
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = updateObject(&f, "fieldmanager_test", []byte(`{
 		"apiVersion": "v1",
@@ -76,7 +77,7 @@ func TestManagedFieldsUpdateDoesModifyTime(t *testing.T) {
 
 func TestManagedFieldsApplyDoesModifyTime(t *testing.T) {
 	var err error
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = applyObject(&f, "fieldmanager_test", []byte(`{
 		"apiVersion": "v1",
@@ -117,7 +118,7 @@ func TestManagedFieldsApplyDoesModifyTime(t *testing.T) {
 
 func TestManagedFieldsUpdateWithoutChangesDoesNotModifyTime(t *testing.T) {
 	var err error
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = updateObject(&f, "fieldmanager_test", []byte(`{
 		"apiVersion": "v1",
@@ -158,7 +159,7 @@ func TestManagedFieldsUpdateWithoutChangesDoesNotModifyTime(t *testing.T) {
 
 func TestManagedFieldsApplyWithoutChangesDoesNotModifyTime(t *testing.T) {
 	var err error
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = applyObject(&f, "fieldmanager_test", []byte(`{
 		"apiVersion": "v1",
@@ -199,7 +200,7 @@ func TestManagedFieldsApplyWithoutChangesDoesNotModifyTime(t *testing.T) {
 
 func TestNonManagedFieldsUpdateDoesNotModifyTime(t *testing.T) {
 	var err error
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = updateObject(&f, "fieldmanager_a_test", []byte(`{
 		"apiVersion": "v1",
@@ -262,7 +263,7 @@ func TestNonManagedFieldsUpdateDoesNotModifyTime(t *testing.T) {
 
 func TestNonManagedFieldsApplyDoesNotModifyTime(t *testing.T) {
 	var err error
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = applyObject(&f, "fieldmanager_a_test", []byte(`{
 		"apiVersion": "v1",
@@ -325,7 +326,7 @@ func TestNonManagedFieldsApplyDoesNotModifyTime(t *testing.T) {
 
 func TestTakingOverManagedFieldsDuringUpdateDoesNotModifyPreviousManagerTime(t *testing.T) {
 	var err error
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = updateObject(&f, "fieldmanager_a_test", []byte(`{
 		"apiVersion": "v1",
@@ -376,7 +377,7 @@ func TestTakingOverManagedFieldsDuringUpdateDoesNotModifyPreviousManagerTime(t *
 
 func TestTakingOverManagedFieldsDuringApplyDoesNotModifyPreviousManagerTime(t *testing.T) {
 	var err error
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"), "", nil)
+	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = applyObject(&f, "fieldmanager_a_test", []byte(`{
 		"apiVersion": "v1",
@@ -435,7 +436,7 @@ func (NoopManager) Update(liveObj, newObj runtime.Object, managed fieldmanager.M
 	return nil, nil, nil
 }
 
-func updateObject(f *TestFieldManager, fieldManagerName string, object []byte) error {
+func updateObject(f *fieldmanagertest.TestFieldManager, fieldManagerName string, object []byte) error {
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
 	if err := yaml.Unmarshal(object, &obj.Object); err != nil {
 		return fmt.Errorf("error decoding YAML: %v", err)
@@ -446,7 +447,7 @@ func updateObject(f *TestFieldManager, fieldManagerName string, object []byte) e
 	return nil
 }
 
-func applyObject(f *TestFieldManager, fieldManagerName string, object []byte) error {
+func applyObject(f *fieldmanagertest.TestFieldManager, fieldManagerName string, object []byte) error {
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
 	if err := yaml.Unmarshal(object, &obj.Object); err != nil {
 		return fmt.Errorf("error decoding YAML: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied_test.go
@@ -23,30 +23,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanagertest"
 	"sigs.k8s.io/yaml"
 )
 
-type fakeObjectCreater struct {
-	gvk schema.GroupVersionKind
-}
-
-var _ runtime.ObjectCreater = &fakeObjectCreater{}
-
-func (f *fakeObjectCreater) New(_ schema.GroupVersionKind) (runtime.Object, error) {
-	u := unstructured.Unstructured{Object: map[string]interface{}{}}
-	u.SetAPIVersion(f.gvk.GroupVersion().String())
-	u.SetKind(f.gvk.Kind)
-	return &u, nil
-}
-
 func TestNoUpdateBeforeFirstApply(t *testing.T) {
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m fieldmanager.Manager) fieldmanager.Manager {
+	f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m fieldmanager.Manager) fieldmanager.Manager {
 		return fieldmanager.NewSkipNonAppliedManager(
 			m,
-			&fakeObjectCreater{gvk: schema.GroupVersionKind{Version: "v1", Kind: "Pod"}},
+			fieldmanagertest.NewFakeObjectCreater(schema.FromAPIVersionAndKind("v1", "Pod")),
 			schema.GroupVersionKind{},
 		)
 	})
@@ -83,10 +70,10 @@ func TestNoUpdateBeforeFirstApply(t *testing.T) {
 }
 
 func TestUpdateBeforeFirstApply(t *testing.T) {
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m fieldmanager.Manager) fieldmanager.Manager {
+	f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m fieldmanager.Manager) fieldmanager.Manager {
 		return fieldmanager.NewSkipNonAppliedManager(
 			m,
-			&fakeObjectCreater{gvk: schema.GroupVersionKind{Version: "v1", Kind: "Pod"}},
+			fieldmanagertest.NewFakeObjectCreater(schema.FromAPIVersionAndKind("v1", "Pod")),
 			schema.GroupVersionKind{},
 		)
 	})

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied_test.go
@@ -33,8 +33,8 @@ func TestNoUpdateBeforeFirstApply(t *testing.T) {
 	f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m fieldmanager.Manager) fieldmanager.Manager {
 		return fieldmanager.NewSkipNonAppliedManager(
 			m,
-			fieldmanagertest.NewFakeObjectCreater(schema.FromAPIVersionAndKind("v1", "Pod")),
-			schema.GroupVersionKind{},
+			fieldmanagertest.NewFakeObjectCreater(),
+			schema.FromAPIVersionAndKind("v1", "Pod"),
 		)
 	})
 
@@ -73,8 +73,8 @@ func TestUpdateBeforeFirstApply(t *testing.T) {
 	f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m fieldmanager.Manager) fieldmanager.Manager {
 		return fieldmanager.NewSkipNonAppliedManager(
 			m,
-			fieldmanagertest.NewFakeObjectCreater(schema.FromAPIVersionAndKind("v1", "Pod")),
-			schema.GroupVersionKind{},
+			fieldmanagertest.NewFakeObjectCreater(),
+			schema.FromAPIVersionAndKind("v1", "Pod"),
 		)
 	})
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package fieldmanager
+package fieldmanager_test
 
 import (
 	"strings"
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
 	"sigs.k8s.io/yaml"
 )
 
@@ -42,8 +43,8 @@ func (f *fakeObjectCreater) New(_ schema.GroupVersionKind) (runtime.Object, erro
 }
 
 func TestNoUpdateBeforeFirstApply(t *testing.T) {
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m Manager) Manager {
-		return NewSkipNonAppliedManager(
+	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m fieldmanager.Manager) fieldmanager.Manager {
+		return fieldmanager.NewSkipNonAppliedManager(
 			m,
 			&fakeObjectCreater{gvk: schema.GroupVersionKind{Version: "v1", Kind: "Pod"}},
 			schema.GroupVersionKind{},
@@ -82,8 +83,8 @@ func TestNoUpdateBeforeFirstApply(t *testing.T) {
 }
 
 func TestUpdateBeforeFirstApply(t *testing.T) {
-	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m Manager) Manager {
-		return NewSkipNonAppliedManager(
+	f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m fieldmanager.Manager) fieldmanager.Manager {
+		return fieldmanager.NewSkipNonAppliedManager(
 			m,
 			&fakeObjectCreater{gvk: schema.GroupVersionKind{Version: "v1", Kind: "Pod"}},
 			schema.GroupVersionKind{},


### PR DESCRIPTION
This is refactoring some things in the fieldmanager package so that we can
more easily extract the testing parts to re-use them across different projects.

This will eventually allow better testing for server-side apply code.

There's a lot of appetite for being able to test controllers that use server-side apply, but unfortunately there is no good way to simulate server-side apply in a test currently (since it's more complicated than just running a patch function). This is the first step toward that.

This shouldn't impact the public API at all.

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```
