### PR TITLE
Skip resize if fs is readonly

### DIFF
--- a/staging/src/k8s.io/mount-utils/resizefs_linux.go
+++ b/staging/src/k8s.io/mount-utils/resizefs_linux.go
@@ -28,6 +28,10 @@ import (
 	utilexec "k8s.io/utils/exec"
 )
 
+const (
+	blockDev = "blockdev"
+)
+
 // ResizeFs Provides support for resizing file systems
 type ResizeFs struct {
 	exec utilexec.Interface
@@ -104,6 +108,16 @@ func (resizefs *ResizeFs) btrfsResize(deviceMountPath string) (bool, error) {
 }
 
 func (resizefs *ResizeFs) NeedResize(devicePath string, deviceMountPath string) (bool, error) {
+	// Do nothing if device is mounted as readonly
+	readonly, err := resizefs.getDeviceRO(devicePath)
+	if err != nil {
+		return false, err
+	}
+
+	if readonly {
+		return false, nil
+	}
+
 	deviceSize, err := resizefs.getDeviceSize(devicePath)
 	if err != nil {
 		return false, err
@@ -147,7 +161,7 @@ func (resizefs *ResizeFs) NeedResize(devicePath string, deviceMountPath string) 
 	return true, nil
 }
 func (resizefs *ResizeFs) getDeviceSize(devicePath string) (uint64, error) {
-	output, err := resizefs.exec.Command("blockdev", "--getsize64", devicePath).CombinedOutput()
+	output, err := resizefs.exec.Command(blockDev, "--getsize64", devicePath).CombinedOutput()
 	outStr := strings.TrimSpace(string(output))
 	if err != nil {
 		return 0, fmt.Errorf("failed to read size of device %s: %s: %s", devicePath, err, outStr)
@@ -157,6 +171,22 @@ func (resizefs *ResizeFs) getDeviceSize(devicePath string) (uint64, error) {
 		return 0, fmt.Errorf("failed to parse size of device %s %s: %s", devicePath, outStr, err)
 	}
 	return size, nil
+}
+
+func (resizefs *ResizeFs) getDeviceRO(devicePath string) (bool, error) {
+	output, err := resizefs.exec.Command(blockDev, "--getro", devicePath).CombinedOutput()
+	outStr := strings.TrimSpace(string(output))
+	if err != nil {
+		return false, fmt.Errorf("failed to read size of device %s: %s: %s", devicePath, err, outStr)
+	}
+	switch outStr {
+	case "0":
+		return false, nil
+	case "1":
+		return true, nil
+	default:
+		return false, fmt.Errorf("Failed readonly device check. Expected 1 or 0, got '%s'", outStr)
+	}
 }
 
 func (resizefs *ResizeFs) getExtSize(devicePath string) (uint64, uint64, error) {

--- a/staging/src/k8s.io/mount-utils/resizefs_linux.go
+++ b/staging/src/k8s.io/mount-utils/resizefs_linux.go
@@ -178,7 +178,7 @@ func (resizefs *ResizeFs) getDeviceRO(devicePath string) (bool, error) {
 	output, err := resizefs.exec.Command(blockDev, "--getro", devicePath).CombinedOutput()
 	outStr := strings.TrimSpace(string(output))
 	if err != nil {
-		return false, fmt.Errorf("failed to read size of device %s: %s: %s", devicePath, err, outStr)
+		return false, fmt.Errorf("failed to get readonly bit from device %s: %s: %s", devicePath, err, outStr)
 	}
 	switch outStr {
 	case "0":

--- a/staging/src/k8s.io/mount-utils/resizefs_linux.go
+++ b/staging/src/k8s.io/mount-utils/resizefs_linux.go
@@ -115,6 +115,7 @@ func (resizefs *ResizeFs) NeedResize(devicePath string, deviceMountPath string) 
 	}
 
 	if readonly {
+		klog.V(3).Infof("ResizeFs.needResize - no resize possible since filesystem %s is readonly", devicePath)
 		return false, nil
 	}
 

--- a/staging/src/k8s.io/mount-utils/resizefs_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/resizefs_linux_test.go
@@ -500,7 +500,7 @@ func TestNeedResize(t *testing.T) {
 		deviceMountPath string
 		readonly        string
 		deviceSize      string
-		extSize 				string
+		extSize         string
 		cmdOutputFsType string
 		expectError     bool
 		expectResult    bool
@@ -544,7 +544,7 @@ func TestNeedResize(t *testing.T) {
 			deviceMountPath: "/mnt/test1",
 			readonly:        "0",
 			deviceSize:      "2048",
-			extSize:				 "1",
+			extSize:         "1",
 			cmdOutputFsType: "TYPE=ntfs",
 			expectError:     true,
 			expectResult:    false,
@@ -558,7 +558,9 @@ func TestNeedResize(t *testing.T) {
 					func() ([]byte, []byte, error) { return []byte(test.readonly), nil, nil },
 					func() ([]byte, []byte, error) { return []byte(test.deviceSize), nil, nil },
 					func() ([]byte, []byte, error) { return []byte(test.cmdOutputFsType), nil, nil },
-					func() ([]byte, []byte, error) { return []byte(fmt.Sprintf("block size: %s\nblock count: 1", test.extSize)), nil, nil },
+					func() ([]byte, []byte, error) {
+						return []byte(fmt.Sprintf("block size: %s\nblock count: 1", test.extSize)), nil, nil
+					},
 				},
 			}
 			fexec := fakeexec.FakeExec{

--- a/staging/src/k8s.io/mount-utils/resizefs_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/resizefs_linux_test.go
@@ -20,9 +20,11 @@ limitations under the License.
 package mount
 
 import (
+	"fmt"
+	"testing"
+
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
-	"testing"
 )
 
 func TestGetFileSystemSize(t *testing.T) {
@@ -179,7 +181,7 @@ flags                   0x1
 magic                   _BHRfS_M [match]
 fsid                    3f53c8f7-3c57-4185-bf1d-b305b42cce97
 metadata_uuid           3f53c8f7-3c57-4185-bf1d-b305b42cce97
-label                   
+label
 generation              7
 root                    30441472
 sys_array_size          129
@@ -289,7 +291,7 @@ flags                   0x1
 magic                   _BHRfS_M [match]
 fsid                    3f53c8f7-3c57-4185-bf1d-b305b42cce97
 metadata_uuid           3f53c8f7-3c57-4185-bf1d-b305b42cce97
-label                   
+label
 generation              7
 root                    30441472
 sys_array_size          129
@@ -496,16 +498,53 @@ func TestNeedResize(t *testing.T) {
 		name            string
 		devicePath      string
 		deviceMountPath string
+		readonly        string
 		deviceSize      string
+		extSize 				string
 		cmdOutputFsType string
 		expectError     bool
 		expectResult    bool
 	}{
 		{
+			name:            "True",
+			devicePath:      "/dev/test1",
+			deviceMountPath: "/mnt/test1",
+			readonly:        "0",
+			deviceSize:      "2048",
+			cmdOutputFsType: "TYPE=ext3",
+			extSize:         "20",
+			expectError:     false,
+			expectResult:    true,
+		},
+		{
+			name:            "False - needed by size but fs is readonly",
+			devicePath:      "/dev/test1",
+			deviceMountPath: "/mnt/test1",
+			readonly:        "1",
+			deviceSize:      "2048",
+			cmdOutputFsType: "TYPE=ext3",
+			extSize:         "20",
+			expectError:     false,
+			expectResult:    false,
+		},
+		{
+			name:            "False - Not needed by size",
+			devicePath:      "/dev/test1",
+			deviceMountPath: "/mnt/test1",
+			readonly:        "0",
+			deviceSize:      "20",
+			cmdOutputFsType: "TYPE=ext3",
+			extSize:         "2048",
+			expectError:     false,
+			expectResult:    false,
+		},
+		{
 			name:            "False - Unsupported fs type",
 			devicePath:      "/dev/test1",
 			deviceMountPath: "/mnt/test1",
+			readonly:        "0",
 			deviceSize:      "2048",
+			extSize:				 "1",
 			cmdOutputFsType: "TYPE=ntfs",
 			expectError:     true,
 			expectResult:    false,
@@ -516,12 +555,16 @@ func TestNeedResize(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fcmd := fakeexec.FakeCmd{
 				CombinedOutputScript: []fakeexec.FakeAction{
+					func() ([]byte, []byte, error) { return []byte(test.readonly), nil, nil },
 					func() ([]byte, []byte, error) { return []byte(test.deviceSize), nil, nil },
 					func() ([]byte, []byte, error) { return []byte(test.cmdOutputFsType), nil, nil },
+					func() ([]byte, []byte, error) { return []byte(fmt.Sprintf("block size: %s\nblock count: 1", test.extSize)), nil, nil },
 				},
 			}
 			fexec := fakeexec.FakeExec{
 				CommandScript: []fakeexec.FakeCommandAction{
+					func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+					func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 					func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 					func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 				},
@@ -529,11 +572,11 @@ func TestNeedResize(t *testing.T) {
 			resizefs := ResizeFs{exec: &fexec}
 
 			needResize, err := resizefs.NeedResize(test.devicePath, test.deviceMountPath)
-			if needResize != test.expectResult {
-				t.Fatalf("Expect result is %v but got %v", test.expectResult, needResize)
-			}
 			if !test.expectError && err != nil {
 				t.Fatalf("Expect no error but got %v", err)
+			}
+			if needResize != test.expectResult {
+				t.Fatalf("Expect result is %v but got %v", test.expectResult, needResize)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

See https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/1088. Right now we attempt a filesystem resize without checking whether it's readonly. This change checks the readonly bit of the filesystem, and skips resizing if it is set to "1".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
