### PR TITLE
Deflake a preemption test that may patch Node incorrectly

### DIFF
--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -88,6 +88,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		for _, node := range nodeList.Items {
 			nodeCopy := node.DeepCopy()
 			delete(nodeCopy.Status.Capacity, testExtendedResource)
+			delete(nodeCopy.Status.Allocatable, testExtendedResource)
 			err := patchNode(cs, &node, nodeCopy)
 			framework.ExpectNoError(err)
 		}
@@ -138,6 +139,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			// Update each node to advertise 3 available extended resources
 			nodeCopy := node.DeepCopy()
 			nodeCopy.Status.Capacity[testExtendedResource] = resource.MustParse("5")
+			nodeCopy.Status.Allocatable[testExtendedResource] = resource.MustParse("5")
 			err := patchNode(cs, &node, nodeCopy)
 			framework.ExpectNoError(err)
 
@@ -228,6 +230,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			// Update each node to advertise 3 available extended resources
 			nodeCopy := node.DeepCopy()
 			nodeCopy.Status.Capacity[testExtendedResource] = resource.MustParse("5")
+			nodeCopy.Status.Allocatable[testExtendedResource] = resource.MustParse("5")
 			err := patchNode(cs, &node, nodeCopy)
 			framework.ExpectNoError(err)
 
@@ -329,6 +332,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		node := nodeList.Items[0]
 		nodeCopy := node.DeepCopy()
 		nodeCopy.Status.Capacity[testExtendedResource] = resource.MustParse("1")
+		nodeCopy.Status.Allocatable[testExtendedResource] = resource.MustParse("1")
 		err := patchNode(cs, &node, nodeCopy)
 		framework.ExpectNoError(err)
 
@@ -408,6 +412,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 				ginkgo.By(fmt.Sprintf("Apply 10 fake resource to node %v.", node.Name))
 				nodeCopy := node.DeepCopy()
 				nodeCopy.Status.Capacity[fakeRes] = resource.MustParse("10")
+				nodeCopy.Status.Allocatable[fakeRes] = resource.MustParse("10")
 				err = patchNode(cs, node, nodeCopy)
 				framework.ExpectNoError(err)
 				nodes = append(nodes, node)
@@ -420,6 +425,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			for _, node := range nodes {
 				nodeCopy := node.DeepCopy()
 				delete(nodeCopy.Status.Capacity, fakeRes)
+				delete(nodeCopy.Status.Allocatable, fakeRes)
 				err := patchNode(cs, node, nodeCopy)
 				framework.ExpectNoError(err)
 			}
@@ -558,6 +564,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			if node != nil {
 				nodeCopy := node.DeepCopy()
 				delete(nodeCopy.Status.Capacity, fakecpu)
+				delete(nodeCopy.Status.Allocatable, fakecpu)
 				err := patchNode(cs, node, nodeCopy)
 				framework.ExpectNoError(err)
 			}
@@ -590,6 +597,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			// update Node API object with a fake resource
 			nodeCopy := node.DeepCopy()
 			nodeCopy.Status.Capacity[fakecpu] = resource.MustParse("1000")
+			nodeCopy.Status.Allocatable[fakecpu] = resource.MustParse("1000")
 			err = patchNode(cs, node, nodeCopy)
 			framework.ExpectNoError(err)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind failing-test
/kind flake
/sig scheduling


#### What this PR does / why we need it:

In the [e2e-test grid](https://testgrid.k8s.io/sig-network-gce#gci-gce-serial-kube-dns), `[sig-scheduling] SchedulerPreemption [Serial] validates pod disruption condition is added to the preempted pod` is failing flakily.

We had a discussion in slack: https://kubernetes.slack.com/archives/C09TP78DV/p1670410754287509.

The preemptor was expected to be pending b/c the only extended source piece was occupied by a low-priority pod, but the [log](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-kube-dns/1600208320755404800) shows the preemptor gets into running directly:

```
I1206 20:06:08.373180       9 schedule_one.go:81] "Attempting to schedule pod" pod="sched-preemption-3784/victim-pod"
I1206 20:06:08.373416       9 default_binder.go:52] "Attempting to bind pod to node" pod="sched-preemption-3784/victim-pod" node="bootstrap-e2e-minion-group-c44v"
...
I1206 20:06:10.503305       9 schedule_one.go:81] "Attempting to schedule pod" pod="sched-preemption-3784/preemptor-pod"
I1206 20:06:10.503652       9 default_binder.go:52] "Attempting to bind pod to node" pod="sched-preemption-3784/preemptor-pod" node="bootstrap-e2e-minion-group-c44v"
I1206 20:06:10.507929       9 schedule_one.go:252] "Successfully bound pod to node" pod="sched-preemption-3784/preemptor-pod" node="bootstrap-e2e-minion-group-c44v" evaluatedNodes=1 feasibleNodes=1
```

A suspicious clue is that the e2e test patch Node by only updating the `capacity` (instead of both `capacity` and `allocatable`), it works most of the time as kubelet is working _asynchronously_ to sync the `capacity` value to `allocatable`:

![image](https://user-images.githubusercontent.com/1425903/206311650-0e1e2b1c-2af2-4daf-86a6-e5575a20bc64.png)

But we'd better not count on that due to:

1. it's an asynchronous process
2. kubelet may not function properly

So this PR enforces setting both `capacity` and `allocatable` in the e2e when we want to update a Node's resource capacity.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Deflake a preemption test that may patch Nodes incorrectly.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
