### PR TITLE
Check the correct error in d.downloadAPIs

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -196,7 +196,7 @@ func (d *DiscoveryClient) GroupsAndMaybeResources() (*metav1.APIGroupList, map[s
 	}
 	// Discovery groups and (possibly) resources downloaded from /apis.
 	apiGroups, apiResources, aerr := d.downloadAPIs()
-	if err != nil {
+	if aerr != nil {
 		return nil, nil, aerr
 	}
 	// Merge apis groups into the legacy groups.


### PR DESCRIPTION
The error result of `d.downloadAPIs()` is set in `aerr`, not `err`.

This prevents a nil-ptr dereference of apiGroups in the next step.

Signed-off-by: Abhijit Hoskeri <abhijithoskeri@gmail.com>

/kind bug

#### What this PR does / why we need it:

The error result of `d.downloadAPIs()` is set in `aerr`, not `err`.
This prevents a nil-ptr dereference of apiGroups in the next step.


```release-note
Fixes a 1.26 regression in client-go discovery fetching that can lead to a panic
```