### PR TITLE
e2e: bring back total test spec for Ginkgo v2

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -151,6 +151,10 @@ var _ = ginkgo.ReportAfterEach(func(report ginkgo.SpecReport) {
 	progressReporter.ProcessSpecReport(report)
 })
 
+var _ = ginkgo.ReportBeforeSuite(func(report ginkgo.Report) {
+	progressReporter.SetTestsTotal(report.PreRunStats.SpecsThatWillRun)
+})
+
 var _ = ginkgo.ReportAfterSuite("Kubernetes e2e suite report", func(report ginkgo.Report) {
 	var err error
 	// The DetailsRepoerter will output details about every test (name, files, lines, etc) which helps

--- a/test/e2e/reporters/progress.go
+++ b/test/e2e/reporters/progress.go
@@ -33,11 +33,10 @@ import (
 // ProgressReporter is a ginkgo reporter which tracks the total number of tests to be run/passed/failed/skipped.
 // As new tests are completed it updates the values and prints them to stdout and optionally, sends the updates
 // to the configured URL.
-// TODO: Number of test specs is not available now, we can add it back when this is fixed in the Ginkgo V2.
-// pls see: https://github.com/kubernetes/kubernetes/issues/109744
 type ProgressReporter struct {
 	LastMsg string `json:"msg"`
 
+	TestsTotal     int `json:"total"`
 	TestsCompleted int `json:"completed"`
 	TestsSkipped   int `json:"skipped"`
 	TestsFailed    int `json:"failed"`
@@ -106,6 +105,11 @@ func (reporter *ProgressReporter) serialize() []byte {
 
 func (reporter *ProgressReporter) SetStartMsg() {
 	reporter.LastMsg = "Test Suite starting"
+	reporter.SendUpdates()
+}
+
+func (reporter *ProgressReporter) SetTestsTotal(totalSpec int) {
+	reporter.TestsTotal = totalSpec
 	reporter.SendUpdates()
 }
 

--- a/test/e2e/reporters/progress.go
+++ b/test/e2e/reporters/progress.go
@@ -33,6 +33,23 @@ import (
 // ProgressReporter is a ginkgo reporter which tracks the total number of tests to be run/passed/failed/skipped.
 // As new tests are completed it updates the values and prints them to stdout and optionally, sends the updates
 // to the configured URL.
+
+// One known limitation of the ProgressReporter it this reporter will not consolidate the reporter from each sub-process
+// if the tests are run in parallel.
+// As what's observed the reporter sent before test suite is started will be assembled correctly but each process will report
+// on its own after each test or suite are completed.
+// Here is a sample report that 5 testcases are executed totally, and run in parallel with 3 procs,
+// 3 of them are failed and other 2 passed.
+// {"msg":"","total":5,"completed":0,"skipped":0,"failed":0}
+// {"msg":"Test Suite starting","total":5,"completed":0,"skipped":0,"failed":0}
+// {"msg":"FAILED [sig-node] NoExecuteTaintManager Single Pod doesn't evict pod with tolerations from tainted nodes","total":0,"completed":0,"skipped":1332,"failed":1,"failures":["[sig-node] NoExecuteTaintManager..."]}
+// {"msg":"FAILED [sig-node] NoExecuteTaintManager Single Pod evicts pods from tainted nodes","total":5,"completed":0,"skipped":2524,"failed":1,"failures":["[sig-node] NoExecuteTaintManager Single Pod evicts pods from tainted nodes"]}
+// {"msg":"PASSED [sig-node] NoExecuteTaintManager Single Pod removing taint cancels eviction [Disruptive] [Conformance]","total":0,"completed":1,"skipped":1181,"failed":0}
+// {"msg":"Test Suite completed","total":0,"completed":1,"skipped":2592,"failed":0}
+// {"msg":"PASSED [sig-node] NoExecuteTaintManager Single Pod eventually evict pod with finite tolerations from tainted nodes","total":0,"completed":1,"skipped":1399,"failed":1,"failures":["[sig-node] NoExecuteTaintManager..."]}
+// {"msg":"Test Suite completed","total":0,"completed":1,"skipped":1399,"failed":1,"failures":["[sig-node] NoExecuteTaintManager Single Pod doesn't evict pod with tolerations from tainted nodes"]}
+// {"msg":"FAILED [sig-node] NoExecuteTaintManager Single Pod pods evicted from tainted nodes...","total":5,"completed":0,"skipped":3076,"failed":2,"failures":["[sig-node] NoExecuteTaintManager...","[sig-node] NoExecuteTaintManager..."]}
+// {"msg":"Test Suite completed","total":5,"completed":0,"skipped":3076,"failed":2,"failures":["[sig-node] NoExecuteTaintManager Single Pod evicts pods from tainted nodes","[sig-node] NoExecuteTaintManager..."]}
 type ProgressReporter struct {
 	LastMsg string `json:"msg"`
 


### PR DESCRIPTION
/kind bug



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/114313

#### Special notes for your reviewer:
this was tested locally,

```bash
dlv exec ./e2e.test -- -ginkgo.focus="NoExecuteTaintManager Single Pod \[Serial\]" -report-dir=/var/log/kubernetes/e2e -spec-dump=/var/log/kubernetes/dump

p reporter
*k8s.io/kubernetes/test/e2e/reporters.ProgressReporter {
        LastMsg: "PASSED [sig-node] NoExecuteTaintManager Single Pod [Serial] even...+59 more",
        TestsTotal: 5,
        TestsCompleted: 5,
        TestsSkipped: 7067,
        TestsFailed: 0,
        Failures: []string len: 0, cap: 0, [],
        progressURL: "",
        client: *net/http.Client nil,}
(dlv) p reporter.TestsTotal
5

```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
total test spec is now available by `ProgressReporter`, it will be reported before test suite got executed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


/sig testing