### PR TITLE
kubectl exec: return descriptive error message when multi resource passed

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -33,6 +33,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
@@ -308,6 +309,10 @@ func (p *ExecOptions) Run() error {
 		obj, err := builder.Do().Object()
 		if err != nil {
 			return err
+		}
+
+		if meta.IsListType(obj) {
+			return fmt.Errorf("cannot exec into multiple objects at a time")
 		}
 
 		p.Pod, err = p.ExecutablePodFn(p.restClientGetter, obj, p.GetPodTimeout)

--- a/test/cmd/exec.sh
+++ b/test/cmd/exec.sh
@@ -30,6 +30,29 @@ run_kubectl_exec_pod_tests() {
   # POD abc should error since it doesn't exist
   kube::test::if_has_string "${output_message}" 'pods "abc" not found'
 
+  ### Test execute multiple resources
+  output_message=$(! kubectl exec -f - 2>&1 -- echo test << __EOF__
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test2
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+__EOF__
+)
+  kube::test::if_has_string "${output_message}" 'cannot exec into multiple objects at a time'
+
   ### Test execute existing POD
   # Create test-pod
   kubectl create -f hack/testdata/pod.yaml


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`kubectl exec` command supports getting files as inputs. However, if the file contains multiple resources, it returns unclear error message; `cannot attach to *v1.List: selector for *v1.List not implemented`.

Since `exec` command does not support multi resources, this PR handles that and returns descriptive error message earlier.

#### Does this PR introduce a user-facing change?
```release-note
change the error message to "cannot exec into multiple objects at a time" when file passed to kubectl exec contains multiple resources
```