### PR TITLE
Update publishing-bot rules to Go 1.18.9

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -16,7 +16,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/code-generator
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
@@ -47,7 +47,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
@@ -88,7 +88,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/api
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -156,7 +156,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -236,7 +236,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-base
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -310,7 +310,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -404,7 +404,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apiserver
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -504,7 +504,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -630,7 +630,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -757,7 +757,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -877,7 +877,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -980,7 +980,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/metrics
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1060,7 +1060,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1140,7 +1140,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1225,7 +1225,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1311,7 +1311,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubelet
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1397,7 +1397,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1491,7 +1491,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1603,7 +1603,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1733,7 +1733,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1831,7 +1831,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1893,7 +1893,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1940,7 +1940,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
@@ -2035,7 +2035,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: api
       branch: release-1.24
@@ -2130,7 +2130,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cri-api
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
@@ -2213,7 +2213,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubectl
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: api
       branch: release-1.24
@@ -2331,7 +2331,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.24
-    go: 1.18.8
+    go: 1.18.9
     dependencies:
     - repository: api
       branch: release-1.24


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

This PR updates publishing-bot branch rules to Go 1.18.9.

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2788

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

cc @kubernetes/release-engineering 