### PR TITLE
Add "--json-report=e2e.json" e2e image

### DIFF
--- a/test/conformance/image/run_e2e.sh
+++ b/test/conformance/image/run_e2e.sh
@@ -68,6 +68,7 @@ ginkgo_args+=(
     "--focus=${E2E_FOCUS}"
     "--skip=${E2E_SKIP}"
     "--noColor=true"
+    "--json-report=e2e.json"
 )
 
 set -x


### PR DESCRIPTION
Recent upgrades from ginkgo framework version 1 to 2 have resulted in e2e.log no longer being json. The cncf/k8s-conformance program depends on the machine-readable json to verify all conformance tests have been run, and to inform submissions which tests they may be missing.

Fixes cncf-infra/verify-conformance#39

Note this does generate an new file, e2e.json, when run.

Any software requiring this file (including Sonobuoy) will need to retrieve it, in particular e2e.json would be required for conformance submissions going forward.

From https://onsi.github.io/ginkgo/MIGRATING_TO_V2#generating-machine-readable-reports

> Ginkgo V2 introduces a new JSON format that faithfully captures all available information about a Ginkgo test suite. JSON reports can be generated via ginkgo --json-report=out.json. The resulting JSON file encodes an array of types.Report. Each entry in that array lists detailed information about the test suite and includes a list of types.SpecReport that captures detailed information about each spec. These types are documented here.
