### PR TITLE
kubelet : add flag for pod runtime-cache time

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -128,6 +128,10 @@ type KubeletFlags struct {
 	// maxContainerCount is the maximum number of old instances of containers
 	// to retain globally. Each container takes up some disk space.
 	MaxContainerCount int32
+	// cacheTime is the number of cache second time for cache pods.
+	// returns the cached pods if they are not outdated; otherwise, it
+	// retrieves the latest pods and return them.
+	CacheTime int32
 	// masterServiceNamespace is The namespace from which the kubernetes
 	// master services should be injected into pods.
 	MasterServiceNamespace string
@@ -200,6 +204,9 @@ func ValidateKubeletFlags(f *KubeletFlags) error {
 		return fmt.Errorf("the container runtime endpoint address was not specified or empty, use --container-runtime-endpoint to set")
 	}
 
+	if f.CacheTime < 0 {
+		return fmt.Errorf("the pod cache time second can not less than 0")
+	}
 	return nil
 }
 
@@ -339,6 +346,7 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 	fs.Int32Var(&f.MaxPerPodContainerCount, "maximum-dead-containers-per-container", f.MaxPerPodContainerCount, "Maximum number of old instances to retain per container.  Each container takes up some disk space.")
 	fs.MarkDeprecated("maximum-dead-containers-per-container", "Use --eviction-hard or --eviction-soft instead. Will be removed in a future version.")
 	fs.Int32Var(&f.MaxContainerCount, "maximum-dead-containers", f.MaxContainerCount, "Maximum number of old instances of containers to retain globally.  Each container takes up some disk space. To disable, set to a negative number.")
+	fs.Int32Var(&f.CacheTime, "cache-pods-time", 2, "Second time for cache pods. Returns the cached pods if they are not outdated; otherwise, it retrieves the latest pods and return them.")
 	fs.MarkDeprecated("maximum-dead-containers", "Use --eviction-hard or --eviction-soft instead. Will be removed in a future version.")
 	fs.StringVar(&f.MasterServiceNamespace, "master-service-namespace", f.MasterServiceNamespace, "The namespace from which the kubernetes master services should be injected into pods")
 	fs.MarkDeprecated("master-service-namespace", "This flag will be removed in a future version.")

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1214,6 +1214,7 @@ func createAndInitKubelet(kubeServer *options.KubeletServer,
 	// up into "per source" synchronizations
 
 	k, err = kubelet.NewMainKubelet(&kubeServer.KubeletConfiguration,
+		kubeServer.CacheTime,
 		kubeDeps,
 		&kubeServer.ContainerRuntimeOptions,
 		hostname,

--- a/pkg/kubelet/container/runtime_cache_fake.go
+++ b/pkg/kubelet/container/runtime_cache_fake.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package container
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // TestRuntimeCache embeds runtimeCache with some additional methods for testing.
 // It must be declared in the container package to have visibility to runtimeCache.
@@ -45,6 +48,16 @@ func NewTestRuntimeCache(getter podsGetter) *TestRuntimeCache {
 	return &TestRuntimeCache{
 		runtimeCache: runtimeCache{
 			getter: getter,
+		},
+	}
+}
+
+// NewTestRuntimeCache creates a new instance of TestRuntimeCache.
+func NewTestRuntimeCacheAndTime(getter podsGetter, cacheTime int32) *TestRuntimeCache {
+	return &TestRuntimeCache{
+		runtimeCache: runtimeCache{
+			getter:      getter,
+			cachePeriod: time.Second * time.Duration(cacheTime),
 		},
 	}
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -327,6 +327,7 @@ func PreInitRuntimeService(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 // NewMainKubelet instantiates a new Kubelet object along with all the required internal modules.
 // No initialization of Kubelet and its modules should happen here.
 func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
+	cacheTime int32,
 	kubeDeps *Dependencies,
 	crOptions *config.ContainerRuntimeOptions,
 	hostname string,
@@ -685,7 +686,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.streamingRuntime = runtime
 	klet.runner = runtime
 
-	runtimeCache, err := kubecontainer.NewRuntimeCache(klet.containerRuntime)
+	runtimeCache, err := kubecontainer.NewRuntimeCache(klet.containerRuntime, cacheTime)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2806,6 +2806,7 @@ func TestNewMainKubeletStandAlone(t *testing.T) {
 
 	testMainKubelet, err := NewMainKubelet(
 		kubeCfg,
+		2,
 		kubeDep,
 		crOptions,
 		"hostname",


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Before the kubelet RuntimeCache cachePeriod is a constant 2 second.
Now we can modify it through 
```kubelet --cache-pods-time ```

#### Does this PR introduce a user-facing change?
```
Kubelet : add flag for pod runtime-cache time ([#114308](https://github.com/kubernetes/kubernetes/pull/114308),[@yanggangtony](https://github.com/yanggangtony)).
```

```release-note
Kubelet : add flag for pod runtime-cache time.
```
