### PR TITLE
Automated cherry pick of #114404: Check the correct error in d.downloadAPIs

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -196,7 +196,7 @@ func (d *DiscoveryClient) GroupsAndMaybeResources() (*metav1.APIGroupList, map[s
 	}
 	// Discovery groups and (possibly) resources downloaded from /apis.
 	apiGroups, apiResources, aerr := d.downloadAPIs()
-	if err != nil {
+	if aerr != nil {
 		return nil, nil, aerr
 	}
 	// Merge apis groups into the legacy groups.


### PR DESCRIPTION
Cherry pick of #114404 on release-1.26.

#114404: Check the correct error in d.downloadAPIs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.26 regression in client-go discovery fetching that can lead to a panic
```