### PR TITLE
Refactor to simplify factory Validator

### DIFF
--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -128,12 +128,7 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) (err er
 		if err != nil {
 			return nil, err
 		}
-		dynamicClient, err := f.DynamicClient()
-		if err != nil {
-			return nil, err
-		}
-		verifier := resource.NewQueryParamVerifier(dynamicClient, f.OpenAPIGetter(), resource.QueryParamFieldValidation)
-		return f.Validator(directive, verifier)
+		return f.Validator(directive)
 	}
 
 	// build the printer

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -86,18 +86,17 @@ type ApplyOptions struct {
 
 	DeleteOptions *delete.DeleteOptions
 
-	ServerSideApply         bool
-	ForceConflicts          bool
-	FieldManager            string
-	Selector                string
-	DryRunStrategy          cmdutil.DryRunStrategy
-	FieldValidationVerifier *resource.QueryParamVerifier
-	Prune                   bool
-	PruneResources          []prune.Resource
-	cmdBaseName             string
-	All                     bool
-	Overwrite               bool
-	OpenAPIPatch            bool
+	ServerSideApply bool
+	ForceConflicts  bool
+	FieldManager    string
+	Selector        string
+	DryRunStrategy  cmdutil.DryRunStrategy
+	Prune           bool
+	PruneResources  []prune.Resource
+	cmdBaseName     string
+	All             bool
+	Overwrite       bool
+	OpenAPIPatch    bool
 
 	ValidationDirective string
 	Validator           validation.Schema
@@ -255,7 +254,6 @@ func (flags *ApplyFlags) ToOptions(cmd *cobra.Command, baseName string, args []s
 		return nil, err
 	}
 
-	fieldValidationVerifier := resource.NewQueryParamVerifier(dynamicClient, flags.Factory.OpenAPIGetter(), resource.QueryParamFieldValidation)
 	fieldManager := GetApplyFieldManagerFlag(cmd, serverSideApply)
 
 	// allow for a success message operation to be specified at print time
@@ -287,7 +285,7 @@ func (flags *ApplyFlags) ToOptions(cmd *cobra.Command, baseName string, args []s
 	if err != nil {
 		return nil, err
 	}
-	validator, err := flags.Factory.Validator(validationDirective, fieldValidationVerifier)
+	validator, err := flags.Factory.Validator(validationDirective)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -51,8 +51,7 @@ type CreateOptions struct {
 	PrintFlags  *genericclioptions.PrintFlags
 	RecordFlags *genericclioptions.RecordFlags
 
-	DryRunStrategy          cmdutil.DryRunStrategy
-	FieldValidationVerifier *resource.QueryParamVerifier
+	DryRunStrategy cmdutil.DryRunStrategy
 
 	ValidationDirective string
 
@@ -205,11 +204,6 @@ func (o *CreateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 		return err
 	}
 	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
-	dynamicClient, err := f.DynamicClient()
-	if err != nil {
-		return err
-	}
-	o.FieldValidationVerifier = resource.NewQueryParamVerifier(dynamicClient, f.OpenAPIGetter(), resource.QueryParamFieldValidation)
 
 	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
 	if err != nil {
@@ -244,7 +238,7 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 		return RunEditOnCreate(f, o.PrintFlags, o.RecordFlags, o.IOStreams, cmd, &o.FilenameOptions, o.fieldManager)
 	}
 
-	schema, err := f.Validator(o.ValidationDirective, o.FieldValidationVerifier)
+	schema, err := f.Validator(o.ValidationDirective)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -76,9 +76,8 @@ type ReplaceOptions struct {
 	DeleteFlags   *delete.DeleteFlags
 	DeleteOptions *delete.DeleteOptions
 
-	DryRunStrategy          cmdutil.DryRunStrategy
-	FieldValidationVerifier *resource.QueryParamVerifier
-	validationDirective     string
+	DryRunStrategy      cmdutil.DryRunStrategy
+	validationDirective string
 
 	PrintObj func(obj runtime.Object) error
 
@@ -164,7 +163,6 @@ func (o *ReplaceOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	if err != nil {
 		return err
 	}
-	o.FieldValidationVerifier = resource.NewQueryParamVerifier(dynamicClient, f.OpenAPIGetter(), resource.QueryParamFieldValidation)
 	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
 
 	printer, err := o.PrintFlags.ToPrinter()
@@ -198,7 +196,7 @@ func (o *ReplaceOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 		return err
 	}
 
-	schema, err := f.Validator(o.validationDirective, o.FieldValidationVerifier)
+	schema, err := f.Validator(o.validationDirective)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -524,7 +524,7 @@ func (f *TestFactory) UnstructuredClientForMapping(mapping *meta.RESTMapping) (r
 }
 
 // Validator returns a validation schema
-func (f *TestFactory) Validator(validateDirective string, verifier *resource.QueryParamVerifier) (validation.Schema, error) {
+func (f *TestFactory) Validator(validateDirective string) (validation.Schema, error) {
 	return validation.NullSchema{}, nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -68,8 +68,7 @@ type EditOptions struct {
 	WindowsLineEndings bool
 
 	cmdutil.ValidateOptions
-	ValidationDirective     string
-	FieldValidationVerifier *resource.QueryParamVerifier
+	ValidationDirective string
 
 	OriginalResult *resource.Result
 
@@ -217,12 +216,6 @@ func (o *EditOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Comm
 		return o.PrintFlags.ToPrinter()
 	}
 
-	dynamicClient, err := f.DynamicClient()
-	if err != nil {
-		return err
-	}
-	o.FieldValidationVerifier = resource.NewQueryParamVerifier(dynamicClient, f.OpenAPIGetter(), resource.QueryParamFieldValidation)
-
 	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
 	if err != nil {
 		return err
@@ -322,7 +315,7 @@ func (o *EditOptions) Run() error {
 			klog.V(4).Infof("User edited:\n%s", string(edited))
 
 			// Apply validation
-			schema, err := o.f.Validator(o.ValidationDirective, o.FieldValidationVerifier)
+			schema, err := o.f.Validator(o.ValidationDirective)
 			if err != nil {
 				return preservedFile(err, file, o.ErrOut)
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/factory.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/factory.go
@@ -61,7 +61,7 @@ type Factory interface {
 	UnstructuredClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error)
 
 	// Returns a schema that can validate objects stored on disk.
-	Validator(validationDirective string, verifier *resource.QueryParamVerifier) (validation.Schema, error)
+	Validator(validationDirective string) (validation.Schema, error)
 	// OpenAPISchema returns the parsed openapi schema definition
 	OpenAPISchema() (openapi.Resources, error)
 	// OpenAPIGetter returns a getter for the openapi schema document

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
@@ -142,7 +142,7 @@ func (f *factoryImpl) UnstructuredClientForMapping(mapping *meta.RESTMapping) (r
 	return restclient.RESTClientFor(cfg)
 }
 
-func (f *factoryImpl) Validator(validationDirective string, verifier *resource.QueryParamVerifier) (validation.Schema, error) {
+func (f *factoryImpl) Validator(validationDirective string) (validation.Schema, error) {
 	// client-side schema validation is only performed
 	// when the validationDirective is strict.
 	// If the directive is warn, we rely on the ParamVerifyingSchema
@@ -162,6 +162,13 @@ func (f *factoryImpl) Validator(validationDirective string, verifier *resource.Q
 		openapivalidation.NewSchemaValidation(resources),
 		validation.NoDoubleKeySchema{},
 	}
+
+	dynamicClient, err := f.DynamicClient()
+	if err != nil {
+		return nil, err
+	}
+	// Create the FieldValidationVerifier for use in the ParamVerifyingSchema.
+	verifier := resource.NewQueryParamVerifier(dynamicClient, f.OpenAPIGetter(), resource.QueryParamFieldValidation)
 	return validation.NewParamVerifyingSchema(schema, verifier, string(validationDirective)), nil
 }
 


### PR DESCRIPTION
* Refactors `factory.Validator()` to remove the `FieldValidationVerifier` as parameter. `FieldValidationVerifier` is now only created in one place in the factory implementation, instead of several places and passed as parameter.
* This refactor helps in the effort to move `kubectl` from OpenAPI V2 -> V3 by removing some dependencies on `OpenAPIGetter`

/kind cleanup
/sig cli
/priority important-longterm

```release-note
NONE
```