### PR TITLE
Count resources from watchCache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -745,6 +745,14 @@ func (c *Cacher) GuaranteedUpdate(
 
 // Count implements storage.Interface.
 func (c *Cacher) Count(pathPrefix string) (int64, error) {
+	if !c.ready.check() {
+		return c.storage.Count(pathPrefix)
+	}
+	keys := c.watchCache.ListKeys()
+	if len(keys) > 0 {
+		klog.V(4).Infof("cacher (%v): Count (%v) objects from watchCache.", c.objectType.String(), len(keys))
+		return int64(len(keys)), nil
+	}
 	return c.storage.Count(pathPrefix)
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In large-scale scenarios, it's so expensive that list or count resources from ETCD.    
In our test, we found etcd latency would be more than 1 seconds with increasing raft requests which contain a lot of linearizable read requests. Such as the following scenario：

t0:  Linearizable Range request R0 reach to follower A0 node, then treeIndex would be locked by ReadWriteLock. 
t1:  Other raft writing request R1 would be blocked by ReadWriteLock and try to grab the Mutex after R0 unlocked.
t2:  Another linearizable Range request R2 reach to follower A0 node. It would be blocked until R0 and R1 finished.

The time of locking treeIndex would increase along with increasing kubernetes's resources. So we want to reduce latency and  decrease time spent in treeIndex and blotdb as follow.
1.  List resources from watchCache by resourceVersion="0" when clients do not have strong consistent read requests.
2.  Count resources from watchCache firstly. 
  

 



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
