### PR TITLE
Link `kubelet` binary statically

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -333,6 +333,7 @@ readonly KUBE_STATIC_LIBRARIES=(
   kubeadm
   kubectl
   kubectl-convert
+  kubelet
   kubemark
 )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The kubelet itself only depends on the following runtime libraries when linking dynamically:

```
> ldd _output/bin/kubelet
    linux-vdso.so.1 (0x00007ffff6dfb000)
    libpthread.so.0 => /nix/store/4nlgxhb09sdr51nc9hdm8az5b08vzkgx-glibc-2.35-163/lib/libpthread.so.0 (0x00007fce3f0e4000)
    libdl.so.2 => /nix/store/4nlgxhb09sdr51nc9hdm8az5b08vzkgx-glibc-2.35-163/lib/libdl.so.2 (0x00007fce3f0df000)
    libc.so.6 => /nix/store/4nlgxhb09sdr51nc9hdm8az5b08vzkgx-glibc-2.35-163/lib/libc.so.6 (0x00007fce3ee00000)
    /nix/store/4nlgxhb09sdr51nc9hdm8az5b08vzkgx-glibc-2.35-163/lib/ld-linux-x86-64.so.2 => /nix/store/4nlgxhb09sdr51nc9hdm8az5b08vzkgx-glibc-2.35-163/lib64/ld-linux-x86-64.so.2 (0x00007fce3f0eb000)
```

We now move the kubelet to become a static binary as well to achieve maximum portability.

#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes/release/issues/2786

#### Special notes for your reviewer:
/sig release
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Make `kubelet` binary linking static (also affects the deb and rpm packages).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
