### PR TITLE
add handling when calculating average numa distance

### DIFF
--- a/pkg/kubelet/cm/topologymanager/numa_info.go
+++ b/pkg/kubelet/cm/topologymanager/numa_info.go
@@ -105,5 +105,9 @@ func (d NUMADistances) CalculateAverageFor(bm bitmask.BitMask) float64 {
 		}
 	}
 
+	if count == 0 {
+		return 0
+	}
+
 	return sum / count
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When count is zero, we can't calculate sum/count，so add handling priviously.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
