### PR TITLE
kubectl scale: Use visitor only once

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
@@ -211,10 +211,11 @@ func (o *ScaleOptions) RunScale() error {
 		return err
 	}
 
-	infos, err := r.Infos()
-	if err != nil {
-		return err
-	}
+	// We don't immediately return infoErr if it is not nil.
+	// Because we want to proceed for other valid resources and
+	// at the end of the function, we'll return this
+	// to show invalid resources to the user.
+	infos, infoErr := r.Infos()
 
 	if len(o.ResourceVersion) != 0 && len(infos) > 1 {
 		return fmt.Errorf("cannot use --resource-version with multiple resources")
@@ -270,7 +271,7 @@ func (o *ScaleOptions) RunScale() error {
 		}
 	}
 
-	return nil
+	return infoErr
 }
 
 func scaler(f cmdutil.Factory) (scale.Scaler, error) {

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -1289,6 +1289,15 @@ run_rc_tests() {
   # Clean-up
   kubectl delete deployment/nginx-deployment "${kube_flags[@]}"
 
+  ### Scale a deployment with piped input
+  kubectl create -f test/fixtures/doc-yaml/user-guide/deployment.yaml "${kube_flags[@]}"
+  # Command
+  kubectl get deployment/nginx-deployment -o json | kubectl scale --replicas=2 -f -
+  # Post-condition: 2 replica for nginx-deployment
+  kube::test::get_object_assert 'deployment nginx-deployment' "{{${deployment_replicas:?}}}" '2'
+  # Clean-up
+  kubectl delete deployment/nginx-deployment "${kube_flags[@]}"
+
   ### Expose deployments by creating a service
   # Uses deployment selectors for created service
   output_message=$(kubectl expose -f test/fixtures/pkg/kubectl/cmd/expose/appsv1deployment.yaml --port 80 2>&1 "${kube_flags[@]}")


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`kubectl scale` calls visitor two times. Second call fails when the piped input is passed by returning an
`error: no objects passed to scale` error.

This PR uses the result of first visitor and fixes that piped input problem. In addition to that, this PR also adds new integration tests to verify.

This PR is continuation of https://github.com/kubernetes/kubernetes/pull/109196

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1183

#### Does this PR introduce a user-facing change?
```release-note
Adding (dry run) and (server dry run) suffixes to kubectl scale command when dry-run is passed
```