### PR TITLE
Add pod to dsw if termination is not completed during reconstruction

### DIFF
--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -205,10 +205,18 @@ func (dswp *desiredStateOfWorldPopulator) findAndAddNewPods() {
 	}
 
 	for _, pod := range dswp.podManager.GetPods() {
-		if dswp.podStateProvider.ShouldPodContainersBeTerminating(pod.UID) {
+		// Keep consistency of adding pod during reconstruction
+		if dswp.hasAddedPods && dswp.podStateProvider.ShouldPodContainersBeTerminating(pod.UID) {
 			// Do not (re)add volumes for pods that can't also be starting containers
 			continue
 		}
+
+		if !dswp.hasAddedPods && dswp.podStateProvider.ShouldPodRuntimeBeRemoved(pod.UID) {
+			// When kubelet restarts, we need to add pods to dsw if there is a possibility
+			// that the container may still be running
+			continue
+		}
+
 		dswp.processPodVolumes(pod, mountedVolumesForPod)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The bug is about while a container is in the process of being torn down, but not completed, the volume gets unmounted and then subsequently detached, causing the fs to enter read-only mode. 

The fix is to change the add pod criteria at [DSW populator](https://github.com/kubernetes/kubernetes/blob/release-1.22/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go#L203)to also add even if it's started terminating during reconstruction. Please see [#113979](https://github.com/kubernetes/kubernetes/issues/113979)

#### Which issue(s) this PR fixes:

Fixes [#113979](https://github.com/kubernetes/kubernetes/issues/113979)

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
NONE

