### PR TITLE
Make time nullable in OpenAPIv3 schemas

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
@@ -19,6 +19,9 @@ package v1
 import (
 	"encoding/json"
 	"time"
+
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // Time is a wrapper around time.Time which supports correct
@@ -161,15 +164,36 @@ func (t Time) ToUnstructured() interface{} {
 	return string(buf)
 }
 
-// OpenAPISchemaType is used by the kube-openapi generator when constructing
+// OpenAPIDefinition is used by the kube-openapi generator when constructing
 // the OpenAPI spec of this type.
 //
 // See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
-func (_ Time) OpenAPISchemaType() []string { return []string{"string"} }
+func (_ Time) OpenAPIDefinition() common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type:   []string{"string"},
+				Format: "date-time",
+			},
+		},
+	}
+}
 
-// OpenAPISchemaFormat is used by the kube-openapi generator when constructing
+// OpenAPIV3Definition is used by the kube-openapi generator when constructing
 // the OpenAPI spec of this type.
-func (_ Time) OpenAPISchemaFormat() string { return "date-time" }
+//
+// See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
+func (_ Time) OpenAPIV3Definition() common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type:     []string{"string"},
+				Format:   "date-time",
+				Nullable: true,
+			},
+		},
+	}
+}
 
 // MarshalQueryParameter converts to a URL query parameter value
 func (t Time) MarshalQueryParameter() (string, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #109427

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
OpenAPIv3 for Time fields is now marked as "nullable: true".
```

