### PR TITLE
Allow to create shared index informers with custom key functions

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -297,10 +297,17 @@ func (r FilteringResourceEventHandler) OnDelete(obj interface{}) {
 // DeletedFinalStateUnknown objects before calling
 // MetaNamespaceKeyFunc.
 func DeletionHandlingMetaNamespaceKeyFunc(obj interface{}) (string, error) {
+	return DeletionHandlingWithKeyFunc(obj, MetaNamespaceKeyFunc)
+}
+
+// DeletionHandlingWithKeyFunc checks for
+// DeletedFinalStateUnknown objects before calling
+// the specified key function.
+func DeletionHandlingWithKeyFunc(obj interface{}, fn KeyFunc) (string, error) {
 	if d, ok := obj.(DeletedFinalStateUnknown); ok {
 		return d.Key, nil
 	}
-	return MetaNamespaceKeyFunc(obj)
+	return fn(obj)
 }
 
 // NewInformer returns a Store and a controller for populating the store


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@prigna.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

In the current state of things, a shared informer can only ever be created with the default KeyFunc which calls the `DeletionHandlingMetaNamespaceKeyFunc` function. In an effort to allow more customizability of the KeyFunc this PR adds a new exported function that allows users to pass in a custom KeyFunc, which is then wrapped with the DeletionHandling logic.

This allows better compatibility when using custom indexers and key function logic, for example if I want to partition the data in the store by regions or availability zones, I can setup custom indexers, although the moment a key is retrieved through `GetByKey`, the partitioning logic doesn't work anymore, given that the items are keyed with namespace/name.

> Note: This PR is a starting point, I'll happily take other paths to achieve the same, and add tests once we agree on a design.

/sig api-machinery

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

The PR above is needed in controller runtime for better support for controllers spanning across multiple clusters, see [this proposal](https://github.com/kubernetes-sigs/controller-runtime/blob/master/designs/move-cluster-specific-code-out-of-manager.md) which was accepted a while back.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
