### PR TITLE
Add recovery expansion tests

### DIFF
--- a/test/e2e/storage/csi_mock/base.go
+++ b/test/e2e/storage/csi_mock/base.go
@@ -89,14 +89,15 @@ type testParameters struct {
 	enableResizing      bool   // enable resizing for both CSI mock driver and storageClass.
 	enableNodeExpansion bool   // enable node expansion for CSI mock driver
 	// just disable resizing on driver it overrides enableResizing flag for CSI mock driver
-	disableResizingOnDriver bool
-	enableSnapshot          bool
-	enableVolumeMountGroup  bool // enable the VOLUME_MOUNT_GROUP node capability in the CSI mock driver.
-	hooks                   *drivers.Hooks
-	tokenRequests           []storagev1.TokenRequest
-	requiresRepublish       *bool
-	fsGroupPolicy           *storagev1.FSGroupPolicy
-	enableSELinuxMount      *bool
+	disableResizingOnDriver       bool
+	enableSnapshot                bool
+	enableVolumeMountGroup        bool // enable the VOLUME_MOUNT_GROUP node capability in the CSI mock driver.
+	hooks                         *drivers.Hooks
+	tokenRequests                 []storagev1.TokenRequest
+	requiresRepublish             *bool
+	fsGroupPolicy                 *storagev1.FSGroupPolicy
+	enableSELinuxMount            *bool
+	enableRecoverExpansionFailure bool
 }
 
 type mockDriverSetup struct {
@@ -148,20 +149,21 @@ func (m *mockDriverSetup) init(tp testParameters) {
 
 	var err error
 	driverOpts := drivers.CSIMockDriverOpts{
-		RegisterDriver:         tp.registerDriver,
-		PodInfo:                tp.podInfo,
-		StorageCapacity:        tp.storageCapacity,
-		EnableTopology:         tp.enableTopology,
-		AttachLimit:            tp.attachLimit,
-		DisableAttach:          tp.disableAttach,
-		EnableResizing:         tp.enableResizing,
-		EnableNodeExpansion:    tp.enableNodeExpansion,
-		EnableSnapshot:         tp.enableSnapshot,
-		EnableVolumeMountGroup: tp.enableVolumeMountGroup,
-		TokenRequests:          tp.tokenRequests,
-		RequiresRepublish:      tp.requiresRepublish,
-		FSGroupPolicy:          tp.fsGroupPolicy,
-		EnableSELinuxMount:     tp.enableSELinuxMount,
+		RegisterDriver:                tp.registerDriver,
+		PodInfo:                       tp.podInfo,
+		StorageCapacity:               tp.storageCapacity,
+		EnableTopology:                tp.enableTopology,
+		AttachLimit:                   tp.attachLimit,
+		DisableAttach:                 tp.disableAttach,
+		EnableResizing:                tp.enableResizing,
+		EnableNodeExpansion:           tp.enableNodeExpansion,
+		EnableSnapshot:                tp.enableSnapshot,
+		EnableVolumeMountGroup:        tp.enableVolumeMountGroup,
+		TokenRequests:                 tp.tokenRequests,
+		RequiresRepublish:             tp.requiresRepublish,
+		FSGroupPolicy:                 tp.fsGroupPolicy,
+		EnableSELinuxMount:            tp.enableSELinuxMount,
+		EnableRecoverExpansionFailure: tp.enableRecoverExpansionFailure,
 	}
 
 	// At the moment, only tests which need hooks are

--- a/test/e2e/storage/utils/deployment.go
+++ b/test/e2e/storage/utils/deployment.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"path"
 	"strings"
 
@@ -92,6 +93,11 @@ func PatchCSIDeployment(f *e2eframework.Framework, o PatchCSIOptions, object int
 			}
 			for e := range container.VolumeMounts {
 				container.VolumeMounts[e].MountPath = substKubeletRootDir(container.VolumeMounts[e].MountPath)
+			}
+
+			if len(o.Features) > 0 && len(o.Features[container.Name]) > 0 {
+				featuregateString := strings.Join(o.Features[container.Name], ",")
+				container.Args = append(container.Args, fmt.Sprintf("--feature-gates=%s", featuregateString))
 			}
 
 			// Overwrite driver name resp. provider name
@@ -218,4 +224,10 @@ type PatchCSIOptions struct {
 	// field *if* the driver deploys a CSIDriver object. Ignored
 	// otherwise.
 	SELinuxMount *bool
+	// If not nil, the values will be used for setting feature arguments to
+	// specific sidecar.
+	// Feature is a map - where key is sidecar name such as:
+	//	-- key: resizer
+	//	-- value: []string{feature-gates}
+	Features map[string][]string
 }


### PR DESCRIPTION
Add e2e tests for recovery from volume expansion failure

xref - https://github.com/kubernetes/enhancements/issues/1790

Also partially includes changes from - https://github.com/kubernetes/kubernetes/pull/113930



