### PR TITLE
kubeadm: set priority for "system-node-critical" Pods

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -56,6 +56,8 @@ var (
 
 // ComponentPod returns a Pod object from the container, volume and annotations specifications
 func ComponentPod(container v1.Container, volumes map[string]v1.Volume, annotations map[string]string) v1.Pod {
+	// priority value for system-node-critical class
+	priority := int32(2000001000)
 	return v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -71,6 +73,7 @@ func ComponentPod(container v1.Container, volumes map[string]v1.Volume, annotati
 		},
 		Spec: v1.PodSpec{
 			Containers:        []v1.Container{container},
+			Priority:          &priority,
 			PriorityClassName: "system-node-critical",
 			HostNetwork:       true,
 			Volumes:           VolumeMapToSlice(volumes),

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -392,6 +392,8 @@ func TestGetEtcdProbeEndpoint(t *testing.T) {
 }
 
 func TestComponentPod(t *testing.T) {
+	// priority value for system-node-critical class
+	priority := int32(2000001000)
 	var tests = []struct {
 		name     string
 		expected v1.Pod
@@ -419,6 +421,7 @@ func TestComponentPod(t *testing.T) {
 							Name: "foo",
 						},
 					},
+					Priority:          &priority,
 					PriorityClassName: "system-node-critical",
 					HostNetwork:       true,
 					Volumes:           []v1.Volume{},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
By explicitly setting priority, we allow Graceful Node Shutdown to work properly. 

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/113940

#### Special notes for your reviewer:
This is the easy workaround, but it's not fixing the issue that kubelet doesn't see the priority set by the admission controller.
I haven't build and run tested this PR, I only tested that manually adding `priority` fixes Graceful Node Shutdown

#### Does this PR introduce a user-facing change?
```release-note
kubeadm: explicitly set `priority` for static pods with `priorityClassName: system-node-critical`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
By explicitly setting `priority` for static pods, Graceful Node Shutdown now stops these pods last as it should
```
