### PR TITLE
[1.24] change k8s.gcr.io/pause to registry.k8s.io/pause

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -172,12 +172,12 @@ dependencies:
       match: validTmplOut\s+=
     - path: cmd/kubeadm/app/util/template_test.go
       match: doNothing\s+=
+    - path: cmd/kubelet/app/options/container_runtime.go
+      match: defaultPodSandboxImageVersion\s+=
 
   - name: "k8s.gcr.io/pause: dependents"
     version: 3.7
     refPaths:
-    - path: cmd/kubelet/app/options/container_runtime.go
-      match: defaultPodSandboxImageVersion\s+=
     - path: hack/testdata/pod-with-precision.json
       match: k8s.gcr.io\/pause:\d+\.\d+
     - path: staging/src/k8s.io/kubectl/testdata/set/multi-resource-yaml.yaml

--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// When these values are updated, also update test/utils/image/manifest.go
-	defaultPodSandboxImageName    = "k8s.gcr.io/pause"
+	defaultPodSandboxImageName    = "registry.k8s.io/pause"
 	defaultPodSandboxImageVersion = "3.7"
 )
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Supports the migration of the image registry from gcr to registry.k8s.io.

Rather than a full backport of https://github.com/kubernetes/kubernetes/pull/109938, kubeadm narrowly changed the referenced images in https://github.com/kubernetes/kubernetes/pull/113395 and this PR changes the default pause image registry used by the kubelet.

#### Special notes for your reviewer:

This is a trimmed down version of https://github.com/kubernetes/kubernetes/pull/113417 that *only* changes the kubelet default pause image

#### Does this PR introduce a user-facing change?
```release-note
kubelet now defaults to pulling the pause image from registry.k8s.io
```