### PR TITLE
Graduate ReadWriteOncePod to beta, updated e2e test

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -652,7 +652,9 @@ const (
 	QOSReserved featuregate.Feature = "QOSReserved"
 
 	// owner: @chrishenzie
+	// kep: https://kep.k8s.io/2485
 	// alpha: v1.22
+	// beta: v1.27
 	//
 	// Enables usage of the ReadWriteOncePod PersistentVolume access mode.
 	ReadWriteOncePod featuregate.Feature = "ReadWriteOncePod"
@@ -1009,7 +1011,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	QOSReserved: {Default: false, PreRelease: featuregate.Alpha},
 
-	ReadWriteOncePod: {Default: false, PreRelease: featuregate.Alpha},
+	ReadWriteOncePod: {Default: true, PreRelease: featuregate.Beta},
 
 	RecoverVolumeExpansionFailure: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -218,7 +218,7 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.9.0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.11.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Graduates the ReadWriteOncePod feature from alpha to beta which now includes scheduler preemption handling for pods with this access mode. See https://github.com/kubernetes/kubernetes/pull/114051 for context. Updates the ReadWriteOncePod e2e test to handle the new behavior. Also updates the CSI hostpath driver to v1.11.0 which performs strict enforcement of the `SINGLE_NODE_SINGLE_WRITER` CSI access mode. See for more context:
https://github.com/kubernetes-csi/csi-driver-host-path/pull/381

#### Which issue(s) this PR fixes:
Fixes #114493

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Graduate the `ReadWriteOncePod` feature gate to beta
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2485
```

/sig storage
/sig scheduling
/milestone v1.27
/cc @msau42
/cc @jsafrane
/cc @alculquicondor
/hold