### PR TITLE
[WIP] add Run to Informer Factories

### DIFF
--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -232,10 +232,14 @@ func TestSyncHandler(t *testing.T) {
 			}
 
 			// Ensure informers are up-to-date.
-			go informerFactory.Start(ctx.Done())
+			factoryDone := make(chan struct{})
+			go func() {
+				defer close(factoryDone)
+				informerFactory.Run(ctx.Done())
+			}()
 			stopInformers := func() {
 				cancel()
-				informerFactory.Shutdown()
+				<-factoryDone
 			}
 			defer stopInformers()
 			informerFactory.WaitForCacheSync(ctx.Done())

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
@@ -107,17 +107,35 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
-// Start initializes all requested informers.
-func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+func (f *sharedInformerFactory) start(stopCh <-chan struct{}) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			wg.Add(1)
+			informerCopy := informer
+			go func() {
+				defer wg.Done()
+				informerCopy.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	return wg
+}
+
+// Start initializes all requested informers.
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.start(stopCh)
+}
+
+// Run initializes all requested informers and blocks until they
+// all complete
+func (f *sharedInformerFactory) Run(stopCh <-chan struct{}) {
+	f.start(stopCh).Wait()
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
@@ -47,11 +47,6 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
-	// wg tracks how many goroutines were started.
-	wg sync.WaitGroup
-	// shuttingDown is true when Shutdown has been called. It may still be running
-	// because it needs to wait for goroutines.
-	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -112,39 +107,20 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
+// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	if f.shuttingDown {
-		return
-	}
-
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			go informer.Run(stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
 }
 
-func (f *sharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
-	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
-}
-
+// WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
@@ -191,57 +167,10 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
-//
-// It is typically used like this:
-//
-//	ctx, cancel := context.Background()
-//	defer cancel()
-//	factory := NewSharedInformerFactory(client, resyncPeriod)
-//	defer factory.WaitForStop()    // Returns immediately if nothing was started.
-//	genericInformer := factory.ForResource(resource)
-//	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
-//	}
-//
-//	// Creating informers can also be created after Start, but then
-//	// Start must be called again:
-//	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
-
-	// Start initializes all requested informers. They are handled in goroutines
-	// which run until the stop channel gets closed.
-	Start(stopCh <-chan struct{})
-
-	// Shutdown marks a factory as shutting down. At that point no new
-	// informers can be started anymore and Start will return without
-	// doing anything.
-	//
-	// In addition, Shutdown blocks until all goroutines have terminated. For that
-	// to happen, the close channel(s) that they were started with must be closed,
-	// either before Shutdown gets called or while it is waiting.
-	//
-	// Shutdown may be called multiple times, even concurrently. All such calls will
-	// block until all goroutines have terminated.
-	Shutdown()
-
-	// WaitForCacheSync blocks until all started informers' caches were synced
-	// or the stop channel gets closed.
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-
-	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
-
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-	// client.
-	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	Cr() cr.Interface
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -33,6 +33,7 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -47,11 +47,6 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
-	// wg tracks how many goroutines were started.
-	wg sync.WaitGroup
-	// shuttingDown is true when Shutdown has been called. It may still be running
-	// because it needs to wait for goroutines.
-	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -112,39 +107,20 @@ func NewSharedInformerFactoryWithOptions(client clientset.Interface, defaultResy
 	return factory
 }
 
+// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	if f.shuttingDown {
-		return
-	}
-
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			go informer.Run(stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
 }
 
-func (f *sharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
-	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
-}
-
+// WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
@@ -191,57 +167,10 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
-//
-// It is typically used like this:
-//
-//	ctx, cancel := context.Background()
-//	defer cancel()
-//	factory := NewSharedInformerFactory(client, resyncPeriod)
-//	defer factory.WaitForStop()    // Returns immediately if nothing was started.
-//	genericInformer := factory.ForResource(resource)
-//	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
-//	}
-//
-//	// Creating informers can also be created after Start, but then
-//	// Start must be called again:
-//	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
-
-	// Start initializes all requested informers. They are handled in goroutines
-	// which run until the stop channel gets closed.
-	Start(stopCh <-chan struct{})
-
-	// Shutdown marks a factory as shutting down. At that point no new
-	// informers can be started anymore and Start will return without
-	// doing anything.
-	//
-	// In addition, Shutdown blocks until all goroutines have terminated. For that
-	// to happen, the close channel(s) that they were started with must be closed,
-	// either before Shutdown gets called or while it is waiting.
-	//
-	// Shutdown may be called multiple times, even concurrently. All such calls will
-	// block until all goroutines have terminated.
-	Shutdown()
-
-	// WaitForCacheSync blocks until all started informers' caches were synced
-	// or the stop channel gets closed.
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-
-	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
-
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-	// client.
-	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	Apiextensions() apiextensions.Interface
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -107,17 +107,35 @@ func NewSharedInformerFactoryWithOptions(client clientset.Interface, defaultResy
 	return factory
 }
 
