### PR TITLE
cleanup: remove ioutil for new go version

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/compatibility.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/compatibility.go
@@ -19,7 +19,6 @@ package roundtrip
 import (
 	"bytes"
 	gojson "encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -333,11 +332,11 @@ func (c *CompatibilityTestOptions) encode(t *testing.T, obj runtime.Object) (jso
 
 func read(dir string, gvk schema.GroupVersionKind, suffix string, usedFiles sets.String) (json, yaml, proto []byte, err error) {
 	jsonFilename := makeName(gvk) + suffix + ".json"
-	actualJSON, jsonErr := ioutil.ReadFile(filepath.Join(dir, jsonFilename))
+	actualJSON, jsonErr := os.ReadFile(filepath.Join(dir, jsonFilename))
 	yamlFilename := makeName(gvk) + suffix + ".yaml"
-	actualYAML, yamlErr := ioutil.ReadFile(filepath.Join(dir, yamlFilename))
+	actualYAML, yamlErr := os.ReadFile(filepath.Join(dir, yamlFilename))
 	protoFilename := makeName(gvk) + suffix + ".pb"
-	actualProto, protoErr := ioutil.ReadFile(filepath.Join(dir, protoFilename))
+	actualProto, protoErr := os.ReadFile(filepath.Join(dir, protoFilename))
 	if usedFiles != nil {
 		usedFiles.Insert(jsonFilename)
 		usedFiles.Insert(yamlFilename)
@@ -359,7 +358,7 @@ func writeFile(t *testing.T, dir string, gvk schema.GroupVersionKind, suffix, ex
 	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
 		t.Fatal("error making directory", err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, makeName(gvk)+suffix+"."+extension), data, os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, makeName(gvk)+suffix+"."+extension), data, os.FileMode(0644)); err != nil {
 		t.Fatalf("error writing %s: %v", extension, err)
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package unstructured
 
 import (
-	"io/ioutil"
+	"io"
 	"sync"
 	"testing"
 
@@ -38,7 +38,7 @@ func TestCodecOfUnstructuredList(t *testing.T) {
 	for i := 0; i < concurrency; i++ {
 		go func() {
 			defer wg.Done()
-			assert.NoError(t, UnstructuredJSONScheme.Encode(&list, ioutil.Discard))
+			assert.NoError(t, UnstructuredJSONScheme.Encode(&list, io.Discard))
 		}()
 	}
 	wg.Wait()

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/encoder_with_allocator_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/encoder_with_allocator_test.go
@@ -18,7 +18,7 @@ package serializer
 
 import (
 	"crypto/rand"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +49,7 @@ func benchmarkEncodeFor(b *testing.B, target runtime.Encoder) {
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for n := 0; n < b.N; n++ {
-				err := target.Encode(tc.obj, ioutil.Discard)
+				err := target.Encode(tc.obj, io.Discard)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -64,7 +64,7 @@ func benchmarkEncodeWithAllocatorFor(b *testing.B, target runtime.EncoderWithAll
 			b.ReportAllocs()
 			allocator := &runtime.Allocator{}
 			for n := 0; n < b.N; n++ {
-				err := target.EncodeWithAllocator(tc.obj, ioutil.Discard, allocator)
+				err := target.EncodeWithAllocator(tc.obj, io.Discard, allocator)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
@@ -19,7 +19,6 @@ package streaming
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,7 +40,7 @@ func (d *fakeDecoder) Decode(data []byte, gvk *schema.GroupVersionKind, into run
 func TestEmptyDecoder(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	d := &fakeDecoder{}
-	_, _, err := NewDecoder(ioutil.NopCloser(buf), d).Decode(nil, nil)
+	_, _, err := NewDecoder(io.NopCloser(buf), d).Decode(nil, nil)
 	if err != io.EOF {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
@@ -19,7 +19,6 @@ package versioning
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"testing"
 
@@ -112,7 +111,7 @@ func TestNestedEncode(t *testing.T) {
 		schema.GroupVersion{Group: "other"}, nil,
 		"TestNestedEncode",
 	)
-	if err := codec.Encode(n, ioutil.Discard); err != n2.nestedErr {
+	if err := codec.Encode(n, io.Discard); err != n2.nestedErr {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if n.nestedCalled || !n2.nestedCalled {
@@ -135,7 +134,7 @@ func TestNestedEncodeError(t *testing.T) {
 		schema.GroupVersion{Group: "other", Version: "v2"}, nil,
 		"TestNestedEncodeError",
 	)
-	if err := codec.Encode(n, ioutil.Discard); err != n.nestedErr {
+	if err := codec.Encode(n, io.Discard); err != n.nestedErr {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if n.GroupVersionKind() != gvk1 {
@@ -371,7 +370,7 @@ func TestDirectCodecEncode(t *testing.T) {
 		Encoder:     &serializer,
 		ObjectTyper: &typer,
 	}
-	c.Encode(&testDecodable{}, ioutil.Discard)
+	c.Encode(&testDecodable{}, io.Discard)
 	if e, a := "expected_group", serializer.encodingObjGVK.Group; e != a {
 		t.Errorf("expected group to be %v, got %v", e, a)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_unstructured_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_unstructured_test.go
@@ -18,7 +18,7 @@ package versioning
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -133,7 +133,7 @@ func TestEncodeUnstructured(t *testing.T) {
 	for _, testCase := range testCases {
 		serializer := &mockSerializer{}
 		codec := NewCodec(serializer, serializer, testCase.convertor, nil, testCase.typer, nil, testCase.targetVersion, nil, "noxu-scheme")
-		err := codec.Encode(testCase.outObj, ioutil.Discard)
+		err := codec.Encode(testCase.outObj, io.Discard)
 		if testCase.errFunc != nil {
 			if !testCase.errFunc(err) {
 				t.Errorf("%v: failed: %v", testCase.name, err)

--- a/staging/src/k8s.io/apimachinery/pkg/util/framer/framer_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/framer/framer_test.go
@@ -19,7 +19,6 @@ package framer
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 )
 
@@ -34,7 +33,7 @@ func TestRead(t *testing.T) {
 		0x08,
 	}
 	b := bytes.NewBuffer(data)
-	r := NewLengthDelimitedFrameReader(ioutil.NopCloser(b))
+	r := NewLengthDelimitedFrameReader(io.NopCloser(b))
 	buf := make([]byte, 1)
 	if n, err := r.Read(buf); err != io.ErrShortBuffer && n != 1 && bytes.Equal(buf, []byte{0x01}) {
 		t.Fatalf("unexpected: %v %d %v", err, n, buf)
@@ -79,7 +78,7 @@ func TestReadLarge(t *testing.T) {
 		0x08,
 	}
 	b := bytes.NewBuffer(data)
-	r := NewLengthDelimitedFrameReader(ioutil.NopCloser(b))
+	r := NewLengthDelimitedFrameReader(io.NopCloser(b))
 	buf := make([]byte, 40)
 	if n, err := r.Read(buf); err != nil && n != 4 && bytes.Equal(buf, []byte{0x01, 0x02, 0x03, 0x04}) {
 		t.Fatalf("unexpected: %v %d %v", err, n, buf)
@@ -104,7 +103,7 @@ func TestReadInvalidFrame(t *testing.T) {
 		0x01, 0x02,
 	}
 	b := bytes.NewBuffer(data)
-	r := NewLengthDelimitedFrameReader(ioutil.NopCloser(b))
+	r := NewLengthDelimitedFrameReader(io.NopCloser(b))
 	buf := make([]byte, 1)
 	if n, err := r.Read(buf); err != io.ErrShortBuffer && n != 1 && bytes.Equal(buf, []byte{0x01}) {
 		t.Fatalf("unexpected: %v %d %v", err, n, buf)
@@ -122,7 +121,7 @@ func TestReadInvalidFrame(t *testing.T) {
 
 func TestJSONFrameReader(t *testing.T) {
 	b := bytes.NewBufferString("{\"test\":true}\n1\n[\"a\"]")
-	r := NewJSONFramedReader(ioutil.NopCloser(b))
+	r := NewJSONFramedReader(io.NopCloser(b))
 	buf := make([]byte, 20)
 	if n, err := r.Read(buf); err != nil || n != 13 || string(buf[:n]) != `{"test":true}` {
 		t.Fatalf("unexpected: %v %d %q", err, n, buf)
@@ -140,7 +139,7 @@ func TestJSONFrameReader(t *testing.T) {
 
 func TestJSONFrameReaderShortBuffer(t *testing.T) {
 	b := bytes.NewBufferString("{\"test\":true}\n1\n[\"a\"]")
-	r := NewJSONFramedReader(ioutil.NopCloser(b))
+	r := NewJSONFramedReader(io.NopCloser(b))
 	buf := make([]byte, 3)
 
 	if n, err := r.Read(buf); err != io.ErrShortBuffer || n != 3 || string(buf[:n]) != `{"t` {

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -23,7 +23,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -337,7 +337,7 @@ func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connec
 	if (resp.StatusCode != http.StatusSwitchingProtocols) || !strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) || !strings.Contains(upgradeHeader, strings.ToLower(HeaderSpdy31)) {
 		defer resp.Body.Close()
 		responseError := ""
-		responseErrorBytes, err := ioutil.ReadAll(resp.Body)
+		responseErrorBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			responseError = "unable to read error from server response"
 		} else {

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
@@ -18,7 +18,6 @@ package net
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -700,7 +699,7 @@ func TestGetIPFromHostInterfaces(t *testing.T) {
 }
 
 func makeRouteFile(content string, t *testing.T) (*os.File, error) {
-	routeFile, err := ioutil.TempFile("", "route")
+	routeFile, err := os.CreateTemp("", "route")
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go
@@ -22,7 +22,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -263,7 +262,7 @@ func (t *Transport) rewriteResponse(req *http.Request, resp *http.Response) (*ht
 		return resp, err
 	}
 
-	resp.Body = ioutil.NopCloser(newContent)
+	resp.Body = io.NopCloser(newContent)
 	// Update header node with new content-length
 	// TODO: Remove any hash/signature headers here?
 	resp.Header.Del("Content-Length")

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport_test.go
@@ -21,7 +21,7 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -300,7 +300,7 @@ func TestProxyTransport(t *testing.T) {
 			}
 			return
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("%v: Unexpected error: %v", name, err)
 			return
@@ -342,12 +342,12 @@ func TestRewriteResponse(t *testing.T) {
 				gzw.Write([]byte(ept))
 				gzw.Flush()
 				return &http.Response{
-					Body: ioutil.NopCloser(gzipbuf),
+					Body: io.NopCloser(gzipbuf),
 				}
 			},
 			reader: func(rep *http.Response) string {
 				reader, _ := gzip.NewReader(rep.Body)
-				s, _ := ioutil.ReadAll(reader)
+				s, _ := io.ReadAll(reader)
 				return string(s)
 			},
 		},
@@ -360,12 +360,12 @@ func TestRewriteResponse(t *testing.T) {
 				flw.Write([]byte(ept))
 				flw.Flush()
 				return &http.Response{
-					Body: ioutil.NopCloser(flatebuf),
+					Body: io.NopCloser(flatebuf),
 				}
 			},
 			reader: func(rep *http.Response) string {
 				reader := flate.NewReader(rep.Body)
-				s, _ := ioutil.ReadAll(reader)
+				s, _ := io.ReadAll(reader)
 				return string(s)
 			},
 		},

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -148,7 +147,7 @@ func (onewayRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		Status:     "200 OK",
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(&bytes.Buffer{}),
+		Body:       io.NopCloser(&bytes.Buffer{}),
 		Request:    req,
 	}, nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -100,7 +99,7 @@ func (s *SimpleBackendHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 	s.requestHeader = req.Header
 	s.requestMethod = req.Method
 	var err error
-	s.requestBody, err = ioutil.ReadAll(req.Body)
+	s.requestBody, err = io.ReadAll(req.Body)
 	if err != nil {
 		s.t.Errorf("Unexpected error: %v", err)
 		return
@@ -370,7 +369,7 @@ func TestServeHTTP(t *testing.T) {
 			validateHeaders(t, test.name+" backend headers", res.Header, test.expectedRespHeader, test.notExpectedRespHeader)
 
 			// Validate Body
-			responseBody, err := ioutil.ReadAll(res.Body)
+			responseBody, err := io.ReadAll(res.Body)
 			if err != nil {
 				t.Errorf("Unexpected error reading response body: %v", err)
 			}
@@ -601,7 +600,7 @@ func TestProxyUpgradeConnectionErrorResponse(t *testing.T) {
 	// Expect error response.
 	assert.True(t, responder.called)
 	assert.Equal(t, fakeStatusCode, resp.StatusCode)
-	msg, err := ioutil.ReadAll(resp.Body)
+	msg, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(msg), expectedErr.Error())
 }
@@ -640,7 +639,7 @@ func TestProxyUpgradeErrorResponseTerminates(t *testing.T) {
 			// Verify we get the correct response and full message body content
 			resp, err := http.ReadResponse(bufferedReader, nil)
 			require.NoError(t, err)
-			data, err := ioutil.ReadAll(resp.Body)
+			data, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.Equal(t, resp.StatusCode, code)
 			require.Equal(t, data, []byte(`some data`))
@@ -790,7 +789,7 @@ func TestRejectForwardingRedirectsOption(t *testing.T) {
 			resp, err := http.ReadResponse(bufferedReader, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectStatusCode, resp.StatusCode)
-			data, err := ioutil.ReadAll(resp.Body)
+			data, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectBody, data)
 			assert.Equal(t, int64(len(tc.expectBody)), resp.ContentLength)
@@ -976,7 +975,7 @@ func TestProxyRequestContentLengthAndTransferEncoding(t *testing.T) {
 			}
 
 			// Read body
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			if err != nil {
 				t.Errorf("%s: unexpected error %v", k, err)
 			}
@@ -1039,7 +1038,7 @@ func TestProxyRequestContentLengthAndTransferEncoding(t *testing.T) {
 		}
 
 		// Read response
-		response, err := ioutil.ReadAll(conn)
+		response, err := io.ReadAll(conn)
 		if err != nil {
 			t.Errorf("%s: unexpected error %v", k, err)
 			continue

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testing/openapi.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testing/openapi.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"io/ioutil"
 	"os"
 	"sync"
 
@@ -43,7 +42,7 @@ func (f *Fake) OpenAPISchema() (*openapi_v2.Document, error) {
 			f.err = err
 			return
 		}
-		spec, err := ioutil.ReadFile(f.Path)
+		spec, err := os.ReadFile(f.Path)
 		if err != nil {
 			f.err = err
 			return

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -45,7 +44,7 @@ stuff: 1
 	}
 
 	for i, testCase := range testCases {
-		r := NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(d))))
+		r := NewDocumentDecoder(io.NopCloser(bytes.NewReader([]byte(d))))
 		b := make([]byte, testCase.bufLen)
 		n, err := r.Read(b)
 		if err != testCase.expectErr || n != testCase.expectLen {
@@ -62,7 +61,7 @@ stuff: 1
 	bufferLen := 4 * 1024
 	//  maxLen 5 M
 	dd := strings.Repeat(d, 512*1024)
-	r := NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(dd[:maxLen-1]))))
+	r := NewDocumentDecoder(io.NopCloser(bytes.NewReader([]byte(dd[:maxLen-1]))))
 	b := make([]byte, bufferLen)
 	n, err := r.Read(b)
 	if err != io.ErrShortBuffer {
@@ -73,7 +72,7 @@ stuff: 1
 	if err != nil {
 		t.Fatalf("expected nil: %d / %v", n, err)
 	}
-	r = NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(dd))))
+	r = NewDocumentDecoder(io.NopCloser(bytes.NewReader([]byte(dd))))
 	b = make([]byte, maxLen)
 	n, err = r.Read(b)
 	if err != bufio.ErrTooLong {
@@ -85,7 +84,7 @@ func TestYAMLDecoderCallsAfterErrShortBufferRestOfFrame(t *testing.T) {
 	d := `---
 stuff: 1
 	test-foo: 1`
-	r := NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(d))))
+	r := NewDocumentDecoder(io.NopCloser(bytes.NewReader([]byte(d))))
 	b := make([]byte, 12)
 	n, err := r.Read(b)
 	if err != io.ErrShortBuffer || n != 12 {

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
@@ -359,8 +359,9 @@ const (
 // 4) simpleLetterEqualFold, no specials, no non-letters.
 //
 // The letters S and K are special because they map to 3 runes, not just 2:
-//  * S maps to s and to U+017F 'ſ' Latin small letter long s
-//  * k maps to K and to U+212A 'K' Kelvin sign
+//   - S maps to s and to U+017F 'ſ' Latin small letter long s
+//   - k maps to K and to U+212A 'K' Kelvin sign
+//
 // See http://play.golang.org/p/tTxjOc0OGo
 //
 // The returned function is specialized for matching against s and


### PR DESCRIPTION
`io/util` package has been deprecated, we should clean it.
The docs url: https://go.dev/doc/go1.16#ioutil

/kind cleanup