### PR TITLE
staging: add DRA repo to list

### DIFF
--- a/staging/README.md
+++ b/staging/README.md
@@ -20,6 +20,7 @@ Repositories currently staged here:
 - [`k8s.io/controller-manager`](https://github.com/kubernetes/controller-manager)
 - [`k8s.io/cri-api`](https://github.com/kubernetes/cri-api)
 - [`k8s.io/csi-translation-lib`](https://github.com/kubernetes/csi-translation-lib)
+- [`k8s.io/dynamic-resource-allocation`](https://github.com/kubernetes/dynamic-resource-allocation)
 - [`k8s.io/kms`](https://github.com/kubernetes/kms)
 - [`k8s.io/kube-aggregator`](https://github.com/kubernetes/kube-aggregator)
 - [`k8s.io/kube-controller-manager`](https://github.com/kubernetes/kube-controller-manager)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This was overlooked when adding the DRA staging repo in Kubernetes 1.26.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```
