### PR TITLE
kubelet/kuberuntime: Improving test coverage

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -37,6 +37,49 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+func TestGeneratePodSandboxConfig(t *testing.T) {
+	_, _, m, err := createTestRuntimeManager()
+	require.NoError(t, err)
+	pod := newTestPod()
+
+	expectedLogDirectory := filepath.Join(podLogsRootDirectory, pod.Namespace+"_"+pod.Name+"_12345678")
+	expectedLabels := map[string]string{
+		"io.kubernetes.pod.name":      pod.Name,
+		"io.kubernetes.pod.namespace": pod.Namespace,
+		"io.kubernetes.pod.uid":       string(pod.UID),
+	}
+	expectedLinuxPodSandboxConfig := &runtimeapi.LinuxPodSandboxConfig{
+		SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
+			SelinuxOptions: &runtimeapi.SELinuxOption{
+				User: "qux",
+			},
+			RunAsUser:  &runtimeapi.Int64Value{Value: 1000},
+			RunAsGroup: &runtimeapi.Int64Value{Value: 10},
+		},
+	}
+	expectedMetadata := &runtimeapi.PodSandboxMetadata{
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+		Uid:       string(pod.UID),
+		Attempt:   uint32(1),
+	}
+	expectedPortMappings := []*runtimeapi.PortMapping{
+		{
+			HostPort: 8080,
+		},
+	}
+
+	podSandboxConfig, err := m.generatePodSandboxConfig(pod, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedLabels, podSandboxConfig.Labels)
+	assert.Equal(t, expectedLogDirectory, podSandboxConfig.LogDirectory)
+	assert.Equal(t, expectedMetadata, podSandboxConfig.Metadata)
+	assert.Equal(t, expectedPortMappings, podSandboxConfig.PortMappings)
+	assert.Equal(t, expectedLinuxPodSandboxConfig.SecurityContext.SelinuxOptions, podSandboxConfig.Linux.SecurityContext.SelinuxOptions)
+	assert.Equal(t, expectedLinuxPodSandboxConfig.SecurityContext.RunAsUser, podSandboxConfig.Linux.SecurityContext.RunAsUser)
+	assert.Equal(t, expectedLinuxPodSandboxConfig.SecurityContext.RunAsGroup, podSandboxConfig.Linux.SecurityContext.RunAsGroup)
+}
+
 // TestCreatePodSandbox tests creating sandbox and its corresponding pod log directory.
 func TestCreatePodSandbox(t *testing.T) {
 	ctx := context.Background()
@@ -57,7 +100,8 @@ func TestCreatePodSandbox(t *testing.T) {
 	sandboxes, err := fakeRuntime.ListPodSandbox(ctx, &runtimeapi.PodSandboxFilter{Id: id})
 	assert.NoError(t, err)
 	assert.Equal(t, len(sandboxes), 1)
-	// TODO Check pod sandbox configuration
+	assert.Equal(t, sandboxes[0].Id, fmt.Sprintf("%s_%s_%s_1", pod.Name, pod.Namespace, pod.UID))
+	assert.Equal(t, sandboxes[0].State, runtimeapi.PodSandboxState_SANDBOX_READY)
 }
 
 func TestGeneratePodSandboxLinuxConfigSeccomp(t *testing.T) {
@@ -141,6 +185,8 @@ func TestCreatePodSandbox_RuntimeClass(t *testing.T) {
 }
 
 func newTestPod() *v1.Pod {
+	anyGroup := int64(10)
+	anyUser := int64(1000)
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       "12345678",
@@ -148,11 +194,23 @@ func newTestPod() *v1.Pod {
 			Namespace: "new",
 		},
 		Spec: v1.PodSpec{
+			SecurityContext: &v1.PodSecurityContext{
+				SELinuxOptions: &v1.SELinuxOptions{
+					User: "qux",
+				},
+				RunAsUser:  &anyUser,
+				RunAsGroup: &anyGroup,
+			},
 			Containers: []v1.Container{
 				{
 					Name:            "foo",
 					Image:           "busybox",
 					ImagePullPolicy: v1.PullIfNotPresent,
+					Ports: []v1.ContainerPort{
+						{
+							HostPort: 8080,
+						},
+					},
 				},
 			},
 		},

--- a/pkg/kubelet/kuberuntime/security_context_others_test.go
+++ b/pkg/kubelet/kuberuntime/security_context_others_test.go
@@ -20,11 +20,12 @@ limitations under the License.
 package kuberuntime
 
 import (
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestVerifyRunAsNonRoot(t *testing.T) {
@@ -62,6 +63,14 @@ func TestVerifyRunAsNonRoot(t *testing.T) {
 			desc: "Pass if SecurityContext is not set",
 			sc:   nil,
 			uid:  &rootUser,
+			fail: false,
+		},
+		{
+			desc: "Pass if RunAsUser is non-root and RunAsNonRoot is true",
+			sc: &v1.SecurityContext{
+				RunAsNonRoot: &runAsNonRootTrue,
+				RunAsUser:    &anyUser,
+			},
 			fail: false,
 		},
 		{


### PR DESCRIPTION
Signed-off-by: TommyStarK <thomasmilox@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If applied this commit will increase the unit tests code coverage of `pkg/kubelet/kuberuntime`

- Initial unit tests code coverage

<img width="668" alt="Screenshot 2022-12-08 at 14 48 18" src="https://user-images.githubusercontent.com/9576370/206545171-a0342d67-be0f-4235-b340-0f627dcfb79d.png">

![Screenshot 2022-12-08 at 19 58 07](https://user-images.githubusercontent.com/9576370/206545221-b69b6d28-167a-482b-8c86-ea317e4a9356.png)

- After changes

<img width="698" alt="Screenshot 2022-12-08 at 19 57 43" src="https://user-images.githubusercontent.com/9576370/206545257-147b70fb-8793-4b30-81e6-c2d8c9962bdb.png">

![Screenshot 2022-12-08 at 19 56 38](https://user-images.githubusercontent.com/9576370/206545298-ab2c1be0-9b42-4cd3-8ce7-e3bd0307edab.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
