### PR TITLE
[1.22] Change kubelet pause default to registry.k8s.io

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -174,15 +174,15 @@ dependencies:
       match: validTmplOut\s+=
     - path: cmd/kubeadm/app/util/template_test.go
       match: doNothing\s+=
+    - path: cmd/kubelet/app/options/container_runtime.go
+      match: defaultPodSandboxImageVersion\s+=
+    - path: pkg/kubelet/dockershim/docker_sandbox.go
+      match: registry.k8s.io\/pause:\d+\.\d+
 
   - name: "k8s.gcr.io/pause: dependents"
     version: 3.5
     refPaths:
-    - path: cmd/kubelet/app/options/container_runtime.go
-      match: defaultPodSandboxImageVersion\s+=
     - path: hack/testdata/pod-with-precision.json
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: pkg/kubelet/dockershim/docker_sandbox.go
       match: k8s.gcr.io\/pause:\d+\.\d+
     - path: staging/src/k8s.io/kubectl/testdata/set/multi-resource-yaml.yaml
       match: k8s.gcr.io\/pause:\d+\.\d+

--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// When these values are updated, also update test/utils/image/manifest.go
-	defaultPodSandboxImageName    = "k8s.gcr.io/pause"
+	defaultPodSandboxImageName    = "registry.k8s.io/pause"
 	defaultPodSandboxImageVersion = "3.5"
 )
 

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	defaultSandboxImage = "k8s.gcr.io/pause:3.5"
+	defaultSandboxImage = "registry.k8s.io/pause:3.5"
 
 	// Various default sandbox resources requests/limits.
 	defaultSandboxCPUshares int64 = 2


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Supports the migration of the image registry from gcr to registry.k8s.io.

Rather than a full backport of https://github.com/kubernetes/kubernetes/pull/109938, kubeadm narrowly changed the referenced images in https://github.com/kubernetes/kubernetes/pull/113388 and this PR changes the default pause image registry used by the kubelet.

#### Special notes for your reviewer:

This is a trimmed down version of https://github.com/kubernetes/kubernetes/pull/113417 that *only* changes the kubelet default pause image

#### Does this PR introduce a user-facing change?
```release-note
kubelet now defaults to pulling the pause image from registry.k8s.io
```