### PR TITLE
staging/publishing: add kms to apiserver 1.26 rules

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -442,6 +442,8 @@ rules:
       branch: release-1.26
     - repository: component-base
       branch: release-1.26
+    - repository: kms
+      branch: release-1.26
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/apiserver


### PR DESCRIPTION


#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

publishing-bot is broken - https://github.com/kubernetes/kubernetes/issues/56876#issuecomment-1340693124

While publishing apiserver, we see:

```
    	+ GOPRIVATE=k8s.io/apimachinery,k8s.io/api,k8s.io/client-go,k8s.io/component-base
    	+ GOPROXY=https://proxy.golang.org
    	+ go mod download
    	go: k8s.io/kms@v0.0.0: reading https://proxy.golang.org/k8s.io/kms/@v/v0.0.0.mod: 404 Not Found
    		server response: not found: k8s.io/kms@v0.0.0: invalid version: unknown revision v0.0.0
```
kms is present in apiserver's go.mod but missing from the list of dependencies in rules.yaml. Once it's added to rules.yaml, it'll be included in `GOPRIVATE` and we won't hit this error anymore.

https://github.com/kubernetes/kubernetes/blob/713b671a8a3fb526ba616a26953a91026c77611f/staging/src/k8s.io/apiserver/go.mod#L130


#### Which issue(s) this PR fixes:

https://github.com/kubernetes/kubernetes/issues/56876#issuecomment-1340693124

#### Special notes for your reviewer:

Likely triggered by an update to go.mod in https://github.com/kubernetes/kubernetes/pull/114319, which was merged recently.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

