### PR TITLE
fix double lock and excercise its codepath in tests

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -226,9 +226,6 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 
 	switch writer.respCode {
 	case http.StatusNotModified:
-		dm.resultsLock.Lock()
-		defer dm.resultsLock.Unlock()
-
 		// Keep old entry, update timestamp
 		cached = cachedResult{
 			discovery:   cached.discovery,


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

This removes a duplicate lock on the 304 Not Modified codepath likely forgotten to be removed during a refactor.

It is probable that no users have discovered this bug, as it occurs only if the user has an aggregated APIService which makes use of aggregated discovery, which was just released a few days ago. 

Also includes a reproducer unit test which fails easily without the change, and is now fixed.

More information in [#114442](https://github.com/kubernetes/kubernetes/pull/114442#issuecomment-1349023299)

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a 1.26 regression in the alpha Aggregated Discovery feature that can cause a stuck apiserver if an aggregated apiservice returned 304 Not Modified for aggregated discovery information
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
