### PR TITLE
Automated cherry pick of #114407: Windows Kube-Proxy implementation for internal traffic

### DIFF
--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -129,6 +129,7 @@ type serviceInfo struct {
 	preserveDIP            bool
 	localTrafficDSR        bool
 	winProxyOptimization   bool
+	internalTrafficLocal   bool
 }
 
 type hnsNetworkInfo struct {
@@ -530,6 +531,10 @@ func (proxier *Proxier) newServiceInfo(port *v1.ServicePort, service *v1.Service
 	// Annotation introduced to enable optimized loadbalancing
 	winProxyOptimization := !(strings.ToUpper(service.Annotations["winProxyOptimization"]) == "DISABLED")
 	localTrafficDSR := service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal
+	var internalTrafficLocal bool
+	if service.Spec.InternalTrafficPolicy != nil {
+		internalTrafficLocal = *service.Spec.InternalTrafficPolicy == v1.ServiceInternalTrafficPolicyLocal
+	}
 	err := hcn.DSRSupported()
 	if err != nil {
 		preserveDIP = false
@@ -547,8 +552,8 @@ func (proxier *Proxier) newServiceInfo(port *v1.ServicePort, service *v1.Service
 	info.hns = proxier.hns
 	info.localTrafficDSR = localTrafficDSR
 	info.winProxyOptimization = winProxyOptimization
-
-	klog.V(3).InfoS("Flags enabled for service", "service", service.Name, "localTrafficDSR", localTrafficDSR, "preserveDIP", preserveDIP, "winProxyOptimization", winProxyOptimization)
+	info.internalTrafficLocal = internalTrafficLocal
+	klog.V(3).InfoS("Flags enabled for service", "service", service.Name, "localTrafficDSR", localTrafficDSR, "winProxyOptimization", winProxyOptimization, "internalTrafficLocal", internalTrafficLocal, "preserveDIP", preserveDIP)
 
 	for _, eip := range service.Spec.ExternalIPs {
 		info.externalIPs = append(info.externalIPs, &externalIPInfo{ip: eip})
@@ -1295,6 +1300,12 @@ func (proxier *Proxier) syncProxyRules() {
 				continue
 			}
 
+			if svcInfo.internalTrafficLocal && svcInfo.localTrafficDSR && !ep.GetIsLocal() {
+				// No need to use or create remote endpoint when internal and external traffic policy is remote
+				klog.V(3).InfoS("Skipping the endpoint. Both internalTraffic and external traffic policies are local", "EpIP", ep.ip, " EpPort", ep.port)
+				continue
+			}
+
 			if someEndpointsServing {
 
 				if !allEndpointsTerminating && !ep.IsReady() {
@@ -1456,10 +1467,18 @@ func (proxier *Proxier) syncProxyRules() {
 		proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &svcInfo.hnsID, sourceVip, Enum(svcInfo.Protocol()), uint16(svcInfo.targetPort), uint16(svcInfo.Port()), hnsEndpoints, queriedLoadBalancers)
 
 		if endpointsAvailableForLB {
+
+			// clusterIPEndpoints is the endpoint list used for creating ClusterIP loadbalancer.
+			clusterIPEndpoints := hnsEndpoints
+			if svcInfo.internalTrafficLocal {
+				// Take local endpoints for clusterip loadbalancer when internal traffic policy is local.
+				clusterIPEndpoints = hnsLocalEndpoints
+			}
+
 			// If all endpoints are terminating, then no need to create Cluster IP LoadBalancer
 			// Cluster IP LoadBalancer creation
 			hnsLoadBalancer, err := hns.getLoadBalancer(
-				hnsEndpoints,
+				clusterIPEndpoints,
 				loadBalancerFlags{isDSR: proxier.isDSR, isIPv6: proxier.isIPv6Mode, sessionAffinity: sessionAffinityClientIP},
 				sourceVip,
 				svcInfo.ClusterIP().String(),


### PR DESCRIPTION
Cherry pick of #114407 on release-1.24.

#114407: Windows Kube-Proxy implementation for internal traffic

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Optimizing loadbalancer creation with the help of attribute Internal Traffic Policy: Local
```
