### PR TITLE
Unexport OpenAPIGetter factory method

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"testing"
 
-	openapi_v2 "github.com/google/gnostic/openapiv2"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
@@ -44,7 +43,6 @@ import (
 	sptest "k8s.io/apimachinery/pkg/util/strategicpatch/testing"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/discovery"
 	dynamicfakeclient "k8s.io/client-go/dynamic/fake"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
@@ -60,12 +58,11 @@ import (
 
 var (
 	fakeSchema                = sptest.Fake{Path: filepath.Join("..", "..", "..", "testdata", "openapi", "swagger.json")}
-	testingOpenAPISchemas     = []testOpenAPISchema{{OpenAPIGetter: &fakeSchema}, AlwaysErrorsOpenAPISchema, FakeOpenAPISchema}
+	testingOpenAPISchemas     = []testOpenAPISchema{AlwaysErrorsOpenAPISchema, FakeOpenAPISchema}
 	AlwaysErrorsOpenAPISchema = testOpenAPISchema{
 		OpenAPISchemaFn: func() (openapi.Resources, error) {
 			return nil, errors.New("cannot get openapi spec")
 		},
-		OpenAPIGetter: &alwaysErrorsOpenAPISchema{},
 	}
 	FakeOpenAPISchema = testOpenAPISchema{
 		OpenAPISchemaFn: func() (openapi.Resources, error) {
@@ -75,20 +72,12 @@ var (
 			}
 			return openapi.NewOpenAPIData(s)
 		},
-		OpenAPIGetter: &fakeSchema,
 	}
 	codec = scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
 )
 
 type testOpenAPISchema struct {
 	OpenAPISchemaFn func() (openapi.Resources, error)
-	OpenAPIGetter   discovery.OpenAPISchemaInterface
-}
-
-type alwaysErrorsOpenAPISchema struct{}
-
-func (o *alwaysErrorsOpenAPISchema) OpenAPISchema() (*openapi_v2.Document, error) {
-	return nil, errors.New("cannot get openapi schema")
 }
 
 func TestApplyExtraArgsFail(t *testing.T) {
@@ -644,7 +633,6 @@ func TestApplyObject(t *testing.T) {
 				}),
 			}
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
-			tf.FakeOpenAPIGetter = testingOpenAPISchema.OpenAPIGetter
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
@@ -693,7 +681,6 @@ func TestApplyPruneObjects(t *testing.T) {
 				}),
 			}
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
-			tf.FakeOpenAPIGetter = testingOpenAPISchema.OpenAPIGetter
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
@@ -930,7 +917,6 @@ func TestApplyPruneObjectsWithAllowlist(t *testing.T) {
 					}),
 				}
 				tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
-				tf.FakeOpenAPIGetter = testingOpenAPISchema.OpenAPIGetter
 				tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 				for _, resource := range tc.currentResources {
@@ -1109,7 +1095,6 @@ func TestApplyCSAMigration(t *testing.T) {
 		}),
 	}
 	tf.OpenAPISchemaFunc = FakeOpenAPISchema.OpenAPISchemaFn
-	tf.FakeOpenAPIGetter = FakeOpenAPISchema.OpenAPIGetter
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 	ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
@@ -1198,7 +1183,6 @@ func TestApplyObjectOutput(t *testing.T) {
 				}),
 			}
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
-			tf.FakeOpenAPIGetter = testingOpenAPISchema.OpenAPIGetter
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
@@ -1260,7 +1244,6 @@ func TestApplyRetry(t *testing.T) {
 				}),
 			}
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
-			tf.FakeOpenAPIGetter = testingOpenAPISchema.OpenAPIGetter
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
@@ -1436,7 +1419,6 @@ func testApplyMultipleObjects(t *testing.T, asList bool) {
 				}),
 			}
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
-			tf.FakeOpenAPIGetter = testingOpenAPISchema.OpenAPIGetter
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
@@ -1532,7 +1514,6 @@ func TestApplyNULLPreservation(t *testing.T) {
 				}),
 			}
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
-			tf.FakeOpenAPIGetter = testingOpenAPISchema.OpenAPIGetter
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
@@ -1595,7 +1576,6 @@ func TestUnstructuredApply(t *testing.T) {
 				}),
 			}
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
-			tf.FakeOpenAPIGetter = testingOpenAPISchema.OpenAPIGetter
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
@@ -1660,7 +1640,6 @@ func TestUnstructuredIdempotentApply(t *testing.T) {
 				}),
 			}
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
-			tf.FakeOpenAPIGetter = testingOpenAPISchema.OpenAPIGetter
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
@@ -1903,7 +1882,6 @@ func TestForceApply(t *testing.T) {
 			fakeDynamicClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
 			tf.FakeDynamicClient = fakeDynamicClient
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
-			tf.FakeOpenAPIGetter = testingOpenAPISchema.OpenAPIGetter
 			tf.Client = tf.UnstructuredClient
 			tf.ClientConfigVal = &restclient.Config{}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	sptest "k8s.io/apimachinery/pkg/util/strategicpatch/testing"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/discovery"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/util/openapi"
 )
@@ -39,13 +38,11 @@ var (
 			}
 			return openapi.NewOpenAPIData(s)
 		},
