### PR TITLE
e2e framework: fix unit test flake

### DIFF
--- a/test/e2e/framework/internal/output/output.go
+++ b/test/e2e/framework/internal/output/output.go
@@ -104,7 +104,7 @@ var timePrefix = regexp.MustCompile(`(?m)^[[:alpha:]]{3} +[[:digit:]]{1,2} +[[:d
 var elapsedSuffix = regexp.MustCompile(`Elapsed: [[:digit:]]+(\.[[:digit:]]+)?(µs|ns|ms|s|m)`)
 
 // timeSuffix matches "09/06/22 15:36:43.445" as printed by Ginkgo v2 for log output.
-var timeSuffix = regexp.MustCompile(`(?m)[[:space:]][[:digit:]]{2}/[[:digit:]]{2}/[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\.[[:digit:]]{1,3}$`)
+var timeSuffix = regexp.MustCompile(`(?m)[[:space:]][[:digit:]]{2}/[[:digit:]]{2}/[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}(\.[[:digit:]]{1,3})?$`)
 
 func stripTimes(in string) string {
 	out := timePrefix.ReplaceAllString(in, "")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

The Gingo v2 time suffix is hh:mm:ss without the .xyz sub-second details if the time stamp happens to land exactly on a second.

This change fixes test flakes like the following:

    -STEP: Building a namespace api object, basename test-namespace
    +STEP: Building a namespace api object, basename test-namespace 12/13/22 11:43:53

    --- FAIL: TestCleanup (36.79s)


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

