### PR TITLE
Retry when recording an EventSerie results in an AlreadyExist error

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRecordEventToSink(t *testing.T) {
+	nonIsomorphicEvent := eventsv1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Series: nil,
+	}
+
+	isomorphicEvent := *nonIsomorphicEvent.DeepCopy()
+	isomorphicEvent.Series = &eventsv1.EventSeries{Count: 2}
+
+	testCases := []struct {
+		name                  string
+		eventsToRecord        []eventsv1.Event
+		expectedRecordedEvent eventsv1.Event
+	}{
+		{
+			name: "record one Event",
+			eventsToRecord: []eventsv1.Event{
+				nonIsomorphicEvent,
+			},
+			expectedRecordedEvent: nonIsomorphicEvent,
+		},
+		{
+			name: "record one Event followed by an isomorphic one",
+			eventsToRecord: []eventsv1.Event{
+				nonIsomorphicEvent,
+				isomorphicEvent,
+			},
+			expectedRecordedEvent: isomorphicEvent,
+		},
+		{
+			name: "record one isomorphic Event before the original",
+			eventsToRecord: []eventsv1.Event{
+				isomorphicEvent,
+				nonIsomorphicEvent,
+			},
+			expectedRecordedEvent: isomorphicEvent,
+		},
+		{
+			name: "record one isomorphic Event without one already existing",
+			eventsToRecord: []eventsv1.Event{
+				isomorphicEvent,
+			},
+			expectedRecordedEvent: isomorphicEvent,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset()
+			eventSink := &EventSinkImpl{Interface: kubeClient.EventsV1()}
+
+			for _, ev := range tc.eventsToRecord {
+				recordEvent(eventSink, &ev)
+			}
+
+			recordedEvents, err := kubeClient.EventsV1().Events(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})
+			if err != nil {
+				t.Errorf("expected to be able to list Events from fake client")
+			}
+
+			if len(recordedEvents.Items) != 1 {
+				t.Errorf("expected one Event to be recorded, found: %d", len(recordedEvents.Items))
+			}
+
+			recordedEvent := recordedEvents.Items[0]
+			if !reflect.DeepEqual(recordedEvent, tc.expectedRecordedEvent) {
+				t.Errorf("expected to have recorded Event: %#+v, got: %#+v\n diff: %s", tc.expectedRecordedEvent, recordedEvent, diff.ObjectReflectDiff(tc.expectedRecordedEvent, recordedEvent))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When attempting to record a new Event and a new Serie on the apiserver
at the same time, the patch of the Serie might happen before the Event
is actually created. In that case, we handle the error and try to create
the Event. But the Event might be created during that period of time and
it is treated as an error today. So in order to handle that scenario, we
need to retry when a Create call for a Serie results in an AlreadyExist
error.

#### Special notes for your reviewer:

This issue was highlighted when fixing a data race with a similar scenario and writing a test for it in: https://github.com/kubernetes/kubernetes/pull/114236.

The test testing this particular scenario was written in the PR above and we can't add it here since it requires the bug fix from the other PR. Also, this would need to go in before the other PR since the test fails without it.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a bug where when emitting similar Events consecutively, some were rejected by the apiserver.
```

/cc @wojtek-t 