-// Start initializes all requested informers.
-func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+func (f *sharedInformerFactory) start(stopCh <-chan struct{}) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			wg.Add(1)
+			informerCopy := informer
+			go func() {
+				defer wg.Done()
+				informerCopy.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	return wg
+}
+
+// Start initializes all requested informers.
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.start(stopCh)
+}
+
+// Run initializes all requested informers and blocks until they
+// all complete
+func (f *sharedInformerFactory) Run(stopCh <-chan struct{}) {
+	f.start(stopCh).Wait()
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -33,6 +33,7 @@ type NewInformerFunc func(clientset.Interface, time.Duration) cache.SharedIndexI
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/interface.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/interface.go
@@ -25,6 +25,7 @@ import (
 // DynamicSharedInformerFactory provides access to a shared informer and lister for dynamic client
 type DynamicSharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer
 	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
 }

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -65,11 +65,6 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
-	// wg tracks how many goroutines were started.
-	wg sync.WaitGroup
-	// shuttingDown is true when Shutdown has been called. It may still be running
-	// because it needs to wait for goroutines.
-	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -130,39 +125,20 @@ func NewSharedInformerFactoryWithOptions(client kubernetes.Interface, defaultRes
 	return factory
 }
 
+// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	if f.shuttingDown {
-		return
-	}
-
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			go informer.Run(stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
 }
 
-func (f *sharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
-	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
-}
-
+// WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
@@ -209,57 +185,10 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
-//
-// It is typically used like this:
-//
-//	ctx, cancel := context.Background()
-//	defer cancel()
-//	factory := NewSharedInformerFactory(client, resyncPeriod)
-//	defer factory.WaitForStop()    // Returns immediately if nothing was started.
-//	genericInformer := factory.ForResource(resource)
-//	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
-//	}
-//
-//	// Creating informers can also be created after Start, but then
-//	// Start must be called again:
-//	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
-
-	// Start initializes all requested informers. They are handled in goroutines
-	// which run until the stop channel gets closed.
-	Start(stopCh <-chan struct{})
-
-	// Shutdown marks a factory as shutting down. At that point no new
-	// informers can be started anymore and Start will return without
-	// doing anything.
-	//
-	// In addition, Shutdown blocks until all goroutines have terminated. For that
-	// to happen, the close channel(s) that they were started with must be closed,
-	// either before Shutdown gets called or while it is waiting.
-	//
-	// Shutdown may be called multiple times, even concurrently. All such calls will
-	// block until all goroutines have terminated.
-	Shutdown()
-
-	// WaitForCacheSync blocks until all started informers' caches were synced
-	// or the stop channel gets closed.
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-
-	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
-
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-	// client.
-	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	Admissionregistration() admissionregistration.Interface
 	Internal() apiserverinternal.Interface

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -125,17 +125,35 @@ func NewSharedInformerFactoryWithOptions(client kubernetes.Interface, defaultRes
 	return factory
 }
 
