### PR TITLE
legacy-cloud-providers: prevent index out-of-range in getNextUnitNumber

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils.go
@@ -94,7 +94,7 @@ func getNextUnitNumber(devices object.VirtualDeviceList, c types.BaseVirtualCont
 	for _, device := range devices {
 		d := device.GetVirtualDevice()
 		if d.ControllerKey == key {
-			if d.UnitNumber != nil {
+			if d.UnitNumber != nil && *d.UnitNumber < SCSIDeviceSlots {
 				takenUnitNumbers[*d.UnitNumber] = true
 			}
 		}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/sig storage
/triage accepted
/priority important-soon

#### What this PR does / why we need it:

One of our users encountered a panic during PV attachment with the `kubernetes.io/vsphere-volume` provisioner:

```
Error: recovered from panic "runtime error: index out of range [16] with length 16". (err=<nil>) Call stack:
goroutine 19411574 [running]:
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.RecoverFromPanic(0xc008d93e78)
 vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:159 +0x6b
panic({0x4526ee0, 0xc010442cd8})
 /usr/lib/golang/src/runtime/panic.go:844 +0x258
k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/vsphere/vclib.getNextUnitNumber({0xc0050d4800, 0xf, 0xc0050d4800?}, {0x508cf80?, 0xc00a613b90?})
 vendor/k8s.io/legacy-cloud-providers/vsphere/vclib/utils.go:98 +0x15a
k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/vsphere/vclib.(*VirtualMachine).CreateDiskSpec(0xc0059bf910, {0x50b88d0, 0xc010158a80}, {0xc004f16850, 0x64}, 0xc01300fc10, 0xc008d93898)
 vendor/k8s.io/legacy-cloud-providers/vsphere/vclib/virtualmachine.go:338 +0x65f
k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/vsphere/vclib.(*VirtualMachine).AttachDisk(0xc0059bf910, {0x50b88d0, 0xc010158a80}, {0xc004f16850, 0x64}, 0xc008d93898)
 vendor/k8s.io/legacy-cloud-providers/vsphere/vclib/virtualmachine.go:101 +0x453
k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/vsphere.(*VSphere).AttachDisk.func1({0xc004f16850, 0x64}, {0x0, 0x0}, {0xc00066a9f0?, 0x0?})
 vendor/k8s.io/legacy-cloud-providers/vsphere/vsphere.go:969 +0x396
k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/vsphere.(*VSphere).AttachDisk(0xc0016b2600, {0xc004f16850, 0x64}, {0x0, 0x0}, {0xc00066a9f0, 0x24})
 vendor/k8s.io/legacy-cloud-providers/vsphere/vsphere.go:977 +0xe4
k8s.io/kubernetes/pkg/volume/vsphere_volume.(*vsphereVMDKAttacher).Attach(0xc011f9a4e0, 0xc00ecfde48?, {0xc00066a9f0, 0x24})
 pkg/volume/vsphere_volume/attacher.go:92 +0x20a
k8s.io/kubernetes/pkg/volume/util/operationexecutor.(*operationGenerator).GenerateAttachVolumeFunc.func1()
 pkg/volume/util/operationexecutor/operation_generator.go:372 +0x1ae
k8s.io/kubernetes/pkg/volume/util/types.(*GeneratedOperations).Run(0xc00d312a80)
 pkg/volume/util/types/types.go:79 +0x1c2
k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations.(*nestedPendingOperations).Run.func1()
 pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go:190 +0xf4
created by k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations.(*nestedPendingOperations).Run
 pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go:185 +0x8ca
```

The panic occurs [here](https://github.com/kubernetes/kubernetes/blob/57eb5d631ccd615cd161b6da36afc759af004b93/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils.go#L98) in getNextUnitNumber. There is a virtual device attached to the VM where `d.UnitNumber = 16`, but `takenUnitNumbers` only allocates [16 slots](https://github.com/kubernetes/kubernetes/blob/57eb5d631ccd615cd161b6da36afc759af004b93/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/constants.go#L31) (0 - 15).

From code inspection, I don't see a way for the in-tree driver to assign `UnitNumber = 16` since it relies on getNexUnitNumber to assign the value [here](https://github.com/kubernetes/kubernetes/blob/57eb5d631ccd615cd161b6da36afc759af004b93/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/virtualmachine.go#L338). Still, it appears that it is possible to attach a device out-of-band with UnitNumber = 16, which will trigger the panic.

I have included a small unit test for this function to prove that the panic happens when a virtual device exists with UnitNumber 16, and also to prove that this patch prevents the panic.

```
$ make test WHAT='./staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib' KUBE_TEST_ARGS='-run TestGetNextUnitNumber'
+++ [1202 14:39:44] Running tests without code coverage and with -race
ok      k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib       (cached)
```

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

/cc @gnufied @xing-yang @divyenpatel

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

