### PR TITLE
kubeadm upgrade: fix dry run of backing up kubelet config file

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
@@ -78,9 +78,13 @@ func runKubeletConfigPhase() func(c workflow.RunData) error {
 		}
 		src := filepath.Join(kubeletDir, constants.KubeletConfigurationFileName)
 		dest := filepath.Join(backupDir, constants.KubeletConfigurationFileName)
-		fmt.Printf("[upgrade] backing up kubelet config file to %s\n", dest)
-		if err := os.Rename(src, dest); err != nil {
-			return errors.Wrap(err, "error backing up the kubelet config file")
+		if !dryRun {
+			fmt.Printf("[upgrade] Backing up kubelet config file to %s\n", dest)
+			if err := os.Rename(src, dest); err != nil {
+				return errors.Wrap(err, "error backing up the kubelet config file")
+			}
+		} else {
+			fmt.Printf("[dryrun] Would back up kubelet config file to %s\n", dest)
 		}
 		// Store the kubelet component configuration.
 		if err = kubeletphase.WriteConfigToDisk(&cfg.ClusterConfiguration, kubeletDir, data.PatchesDir(), data.OutputWriter()); err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:

```
[upgrade] Skipping phase. Not a control plane node.
[upgrade] backing up kubelet config file to /etc/kubernetes/tmp/kubeadm-kubelet-config4028019749/config.yaml
rename /etc/kubernetes/tmp/kubeadm-upgrade-dryrun1808990387/config.yaml /etc/kubernetes/tmp/kubeadm-kubelet-config4028019749/config.yaml: no such file or directory
error backing up the kubelet config file
```

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubeadm/issues/2796

#### Special notes for your reviewer:
https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-dryrun-latest
https://github.com/kubernetes/kubernetes/pull/114330#issuecomment-1354315864

#### Does this PR introduce a user-facing change?

```release-note
None
```
