### PR TITLE
unittests: Fixes unit tests for Windows (part 6)

### DIFF
--- a/pkg/kubelet/images/image_gc_manager_test.go
+++ b/pkg/kubelet/images/image_gc_manager_test.go
@@ -19,6 +19,7 @@ package images
 import (
 	"context"
 	"fmt"
+	goruntime "runtime"
 	"testing"
 	"time"
 
@@ -463,6 +464,13 @@ func TestFreeSpaceRemoveByLeastRecentlyUsed(t *testing.T) {
 				makeContainer(1),
 			},
 		}},
+	}
+	// manager.detectImages uses time.Now() to update the image's lastUsed field.
+	// On Windows, consecutive time.Now() calls can return the same timestamp, which would mean
+	// that the second image is NOT newer than the first one.
+	// time.Sleep will result in the timestamp to be updated as well.
+	if goruntime.GOOS == "windows" {
+		time.Sleep(time.Millisecond)
 	}
 	_, err = manager.detectImages(ctx, time.Now())
 	require.NoError(t, err)

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_windows_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_windows_test.go
@@ -86,6 +86,11 @@ func TestApplyPlatformSpecificContainerConfig(t *testing.T) {
 
 	limit := int64(3000)
 	expectedCpuMax := 10 * limit / int64(winstats.ProcessorCount())
+	// Above, we're setting the limit to 3 CPUs. But we can't expect more than 100% of the CPUs
+	// we have. (e.g.: if we only have 2 CPUs, we can't have 150% CPU max).
+	if expectedCpuMax > 10000 {
+		expectedCpuMax = 10000
+	}
 	expectedWindowsConfig := &runtimeapi.WindowsContainerConfig{
 		Resources: &runtimeapi.WindowsContainerResources{
 			CpuMaximum:         expectedCpuMax,

--- a/pkg/kubelet/server/stats/summary_windows_test.go
+++ b/pkg/kubelet/server/stats/summary_windows_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package stats
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 
 func TestSummaryProvider(t *testing.T) {
 	var (
+		ctx            = context.Background()
 		podStats       = []statsapi.PodStats{*getPodStats()}
 		imageFsStats   = getFsStats()
 		rootFsStats    = getFsStats()
@@ -60,9 +62,9 @@ func TestSummaryProvider(t *testing.T) {
 	mockStatsProvider.EXPECT().GetNode().Return(node, nil).AnyTimes()
 	mockStatsProvider.EXPECT().GetNodeConfig().Return(nodeConfig).AnyTimes()
 	mockStatsProvider.EXPECT().GetPodCgroupRoot().Return(cgroupRoot).AnyTimes()
-	mockStatsProvider.EXPECT().ListPodStats().Return(podStats, nil).AnyTimes()
-	mockStatsProvider.EXPECT().ListPodStatsAndUpdateCPUNanoCoreUsage().Return(podStats, nil).AnyTimes()
-	mockStatsProvider.EXPECT().ImageFsStats().Return(imageFsStats, nil).AnyTimes()
+	mockStatsProvider.EXPECT().ListPodStats(ctx).Return(podStats, nil).AnyTimes()
+	mockStatsProvider.EXPECT().ListPodStatsAndUpdateCPUNanoCoreUsage(ctx).Return(podStats, nil).AnyTimes()
+	mockStatsProvider.EXPECT().ImageFsStats(ctx).Return(imageFsStats, nil).AnyTimes()
 	mockStatsProvider.EXPECT().RootFsStats().Return(rootFsStats, nil).AnyTimes()
 	mockStatsProvider.EXPECT().RlimitStats().Return(nil, nil).AnyTimes()
 	mockStatsProvider.EXPECT().GetCgroupStats("/", true).Return(cgroupStatsMap["/"].cs, cgroupStatsMap["/"].ns, nil).AnyTimes()
@@ -70,7 +72,7 @@ func TestSummaryProvider(t *testing.T) {
 	kubeletCreationTime := metav1.Now()
 	systemBootTime := metav1.Now()
 	provider := summaryProviderImpl{kubeletCreationTime: kubeletCreationTime, systemBootTime: systemBootTime, provider: mockStatsProvider}
-	summary, err := provider.Get(true)
+	summary, err := provider.Get(ctx, true)
 	assert.NoError(err)
 
 	assert.Equal(summary.Node.NodeName, "test-node")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/sig testing
/sig windows

/kind failing-tests
/priority important-soon
/milestone v1.27

#### What this PR does / why we need it:

Currently, there are some unit tests that are failing on Windows due to various reasons:

- On Windows, consecutive ``time.Now()`` calls may return the same timestamp, which would cause the ``TestFreeSpaceRemoveByLeastRecentlyUsed`` test to flake.
- tests in ``kuberuntime_container_windows_test.go`` fail on Nodes that have fewer than 3 CPUs, expecting the CPU max set to be more than 100% of available CPUs, which is not possible.
- calls in ``summary_windows_test.go`` are missing context.
- ``filterTerminatedContainerInfoAndAssembleByPodCgroupKey`` will filter and group container information by the Pod cgroup key, if it exists. However, we don't have cgroups on Windows, thus we can't make the same assertions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related: https://github.com/kubernetes/kubernetes/issues/51540

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
