### PR TITLE
update coredns to v1.10.0

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -39,7 +39,7 @@ dependencies:
       match: registry.k8s.io/coredns
 
   - name: "coredns-kubeadm"
-    version: 1.9.3
+    version: 1.10.0
     refPaths:
     - path: cmd/kubeadm/app/constants/constants.go
       match: CoreDNSVersion =

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -29,7 +29,7 @@ dependencies:
 
   # CoreDNS
   - name: "coredns-kube-up"
-    version: 1.9.3
+    version: 1.10.0
     refPaths:
     - path: cluster/addons/dns/coredns/coredns.yaml.base
       match: registry.k8s.io/coredns

--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -139,7 +139,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.9.3
+        image: registry.k8s.io/coredns/coredns:v1.10.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -139,7 +139,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.9.3
+        image: registry.k8s.io/coredns/coredns:v1.10.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -139,7 +139,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.9.3
+        image: registry.k8s.io/coredns/coredns:v1.10.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -345,7 +345,7 @@ const (
 	CoreDNSImageName = "coredns"
 
 	// CoreDNSVersion is the version of CoreDNS to be deployed if it is used
-	CoreDNSVersion = "v1.9.3"
+	CoreDNSVersion = "v1.10.0"
 
 	// ClusterConfigurationKind is the string kind value for the ClusterConfiguration struct
 	ClusterConfigurationKind = "ClusterConfiguration"

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -233,7 +233,7 @@ func TestGetDNSImage(t *testing.T) {
 		cfg      *kubeadmapi.ClusterConfiguration
 	}{
 		{
-			expected: "foo.io/coredns:v1.9.3",
+			expected: "foo.io/coredns:v1.10.0",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: "foo.io",
 				DNS: kubeadmapi.DNS{
@@ -242,7 +242,7 @@ func TestGetDNSImage(t *testing.T) {
 			},
 		},
 		{
-			expected: kubeadmapiv1beta2.DefaultImageRepository + "/coredns/coredns:v1.9.3",
+			expected: kubeadmapiv1beta2.DefaultImageRepository + "/coredns/coredns:v1.10.0",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: kubeadmapiv1beta2.DefaultImageRepository,
 				DNS: kubeadmapi.DNS{
@@ -251,7 +251,7 @@ func TestGetDNSImage(t *testing.T) {
 			},
 		},
 		{
-			expected: "foo.io/coredns/coredns:v1.9.3",
+			expected: "foo.io/coredns/coredns:v1.10.0",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: "foo.io",
 				DNS: kubeadmapi.DNS{

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.116
 	github.com/blang/semver/v4 v4.0.0
 	github.com/container-storage-interface/spec v1.7.0
-	github.com/coredns/corefile-migration v1.0.17
+	github.com/coredns/corefile-migration v1.0.18
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/cpuguy83/go-md2man/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY
 github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcDZXTn6oPz9s=
 github.com/coredns/caddy v1.1.0 h1:ezvsPrT/tA/7pYDBZxu0cT0VmWk75AfIaf6GSYCNMf0=
 github.com/coredns/caddy v1.1.0/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
-github.com/coredns/corefile-migration v1.0.17 h1:tNwh8+4WOANV6NjSljwgW7qViJfhvPUt1kosj4rR8yg=
-github.com/coredns/corefile-migration v1.0.17/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
+github.com/coredns/corefile-migration v1.0.18 h1:zs5PJm/VGZVje1ESRj6ZqyUuVsVfagExkbLU2QKV5mI=
+github.com/coredns/corefile-migration v1.0.18/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/vendor/github.com/coredns/corefile-migration/migration/migrate.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/migrate.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/coredns/corefile-migration/migration/corefile"
 )
@@ -420,7 +422,26 @@ func ValidVersions() []string {
 	for vStr := range Versions {
 		vStrs = append(vStrs, vStr)
 	}
-	sort.Strings(vStrs)
+	sort.Slice(vStrs, func(i, j int) bool {
+		iSegs := strings.Split(vStrs[i], ".")
+		jSegs := strings.Split(vStrs[j], ".")
+		for k, iSeg := range iSegs {
+			if iSeg == jSegs[k] {
+				continue
+			}
+			iInt, err := strconv.Atoi(iSeg)
+			if err != nil {
+				panic(err)
+			}
+			jInt, err := strconv.Atoi(jSegs[k])
+			if err != nil {
+				panic(err)
+			}
+			return iInt < jInt
+		}
+		return false
+	})
+
 	return vStrs
 }
 

--- a/vendor/github.com/coredns/corefile-migration/migration/versions.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/versions.go
@@ -30,27 +30,22 @@ type release struct {
 
 // Versions holds a map of plugin/option migrations per CoreDNS release (since 1.1.4)
 var Versions = map[string]release{
+	"1.10.0": {
+		priorVersion:   "1.9.4",
+		dockerImageSHA: "017727efcfeb7d053af68e51436ce8e65edbc6ca573720afb4f79c8594036955",
+		plugins:        plugins_1_9_3,
+	},
+	"1.9.4": {
+		nextVersion:    "1.10.0",
+		priorVersion:   "1.9.3",
+		dockerImageSHA: "b82e294de6be763f73ae71266c8f5466e7e03c69f3a1de96efd570284d35bb18",
+		plugins:        plugins_1_9_3,
+	},
 	"1.9.3": {
+		nextVersion:    "1.9.4",
 		priorVersion:   "1.9.2",
 		dockerImageSHA: "8e352a029d304ca7431c6507b56800636c321cb52289686a581ab70aaa8a2e2a",
-		plugins: map[string]plugin{
-			"errors":       plugins["errors"]["v3"], // stacktrace option added
-			"log":          plugins["log"]["v1"],
-			"health":       plugins["health"]["v1"],
-			"ready":        {},
-			"autopath":     {},
-			"kubernetes":   plugins["kubernetes"]["v8"],
-			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus":   {},
-			"forward":      plugins["forward"]["v3"],
-			"cache":        plugins["cache"]["v1"],
-			"loop":         {},
-			"reload":       {},
-			"loadbalance":  {},
-			"hosts":        plugins["hosts"]["v1"],
-			"rewrite":      plugins["rewrite"]["v2"],
-			"transfer":     plugins["transfer"]["v1"],
-		},
+		plugins:        plugins_1_9_3,
 	},
 	"1.9.2": {
 		nextVersion:    "1.9.3",
@@ -742,6 +737,25 @@ var Versions = map[string]release{
     cache 30
     reload
 }`},
+}
+
+var plugins_1_9_3 = map[string]plugin{
+	"errors":       plugins["errors"]["v3"], // stacktrace option added
+	"log":          plugins["log"]["v1"],
+	"health":       plugins["health"]["v1"],
+	"ready":        {},
+	"autopath":     {},
+	"kubernetes":   plugins["kubernetes"]["v8"],
+	"k8s_external": plugins["k8s_external"]["v1"],
+	"prometheus":   {},
+	"forward":      plugins["forward"]["v3"],
+	"cache":        plugins["cache"]["v1"],
+	"loop":         {},
+	"reload":       {},
+	"loadbalance":  {},
+	"hosts":        plugins["hosts"]["v1"],
+	"rewrite":      plugins["rewrite"]["v2"],
+	"transfer":     plugins["transfer"]["v1"],
 }
 
 var plugins_1_8_3 = map[string]plugin{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -199,7 +199,7 @@ github.com/containerd/ttrpc
 # github.com/coredns/caddy v1.1.0
 ## explicit; go 1.13
 github.com/coredns/caddy/caddyfile
-# github.com/coredns/corefile-migration v1.0.17
+# github.com/coredns/corefile-migration v1.0.18
 ## explicit; go 1.14
 github.com/coredns/corefile-migration/migration
 github.com/coredns/corefile-migration/migration/corefile


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup feature

#### What this PR does / why we need it:
- corefile-migration support: https://github.com/coredns/corefile-migration/pull/72
- coredns release note:
- - https://github.com/coredns/coredns/blob/master/notes/coredns-1.9.4.md
- - https://github.com/coredns/coredns/blob/master/notes/coredns-1.10.0.md: [new 'view' plugin was added](https://github.com/coredns/coredns/pull/5538).

Example:
```
. {
  view example-view {
    expr incidr(client_ip(), '10.9.0.0/24')
  }
  forward . 10.9.0.100
}

. {
  forward . /etc/resolv.conf
}
```
#### Which issue(s) this PR fixes:
Fixes None

#### Special notes for your reviewer:

- [x] waiting for https://github.com/kubernetes/k8s.io/pull/4520

#### Does this PR introduce a user-facing change?
```release-note
kube-up now includes CoreDNS version v1.9.3
```
