### PR TITLE
Update `reason` of the api conflict status code & Improve unit test coverage of http status

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
@@ -59,10 +59,12 @@ func ErrorToAPIStatus(err error) *metav1.Status {
 		return &status
 	default:
 		status := http.StatusInternalServerError
+		reason := metav1.StatusReasonUnknown
 		switch {
 		//TODO: replace me with NewConflictErr
 		case storage.IsConflict(err):
 			status = http.StatusConflict
+			reason = metav1.StatusReasonConflict
 		}
 		// Log errors that were not converted to an error status
 		// by REST storage - these typically indicate programmer
@@ -76,7 +78,7 @@ func ErrorToAPIStatus(err error) *metav1.Status {
 			},
 			Status:  metav1.StatusFailure,
 			Code:    int32(status),
-			Reason:  metav1.StatusReasonUnknown,
+			Reason:  reason,
 			Message: err.Error(),
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### What this PR does / why we need it:
- In case of 409 conflict, the `reason` returned currently is `StatusReasonUnknown` and need to update it to `StatusReasonConflict`.
- Improve unit test coverage of  `status.go`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
