### PR TITLE
kubelet: prepare DRA resources before CNI setup

### DIFF
--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/apis/podresources"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
-	"k8s.io/kubernetes/pkg/kubelet/cm/dra"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
@@ -118,11 +117,11 @@ type ContainerManager interface {
 	// GetNodeAllocatableAbsolute returns the absolute value of Node Allocatable which is primarily useful for enforcement.
 	GetNodeAllocatableAbsolute() v1.ResourceList
 
-	// PrepareResource prepares pod resources
-	PrepareResources(pod *v1.Pod, container *v1.Container) (*dra.ContainerInfo, error)
+	// PrepareDynamicResource prepares dynamic pod resources
+	PrepareDynamicResources(*v1.Pod) error
 
-	// UnrepareResources unprepares pod resources
-	UnprepareResources(*v1.Pod) error
+	// UnrepareDynamicResources unprepares dynamic pod resources
+	UnprepareDynamicResources(*v1.Pod) error
 
 	// PodMightNeedToUnprepareResources returns true if the pod with the given UID
 	// might need to unprepare resources.

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -25,7 +25,6 @@ import (
 	internalapi "k8s.io/cri-api/pkg/apis"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
-	"k8s.io/kubernetes/pkg/kubelet/cm/dra"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/config"
@@ -156,11 +155,11 @@ func (cm *containerManagerStub) GetNodeAllocatableAbsolute() v1.ResourceList {
 	return nil
 }
 
-func (cm *containerManagerStub) PrepareResources(pod *v1.Pod, container *v1.Container) (*dra.ContainerInfo, error) {
-	return nil, nil
+func (cm *containerManagerStub) PrepareDynamicResources(pod *v1.Pod) error {
+	return nil
 }
 
-func (cm *containerManagerStub) UnprepareResources(*v1.Pod) error {
+func (cm *containerManagerStub) UnprepareDynamicResources(*v1.Pod) error {
 	return nil
 }
 

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
-	"k8s.io/kubernetes/pkg/kubelet/cm/dra"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/config"
@@ -254,11 +253,11 @@ func (cm *containerManagerImpl) GetNodeAllocatableAbsolute() v1.ResourceList {
 	return nil
 }
 
-func (cm *containerManagerImpl) PrepareResources(pod *v1.Pod, container *v1.Container) (*dra.ContainerInfo, error) {
-	return nil, nil
+func (cm *containerManagerImpl) PrepareDynamicResources(pod *v1.Pod) error {
+	return nil
 }
 
-func (cm *containerManagerImpl) UnprepareResources(*v1.Pod) error {
+func (cm *containerManagerImpl) UnprepareDynamicResources(*v1.Pod) error {
 	return nil
 }
 

--- a/pkg/kubelet/cm/dra/types.go
+++ b/pkg/kubelet/cm/dra/types.go
@@ -24,13 +24,16 @@ import (
 
 // Manager manages all the DRA resource plugins running on a node.
 type Manager interface {
-	// PrepareResources prepares resources for a container in a pod.
-	// It communicates with the DRA resource plugin to prepare resources and
-	// returns resource info to trigger CDI injection by the runtime.
-	PrepareResources(pod *v1.Pod, container *v1.Container) (*ContainerInfo, error)
+	// PrepareResources prepares resources for a pod.
+	// It communicates with the DRA resource plugin to prepare resources.
+	PrepareResources(pod *v1.Pod) error
 
 	// UnprepareResources calls NodeUnprepareResource GRPC from DRA plugin to unprepare pod resources
 	UnprepareResources(pod *v1.Pod) error
+
+	// GetResources gets a ContainerInfo object from the claimInfo cache.
+	// This information is used by the caller to update a container config.
+	GetResources(pod *v1.Pod, container *v1.Container) (*ContainerInfo, error)
 
 	// PodMightNeedToUnprepareResources returns true if the pod with the given UID
 	// might need to unprepare resources.

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -26,7 +26,6 @@ import (
 	internalapi "k8s.io/cri-api/pkg/apis"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
-	"k8s.io/kubernetes/pkg/kubelet/cm/dra"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/config"
@@ -239,11 +238,11 @@ func (cm *FakeContainerManager) GetNodeAllocatableAbsolute() v1.ResourceList {
 	return nil
 }
 
-func (cm *FakeContainerManager) PrepareResources(pod *v1.Pod, container *v1.Container) (*dra.ContainerInfo, error) {
-	return nil, nil
+func (cm *FakeContainerManager) PrepareDynamicResources(pod *v1.Pod) error {
+	return nil
 }
 
-func (cm *FakeContainerManager) UnprepareResources(*v1.Pod) error {
+func (cm *FakeContainerManager) UnprepareDynamicResources(*v1.Pod) error {
 	return nil
 }
 

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -60,6 +60,12 @@ type RuntimeHelper interface {
 
 	// GetOrCreateUserNamespaceMappings returns the configuration for the sandbox user namespace
 	GetOrCreateUserNamespaceMappings(pod *v1.Pod) (*runtimeapi.UserNamespace, error)
+
+	// PrepareDynamicResources prepares resources for a pod.
+	PrepareDynamicResources(pod *v1.Pod) error
+
+	// UnprepareDynamicResources unprepares resources for a a pod.
+	UnprepareDynamicResources(pod *v1.Pod) error
 }
 
 // ShouldContainerBeRestarted checks whether a container needs to be restarted.

--- a/pkg/kubelet/container/testing/fake_runtime_helper.go
+++ b/pkg/kubelet/container/testing/fake_runtime_helper.go
@@ -71,3 +71,11 @@ func (f *FakeRuntimeHelper) GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int6
 func (f *FakeRuntimeHelper) GetOrCreateUserNamespaceMappings(pod *v1.Pod) (*runtimeapi.UserNamespace, error) {
 	return nil, nil
 }
+
+func (f *FakeRuntimeHelper) PrepareDynamicResources(pod *v1.Pod) error {
+	return nil
+}
+
+func (f *FakeRuntimeHelper) UnprepareDynamicResources(pod *v1.Pod) error {
+	return nil
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1943,7 +1943,7 @@ func (kl *Kubelet) syncTerminatingPod(_ context.Context, pod *v1.Pod, podStatus 
 	// and BEFORE the pod status is changed on the API server
 	// to avoid race conditions with the resource deallocation code in kubernetes core.
 	if utilfeature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
-		if err := kl.containerManager.UnprepareResources(pod); err != nil {
+		if err := kl.UnprepareDynamicResources(pod); err != nil {
 			return err
 		}
 	}
@@ -2612,4 +2612,16 @@ func (kl *Kubelet) supportLocalStorageCapacityIsolation() bool {
 func isSyncPodWorthy(event *pleg.PodLifecycleEvent) bool {
 	// ContainerRemoved doesn't affect pod state
 	return event.Type != pleg.ContainerRemoved
+}
+
+// PrepareDynamicResources calls the container Manager PrepareDynamicResources API
+// This method implements the RuntimeHelper interface
+func (kl *Kubelet) PrepareDynamicResources(pod *v1.Pod) error {
+	return kl.containerManager.PrepareDynamicResources(pod)
+}
+
+// UnprepareDynamicResources calls the container Manager UnprepareDynamicResources API
+// This method implements the RuntimeHelper interface
+func (kl *Kubelet) UnprepareDynamicResources(pod *v1.Pod) error {
+	return kl.containerManager.UnprepareDynamicResources(pod)
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -764,6 +764,13 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		// When runc supports slash as sysctl separator, this function can no longer be used.
 		sysctl.ConvertPodSysctlsVariableToDotsSeparator(pod.Spec.SecurityContext)
 
+		// Prepare resources allocated by the Dynammic Resource Allocation feature for the pod
+		if utilfeature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
+			if m.runtimeHelper.PrepareDynamicResources(pod) != nil {
+				return
+			}
+		}
+
 		podSandboxID, msg, err = m.createPodSandbox(ctx, pod, podContainerChanges.Attempt)
 		if err != nil {
 			// createPodSandbox can return an error from CNI, CSI,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
It calls DRA PrepareResources API before CNI is initialized to enable DRA usage for network devices.

#### Which issue(s) this PR fixes:
Fixes #113785

#### Special notes for your reviewer:
This is a modified version of the https://github.com/pohly/kubernetes/pull/43 that keeps most of the logic in the container manager and adds only one call to the Kubelet just to be able to call container manager PrepareResources API.

#### Does this PR introduce a user-facing change?

```release-note
Dynamic Resource Allocation framework can be used for network devices
```