### PR TITLE
apimachinery/wait: tweak

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -734,7 +734,7 @@ func poller(interval, timeout time.Duration) WaitWithContextFunc {
 
 // ExponentialBackoffWithContext works with a request context and a Backoff. It ensures that the retry wait never
 // exceeds the deadline specified by the request context.
-func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, condition ConditionFunc) error {
+func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, condition ConditionWithContextFunc) error {
 	for backoff.Steps > 0 {
 		select {
 		case <-ctx.Done():
@@ -742,7 +742,7 @@ func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, conditi
 		default:
 		}
 
-		if ok, err := runConditionWithCrashProtection(condition); err != nil || ok {
+		if ok, err := runConditionWithCrashProtectionWithContext(ctx, condition); err != nil || ok {
 			return err
 		}
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -875,7 +875,7 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 			}
 
 			attempts := 0
-			err := ExponentialBackoffWithContext(test.ctxGetter(), backoff, func() (bool, error) {
+			err := ExponentialBackoffWithContext(test.ctxGetter(), backoff, func(context.Context) (bool, error) {
 				attempts++
 				return test.callback(attempts)
 			})

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook.go
@@ -121,7 +121,7 @@ func WithExponentialBackoff(ctx context.Context, retryBackoff wait.Backoff, webh
 	// having a webhook error allows us to track the last actual webhook error for requests that
 	// are later cancelled or time out.
 	var webhookErr error
-	err := wait.ExponentialBackoffWithContext(ctx, retryBackoff, func() (bool, error) {
+	err := wait.ExponentialBackoffWithContext(ctx, retryBackoff, func(context.Context) (bool, error) {
 		webhookErr = webhookFn()
 		if shouldRetry(webhookErr) {
 			return false, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR does below tweaks to apimachinery/wait:
* correctly stop and drain timers for best efficiency
* use `ConditionWithContextFunc` for condition of `ExponentialBackoffWithContext` because it should use by convention

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
