### PR TITLE
Changed the NodeName Filter to PreFilter

### DIFF
--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -30,6 +30,7 @@ var PluginsV1beta2 = &config.Plugins{
 	},
 	PreFilter: config.PluginSet{
 		Enabled: []config.Plugin{
+			{Name: names.NodeName},
 			{Name: names.NodeResourcesFit},
 			{Name: names.NodePorts},
 			{Name: names.VolumeRestrictions},
@@ -42,7 +43,6 @@ var PluginsV1beta2 = &config.Plugins{
 	Filter: config.PluginSet{
 		Enabled: []config.Plugin{
 			{Name: names.NodeUnschedulable},
-			{Name: names.NodeName},
 			{Name: names.TaintToleration},
 			{Name: names.NodeAffinity},
 			{Name: names.NodePorts},
@@ -188,6 +188,7 @@ var ExpandedPluginsV1beta3 = &config.Plugins{
 	},
 	PreFilter: config.PluginSet{
 		Enabled: []config.Plugin{
+			{Name: names.NodeName},
 			{Name: names.NodeAffinity},
 			{Name: names.NodePorts},
 			{Name: names.NodeResourcesFit},
@@ -200,7 +201,6 @@ var ExpandedPluginsV1beta3 = &config.Plugins{
 	Filter: config.PluginSet{
 		Enabled: []config.Plugin{
 			{Name: names.NodeUnschedulable},
-			{Name: names.NodeName},
 			{Name: names.TaintToleration},
 			{Name: names.NodeAffinity},
 			{Name: names.NodePorts},
@@ -358,6 +358,7 @@ var ExpandedPluginsV1 = &config.Plugins{
 	},
 	PreFilter: config.PluginSet{
 		Enabled: []config.Plugin{
+			{Name: names.NodeName},
 			{Name: names.NodeAffinity},
 			{Name: names.NodePorts},
 			{Name: names.NodeResourcesFit},
@@ -370,7 +371,6 @@ var ExpandedPluginsV1 = &config.Plugins{
 	Filter: config.PluginSet{
 		Enabled: []config.Plugin{
 			{Name: names.NodeUnschedulable},
-			{Name: names.NodeName},
 			{Name: names.TaintToleration},
 			{Name: names.NodeAffinity},
 			{Name: names.NodePorts},

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins.go
@@ -36,6 +36,7 @@ func getDefaultPlugins() *v1beta2.Plugins {
 		},
 		PreFilter: v1beta2.PluginSet{
 			Enabled: []v1beta2.Plugin{
+				{Name: names.NodeName},
 				{Name: names.NodeResourcesFit},
 				{Name: names.NodePorts},
 				{Name: names.VolumeRestrictions},
@@ -48,7 +49,6 @@ func getDefaultPlugins() *v1beta2.Plugins {
 		Filter: v1beta2.PluginSet{
 			Enabled: []v1beta2.Plugin{
 				{Name: names.NodeUnschedulable},
-				{Name: names.NodeName},
 				{Name: names.TaintToleration},
 				{Name: names.NodeAffinity},
 				{Name: names.NodePorts},

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
@@ -45,6 +45,7 @@ func TestApplyFeatureGates(t *testing.T) {
 				},
 				PreFilter: v1beta2.PluginSet{
 					Enabled: []v1beta2.Plugin{
+						{Name: names.NodeName},
 						{Name: names.NodeResourcesFit},
 						{Name: names.NodePorts},
 						{Name: names.VolumeRestrictions},
@@ -57,7 +58,6 @@ func TestApplyFeatureGates(t *testing.T) {
 				Filter: v1beta2.PluginSet{
 					Enabled: []v1beta2.Plugin{
 						{Name: names.NodeUnschedulable},
-						{Name: names.NodeName},
 						{Name: names.TaintToleration},
 						{Name: names.NodeAffinity},
 						{Name: names.NodePorts},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

leverage the new PreFilterResult to Changed the NodeName Filter to PreFilter

this PR will improve the scheduling efficiency of pod with NodeName

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```doc

scheduler: Changed the NodeName Filter to PreFilter

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```doc

```
