### PR TITLE
add etcd 3.5.6-0 to kuebadm supported etcd version

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -480,6 +480,7 @@ var (
 		23: "3.5.6-0",
 		24: "3.5.6-0",
 		25: "3.5.6-0",
+		26: "3.5.6-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
```
[init] Using Kubernetes version: v1.26.0-rc.1
W1201 18:38:22.238280   13854 images.go:80] could not find officially supported version of etcd for Kubernetes v1.26.0-rc.1, falling back to the nearest etcd version (3.5.6-0)
```
#### Special notes for your reviewer:
/cc @neolit123 
when I test v1.26.0-rc.1, I got this warning during init. 
Should we add this like before to avoid the warning message? This would help when new version is released and new alpha version can work with a warning. But we still need to update it IMO.
#### Does this PR introduce a user-facing change?
```release-note
None
```
