### PR TITLE
e2e storage: pass around topologyTest pointer

### DIFF
--- a/test/e2e/storage/testsuites/topology.go
+++ b/test/e2e/storage/testsuites/topology.go
@@ -104,9 +104,9 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 	f := framework.NewFrameworkWithCustomTimeouts("topology", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	init := func() topologyTest {
+	init := func() *topologyTest {
 		dDriver, _ = driver.(storageframework.DynamicPVTestDriver)
-		l := topologyTest{}
+		l := &topologyTest{}
 
 		// Now do the more expensive test initialization.
 		l.config = driver.PrepareTest(f)
@@ -123,7 +123,7 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 			e2eskipper.Skipf("Driver didn't provide topology keys -- skipping")
 		}
 
-		ginkgo.DeferCleanup(t.CleanupResources, cs, &l)
+		ginkgo.DeferCleanup(t.CleanupResources, cs, l)
 
 		if dInfo.NumAllowedTopologies == 0 {
 			// Any plugin that supports topology defaults to 1 topology
@@ -166,7 +166,7 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 		}
 		allowedTopologies := t.setAllowedTopologies(l.resource.Sc, l.allTopologies, excludedIndex)
 
-		t.createResources(cs, &l, nil)
+		t.createResources(cs, l, nil)
 
 		err = e2epod.WaitTimeoutForPodRunningInNamespace(cs, l.pod.Name, l.pod.Namespace, f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
@@ -213,7 +213,7 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 				},
 			},
 		}
-		t.createResources(cs, &l, affinity)
+		t.createResources(cs, l, affinity)
 
 		// Wait for pod to fail scheduling
 		// With delayed binding, the scheduler errors before provisioning


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Copying the instance makes no sense because the fields are meant to be shared between test and cleanup code.

#### Special notes for your reviewer:

This probably only affected pod deletion which is optional because the pod also gets deleted together with the namespace.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