-		OpenAPIGetter: &fakeSchema,
 	}
 )
 
 type testOpenAPISchema struct {
 	OpenAPISchemaFn func() (openapi.Resources, error)
-	OpenAPIGetter   discovery.OpenAPISchemaInterface
 }
 
 func TestExplainInvalidArgs(t *testing.T) {
@@ -125,7 +122,6 @@ func TestExplain(t *testing.T) {
 	defer tf.Cleanup()
 
 	tf.OpenAPISchemaFunc = FakeOpenAPISchema.OpenAPISchemaFn
-	tf.FakeOpenAPIGetter = FakeOpenAPISchema.OpenAPIGetter
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -31,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
-	sptest "k8s.io/apimachinery/pkg/util/strategicpatch/testing"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
@@ -587,9 +585,6 @@ func TestLabelResourceVersion(t *testing.T) {
 func TestRunLabelMsg(t *testing.T) {
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
-
-	fakeSchema := sptest.Fake{Path: filepath.Join("..", "..", "..", "testdata", "openapi", "swagger.json")}
-	tf.FakeOpenAPIGetter = &fakeSchema
 
 	tf.UnstructuredClient = &fake.RESTClient{
 		GroupVersion:         schema.GroupVersion{Group: "testgroup", Version: "v1"},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -49,8 +49,6 @@ import (
 	"k8s.io/kubectl/pkg/util/openapi"
 	openapitesting "k8s.io/kubectl/pkg/util/openapi/testing"
 	"k8s.io/kubectl/pkg/validation"
-
-	openapi_v2 "github.com/google/gnostic/openapiv2"
 )
 
 // InternalType is the schema for internal type
@@ -420,7 +418,6 @@ type TestFactory struct {
 
 	UnstructuredClientForMappingFunc resource.FakeClientFunc
 	OpenAPISchemaFunc                func() (openapi.Resources, error)
-	FakeOpenAPIGetter                discovery.OpenAPISchemaInterface
 }
 
 // NewTestFactory returns an initialized TestFactory instance
@@ -534,23 +531,6 @@ func (f *TestFactory) OpenAPISchema() (openapi.Resources, error) {
 		return f.OpenAPISchemaFunc()
 	}
 	return openapitesting.EmptyResources{}, nil
-}
-
-type EmptyOpenAPI struct{}
-
-func (EmptyOpenAPI) OpenAPISchema() (*openapi_v2.Document, error) {
-	return &openapi_v2.Document{}, nil
-}
-
-func (f *TestFactory) OpenAPIGetter() discovery.OpenAPISchemaInterface {
-	if f.FakeOpenAPIGetter != nil {
-		return f.FakeOpenAPIGetter
-	}
-	client, err := f.ToDiscoveryClient()
-	if err != nil {
-		return EmptyOpenAPI{}
-	}
-	return client
 }
 
 // NewBuilder returns an initialized resource.Builder instance

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/factory.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/factory.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -64,6 +63,4 @@ type Factory interface {
 	Validator(validationDirective string) (validation.Schema, error)
 	// OpenAPISchema returns the parsed openapi schema definition
 	OpenAPISchema() (openapi.Resources, error)
-	// OpenAPIGetter returns a getter for the openapi schema document
-	OpenAPIGetter() discovery.OpenAPISchemaInterface
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
@@ -42,7 +42,7 @@ type factoryImpl struct {
 
 	// Caches OpenAPI document and parsed resources
 	openAPIParser *openapi.CachedOpenAPIParser
-	openAPIGetter *openapi.CachedOpenAPIGetter
+	oapi          *openapi.CachedOpenAPIGetter
 	parser        sync.Once
 	getter        sync.Once
 }
@@ -168,14 +168,14 @@ func (f *factoryImpl) Validator(validationDirective string) (validation.Schema, 
 		return nil, err
 	}
 	// Create the FieldValidationVerifier for use in the ParamVerifyingSchema.
-	verifier := resource.NewQueryParamVerifier(dynamicClient, f.OpenAPIGetter(), resource.QueryParamFieldValidation)
+	verifier := resource.NewQueryParamVerifier(dynamicClient, f.openAPIGetter(), resource.QueryParamFieldValidation)
 	return validation.NewParamVerifyingSchema(schema, verifier, string(validationDirective)), nil
 }
 
 // OpenAPISchema returns metadata and structural information about
 // Kubernetes object definitions.
 func (f *factoryImpl) OpenAPISchema() (openapi.Resources, error) {
-	openAPIGetter := f.OpenAPIGetter()
+	openAPIGetter := f.openAPIGetter()
 	if openAPIGetter == nil {
 		return nil, errors.New("no openapi getter")
 	}
@@ -183,21 +183,21 @@ func (f *factoryImpl) OpenAPISchema() (openapi.Resources, error) {
 	// Lazily initialize the OpenAPIParser once
 	f.parser.Do(func() {
 		// Create the caching OpenAPIParser
-		f.openAPIParser = openapi.NewOpenAPIParser(f.OpenAPIGetter())
+		f.openAPIParser = openapi.NewOpenAPIParser(f.openAPIGetter())
 	})
 
 	// Delegate to the OpenAPIPArser
 	return f.openAPIParser.Parse()
 }
 
-func (f *factoryImpl) OpenAPIGetter() discovery.OpenAPISchemaInterface {
+func (f *factoryImpl) openAPIGetter() discovery.OpenAPISchemaInterface {
 	discovery, err := f.clientGetter.ToDiscoveryClient()
 	if err != nil {
 		return nil
 	}
 	f.getter.Do(func() {
-		f.openAPIGetter = openapi.NewOpenAPIGetter(discovery)
+		f.oapi = openapi.NewOpenAPIGetter(discovery)
 	})
 
-	return f.openAPIGetter
+	return f.oapi
 }


### PR DESCRIPTION
* Since `OpenAPIGetter()` factory method is now only used in one place, unexport this method.
* In addition to simplification, this refactor help with the effort to move OpenAPI from V2 -> V3.

/kind cleanup
/sig cli
/priority important-longterm

```release-note
NONE
```