### PR TITLE
portforward: return error on lost connection to pod

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -37,6 +37,8 @@ import (
 // TODO move to API machinery and re-unify with kubelet/server/portfoward
 const PortForwardProtocolV1Name = "portforward.k8s.io"
 
+var ErrLostConnectionToPod = errors.New("lost connection to pod")
+
 // PortForwarder knows how to listen for local connections and forward them to
 // a remote pod via an upgraded HTTP request.
 type PortForwarder struct {
@@ -230,7 +232,7 @@ func (pf *PortForwarder) forward() error {
 	select {
 	case <-pf.stopChan:
 	case <-pf.streamConn.CloseChan():
-		runtime.HandleError(errors.New("lost connection to pod"))
+		return ErrLostConnectionToPod
 	}
 
 	return nil


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently, when the remote connection is unexpected closed, forward() prints an error message saying "lost connection to pod" via `runtime.HandleError`, but then it returns nil for the error.

This prevents the caller from being able to handle this error.

This PR changes `forward()` to return the "lost connection to pod" error so that it can be handled by the caller.

Making this change enables kubectl port-forward to exit with code 1, instead of 0, which is the expected behavior for a command that has failed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
n/a

This is groundwork for improving kubectl port-forward resiliency, so that it can handle specific errors more appropriately.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubectl port-forward now exits with exit code 1 when remote connection is lost
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
