### PR TITLE
Add TaintToleration PreFilter to improve the scheduling efficiency of pod

### DIFF
--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -38,6 +38,7 @@ var PluginsV1beta2 = &config.Plugins{
 			{Name: names.VolumeBinding},
 			{Name: names.VolumeZone},
 			{Name: names.NodeAffinity},
+			{Name: names.TaintToleration},
 		},
 	},
 	Filter: config.PluginSet{
@@ -197,6 +198,7 @@ var ExpandedPluginsV1beta3 = &config.Plugins{
 			{Name: names.VolumeZone},
 			{Name: names.PodTopologySpread},
 			{Name: names.InterPodAffinity},
+			{Name: names.TaintToleration},
 		},
 	},
 	Filter: config.PluginSet{
@@ -368,6 +370,7 @@ var ExpandedPluginsV1 = &config.Plugins{
 			{Name: names.VolumeZone},
 			{Name: names.PodTopologySpread},
 			{Name: names.InterPodAffinity},
+			{Name: names.TaintToleration},
 		},
 	},
 	Filter: config.PluginSet{

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins.go
@@ -44,6 +44,7 @@ func getDefaultPlugins() *v1beta2.Plugins {
 				{Name: names.VolumeBinding},
 				{Name: names.VolumeZone},
 				{Name: names.NodeAffinity},
+				{Name: names.TaintToleration},
 			},
 		},
 		Filter: v1beta2.PluginSet{

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
@@ -53,6 +53,7 @@ func TestApplyFeatureGates(t *testing.T) {
 						{Name: names.VolumeBinding},
 						{Name: names.VolumeZone},
 						{Name: names.NodeAffinity},
+						{Name: names.TaintToleration},
 					},
 				},
 				Filter: v1beta2.PluginSet{
@@ -141,6 +142,7 @@ func TestApplyFeatureGates(t *testing.T) {
 						{Name: names.VolumeBinding},
 						{Name: names.VolumeZone},
 						{Name: names.NodeAffinity},
+						{Name: names.TaintToleration},
 					},
 				},
 				Filter: v1beta2.PluginSet{

--- a/pkg/scheduler/apis/config/v1beta2/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults_test.go
@@ -341,6 +341,7 @@ func TestSchedulerDefaults(t *testing.T) {
 									{Name: names.VolumeBinding},
 									{Name: names.VolumeZone},
 									{Name: names.NodeAffinity},
+									{Name: names.TaintToleration},
 								},
 							},
 							Filter: v1beta2.PluginSet{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add TaintToleration PreFilter to PreFilter plugins

This PR will improve the scheduling efficiency of pod.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #114399 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
scheduler: Add TaintToleration PreFilter to improve the scheduling efficiency of pod
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
