### PR TITLE
[client-gen]: allow fake generator generate RESTClient() func return non-nil interface 

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/fake/fake_cr_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/fake/fake_cr_client.go
@@ -35,6 +35,5 @@ func (c *FakeCrV1) Examples(namespace string) v1.ExampleInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeCrV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/fake/fake_apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/fake/fake_apiextensions_client.go
@@ -35,6 +35,5 @@ func (c *FakeApiextensionsV1) CustomResourceDefinitions() v1.CustomResourceDefin
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeApiextensionsV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake/fake_apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake/fake_apiextensions_client.go
@@ -35,6 +35,5 @@ func (c *FakeApiextensionsV1beta1) CustomResourceDefinitions() v1beta1.CustomRes
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeApiextensionsV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/fake/fake_admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/fake/fake_admissionregistration_client.go
@@ -39,6 +39,5 @@ func (c *FakeAdmissionregistrationV1) ValidatingWebhookConfigurations() v1.Valid
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAdmissionregistrationV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_admissionregistration_client.go
@@ -39,6 +39,5 @@ func (c *FakeAdmissionregistrationV1alpha1) ValidatingAdmissionPolicyBindings() 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAdmissionregistrationV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_admissionregistration_client.go
@@ -39,6 +39,5 @@ func (c *FakeAdmissionregistrationV1beta1) ValidatingWebhookConfigurations() v1b
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAdmissionregistrationV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake/fake_apiserverinternal_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake/fake_apiserverinternal_client.go
@@ -35,6 +35,5 @@ func (c *FakeInternalV1alpha1) StorageVersions() v1alpha1.StorageVersionInterfac
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeInternalV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_apps_client.go
@@ -51,6 +51,5 @@ func (c *FakeAppsV1) StatefulSets(namespace string) v1.StatefulSetInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAppsV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_apps_client.go
@@ -43,6 +43,5 @@ func (c *FakeAppsV1beta1) StatefulSets(namespace string) v1beta1.StatefulSetInte
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAppsV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_apps_client.go
@@ -51,6 +51,5 @@ func (c *FakeAppsV1beta2) StatefulSets(namespace string) v1beta2.StatefulSetInte
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAppsV1beta2) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/fake/fake_authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/fake/fake_authentication_client.go
@@ -35,6 +35,5 @@ func (c *FakeAuthenticationV1) TokenReviews() v1.TokenReviewInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAuthenticationV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1alpha1/fake/fake_authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1alpha1/fake/fake_authentication_client.go
@@ -35,6 +35,5 @@ func (c *FakeAuthenticationV1alpha1) SelfSubjectReviews() v1alpha1.SelfSubjectRe
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAuthenticationV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/fake/fake_authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/fake/fake_authentication_client.go
@@ -35,6 +35,5 @@ func (c *FakeAuthenticationV1beta1) TokenReviews() v1beta1.TokenReviewInterface 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAuthenticationV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/fake/fake_authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/fake/fake_authorization_client.go
@@ -47,6 +47,5 @@ func (c *FakeAuthorizationV1) SubjectAccessReviews() v1.SubjectAccessReviewInter
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAuthorizationV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/fake/fake_authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/fake/fake_authorization_client.go
@@ -47,6 +47,5 @@ func (c *FakeAuthorizationV1beta1) SubjectAccessReviews() v1beta1.SubjectAccessR
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAuthorizationV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake/fake_autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake/fake_autoscaling_client.go
@@ -35,6 +35,5 @@ func (c *FakeAutoscalingV1) HorizontalPodAutoscalers(namespace string) v1.Horizo
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAutoscalingV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2/fake/fake_autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2/fake/fake_autoscaling_client.go
@@ -35,6 +35,5 @@ func (c *FakeAutoscalingV2) HorizontalPodAutoscalers(namespace string) v2.Horizo
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAutoscalingV2) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/fake/fake_autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/fake/fake_autoscaling_client.go
@@ -35,6 +35,5 @@ func (c *FakeAutoscalingV2beta1) HorizontalPodAutoscalers(namespace string) v2be
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAutoscalingV2beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/fake/fake_autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/fake/fake_autoscaling_client.go
@@ -35,6 +35,5 @@ func (c *FakeAutoscalingV2beta2) HorizontalPodAutoscalers(namespace string) v2be
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeAutoscalingV2beta2) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_batch_client.go
@@ -39,6 +39,5 @@ func (c *FakeBatchV1) Jobs(namespace string) v1.JobInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeBatchV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/fake/fake_batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/fake/fake_batch_client.go
@@ -35,6 +35,5 @@ func (c *FakeBatchV1beta1) CronJobs(namespace string) v1beta1.CronJobInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeBatchV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/fake/fake_certificates_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/fake/fake_certificates_client.go
@@ -35,6 +35,5 @@ func (c *FakeCertificatesV1) CertificateSigningRequests() v1.CertificateSigningR
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeCertificatesV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificates_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificates_client.go
@@ -35,6 +35,5 @@ func (c *FakeCertificatesV1beta1) CertificateSigningRequests() v1beta1.Certifica
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeCertificatesV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/fake/fake_coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/fake/fake_coordination_client.go
@@ -35,6 +35,5 @@ func (c *FakeCoordinationV1) Leases(namespace string) v1.LeaseInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeCoordinationV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/fake/fake_coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/fake/fake_coordination_client.go
@@ -35,6 +35,5 @@ func (c *FakeCoordinationV1beta1) Leases(namespace string) v1beta1.LeaseInterfac
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeCoordinationV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_core_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_core_client.go
@@ -95,6 +95,5 @@ func (c *FakeCoreV1) ServiceAccounts(namespace string) v1.ServiceAccountInterfac
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeCoreV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/fake/fake_discovery_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/fake/fake_discovery_client.go
@@ -35,6 +35,5 @@ func (c *FakeDiscoveryV1) EndpointSlices(namespace string) v1.EndpointSliceInter
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeDiscoveryV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/fake/fake_discovery_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/fake/fake_discovery_client.go
@@ -35,6 +35,5 @@ func (c *FakeDiscoveryV1beta1) EndpointSlices(namespace string) v1beta1.Endpoint
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeDiscoveryV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/fake/fake_events_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/fake/fake_events_client.go
@@ -35,6 +35,5 @@ func (c *FakeEventsV1) Events(namespace string) v1.EventInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeEventsV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/fake/fake_events_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/fake/fake_events_client.go
@@ -35,6 +35,5 @@ func (c *FakeEventsV1beta1) Events(namespace string) v1beta1.EventInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeEventsV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_extensions_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_extensions_client.go
@@ -55,6 +55,5 @@ func (c *FakeExtensionsV1beta1) ReplicaSets(namespace string) v1beta1.ReplicaSet
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeExtensionsV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/fake/fake_flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/fake/fake_flowcontrol_client.go
@@ -39,6 +39,5 @@ func (c *FakeFlowcontrolV1alpha1) PriorityLevelConfigurations() v1alpha1.Priorit
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeFlowcontrolV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/fake_flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/fake_flowcontrol_client.go
@@ -39,6 +39,5 @@ func (c *FakeFlowcontrolV1beta1) PriorityLevelConfigurations() v1beta1.PriorityL
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeFlowcontrolV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/fake_flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/fake_flowcontrol_client.go
@@ -39,6 +39,5 @@ func (c *FakeFlowcontrolV1beta2) PriorityLevelConfigurations() v1beta2.PriorityL
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeFlowcontrolV1beta2) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/fake_flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/fake_flowcontrol_client.go
@@ -39,6 +39,5 @@ func (c *FakeFlowcontrolV1beta3) PriorityLevelConfigurations() v1beta3.PriorityL
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeFlowcontrolV1beta3) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_networking_client.go
@@ -43,6 +43,5 @@ func (c *FakeNetworkingV1) NetworkPolicies(namespace string) v1.NetworkPolicyInt
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeNetworkingV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1alpha1/fake/fake_networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1alpha1/fake/fake_networking_client.go
@@ -35,6 +35,5 @@ func (c *FakeNetworkingV1alpha1) ClusterCIDRs() v1alpha1.ClusterCIDRInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeNetworkingV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/fake/fake_networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/fake/fake_networking_client.go
@@ -39,6 +39,5 @@ func (c *FakeNetworkingV1beta1) IngressClasses() v1beta1.IngressClassInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeNetworkingV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/fake/fake_node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/fake/fake_node_client.go
@@ -35,6 +35,5 @@ func (c *FakeNodeV1) RuntimeClasses() v1.RuntimeClassInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeNodeV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/fake/fake_node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/fake/fake_node_client.go
@@ -35,6 +35,5 @@ func (c *FakeNodeV1alpha1) RuntimeClasses() v1alpha1.RuntimeClassInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeNodeV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/fake/fake_node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/fake/fake_node_client.go
@@ -35,6 +35,5 @@ func (c *FakeNodeV1beta1) RuntimeClasses() v1beta1.RuntimeClassInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeNodeV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/fake/fake_policy_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/fake/fake_policy_client.go
@@ -39,6 +39,5 @@ func (c *FakePolicyV1) PodDisruptionBudgets(namespace string) v1.PodDisruptionBu
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakePolicyV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_policy_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_policy_client.go
@@ -43,6 +43,5 @@ func (c *FakePolicyV1beta1) PodSecurityPolicies() v1beta1.PodSecurityPolicyInter
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakePolicyV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_rbac_client.go
@@ -47,6 +47,5 @@ func (c *FakeRbacV1) RoleBindings(namespace string) v1.RoleBindingInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeRbacV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rbac_client.go
@@ -47,6 +47,5 @@ func (c *FakeRbacV1alpha1) RoleBindings(namespace string) v1alpha1.RoleBindingIn
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeRbacV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rbac_client.go
@@ -47,6 +47,5 @@ func (c *FakeRbacV1beta1) RoleBindings(namespace string) v1beta1.RoleBindingInte
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeRbacV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha1/fake/fake_resource_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha1/fake/fake_resource_client.go
@@ -47,6 +47,5 @@ func (c *FakeResourceV1alpha1) ResourceClasses() v1alpha1.ResourceClassInterface
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeResourceV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/fake/fake_scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/fake/fake_scheduling_client.go
@@ -35,6 +35,5 @@ func (c *FakeSchedulingV1) PriorityClasses() v1.PriorityClassInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeSchedulingV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake/fake_scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake/fake_scheduling_client.go
@@ -35,6 +35,5 @@ func (c *FakeSchedulingV1alpha1) PriorityClasses() v1alpha1.PriorityClassInterfa
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeSchedulingV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/fake/fake_scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/fake/fake_scheduling_client.go
@@ -35,6 +35,5 @@ func (c *FakeSchedulingV1beta1) PriorityClasses() v1beta1.PriorityClassInterface
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeSchedulingV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storage_client.go
@@ -51,6 +51,5 @@ func (c *FakeStorageV1) VolumeAttachments() v1.VolumeAttachmentInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeStorageV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake/fake_storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake/fake_storage_client.go
@@ -39,6 +39,5 @@ func (c *FakeStorageV1alpha1) VolumeAttachments() v1alpha1.VolumeAttachmentInter
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeStorageV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storage_client.go
@@ -51,6 +51,5 @@ func (c *FakeStorageV1beta1) VolumeAttachments() v1beta1.VolumeAttachmentInterfa
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeStorageV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_group.go
@@ -126,3 +126,4 @@ var getRESTClient = `
 func (c *Fake$.GroupGoName$$.Version$) RESTClient() $.RESTClientInterface|raw$ {
 	return &$.RESTClient|raw${}
 }
+`

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_group.go
@@ -124,7 +124,5 @@ var getRESTClient = `
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *Fake$.GroupGoName$$.Version$) RESTClient() $.RESTClientInterface|raw$ {
-	var ret *$.RESTClient|raw$
-	return ret
+	return &$.RESTClient|raw${}
 }
-`

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/fake_example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/fake_example_client.go
@@ -39,6 +39,5 @@ func (c *FakeExampleGroupV1) TestTypes(namespace string) v1.TestTypeInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeExampleGroupV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_example_client.go
@@ -39,6 +39,5 @@ func (c *FakeExampleV1) TestTypes(namespace string) v1.TestTypeInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeExampleV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion/fake/fake_example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion/fake/fake_example_client.go
@@ -35,6 +35,5 @@ func (c *FakeExample) TestTypes(namespace string) internalversion.TestTypeInterf
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeExample) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion/fake/fake_example2_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion/fake/fake_example2_client.go
@@ -35,6 +35,5 @@ func (c *FakeSecondExample) TestTypes() internalversion.TestTypeInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeSecondExample) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/fake/fake_example3.io_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/fake/fake_example3.io_client.go
@@ -35,6 +35,5 @@ func (c *FakeThirdExample) TestTypes(namespace string) internalversion.TestTypeI
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeThirdExample) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/fake/fake_example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/fake/fake_example_client.go
@@ -35,6 +35,5 @@ func (c *FakeExampleV1) TestTypes(namespace string) v1.TestTypeInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeExampleV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/fake/fake_example2_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/fake/fake_example2_client.go
@@ -35,6 +35,5 @@ func (c *FakeSecondExampleV1) TestTypes(namespace string) v1.TestTypeInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeSecondExampleV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/fake/fake_example3.io_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/fake/fake_example3.io_client.go
@@ -35,6 +35,5 @@ func (c *FakeThirdExampleV1) TestTypes(namespace string) v1.TestTypeInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeThirdExampleV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/fake/fake_example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/fake/fake_example_client.go
@@ -39,6 +39,5 @@ func (c *FakeExampleV1) TestTypes(namespace string) v1.TestTypeInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeExampleV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/fake/fake_example2_client.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/fake/fake_example2_client.go
@@ -35,6 +35,5 @@ func (c *FakeSecondExampleV1) TestTypes(namespace string) v1.TestTypeInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeSecondExampleV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/fake/fake_apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/fake/fake_apiregistration_client.go
@@ -35,6 +35,5 @@ func (c *FakeApiregistrationV1) APIServices() v1.APIServiceInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeApiregistrationV1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/fake/fake_apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/fake/fake_apiregistration_client.go
@@ -35,6 +35,5 @@ func (c *FakeApiregistrationV1beta1) APIServices() v1beta1.APIServiceInterface {
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeApiregistrationV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_metrics_client.go
@@ -39,6 +39,5 @@ func (c *FakeMetricsV1alpha1) PodMetricses(namespace string) v1alpha1.PodMetrics
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeMetricsV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_metrics_client.go
@@ -39,6 +39,5 @@ func (c *FakeMetricsV1beta1) PodMetricses(namespace string) v1beta1.PodMetricsIn
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeMetricsV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_wardle_client.go
@@ -39,6 +39,5 @@ func (c *FakeWardleV1alpha1) Flunders(namespace string) v1alpha1.FlunderInterfac
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeWardleV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/fake/fake_wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/fake/fake_wardle_client.go
@@ -35,6 +35,5 @@ func (c *FakeWardleV1beta1) Flunders(namespace string) v1beta1.FlunderInterface 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeWardleV1beta1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/fake/fake_samplecontroller_client.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/fake/fake_samplecontroller_client.go
@@ -35,6 +35,5 @@ func (c *FakeSamplecontrollerV1alpha1) Foos(namespace string) v1alpha1.FooInterf
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeSamplecontrollerV1alpha1) RESTClient() rest.Interface {
-	var ret *rest.RESTClient
-	return ret
+	return &rest.RESTClient{}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

allow fake generator generate RESTClient() func return non-nil interface 

#### Which issue(s) this PR fixes:

Fixes [#114382](https://github.com/kubernetes/kubernetes/issues/114382)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