-// Start initializes all requested informers.
-func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+func (f *sharedInformerFactory) start(stopCh <-chan struct{}) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			wg.Add(1)
+			informerCopy := informer
+			go func() {
+				defer wg.Done()
+				informerCopy.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	return wg
+}
+
+// Start initializes all requested informers.
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.start(stopCh)
+}
+
+// Run initializes all requested informers and blocks until they
+// all complete
+func (f *sharedInformerFactory) Run(stopCh <-chan struct{}) {
+	f.start(stopCh).Wait()
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.

--- a/staging/src/k8s.io/client-go/informers/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/client-go/informers/internalinterfaces/factory_interfaces.go
@@ -33,6 +33,7 @@ type NewInformerFunc func(kubernetes.Interface, time.Duration) cache.SharedIndex
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/interface.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/interface.go
@@ -25,6 +25,7 @@ import (
 // SharedInformerFactory provides access to a shared informer and lister for dynamic client
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer
 	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
 }

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
@@ -114,11 +114,6 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[{{.reflectType|raw}}]bool
-	// wg tracks how many goroutines were started.
-	wg sync.WaitGroup
-	// shuttingDown is true when Shutdown has been called. It may still be running
-	// because it needs to wait for goroutines.
-	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -179,40 +174,20 @@ func NewSharedInformerFactoryWithOptions(client {{.clientSetInterface|raw}}, def
 	return factory
 }
 
+// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
-	f.lock.Lock()
-	defer f.lock.Unlock()
+  f.lock.Lock()
+  defer f.lock.Unlock()
 
-	if f.shuttingDown {
-		return
-	}
-
-	for informerType, informer := range f.informers {
-		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
-			f.startedInformers[informerType] = true
-		}
-	}
+  for informerType, informer := range f.informers {
+    if !f.startedInformers[informerType] {
+      go informer.Run(stopCh)
+      f.startedInformers[informerType] = true
+    }
+  }
 }
 
-func (f *sharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
-
-	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
-}
-
+// WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func()map[reflect.Type]cache.SharedIndexInformer{
                f.lock.Lock()
