### PR TITLE
be more strict on e2e network timeouts

### DIFF
--- a/test/e2e/framework/service/const.go
+++ b/test/e2e/framework/service/const.go
@@ -32,9 +32,9 @@ const (
 
 	// KubeProxyLagTimeout is the maximum time a kube-proxy daemon on a node is allowed
 	// to not notice a Service update, such as type=NodePort.
-	// TODO: This timeout should be O(10s), observed values are O(1m), 5m is very
+	// TODO: This timeout should be O(10s), observed values are O(1m), 2m is very
 	// liberal. Fix tracked in #20567.
-	KubeProxyLagTimeout = 5 * time.Minute
+	KubeProxyLagTimeout = 2 * time.Minute
 
 	// KubeProxyEndpointLagTimeout is the maximum time a kube-proxy daemon on a node is allowed
 	// to not notice an Endpoint update.


### PR DESCRIPTION

/kind cleanup

```release-note
NONE
```

If a cluster takes 5 minutes propagating the Services changes to the dataplane that is a bug, 2 minutes is still very liberal, but let's reduce this incrementally and observe the trends

