### PR TITLE
Remove redundant subsystem in kube-apiserver pod logs metrics name

### DIFF
--- a/pkg/registry/core/pod/rest/log.go
+++ b/pkg/registry/core/pod/rest/log.go
@@ -94,13 +94,14 @@ func (r *LogREST) Get(ctx context.Context, name string, opts runtime.Object) (ru
 		return nil, err
 	}
 	return &genericrest.LocationStreamer{
-		Location:                    location,
-		Transport:                   transport,
-		ContentType:                 "text/plain",
-		Flush:                       logOpts.Follow,
-		ResponseChecker:             genericrest.NewGenericHttpResponseChecker(api.Resource("pods/log"), name),
-		RedirectChecker:             genericrest.PreventRedirects,
-		TLSVerificationErrorCounter: podLogsTLSFailure,
+		Location:                              location,
+		Transport:                             transport,
+		ContentType:                           "text/plain",
+		Flush:                                 logOpts.Follow,
+		ResponseChecker:                       genericrest.NewGenericHttpResponseChecker(api.Resource("pods/log"), name),
+		RedirectChecker:                       genericrest.PreventRedirects,
+		TLSVerificationErrorCounter:           podLogsTLSFailure,
+		DeprecatedTLSVerificationErrorCounter: deprecatedPodLogsTLSFailure,
 	}, nil
 }
 
@@ -116,6 +117,13 @@ func countSkipTLSMetric(insecureSkipTLSVerifyBackend bool) {
 		return
 	}
 	counter.Inc()
+
+	deprecatedCounter, err := deprecatedPodLogsUsage.GetMetricWithLabelValues(usageType)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	deprecatedCounter.Inc()
 }
 
 // NewGetOptions creates a new options object

--- a/pkg/registry/core/pod/rest/metrics.go
+++ b/pkg/registry/core/pod/rest/metrics.go
@@ -37,9 +37,22 @@ var (
 		&metrics.CounterOpts{
 			Namespace:      namespace,
 			Subsystem:      subsystem,
-			Name:           "pods_logs_insecure_backend_total",
+			Name:           "insecure_backend_total",
 			Help:           "Total number of requests for pods/logs sliced by usage type: enforce_tls, skip_tls_allowed, skip_tls_denied",
 			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"usage"},
+	)
+
+	// deprecatedPodLogsUsage counts and categorizes how the insecure backend skip TLS option is used and allowed.
+	deprecatedPodLogsUsage = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:         namespace,
+			Subsystem:         subsystem,
+			Name:              "pods_logs_insecure_backend_total",
+			Help:              "Total number of requests for pods/logs sliced by usage type: enforce_tls, skip_tls_allowed, skip_tls_denied",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.27.0",
 		},
 		[]string{"usage"},
 	)
@@ -49,9 +62,21 @@ var (
 		&metrics.CounterOpts{
 			Namespace:      namespace,
 			Subsystem:      subsystem,
-			Name:           "pods_logs_backend_tls_failure_total",
+			Name:           "backend_tls_failure_total",
 			Help:           "Total number of requests for pods/logs that failed due to kubelet server TLS verification",
 			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	// deprecatedPodLogsTLSFailure counts how many attempts to get pod logs fail on tls verification
+	deprecatedPodLogsTLSFailure = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Namespace:         namespace,
+			Subsystem:         subsystem,
+			Name:              "pods_logs_backend_tls_failure_total",
+			Help:              "Total number of requests for pods/logs that failed due to kubelet server TLS verification",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.27.0",
 		},
 	)
 )
@@ -62,5 +87,7 @@ func registerMetrics() {
 	registerMetricsOnce.Do(func() {
 		legacyregistry.MustRegister(podLogsUsage)
 		legacyregistry.MustRegister(podLogsTLSFailure)
+		legacyregistry.MustRegister(deprecatedPodLogsUsage)
+		legacyregistry.MustRegister(deprecatedPodLogsTLSFailure)
 	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer.go
@@ -46,6 +46,10 @@ type LocationStreamer struct {
 	// TLSVerificationErrorCounter is an optional value that will Inc every time a TLS error is encountered.  This can
 	// be wired a single prometheus counter instance to get counts overall.
 	TLSVerificationErrorCounter CounterMetric
+	// DeprecatedTLSVerificationErrorCounter is a temporary field used to rename
+	// the kube_apiserver_pod_logs_pods_logs_backend_tls_failure_total metric
+	// with a one release deprecation period in 1.27.0.
+	DeprecatedTLSVerificationErrorCounter CounterMetric
 }
 
 // a LocationStreamer must implement a rest.ResourceStreamer
@@ -87,6 +91,9 @@ func (s *LocationStreamer) InputStream(ctx context.Context, apiVersion, acceptHe
 		// TODO prefer segregate TLS errors more reliably, but we do want to increment a count
 		if strings.Contains(err.Error(), "x509:") && s.TLSVerificationErrorCounter != nil {
 			s.TLSVerificationErrorCounter.Inc()
+			if s.DeprecatedTLSVerificationErrorCounter != nil {
+				s.DeprecatedTLSVerificationErrorCounter.Inc()
+			}
 		}
 		return nil, false, "", err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The pod_logs subsystem was inadvertently made redundant in the following
kube-apiserver metrics:
- kube_apiserver_pod_logs_pods_logs_backend_tls_failure_total
- kube_apiserver_pod_logs_pods_logs_insecure_backend_total

Since these metrics have been added 2 years ago, it is safer to deprecate the original ones in 1.27 and give them a one release deprecation period.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduce new metrics removing the redundant subsystem in kube-apiserver pod logs metrics and deprecate the original ones:
- kube_apiserver_pod_logs_pods_logs_backend_tls_failure_total becomes kube_apiserver_pod_logs_backend_tls_failure_total
- kube_apiserver_pod_logs_pods_logs_insecure_backend_total becomes kube_apiserver_pod_logs_insecure_backend_total
```

/cc @logicalhan 