@@ -262,57 +237,10 @@ func (f *sharedInformerFactory) InformerFor(obj {{.runtimeObject|raw}}, newFunc 
 var sharedInformerFactoryInterface = `
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
-//
-// It is typically used like this:
-//
-//   ctx, cancel := context.Background()
-//   defer cancel()
-//   factory := NewSharedInformerFactory(client, resyncPeriod)
-//   defer factory.WaitForStop()    // Returns immediately if nothing was started.
-//   genericInformer := factory.ForResource(resource)
-//   typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//   factory.Start(ctx.Done())          // Start processing these informers.
-//   synced := factory.WaitForCacheSync(ctx.Done())
-//   for v, ok := range synced {
-//       if !ok {
-//           fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//           return
-//       }
-//   }
-//
-//   // Creating informers can also be created after Start, but then
-//   // Start must be called again:
-//   anotherGenericInformer := factory.ForResource(resource)
-//   factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	{{.informerFactoryInterface|raw}}
-
-	// Start initializes all requested informers. They are handled in goroutines
-	// which run until the stop channel gets closed.
-        Start(stopCh <-chan struct{})
-
-	// Shutdown marks a factory as shutting down. At that point no new
-	// informers can be started anymore and Start will return without
-	// doing anything.
-	//
-	// In addition, Shutdown blocks until all goroutines have terminated. For that
-	// to happen, the close channel(s) that they were started with must be closed,
-	// either before Shutdown gets called or while it is waiting.
-	//
-	// Shutdown may be called multiple times, even concurrently. All such calls will
-	// block until all goroutines have terminated.
-	Shutdown()
-
-	// WaitForCacheSync blocks until all started informers' caches were synced
-	// or the stop channel gets closed.
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-
-	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource {{.schemaGroupVersionResource|raw}}) (GenericInformer, error)
-
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-	// client.
-	InformerFor(obj {{.runtimeObject|raw}}, newFunc {{.interfacesNewInformerFunc|raw}}) {{.cacheSharedIndexInformer|raw}}
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	{{$gvInterfaces := .gvInterfaces}}
 	{{$gvGoNames := .gvGoNames}}

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
@@ -174,17 +174,35 @@ func NewSharedInformerFactoryWithOptions(client {{.clientSetInterface|raw}}, def
 	return factory
 }
 
+func (f *sharedInformerFactory) start(stopCh <-chan struct{}) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	for informerType, informer := range f.informers {
+		if !f.startedInformers[informerType] {
+			wg.Add(1)
+			informerCopy := informer
+			go func() {
+				defer wg.Done()
+				informerCopy.Run(stopCh)
+			}()
+			f.startedInformers[informerType] = true
+		}
+	}
+
+	return wg
+}
+
 // Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
-  f.lock.Lock()
-  defer f.lock.Unlock()
+	f.start(stopCh)
+}
 
-  for informerType, informer := range f.informers {
-    if !f.startedInformers[informerType] {
-      go informer.Run(stopCh)
-      f.startedInformers[informerType] = true
-    }
-  }
+// Run initializes all requested informers and blocks until they
+// all complete
+func (f *sharedInformerFactory) Run(stopCh <-chan struct{}) {
+	f.start(stopCh).Wait()
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factoryinterface.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factoryinterface.go
@@ -82,6 +82,7 @@ type NewInformerFunc func({{.clientSetPackage|raw}}, {{.timeDuration|raw}}) cach
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	InformerFor(obj {{.runtimeObject|raw}}, newFunc NewInformerFunc) {{.cacheSharedIndexInformer|raw}}
 }
 

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
@@ -107,17 +107,35 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
-// Start initializes all requested informers.
-func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+func (f *sharedInformerFactory) start(stopCh <-chan struct{}) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			wg.Add(1)
+			informerCopy := informer
+			go func() {
+				defer wg.Done()
+				informerCopy.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	return wg
+}
+
+// Start initializes all requested informers.
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.start(stopCh)
+}
+
+// Run initializes all requested informers and blocks until they
+// all complete
+func (f *sharedInformerFactory) Run(stopCh <-chan struct{}) {
+	f.start(stopCh).Wait()
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
@@ -47,11 +47,6 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
-	// wg tracks how many goroutines were started.
-	wg sync.WaitGroup
-	// shuttingDown is true when Shutdown has been called. It may still be running
-	// because it needs to wait for goroutines.
-	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -112,39 +107,20 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
+// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	if f.shuttingDown {
-		return
-	}
-
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			go informer.Run(stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
 }
 
-func (f *sharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
-	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
-}
-
+// WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
@@ -191,57 +167,10 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
-//
-// It is typically used like this:
-//
-//	ctx, cancel := context.Background()
-//	defer cancel()
-//	factory := NewSharedInformerFactory(client, resyncPeriod)
-//	defer factory.WaitForStop()    // Returns immediately if nothing was started.
-//	genericInformer := factory.ForResource(resource)
-//	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
-//	}
-//
-//	// Creating informers can also be created after Start, but then
-//	// Start must be called again:
-//	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
-
-	// Start initializes all requested informers. They are handled in goroutines
-	// which run until the stop channel gets closed.
-	Start(stopCh <-chan struct{})
-
-	// Shutdown marks a factory as shutting down. At that point no new
-	// informers can be started anymore and Start will return without
-	// doing anything.
-	//
-	// In addition, Shutdown blocks until all goroutines have terminated. For that
-	// to happen, the close channel(s) that they were started with must be closed,
-	// either before Shutdown gets called or while it is waiting.
-	//
-	// Shutdown may be called multiple times, even concurrently. All such calls will
-	// block until all goroutines have terminated.
-	Shutdown()
-
-	// WaitForCacheSync blocks until all started informers' caches were synced
-	// or the stop channel gets closed.
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-
-	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
-
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-	// client.
-	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	ExampleGroup() example.Interface
 }

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -33,6 +33,7 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
@@ -107,17 +107,35 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
-// Start initializes all requested informers.
-func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+func (f *sharedInformerFactory) start(stopCh <-chan struct{}) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			wg.Add(1)
+			informerCopy := informer
+			go func() {
+				defer wg.Done()
+				informerCopy.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	return wg
+}
+
+// Start initializes all requested informers.
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.start(stopCh)
+}
+
+// Run initializes all requested informers and blocks until they
+// all complete
+func (f *sharedInformerFactory) Run(stopCh <-chan struct{}) {
+	f.start(stopCh).Wait()
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
@@ -47,11 +47,6 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
-	// wg tracks how many goroutines were started.
-	wg sync.WaitGroup
-	// shuttingDown is true when Shutdown has been called. It may still be running
-	// because it needs to wait for goroutines.
-	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -112,39 +107,20 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
+// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	if f.shuttingDown {
-		return
-	}
-
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			go informer.Run(stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
 }
 
-func (f *sharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
-	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
-}
-
+// WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
@@ -191,57 +167,10 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
-//
-// It is typically used like this:
-//
-//	ctx, cancel := context.Background()
-//	defer cancel()
-//	factory := NewSharedInformerFactory(client, resyncPeriod)
-//	defer factory.WaitForStop()    // Returns immediately if nothing was started.
-//	genericInformer := factory.ForResource(resource)
-//	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
-//	}
-//
-//	// Creating informers can also be created after Start, but then
-//	// Start must be called again:
-//	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
-
-	// Start initializes all requested informers. They are handled in goroutines
-	// which run until the stop channel gets closed.
-	Start(stopCh <-chan struct{})
-
-	// Shutdown marks a factory as shutting down. At that point no new
-	// informers can be started anymore and Start will return without
-	// doing anything.
-	//
-	// In addition, Shutdown blocks until all goroutines have terminated. For that
-	// to happen, the close channel(s) that they were started with must be closed,
-	// either before Shutdown gets called or while it is waiting.
-	//
-	// Shutdown may be called multiple times, even concurrently. All such calls will
-	// block until all goroutines have terminated.
-	Shutdown()
-
-	// WaitForCacheSync blocks until all started informers' caches were synced
-	// or the stop channel gets closed.
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-
-	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
-
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-	// client.
-	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	Example() example.Interface
 }

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -33,6 +33,7 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
@@ -109,17 +109,35 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
-// Start initializes all requested informers.
-func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+func (f *sharedInformerFactory) start(stopCh <-chan struct{}) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			wg.Add(1)
+			informerCopy := informer
+			go func() {
+				defer wg.Done()
+				informerCopy.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	return wg
+}
+
+// Start initializes all requested informers.
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.start(stopCh)
+}
+
+// Run initializes all requested informers and blocks until they
+// all complete
+func (f *sharedInformerFactory) Run(stopCh <-chan struct{}) {
+	f.start(stopCh).Wait()
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
@@ -49,11 +49,6 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
-	// wg tracks how many goroutines were started.
-	wg sync.WaitGroup
-	// shuttingDown is true when Shutdown has been called. It may still be running
-	// because it needs to wait for goroutines.
-	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -114,39 +109,20 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
+// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	if f.shuttingDown {
-		return
-	}
-
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			go informer.Run(stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
 }
 
-func (f *sharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
-	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
-}
-
+// WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
@@ -193,57 +169,10 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
-//
-// It is typically used like this:
-//
-//	ctx, cancel := context.Background()
-//	defer cancel()
-//	factory := NewSharedInformerFactory(client, resyncPeriod)
-//	defer factory.WaitForStop()    // Returns immediately if nothing was started.
-//	genericInformer := factory.ForResource(resource)
-//	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
-//	}
-//
-//	// Creating informers can also be created after Start, but then
-//	// Start must be called again:
-//	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
-
-	// Start initializes all requested informers. They are handled in goroutines
-	// which run until the stop channel gets closed.
-	Start(stopCh <-chan struct{})
-
-	// Shutdown marks a factory as shutting down. At that point no new
-	// informers can be started anymore and Start will return without
-	// doing anything.
-	//
-	// In addition, Shutdown blocks until all goroutines have terminated. For that
-	// to happen, the close channel(s) that they were started with must be closed,
-	// either before Shutdown gets called or while it is waiting.
-	//
-	// Shutdown may be called multiple times, even concurrently. All such calls will
-	// block until all goroutines have terminated.
-	Shutdown()
-
-	// WaitForCacheSync blocks until all started informers' caches were synced
-	// or the stop channel gets closed.
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-
-	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
-
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-	// client.
-	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	Example() example.Interface
 	SecondExample() example2.Interface

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -33,6 +33,7 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/factory.go
@@ -49,11 +49,6 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
-	// wg tracks how many goroutines were started.
-	wg sync.WaitGroup
-	// shuttingDown is true when Shutdown has been called. It may still be running
-	// because it needs to wait for goroutines.
-	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -114,39 +109,20 @@ func NewSharedInformerFactoryWithOptions(client internalversion.Interface, defau
 	return factory
 }
 
+// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	if f.shuttingDown {
-		return
-	}
-
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			go informer.Run(stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
 }
 
-func (f *sharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
-	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
-}
-
+// WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
@@ -193,57 +169,10 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
-//
-// It is typically used like this:
-//
-//	ctx, cancel := context.Background()
-//	defer cancel()
-//	factory := NewSharedInformerFactory(client, resyncPeriod)
-//	defer factory.WaitForStop()    // Returns immediately if nothing was started.
-//	genericInformer := factory.ForResource(resource)
-//	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
-//	}
-//
-//	// Creating informers can also be created after Start, but then
-//	// Start must be called again:
-//	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
-
-	// Start initializes all requested informers. They are handled in goroutines
-	// which run until the stop channel gets closed.
-	Start(stopCh <-chan struct{})
-
-	// Shutdown marks a factory as shutting down. At that point no new
-	// informers can be started anymore and Start will return without
-	// doing anything.
-	//
-	// In addition, Shutdown blocks until all goroutines have terminated. For that
-	// to happen, the close channel(s) that they were started with must be closed,
-	// either before Shutdown gets called or while it is waiting.
-	//
-	// Shutdown may be called multiple times, even concurrently. All such calls will
-	// block until all goroutines have terminated.
-	Shutdown()
-
-	// WaitForCacheSync blocks until all started informers' caches were synced
-	// or the stop channel gets closed.
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-
-	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
-
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-	// client.
-	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	Example() example.Interface
 	SecondExample() example2.Interface

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/factory.go
@@ -109,17 +109,35 @@ func NewSharedInformerFactoryWithOptions(client internalversion.Interface, defau
 	return factory
 }
 
-// Start initializes all requested informers.
-func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+func (f *sharedInformerFactory) start(stopCh <-chan struct{}) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			wg.Add(1)
+			informerCopy := informer
+			go func() {
+				defer wg.Done()
+				informerCopy.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	return wg
+}
+
+// Start initializes all requested informers.
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.start(stopCh)
+}
+
+// Run initializes all requested informers and blocks until they
+// all complete
+func (f *sharedInformerFactory) Run(stopCh <-chan struct{}) {
+	f.start(stopCh).Wait()
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/internalinterfaces/factory_interfaces.go
@@ -33,6 +33,7 @@ type NewInformerFunc func(internalversion.Interface, time.Duration) cache.Shared
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
@@ -48,11 +48,6 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
-	// wg tracks how many goroutines were started.
-	wg sync.WaitGroup
-	// shuttingDown is true when Shutdown has been called. It may still be running
-	// because it needs to wait for goroutines.
-	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -113,39 +108,20 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
+// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	if f.shuttingDown {
-		return
-	}
-
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			go informer.Run(stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
 }
 
-func (f *sharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
-	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
-}
-
+// WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
@@ -192,57 +168,10 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
-//
-// It is typically used like this:
-//
-//	ctx, cancel := context.Background()
-//	defer cancel()
-//	factory := NewSharedInformerFactory(client, resyncPeriod)
-//	defer factory.WaitForStop()    // Returns immediately if nothing was started.
-//	genericInformer := factory.ForResource(resource)
-//	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
-//	}
-//
-//	// Creating informers can also be created after Start, but then
-//	// Start must be called again:
-//	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
-
-	// Start initializes all requested informers. They are handled in goroutines
-	// which run until the stop channel gets closed.
-	Start(stopCh <-chan struct{})
-
-	// Shutdown marks a factory as shutting down. At that point no new
-	// informers can be started anymore and Start will return without
-	// doing anything.
-	//
-	// In addition, Shutdown blocks until all goroutines have terminated. For that
-	// to happen, the close channel(s) that they were started with must be closed,
-	// either before Shutdown gets called or while it is waiting.
-	//
-	// Shutdown may be called multiple times, even concurrently. All such calls will
-	// block until all goroutines have terminated.
-	Shutdown()
-
-	// WaitForCacheSync blocks until all started informers' caches were synced
-	// or the stop channel gets closed.
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-
-	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
-
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-	// client.
-	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	Example() example.Interface
 	SecondExample() example2.Interface

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
@@ -108,17 +108,35 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
-// Start initializes all requested informers.
-func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+func (f *sharedInformerFactory) start(stopCh <-chan struct{}) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			wg.Add(1)
+			informerCopy := informer
+			go func() {
+				defer wg.Done()
+				informerCopy.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	return wg
+}
+
+// Start initializes all requested informers.
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.start(stopCh)
+}
+
+// Run initializes all requested informers and blocks until they
+// all complete
+func (f *sharedInformerFactory) Run(stopCh <-chan struct{}) {
+	f.start(stopCh).Wait()
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -33,6 +33,7 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -107,17 +107,35 @@ func NewSharedInformerFactoryWithOptions(client clientset.Interface, defaultResy
 	return factory
 }
 
-// Start initializes all requested informers.
-func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+func (f *sharedInformerFactory) start(stopCh <-chan struct{}) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			wg.Add(1)
+			informerCopy := informer
+			go func() {
+				defer wg.Done()
+				informerCopy.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	return wg
+}
+
+// Start initializes all requested informers.
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.start(stopCh)
+}
+
+// Run initializes all requested informers and blocks until they
+// all complete
+func (f *sharedInformerFactory) Run(stopCh <-chan struct{}) {
+	f.start(stopCh).Wait()
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -47,11 +47,6 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
-	// wg tracks how many goroutines were started.
-	wg sync.WaitGroup
-	// shuttingDown is true when Shutdown has been called. It may still be running
-	// because it needs to wait for goroutines.
-	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -112,39 +107,20 @@ func NewSharedInformerFactoryWithOptions(client clientset.Interface, defaultResy
 	return factory
 }
 
+// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	if f.shuttingDown {
-		return
-	}
-
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			go informer.Run(stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
 }
 
-func (f *sharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
-	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
-}
-
+// WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
@@ -191,57 +167,10 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
-//
-// It is typically used like this:
-//
-//	ctx, cancel := context.Background()
-//	defer cancel()
-//	factory := NewSharedInformerFactory(client, resyncPeriod)
-//	defer factory.WaitForStop()    // Returns immediately if nothing was started.
-//	genericInformer := factory.ForResource(resource)
-//	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
-//	}
-//
-//	// Creating informers can also be created after Start, but then
-//	// Start must be called again:
-//	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
-
-	// Start initializes all requested informers. They are handled in goroutines
-	// which run until the stop channel gets closed.
-	Start(stopCh <-chan struct{})
-
-	// Shutdown marks a factory as shutting down. At that point no new
-	// informers can be started anymore and Start will return without
-	// doing anything.
-	//
-	// In addition, Shutdown blocks until all goroutines have terminated. For that
-	// to happen, the close channel(s) that they were started with must be closed,
-	// either before Shutdown gets called or while it is waiting.
-	//
-	// Shutdown may be called multiple times, even concurrently. All such calls will
-	// block until all goroutines have terminated.
-	Shutdown()
-
-	// WaitForCacheSync blocks until all started informers' caches were synced
-	// or the stop channel gets closed.
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-
-	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
-
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-	// client.
-	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	Apiregistration() apiregistration.Interface
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -33,6 +33,7 @@ type NewInformerFunc func(clientset.Interface, time.Duration) cache.SharedIndexI
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
@@ -107,17 +107,35 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
-// Start initializes all requested informers.
-func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+func (f *sharedInformerFactory) start(stopCh <-chan struct{}) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			wg.Add(1)
+			informerCopy := informer
+			go func() {
+				defer wg.Done()
+				informerCopy.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	return wg
+}
+
+// Start initializes all requested informers.
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.start(stopCh)
+}
+
+// Run initializes all requested informers and blocks until they
+// all complete
+func (f *sharedInformerFactory) Run(stopCh <-chan struct{}) {
+	f.start(stopCh).Wait()
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
@@ -47,11 +47,6 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
-	// wg tracks how many goroutines were started.
-	wg sync.WaitGroup
-	// shuttingDown is true when Shutdown has been called. It may still be running
-	// because it needs to wait for goroutines.
-	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -112,39 +107,20 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
+// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	if f.shuttingDown {
-		return
-	}
-
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			go informer.Run(stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
 }
 
-func (f *sharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
-	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
-}
-
+// WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
@@ -191,57 +167,10 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
-//
-// It is typically used like this:
-//
-//	ctx, cancel := context.Background()
-//	defer cancel()
-//	factory := NewSharedInformerFactory(client, resyncPeriod)
-//	defer factory.WaitForStop()    // Returns immediately if nothing was started.
-//	genericInformer := factory.ForResource(resource)
-//	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
-//	}
-//
-//	// Creating informers can also be created after Start, but then
-//	// Start must be called again:
-//	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
-
-	// Start initializes all requested informers. They are handled in goroutines
-	// which run until the stop channel gets closed.
-	Start(stopCh <-chan struct{})
-
-	// Shutdown marks a factory as shutting down. At that point no new
-	// informers can be started anymore and Start will return without
-	// doing anything.
-	//
-	// In addition, Shutdown blocks until all goroutines have terminated. For that
-	// to happen, the close channel(s) that they were started with must be closed,
-	// either before Shutdown gets called or while it is waiting.
-	//
-	// Shutdown may be called multiple times, even concurrently. All such calls will
-	// block until all goroutines have terminated.
-	Shutdown()
-
-	// WaitForCacheSync blocks until all started informers' caches were synced
-	// or the stop channel gets closed.
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-
-	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
-
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-	// client.
-	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	Wardle() wardle.Interface
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -33,6 +33,7 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
@@ -107,17 +107,35 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
-// Start initializes all requested informers.
-func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+func (f *sharedInformerFactory) start(stopCh <-chan struct{}) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			wg.Add(1)
+			informerCopy := informer
+			go func() {
+				defer wg.Done()
+				informerCopy.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	return wg
+}
+
+// Start initializes all requested informers.
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.start(stopCh)
+}
+
+// Run initializes all requested informers and blocks until they
+// all complete
+func (f *sharedInformerFactory) Run(stopCh <-chan struct{}) {
+	f.start(stopCh).Wait()
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
@@ -47,11 +47,6 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
-	// wg tracks how many goroutines were started.
-	wg sync.WaitGroup
-	// shuttingDown is true when Shutdown has been called. It may still be running
-	// because it needs to wait for goroutines.
-	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -112,39 +107,20 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 	return factory
 }
 
+// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	if f.shuttingDown {
-		return
-	}
-
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			go informer.Run(stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
 }
 
-func (f *sharedInformerFactory) Shutdown() {
-	f.lock.Lock()
-	f.shuttingDown = true
-	f.lock.Unlock()
-
-	// Will return immediately if there is nothing to wait for.
-	f.wg.Wait()
-}
-
+// WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
@@ -191,57 +167,10 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
-//
-// It is typically used like this:
-//
-//	ctx, cancel := context.Background()
-//	defer cancel()
-//	factory := NewSharedInformerFactory(client, resyncPeriod)
-//	defer factory.WaitForStop()    // Returns immediately if nothing was started.
-//	genericInformer := factory.ForResource(resource)
-//	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
-//	}
-//
-//	// Creating informers can also be created after Start, but then
-//	// Start must be called again:
-//	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
-
-	// Start initializes all requested informers. They are handled in goroutines
-	// which run until the stop channel gets closed.
-	Start(stopCh <-chan struct{})
-
-	// Shutdown marks a factory as shutting down. At that point no new
-	// informers can be started anymore and Start will return without
-	// doing anything.
-	//
-	// In addition, Shutdown blocks until all goroutines have terminated. For that
-	// to happen, the close channel(s) that they were started with must be closed,
-	// either before Shutdown gets called or while it is waiting.
-	//
-	// Shutdown may be called multiple times, even concurrently. All such calls will
-	// block until all goroutines have terminated.
-	Shutdown()
-
-	// WaitForCacheSync blocks until all started informers' caches were synced
-	// or the stop channel gets closed.
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-
-	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
-
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-	// client.
-	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	Samplecontroller() samplecontroller.Interface
 }

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -33,6 +33,7 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
+	Run(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
#### What this PR does / why we need it:

Following up discussion from https://github.com/kubernetes/kubernetes/pull/114434#discussion_r1048820259

Reverts a change that added `Shutdown` to `SharedInformerFactory`, and instead replaces it and its usages with a more idiomatic `Run` implementation. Also does the same to `DynamicInformerFactory` as well as `MetadataInformerFactory`.

/sig api-machinery
/triage accepted
/cc @apelisse  @lavalamp @howardjohn @pohly 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #114434
Reverts #112200

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

