### PR TITLE
Automated cherry pick of #114459: fix double lock and excercise its codepath in tests

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -226,9 +226,6 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 
 	switch writer.respCode {
 	case http.StatusNotModified:
-		dm.resultsLock.Lock()
-		defer dm.resultsLock.Unlock()
-
 		// Keep old entry, update timestamp
 		cached = cachedResult{
 			discovery:   cached.discovery,


### PR DESCRIPTION
Cherry pick of #114459 on release-1.26.

#114459: fix double lock and excercise its codepath in tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.26 regression in the alpha Aggregated Discovery feature that can cause a stuck apiserver if an aggregated apiservice returned 304 Not Modified for aggregated discovery information
```
