### PR TITLE
Cleanup sysctl conversion since `github.com/opencontainers/runc` has implemented it.

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -59,7 +59,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/runtimeclass"
-	"k8s.io/kubernetes/pkg/kubelet/sysctl"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/cache"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
@@ -1086,16 +1085,6 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		metrics.StartedPodsTotal.Inc()
 		createSandboxResult := kubecontainer.NewSyncResult(kubecontainer.CreatePodSandbox, format.Pod(pod))
 		result.AddSyncResult(createSandboxResult)
-
-		// ConvertPodSysctlsVariableToDotsSeparator converts sysctl variable
-		// in the Pod.Spec.SecurityContext.Sysctls slice into a dot as a separator.
-		// runc uses the dot as the separator to verify whether the sysctl variable
-		// is correct in a separate namespace, so when using the slash as the sysctl
-		// variable separator, runc returns an error: "sysctl is not in a separate kernel namespace"
-		// and the podSandBox cannot be successfully created. Therefore, before calling runc,
-		// we need to convert the sysctl variable, the dot is used as a separator to separate the kernel namespace.
-		// When runc supports slash as sysctl separator, this function can no longer be used.
-		sysctl.ConvertPodSysctlsVariableToDotsSeparator(pod.Spec.SecurityContext)
 
 		// Prepare resources allocated by the Dynammic Resource Allocation feature for the pod
 		if utilfeature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -650,64 +650,6 @@ func TestSyncPod(t *testing.T) {
 	}
 }
 
-func TestSyncPodWithConvertedPodSysctls(t *testing.T) {
-	fakeRuntime, _, m, err := createTestRuntimeManager()
-	assert.NoError(t, err)
-
-	containers := []v1.Container{
-		{
-			Name:            "foo",
-			Image:           "busybox",
-			ImagePullPolicy: v1.PullIfNotPresent,
-		},
-	}
-
-	securityContext := &v1.PodSecurityContext{
-		Sysctls: []v1.Sysctl{
-			{
-				Name:  "kernel/shm_rmid_forced",
-				Value: "1",
-			},
-			{
-				Name:  "net/ipv4/ip_local_port_range",
-				Value: "1024 65535",
-			},
-		},
-	}
-	exceptSysctls := []v1.Sysctl{
-		{
-			Name:  "kernel.shm_rmid_forced",
-			Value: "1",
-		},
-		{
-			Name:  "net.ipv4.ip_local_port_range",
-			Value: "1024 65535",
-		},
-	}
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			UID:       "12345678",
-			Name:      "foo",
-			Namespace: "new",
-		},
-		Spec: v1.PodSpec{
-			Containers:      containers,
-			SecurityContext: securityContext,
-		},
-	}
-
-	backOff := flowcontrol.NewBackOff(time.Second, time.Minute)
-	result := m.SyncPod(context.Background(), pod, &kubecontainer.PodStatus{}, []v1.Secret{}, backOff)
-	assert.NoError(t, result.Error())
-	assert.Equal(t, exceptSysctls, pod.Spec.SecurityContext.Sysctls)
-	for _, sandbox := range fakeRuntime.Sandboxes {
-		assert.Equal(t, runtimeapi.PodSandboxState_SANDBOX_READY, sandbox.State)
-	}
-	for _, c := range fakeRuntime.Containers {
-		assert.Equal(t, runtimeapi.ContainerState_CONTAINER_RUNNING, c.State)
-	}
-}
-
 func TestPruneInitContainers(t *testing.T) {
 	ctx := context.Background()
 	fakeRuntime, _, m, err := createTestRuntimeManager()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Cleanup sysctl conversion since `github.com/opencontainers/runc` [has implemented it](https://github.com/opencontainers/runc) in [ `v1.1.0`](https://github.com/opencontainers/runc/blob/main/CHANGELOG.md#110---2022-01-14).

The `github.com/opencontainers/runc` version used by the Kubernetes repo is v1.1.4, which is greater than v1.1.0.

go.mod:
```
	github.com/opencontainers/runc v1.1.4
```
So we can remove the sysctl conversion safely.

see the following links for more details:
- https://github.com/kubernetes/kubernetes/pull/102393#issuecomment-955880917
```
We can remove the conversion function in the kubernetes code after runc releases a new version that solves this problem.
```
- https://github.com/opencontainers/runc/pull/3257
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
