### PR TITLE
client-go: support `Shutdown()` for metadata and dynamic informers

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -135,12 +135,12 @@ func (f *dynamicSharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) 
 }
 
 func (f *dynamicSharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
 	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
+	defer f.wg.Wait()
+
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.shuttingDown = true
 }
 
 // NewFilteredDynamicInformer constructs a new informer for a dynamic type.

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -61,6 +61,12 @@ type dynamicSharedInformerFactory struct {
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[schema.GroupVersionResource]bool
 	tweakListOptions TweakListOptionsFunc
+
+	// wg tracks how many goroutines were started.
+	wg sync.WaitGroup
+	// shuttingDown is true when Shutdown has been called. It may still be running
+	// because it needs to wait for goroutines.
+	shuttingDown bool
 }
 
 var _ DynamicSharedInformerFactory = &dynamicSharedInformerFactory{}
@@ -86,9 +92,21 @@ func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.shuttingDown {
+		return
+	}
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Informer().Run(stopCh)
+			f.wg.Add(1)
+			// We need a new variable in each loop iteration,
+			// otherwise the goroutine would use the loop variable
+			// and that keeps changing.
+			informer := informer.Informer()
+			go func() {
+				defer f.wg.Done()
+				informer.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -114,6 +132,15 @@ func (f *dynamicSharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) 
 		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
 	}
 	return res
+}
+
+func (f *dynamicSharedInformerFactory) Shutdown() {
+	f.lock.Lock()
+	f.shuttingDown = true
+	f.lock.Unlock()
+
+	// Will return immediately if there is nothing to wait for.
+	f.wg.Wait()
 }
 
 // NewFilteredDynamicInformer constructs a new informer for a dynamic type.

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/interface.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/interface.go
@@ -24,9 +24,27 @@ import (
 
 // DynamicSharedInformerFactory provides access to a shared informer and lister for dynamic client
 type DynamicSharedInformerFactory interface {
+	// Start initializes all requested informers. They are handled in goroutines
+	// which run until the stop channel gets closed.
 	Start(stopCh <-chan struct{})
+
+	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer
+
+	// WaitForCacheSync blocks until all started informers' caches were synced
+	// or the stop channel gets closed.
 	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
+
+	// Shutdown marks a factory as shutting down. At that point no new
+	// informers can be started anymore and Start will return without
+	// doing anything.
+	//
+	// In addition, Shutdown blocks until all goroutines have terminated. For that
+	// to happen, the close channel(s) that they were started with must be closed,
+	// either before Shutdown gets called or while it is waiting.
+	//
+	// Shutdown may be called multiple times, even concurrently. All such calls will
+	// block until all goroutines have terminated.
 	Shutdown()
 }
 

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/interface.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/interface.go
@@ -27,6 +27,7 @@ type DynamicSharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer
 	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
+	Shutdown()
 }
 
 // TweakListOptionsFunc defines the signature of a helper function

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/informer.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/informer.go
@@ -133,12 +133,12 @@ func (f *metadataSharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{})
 }
 
 func (f *metadataSharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
 	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
+	defer f.wg.Wait()
+
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.shuttingDown = true
 }
 
 // NewFilteredMetadataInformer constructs a new informer for a metadata type.

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/informer.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/informer.go
@@ -60,6 +60,11 @@ type metadataSharedInformerFactory struct {
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[schema.GroupVersionResource]bool
 	tweakListOptions TweakListOptionsFunc
+	// wg tracks how many goroutines were started.
+	wg sync.WaitGroup
+	// shuttingDown is true when Shutdown has been called. It may still be running
+	// because it needs to wait for goroutines.
+	shuttingDown bool
 }
 
 var _ SharedInformerFactory = &metadataSharedInformerFactory{}
@@ -85,9 +90,21 @@ func (f *metadataSharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.shuttingDown {
+		return
+	}
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Informer().Run(stopCh)
+			f.wg.Add(1)
+			// We need a new variable in each loop iteration,
+			// otherwise the goroutine would use the loop variable
+			// and that keeps changing.
+			informer := informer.Informer()
+			go func() {
+				defer f.wg.Done()
+				informer.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -113,6 +130,15 @@ func (f *metadataSharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{})
 		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
 	}
 	return res
+}
+
+func (f *metadataSharedInformerFactory) Shutdown() {
+	f.lock.Lock()
+	f.shuttingDown = true
+	f.lock.Unlock()
+
+	// Will return immediately if there is nothing to wait for.
+	f.wg.Wait()
 }
 
 // NewFilteredMetadataInformer constructs a new informer for a metadata type.

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/interface.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/interface.go
@@ -24,9 +24,27 @@ import (
 
 // SharedInformerFactory provides access to a shared informer and lister for dynamic client
 type SharedInformerFactory interface {
+	// Start initializes all requested informers. They are handled in goroutines
+	// which run until the stop channel gets closed.
 	Start(stopCh <-chan struct{})
+
+	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer
+
+	// WaitForCacheSync blocks until all started informers' caches were synced
+	// or the stop channel gets closed.
 	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
+
+	// Shutdown marks a factory as shutting down. At that point no new
+	// informers can be started anymore and Start will return without
+	// doing anything.
+	//
+	// In addition, Shutdown blocks until all goroutines have terminated. For that
+	// to happen, the close channel(s) that they were started with must be closed,
+	// either before Shutdown gets called or while it is waiting.
+	//
+	// Shutdown may be called multiple times, even concurrently. All such calls will
+	// block until all goroutines have terminated.
 	Shutdown()
 }
 

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/interface.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/interface.go
@@ -27,6 +27,7 @@ type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer
 	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
+	Shutdown()
 }
 
 // TweakListOptionsFunc defines the signature of a helper function


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Followup to https://github.com/kubernetes/kubernetes/pull/112200, specifically https://github.com/kubernetes/kubernetes/pull/112200#issuecomment-1344812038.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
client-go: metadatainformer and dynamicinformer `SharedInformerFactory`s now supports waiting for goroutines during shutdown
```
