### PR TITLE
Automated cherry pick of #113283: Fix SPDY proxy authentication with special chars

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -185,11 +185,14 @@ func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 
 	//nolint:staticcheck // SA1019 ignore deprecated httputil.NewProxyClientConn
 	proxyClientConn := httputil.NewProxyClientConn(proxyDialConn, nil)
-	_, err = proxyClientConn.Do(&proxyReq)
+	response, err := proxyClientConn.Do(&proxyReq)
 	//nolint:staticcheck // SA1019 ignore deprecated httputil.ErrPersistEOF: it might be
 	// returned from the invocation of proxyClientConn.Do
 	if err != nil && err != httputil.ErrPersistEOF {
 		return nil, err
+	}
+	if response != nil && response.StatusCode >= 300 || response.StatusCode < 200 {
+		return nil, fmt.Errorf("CONNECT request to %s returned response: %s", proxyURL.Redacted(), response.Status)
 	}
 
 	rwc, _ := proxyClientConn.Hijack()

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -284,9 +284,10 @@ func (s *SpdyRoundTripper) proxyAuth(proxyURL *url.URL) string {
 	if proxyURL == nil || proxyURL.User == nil {
 		return ""
 	}
-	credentials := proxyURL.User.String()
-	encodedAuth := base64.StdEncoding.EncodeToString([]byte(credentials))
-	return fmt.Sprintf("Basic %s", encodedAuth)
+	username := proxyURL.User.Username()
+	password, _ := proxyURL.User.Password()
+	auth := username + ":" + password
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
 }
 
 // RoundTrip executes the Request and upgrades it. After a successful upgrade,

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
@@ -19,7 +19,6 @@ package spdy
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -240,6 +239,16 @@ func TestRoundTripAndNewConnection(t *testing.T) {
 					serverStatusCode:       http.StatusSwitchingProtocols,
 					shouldError:            false,
 				},
+				"proxied valid https, proxy auth with chars that percent escape -> valid https": {
+					serverFunc:             httpsServerValidHostname,
+					proxyServerFunc:        httpsServerValidHostname,
+					proxyAuth:              url.UserPassword("proxy user", "proxypasswd%"),
+					clientTLS:              &tls.Config{RootCAs: localhostPool},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false,
+				},
 			}
 
 			for k, testCase := range testCases {
@@ -368,16 +377,18 @@ func TestRoundTripAndNewConnection(t *testing.T) {
 					}
 				}
 
-				var expectedProxyAuth string
 				if testCase.proxyAuth != nil {
-					encodedCredentials := base64.StdEncoding.EncodeToString([]byte(testCase.proxyAuth.String()))
-					expectedProxyAuth = "Basic " + encodedCredentials
-				}
-				if len(expectedProxyAuth) == 0 && proxyCalledWithAuth {
-					t.Fatalf("%s: Proxy authorization unexpected, got %q", k, proxyCalledWithAuthHeader)
-				}
-				if proxyCalledWithAuthHeader != expectedProxyAuth {
-					t.Fatalf("%s: Expected to see a call to the proxy with credentials %q, got %q", k, testCase.proxyAuth, proxyCalledWithAuthHeader)
+					expectedUsername := testCase.proxyAuth.Username()
+					expectedPassword, _ := testCase.proxyAuth.Password()
+					username, password, ok := (&http.Request{Header: http.Header{"Authorization": []string{proxyCalledWithAuthHeader}}}).BasicAuth()
+					if !ok {
+						t.Fatalf("invalid proxy auth header %s", proxyCalledWithAuthHeader)
+					}
+					if username != expectedUsername || password != expectedPassword {
+						t.Fatalf("expected proxy auth \"%s:%s\", got \"%s:%s\"", expectedUsername, expectedPassword, username, password)
+					}
+				} else if proxyCalledWithAuth {
+					t.Fatalf("proxy authorization unexpected, got %q", proxyCalledWithAuthHeader)
 				}
 			}
 		})


### PR DESCRIPTION
Cherry pick of #113283 on release-1.23.

See https://github.com/kubernetes/kubernetes/pull/113283#issuecomment-1309411855 for context

#113283: Fix SPDY proxy authentication with special chars and improve error message when proxy connection fails

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```