### PR TITLE
e2e: clean up listing

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	e2etestingmanifests "k8s.io/kubernetes/test/e2e/testing-manifests"
 	testfixtures "k8s.io/kubernetes/test/fixtures"
-	"k8s.io/kubernetes/test/utils/image"
 
 	// test sources
 	_ "k8s.io/kubernetes/test/e2e/apimachinery"
@@ -83,16 +82,11 @@ func handleFlags() {
 func TestMain(m *testing.M) {
 	var versionFlag bool
 	flag.CommandLine.BoolVar(&versionFlag, "version", false, "Displays version information.")
+	listConformanceTests := flag.CommandLine.Bool("list-conformance-tests", false, "If true, will show list of conformance tests.")
 
 	// Register test flags, then parse flags.
 	handleFlags()
 
-	if framework.TestContext.ListImages {
-		for _, v := range image.GetImageConfigs() {
-			fmt.Println(v.GetE2EImage())
-		}
-		os.Exit(0)
-	}
 	if versionFlag {
 		fmt.Printf("%s\n", version.Get())
 		os.Exit(0)
@@ -103,7 +97,7 @@ func TestMain(m *testing.M) {
 	testfiles.AddFileSource(testfixtures.GetTestFixturesFS())
 	testfiles.AddFileSource(conformancetestdata.GetConformanceTestdataFS())
 
-	if framework.TestContext.ListConformanceTests {
+	if *listConformanceTests {
 		var tests []struct {
 			Testname    string `yaml:"testname"`
 			Codename    string `yaml:"codename"`

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -41,6 +41,7 @@ import (
 
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework/internal/junit"
+	"k8s.io/kubernetes/test/utils/image"
 	"k8s.io/kubernetes/test/utils/kubeconfig"
 )
 
@@ -345,7 +346,6 @@ func RegisterCommonFlags(flags *flag.FlagSet) {
 	flags.StringVar(&TestContext.NonblockingTaints, "non-blocking-taints", `node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master`, "Nodes with taints in this comma-delimited list will not block the test framework from starting tests. The default taint 'node-role.kubernetes.io/master' is DEPRECATED and will be removed from the list in a future release.")
 
 	flags.BoolVar(&TestContext.ListImages, "list-images", false, "If true, will show list of images used for running tests.")
-	flags.BoolVar(&TestContext.ListConformanceTests, "list-conformance-tests", false, "If true, will show list of conformance tests.")
 	flags.StringVar(&TestContext.KubectlPath, "kubectl-path", "kubectl", "The kubectl binary to use. For development, you might use 'cluster/kubectl.sh' here.")
 
 	flags.StringVar(&TestContext.ProgressReportURL, "progress-report-url", "", "The URL to POST progress updates to as the suite runs to assist in aiding integrations. If empty, no messages sent.")
@@ -461,6 +461,13 @@ func AfterReadingAllFlags(t *TestContextType) {
 	fs.Set("one_output", "true")
 	fs.Set("stderrthreshold", "10" /* higher than any of the severities -> none pass the threshold */)
 	klog.SetOutput(ginkgo.GinkgoWriter)
+
+	if t.ListImages {
+		for _, v := range image.GetImageConfigs() {
+			fmt.Println(v.GetE2EImage())
+		}
+		os.Exit(0)
+	}
 
 	// Only set a default host if one won't be supplied via kubeconfig
 	if len(t.Host) == 0 && len(t.KubeConfig) == 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It doesn't make sense for the E2E framework to have command line options that don't do anything because then all test suites built with the framework inherit those options.

For `-list-images` and `-list-conformance-tests` the solution is to move the implementation into the framework (`-list-images`) respectively move the flag into `test/e2e` (`-list-conformance-tests`).

The placement was decided based on the observation that image patching is common functionality while conformance testing is specific to one test suite.

#### Special notes for your reviewer:

This is in preparation for https://github.com/kubernetes/kubernetes/pull/112894 which will add further `-list-*` options.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
