### PR TITLE
update IPTablesOwnershipCleanup to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -385,6 +385,7 @@ const (
 	// owner: @danwinship
 	// kep: https://kep.k8s.io/3178
 	// alpha: v1.25
+	// beta: v1.27
 	//
 	// Causes kubelet to no longer create legacy IPTables rules
 	IPTablesOwnershipCleanup featuregate.Feature = "IPTablesOwnershipCleanup"
@@ -936,7 +937,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	InTreePluginvSphereUnregister: {Default: false, PreRelease: featuregate.Alpha},
 
-	IPTablesOwnershipCleanup: {Default: false, PreRelease: featuregate.Alpha},
+	IPTablesOwnershipCleanup: {Default: true, PreRelease: featuregate.Beta},
 
 	JobPodFailurePolicy: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
update KEP-3178 / IPTablesOwnershipCleanup to beta, enabled-by-default

#### Which issue(s) this PR fixes:
none

#### Special notes for your reviewer:
~(waiting for https://github.com/kubernetes/enhancements/pull/3690 to merge)~

#### Does this PR introduce a user-facing change?
```release-note
Kubelet no longer creates certain legacy iptables rules by default.
It is possible that this will cause problems with some third-party components
that improperly depended on those rules. If this affects you, you can run
kubelet with `--feature-gates=IPTablesOwnershipCleanup=false`, but you should
also file a bug against the third-party component.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3178
- [Other doc]: https://kubernetes.io/blog/2022/09/07/iptables-chains-not-api/
```

/sig network
/priority important-soon