### PR TITLE
win: fix cpu count to calculate cpu_maximum

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_windows_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_windows_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package kuberuntime
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,10 +28,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
-	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/winstats"
 )
 
 func TestApplyPlatformSpecificContainerConfig(t *testing.T) {
@@ -87,7 +84,8 @@ func TestApplyPlatformSpecificContainerConfig(t *testing.T) {
 	err = fakeRuntimeSvc.applyPlatformSpecificContainerConfig(containerConfig, &pod.Spec.Containers[0], pod, new(int64), "foo", nil)
 	require.NoError(t, err)
 
-	expectedCpuMax := ((10000 * 3000) / int64(runtime.NumCPU()) / 1000)
+	limit := int64(3000)
+	expectedCpuMax := 10 * limit / int64(winstats.ProcessorCount())
 	expectedWindowsConfig := &runtimeapi.WindowsContainerConfig{
 		Resources: &runtimeapi.WindowsContainerResources{
 			CpuMaximum:         expectedCpuMax,
@@ -100,4 +98,49 @@ func TestApplyPlatformSpecificContainerConfig(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expectedWindowsConfig, containerConfig.Windows)
+}
+
+func TestCalculateCPUMaximum(t *testing.T) {
+	tests := []struct {
+		name     string
+		cpuLimit resource.Quantity
+		cpuCount int64
+		want     int64
+	}{
+		{
+			name:     "max range when same amount",
+			cpuLimit: resource.MustParse("1"),
+			cpuCount: 1,
+			want:     10000,
+		},
+		{
+			name:     "percentage calculation is working as intended",
+			cpuLimit: resource.MustParse("94"),
+			cpuCount: 96,
+			want:     9791,
+		},
+		{
+			name:     "half range when half amount",
+			cpuLimit: resource.MustParse("1"),
+			cpuCount: 2,
+			want:     5000,
+		},
+		{
+			name:     "max range when more requested than available",
+			cpuLimit: resource.MustParse("2"),
+			cpuCount: 1,
+			want:     10000,
+		},
+		{
+			name:     "min range when less than minimum",
+			cpuLimit: resource.MustParse("1m"),
+			cpuCount: 100,
+			want:     1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, calculateCPUMaximum(&tt.cpuLimit, tt.cpuCount))
+		})
+	}
 }

--- a/pkg/kubelet/winstats/perfcounter_nodestats.go
+++ b/pkg/kubelet/winstats/perfcounter_nodestats.go
@@ -157,7 +157,7 @@ func (p *perfCounterNodeStatsClient) getMachineInfo() (*cadvisorapi.MachineInfo,
 	}
 
 	return &cadvisorapi.MachineInfo{
-		NumCores:       processorCount(),
+		NumCores:       ProcessorCount(),
 		MemoryCapacity: p.nodeInfo.memoryPhysicalCapacityBytes,
 		MachineID:      hostname,
 		SystemUUID:     systemUUID,
@@ -173,7 +173,7 @@ func (p *perfCounterNodeStatsClient) getMachineInfo() (*cadvisorapi.MachineInfo,
 // more notes for this issue:
 // same issue in moby: https://github.com/moby/moby/issues/38935#issuecomment-744638345
 // solution in hcsshim: https://github.com/microsoft/hcsshim/blob/master/internal/processorinfo/processor_count.go
-func processorCount() int {
+func ProcessorCount() int {
 	if amount := getActiveProcessorCount(allProcessorGroups); amount != 0 {
 		return int(amount)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
/sig windows
/hold

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Take all processor groups into account when calculating cpu maximum for windows.

Signed-off-by: Michael Weibel <michael@helio.exchange>

#### Which issue(s) this PR fixes:

Fixes #114211

#### Special notes for your reviewer:
I'd appreciate help with writing tests for this. 

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue when calculating CPU limits on Windows nodes with more than 64 logical processors
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
