### PR TITLE
kubeapiserver/admission: Improving test coverage

### DIFF
--- a/pkg/kubeapiserver/admission/initializer_test.go
+++ b/pkg/kubeapiserver/admission/initializer_test.go
@@ -20,7 +20,10 @@ import (
 	"context"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
+	quota "k8s.io/apiserver/pkg/quota/v1"
 )
 
 type doNothingAdmission struct{}
@@ -30,6 +33,10 @@ func (doNothingAdmission) Admit(ctx context.Context, a admission.Attributes, o a
 }
 func (doNothingAdmission) Handles(o admission.Operation) bool { return false }
 func (doNothingAdmission) Validate() error                    { return nil }
+
+type doNothingPluginInitialization struct{}
+
+func (doNothingPluginInitialization) ValidateInitialization() error { return nil }
 
 type WantsCloudConfigAdmissionPlugin struct {
 	doNothingAdmission
@@ -48,5 +55,77 @@ func TestCloudConfigAdmissionPlugin(t *testing.T) {
 
 	if wantsCloudConfigAdmission.cloudConfig == nil {
 		t.Errorf("Expected cloud config to be initialized but found nil")
+	}
+}
+
+type doNothingRESTMapper struct{}
+
+func (doNothingRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, nil
+}
+func (doNothingRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, nil
+}
+func (doNothingRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, nil
+}
+func (doNothingRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, nil
+}
+func (doNothingRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	return nil, nil
+}
+func (doNothingRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	return nil, nil
+}
+func (doNothingRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	return "", nil
+}
+
+type WantsRESTMapperAdmissionPlugin struct {
+	doNothingAdmission
+	doNothingPluginInitialization
+	mapper meta.RESTMapper
+}
+
+func (p *WantsRESTMapperAdmissionPlugin) SetRESTMapper(mapper meta.RESTMapper) {
+	p.mapper = mapper
+}
+
+func TestRESTMapperAdmissionPlugin(t *testing.T) {
+	mapper := doNothingRESTMapper{}
+	initializer := NewPluginInitializer(nil, mapper, nil)
+	wantsRESTMapperAdmission := &WantsRESTMapperAdmissionPlugin{}
+	initializer.Initialize(wantsRESTMapperAdmission)
+
+	if wantsRESTMapperAdmission.mapper == nil {
+		t.Errorf("Expected REST mapper to be initialized but found nil")
+	}
+}
+
+type doNothingQuotaConfiguration struct{}
+
+func (doNothingQuotaConfiguration) IgnoredResources() map[schema.GroupResource]struct{} { return nil }
+
+func (doNothingQuotaConfiguration) Evaluators() []quota.Evaluator { return nil }
+
+type WantsQuotaConfigurationAdmissionPlugin struct {
+	doNothingAdmission
+	doNothingPluginInitialization
+	config quota.Configuration
+}
+
+func (p *WantsQuotaConfigurationAdmissionPlugin) SetQuotaConfiguration(config quota.Configuration) {
+	p.config = config
+}
+
+func TestQuotaConfigurationAdmissionPlugin(t *testing.T) {
+	config := doNothingQuotaConfiguration{}
+	initializer := NewPluginInitializer(nil, nil, config)
+	wantsQuotaConfigurationAdmission := &WantsQuotaConfigurationAdmissionPlugin{}
+	initializer.Initialize(wantsQuotaConfigurationAdmission)
+
+	if wantsQuotaConfigurationAdmission.config == nil {
+		t.Errorf("Expected quota configuration to be initialized but found nil")
 	}
 }


### PR DESCRIPTION
Signed-off-by: TommyStarK <thomasmilox@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If applied this commit will increase the unit tests code coverage of `pkg/kubeapiserver/admission/initializer.go`

- Initial unit tests code coverage

![Screenshot 2022-12-15 at 13 17 16](https://user-images.githubusercontent.com/9576370/207857581-946f6de7-c55d-4280-a3a9-42d1ecec1963.png)

- After changes

![Screenshot 2022-12-15 at 13 19 47](https://user-images.githubusercontent.com/9576370/207857795-9214c94e-817f-417e-b354-11780f78c67b.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
