### PR TITLE
graduate LegacyServiceAccountTokenTracking to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -478,6 +478,7 @@ const (
 	// owner: @zshihang
 	// kep: http://kep.k8s.io/2800
 	// alpha: v1.26
+	// beta: v1.27
 	//
 	// Enables tracking of secret-based service account tokens usage.
 	LegacyServiceAccountTokenTracking featuregate.Feature = "LegacyServiceAccountTokenTracking"
@@ -958,7 +959,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	LegacyServiceAccountTokenNoAutoGeneration: {Default: true, PreRelease: featuregate.GA},
 
-	LegacyServiceAccountTokenTracking: {Default: false, PreRelease: featuregate.Alpha},
+	LegacyServiceAccountTokenTracking: {Default: true, PreRelease: featuregate.Beta},
 
 	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -18,6 +18,7 @@ package authenticator
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
@@ -277,8 +278,12 @@ func newLegacyServiceAccountAuthenticator(keyfiles []string, lookup bool, apiAud
 		}
 		allPublicKeys = append(allPublicKeys, publicKeys...)
 	}
+	validator, err := serviceaccount.NewLegacyValidator(lookup, serviceAccountGetter, secretsWriter)
+	if err != nil {
+		return nil, fmt.Errorf("while creating legacy validator, err: %w", err)
+	}
 
-	tokenAuthenticator := serviceaccount.JWTTokenAuthenticator([]string{serviceaccount.LegacyIssuer}, allPublicKeys, apiAudiences, serviceaccount.NewLegacyValidator(lookup, serviceAccountGetter, secretsWriter))
+	tokenAuthenticator := serviceaccount.JWTTokenAuthenticator([]string{serviceaccount.LegacyIssuer}, allPublicKeys, apiAudiences, validator)
 	return tokenAuthenticator, nil
 }
 

--- a/pkg/serviceaccount/legacy.go
+++ b/pkg/serviceaccount/legacy.go
@@ -64,7 +64,7 @@ func NewLegacyValidator(lookup bool, getter ServiceAccountTokenGetter, secretsWr
 	if lookup && getter == nil {
 		return nil, errors.New("ServiceAccountTokenGetter must be provided")
 	}
-	if lookup && secretsWriter == nil {
+	if lookup && secretsWriter == nil && utilfeature.DefaultFeatureGate.Enabled(kubefeatures.LegacyServiceAccountTokenTracking) {
 		return nil, errors.New("SecretsWriter must be provided")
 	}
 	return &legacyValidator{

--- a/pkg/serviceaccount/legacy.go
+++ b/pkg/serviceaccount/legacy.go
@@ -60,12 +60,18 @@ type legacyPrivateClaims struct {
 	Namespace          string `json:"kubernetes.io/serviceaccount/namespace"`
 }
 
-func NewLegacyValidator(lookup bool, getter ServiceAccountTokenGetter, secretsWriter typedv1core.SecretsGetter) Validator {
+func NewLegacyValidator(lookup bool, getter ServiceAccountTokenGetter, secretsWriter typedv1core.SecretsGetter) (Validator, error) {
+	if lookup && getter == nil {
+		return nil, errors.New("ServiceAccountTokenGetter must be provided")
+	}
+	if lookup && secretsWriter == nil {
+		return nil, errors.New("SecretsWriter must be provided")
+	}
 	return &legacyValidator{
 		lookup:        lookup,
 		getter:        getter,
 		secretsWriter: secretsWriter,
-	}
+	}, nil
 }
 
 type legacyValidator struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Graduated the `LegacyServiceAccountTokenTracking` feature gate to Beta. The usage of auto-generated secret-based service account token now produces warnings by default, and relevant Secrets are labeled with a last-used timestamp (label key `kubernetes.io/legacy-token-last-used`).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2799-reduction-of-secret-based-service-account-token
```
