### PR TITLE
Reserve Nodeport Ranges For Dynamic And Static Port Allocation

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -783,6 +783,13 @@ const (
 	// Subdivide the ClusterIP range for dynamic and static IP allocation.
 	ServiceIPStaticSubrange featuregate.Feature = "ServiceIPStaticSubrange"
 
+	// owner: @xuzhenglun
+	// kep: http://kep.k8s.io/3682
+	// alpha: v1.27
+	//
+	// Subdivide the NodePort range for dynamic and static port allocation.
+	ServiceNodePortStaticSubrange featuregate.Feature = "ServiceNodePortStaticSubrange"
+
 	// owner: @derekwaynecarr
 	// alpha: v1.20
 	// beta: v1.22
@@ -1122,6 +1129,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ServiceIPStaticSubrange: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.28
 
 	ServiceInternalTrafficPolicy: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.28
+
+	ServiceNodePortStaticSubrange: {Default: false, PreRelease: featuregate.Alpha},
 
 	SizeMemoryBackedVolumes: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -237,8 +237,8 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(apiResourceConfigSource 
 	}
 
 	var serviceNodePortRegistry rangeallocation.RangeRegistry
-	serviceNodePortAllocator, err := portallocator.New(c.ServiceNodePortRange, func(max int, rangeSpec string) (allocator.Interface, error) {
-		mem := allocator.NewAllocationMap(max, rangeSpec)
+	serviceNodePortAllocator, err := portallocator.New(c.ServiceNodePortRange, func(max int, rangeSpec string, offset int) (allocator.Interface, error) {
+		mem := allocator.NewAllocationMapWithOffset(max, rangeSpec, offset)
 		// TODO etcdallocator package to return a storage interface via the storageFactory
 		etcd, err := serviceallocator.NewEtcd(mem, "/ranges/servicenodeports", serviceStorageConfig.ForResource(api.Resource("servicenodeportallocations")))
 		if err != nil {

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -250,6 +250,7 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(apiResourceConfigSource 
 	if err != nil {
 		return LegacyRESTStorage{}, genericapiserver.APIGroupInfo{}, fmt.Errorf("cannot create cluster port allocator: %v", err)
 	}
+	serviceNodePortAllocator.EnableMetrics()
 	restStorage.ServiceNodePortAllocator = serviceNodePortRegistry
 
 	controllerStorage, err := controllerstore.NewStorage(restOptionsGetter)

--- a/pkg/registry/core/service/portallocator/metrics.go
+++ b/pkg/registry/core/service/portallocator/metrics.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portallocator
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	namespace = "kube_apiserver"
+	subsystem = "nodeport_allocator"
+)
+
+var (
+	// nodePortAllocated indicates the amount of ports allocated by NodePort Service.
+	nodePortAllocated = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "allocated_ports",
+			Help:           "Gauge measuring the number of allocated NodePorts for Services",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+	// nodePortAvailable indicates the amount of ports available by NodePort Service.
+	nodePortAvailable = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "available_ports",
+			Help:           "Gauge measuring the number of available NodePorts for Services",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+	// nodePortAllocation counts the total number of ports allocation and allocation mode: static or dynamic.
+	nodePortAllocations = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "allocation_total",
+			Help:           "Number of NodePort allocations",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"scope"},
+	)
+	// nodePortAllocationErrors counts the number of error trying to allocate a nodePort and allocation mode: static or dynamic.
+	nodePortAllocationErrors = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "allocation_errors_total",
+			Help:           "Number of errors trying to allocate NodePort",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"scope"},
+	)
+)
+
+var registerMetricsOnce sync.Once
+
+func registerMetrics() {
+	registerMetricsOnce.Do(func() {
+		legacyregistry.MustRegister(nodePortAllocated)
+		legacyregistry.MustRegister(nodePortAvailable)
+		legacyregistry.MustRegister(nodePortAllocations)
+		legacyregistry.MustRegister(nodePortAllocationErrors)
+	})
+}
+
+// metricsRecorderInterface is the interface to record metrics.
+type metricsRecorderInterface interface {
+	setAllocated(allocated int)
+	setAvailable(available int)
+	incrementAllocations(scope string)
+	incrementAllocationErrors(scope string)
+}
+
+// metricsRecorder implements metricsRecorderInterface.
+type metricsRecorder struct{}
+
+func (m *metricsRecorder) setAllocated(allocated int) {
+	nodePortAllocated.Set(float64(allocated))
+}
+
+func (m *metricsRecorder) setAvailable(available int) {
+	nodePortAvailable.Set(float64(available))
+}
+
+func (m *metricsRecorder) incrementAllocations(scope string) {
+	nodePortAllocations.WithLabelValues(scope).Inc()
+}
+
+func (m *metricsRecorder) incrementAllocationErrors(scope string) {
+	nodePortAllocationErrors.WithLabelValues(scope).Inc()
+}
+
+// emptyMetricsRecorder is a null object implements metricsRecorderInterface.
+type emptyMetricsRecorder struct{}
+
+func (*emptyMetricsRecorder) setAllocated(allocated int)             {}
+func (*emptyMetricsRecorder) setAvailable(available int)             {}
+func (*emptyMetricsRecorder) incrementAllocations(scope string)      {}
+func (*emptyMetricsRecorder) incrementAllocationErrors(scope string) {}

--- a/pkg/registry/core/service/portallocator/storage/storage_test.go
+++ b/pkg/registry/core/service/portallocator/storage/storage_test.go
@@ -216,7 +216,7 @@ func TestAllocateReserved(t *testing.T) {
 	for i := 0; i < dynamicOffset; i++ {
 		port := i + basePortRange
 		if err := storage.Allocate(port); err != nil {
-			t.Errorf("Unexpected error trying to allocate IP %d: %v", port, err)
+			t.Errorf("Unexpected error trying to allocate Port %d: %v", port, err)
 		}
 	}
 	if _, err := storage.AllocateNext(); err == nil {
@@ -224,7 +224,7 @@ func TestAllocateReserved(t *testing.T) {
 	}
 	// release one port in the allocated block and another a new one randomly
 	if err := storage.Release(basePortRange + 53); err != nil {
-		t.Fatalf("Unexpected error trying to release ip 30053: %v", err)
+		t.Fatalf("Unexpected error trying to release port 30053: %v", err)
 	}
 	if _, err := storage.AllocateNext(); err != nil {
 		t.Error(err)

--- a/pkg/registry/core/service/portallocator/storage/storage_test.go
+++ b/pkg/registry/core/service/portallocator/storage/storage_test.go
@@ -27,8 +27,11 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	"k8s.io/apiserver/pkg/storage/storagebackend/factory"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/registry/core/service/allocator"
 	allocatorstore "k8s.io/kubernetes/pkg/registry/core/service/allocator/storage"
 	"k8s.io/kubernetes/pkg/registry/core/service/portallocator"
@@ -46,8 +49,8 @@ func newStorage(t *testing.T) (*etcd3testing.EtcdTestServer, portallocator.Inter
 	serviceNodePortRange := utilnet.PortRange{Base: basePortRange, Size: sizePortRange}
 	configForAllocations := etcdStorage.ForResource(api.Resource("servicenodeportallocations"))
 	var backing allocator.Interface
-	storage, err := portallocator.New(serviceNodePortRange, func(max int, rangeSpec string) (allocator.Interface, error) {
-		mem := allocator.NewAllocationMap(max, rangeSpec)
+	storage, err := portallocator.New(serviceNodePortRange, func(max int, rangeSpec string, offset int) (allocator.Interface, error) {
+		mem := allocator.NewAllocationMapWithOffset(max, rangeSpec, offset)
 		backing = mem
 		etcd, err := allocatorstore.NewEtcd(mem, "/ranges/servicenodeports", configForAllocations)
 		if err != nil {
@@ -182,4 +185,80 @@ func TestReallocate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+}
+
+func TestAllocateReserved(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceNodePortStaticSubrange, true)()
+
+	_, storage, _, si, destroyFunc := newStorage(t)
+	defer destroyFunc()
+	if err := si.Create(context.TODO(), key(), validNewRangeAllocation(), nil, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// allocate all ports on the dynamic block
+	// default range size is 2768, and dynamic block size is min(max(16,2768/32),128) = 86
+	dynamicOffset := 86
+	dynamicBlockSize := sizePortRange - dynamicOffset
+	for i := 0; i < dynamicBlockSize; i++ {
+		if _, err := storage.AllocateNext(); err != nil {
+			t.Errorf("Unexpected error trying to allocate: %v", err)
+		}
+	}
+	for i := dynamicOffset; i < sizePortRange; i++ {
+		port := i + basePortRange
+		if !storage.Has(port) {
+			t.Errorf("Port %d expected to be allocated", port)
+		}
+	}
+
+	// allocate all ports on the static block
+	for i := 0; i < dynamicOffset; i++ {
+		port := i + basePortRange
+		if err := storage.Allocate(port); err != nil {
+			t.Errorf("Unexpected error trying to allocate IP %d: %v", port, err)
+		}
+	}
+	if _, err := storage.AllocateNext(); err == nil {
+		t.Error("Allocator expected to be full")
+	}
+	// release one port in the allocated block and another a new one randomly
+	if err := storage.Release(basePortRange + 53); err != nil {
+		t.Fatalf("Unexpected error trying to release ip 30053: %v", err)
+	}
+	if _, err := storage.AllocateNext(); err != nil {
+		t.Error(err)
+	}
+	if _, err := storage.AllocateNext(); err == nil {
+		t.Error("Allocator expected to be full")
+	}
+}
+
+func TestAllocateReservedDynamicBlockExhausted(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceNodePortStaticSubrange, true)()
+
+	_, storage, _, si, destroyFunc := newStorage(t)
+	defer destroyFunc()
+	if err := si.Create(context.TODO(), key(), validNewRangeAllocation(), nil, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// allocate all ports both on the dynamic and reserved blocks
+	// once the dynamic block has been exhausted
+	// the dynamic allocator will use the reserved block
+	for i := 0; i < sizePortRange; i++ {
+		if _, err := storage.AllocateNext(); err != nil {
+			t.Errorf("Unexpected error trying to allocate: %v", err)
+		}
+	}
+	for i := 0; i < sizePortRange; i++ {
+		port := i + basePortRange
+		if !storage.Has(port) {
+			t.Errorf("Port %d expected to be allocated", port)
+		}
+	}
+
+	if _, err := storage.AllocateNext(); err == nil {
+		t.Error("Allocator expected to be full")
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
quote from https://github.com/kubernetes/kubernetes/issues/114129:
> In our cluster, some applications are NOT deployed in Kubernetes. But they need to connect to service in Kubernetes too.
> For example, some applications need to connect to the minio service but they have no idea what cluster-ip it is. In our situation, those applications just connect to a specific port (30009) of the Kubernetes master node.
> This situation works most time, but in something 30009 is allocated by something else. And minio service will be failed to applied.


This PR implements [KEP 3682](https://github.com/kubernetes/enhancements/pull/3682):

- [X] subdivide node port range and allocate nodeport with offset
- [x] add 4 more metrics to improve observability of this feature


#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/114129

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
New feature gate, ServiceNodePortStaticSubrange, to enable the new strategy in the NodePort Service port allocators, so the node port range is subdivided and dynamic allocated NodePort port for Services are allocated preferentially from the upper range.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/3682
```

