### PR TITLE
kubelet-eviction-manager: don't update threshold for memory if usage_in_bytes greater than capacity_in_bytes

### DIFF
--- a/pkg/kubelet/eviction/memory_threshold_notifier_test.go
+++ b/pkg/kubelet/eviction/memory_threshold_notifier_test.go
@@ -80,6 +80,7 @@ func TestUpdateThreshold(t *testing.T) {
 		evictionThreshold  evictionapi.Threshold
 		expectedThreshold  resource.Quantity
 		updateThresholdErr error
+		expectedCalls      bool
 		expectErr          bool
 	}{
 		{
@@ -95,6 +96,7 @@ func TestUpdateThreshold(t *testing.T) {
 				},
 			},
 			expectedThreshold:  resource.MustParse("4Gi"),
+			expectedCalls:      true,
 			updateThresholdErr: nil,
 			expectErr:          false,
 		},
@@ -111,6 +113,7 @@ func TestUpdateThreshold(t *testing.T) {
 				},
 			},
 			expectedThreshold:  resource.MustParse("6Gi"),
+			expectedCalls:      true,
 			updateThresholdErr: nil,
 			expectErr:          false,
 		},
@@ -127,7 +130,24 @@ func TestUpdateThreshold(t *testing.T) {
 				},
 			},
 			expectedThreshold:  resource.MustParse("4Gi"),
+			expectedCalls:      true,
 			updateThresholdErr: fmt.Errorf("unexpected error"),
+			expectErr:          true,
+		},
+		{
+			description: "error updating when capacity is less than usage_in_bytes",
+			available:   resource.MustParse("2Gi"),
+			usage:       resource.MustParse("3Gi"),
+			evictionThreshold: evictionapi.Threshold{
+				Signal:   evictionapi.SignalMemoryAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1Gi"),
+				},
+			},
+			expectedThreshold:  resource.MustParse("0Gi"),
+			expectedCalls:      false,
+			updateThresholdErr: nil,
 			expectErr:          true,
 		},
 	}
@@ -138,7 +158,9 @@ func TestUpdateThreshold(t *testing.T) {
 			notifier := NewMockCgroupNotifier(t)
 
 			m := newTestMemoryThresholdNotifier(tc.evictionThreshold, notifierFactory, nil)
-			notifierFactory.EXPECT().NewCgroupNotifier(testCgroupPath, memoryUsageAttribute, tc.expectedThreshold.Value()).Return(notifier, tc.updateThresholdErr).Times(1)
+			if tc.expectedCalls {
+				notifierFactory.EXPECT().NewCgroupNotifier(testCgroupPath, memoryUsageAttribute, tc.expectedThreshold.Value()).Return(notifier, tc.updateThresholdErr).Times(1)
+			}
 			var events chan<- struct{} = m.events
 			notifier.EXPECT().Start(events).Return().Maybe()
 			err := m.UpdateThreshold(nodeSummary(tc.available, tc.workingSet, tc.usage, isAllocatableEvictionThreshold(tc.evictionThreshold)))


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This should be a bug in operating system but I think this is valid to check capacity/usage_in_bytes before we calculate the eviction threshold.

- 4.19.90-23.8.v2101.ky10.aarch64 
- https://kubernetes.io/examples/admin/resource/memory-available.sh this is script to calculate memory.available from https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/

We finally got 
```
memory.capacity_in_bytes   32879017984 (~32Gi)
memory.usage_in_bytes       80342220800 (~80Gi)
memory.total_inactive_file    10048962560 (~10Gi)
memory.working_set             70293258240 (~70Gi)
memory.available_in_bytes -37414240256 (-35Gi)
memory.available_in_kb      -36537344
memory.available_in_mb     -35681
```

#### Which issue(s) this PR fixes:
Fixes #114332


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: the eviction manager should not evict pods if usage_in_bytes is greater than capacity_in_bytes due to OS bug
```


> The kernel maybe very lazy to sync memory usage counters of the root cgroup.
> Lots of dying cgroups make usage_in_bytes greater than capacity_in_bytes.
> See https://github.com/torvalds/linux/commit/c350a99ea2b1b666c28948d74ab46c16913c28a7
> 
> echo 3 > /proc/sys/vm/drop_caches is a quick and dirty workaround.
> 
> We fixed the issue by:
> 
> backport https://github.com/torvalds/linux/commit/f82a7a86dbfbd0ee81a4907ca41ba78bda1846f4
> find out the source of dying cgroups with the help of https://github.com/osandov/drgn/pull/306 and fix it

See https://github.com/kubernetes/kubernetes/pull/114333#issuecomment-1573519414.