### PR TITLE
Cleanup: fix variable names in comments

### DIFF
--- a/pkg/apis/authentication/types.go
+++ b/pkg/apis/authentication/types.go
@@ -26,7 +26,7 @@ const (
 	ImpersonateUserHeader = "Impersonate-User"
 
 	// ImpersonateUIDHeader is used to impersonate a particular UID during an API server request.
-	ImpersonateUidHeader = "Impersonate-Uid"
+	ImpersonateUIDHeader = "Impersonate-Uid"
 
 	// ImpersonateGroupHeader is used to impersonate a particular group during an API server request.
 	// It can be repeated multiplied times for multiple groups.

--- a/pkg/controller/job/metrics/metrics.go
+++ b/pkg/controller/job/metrics/metrics.go
@@ -103,7 +103,7 @@ var (
 		},
 		[]string{"action"})
 
-	// TerminatedPodsWithTrackingFinalizer records the addition and removal of
+	// TerminatedPodsTrackingFinalizerTotal records the addition and removal of
 	// terminated pods that have the finalizer batch.kubernetes.io/job-tracking,
 	// regardless of whether they are owned by a Job.
 	TerminatedPodsTrackingFinalizerTotal = metrics.NewCounterVec(

--- a/pkg/controller/util/selectors/bimultimap.go
+++ b/pkg/controller/util/selectors/bimultimap.go
@@ -152,7 +152,7 @@ func (m *BiMultimap) Put(key Key, labels map[string]string) {
 		m.selectingByLabeled[labelsKey] = selecting
 	}
 	selecting := m.selectingByLabeled[labelsKey]
-	selecting.refCount += 1
+	selecting.refCount++
 	for _, sObject := range selecting.objects {
 		// Associate labeled with selecting.
 		labeled := m.labeledBySelecting[sObject.selectorKey]
@@ -185,7 +185,7 @@ func (m *BiMultimap) delete(key Key) {
 		// Delete selectingObject to labeledObject association.
 		delete(m.labeledBySelecting[selectorKey].objects, key)
 	}
-	m.selectingByLabeled[labelsKey].refCount -= 1
+	m.selectingByLabeled[labelsKey].refCount--
 	// Garbage collect labeledObject to selectingObject associations.
 	if m.selectingByLabeled[labelsKey].refCount == 0 {
 		delete(m.selectingByLabeled, labelsKey)
@@ -246,7 +246,7 @@ func (m *BiMultimap) PutSelector(key Key, selector pkglabels.Selector) {
 		m.labeledBySelecting[selectorKey] = labeled
 	}
 	labeled := m.labeledBySelecting[selectorKey]
-	labeled.refCount += 1
+	labeled.refCount++
 	for _, labeledObject := range labeled.objects {
 		// Associate selecting with labeled.
 		selecting := m.selectingByLabeled[labeledObject.labelsKey]
@@ -280,7 +280,7 @@ func (m *BiMultimap) deleteSelector(key Key) {
 		// Delete labeledObject to selectingObject association.
 		delete(m.selectingByLabeled[labelsKey].objects, key)
 	}
-	m.labeledBySelecting[selectorKey].refCount -= 1
+	m.labeledBySelecting[selectorKey].refCount--
 	// Garbage collect selectingObjects to labeledObject associations.
 	if m.labeledBySelecting[selectorKey].refCount == 0 {
 		delete(m.labeledBySelecting, selectorKey)

--- a/pkg/controller/util/selectors/bimultimap_test.go
+++ b/pkg/controller/util/selectors/bimultimap_test.go
@@ -623,11 +623,11 @@ func unorderedEqual(as, bs []Key) bool {
 	}
 	aMap := make(map[Key]int)
 	for _, a := range as {
-		aMap[a] += 1
+		aMap[a]++
 	}
 	bMap := make(map[Key]int)
 	for _, b := range bs {
-		bMap[b] += 1
+		bMap[b]++
 	}
 	if len(aMap) != len(bMap) {
 		return false


### PR DESCRIPTION
What type of PR is this?
/kind cleanup
What this PR does / why we need it:
optimised some code, such as the comment does not match the exported var