### PR TITLE
releng: Update images, dependencies and version to Go 1.19.4

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.25.0-go1.19.3-bullseye.0
+v1.25.0-go1.19.4-bullseye.0

--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.25.0-go1.19.4-bullseye.0
+v1.26.0-go1.19.4-bullseye.1

--- a/build/common.sh
+++ b/build/common.sh
@@ -96,7 +96,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
 readonly __default_distroless_iptables_version=v0.1.2
-readonly __default_go_runner_version=v2.3.1-go1.19.3-bullseye.0
+readonly __default_go_runner_version=v2.3.1-go1.19.4-bullseye.0
 readonly __default_setcap_version=bullseye-v1.3.0
 
 # These are the base images for the Docker-wrapped binaries.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -88,7 +88,7 @@ dependencies:
 
   # Golang
   - name: "golang: upstream version"
-    version: 1.19.3
+    version: 1.19.4
     refPaths:
     - path: build/build-image/cross/VERSION
     - path: staging/publishing/rules.yaml
@@ -109,7 +109,7 @@ dependencies:
       match: minimum_go_version=go([0-9]+\.[0-9]+)
 
   - name: "registry.k8s.io/kube-cross: dependents"
-    version: v1.25.0-go1.19.3-bullseye.0
+    version: v1.25.0-go1.19.4-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -139,7 +139,7 @@ dependencies:
       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
 
   - name: "registry.k8s.io/go-runner: dependents"
-    version: v2.3.1-go1.19.3-bullseye.0
+    version: v2.3.1-go1.19.4-bullseye.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -109,7 +109,7 @@ dependencies:
       match: minimum_go_version=go([0-9]+\.[0-9]+)
 
   - name: "registry.k8s.io/kube-cross: dependents"
-    version: v1.25.0-go1.19.4-bullseye.0
+    version: v1.26.0-go1.19.4-bullseye.1
     refPaths:
     - path: build/build-image/cross/VERSION
 

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -21,12 +21,12 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     source: 
       branch: release-1.26
       dir: staging/src/k8s.io/code-generator
@@ -52,12 +52,12 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     source: 
       branch: release-1.26
       dir: staging/src/k8s.io/apimachinery
@@ -96,7 +96,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/api
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -104,7 +104,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -170,7 +170,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -184,7 +184,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -248,7 +248,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-base
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -260,7 +260,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -322,7 +322,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -334,7 +334,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -354,7 +354,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/kms
@@ -418,7 +418,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/apiserver
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -432,7 +432,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -522,7 +522,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -540,7 +540,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -653,7 +653,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -676,7 +676,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -776,7 +776,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -795,7 +795,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -897,7 +897,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -917,7 +917,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -994,7 +994,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/metrics
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1008,7 +1008,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1072,7 +1072,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1084,7 +1084,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1154,7 +1154,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1168,7 +1168,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1239,7 +1239,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1253,7 +1253,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1325,7 +1325,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubelet
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1339,7 +1339,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1411,7 +1411,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1425,7 +1425,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1507,7 +1507,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1523,7 +1523,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1623,7 +1623,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1643,7 +1643,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1755,7 +1755,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1777,7 +1777,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1841,7 +1841,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1851,7 +1851,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1903,7 +1903,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1913,7 +1913,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1945,12 +1945,12 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/mount-utils
@@ -2061,7 +2061,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.25
@@ -2087,7 +2087,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2135,12 +2135,12 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/cri-api
@@ -2235,7 +2235,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubectl
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.25
@@ -2257,7 +2257,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2347,7 +2347,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.25
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.25
@@ -2363,7 +2363,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2397,7 +2397,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.19.3
+    go: 1.19.4
     dependencies:
       - repository: apimachinery
         branch: release-1.26
@@ -2414,4 +2414,4 @@ rules:
       dir: staging/src/k8s.io/dynamic-resource-allocation
 recursive-delete-patterns:
 - '*/.gitattributes'
-default-go-version: 1.19.3
+default-go-version: 1.19.4

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -16,7 +16,7 @@ REGISTRY ?= registry.k8s.io/e2e-test-images
 GOARM ?= 7
 DOCKER_CERT_BASE_PATH ?=
 QEMUVERSION=v5.1.0-2
-GOLANG_VERSION=1.19.3
+GOLANG_VERSION=1.19.4
 export
 
 ifndef WHAT


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- Bump kube-cross and go-runner images to Go 1.19.4 based ones
- Bump test Makefile to Go 1.19.4
- Bump default Go version for publishing bot to 1.19.4
- Update kube-cross to `v1.26.0-go1.19.4-bullseye.1` (follow-up on https://github.com/kubernetes/release/pull/2798 and https://github.com/kubernetes/release/pull/2794)

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2788

#### Does this PR introduce a user-facing change?
```release-note
Kubernetes is now built with Go 1.19.4
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

cc @kubernetes/release-engineering 