### PR TITLE
Fix installDriverToCSINode(): do not skip CSINode update if Allocatable.Count changed

### DIFF
--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
@@ -505,6 +505,15 @@ func setMigrationAnnotation(migratedPlugins map[string](func() bool), nodeInfo *
 	return true
 }
 
+// Returns true if and only if new maxAttachLimit doesn't require CSINode update
+func keepAllocatableCount(driverInfoSpec storagev1.CSINodeDriver, maxAttachLimit int64) bool {
+	if maxAttachLimit == 0 {
+		return driverInfoSpec.Allocatable == nil || driverInfoSpec.Allocatable.Count == nil
+	}
+
+	return driverInfoSpec.Allocatable != nil && driverInfoSpec.Allocatable.Count != nil && int64(*driverInfoSpec.Allocatable.Count) == maxAttachLimit
+}
+
 func (nim *nodeInfoManager) installDriverToCSINode(
 	nodeInfo *storagev1.CSINode,
 	driverName string,
@@ -528,7 +537,8 @@ func (nim *nodeInfoManager) installDriverToCSINode(
 	for _, driverInfoSpec := range nodeInfo.Spec.Drivers {
 		if driverInfoSpec.Name == driverName {
 			if driverInfoSpec.NodeID == driverNodeID &&
-				sets.NewString(driverInfoSpec.TopologyKeys...).Equal(topologyKeys) {
+				sets.NewString(driverInfoSpec.TopologyKeys...).Equal(topologyKeys) &&
+				keepAllocatableCount(driverInfoSpec, maxAttachLimit) {
 				specModified = false
 			}
 		} else {

--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
@@ -593,7 +593,7 @@ func TestInstallCSIDriver(t *testing.T) {
 							Name:         "com.example.csi.driver1",
 							NodeID:       "com.example.csi/csi-node1",
 							TopologyKeys: nil,
-							Allocatable:  generateVolumeLimits(10),
+							Allocatable:  generateVolumeLimits(20),
 						},
 					},
 				},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig storage
/triage accepted
/priority important-soon

#### What this PR does / why we need it:

If a CSI driver is updated on top of existing cluster, and new version of driver brings new volume limits, `kubelet` invokes `InstallCSIDriver()` from `nodeinfomanager.go`, but it skips CSINode update because `specModified` is set to `false` in `installDriverToCSINode()`. Consequently, end users keeps seeing older limits in `oc get csinode` output:

```
$ oc get csinodes <node-name> -o yaml
...
spec:
  drivers:
  - allocatable:
      count: 25
```

And `kube-scheduler` keeps using older value too.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

/cc @gnufied

#### Does this PR introduce a user-facing change?

```release-note
NONE
```