### PR TITLE
Add maximum TLS version option to the tls.Config of apiserver.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -303,6 +303,10 @@ type SecureServingInfo struct {
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 	MinTLSVersion uint16
 
+	// MaxTLSVersion optionally overrides the maximum TLS version supported.
+	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+	MaxTLSVersion uint16
+
 	// CipherSuites optionally overrides the list of allowed cipher suites for the server.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 	CipherSuites []uint16

--- a/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -60,6 +60,9 @@ func (s *SecureServingInfo) tlsConfig(stopCh <-chan struct{}) (*tls.Config, erro
 	if s.MinTLSVersion > 0 {
 		tlsConfig.MinVersion = s.MinTLSVersion
 	}
+	if s.MaxTLSVersion > 0 {
+		tlsConfig.MaxVersion = s.MaxTLSVersion
+	}
 	if len(s.CipherSuites) > 0 {
 		tlsConfig.CipherSuites = s.CipherSuites
 		insecureCiphers := flag.InsecureTLSCiphers()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Currently, it is possible to specify a MinTLSVersion for the apiserver project, but not possible to specify a MaxTLSVersion. Under some conditions, setting a MaxTLSVersion may be necessary. For example when you are FIPS validated only for specific TLS versions. This PR adds the configuration value for MaxTLSVersion, such that you can specify it as a run time arg.
For example: 
"--tls-max-version=VersionTLS12"
If specified, the tls.Config in secure_serving.go will be populated and the apiserver will only serve traffic according to your settings.

Variable and flag names have been chosen to be consistent with MinTLSVersion. 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Adds optional `--tls-max-version` command line argument to kube-apiserver.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

