### PR TITLE
scheduler/internal: Improving cache and heap test coverage

### DIFF
--- a/pkg/scheduler/internal/cache/node_tree_test.go
+++ b/pkg/scheduler/internal/cache/node_tree_test.go
@@ -166,6 +166,11 @@ func TestNodeTree_AddNode(t *testing.T) {
 			expectedTree: map[string][]string{"": {"node-0"}},
 		},
 		{
+			name:         "same node specified twice",
+			nodesToAdd:   []*v1.Node{allNodes[0], allNodes[0]},
+			expectedTree: map[string][]string{"": {"node-0"}},
+		},
+		{
 			name:       "mix of nodes with and without proper labels",
 			nodesToAdd: allNodes[:4],
 			expectedTree: map[string][]string{

--- a/pkg/scheduler/internal/cache/snapshot_test.go
+++ b/pkg/scheduler/internal/cache/snapshot_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -225,6 +226,217 @@ func TestCreateUsedPVCSet(t *testing.T) {
 			usedPVCs := createUsedPVCSet(test.pods)
 			if diff := cmp.Diff(test.expected, usedPVCs); diff != "" {
 				t.Errorf("Unexpected usedPVCs (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewSnapshot(t *testing.T) {
+	podWithAnnotations := st.MakePod().Name("foo").Namespace("ns").Node("node-1").Annotations(map[string]string{"custom": "annotation"}).Obj()
+	podWithPort := st.MakePod().Name("foo").Namespace("foo").Node("node-0").ContainerPort([]v1.ContainerPort{{HostPort: 8080}}).Obj()
+	podWithAntiAffitiny := st.MakePod().Name("baz").Namespace("ns").PodAntiAffinity("another", &metav1.LabelSelector{MatchLabels: map[string]string{"another": "label"}}, st.PodAntiAffinityWithRequiredReq).Node("node-0").Obj()
+	podsWithAffitiny := []*v1.Pod{
+		st.MakePod().Name("bar").Namespace("ns").PodAffinity("baz", &metav1.LabelSelector{MatchLabels: map[string]string{"baz": "qux"}}, st.PodAffinityWithRequiredReq).Node("node-2").Obj(),
+		st.MakePod().Name("bar").Namespace("ns").PodAffinity("key", &metav1.LabelSelector{MatchLabels: map[string]string{"key": "value"}}, st.PodAffinityWithRequiredReq).Node("node-0").Obj(),
+	}
+	podsWithPVCs := []*v1.Pod{
+		st.MakePod().Name("foo").Namespace("foo").Node("node-0").PVC("pvc0").Obj(),
+		st.MakePod().Name("bar").Namespace("bar").Node("node-1").PVC("pvc1").Obj(),
+		st.MakePod().Name("baz").Namespace("baz").Node("node-2").PVC("pvc2").Obj(),
+	}
+	testCases := []struct {
+		name                         string
+		pods                         []*v1.Pod
+		nodes                        []*v1.Node
+		expectedNodesInfos           []*framework.NodeInfo
+		expectedNumNodes             int
+		expectedPodsWithAffinity     int
+		expectedPodsWithAntiAffinity int
+		expectedUsedPVCSet           sets.String
+	}{
+		{
+			name:  "no pods no nodes",
+			pods:  nil,
+			nodes: nil,
+		},
+		{
+			name: "single pod single node",
+			pods: []*v1.Pod{
+				podWithPort,
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-0"}},
+			},
+			expectedNodesInfos: []*framework.NodeInfo{
+				{
+					Pods: []*framework.PodInfo{
+						{Pod: podWithPort},
+					},
+				},
+			},
+			expectedNumNodes: 1,
+		},
+		{
+			name: "multiple nodes, pods with PVCs",
+			pods: podsWithPVCs,
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-0"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}},
+			},
+			expectedNodesInfos: []*framework.NodeInfo{
+				{
+					Pods: []*framework.PodInfo{
+						{Pod: podsWithPVCs[0]},
+					},
+				},
+				{
+					Pods: []*framework.PodInfo{
+						{Pod: podsWithPVCs[1]},
+					},
+				},
+				{
+					Pods: []*framework.PodInfo{
+						{Pod: podsWithPVCs[2]},
+					},
+				},
+			},
+			expectedNumNodes:   3,
+			expectedUsedPVCSet: sets.NewString("foo/pvc0", "bar/pvc1", "baz/pvc2"),
+		},
+		{
+			name: "multiple nodes, pod with affinity",
+			pods: []*v1.Pod{
+				podWithAnnotations,
+				podsWithAffitiny[0],
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-0"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-2", Labels: map[string]string{"baz": "qux"}}},
+			},
+			expectedNodesInfos: []*framework.NodeInfo{
+				{
+					Pods: []*framework.PodInfo{},
+				},
+				{
+					Pods: []*framework.PodInfo{
+						{Pod: podWithAnnotations},
+					},
+				},
+				{
+					Pods: []*framework.PodInfo{
+						{
+							Pod: podsWithAffitiny[0],
+							RequiredAffinityTerms: []framework.AffinityTerm{
+								{
+									Namespaces:        sets.NewString("ns"),
+									Selector:          labels.SelectorFromSet(map[string]string{"baz": "qux"}),
+									TopologyKey:       "baz",
+									NamespaceSelector: labels.Nothing(),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNumNodes:         3,
+			expectedPodsWithAffinity: 1,
+		},
+		{
+			name: "multiple nodes, pod with affinity, pod with anti-affinity",
+			pods: []*v1.Pod{
+				podsWithAffitiny[1],
+				podWithAntiAffitiny,
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"key": "value"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"another": "label"}}},
+			},
+			expectedNodesInfos: []*framework.NodeInfo{
+				{
+					Pods: []*framework.PodInfo{
+						{
+							Pod: podsWithAffitiny[1],
+							RequiredAffinityTerms: []framework.AffinityTerm{
+								{
+									Namespaces:        sets.NewString("ns"),
+									Selector:          labels.SelectorFromSet(map[string]string{"key": "value"}),
+									TopologyKey:       "key",
+									NamespaceSelector: labels.Nothing(),
+								},
+							},
+						},
+						{
+							Pod: podWithAntiAffitiny,
+							RequiredAntiAffinityTerms: []framework.AffinityTerm{
+								{
+									Namespaces:        sets.NewString("ns"),
+									Selector:          labels.SelectorFromSet(map[string]string{"another": "label"}),
+									TopologyKey:       "another",
+									NamespaceSelector: labels.Nothing(),
+								},
+							},
+						},
+					},
+				},
+				{
+					Pods: []*framework.PodInfo{},
+				},
+			},
+			expectedNumNodes:             2,
+			expectedPodsWithAffinity:     1,
+			expectedPodsWithAntiAffinity: 1,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := NewSnapshot(test.pods, test.nodes)
+
+			if test.expectedNumNodes != snapshot.NumNodes() {
+				t.Errorf("unexpected number of nodes, want: %v, got: %v", test.expectedNumNodes, snapshot.NumNodes())
+			}
+
+			for i, node := range test.nodes {
+				info, err := snapshot.Get(node.Name)
+				if err != nil {
+					t.Errorf("unexpected error but got %s", err)
+				}
+				if info == nil {
+					t.Error("node infos should not be nil")
+				}
+				for j := range test.expectedNodesInfos[i].Pods {
+					if diff := cmp.Diff(test.expectedNodesInfos[i].Pods[j], info.Pods[j]); diff != "" {
+						t.Errorf("Unexpected PodInfo (-want +got):\n%s", diff)
+					}
+				}
+			}
+
+			affinityList, err := snapshot.HavePodsWithAffinityList()
+			if err != nil {
+				t.Errorf("unexpected error but got %s", err)
+			}
+			if test.expectedPodsWithAffinity != len(affinityList) {
+				t.Errorf("unexpected affinityList number, want: %v, got: %v", test.expectedPodsWithAffinity, len(affinityList))
+			}
+
+			antiAffinityList, err := snapshot.HavePodsWithRequiredAntiAffinityList()
+			if err != nil {
+				t.Errorf("unexpected error but got %s", err)
+			}
+			if test.expectedPodsWithAntiAffinity != len(antiAffinityList) {
+				t.Errorf("unexpected antiAffinityList number, want: %v, got: %v", test.expectedPodsWithAntiAffinity, len(antiAffinityList))
+			}
+
+			for key := range test.expectedUsedPVCSet {
+				if !snapshot.IsPVCUsedByPods(key) {
+					t.Errorf("unexpected IsPVCUsedByPods for %s, want: true, got: false", key)
+				}
+			}
+
+			if diff := cmp.Diff(test.expectedUsedPVCSet, snapshot.usedPVCSet); diff != "" {
+				t.Errorf("Unexpected usedPVCSet (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: TommyStarK <thomasmilox@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If applied this commit will increase the unit tests code coverage of `pkg/scheduler/internal/cache` and `pkg/scheduler/internal/heap`.

- Initial unit tests code coverage

<img width="725" alt="Screenshot 2022-12-03 at 15 16 26" src="https://user-images.githubusercontent.com/9576370/205445532-4b1a22fc-8deb-4021-8f32-6ab59b5b4275.png">

- After changes

<img width="722" alt="Screenshot 2022-12-03 at 15 18 47" src="https://user-images.githubusercontent.com/9576370/205445546-09cb1320-e5dd-4f98-a2f4-e2f38c0c6c94.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
