### PR TITLE
kubectl delete: Introduce new interactive flag for interactive deletion

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -121,6 +121,7 @@ type DeleteOptions struct {
 	Quiet               bool
 	WarnClusterScope    bool
 	Raw                 string
+	Interactive         bool
 
 	GracePeriod int
 	Timeout     time.Duration
@@ -129,9 +130,11 @@ type DeleteOptions struct {
 
 	Output string
 
-	DynamicClient dynamic.Interface
-	Mapper        meta.RESTMapper
-	Result        *resource.Result
+	DynamicClient      dynamic.Interface
+	Mapper             meta.RESTMapper
+	Result             *resource.Result
+	PreviewResult      *resource.Result
+	previewResourceMap map[cmdwait.ResourceLocation]struct{}
 
 	genericiooptions.IOStreams
 	WarningPrinter *printers.WarningPrinter
@@ -197,8 +200,38 @@ func (o *DeleteOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Co
 		return err
 	}
 
-	if len(o.Raw) == 0 {
-		r := f.NewBuilder().
+	// Set default WarningPrinter if not already set.
+	if o.WarningPrinter == nil {
+		o.WarningPrinter = printers.NewWarningPrinter(o.ErrOut, printers.WarningPrinterOptions{Color: term.AllowsColorOutput(o.ErrOut)})
+	}
+
+	if len(o.Raw) != 0 {
+		return nil
+	}
+
+	r := f.NewBuilder().
+		Unstructured().
+		ContinueOnError().
+		NamespaceParam(cmdNamespace).DefaultNamespace().
+		FilenameParam(enforceNamespace, &o.FilenameOptions).
+		LabelSelectorParam(o.LabelSelector).
+		FieldSelectorParam(o.FieldSelector).
+		SelectAllParam(o.DeleteAll).
+		AllNamespaces(o.DeleteAllNamespaces).
+		ResourceTypeOrNameArgs(false, args...).RequireObject(false).
+		Flatten().
+		Do()
+	err = r.Err()
+	if err != nil {
+		return err
+	}
+	o.Result = r
+
+	if o.Interactive {
+		// preview result will be used to list resources for confirmation prior to actual delete.
+		// We can not use r as result object because it can only be used once. But we need to traverse
+		// twice. Parameters in preview result must be equal to genuine result.
+		previewr := f.NewBuilder().
 			Unstructured().
 			ContinueOnError().
 			NamespaceParam(cmdNamespace).DefaultNamespace().
@@ -210,26 +243,22 @@ func (o *DeleteOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Co
 			ResourceTypeOrNameArgs(false, args...).RequireObject(false).
 			Flatten().
 			Do()
-		err = r.Err()
+		err = previewr.Err()
 		if err != nil {
 			return err
 		}
-		o.Result = r
-
-		o.Mapper, err = f.ToRESTMapper()
-		if err != nil {
-			return err
-		}
-
-		o.DynamicClient, err = f.DynamicClient()
-		if err != nil {
-			return err
-		}
+		o.PreviewResult = previewr
+		o.previewResourceMap = make(map[cmdwait.ResourceLocation]struct{})
 	}
 
-	// Set default WarningPrinter if not already set.
-	if o.WarningPrinter == nil {
-		o.WarningPrinter = printers.NewWarningPrinter(o.ErrOut, printers.WarningPrinterOptions{Color: term.AllowsColorOutput(o.ErrOut)})
+	o.Mapper, err = f.ToRESTMapper()
+	if err != nil {
+		return err
+	}
+
+	o.DynamicClient, err = f.DynamicClient()
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -257,24 +286,29 @@ func (o *DeleteOptions) Validate() error {
 		return fmt.Errorf("--force and --grace-period greater than 0 cannot be specified together")
 	}
 
-	if len(o.Raw) > 0 {
-		if len(o.FilenameOptions.Filenames) > 1 {
-			return fmt.Errorf("--raw can only use a single local file or stdin")
-		} else if len(o.FilenameOptions.Filenames) == 1 {
-			if strings.Index(o.FilenameOptions.Filenames[0], "http://") == 0 || strings.Index(o.FilenameOptions.Filenames[0], "https://") == 0 {
-				return fmt.Errorf("--raw cannot read from a url")
-			}
-		}
+	if len(o.Raw) == 0 {
+		return nil
+	}
 
-		if o.FilenameOptions.Recursive {
-			return fmt.Errorf("--raw and --recursive are mutually exclusive")
+	if o.Interactive {
+		return fmt.Errorf("--interactive can not be used with --raw")
+	}
+	if len(o.FilenameOptions.Filenames) > 1 {
+		return fmt.Errorf("--raw can only use a single local file or stdin")
+	} else if len(o.FilenameOptions.Filenames) == 1 {
+		if strings.Index(o.FilenameOptions.Filenames[0], "http://") == 0 || strings.Index(o.FilenameOptions.Filenames[0], "https://") == 0 {
+			return fmt.Errorf("--raw cannot read from a url")
 		}
-		if len(o.Output) > 0 {
-			return fmt.Errorf("--raw and --output are mutually exclusive")
-		}
-		if _, err := url.ParseRequestURI(o.Raw); err != nil {
-			return fmt.Errorf("--raw must be a valid URL path: %v", err)
-		}
+	}
+
+	if o.FilenameOptions.Recursive {
+		return fmt.Errorf("--raw and --recursive are mutually exclusive")
+	}
+	if len(o.Output) > 0 {
+		return fmt.Errorf("--raw and --output are mutually exclusive")
+	}
+	if _, err := url.ParseRequestURI(o.Raw); err != nil {
+		return fmt.Errorf("--raw must be a valid URL path: %v", err)
 	}
 
 	return nil
@@ -291,6 +325,39 @@ func (o *DeleteOptions) RunDelete(f cmdutil.Factory) error {
 		}
 		return rawhttp.RawDelete(restClient, o.IOStreams, o.Raw, o.Filenames[0])
 	}
+
+	if o.Interactive {
+		previewInfos := []*resource.Info{}
+		if o.IgnoreNotFound {
+			o.PreviewResult = o.PreviewResult.IgnoreErrors(errors.IsNotFound)
+		}
+		err := o.PreviewResult.Visit(func(info *resource.Info, err error) error {
+			if err != nil {
+				return err
+			}
+			previewInfos = append(previewInfos, info)
+			o.previewResourceMap[cmdwait.ResourceLocation{
+				GroupResource: info.Mapping.Resource.GroupResource(),
+				Namespace:     info.Namespace,
+				Name:          info.Name,
+			}] = struct{}{}
+
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		if len(previewInfos) == 0 {
+			fmt.Fprintf(o.Out, "No resources found\n")
+			return nil
+		}
+
+		if !o.confirmation(previewInfos) {
+			fmt.Fprintf(o.Out, "deletion is cancelled\n")
+			return nil
+		}
+	}
+
 	return o.DeleteResult(o.Result)
 }
 
@@ -306,6 +373,18 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		if err != nil {
 			return err
 		}
+
+		if o.Interactive {
+			if _, ok := o.previewResourceMap[cmdwait.ResourceLocation{
+				GroupResource: info.Mapping.Resource.GroupResource(),
+				Namespace:     info.Namespace,
+				Name:          info.Name,
+			}]; !ok {
+				// resource not in the list of previewed resources based on resourceLocation
+				return nil
+			}
+		}
+
 		deletedInfos = append(deletedInfos, info)
 		found++
 
@@ -439,4 +518,25 @@ func (o *DeleteOptions) PrintObj(info *resource.Info) {
 
 	// understandable output by default
 	fmt.Fprintf(o.Out, "%s \"%s\" %s\n", kindString, info.Name, operation)
+}
+
+func (o *DeleteOptions) confirmation(infos []*resource.Info) bool {
+	fmt.Fprintf(o.Out, i18n.T("You are about to delete the following %d resource(s):\n"), len(infos))
+	for _, info := range infos {
+		groupKind := info.Mapping.GroupVersionKind
+		kindString := fmt.Sprintf("%s.%s", strings.ToLower(groupKind.Kind), groupKind.Group)
+		if len(groupKind.Group) == 0 {
+			kindString = strings.ToLower(groupKind.Kind)
+		}
+
+		fmt.Fprintf(o.Out, "%s/%s\n", kindString, info.Name)
+	}
+	fmt.Fprintf(o.Out, i18n.T("Do you want to continue?")+" (y/n): ")
+	var input string
+	_, err := fmt.Fscan(o.In, &input)
+	if err != nil {
+		return false
+	}
+
+	return strings.EqualFold(input, "y")
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
@@ -48,6 +48,7 @@ type DeleteFlags struct {
 	Wait              *bool
 	Output            *string
 	Raw               *string
+	Interactive       *bool
 }
 
 func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams genericiooptions.IOStreams) (*DeleteOptions, error) {
@@ -106,6 +107,9 @@ func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams generic
 	if f.Raw != nil {
 		options.Raw = *f.Raw
 	}
+	if f.Interactive != nil {
+		options.Interactive = *f.Interactive
+	}
 
 	return options, nil
 }
@@ -156,6 +160,11 @@ func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 	if f.Raw != nil {
 		cmd.Flags().StringVar(f.Raw, "raw", *f.Raw, "Raw URI to DELETE to the server.  Uses the transport specified by the kubeconfig file.")
 	}
+	if cmdutil.InteractiveDelete.IsEnabled() {
+		if f.Interactive != nil {
+			cmd.Flags().BoolVarP(f.Interactive, "interactive", "i", *f.Interactive, "If true, delete resource only when user confirms. This flag is in Alpha.")
+		}
+	}
 }
 
 // NewDeleteCommandFlags provides default flags and values for use with the "delete" command
@@ -175,6 +184,7 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 	timeout := time.Duration(0)
 	wait := true
 	raw := ""
+	interactive := false
 
 	filenames := []string{}
 	recursive := false
@@ -198,6 +208,7 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 		Wait:           &wait,
 		Output:         &output,
 		Raw:            &raw,
+		Interactive:    &interactive,
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -428,6 +428,7 @@ const (
 	ApplySet              FeatureGate = "KUBECTL_APPLYSET"
 	ExplainOpenapiV3      FeatureGate = "KUBECTL_EXPLAIN_OPENAPIV3"
 	CmdPluginAsSubcommand FeatureGate = "KUBECTL_ENABLE_CMD_SHADOW"
+	InteractiveDelete     FeatureGate = "KUBECTL_INTERACTIVE_DELETE"
 )
 
 func (f FeatureGate) IsEnabled() bool {

--- a/test/cmd/delete.sh
+++ b/test/cmd/delete.sh
@@ -52,3 +52,75 @@ run_kubectl_delete_allnamespaces_tests() {
   set +o nounset
   set +o errexit
 }
+
+# Runs tests related to kubectl delete --confirm
+run_kubectl_delete_interactive_tests() {
+  set -o nounset
+  set -o errexit
+
+  # enable interactivity flag feature environment variable
+  export KUBECTL_INTERACTIVE_DELETE=true
+
+  ns_one="namespace-$(date +%s)-${RANDOM}"
+  ns_two="namespace-$(date +%s)-${RANDOM}"
+  kubectl create namespace "${ns_one}"
+  kubectl create namespace "${ns_two}"
+
+  # create configmaps
+  kubectl create configmap "one" --namespace="${ns_one}"
+  kubectl create configmap "two" --namespace="${ns_two}"
+  kubectl label configmap "one" --namespace="${ns_one}" deletetest=true
+  kubectl label configmap "two" --namespace="${ns_two}" deletetest=true
+
+  # not confirm dry-run=server deletions
+  output_message=$(kubectl delete configmap --dry-run=server --interactive -l deletetest=true --all-namespaces <<< $'n\n')
+  kube::test::if_has_string "${output_message}" 'configmap/two' 'configmap/one'
+  # confirm dry-run=server deletions
+  kubectl delete configmap --dry-run=server --interactive -l deletetest=true --all-namespaces <<< $'y\n'
+  # not confirm resource deletions
+  output_message=$(kubectl delete configmap --interactive -l deletetest=true --all-namespaces <<< $'n\n')
+  kube::test::if_has_string "${output_message}" 'configmap/two' 'configmap/one'
+  kubectl config set-context "${CONTEXT}" --namespace="${ns_one}"
+  kube::test::get_object_assert 'configmap -l deletetest' "{{range.items}}{{${id_field:?}}}:{{end}}" 'one:'
+  kubectl config set-context "${CONTEXT}" --namespace="${ns_two}"
+  kube::test::get_object_assert 'configmap -l deletetest' "{{range.items}}{{${id_field:?}}}:{{end}}" 'two:'
+
+  # clean configmaps with label deletetest=true
+  kubectl delete configmap -l deletetest=true --all-namespaces
+
+  # create new configmaps
+  kubectl create configmap "third" --namespace="${ns_one}"
+  kubectl create configmap "fourth" --namespace="${ns_two}"
+  kubectl label configmap "third" --namespace="${ns_one}" deletetest2=true
+  kubectl label configmap "fourth" --namespace="${ns_two}" deletetest2=true
+
+  # confirm all resource deletions with waiting
+  kubectl delete configmaps --interactive -l deletetest2=true --all-namespaces --wait <<< $'y\n'
+
+  # no configmaps should be in either of those namespaces with label deletetest2
+  kubectl config set-context "${CONTEXT}" --namespace="${ns_one}"
+  kube::test::get_object_assert 'configmap -l deletetest2' "{{range.items}}{{${id_field:?}}}:{{end}}" ''
+  kubectl config set-context "${CONTEXT}" --namespace="${ns_two}"
+  kube::test::get_object_assert 'configmap -l deletetest2' "{{range.items}}{{${id_field:?}}}:{{end}}" ''
+
+  # clean configmaps with label deletetest2=true
+  kubectl delete configmap -l deletetest2=true --all-namespaces
+
+  # create new configmaps in one namespace
+  kubectl create configmap "fifth" --namespace="${ns_one}"
+  kubectl create configmap "sixth" --namespace="${ns_one}"
+  kubectl label configmap "fifth" --namespace="${ns_one}" deletetest3=true
+  kubectl label configmap "sixth" --namespace="${ns_one}" deletetest3=true
+
+  # confirm all resource deletions with forcing and waiting
+  kubectl delete configmaps -l deletetest3=true --force --interactive --namespace="${ns_one}" --wait <<< $'y\n'
+
+  # no configmaps should be in either of those namespaces with label deletetest3
+  kubectl config set-context "${CONTEXT}" --namespace="${ns_one}"
+  kube::test::get_object_assert 'configmap -l deletetest3' "{{range.items}}{{${id_field:?}}}:{{end}}" ''
+
+  unset KUBECTL_INTERACTIVE_DELETE
+
+  set +o nounset
+  set +o errexit
+}

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -618,6 +618,13 @@ runTests() {
     record_command run_kubectl_delete_allnamespaces_tests
   fi
 
+  ######################
+  # Delete --interactive   #
+  ######################
+  if kube::test::if_supports_resource "${configmaps}" ; then
+    record_command run_kubectl_delete_interactive_tests
+  fi
+
   ##################
   # Global timeout #
   ##################


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR introduces new interactive flag, namely `interactive`, into delete command. When this flag is set, users have to confirm resource deletion per resource. As alpha stage, this flag will be hidden behind `KUBECTL_INTERACTIVE_DELETE` environment variable and can only be used after `KUBECTL_INTERACTIVE_DELETE=true`.

This PR is continuation of @eddiezane's previous work https://github.com/eddiezane/kubernetes/commit/e970248e1f0d95130f00884bc66fffe359c18922 

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1330

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Added a new command line argument `--interactive` to kubectl. The new command line argument lets a user confirm deletion requests per resource interactively.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
Alpha implementation of KEP-3895: https://github.com/kubernetes/enhancements/issues/3895
