### PR TITLE
add direct construction of TypeConverter from OpenAPI

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder.go
@@ -499,7 +499,9 @@ func addTypeMetaProperties(s *spec.Schema, v2 bool) {
 func (b *builder) buildListSchema(v2 bool) *spec.Schema {
 	name := definitionPrefix + util.ToRESTFriendlyName(fmt.Sprintf("%s/%s/%s", b.group, b.version, b.kind))
 	doc := fmt.Sprintf("List of %s. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md", b.plural)
-	s := new(spec.Schema).WithDescription(fmt.Sprintf("%s is a list of %s", b.listKind, b.kind)).
+	s := new(spec.Schema).
+		Typed("object", "").
+		WithDescription(fmt.Sprintf("%s is a list of %s", b.listKind, b.kind)).
 		WithRequired("items").
 		SetProperty("items", *spec.ArrayProperty(spec.RefSchema(refForOpenAPIVersion(name, v2))).WithDescription(doc)).
 		SetProperty("metadata", *spec.RefSchema(refForOpenAPIVersion(listMetaSchemaRef, v2)).WithDescription(swaggerPartialObjectMetadataListDescriptions["metadata"]))

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/fieldmanager_test.go
@@ -43,19 +43,3 @@ var fakeTypeConverter = func() internal.TypeConverter {
 	}
 	return typeConverter
 }()
-
-var testTypeConverter = func() internal.TypeConverter {
-	data, err := ioutil.ReadFile(filepath.Join("testdata", "swagger.json"))
-	if err != nil {
-		panic(err)
-	}
-	spec := spec.Swagger{}
-	if err := json.Unmarshal(data, &spec); err != nil {
-		panic(err)
-	}
-	typeConverter, err := internal.NewTypeConverter(&spec, false)
-	if err != nil {
-		panic(err)
-	}
-	return typeConverter
-}()


### PR DESCRIPTION
/sig api-machinery
/triage accepted

@apelisse 

#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

Constructs TypeConverter from OpenAPI models directly using new kube-openapi support. Has two main benefits:

1. No longer need to roundtrip via JSON and gnostic types. Removing gnostic validation also removes need for some workarounds/code complexity like StripNullable/StripValidations in builder
2. Enables transition to OpenAPIV3 models. SMD converter works for both V2 and V3 types.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
