### PR TITLE
Automated cherry pick of #111772: kubelet: make the image pull time more accurate in event

### DIFF
--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -18,6 +18,7 @@ package images
 
 import (
 	"fmt"
+	"time"
 
 	dockerref "github.com/docker/distribution/reference"
 	v1 "k8s.io/api/core/v1"
@@ -138,6 +139,7 @@ func (m *imageManager) EnsureImageExists(pod *v1.Pod, container *v1.Container, p
 		return "", msg, ErrImagePullBackOff
 	}
 	m.logIt(ref, v1.EventTypeNormal, events.PullingImage, logPrefix, fmt.Sprintf("Pulling image %q", container.Image), klog.Info)
+	startTime := time.Now()
 	pullChan := make(chan pullResult)
 	m.puller.pullImage(spec, pullSecrets, pullChan, podSandboxConfig)
 	imagePullResult := <-pullChan

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -18,7 +18,6 @@ package images
 
 import (
 	"fmt"
-	"time"
 
 	dockerref "github.com/docker/distribution/reference"
 	v1 "k8s.io/api/core/v1"
@@ -139,7 +138,6 @@ func (m *imageManager) EnsureImageExists(pod *v1.Pod, container *v1.Container, p
 		return "", msg, ErrImagePullBackOff
 	}
 	m.logIt(ref, v1.EventTypeNormal, events.PullingImage, logPrefix, fmt.Sprintf("Pulling image %q", container.Image), klog.Info)
-	startTime := time.Now()
 	pullChan := make(chan pullResult)
 	m.puller.pullImage(spec, pullSecrets, pullChan, podSandboxConfig)
 	imagePullResult := <-pullChan

--- a/pkg/kubelet/images/puller.go
+++ b/pkg/kubelet/images/puller.go
@@ -26,8 +26,9 @@ import (
 )
 
 type pullResult struct {
-	imageRef string
-	err      error
+	imageRef     string
+	err          error
+	pullDuration time.Duration
 }
 
 type imagePuller interface {
@@ -46,10 +47,12 @@ func newParallelImagePuller(imageService kubecontainer.ImageService) imagePuller
 
 func (pip *parallelImagePuller) pullImage(spec kubecontainer.ImageSpec, pullSecrets []v1.Secret, pullChan chan<- pullResult, podSandboxConfig *runtimeapi.PodSandboxConfig) {
 	go func() {
+		startTime := time.Now()
 		imageRef, err := pip.imageService.PullImage(spec, pullSecrets, podSandboxConfig)
 		pullChan <- pullResult{
-			imageRef: imageRef,
-			err:      err,
+			imageRef:     imageRef,
+			err:          err,
+			pullDuration: time.Since(startTime),
 		}
 	}()
 }
@@ -86,10 +89,12 @@ func (sip *serialImagePuller) pullImage(spec kubecontainer.ImageSpec, pullSecret
 
 func (sip *serialImagePuller) processImagePullRequests() {
 	for pullRequest := range sip.pullRequests {
+		startTime := time.Now()
 		imageRef, err := sip.imageService.PullImage(pullRequest.spec, pullRequest.pullSecrets, pullRequest.podSandboxConfig)
 		pullRequest.pullChan <- pullResult{
-			imageRef: imageRef,
-			err:      err,
+			imageRef:     imageRef,
+			err:          err,
+			pullDuration: time.Since(startTime),
 		}
 	}
 }


### PR DESCRIPTION
Cherry pick of #111772 on release-1.24.

#111772: kubelet: make the image pull time more accurate in event

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubelet: make the image pull time more accurate in event
```
https://github.com/kubernetes/kubernetes/pull/111772#issuecomment-1335989517

> Can we consider to backport this to the recent few releases, e.g. 1.25, 1.24? I think it's a pretty small isolated change and will help to reduce a lot of confusion.
> 
> cc @pacoxu
> 
> I've seen quite a few folks being confused with the misleading events regarding image pulls, especially when used with serial image pulls. Often the case is that a small image pull may report a very long image pull time when in reality it was blocked behind a much larger image pull.