### PR TITLE
Add NodeName PreFilter to improve the scheduling efficiency of pod with NodeName

### DIFF
--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -30,6 +30,7 @@ var PluginsV1beta2 = &config.Plugins{
 	},
 	PreFilter: config.PluginSet{
 		Enabled: []config.Plugin{
+			{Name: names.NodeName},
 			{Name: names.NodeResourcesFit},
 			{Name: names.NodePorts},
 			{Name: names.VolumeRestrictions},
@@ -189,6 +190,7 @@ var ExpandedPluginsV1beta3 = &config.Plugins{
 	},
 	PreFilter: config.PluginSet{
 		Enabled: []config.Plugin{
+			{Name: names.NodeName},
 			{Name: names.NodeAffinity},
 			{Name: names.NodePorts},
 			{Name: names.NodeResourcesFit},
@@ -360,6 +362,7 @@ var ExpandedPluginsV1 = &config.Plugins{
 	},
 	PreFilter: config.PluginSet{
 		Enabled: []config.Plugin{
+			{Name: names.NodeName},
 			{Name: names.NodeAffinity},
 			{Name: names.NodePorts},
 			{Name: names.NodeResourcesFit},

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins.go
@@ -36,6 +36,7 @@ func getDefaultPlugins() *v1beta2.Plugins {
 		},
 		PreFilter: v1beta2.PluginSet{
 			Enabled: []v1beta2.Plugin{
+				{Name: names.NodeName},
 				{Name: names.NodeResourcesFit},
 				{Name: names.NodePorts},
 				{Name: names.VolumeRestrictions},

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
@@ -45,6 +45,7 @@ func TestApplyFeatureGates(t *testing.T) {
 				},
 				PreFilter: v1beta2.PluginSet{
 					Enabled: []v1beta2.Plugin{
+						{Name: names.NodeName},
 						{Name: names.NodeResourcesFit},
 						{Name: names.NodePorts},
 						{Name: names.VolumeRestrictions},
@@ -133,6 +134,7 @@ func TestApplyFeatureGates(t *testing.T) {
 				},
 				PreFilter: v1beta2.PluginSet{
 					Enabled: []v1beta2.Plugin{
+						{Name: names.NodeName},
 						{Name: names.NodeResourcesFit},
 						{Name: names.NodePorts},
 						{Name: names.VolumeRestrictions},

--- a/pkg/scheduler/apis/config/v1beta2/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults_test.go
@@ -333,6 +333,7 @@ func TestSchedulerDefaults(t *testing.T) {
 							},
 							PreFilter: v1beta2.PluginSet{
 								Enabled: []v1beta2.Plugin{
+									{Name: names.NodeName},
 									{Name: names.NodeResourcesFit},
 									{Name: names.NodePorts},
 									{Name: names.VolumeRestrictions},

--- a/pkg/scheduler/framework/plugins/nodename/node_name.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name.go
@@ -57,9 +57,9 @@ func (pl *NodeName) Name() string {
 // PreFilter builds and writes cycle state used by Filter.
 func (pl *NodeName) PreFilter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod) (*framework.PreFilterResult, *framework.Status) {
 	if len(pod.Spec.NodeName) != 0 {
-		return &framework.PreFilterResult{NodeNames: sets.NewString(pod.Spec.NodeName)}, nil
+		return &framework.PreFilterResult{NodeNames: sets.NewString(pod.Spec.NodeName)}, framework.NewStatus(framework.Skip)
 	}
-	return nil, nil
+	return nil, framework.NewStatus(framework.Skip)
 }
 
 // PreFilterExtensions not necessary for this plugin as state doesn't depend on pod additions or deletions.

--- a/pkg/scheduler/framework/plugins/nodename/node_name.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
@@ -28,6 +29,7 @@ import (
 // NodeName is a plugin that checks if a pod spec node name matches the current node.
 type NodeName struct{}
 
+var _ framework.PreFilterPlugin = &NodeName{}
 var _ framework.FilterPlugin = &NodeName{}
 var _ framework.EnqueueExtensions = &NodeName{}
 
@@ -50,6 +52,19 @@ func (pl *NodeName) EventsToRegister() []framework.ClusterEvent {
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *NodeName) Name() string {
 	return Name
+}
+
+// PreFilter builds and writes cycle state used by Filter.
+func (pl *NodeName) PreFilter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod) (*framework.PreFilterResult, *framework.Status) {
+	if len(pod.Spec.NodeName) != 0 {
+		return &framework.PreFilterResult{NodeNames: sets.NewString(pod.Spec.NodeName)}, nil
+	}
+	return nil, nil
+}
+
+// PreFilterExtensions not necessary for this plugin as state doesn't depend on pod additions or deletions.
+func (pl *NodeName) PreFilterExtensions() framework.PreFilterExtensions {
+	return nil
 }
 
 // Filter invoked at the filter extension point.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

leverage the new PreFilterResult to Add NodeName PreFilter

this PR will improve the scheduling efficiency of pod with NodeName

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
scheduler: Add NodeName PreFilter to improve the scheduling efficiency of pod with NodeName
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
