### PR TITLE
don't assert error inside wait.Poll loops

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -319,9 +319,13 @@ var _ = common.SIGDescribe("Loadbalancing: L7", func() {
 			framework.ExpectNoError(err)
 			err = wait.Poll(10*time.Second, propagationTimeout, func() (bool, error) {
 				res, err := jig.GetDistinctResponseFromIngress()
-				framework.ExpectNoError(err)
+				if err != nil {
+					return false, err
+				}
 				deploy, err := f.ClientSet.AppsV1().Deployments(ns).Get(context.TODO(), name, metav1.GetOptions{})
-				framework.ExpectNoError(err)
+				if err != nil {
+					return false, err
+				}
 				if int(deploy.Status.UpdatedReplicas) == replicas {
 					if res.Len() == replicas {
 						return true, nil


### PR DESCRIPTION

/kind bug
/kind flake
```release-note
NONE
```

Seen in https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/114144/pull-kubernetes-e2e-gci-gce-ingress/1601531830031355904

> E1210 12:02:51.170846   84451 runtime.go:79] Observed a panic: types.GinkgoError{Heading:"Your Test Panicked", Message:"When you, or your assertion library, calls Ginkgo's Fail(),\nGinkgo panics to prevent subsequent assertions from running.\n\nNormally Ginkgo rescues this panic so you shouldn't see it.\n\nHowever, if you make an assertion in a goroutine, Ginkgo can't capture the panic.\nTo circumvent this, you should call\n\n\tdefer GinkgoRecover()\n\nat the top of the goroutine that caused this panic.\n\nAlternatively, you may have made an assertion outside of a Ginkgo\nleaf node (e.g. in a container node or some out-of-band function) - please move your assertion to\nan appropriate Ginkgo node (e.g. a BeforeSuite, BeforeEach, It, etc...).", DocLink:"mental-model-how-ginkgo-handles-failure", CodeLocation:types.CodeLocation{FileName:"test/e2e/network/ingress.go", LineNumber:322, FullStackTrace:"k8s.io/kubernetes/test/e2e/network.glob..func13.3.7.2()\n\ttest/e2e/network/ingress.go:322 +0x7c\nk8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.ConditionFunc.WithContext.func1({0x2749911, 0x0})\n\tvendor/k8s.io/apimachinery/pkg/util/wait/wait.go:222 +0x1b\nk8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext({0x8006a08?, 0xc00013c000?}, 0x263161f?)\n\tvendor/k8s.io/apimachinery/pkg/util/wait/wait.go:235 +0x57\nk8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.WaitForWithContext({0x8006a08, 0xc00013c000}, 0xc0039c32a8, 0x2fe296a?)\n\tvendor/k8s.io/apimachinery/pkg/util/wait/wait.go:662 +0x10c\nk8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.poll({0x8006a08, 0xc00013c000}, 0xc8?, 0x2fe1505?, 0x28?)\n\tvendor/k8s.io/apimachinery/pkg/util/wait/wait.go:596 +0x9a\nk8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.PollWithContext({0x8006a08, 0xc00013c000}, 0x23?, 0xc002135d18?, 0x2631967?)\n\tvendor/k8s.io/apimachinery/pkg/util/wait/wait.go:460 +0x47\nk8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.Poll(0x0?, 0x0?, 0x0?)\n\tvendor/k8s.io/apimachinery/pkg/util/wait/wait.go:445 +0x50\nk8s.io/kubernetes/test/e2e/network.glob..func13.3.7()\n\ttest/e2e/network/ingress.go:320 +0x633", CustomMessage:""}} (ï¿½[1mï¿½[38;5;9mYour Test Panickedï¿½[0m


Don't try to assert inside the Wait loop, just return an error , it will break the loop and fail the test without panic