### PR TITLE
dynamic certs: introduce validation for reloaded certificates

### DIFF
--- a/pkg/controller/certificates/signer/ca_provider.go
+++ b/pkg/controller/certificates/signer/ca_provider.go
@@ -29,7 +29,7 @@ import (
 )
 
 func newCAProvider(caFile, caKeyFile string) (*caProvider, error) {
-	caLoader, err := dynamiccertificates.NewDynamicServingContentFromFiles("csr-controller", caFile, caKeyFile)
+	caLoader, err := dynamiccertificates.NewDynamicCertKeyPairContentFromFiles("csr-controller", caFile, caKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("error reading CA cert file %q: %v", caFile, err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/cert_validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/cert_validation.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiccertificates
+
+import (
+	"crypto/x509"
+	"fmt"
+	"time"
+)
+
+type CertificateValidator interface {
+	Validate(c *x509.Certificate) []error
+}
+
+type certValidatorUnion []CertificateValidator
+
+var _ CertificateValidator = &certValidatorUnion{}
+
+func (u certValidatorUnion) Validate(c *x509.Certificate) []error {
+	var errs []error
+	for _, v := range u {
+		errs = append(errs, v.Validate(c)...)
+	}
+	return errs
+}
+
+type ServerCertValidator struct{}
+
+func (v *ServerCertValidator) Validate(c *x509.Certificate) []error {
+	var errs []error
+
+	if err := validateCertLifetime(c); err != nil {
+		errs = append(errs, err)
+	}
+
+	if !hasSAN(c) {
+		errs = append(errs, fmt.Errorf("missing the Subject Alternative Name extension"))
+	}
+
+	var serverAuthEKUFound bool
+	for _, eku := range c.ExtKeyUsage {
+		if eku == x509.ExtKeyUsageServerAuth {
+			serverAuthEKUFound = true
+			break
+		}
+	}
+	if !serverAuthEKUFound {
+		errs = append(errs, fmt.Errorf("missing ServerAuth extended key usage extension"))
+	}
+
+	return errs
+}
+
+type ClientCertValidator struct{}
+
+func (v *ClientCertValidator) Validate(c *x509.Certificate) []error {
+	var errs []error
+
+	if err := validateCertLifetime(c); err != nil {
+		errs = append(errs, err)
+	}
+
+	var clientAuthEKUFound bool
+	for _, eku := range c.ExtKeyUsage {
+		if eku == x509.ExtKeyUsageClientAuth {
+			clientAuthEKUFound = true
+			break
+		}
+	}
+	if !clientAuthEKUFound {
+		errs = append(errs, fmt.Errorf("missing ClientAuth extended key usage extension"))
+	}
+
+	return errs
+}
+
+func validateCertLifetime(cert *x509.Certificate) error {
+	now := time.Now()
+	if now.Before(cert.NotBefore) {
+		return fmt.Errorf("not yet valid")
+	}
+	if now.After(cert.NotAfter) {
+		return fmt.Errorf("expired")
+	}
+	return nil
+}
+
+func hasSAN(c *x509.Certificate) bool {
+	sanOID := []int{2, 5, 29, 17}
+
+	for _, e := range c.Extensions {
+		if e.Id.Equal(sanOID) {
+			return true
+		}
+	}
+	return false
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/cert_validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/cert_validation_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiccertificates
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerCertValidator_Validate(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		template *x509.Certificate
+		want     []error
+	}{
+		{
+			name: "no ServerAuth EKU",
+			template: &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				NotBefore:    time.Now().Add(-10 * time.Second),
+				NotAfter:     time.Now().Add(10 * time.Minute),
+				Subject:      pkix.Name{CommonName: "test-server"},
+				ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+				DNSNames:     []string{"dns.name.one"},
+			},
+			want: []error{fmt.Errorf("missing ServerAuth extended key usage extension")},
+		},
+		{
+			name: "no SAN",
+			template: &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				NotBefore:    time.Now().Add(-10 * time.Second),
+				NotAfter:     time.Now().Add(10 * time.Minute),
+				Subject:      pkix.Name{CommonName: "test-server"},
+				ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+			},
+			want: []error{fmt.Errorf("missing the Subject Alternative Name extension")},
+		},
+		{
+			name: "expired",
+			template: &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				NotBefore:    time.Now().Add(-10 * time.Minute),
+				NotAfter:     time.Now().Add(-10 * time.Second),
+				Subject:      pkix.Name{CommonName: "test-server"},
+				ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+				DNSNames:     []string{"dns.name.one"},
+			},
+			want: []error{fmt.Errorf("expired")},
+		},
+		{
+			name: "not yet valid",
+			template: &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				NotBefore:    time.Now().Add(10 * time.Second),
+				NotAfter:     time.Now().Add(10 * time.Minute),
+				Subject:      pkix.Name{CommonName: "test-server"},
+				ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+				DNSNames:     []string{"dns.name.one"},
+			},
+			want: []error{fmt.Errorf("not yet valid")},
+		},
+		{
+			name: "proper server cert",
+			template: &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				NotBefore:    time.Now().Add(-10 * time.Second),
+				NotAfter:     time.Now().Add(10 * time.Minute),
+				Subject:      pkix.Name{CommonName: "test-server"},
+				ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+				DNSNames:     []string{"dns.name.one"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			certDER, err := x509.CreateCertificate(rand.Reader, tt.template, tt.template, rsaKey.Public(), rsaKey)
+			require.NoError(t, err)
+
+			cert, err := x509.ParseCertificate(certDER)
+			require.NoError(t, err)
+
+			v := &ServerCertValidator{}
+			if got := v.Validate(cert); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ServerCertValidator.Validate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClientCertValidator_Validate(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		template *x509.Certificate
+		want     []error
+	}{
+		{
+			name: "no ClientAuth EKU",
+			template: &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				NotBefore:    time.Now().Add(-10 * time.Second),
+				NotAfter:     time.Now().Add(10 * time.Minute),
+				Subject:      pkix.Name{CommonName: "test-client"},
+				DNSNames:     []string{"dns.name.one"},
+			},
+			want: []error{fmt.Errorf("missing ClientAuth extended key usage extension")},
+		},
+		{
+			name: "expired",
+			template: &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				NotBefore:    time.Now().Add(-10 * time.Minute),
+				NotAfter:     time.Now().Add(-10 * time.Second),
+				Subject:      pkix.Name{CommonName: "test-client"},
+				ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			},
+			want: []error{fmt.Errorf("expired")},
+		},
+		{
+			name: "not yet valid",
+			template: &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				NotBefore:    time.Now().Add(10 * time.Second),
+				NotAfter:     time.Now().Add(10 * time.Minute),
+				Subject:      pkix.Name{CommonName: "test-client"},
+				ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			},
+			want: []error{fmt.Errorf("not yet valid")},
+		},
+		{
+			name: "proper client cert",
+			template: &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				NotBefore:    time.Now().Add(-10 * time.Second),
+				NotAfter:     time.Now().Add(10 * time.Minute),
+				Subject:      pkix.Name{CommonName: "test-client"},
+				ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+				DNSNames:     []string{"client.tld"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			certDER, err := x509.CreateCertificate(rand.Reader, tt.template, tt.template, rsaKey.Public(), rsaKey)
+			require.NoError(t, err)
+
+			cert, err := x509.ParseCertificate(certDER)
+			require.NoError(t, err)
+
+			v := &ClientCertValidator{}
+			if got := v.Validate(cert); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ClientCertValidator.Validate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_cert_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_cert_content.go
@@ -54,9 +54,15 @@ var _ CertKeyContentProvider = &DynamicCertKeyPairContent{}
 var _ ControllerRunner = &DynamicCertKeyPairContent{}
 
 // NewDynamicServingContentFromFiles returns a dynamic CertKeyContentProvider based on a cert and key filename
+// Deprecated: use NewDynamicCertKeyPairContentFromFiles instead
 func NewDynamicServingContentFromFiles(purpose, certFile, keyFile string) (*DynamicCertKeyPairContent, error) {
+	return NewDynamicCertKeyPairContentFromFiles(purpose, certFile, keyFile)
+}
+
+// NewDynamicCertKeyPairContentFromFiles returns a dynamic CertKeyContentProvider based on a cert and key filename
+func NewDynamicCertKeyPairContentFromFiles(purpose, certFile, keyFile string) (*DynamicCertKeyPairContent, error) {
 	if len(certFile) == 0 || len(keyFile) == 0 {
-		return nil, fmt.Errorf("missing filename for serving cert")
+		return nil, fmt.Errorf("missing filename for %q cert", purpose)
 	}
 	name := fmt.Sprintf("%s::%s::%s", purpose, certFile, keyFile)
 
@@ -73,7 +79,7 @@ func NewDynamicServingContentFromFiles(purpose, certFile, keyFile string) (*Dyna
 	return ret, nil
 }
 
-// AddListener adds a listener to be notified when the serving cert content changes.
+// AddListener adds a listener to be notified when the cert content changes.
 func (c *DynamicCertKeyPairContent) AddListener(listener Listener) {
 	c.listeners = append(c.listeners, listener)
 }
@@ -89,7 +95,7 @@ func (c *DynamicCertKeyPairContent) loadCertKeyPair() error {
 		return err
 	}
 	if len(cert) == 0 || len(key) == 0 {
-		return fmt.Errorf("missing content for serving cert %q", c.Name())
+		return fmt.Errorf("missing content for cert %q", c.Name())
 	}
 
 	// Ensure that the key matches the cert and both are valid

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_cert_content_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_cert_content_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiccertificates
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+func TestDynamicCertKeyPairContent(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cert, key, err := certutil.GenerateSelfSignedCertKey("test.host", parseIPList([]string{"127.0.0.1", "172.0.1.1"}), []string{"test_alias.host"})
+	require.NoError(t, err)
+	cert2, key2, err := certutil.GenerateSelfSignedCertKey("test.host2", parseIPList([]string{"172.0.1.2"}), []string{"test_alias.host2"})
+	require.NoError(t, err)
+
+	certPath := filepath.Join(tempDir, "server.crt")
+	keyPath := filepath.Join(tempDir, "server.key")
+	cert2Path := filepath.Join(tempDir, "server_two.crt")
+	key2Path := filepath.Join(tempDir, "server_two.key")
+
+	require.NoError(t, certutil.WriteCert(certPath, cert))
+	require.NoError(t, certutil.WriteCert(cert2Path, cert2))
+	require.NoError(t, os.WriteFile(keyPath, key, 0600))
+	require.NoError(t, os.WriteFile(key2Path, key2, 0600))
+
+	tests := []struct {
+		name                  string
+		certPath, keyPath     string
+		updateCert, updateKey []byte
+		expectUpdate          bool
+		expectListenerUpdate  bool
+		wantInitError         bool
+	}{
+		{
+			name:          "missing cert path",
+			keyPath:       keyPath,
+			wantInitError: true,
+		},
+		{
+			name:          "missing key path",
+			certPath:      certPath,
+			wantInitError: true,
+		},
+		{
+			name:          "missing cert content",
+			certPath:      "/thisisnot/the/file/yourelookingfor",
+			keyPath:       keyPath,
+			wantInitError: true,
+		},
+		{
+			name:          "missing key content",
+			certPath:      certPath,
+			keyPath:       "/thisisnot/the/file/yourelookingfor",
+			wantInitError: true,
+		},
+		{
+			name:          "key does not match the cert",
+			certPath:      certPath,
+			keyPath:       key2Path,
+			wantInitError: true,
+		},
+		{
+			name:          "no cert in the file",
+			certPath:      keyPath,
+			keyPath:       keyPath,
+			wantInitError: true,
+		},
+		{
+			name:          "no key in the file",
+			certPath:      certPath,
+			keyPath:       certPath,
+			wantInitError: true,
+		},
+		{
+			name:     "all good",
+			certPath: certPath,
+			keyPath:  keyPath,
+		},
+		{
+			name:       "update cert to invalid cert",
+			certPath:   certPath,
+			keyPath:    keyPath,
+			updateCert: cert2,
+		},
+		{
+			name:      "update key to invalid key",
+			certPath:  certPath,
+			keyPath:   keyPath,
+			updateKey: key2,
+		},
+		{
+			name:                 "update both to a valid combination",
+			certPath:             certPath,
+			keyPath:              keyPath,
+			updateCert:           cert2,
+			updateKey:            key2,
+			expectUpdate:         true,
+			expectListenerUpdate: true,
+		},
+	}
+	for _, tt := range tests {
+		require.NoError(t, certutil.WriteCert(certPath, cert))
+		require.NoError(t, os.WriteFile(keyPath, key, 0600))
+
+		t.Run(tt.name, func(t *testing.T) {
+			listener := make(testListener)
+
+			c, err := NewDynamicCertKeyPairContentFromFiles("test server auth", tt.certPath, tt.keyPath)
+			if (err != nil) != tt.wantInitError {
+				t.Errorf("DynamicCertKeyPairContent init error = %v, wantErr %v", err, tt.wantInitError)
+			}
+			if c == nil {
+				return
+			}
+
+			c.AddListener(&listener)
+
+			certPre, keyPre := c.CurrentCertKeyContent()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go c.Run(ctx, 1)
+
+			if len(tt.updateCert) > 0 {
+				require.NoError(t, certutil.WriteCert(tt.certPath, tt.updateCert))
+			}
+
+			if len(tt.updateKey) > 0 {
+				require.NoError(t, os.WriteFile(tt.keyPath, tt.updateKey, 0600))
+			}
+
+			if tt.expectListenerUpdate {
+				<-listener
+			} else {
+				select {
+				case <-listener:
+					t.Errorf("did not expect any update in the listener")
+				case <-time.After(500 * time.Millisecond):
+				}
+			}
+
+			certPast, keyPast := c.CurrentCertKeyContent()
+
+			certsUpdated := !bytes.Equal(certPre, certPast)
+			keysUpdated := !bytes.Equal(keyPre, keyPast)
+			if tt.expectUpdate != (certsUpdated || keysUpdated) {
+				t.Errorf("expected cert key update: %t, but got certs updated %t, keys updated %t", tt.expectUpdate, certsUpdated, keysUpdated)
+			}
+		})
+	}
+}
+
+type testListener chan struct{}
+
+func (l testListener) Enqueue() {
+	l <- struct{}{}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_sni_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_sni_content.go
@@ -27,7 +27,7 @@ var _ ControllerRunner = &DynamicFileSNIContent{}
 
 // NewDynamicSNIContentFromFiles returns a dynamic SNICertKeyContentProvider based on a cert and key filename and explicit names
 func NewDynamicSNIContentFromFiles(purpose, certFile, keyFile string, sniNames ...string) (*DynamicFileSNIContent, error) {
-	servingContent, err := NewDynamicServingContentFromFiles(purpose, certFile, keyFile)
+	servingContent, err := NewDynamicCertKeyPairContentFromFiles(purpose, certFile, keyFile)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_sni_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_sni_content.go
@@ -27,7 +27,7 @@ var _ ControllerRunner = &DynamicFileSNIContent{}
 
 // NewDynamicSNIContentFromFiles returns a dynamic SNICertKeyContentProvider based on a cert and key filename and explicit names
 func NewDynamicSNIContentFromFiles(purpose, certFile, keyFile string, sniNames ...string) (*DynamicFileSNIContent, error) {
-	servingContent, err := NewDynamicCertKeyPairContentFromFiles(purpose, certFile, keyFile)
+	servingContent, err := NewDynamicServingCertKeyContentFromFiles(purpose, certFile, keyFile)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -295,7 +295,7 @@ func (s *SecureServingOptions) ApplyTo(config **server.SecureServingInfo) error 
 
 	if len(serverCertFile) != 0 || len(serverKeyFile) != 0 {
 		var err error
-		c.Cert, err = dynamiccertificates.NewDynamicServingContentFromFiles("serving-cert", serverCertFile, serverKeyFile)
+		c.Cert, err = dynamiccertificates.NewDynamicCertKeyPairContentFromFiles("serving-cert", serverCertFile, serverKeyFile)
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -280,7 +280,7 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 
 	apiserviceRegistrationController := NewAPIServiceRegistrationController(informerFactory.Apiregistration().V1().APIServices(), s)
 	if len(c.ExtraConfig.ProxyClientCertFile) > 0 && len(c.ExtraConfig.ProxyClientKeyFile) > 0 {
-		aggregatorProxyCerts, err := dynamiccertificates.NewDynamicServingContentFromFiles("aggregator-proxy-cert", c.ExtraConfig.ProxyClientCertFile, c.ExtraConfig.ProxyClientKeyFile)
+		aggregatorProxyCerts, err := dynamiccertificates.NewDynamicCertKeyPairContentFromFiles("aggregator-proxy-cert", c.ExtraConfig.ProxyClientCertFile, c.ExtraConfig.ProxyClientKeyFile)
 		if err != nil {
 			return nil, err
 		}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -280,7 +280,7 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 
 	apiserviceRegistrationController := NewAPIServiceRegistrationController(informerFactory.Apiregistration().V1().APIServices(), s)
 	if len(c.ExtraConfig.ProxyClientCertFile) > 0 && len(c.ExtraConfig.ProxyClientKeyFile) > 0 {
-		aggregatorProxyCerts, err := dynamiccertificates.NewDynamicCertKeyPairContentFromFiles("aggregator-proxy-cert", c.ExtraConfig.ProxyClientCertFile, c.ExtraConfig.ProxyClientKeyFile)
+		aggregatorProxyCerts, err := dynamiccertificates.NewDynamicClientCertKeyContentFromFiles("aggregator-proxy-cert", c.ExtraConfig.ProxyClientCertFile, c.ExtraConfig.ProxyClientKeyFile)
 		if err != nil {
 			return nil, err
 		}

--- a/test/integration/apiserver/certreload/certreload_test.go
+++ b/test/integration/apiserver/certreload/certreload_test.go
@@ -26,6 +26,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net"
 	"os"
 	"path"
 	"strings"
@@ -379,91 +380,6 @@ M++C29JwS3Hwbubg6WO3wjFjoEhpCwU6qRYUz3MRp4tHO4kxKXx+oQnUiFnR7vW0
 YkNtGc1RUDHwecCTFpJtPb7Yu/E=
 -----END CERTIFICATE-----`)
 
-var anotherServerKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
-MIIJKAIBAAKCAgEAlZJORzCjbzF1SaCXFHyitudlE+q3Z5bGhS2TpXG6d6Laoqtw
-No4UC3i+TnMndtrP2pNkV/ZYivsp1fHz92FqFAT+XpYcG8pLm4iL0k0UufOWdLPT
-X87HCJjKZ4r7fmzstyjqK4sv9I3ye1jKi0VE1BLrF1KVvEE/1PXCug68EBP/aF06
-+uvcr6o8hbMYzgdKSzhRYm9C3kGcawNofqAD/Kk/zn+pMk4Bloy4UgtXFXgj2bEn
-mVE+tRWyLv2+TONlmLnXaBW3/MvZtKC3mIs2KG+6aBNuY8PdWzWvMtp30r/ibgnH
-zuMKtvXJ5XRhTaST4QYXNbGwb1bIV1ylnX8zdXPEQkuYTQDctaYQCe0RXt1I9Fp3
-gVQRxyTM+0IetbsU0k9VvBwQ07mgU8Rik3DxVnfbuJY/wREnERTkgv6ojtRwiszr
-GIY5x36peRs30CqRMv3uJtqC/FU6nCQbHxwssQyB/umN6L7bcpsQFDydeK95hvRQ
-y6tb2v/vMcw7MMo5kSFUHjoL5Zc4DObwiqs+p7F7S0WIJMBzJOcjmgCMzgZ7Jmc7
-bMmrm43GLzOaVLIjuPVVpOp7YgJ/lqRf7K3hZXrMdaXkCm01aL8L59d+3Vfdjp3H
-HvmYpCh8bc+Kjs/nR9Rc+2JKK/H13LH3W5Cr8Fnc/FP6TgbvvNwsQV01gG8CAwEA
-AQKCAgBLBQn8DPo8YDsqxcBhRy45vQ/mkHiTHX3O+JAwkD1tmiI9Ku3qfxKwukwB
-fyKRK6jLQdg3gljgxJ80Ltol/xc8mVCYUoQgsDOB/FfdEEpQBkw1lqhzSnxr5G7I
-xl3kCHAmYgAp/PL9n2C620sj1YdzM1X06bgupy+D+gxEU/WhvtYBG5nklv6moSUg
-DjdnxyJNXh7710Bbx97Tke8Ma+f0B1P4l/FeSN/lCgm9JPD11L9uhbuN28EvBIXN
-qfmUCQ5BLx1KmHIi+n/kaCQN/+0XFQsS/oQEyA2znNaWFBu7egDxHji4nQoXwGoW
-i2vujJibafmkNc5/2bA8mTx8JXvCLhU2L9j2ZumpKOda0g+pfMauesL+9rvZdqwW
-gjdjndOHZlg3qm40hGCDBVmmV3mdnvXrk1BbuB4Y0N7qGo3PyYtJHGwJILaNQVGR
-Sj75uTatxJwFXsqSaJaErV3Q90IiyXX4AOFGnWHOs29GEwtnDbCvT/rzqutTYSXD
-Yv0XFDznzJelhZTH7FbaW3FW3YGEG1ER/0MtKpsAH4i7H9q3KKK8yrzUsgUkGwXt
-xtoLckh91xilPIGbzARdELTEdHrjlFL+qaz3PIqEQScWz3WBu2JcIzGbp6PQfMZ+
-FZXarEb/ADZuX0+WoKFYR5jzwMoQfF/fxe2Ib/37ETNw4BgfSQKCAQEAxOw64XgO
-nUVJslzGK/H5fqTVpD1rfRmvVAiSDLAuWpClbpDZXqEPuoPPYsiccuUWu9VkJE1F
-6MZEexGx1jFkN08QUHD1Bobzu6ThaBc2PrWHRjFGKM60d0AkhOiL4N04FGwVeCN6
-xzIJFk1E4VOOo1+lzeAWRvi1lwuWTgQi+m25nwBJtmYdBLGeS+DXy80Fi6deECei
-ipDzJ4rxJsZ61uqBeYC4CfuHW9m5rCzJWPMMMFrPdl3OxEyZzKng4Co5EYc5i/QH
-piXD6IJayKcTPRK3tBJZp2YCIIdtQLcjAwmDEDowQtelHkbTihXMGRarf3VcOEoN
-ozMRgcLEEynuKwKCAQEAwnF5ZkkJEL/1MCOZ6PZfSKl35ZMIz/4Umk8hOMAQGhCT
-cnxlDUfGSBu4OihdBbIuBSBsYDjgcev8uyiIPDVy0FIkBKRGfgrNCLDh19aHljvE
-bUc3akvbft0mro86AvSd/Rpc7sj841bru37RDUm6AJOtIvb6DWUpMOZgMm0WMmSI
-kNs/UT+7rqg+AZPP8lumnJIFnRK38xOehQAaS1FHWGP//38py8yo8eXpMsoCWMch
-c+kZD2jsAYV+SWjjkZjcrv/52+asd4AotRXIShV8E8xItQeq6vLHKOaIe0tC2Y44
-ONAKiu4dgABt1voy8I5J63MwgeNmgAUS+KsgUclYzQKCAQEAlt/3bPAzIkQH5uQ1
-4U2PvnxEQ4XbaQnYzyWR4K7LlQ/l8ASCxoHYLyr2JdVWKKFk/ZzNERMzUNk3dqNk
-AZvuEII/GaKx2MJk04vMN5gxM3KZpinyeymEEynN0RbqtOpJITx+ZoGofB3V4IRr
-FciTLJEH0+iwqMe9OXDjQ/rfYcfXw/7QezNZYFNF2RT3wWnfqdQduXrkig3sfotx
-oCfJzgf2E0WPu/Y/CxyRqVzXF5N/7zxkX2gYF0YpQCmX5afz+X4FlTju81lT9DyL
-mdiIYO6KWSkGD7+UOaAJEOA/rwAGrtQmTdAy7jONt+pjaYV4+DrO4UG7mSJzc1vq
-JlSl6QKCAQARqwPv8mT7e6XI2QNMMs7XqGZ3mtOrKpguqVAIexM7exQazAjWmxX+
-SV6FElPZh6Y82wRd/e0PDPVrADTY27ZyDXSuY0rwewTEbGYpGZo6YXXoxBbZ9sic
-D3ZLWEJaMGYGsJWPMP4hni1PXSebwH5BPSn3Sl/QRcfnZJeLHXRt4cqy9uka9eKU
-7T6tIAQ+LmvGQFJ4QlIqqTa3ORoqi9kiw/tn+OMQXKlhSZXWApsR/A4jHSQkzVDc
-loeyHfDHsw8ia6oFfEFhnmiUg8UuTiN3HRHiOS8jqCnGoqP2KBGL+StMpkK++wH9
-NozEgvmL+DHpTg8zTjlrGortw4btR5FlAoIBABVni+EsGA5K/PM1gIct2pDm+6Kq
-UCYScTwIjftuwKLk/KqermG9QJLiJouKO3ZSz7iCelu87Dx1cKeXrc2LQ1pnQzCB
-JnI6BCT+zRnQFXjLokJXD2hIS2hXhqV6/9FRXLKKMYePcDxWt/etLNGmpLnhDfb3
-sMOH/9pnaGmtk36Ce03Hh7E1C6io/MKfTq+KKUV1UGwO1BdNQCiclkYzAUqn1O+Y
-c8BaeGKc2c6as8DKrPTGGQGmzo/ZUxQVfVFl2g7+HXISWBBcui/G5gtnU1afZqbW
-mTmDoqs4510vhlkhN9XZ0DyhewDIqNNGEY2vS1x2fJz1XC2Eve4KpSyUsiE=
------END RSA PRIVATE KEY-----
-`)
-
-var anotherServerCert = []byte(`-----BEGIN CERTIFICATE-----
-MIIFJjCCAw6gAwIBAgIJAOcEAbv8NslfMA0GCSqGSIb3DQEBCwUAMEAxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIDAJDQTETMBEGA1UECgwKQWNtZSwgSW5jLjEPMA0GA1UE
-AwwGc29tZUNBMCAXDTE4MDYwODEzMzkyNFoYDzIyMTgwNDIxMTMzOTI0WjBDMQsw
-CQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExEzARBgNVBAoMCkFjbWUsIEluYy4xEjAQ
-BgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIB
-AJWSTkcwo28xdUmglxR8orbnZRPqt2eWxoUtk6Vxunei2qKrcDaOFAt4vk5zJ3ba
-z9qTZFf2WIr7KdXx8/dhahQE/l6WHBvKS5uIi9JNFLnzlnSz01/OxwiYymeK+35s
-7Lco6iuLL/SN8ntYyotFRNQS6xdSlbxBP9T1wroOvBAT/2hdOvrr3K+qPIWzGM4H
-Sks4UWJvQt5BnGsDaH6gA/ypP85/qTJOAZaMuFILVxV4I9mxJ5lRPrUVsi79vkzj
-ZZi512gVt/zL2bSgt5iLNihvumgTbmPD3Vs1rzLad9K/4m4Jx87jCrb1yeV0YU2k
-k+EGFzWxsG9WyFdcpZ1/M3VzxEJLmE0A3LWmEAntEV7dSPRad4FUEcckzPtCHrW7
-FNJPVbwcENO5oFPEYpNw8VZ327iWP8ERJxEU5IL+qI7UcIrM6xiGOcd+qXkbN9Aq
-kTL97ibagvxVOpwkGx8cLLEMgf7pjei+23KbEBQ8nXiveYb0UMurW9r/7zHMOzDK
-OZEhVB46C+WXOAzm8IqrPqexe0tFiCTAcyTnI5oAjM4GeyZnO2zJq5uNxi8zmlSy
-I7j1VaTqe2ICf5akX+yt4WV6zHWl5AptNWi/C+fXft1X3Y6dxx75mKQofG3Pio7P
-50fUXPtiSivx9dyx91uQq/BZ3PxT+k4G77zcLEFdNYBvAgMBAAGjHjAcMBoGA1Ud
-EQQTMBGCCWxvY2FsaG9zdIcEfwAAATANBgkqhkiG9w0BAQsFAAOCAgEABL8kffi7
-48qSD+/l/UwCYdmqta1vAbOkvLnPtfXe1XlDpJipNuPxUBc8nNTemtrbg0erNJnC
-jQHodqmdKBJJOdaEKTwAGp5pYvvjlU3WasmhfJy+QwOWgeqjJcTUo3+DEaHRls16
-AZXlsp3hB6z0gzR/qzUuZwpMbL477JpuZtAcwLYeVvLG8bQRyWyEy8JgGDoYSn8s
-Z16s+r6AX+cnL/2GHkZ+oc3iuXJbnac4xfWTKDiYnyzK6RWRnoyro7X0jiPz6XX3
-wyoWzB1uMSCXscrW6ZcKyKqz75lySLuwGxOMhX4nGOoYHY0ZtrYn5WK2ZAJxsQnn
-8QcjPB0nq37U7ifk1uebmuXe99iqyKnWaLvlcpe+HnO5pVxFkSQEf7Zh+hEnRDkN
-IBzLFnqwDS1ug/oQ1aSvc8oBh2ylKDJuGtPNqGKibNJyb2diXO/aEUOKRUKPAxKa
-dbKsc4Y1bhZNN3/MICMoyghwAOiuwUQMR5uhxTkQmZUwNrPFa+eW6GvyoYLFUsZs
-hZfWLNGD5mLADElxs0HF7F9Zk6pSocTDXba4d4lfxsq88SyZZ7PbjJYFRfLQPzd1
-CfvpRPqolEmZo1Y5Q644PELYiJRKpBxmX5GtC5j5eaUD9XdGKvXsGhb0m0gW75rq
-iUnnLkZt2ya1cDJDiCnJjo7r5KxMo0XXFDc=
------END CERTIFICATE-----
-`)
-
 func TestServingCertUpdate(t *testing.T) {
 	testServingCert(t, false)
 }
@@ -521,6 +437,11 @@ func TestSNICert(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	anotherServerCert, anotherServerKey, err := cert.GenerateSelfSignedCertKey("localhost", []net.IP{net.IPv4(127, 0, 0, 1)}, []string{"localhost"})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 
 	_, kubeconfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
The name of `dynamiccertificates.NewDynamicServingContentFromFiles()` is misleading, suggesting that it can only be used for serving certificates even though it can easily be used to handle client certificates as well as proven by its usage in the aggregator code.

#### Which issue(s) this PR fixes:
Fixes None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
